### PR TITLE
[Data Streaming Service] Support missing data chunks in streams.

### DIFF
--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -249,7 +249,7 @@ impl<T> Response<T> {
 }
 
 /// The different data client response payloads as an enum.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     NewTransactionOutputsWithProof((TransactionOutputListWithProof, LedgerInfoWithSignatures)),

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -23,7 +23,7 @@ pub struct DataNotification {
 
 /// A single payload (e.g. chunk) of data delivered to a data listener.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataPayload {
     ContinuousTransactionOutputsWithProof(LedgerInfoWithSignatures, TransactionOutputListWithProof),
     ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProof),
@@ -179,6 +179,27 @@ pub struct TransactionsOrOutputsWithProofRequest {
 pub struct PendingClientResponse {
     pub client_request: DataClientRequest,
     pub client_response: Option<Result<Response<ResponsePayload>, aptos_data_client::error::Error>>,
+}
+
+impl PendingClientResponse {
+    pub fn new(client_request: DataClientRequest) -> Self {
+        Self {
+            client_request,
+            client_response: None,
+        }
+    }
+
+    #[cfg(test)]
+    /// Creates a new pending client response with a response already available
+    pub fn new_with_response(
+        client_request: DataClientRequest,
+        client_response: Result<Response<ResponsePayload>, aptos_data_client::error::Error>,
+    ) -> Self {
+        Self {
+            client_request,
+            client_response: Some(client_response),
+        }
+    }
 }
 
 impl Debug for PendingClientResponse {

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -16,7 +16,7 @@ use crate::{
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
     metrics,
-    metrics::{increment_counter, increment_counter_multiple, start_timer},
+    metrics::{increment_counter, increment_counter_multiple_labels, start_timer},
     stream_engine::{DataStreamEngine, StreamEngine},
     streaming_client::{NotificationFeedback, StreamRequest},
 };
@@ -291,10 +291,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
     ) -> PendingClientResponse {
         // Create a new pending client response
         let pending_client_response = Arc::new(Mutex::new(Box::new(
-            data_notification::PendingClientResponse {
-                client_request: data_client_request.clone(),
-                client_response: None,
-            },
+            data_notification::PendingClientResponse::new(data_client_request.clone()),
         )));
 
         // Calculate the request timeout to use, based on the
@@ -317,7 +314,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
             );
 
             // Update the retry counter and log the request
-            increment_counter_multiple(
+            increment_counter_multiple_labels(
                 &metrics::RETRIED_DATA_REQUESTS,
                 data_client_request.get_label(),
                 &request_timeout_ms.to_string(),
@@ -412,23 +409,53 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         // Process any ready data responses
         for _ in 0..self.get_max_concurrent_requests() {
             if let Some(pending_response) = self.pop_pending_response_queue()? {
+                // Get the client request and response information
                 let maybe_client_response = pending_response.lock().client_response.take();
                 let client_response = maybe_client_response.ok_or_else(|| {
                     Error::UnexpectedErrorEncountered("The client response should be ready!".into())
                 })?;
                 let client_request = &pending_response.lock().client_request.clone();
 
+                // Process the client response
                 match client_response {
                     Ok(client_response) => {
-                        if sanity_check_client_response(client_request, &client_response) {
+                        // Sanity check and process the response
+                        if sanity_check_client_response_type(client_request, &client_response) {
+                            // If the response wasn't enough to satisfy the original request (e.g.,
+                            // it was truncated), missing data should be requested.
+                            let missing_data_requested = self.missing_data_requested(
+                                client_request,
+                                client_response.payload.clone(),
+                            );
+
+                            // Send the data notification to the client
                             self.send_data_notification_to_client(client_request, client_response)
                                 .await?;
+
+                            // Check if any missing data was requested
+                            match missing_data_requested {
+                                Ok(missing_data_requested) => {
+                                    if missing_data_requested {
+                                        break; // We're now head of line blocked on the missing data
+                                    }
+                                },
+                                Err(error) => {
+                                    warn!(LogSchema::new(LogEntry::ReceivedDataResponse)
+                                        .stream_id(self.data_stream_id)
+                                        .event(LogEvent::Error)
+                                        .error(&error)
+                                        .message(
+                                            "Failed to determine if missing data was requested!"
+                                        ));
+                                },
+                            }
                         } else {
+                            // The sanity check failed
                             self.handle_sanity_check_failure(
                                 client_request,
                                 &client_response.context,
                             )?;
-                            break;
+                            break; // We're now head of line blocked on the failed request
                         }
                     },
                     Err(error) => {
@@ -445,17 +472,48 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
                             // Otherwise, we should handle the error and simply retry
                             self.handle_data_client_error(client_request, &error)?;
                         }
-                        break;
+                        break; // We're now head of line blocked on the failed request
                     },
                 }
             } else {
-                break; // The first response hasn't arrived yet.
+                break; // The first response hasn't arrived yet
             }
         }
 
         // Create and send further client requests to the network
         // to ensure we're maximizing the number of concurrent requests.
         self.create_and_send_client_requests(&global_data_summary)
+    }
+
+    /// Returns true iff we requested missing data from a previous
+    /// client response.
+    fn missing_data_requested(
+        &mut self,
+        data_client_request: &DataClientRequest,
+        response_payload: ResponsePayload,
+    ) -> Result<bool, Error> {
+        // Identify if any missing data needs to be requested
+        if let Some(missing_data_request) =
+            create_missing_data_request(data_client_request, response_payload)?
+        {
+            // Increment the missing client request counter
+            increment_counter(
+                &metrics::SENT_DATA_REQUESTS_FOR_MISSING_DATA,
+                data_client_request.get_label(),
+            );
+
+            // Send the missing data request
+            let pending_client_response =
+                self.send_client_request(false, missing_data_request.clone());
+
+            // Push the pending response to the front of the queue
+            self.get_sent_data_requests()?
+                .push_front(pending_client_response);
+
+            return Ok(true); // Missing data was requested
+        }
+
+        Ok(false) // No missing data was requested
     }
 
     /// Pops and returns the first pending client response if the response has
@@ -738,9 +796,271 @@ impl FusedStream for DataStreamListener {
     }
 }
 
-/// Returns true iff the data client response payload matches the expected type
-/// of the original request. No other sanity checks are done.
-fn sanity_check_client_response(
+/// Creates and returns a missing data request if the given client response
+/// doesn't satisfy the original request. If the request is satisfied,
+/// None is returned.
+pub(crate) fn create_missing_data_request(
+    data_client_request: &DataClientRequest,
+    response_payload: ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine if the request was satisfied, and if not, create
+    // a missing data request to satisfy the original request.
+    match data_client_request {
+        DataClientRequest::EpochEndingLedgerInfos(request) => {
+            create_missing_epoch_ending_ledger_infos_request(request, &response_payload)
+        },
+        DataClientRequest::StateValuesWithProof(request) => {
+            create_missing_state_values_request(request, &response_payload)
+        },
+        DataClientRequest::TransactionsWithProof(request) => {
+            create_missing_transactions_request(request, &response_payload)
+        },
+        DataClientRequest::TransactionOutputsWithProof(request) => {
+            create_missing_transaction_outputs_request(request, &response_payload)
+        },
+        DataClientRequest::TransactionsOrOutputsWithProof(request) => {
+            create_missing_transactions_or_outputs_request(request, &response_payload)
+        },
+        _ => Ok(None), // The request was trivially satisfied (based on the type)
+    }
+}
+
+/// Creates and returns a missing epoch ending ledger info request if the
+/// given client response doesn't satisfy the original request. If the request
+/// is satisfied, None is returned.
+fn create_missing_epoch_ending_ledger_infos_request(
+    request: &EpochEndingLedgerInfosRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine the number of requested ledger infos
+    let num_requested_ledger_infos = request
+        .end_epoch
+        .checked_sub(request.start_epoch)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested ledger infos has overflown!".into())
+        })?;
+
+    // Identify the missing data if the request was not satisfied
+    match response_payload {
+        ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
+            // Check if the request was satisfied
+            let num_received_ledger_infos = ledger_infos.len() as u64;
+            if num_received_ledger_infos < num_requested_ledger_infos {
+                let start_epoch = request
+                    .start_epoch
+                    .checked_add(num_received_ledger_infos)
+                    .ok_or_else(|| Error::IntegerOverflow("Start epoch has overflown!".into()))?;
+                Ok(Some(DataClientRequest::EpochEndingLedgerInfos(
+                    EpochEndingLedgerInfosRequest {
+                        start_epoch,
+                        end_epoch: request.end_epoch,
+                    },
+                )))
+            } else {
+                Ok(None) // The request was satisfied!
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for epoch ending ledger info request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing state values request if the given client
+/// response doesn't satisfy the original request. If the request is satisfied,
+/// None is returned.
+fn create_missing_state_values_request(
+    request: &StateValuesWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine the number of requested state values
+    let num_requested_state_values = request
+        .end_index
+        .checked_sub(request.start_index)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested state values has overflown!".into())
+        })?;
+
+    // Identify the missing data if the request was not satisfied
+    match response_payload {
+        ResponsePayload::StateValuesWithProof(state_values_with_proof) => {
+            // Check if the request was satisfied
+            let num_received_state_values = state_values_with_proof.raw_values.len() as u64;
+            if num_received_state_values < num_requested_state_values {
+                let start_index = request
+                    .start_index
+                    .checked_add(num_received_state_values)
+                    .ok_or_else(|| Error::IntegerOverflow("Start index has overflown!".into()))?;
+                Ok(Some(DataClientRequest::StateValuesWithProof(
+                    StateValuesWithProofRequest {
+                        version: request.version,
+                        start_index,
+                        end_index: request.end_index,
+                    },
+                )))
+            } else {
+                Ok(None) // The request was satisfied!
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for state values request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing transactions request if the given client
+/// response doesn't satisfy the original request. If the request is satisfied,
+/// None is returned.
+fn create_missing_transactions_request(
+    request: &TransactionsWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine the number of requested transactions
+    let num_requested_transactions = request
+        .end_version
+        .checked_sub(request.start_version)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested transactions has overflown!".into())
+        })?;
+
+    // Identify the missing data if the request was not satisfied
+    match response_payload {
+        ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
+            // Check if the request was satisfied
+            let num_received_transactions = transactions_with_proof.transactions.len() as u64;
+            if num_received_transactions < num_requested_transactions {
+                let start_version = request
+                    .start_version
+                    .checked_add(num_received_transactions)
+                    .ok_or_else(|| Error::IntegerOverflow("Start version has overflown!".into()))?;
+                Ok(Some(DataClientRequest::TransactionsWithProof(
+                    TransactionsWithProofRequest {
+                        start_version,
+                        end_version: request.end_version,
+                        proof_version: request.proof_version,
+                        include_events: request.include_events,
+                    },
+                )))
+            } else {
+                Ok(None) // The request was satisfied!
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for transactions request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing transaction outputs request if the given client
+/// response doesn't satisfy the original request. If the request is satisfied,
+/// None is returned.
+fn create_missing_transaction_outputs_request(
+    request: &TransactionOutputsWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine the number of requested transaction outputs
+    let num_requested_outputs = request
+        .end_version
+        .checked_sub(request.start_version)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow("Number of requested transaction outputs has overflown!".into())
+        })?;
+
+    // Identify the missing data if the request was not satisfied
+    match response_payload {
+        ResponsePayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
+            // Check if the request was satisfied
+            let num_received_outputs = transaction_outputs_with_proof
+                .transactions_and_outputs
+                .len() as u64;
+            if num_received_outputs < num_requested_outputs {
+                let start_version = request
+                    .start_version
+                    .checked_add(num_received_outputs)
+                    .ok_or_else(|| Error::IntegerOverflow("Start version has overflown!".into()))?;
+                Ok(Some(DataClientRequest::TransactionOutputsWithProof(
+                    TransactionOutputsWithProofRequest {
+                        start_version,
+                        end_version: request.end_version,
+                        proof_version: request.proof_version,
+                    },
+                )))
+            } else {
+                Ok(None) // The request was satisfied!
+            }
+        },
+        payload => Err(Error::AptosDataClientResponseIsInvalid(format!(
+            "Invalid response payload found for transaction outputs request: {:?}",
+            payload
+        ))),
+    }
+}
+
+/// Creates and returns a missing transactions or outputs request if the
+/// given client response doesn't satisfy the original request. If the request
+/// is satisfied, None is returned.
+fn create_missing_transactions_or_outputs_request(
+    request: &TransactionsOrOutputsWithProofRequest,
+    response_payload: &ResponsePayload,
+) -> Result<Option<DataClientRequest>, Error> {
+    // Determine the number of requested transactions or outputs
+    let num_request_data_items = request
+        .end_version
+        .checked_sub(request.start_version)
+        .and_then(|v| v.checked_add(1))
+        .ok_or_else(|| {
+            Error::IntegerOverflow(
+                "Number of requested transactions or outputs has overflown!".into(),
+            )
+        })?;
+
+    // Calculate the number of received data items
+    let num_received_data_items = match response_payload {
+        ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
+            transactions_with_proof.transactions.len() as u64
+        },
+        ResponsePayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
+            transaction_outputs_with_proof
+                .transactions_and_outputs
+                .len() as u64
+        },
+        payload => {
+            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                "Invalid response payload found for transactions or outputs request: {:?}",
+                payload
+            )))
+        },
+    };
+
+    // Identify the missing data if the request was not satisfied
+    if num_received_data_items < num_request_data_items {
+        let start_version = request
+            .start_version
+            .checked_add(num_received_data_items)
+            .ok_or_else(|| Error::IntegerOverflow("Start version has overflown!".into()))?;
+        Ok(Some(DataClientRequest::TransactionsOrOutputsWithProof(
+            TransactionsOrOutputsWithProofRequest {
+                start_version,
+                end_version: request.end_version,
+                proof_version: request.proof_version,
+                include_events: request.include_events,
+            },
+        )))
+    } else {
+        Ok(None) // The request was satisfied!
+    }
+}
+
+/// Returns true iff the data client response payload type matches the
+/// expected type of the original request. No other sanity checks are done.
+fn sanity_check_client_response_type(
     data_client_request: &DataClientRequest,
     data_client_response: &Response<ResponsePayload>,
 ) -> bool {

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -423,10 +423,8 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
                         if sanity_check_client_response_type(client_request, &client_response) {
                             // If the response wasn't enough to satisfy the original request (e.g.,
                             // it was truncated), missing data should be requested.
-                            let missing_data_requested = self.missing_data_requested(
-                                client_request,
-                                client_response.payload.clone(),
-                            );
+                            let missing_data_requested =
+                                self.request_missing_data(client_request, &client_response.payload);
 
                             // Send the data notification to the client
                             self.send_data_notification_to_client(client_request, client_response)
@@ -485,12 +483,12 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         self.create_and_send_client_requests(&global_data_summary)
     }
 
-    /// Returns true iff we requested missing data from a previous
-    /// client response.
-    fn missing_data_requested(
+    /// Requests any missing data from the previous client response
+    /// and returns true iff missing data was requested.
+    fn request_missing_data(
         &mut self,
         data_client_request: &DataClientRequest,
-        response_payload: ResponsePayload,
+        response_payload: &ResponsePayload,
     ) -> Result<bool, Error> {
         // Identify if any missing data needs to be requested
         if let Some(missing_data_request) =
@@ -801,25 +799,25 @@ impl FusedStream for DataStreamListener {
 /// None is returned.
 pub(crate) fn create_missing_data_request(
     data_client_request: &DataClientRequest,
-    response_payload: ResponsePayload,
+    response_payload: &ResponsePayload,
 ) -> Result<Option<DataClientRequest>, Error> {
     // Determine if the request was satisfied, and if not, create
     // a missing data request to satisfy the original request.
     match data_client_request {
         DataClientRequest::EpochEndingLedgerInfos(request) => {
-            create_missing_epoch_ending_ledger_infos_request(request, &response_payload)
+            create_missing_epoch_ending_ledger_infos_request(request, response_payload)
         },
         DataClientRequest::StateValuesWithProof(request) => {
-            create_missing_state_values_request(request, &response_payload)
+            create_missing_state_values_request(request, response_payload)
         },
         DataClientRequest::TransactionsWithProof(request) => {
-            create_missing_transactions_request(request, &response_payload)
+            create_missing_transactions_request(request, response_payload)
         },
         DataClientRequest::TransactionOutputsWithProof(request) => {
-            create_missing_transaction_outputs_request(request, &response_payload)
+            create_missing_transaction_outputs_request(request, response_payload)
         },
         DataClientRequest::TransactionsOrOutputsWithProof(request) => {
-            create_missing_transactions_or_outputs_request(request, &response_payload)
+            create_missing_transactions_or_outputs_request(request, response_payload)
         },
         _ => Ok(None), // The request was trivially satisfied (based on the type)
     }

--- a/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
@@ -104,6 +104,16 @@ pub static SENT_DATA_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for tracking sent data requests for missing data
+pub static SENT_DATA_REQUESTS_FOR_MISSING_DATA: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_data_streaming_service_sent_data_requests_for_missing_data",
+        "Counters related to sent data requests for missing data",
+        &["request_type"]
+    )
+    .unwrap()
+});
+
 /// Counter for tracking data requests that were retried (including
 /// the new timeouts).
 pub static RETRIED_DATA_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -160,7 +170,7 @@ pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: &str) {
 }
 
 /// Increments the given counter with two label values.
-pub fn increment_counter_multiple(
+pub fn increment_counter_multiple_labels(
     counter: &Lazy<IntCounterVec>,
     first_label: &str,
     second_label: &str,

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -296,7 +296,7 @@ impl DataStreamEngine for StateStreamEngine {
                 // Identify the last received state index and bound it appropriately
                 let last_received_index = match &client_response_payload {
                     ResponsePayload::StateValuesWithProof(state_values_with_proof) => {
-                        // Verify that we received at least state value
+                        // Verify that we received at least one state value
                         if state_values_with_proof.raw_values.is_empty() {
                             return Err(Error::AptosDataClientResponseIsInvalid(format!(
                                 "Received an empty state values response! Request: {:?}",
@@ -1879,7 +1879,7 @@ impl SubscriptionStream {
 /// If the number is less than the min, the min is returned. If the number is
 /// greater than the max, the max is returned. Otherwise, the number is returned.
 pub(crate) fn bound_by_range(number: u64, min: u64, max: u64) -> u64 {
-    cmp::min(cmp::max(number, min), max)
+    number.clamp(min, max)
 }
 
 /// Verifies that the `expected_next_index` matches the `start_index` and that

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -286,24 +286,43 @@ impl DataStreamEngine for StateStreamEngine {
     ) -> Result<Option<DataNotification>, Error> {
         match client_request {
             StateValuesWithProof(request) => {
+                // Verify the client request indices
                 verify_client_request_indices(
                     self.next_stream_index,
                     request.start_index,
                     request.end_index,
                 )?;
 
-                // Update the local stream notification tracker
-                self.next_stream_index = request.end_index.checked_add(1).ok_or_else(|| {
+                // Identify the last received state index and bound it appropriately
+                let last_received_index = match &client_response_payload {
+                    ResponsePayload::StateValuesWithProof(state_values_with_proof) => {
+                        // Verify that we received at least state value
+                        if state_values_with_proof.raw_values.is_empty() {
+                            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                                "Received an empty state values response! Request: {:?}",
+                                client_request
+                            )));
+                        }
+
+                        // Get the last received state index
+                        state_values_with_proof.last_index
+                    },
+                    _ => invalid_response_type!(client_response_payload),
+                };
+                let last_received_index =
+                    bound_by_range(last_received_index, request.start_index, request.end_index);
+
+                // Update the next stream index
+                self.next_stream_index = last_received_index.checked_add(1).ok_or_else(|| {
                     Error::IntegerOverflow("Next stream index has overflown!".into())
                 })?;
 
                 // Check if the stream is complete
-                if request.end_index
-                    == self
-                        .get_number_of_states()?
-                        .checked_sub(1)
-                        .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?
-                {
+                let last_stream_index = self
+                    .get_number_of_states()?
+                    .checked_sub(1)
+                    .ok_or_else(|| Error::IntegerOverflow("End index has overflown!".into()))?;
+                if last_received_index >= last_stream_index {
                     self.stream_is_complete = true;
                 }
 
@@ -468,14 +487,47 @@ impl ContinuousTransactionStreamEngine {
 
     fn create_notification_for_continuous_data(
         &mut self,
-        request_start: Version,
-        request_end: Version,
+        request_start_version: Version,
+        request_end_version: Version,
         client_response_payload: ResponsePayload,
         notification_id_generator: Arc<U64IdGenerator>,
     ) -> Result<DataNotification, Error> {
+        // Check the number of received versions
+        let num_received_versions = match &client_response_payload {
+            ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
+                transactions_with_proof.transactions.len()
+            },
+            ResponsePayload::TransactionOutputsWithProof(outputs_with_proof) => {
+                outputs_with_proof.transactions_and_outputs.len()
+            },
+            _ => invalid_response_type!(client_response_payload),
+        };
+        if num_received_versions == 0 {
+            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                "Received an empty continuous data response! Request: {:?}",
+                self.request
+            )));
+        }
+
+        // Identify the last received version and bound it appropriately
+        let last_received_version = request_start_version
+            .checked_add(num_received_versions as u64)
+            .and_then(|version| version.checked_sub(1))
+            .ok_or_else(|| Error::IntegerOverflow("Last received version has overflown!".into()))?;
+        let last_received_version = bound_by_range(
+            last_received_version,
+            request_start_version,
+            request_end_version,
+        );
+
         // Update the stream version
         let target_ledger_info = self.get_target_ledger_info()?.clone();
-        self.update_stream_version_and_epoch(request_start, request_end, &target_ledger_info)?;
+        self.update_stream_version_and_epoch(
+            request_start_version,
+            request_end_version,
+            &target_ledger_info,
+            last_received_version,
+        )?;
 
         // Create the data notification
         let data_notification = create_data_notification(
@@ -507,7 +559,12 @@ impl ContinuousTransactionStreamEngine {
 
         // Update the request and stream versions
         self.update_request_version_and_epoch(last_version, &target_ledger_info)?;
-        self.update_stream_version_and_epoch(first_version, last_version, &target_ledger_info)?;
+        self.update_stream_version_and_epoch(
+            first_version,
+            last_version,
+            &target_ledger_info,
+            last_version,
+        )?;
 
         // Create the data notification
         let data_notification = create_data_notification(
@@ -907,7 +964,9 @@ impl ContinuousTransactionStreamEngine {
         request_start_version: Version,
         request_end_version: Version,
         target_ledger_info: &LedgerInfoWithSignatures,
+        last_received_version: Version,
     ) -> Result<(), Error> {
+        // Verify the client request indices
         let (next_stream_version, mut next_stream_epoch) = self.next_stream_version_and_epoch;
         verify_client_request_indices(
             next_stream_version,
@@ -916,46 +975,35 @@ impl ContinuousTransactionStreamEngine {
         )?;
 
         // Update the next stream version and epoch
-        if request_end_version == target_ledger_info.ledger_info().version()
+        if last_received_version == target_ledger_info.ledger_info().version()
             && target_ledger_info.ledger_info().ends_epoch()
         {
             next_stream_epoch = next_stream_epoch
                 .checked_add(1)
                 .ok_or_else(|| Error::IntegerOverflow("Next stream epoch has overflown!".into()))?;
         }
-        let next_stream_version = request_end_version
+        let next_stream_version = last_received_version
             .checked_add(1)
             .ok_or_else(|| Error::IntegerOverflow("Next stream version has overflown!".into()))?;
         self.next_stream_version_and_epoch = (next_stream_version, next_stream_epoch);
 
         // Check if the stream is now complete
-        match &self.request {
-            StreamRequest::ContinuouslyStreamTransactions(request) => {
-                if let Some(target) = &request.target {
-                    if request_end_version == target.ledger_info().version() {
-                        self.stream_is_complete = true;
-                    }
-                }
-            },
-            StreamRequest::ContinuouslyStreamTransactionOutputs(request) => {
-                if let Some(target) = &request.target {
-                    if request_end_version == target.ledger_info().version() {
-                        self.stream_is_complete = true;
-                    }
-                }
-            },
+        let stream_request_target = match &self.request {
+            StreamRequest::ContinuouslyStreamTransactions(request) => request.target.clone(),
+            StreamRequest::ContinuouslyStreamTransactionOutputs(request) => request.target.clone(),
             StreamRequest::ContinuouslyStreamTransactionsOrOutputs(request) => {
-                if let Some(target) = &request.target {
-                    if request_end_version == target.ledger_info().version() {
-                        self.stream_is_complete = true;
-                    }
-                }
+                request.target.clone()
             },
             request => invalid_stream_request!(request),
         };
+        if let Some(target) = stream_request_target {
+            if last_received_version >= target.ledger_info().version() {
+                self.stream_is_complete = true;
+            }
+        }
 
         // Update the current target ledger info if we've hit it
-        if request_end_version == target_ledger_info.ledger_info().version() {
+        if last_received_version >= target_ledger_info.ledger_info().version() {
             self.current_target_ledger_info = None;
         }
 
@@ -1435,19 +1483,42 @@ impl DataStreamEngine for EpochEndingStreamEngine {
     ) -> Result<Option<DataNotification>, Error> {
         match client_request {
             EpochEndingLedgerInfos(request) => {
+                // Verify the client request indices
                 verify_client_request_indices(
                     self.next_stream_epoch,
                     request.start_epoch,
                     request.end_epoch,
                 )?;
 
+                // Identify the last received epoch and bound it appropriately
+                let last_received_epoch = match &client_response_payload {
+                    ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
+                        // Verify that we received at least one ledger info
+                        if ledger_infos.is_empty() {
+                            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                                "Received an empty epoch ending ledger info response! Request: {:?}",
+                                client_request
+                            )));
+                        }
+
+                        // Return the last epoch
+                        ledger_infos
+                            .last()
+                            .map(|ledger_info| ledger_info.ledger_info().epoch())
+                            .unwrap_or(request.start_epoch)
+                    },
+                    _ => invalid_response_type!(client_response_payload),
+                };
+                let last_received_epoch =
+                    bound_by_range(last_received_epoch, request.start_epoch, request.end_epoch);
+
                 // Update the local stream notification tracker
-                self.next_stream_epoch = request.end_epoch.checked_add(1).ok_or_else(|| {
+                self.next_stream_epoch = last_received_epoch.checked_add(1).ok_or_else(|| {
                     Error::IntegerOverflow("Next stream epoch has overflown!".into())
                 })?;
 
                 // Check if the stream is complete
-                if request.end_epoch == self.end_epoch {
+                if last_received_epoch >= self.end_epoch {
                     self.stream_is_complete = true;
                 }
 
@@ -1513,20 +1584,50 @@ impl TransactionStreamEngine {
         request_start_version: Version,
         request_end_version: Version,
         stream_end_version: Version,
+        client_response_payload: &ResponsePayload,
     ) -> Result<(), Error> {
+        // Verify the client request indices
         verify_client_request_indices(
             self.next_stream_version,
             request_start_version,
             request_end_version,
         )?;
 
+        // Check the number of received versions
+        let num_received_versions = match client_response_payload {
+            ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
+                transactions_with_proof.transactions.len()
+            },
+            ResponsePayload::TransactionOutputsWithProof(outputs_with_proof) => {
+                outputs_with_proof.transactions_and_outputs.len()
+            },
+            _ => invalid_response_type!(client_response_payload),
+        };
+        if num_received_versions == 0 {
+            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                "Received an empty response! Request: {:?}",
+                self.request
+            )));
+        }
+
+        // Identify the last received version and bound it appropriately
+        let last_received_version = request_start_version
+            .checked_add(num_received_versions as u64)
+            .and_then(|version| version.checked_sub(1))
+            .ok_or_else(|| Error::IntegerOverflow("Last received version has overflown!".into()))?;
+        let last_received_version = bound_by_range(
+            last_received_version,
+            request_start_version,
+            request_end_version,
+        );
+
         // Update the local stream notification tracker
-        self.next_stream_version = request_end_version
+        self.next_stream_version = last_received_version
             .checked_add(1)
             .ok_or_else(|| Error::IntegerOverflow("Next stream version has overflown!".into()))?;
 
         // Check if the stream is complete
-        if request_end_version == stream_end_version {
+        if last_received_version >= stream_end_version {
             self.stream_is_complete = true;
         }
 
@@ -1654,42 +1755,42 @@ impl DataStreamEngine for TransactionStreamEngine {
         client_response_payload: ResponsePayload,
         notification_id_generator: Arc<U64IdGenerator>,
     ) -> Result<Option<DataNotification>, Error> {
-        match &self.request {
+        // Identify the version information of the stream and client requests
+        let (stream_end_version, request_start_version, request_end_version) = match &self.request {
             StreamRequest::GetAllTransactions(stream_request) => match client_request {
-                TransactionsWithProof(request) => {
-                    let stream_end_version = stream_request.end_version;
-                    self.update_stream_version(
-                        request.start_version,
-                        request.end_version,
-                        stream_end_version,
-                    )?;
-                },
+                TransactionsWithProof(request) => (
+                    stream_request.end_version,
+                    request.start_version,
+                    request.end_version,
+                ),
                 request => invalid_client_request!(request, self),
             },
             StreamRequest::GetAllTransactionOutputs(stream_request) => match client_request {
-                TransactionOutputsWithProof(request) => {
-                    let stream_end_version = stream_request.end_version;
-                    self.update_stream_version(
-                        request.start_version,
-                        request.end_version,
-                        stream_end_version,
-                    )?;
-                },
+                TransactionOutputsWithProof(request) => (
+                    stream_request.end_version,
+                    request.start_version,
+                    request.end_version,
+                ),
                 request => invalid_client_request!(request, self),
             },
             StreamRequest::GetAllTransactionsOrOutputs(stream_request) => match client_request {
-                TransactionsOrOutputsWithProof(request) => {
-                    let stream_end_version = stream_request.end_version;
-                    self.update_stream_version(
-                        request.start_version,
-                        request.end_version,
-                        stream_end_version,
-                    )?;
-                },
+                TransactionsOrOutputsWithProof(request) => (
+                    stream_request.end_version,
+                    request.start_version,
+                    request.end_version,
+                ),
                 request => invalid_client_request!(request, self),
             },
             request => invalid_stream_request!(request),
-        }
+        };
+
+        // Update the stream version
+        self.update_stream_version(
+            request_start_version,
+            request_end_version,
+            stream_end_version,
+            &client_response_payload,
+        )?;
 
         // Create a new data notification
         let data_notification = create_data_notification(
@@ -1772,6 +1873,13 @@ impl SubscriptionStream {
     pub fn increment_subscription_stream_index(&mut self) {
         self.next_subscription_stream_index += 1;
     }
+}
+
+/// Bounds the given number by the specified min and max values, inclusive.
+/// If the number is less than the min, the min is returned. If the number is
+/// greater than the max, the max is returned. Otherwise, the number is returned.
+pub(crate) fn bound_by_range(number: u64, min: u64, max: u64) -> u64 {
+    cmp::min(cmp::max(number, min), max)
 }
 
 /// Verifies that the `expected_next_index` matches the `start_index` and that

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -38,8 +38,13 @@ use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_types::{
-    ledger_info::LedgerInfoWithSignatures, proof::SparseMerkleRangeProof,
-    state_store::state_value::StateValueChunkWithProof, transaction::Version,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::SparseMerkleRangeProof,
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueChunkWithProof},
+    },
+    transaction::Version,
 };
 use claims::{assert_err, assert_ge, assert_matches, assert_none, assert_ok};
 use futures::{FutureExt, StreamExt};
@@ -72,13 +77,10 @@ async fn test_stream_blocked() {
             id: 0,
             response_callback: Box::new(NoopResponseCallback),
         };
-        let pending_response = PendingClientResponse {
-            client_request: client_request.clone(),
-            client_response: Some(Ok(Response {
-                context,
-                payload: ResponsePayload::NumberOfStates(10),
-            })),
-        };
+        let pending_response = PendingClientResponse::new_with_response(
+            client_request.clone(),
+            Ok(Response::new(context, ResponsePayload::NumberOfStates(10))),
+        );
         insert_response_into_pending_queue(&mut data_stream, pending_response);
 
         // Process the data responses and force a data re-fetch
@@ -199,12 +201,12 @@ async fn test_stream_data_error() {
         start_epoch: MIN_ADVERTISED_EPOCH_END,
         end_epoch: MIN_ADVERTISED_EPOCH_END + 1,
     });
-    let pending_response = PendingClientResponse {
-        client_request: client_request.clone(),
-        client_response: Some(Err(aptos_data_client::error::Error::DataIsUnavailable(
+    let pending_response = PendingClientResponse::new_with_response(
+        client_request.clone(),
+        Err(aptos_data_client::error::Error::DataIsUnavailable(
             "Missing data!".into(),
-        ))),
-    };
+        )),
+    );
     insert_response_into_pending_queue(&mut data_stream, pending_response);
 
     // Process the responses and verify the data client request was resent to the network
@@ -236,11 +238,10 @@ async fn test_stream_invalid_response() {
         id: 0,
         response_callback: Box::new(NoopResponseCallback),
     };
-    let client_response = Response::new(context, ResponsePayload::NumberOfStates(10));
-    let pending_response = PendingClientResponse {
-        client_request: client_request.clone(),
-        client_response: Some(Ok(client_response)),
-    };
+    let pending_response = PendingClientResponse::new_with_response(
+        client_request.clone(),
+        Ok(Response::new(context, ResponsePayload::NumberOfStates(10))),
+    );
     insert_response_into_pending_queue(&mut data_stream, pending_response);
 
     // Process the responses and verify the data client request was resent to the network
@@ -352,12 +353,12 @@ async fn test_state_stream_out_of_order_responses() {
     );
 
     // Set a response for the second request and verify no notifications
-    set_state_value_response_in_queue(&mut data_stream, 1);
+    set_state_value_response_in_queue(&mut data_stream, 1, 1, 1);
     process_data_responses(&mut data_stream, &global_data_summary).await;
     assert_none!(stream_listener.select_next_some().now_or_never());
 
     // Set a response for the first request and verify two notifications
-    set_state_value_response_in_queue(&mut data_stream, 0);
+    set_state_value_response_in_queue(&mut data_stream, 0, 0, 0);
     process_data_responses(&mut data_stream, &global_data_summary).await;
     for _ in 0..2 {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
@@ -369,8 +370,8 @@ async fn test_state_stream_out_of_order_responses() {
     assert_none!(stream_listener.select_next_some().now_or_never());
 
     // Set the response for the first and third request and verify one notification sent
-    set_state_value_response_in_queue(&mut data_stream, 0);
-    set_state_value_response_in_queue(&mut data_stream, 2);
+    set_state_value_response_in_queue(&mut data_stream, 2, 2, 0);
+    set_state_value_response_in_queue(&mut data_stream, 4, 4, 2);
     process_data_responses(&mut data_stream, &global_data_summary).await;
     let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
     assert_matches!(
@@ -380,8 +381,8 @@ async fn test_state_stream_out_of_order_responses() {
     assert_none!(stream_listener.select_next_some().now_or_never());
 
     // Set the response for the first and third request and verify three notifications sent
-    set_state_value_response_in_queue(&mut data_stream, 0);
-    set_state_value_response_in_queue(&mut data_stream, 2);
+    set_state_value_response_in_queue(&mut data_stream, 3, 3, 0);
+    set_state_value_response_in_queue(&mut data_stream, 5, 5, 2);
     process_data_responses(&mut data_stream, &global_data_summary).await;
     for _ in 0..3 {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
@@ -887,14 +888,14 @@ async fn test_stream_timeouts() {
 
         // Handle multiple invalid type responses on the first request
         for _ in 0..max_request_retry / 2 {
-            set_state_value_response_in_queue(&mut data_stream, 0);
+            set_state_value_response_in_queue(&mut data_stream, 0, 0, 0);
             process_data_responses(&mut data_stream, &global_data_summary).await;
             wait_for_data_client_to_respond(&mut data_stream, 0).await;
         }
 
         // Handle multiple invalid type responses on the third request
         for _ in 0..max_request_retry / 2 {
-            set_state_value_response_in_queue(&mut data_stream, 2);
+            set_state_value_response_in_queue(&mut data_stream, 2, 2, 2);
             process_data_responses(&mut data_stream, &global_data_summary).await;
             wait_for_data_client_to_respond(&mut data_stream, 2).await;
         }
@@ -1336,17 +1337,23 @@ fn set_num_state_values_response_in_queue(
 /// state value data response.
 fn set_state_value_response_in_queue(
     data_stream: &mut DataStream<MockAptosDataClient>,
-    index: usize,
+    first_state_value_index: u64,
+    last_state_value_index: u64,
+    request_index: usize,
 ) {
     let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
-    let pending_response = sent_requests.as_mut().unwrap().get_mut(index).unwrap();
+    let pending_response = sent_requests
+        .as_mut()
+        .unwrap()
+        .get_mut(request_index)
+        .unwrap();
     let client_response = Some(Ok(create_data_client_response(
         ResponsePayload::StateValuesWithProof(StateValueChunkWithProof {
-            first_index: 0,
-            last_index: 0,
+            first_index: first_state_value_index,
+            last_index: last_state_value_index,
             first_key: Default::default(),
             last_key: Default::default(),
-            raw_values: vec![],
+            raw_values: vec![(StateKey::raw(vec![]), StateValue::new_legacy(vec![].into()))],
             proof: SparseMerkleRangeProof::new(vec![]),
             root_hash: Default::default(),
         }),

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/missing_data.rs
@@ -1,0 +1,871 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_notification::{
+        DataClientRequest, DataPayload, EpochEndingLedgerInfosRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+        NewTransactionsWithProofRequest, NumberOfStatesRequest, StateValuesWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
+        SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
+        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
+        TransactionsWithProofRequest,
+    },
+    data_stream::create_missing_data_request,
+    stream_engine::{bound_by_range, DataStreamEngine, StreamEngine},
+    streaming_client::{
+        ContinuouslyStreamTransactionOutputsRequest, GetAllEpochEndingLedgerInfosRequest,
+        GetAllStatesRequest, GetAllTransactionsRequest, StreamRequest,
+    },
+    tests::utils::{create_ledger_info, create_transaction_list_with_proof},
+};
+use aptos_config::config::DataStreamingServiceConfig;
+use aptos_crypto::HashValue;
+use aptos_data_client::{global_summary::GlobalDataSummary, interface::ResponsePayload};
+use aptos_id_generator::U64IdGenerator;
+use aptos_storage_service_types::responses::CompleteDataRange;
+use aptos_types::{
+    proof::{SparseMerkleRangeProof, TransactionInfoListWithProof},
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueChunkWithProof},
+    },
+    transaction::{
+        Transaction, TransactionListWithProof, TransactionOutput, TransactionOutputListWithProof,
+        TransactionStatus,
+    },
+    write_set::WriteSet,
+};
+use std::sync::Arc;
+
+#[test]
+fn test_bound_by_range() {
+    // Test numbers beyond max
+    assert_eq!(bound_by_range(11, 5, 10), 10);
+    assert_eq!(bound_by_range(100, 10, 10), 10);
+    assert_eq!(bound_by_range(1000, 12, 15), 15);
+
+    // Test numbers below min
+    assert_eq!(bound_by_range(4, 5, 10), 5);
+    assert_eq!(bound_by_range(0, 10, 10), 10);
+    assert_eq!(bound_by_range(11, 12, 15), 12);
+
+    // Test numbers within the range
+    assert_eq!(bound_by_range(9, 5, 10), 9);
+    assert_eq!(bound_by_range(14, 5, 15), 14);
+    assert_eq!(bound_by_range(20, 0, 20), 20);
+    assert_eq!(bound_by_range(10, 10, 15), 10);
+    assert_eq!(bound_by_range(13, 12, 15), 13);
+}
+
+#[test]
+fn create_missing_data_request_trivial_request_types() {
+    // Enumerate all data request types that are trivially satisfied
+    let trivial_client_requests = vec![
+        DataClientRequest::NewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
+            known_version: 0,
+            known_epoch: 0,
+        }),
+        DataClientRequest::NewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version: 0,
+            known_epoch: 0,
+            include_events: false,
+        }),
+        DataClientRequest::NewTransactionsOrOutputsWithProof(
+            NewTransactionsOrOutputsWithProofRequest {
+                known_version: 0,
+                known_epoch: 0,
+                include_events: false,
+            },
+        ),
+        DataClientRequest::NumberOfStates(NumberOfStatesRequest { version: 0 }),
+        DataClientRequest::SubscribeTransactionOutputsWithProof(
+            SubscribeTransactionOutputsWithProofRequest {
+                known_version: 0,
+                known_epoch: 0,
+                subscription_stream_id: 0,
+                subscription_stream_index: 0,
+            },
+        ),
+        DataClientRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
+            known_version: 0,
+            known_epoch: 0,
+            include_events: false,
+            subscription_stream_id: 0,
+            subscription_stream_index: 0,
+        }),
+        DataClientRequest::SubscribeTransactionsOrOutputsWithProof(
+            SubscribeTransactionsOrOutputsWithProofRequest {
+                known_version: 0,
+                known_epoch: 0,
+                subscription_stream_id: 0,
+                subscription_stream_index: 0,
+                include_events: false,
+            },
+        ),
+    ];
+
+    // Verify that the missing data request is empty
+    for data_client_request in trivial_client_requests {
+        let missing_data_request =
+            create_missing_data_request(&data_client_request, &ResponsePayload::NumberOfStates(0))
+                .unwrap();
+        assert!(missing_data_request.is_none());
+    }
+}
+
+#[test]
+fn create_missing_data_request_epoch_ending_ledger_infos() {
+    // Create the data client request
+    let start_epoch = 10;
+    let end_epoch = 15;
+    let data_client_request =
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch,
+            end_epoch,
+        });
+
+    // Create the partial response payload
+    let last_response_epoch = end_epoch - 1;
+    let epoch_ending_ledger_infos = (start_epoch..last_response_epoch + 1)
+        .map(|epoch| create_ledger_info(epoch * 100, epoch, true))
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos);
+
+    // Create the missing data request and verify that it's valid
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    let expected_missing_data_request =
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: last_response_epoch + 1,
+            end_epoch,
+        });
+    assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
+
+    // Create a complete response payload
+    let last_response_epoch = end_epoch;
+    let epoch_ending_ledger_infos = (start_epoch..last_response_epoch + 1)
+        .map(|epoch| create_ledger_info(epoch * 100, epoch, true))
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos);
+
+    // Create the missing data request and verify that it's empty
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    assert!(missing_data_request.is_none());
+}
+
+#[test]
+fn create_missing_data_request_state_values() {
+    // Create the data client request
+    let version = 10;
+    let start_index = 100;
+    let end_index = 200;
+    let data_client_request =
+        DataClientRequest::StateValuesWithProof(StateValuesWithProofRequest {
+            version,
+            start_index,
+            end_index,
+        });
+
+    // Create the partial response payload
+    let last_response_index = end_index - 1;
+    let raw_values = (start_index..last_response_index + 1)
+        .map(|_| (StateKey::raw(vec![]), StateValue::new_legacy(vec![].into())))
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::StateValuesWithProof(StateValueChunkWithProof {
+        first_index: start_index,
+        last_index: last_response_index,
+        first_key: HashValue::zero(),
+        last_key: HashValue::zero(),
+        raw_values,
+        proof: SparseMerkleRangeProof::new(vec![]),
+        root_hash: HashValue::zero(),
+    });
+
+    // Create the missing data request and verify that it's valid
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    let expected_missing_data_request =
+        DataClientRequest::StateValuesWithProof(StateValuesWithProofRequest {
+            version,
+            start_index: last_response_index + 1,
+            end_index,
+        });
+    assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
+
+    // Create a complete response payload
+    let last_response_index = end_index;
+    let raw_values = (start_index..last_response_index + 1)
+        .map(|_| (StateKey::raw(vec![]), StateValue::new_legacy(vec![].into())))
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::StateValuesWithProof(StateValueChunkWithProof {
+        first_index: start_index,
+        last_index: last_response_index,
+        first_key: HashValue::zero(),
+        last_key: HashValue::zero(),
+        raw_values,
+        proof: SparseMerkleRangeProof::new(vec![]),
+        root_hash: HashValue::zero(),
+    });
+
+    // Create the missing data request and verify that it's empty
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    assert!(missing_data_request.is_none());
+}
+
+#[test]
+fn create_missing_data_request_transactions() {
+    // Create the data client request
+    let start_version = 100;
+    let end_version = 200;
+    let data_client_request =
+        DataClientRequest::TransactionsWithProof(TransactionsWithProofRequest {
+            start_version,
+            end_version,
+            proof_version: end_version,
+            include_events: true,
+        });
+
+    // Create the partial response payload
+    let last_response_version = end_version - 50;
+    let transactions = (start_version..last_response_version + 1)
+        .map(|_| create_test_transaction())
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::TransactionsWithProof(TransactionListWithProof {
+        transactions,
+        events: None,
+        first_transaction_version: Some(start_version),
+        proof: TransactionInfoListWithProof::new_empty(),
+    });
+
+    // Create the missing data request and verify that it's valid
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    let expected_missing_data_request =
+        DataClientRequest::TransactionsWithProof(TransactionsWithProofRequest {
+            start_version: last_response_version + 1,
+            end_version,
+            proof_version: end_version,
+            include_events: true,
+        });
+    assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
+
+    // Create a complete response payload
+    let last_response_version = end_version;
+    let transactions = (start_version..last_response_version + 1)
+        .map(|_| create_test_transaction())
+        .collect::<Vec<_>>();
+    let response_payload = ResponsePayload::TransactionsWithProof(TransactionListWithProof {
+        transactions,
+        events: None,
+        first_transaction_version: Some(start_version),
+        proof: TransactionInfoListWithProof::new_empty(),
+    });
+
+    // Create the missing data request and verify that it's empty
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    assert!(missing_data_request.is_none());
+}
+
+#[test]
+fn create_missing_data_request_transaction_outputs() {
+    // Create the data client request
+    let start_version = 1000;
+    let end_version = 2000;
+    let data_client_request =
+        DataClientRequest::TransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            start_version,
+            end_version,
+            proof_version: end_version,
+        });
+
+    // Create the partial response payload
+    let last_response_version = end_version - 1000;
+    let transactions_and_outputs = (start_version..last_response_version + 1)
+        .map(|_| (create_test_transaction(), create_test_transaction_output()))
+        .collect::<Vec<_>>();
+    let response_payload =
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
+            transactions_and_outputs,
+            proof: TransactionInfoListWithProof::new_empty(),
+            first_transaction_output_version: Some(start_version),
+        });
+
+    // Create the missing data request and verify that it's valid
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    let expected_missing_data_request =
+        DataClientRequest::TransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            start_version: last_response_version + 1,
+            end_version,
+            proof_version: end_version,
+        });
+    assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
+
+    // Create a complete response payload
+    let last_response_version = end_version;
+    let transactions_and_outputs = (start_version..last_response_version + 1)
+        .map(|_| (create_test_transaction(), create_test_transaction_output()))
+        .collect::<Vec<_>>();
+    let response_payload =
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
+            transactions_and_outputs,
+            proof: TransactionInfoListWithProof::new_empty(),
+            first_transaction_output_version: Some(start_version),
+        });
+
+    // Create the missing data request and verify that it's empty
+    let missing_data_request =
+        create_missing_data_request(&data_client_request, &response_payload).unwrap();
+    assert!(missing_data_request.is_none());
+}
+
+#[test]
+fn create_missing_data_request_transactions_or_outputs() {
+    // Create the data client request
+    let start_version = 0;
+    let end_version = 2000;
+    let data_client_request =
+        DataClientRequest::TransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest {
+            start_version,
+            end_version,
+            include_events: true,
+            proof_version: end_version,
+        });
+
+    // Create a partial response payload with transactions
+    let last_response_version = end_version - 500;
+    let transactions = (start_version..last_response_version + 1)
+        .map(|_| create_test_transaction())
+        .collect::<Vec<_>>();
+    let response_payload_with_transactions =
+        ResponsePayload::TransactionsWithProof(TransactionListWithProof {
+            transactions,
+            events: None,
+            first_transaction_version: Some(start_version),
+            proof: TransactionInfoListWithProof::new_empty(),
+        });
+
+    // Create a partial response payload with transaction outputs
+    let transactions_and_outputs = (start_version..last_response_version + 1)
+        .map(|_| (create_test_transaction(), create_test_transaction_output()))
+        .collect::<Vec<_>>();
+    let response_payload_with_transaction_outputs =
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
+            transactions_and_outputs,
+            proof: TransactionInfoListWithProof::new_empty(),
+            first_transaction_output_version: Some(start_version),
+        });
+
+    // Create the missing data requests and verify that they are valid
+    for response_payload in [
+        response_payload_with_transactions,
+        response_payload_with_transaction_outputs,
+    ] {
+        let missing_data_request =
+            create_missing_data_request(&data_client_request, &response_payload).unwrap();
+        let expected_missing_data_request = DataClientRequest::TransactionsOrOutputsWithProof(
+            TransactionsOrOutputsWithProofRequest {
+                start_version: last_response_version + 1,
+                end_version,
+                proof_version: end_version,
+                include_events: true,
+            },
+        );
+        assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
+    }
+
+    // Create a complete response payload with transactions
+    let last_response_version = end_version;
+    let transactions = (start_version..last_response_version + 1)
+        .map(|_| create_test_transaction())
+        .collect::<Vec<_>>();
+    let response_payload_with_transactions =
+        ResponsePayload::TransactionsWithProof(TransactionListWithProof {
+            transactions,
+            events: None,
+            first_transaction_version: Some(start_version),
+            proof: TransactionInfoListWithProof::new_empty(),
+        });
+
+    // Create a complete response payload with transaction outputs
+    let transactions_and_outputs = (start_version..last_response_version + 1)
+        .map(|_| (create_test_transaction(), create_test_transaction_output()))
+        .collect::<Vec<_>>();
+    let response_payload_with_transaction_outputs =
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
+            transactions_and_outputs,
+            proof: TransactionInfoListWithProof::new_empty(),
+            first_transaction_output_version: Some(start_version),
+        });
+
+    // Create the missing data requests and verify that they are empty
+    for response_payload in [
+        response_payload_with_transactions,
+        response_payload_with_transaction_outputs,
+    ] {
+        let missing_data_request =
+            create_missing_data_request(&data_client_request, &response_payload).unwrap();
+        assert!(missing_data_request.is_none());
+    }
+}
+
+#[test]
+fn transform_epoch_ending_stream_notifications() {
+    // Create an epoch ending stream request
+    let start_epoch = 100;
+    let stream_request =
+        StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+            start_epoch,
+        });
+
+    // Create a global data summary with a single epoch range
+    let end_epoch = 199;
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary
+        .advertised_data
+        .epoch_ending_ledger_infos = vec![CompleteDataRange::new(start_epoch, end_epoch).unwrap()];
+    global_data_summary.optimal_chunk_sizes.epoch_chunk_size = 100;
+
+    // Create a new epoch ending stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::EpochEndingStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected epoch ending stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_epoch, start_epoch);
+    assert_eq!(stream_engine.next_request_epoch, start_epoch);
+
+    // Create a single data client request
+    let notification_id_generator = create_notification_id_generator();
+    let data_client_request = stream_engine
+        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .unwrap();
+    assert_eq!(data_client_request.len(), 1);
+
+    // Create an empty client response
+    let client_response_payload = ResponsePayload::EpochEndingLedgerInfos(vec![]);
+
+    // Transform the client response into a notification and verify an error is returned
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap_err();
+
+    // Create a client response with an invalid epoch
+    let invalid_ledger_infos = vec![create_ledger_info(0, start_epoch - 1, true)];
+    let client_response_payload =
+        ResponsePayload::EpochEndingLedgerInfos(invalid_ledger_infos.clone());
+
+    // Transform the client response into a notification and verify the notification
+    let data_notification = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap();
+    assert_eq!(
+        data_notification.unwrap().data_payload,
+        DataPayload::EpochEndingLedgerInfos(invalid_ledger_infos)
+    );
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_epoch, start_epoch + 1);
+    assert_eq!(stream_engine.next_request_epoch, end_epoch + 1);
+
+    // Create a partial client response
+    let partial_ledger_infos = (start_epoch + 1..end_epoch)
+        .map(|epoch| create_ledger_info(epoch * 100, epoch, true))
+        .collect::<Vec<_>>();
+    let client_response_payload =
+        ResponsePayload::EpochEndingLedgerInfos(partial_ledger_infos.clone());
+
+    // Transform the client response into a notification
+    let data_client_request =
+        DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
+            start_epoch: start_epoch + 1,
+            end_epoch,
+        });
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request,
+            client_response_payload,
+            notification_id_generator,
+        )
+        .unwrap();
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_epoch, end_epoch);
+    assert_eq!(stream_engine.next_request_epoch, end_epoch + 1);
+}
+
+#[test]
+fn transform_state_values_stream_notifications() {
+    // Create a state values stream request
+    let version = 100;
+    let start_index = 1000;
+    let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
+        version,
+        start_index,
+    });
+
+    // Create a global data summary with a single state range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.states =
+        vec![CompleteDataRange::new(start_index, start_index).unwrap()];
+    global_data_summary.optimal_chunk_sizes.state_chunk_size = 20_000;
+
+    // Create a new state values stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::StateStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected state values stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Update the number of states for the stream
+    let number_of_states = 10_000;
+    stream_engine.number_of_states = Some(number_of_states);
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_index, start_index);
+    assert_eq!(stream_engine.next_request_index, start_index);
+
+    // Create a single data client request
+    let notification_id_generator = create_notification_id_generator();
+    let data_client_request = stream_engine
+        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .unwrap();
+    assert_eq!(data_client_request.len(), 1);
+
+    // Create an empty client response
+    let client_response_payload = ResponsePayload::StateValuesWithProof(create_state_value_chunk(
+        start_index,
+        start_index - 1,
+        0,
+    ));
+
+    // Transform the client response into a notification and verify an error is returned
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap_err();
+
+    // Create a client response with an invalid last index
+    let state_value_chunk_with_proof = create_state_value_chunk(start_index, start_index - 1, 1);
+    let client_response_payload =
+        ResponsePayload::StateValuesWithProof(state_value_chunk_with_proof.clone());
+
+    // Transform the client response into a notification and verify the notification
+    let data_notification = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap();
+    assert_eq!(
+        data_notification.unwrap().data_payload,
+        DataPayload::StateValuesWithProof(state_value_chunk_with_proof)
+    );
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_index, start_index + 1);
+    assert_eq!(stream_engine.next_request_index, number_of_states);
+
+    // Create a partial client response
+    let last_index = number_of_states - 500;
+    let state_value_chunk_with_proof =
+        create_state_value_chunk(start_index, last_index, last_index - start_index);
+    let client_response_payload =
+        ResponsePayload::StateValuesWithProof(state_value_chunk_with_proof.clone());
+
+    // Transform the client response into a notification
+    let data_client_request =
+        DataClientRequest::StateValuesWithProof(StateValuesWithProofRequest {
+            version,
+            start_index: start_index + 1,
+            end_index: number_of_states - 1,
+        });
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request,
+            client_response_payload,
+            notification_id_generator,
+        )
+        .unwrap();
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_index, last_index + 1);
+    assert_eq!(stream_engine.next_request_index, number_of_states);
+}
+
+#[test]
+fn transform_transactions_stream_notifications() {
+    // Create a transactions stream request
+    let start_version = 100;
+    let end_version = 200;
+    let stream_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
+        start_version,
+        end_version,
+        proof_version: end_version,
+        include_events: true,
+    });
+
+    // Create a global data summary with a single transaction range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transactions =
+        vec![CompleteDataRange::new(start_version, end_version).unwrap()];
+    global_data_summary
+        .optimal_chunk_sizes
+        .transaction_chunk_size = 10_000;
+
+    // Create a new transactions stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::TransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected transactions stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_version, start_version);
+    assert_eq!(stream_engine.next_request_version, start_version);
+
+    // Create a single data client request
+    let notification_id_generator = create_notification_id_generator();
+    let data_client_request = stream_engine
+        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .unwrap();
+    assert_eq!(data_client_request.len(), 1);
+
+    // Create an empty client response
+    let client_response_payload =
+        ResponsePayload::TransactionsWithProof(TransactionListWithProof::new_empty());
+
+    // Transform the client response into a notification and verify an error is returned
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap_err();
+
+    // Create a partial client response
+    let last_version = end_version - 50;
+    let transactions_with_proof =
+        create_transaction_list_with_proof(start_version, last_version, true);
+    let client_response_payload =
+        ResponsePayload::TransactionsWithProof(transactions_with_proof.clone());
+
+    // Transform the client response into a notification
+    let data_client_request =
+        DataClientRequest::TransactionsWithProof(TransactionsWithProofRequest {
+            start_version,
+            end_version,
+            proof_version: end_version,
+            include_events: true,
+        });
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request,
+            client_response_payload,
+            notification_id_generator,
+        )
+        .unwrap();
+
+    // Verify the tracked stream indices
+    assert_eq!(stream_engine.next_stream_version, last_version + 1);
+    assert_eq!(stream_engine.next_request_version, end_version + 1);
+}
+
+#[test]
+fn transform_continuous_outputs_stream_notifications() {
+    // Create a continuous outputs stream request
+    let known_version = 1000;
+    let known_epoch = 10;
+    let stream_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            known_version,
+            known_epoch,
+            target: None,
+        },
+    );
+
+    // Create a global data summary with a single transaction range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transaction_outputs =
+        vec![CompleteDataRange::new(known_version, known_version).unwrap()];
+    global_data_summary
+        .optimal_chunk_sizes
+        .transaction_output_chunk_size = 10_000;
+
+    // Create a new continuous outputs stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected continuous outputs stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Set the target ledger info for the stream
+    let target_version = known_version + 1000;
+    stream_engine.current_target_ledger_info =
+        Some(create_ledger_info(target_version, known_epoch, false));
+
+    // Verify the tracked stream indices
+    assert_eq!(
+        stream_engine.next_request_version_and_epoch,
+        (known_version + 1, known_epoch)
+    );
+    assert_eq!(
+        stream_engine.next_stream_version_and_epoch,
+        (known_version + 1, known_epoch)
+    );
+
+    // Create a single data client request
+    let notification_id_generator = create_notification_id_generator();
+    let data_client_request = stream_engine
+        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .unwrap();
+    assert_eq!(data_client_request.len(), 1);
+
+    // Create an empty client response
+    let client_response_payload =
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof::new_empty());
+
+    // Transform the client response into a notification and verify an error is returned
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request[0].clone(),
+            client_response_payload,
+            notification_id_generator.clone(),
+        )
+        .unwrap_err();
+
+    // Create a partial client response
+    let last_version = target_version - 10;
+    let transactions_and_outputs = (known_version..last_version + 1)
+        .map(|_| (create_test_transaction(), create_test_transaction_output()))
+        .collect::<Vec<_>>();
+    let transaction_outputs_with_proof = TransactionOutputListWithProof {
+        transactions_and_outputs,
+        proof: TransactionInfoListWithProof::new_empty(),
+        first_transaction_output_version: Some(known_version),
+    };
+    let client_response_payload =
+        ResponsePayload::TransactionOutputsWithProof(transaction_outputs_with_proof.clone());
+
+    // Transform the client response into a notification
+    let data_client_request =
+        DataClientRequest::TransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            start_version: known_version + 1,
+            end_version: last_version,
+            proof_version: target_version,
+        });
+    let _ = stream_engine
+        .transform_client_response_into_notification(
+            &data_client_request,
+            client_response_payload,
+            notification_id_generator,
+        )
+        .unwrap();
+
+    // Verify the tracked stream indices
+    assert_eq!(
+        stream_engine.next_stream_version_and_epoch,
+        (last_version + 1, known_epoch)
+    );
+    assert_eq!(
+        stream_engine.next_request_version_and_epoch,
+        (target_version + 1, known_epoch)
+    );
+}
+
+/// Returns a simple notification ID generator for testing purposes
+fn create_notification_id_generator() -> Arc<U64IdGenerator> {
+    Arc::new(U64IdGenerator::new())
+}
+
+/// Returns a state value chunk with proof for testing purposes
+fn create_state_value_chunk(
+    first_index: u64,
+    last_index: u64,
+    num_values: u64,
+) -> StateValueChunkWithProof {
+    // Create the raw values
+    let raw_values = (0..num_values)
+        .map(|_| (StateKey::raw(vec![]), StateValue::new_legacy(vec![].into())))
+        .collect::<Vec<_>>();
+
+    // Create the chunk of state values
+    StateValueChunkWithProof {
+        first_index,
+        last_index,
+        first_key: HashValue::zero(),
+        last_key: HashValue::zero(),
+        raw_values,
+        proof: SparseMerkleRangeProof::new(vec![]),
+        root_hash: HashValue::zero(),
+    }
+}
+
+/// Returns a dummy transaction for testing purposes
+fn create_test_transaction() -> Transaction {
+    Transaction::StateCheckpoint(HashValue::zero())
+}
+
+/// Returns a dummy transaction output for testing purposes
+fn create_test_transaction_output() -> TransactionOutput {
+    TransactionOutput::new(WriteSet::default(), vec![], 0, TransactionStatus::Retry)
+}

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod data_stream;
+mod missing_data;
 mod stream_engine;
 mod streaming_client;
 pub mod streaming_service;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_engine.rs
@@ -7,7 +7,10 @@ use crate::{
     error::Error,
     stream_engine::{DataStreamEngine, EpochEndingStreamEngine, StreamEngine},
     streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
-    tests::utils::initialize_logger,
+    tests::{
+        utils,
+        utils::{create_ledger_info, initialize_logger},
+    },
 };
 use aptos_config::config::DataStreamingServiceConfig;
 use aptos_data_client::{
@@ -244,7 +247,7 @@ fn test_update_epoch_ending_stream_progress() {
                     start_epoch,
                     end_epoch,
                 }),
-                create_empty_client_response_payload(),
+                create_epoch_ending_ledger_info_payload(start_epoch, end_epoch),
                 create_notification_id_generator(),
             )
             .unwrap();
@@ -261,13 +264,15 @@ fn test_update_epoch_ending_stream_panic() {
     let mut stream_engine = create_epoch_ending_stream_engine(0, 1000);
 
     // Update the engine with a valid notification
+    let client_response_payload =
+        ResponsePayload::EpochEndingLedgerInfos(vec![create_ledger_info(0, 0, true)]);
     let _ = stream_engine
         .transform_client_response_into_notification(
             &DataClientRequest::EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest {
                 start_epoch: 0,
                 end_epoch: 100,
             }),
-            create_empty_client_response_payload(),
+            client_response_payload,
             create_notification_id_generator(),
         )
         .unwrap();
@@ -335,4 +340,12 @@ fn create_notification_id_generator() -> Arc<U64IdGenerator> {
 
 fn create_empty_client_response_payload() -> ResponsePayload {
     ResponsePayload::EpochEndingLedgerInfos(vec![])
+}
+
+/// Creates a response payload with the given number of epoch ending ledger infos
+fn create_epoch_ending_ledger_info_payload(start_epoch: u64, end_epoch: u64) -> ResponsePayload {
+    let epoch_ending_ledger_infos = (start_epoch..end_epoch + 1)
+        .map(|i| utils::create_ledger_info(i, i, true))
+        .collect();
+    ResponsePayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos)
 }


### PR DESCRIPTION
Note: (i) this PR is built on https://github.com/aptos-labs/aptos-core/pull/9934; (ii) 90% of this PR is modifications to unit/integration tests.

### Description
This PR updates the data streaming service to better tolerate missing data along each stream, by automatically filling data gaps within the stream. 

Today, when requests are sent to peers for data chunks, peers may choose to return fewer data items than requested (e.g., if the data is too large to fit into a single chunk). In this case, the data stream has "missing data" and the items in the stream are no longer contiguous. This is problematic for performance because it causes all data chunks after the missing data to be invalid, and thus the stream is terminated and a new stream has to be created. This can be expensive and wasteful.

To avoid this, we update the data streaming service to identify when data responses are not complete (e.g., a data request was made for 1000 transactions, but only 500 transactions were returned). In this case, the data streaming service will automatically request the missing data and block the stream until the missing data can be injected into the stream. This has two benefits: (i) streams no longer need to be terminated and created when data is missing; and (ii) data which may already be fetched in the stream is no longer simply thrown away, avoiding unnecessary refetches.

The PR offers two commits:
1. Update the data streaming service to request missing data chunks.
2. Update the unit and integration tests to verify the new functionality. Most of the code lives here 😄 

Note: I've tested this on a devnet PFN and the node is able to sync 30% faster with only around 2-3% of responses containing missing data.

### Test Plan
New and existing test infrastructure.