### PR TITLE
[Execution][Sharding] Add support for remote execution 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "bcs 0.1.4",
  "clap 4.3.21",
  "crossbeam-channel",
+ "dashmap",
  "itertools",
  "num_cpus",
  "rand 0.7.3",

--- a/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_state_view.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_state_view.rs
@@ -1,6 +1,6 @@
 // Copyright © Aptos Foundation
-// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::sharded_block_executor::remote_state_value::RemoteStateValue;
 use anyhow::Result;
 use aptos_logger::trace;
 use aptos_state_view::{StateView, TStateView};
@@ -11,59 +11,14 @@ use aptos_types::{
     },
     transaction::analyzed_transaction::AnalyzedTransaction,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Arc, Condvar, Mutex},
-};
-
-#[derive(Clone)]
-enum CrossShardValueStatus {
-    /// The state value is available as a result of cross shard execution
-    Ready(Option<StateValue>),
-    /// We are still waiting for remote shard to push the state value
-    Waiting,
-}
-
-#[derive(Clone)]
-struct CrossShardStateValue {
-    value_condition: Arc<(Mutex<CrossShardValueStatus>, Condvar)>,
-}
-
-impl CrossShardStateValue {
-    pub fn waiting() -> Self {
-        Self {
-            value_condition: Arc::new((Mutex::new(CrossShardValueStatus::Waiting), Condvar::new())),
-        }
-    }
-
-    pub fn set_value(&self, value: Option<StateValue>) {
-        let (lock, cvar) = &*self.value_condition;
-        let mut status = lock.lock().unwrap();
-        // We only allow setting the value once and it must be in the waiting state
-        assert!(matches!(*status, CrossShardValueStatus::Waiting));
-        *status = CrossShardValueStatus::Ready(value);
-        cvar.notify_all();
-    }
-
-    pub fn get_value(&self) -> Option<StateValue> {
-        let (lock, cvar) = &*self.value_condition;
-        let mut status = lock.lock().unwrap();
-        while let CrossShardValueStatus::Waiting = *status {
-            status = cvar.wait(status).unwrap();
-        }
-        match &*status {
-            CrossShardValueStatus::Ready(value) => value.clone(),
-            CrossShardValueStatus::Waiting => unreachable!(),
-        }
-    }
-}
+use std::collections::{HashMap, HashSet};
 
 /// A state view for reading cross shard state values. It is backed by a state view
 /// and a hashmap of cross shard state keys. When a cross shard state value is not
 /// available in the hashmap, it will be fetched from the underlying base view.
 #[derive(Clone)]
 pub struct CrossShardStateView<'a, S> {
-    cross_shard_data: HashMap<StateKey, CrossShardStateValue>,
+    cross_shard_data: HashMap<StateKey, RemoteStateValue>,
     base_view: &'a S,
 }
 
@@ -75,7 +30,7 @@ impl<'a, S: StateView + Sync + Send> CrossShardStateView<'a, S> {
             cross_shard_keys.len(),
         );
         for key in cross_shard_keys {
-            cross_shard_data.insert(key, CrossShardStateValue::waiting());
+            cross_shard_data.insert(key, RemoteStateValue::waiting());
         }
         Self {
             cross_shard_data,
@@ -87,12 +42,7 @@ impl<'a, S: StateView + Sync + Send> CrossShardStateView<'a, S> {
     fn waiting_count(&self) -> usize {
         self.cross_shard_data
             .values()
-            .filter(|v| {
-                matches!(
-                    v.value_condition.0.lock().unwrap().clone(),
-                    CrossShardValueStatus::Waiting
-                )
-            })
+            .filter(|v| !v.is_ready())
             .count()
     }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -28,6 +28,7 @@ pub mod global_executor;
 pub mod local_executor_shard;
 pub mod messages;
 pub mod sharded_aggregator_service;
+pub mod remote_state_value;
 pub mod sharded_executor_service;
 #[cfg(test)]
 mod test_utils;

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -27,8 +27,8 @@ pub mod executor_client;
 pub mod global_executor;
 pub mod local_executor_shard;
 pub mod messages;
-pub mod sharded_aggregator_service;
 pub mod remote_state_value;
+pub mod sharded_aggregator_service;
 pub mod sharded_executor_service;
 #[cfg(test)]
 mod test_utils;

--- a/aptos-move/aptos-vm/src/sharded_block_executor/remote_state_value.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/remote_state_value.rs
@@ -1,0 +1,54 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::state_store::state_value::StateValue;
+use std::sync::{Arc, Condvar, Mutex};
+
+#[derive(Clone)]
+// This struct is used to store the status of a remote state value. It provides semantics for
+// blocking on a remote state value to be available locally while it is being asynchronously
+// fetched from a remote server.
+pub struct RemoteStateValue {
+    value_condition: Arc<(Mutex<RemoteValueStatus>, Condvar)>,
+}
+
+impl RemoteStateValue {
+    pub fn waiting() -> Self {
+        Self {
+            value_condition: Arc::new((Mutex::new(RemoteValueStatus::Waiting), Condvar::new())),
+        }
+    }
+
+    pub fn set_value(&self, value: Option<StateValue>) {
+        let (lock, cvar) = &*self.value_condition;
+        let mut status = lock.lock().unwrap();
+        *status = RemoteValueStatus::Ready(value);
+        cvar.notify_all();
+    }
+
+    pub fn get_value(&self) -> Option<StateValue> {
+        let (lock, cvar) = &*self.value_condition;
+        let mut status = lock.lock().unwrap();
+        while let RemoteValueStatus::Waiting = *status {
+            status = cvar.wait(status).unwrap();
+        }
+        match &*status {
+            RemoteValueStatus::Ready(value) => value.clone(),
+            RemoteValueStatus::Waiting => unreachable!(),
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        let (lock, _cvar) = &*self.value_condition;
+        let status = lock.lock().unwrap();
+        matches!(&*status, RemoteValueStatus::Ready(_))
+    }
+}
+
+#[derive(Clone)]
+pub enum RemoteValueStatus {
+    /// The state value is available as a result of cross shard execution
+    Ready(Option<StateValue>),
+    /// We are still waiting for remote shard to push the state value
+    Waiting,
+}

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -45,6 +45,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             rayon::ThreadPoolBuilder::new()
                 // We need two extra threads for the cross-shard commit receiver and the thread
                 // that is blocked on waiting for execute block to finish.
+                .thread_name(move |i| format!("sharded-executor-shard-{}-{}", shard_id, i))
                 .num_threads(num_threads + 2)
                 .build()
                 .unwrap(),

--- a/execution/executor-service/Cargo.toml
+++ b/execution/executor-service/Cargo.toml
@@ -29,6 +29,7 @@ aptos-vm = { workspace = true, features = ["testing"] }
 bcs = { workspace = true }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }
+dashmap = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
 rand = { workspace = true }

--- a/execution/executor-service/src/lib.rs
+++ b/execution/executor-service/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use aptos_state_view::in_memory_state_view::InMemoryStateView;
 use aptos_types::{
-    block_executor::partitioner::SubBlocksForShard,
+    block_executor::partitioner::{ShardId, SubBlocksForShard},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
     vm_status::VMStatus,
 };
@@ -14,6 +14,8 @@ mod remote_cordinator_client;
 mod remote_cross_shard_client;
 mod remote_executor_client;
 pub mod remote_executor_service;
+mod remote_state_view;
+mod remote_state_view_service;
 #[cfg(test)]
 mod test_utils;
 #[cfg(test)]
@@ -40,30 +42,43 @@ pub enum RemoteExecutionRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecuteBlockCommand {
     pub(crate) sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
-    // Currently we only support the state view backed by in-memory hashmap, which means that
-    // the controller needs to pre-read all the KV pairs from the storage and pass them to the
-    // executor service. In the future, we will support other types of state view, e.g., the
-    // state view backed by remote storage service, which will allow the executor service to read the KV pairs
-    // directly from the storage.
-    pub(crate) state_view: InMemoryStateView,
     pub(crate) concurrency_level: usize,
     pub(crate) maybe_block_gas_limit: Option<u64>,
 }
 
 impl ExecuteBlockCommand {
-    pub fn into(
-        self,
-    ) -> (
-        SubBlocksForShard<AnalyzedTransaction>,
-        InMemoryStateView,
-        usize,
-        Option<u64>,
-    ) {
+    pub fn into(self) -> (SubBlocksForShard<AnalyzedTransaction>, usize, Option<u64>) {
         (
             self.sub_blocks,
-            self.state_view,
             self.concurrency_level,
             self.maybe_block_gas_limit,
         )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RemoteKVRequest {
+    pub(crate) shard_id: ShardId,
+    pub(crate) keys: Vec<StateKey>,
+}
+
+impl RemoteKVRequest {
+    pub fn new(shard_id: ShardId, keys: Vec<StateKey>) -> Self {
+        Self { shard_id, keys }
+    }
+
+    pub fn into(self) -> (ShardId, Vec<StateKey>) {
+        (self.shard_id, self.keys)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RemoteKVResponse {
+    pub(crate) inner: Vec<(StateKey, Option<StateValue>)>,
+}
+
+impl RemoteKVResponse {
+    pub fn new(inner: Vec<(StateKey, Option<StateValue>)>) -> Self {
+        Self { inner }
     }
 }

--- a/execution/executor-service/src/remote_cordinator_client.rs
+++ b/execution/executor-service/src/remote_cordinator_client.rs
@@ -1,18 +1,23 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::{RemoteExecutionRequest, RemoteExecutionResult};
+use crate::{
+    remote_state_view::RemoteStateViewClient, ExecuteBlockCommand, RemoteExecutionRequest,
+    RemoteExecutionResult,
+};
 use aptos_secure_net::network_controller::{Message, NetworkController};
-use aptos_state_view::in_memory_state_view::InMemoryStateView;
 use aptos_types::{
-    block_executor::partitioner::ShardId, transaction::TransactionOutput, vm_status::VMStatus,
+    block_executor::partitioner::ShardId, state_store::state_key::StateKey,
+    transaction::TransactionOutput, vm_status::VMStatus,
 };
 use aptos_vm::sharded_block_executor::{
     coordinator_client::CoordinatorClient, ExecutorShardCommand,
 };
 use crossbeam_channel::{Receiver, Sender};
+use rayon::prelude::*;
 use std::{net::SocketAddr, sync::Arc};
 
 pub struct RemoteCoordinatorClient {
+    state_view_client: Arc<RemoteStateViewClient>,
     command_rx: Receiver<Message>,
     result_tx: Sender<Message>,
 }
@@ -29,22 +34,57 @@ impl RemoteCoordinatorClient {
         let result_tx =
             controller.create_outbound_channel(coordinator_address, execute_result_type);
 
+        let state_view_client =
+            RemoteStateViewClient::new(shard_id, controller, coordinator_address);
+
         Self {
+            state_view_client: Arc::new(state_view_client),
             command_rx,
             result_tx,
         }
     }
+
+    // Extract all the state keys from the execute block command. It is possible that there are duplicate state keys.
+    // We are not de-duplicating them here to avoid the overhead of deduplication. The state view server will deduplicate
+    // the state keys.
+    fn extract_state_keys(command: &ExecuteBlockCommand) -> Vec<StateKey> {
+        command
+            .sub_blocks
+            .sub_block_iter()
+            .flat_map(|sub_block| {
+                sub_block
+                    .transactions
+                    .par_iter()
+                    .map(|txn| {
+                        let mut state_keys = vec![];
+                        for storage_location in txn
+                            .txn()
+                            .read_hints()
+                            .iter()
+                            .chain(txn.txn().write_hints().iter())
+                        {
+                            state_keys.push(storage_location.state_key().clone());
+                        }
+                        state_keys
+                    })
+                    .flatten()
+                    .collect::<Vec<StateKey>>()
+            })
+            .collect::<Vec<StateKey>>()
+    }
 }
 
-impl CoordinatorClient<InMemoryStateView> for RemoteCoordinatorClient {
-    fn receive_execute_command(&self) -> ExecutorShardCommand<InMemoryStateView> {
+impl CoordinatorClient<RemoteStateViewClient> for RemoteCoordinatorClient {
+    fn receive_execute_command(&self) -> ExecutorShardCommand<RemoteStateViewClient> {
         let message = self.command_rx.recv().unwrap();
         let request: RemoteExecutionRequest = bcs::from_bytes(&message.data).unwrap();
         match request {
             RemoteExecutionRequest::ExecuteBlock(command) => {
-                let (sub_blocks, state_view, concurrency, gas_limit) = command.into();
+                let state_keys = Self::extract_state_keys(&command);
+                self.state_view_client.init_for_block(state_keys);
+                let (sub_blocks, concurrency, gas_limit) = command.into();
                 ExecutorShardCommand::ExecuteSubBlocks(
-                    Arc::new(state_view),
+                    self.state_view_client.clone(),
                     sub_blocks,
                     concurrency,
                     gas_limit,

--- a/execution/executor-service/src/remote_executor_service.rs
+++ b/execution/executor-service/src/remote_executor_service.rs
@@ -3,10 +3,9 @@
 
 use crate::{
     remote_cordinator_client::RemoteCoordinatorClient,
-    remote_cross_shard_client::RemoteCrossShardClient,
+    remote_cross_shard_client::RemoteCrossShardClient, remote_state_view::RemoteStateViewClient,
 };
 use aptos_secure_net::network_controller::NetworkController;
-use aptos_state_view::in_memory_state_view::InMemoryStateView;
 use aptos_types::block_executor::partitioner::ShardId;
 use aptos_vm::sharded_block_executor::sharded_executor_service::ShardedExecutorService;
 use std::{net::SocketAddr, sync::Arc};
@@ -15,7 +14,7 @@ use std::{net::SocketAddr, sync::Arc};
 /// the remote executor client and executes the block locally and returns the result.
 pub struct ExecutorService {
     controller: NetworkController,
-    executor_service: Arc<ShardedExecutorService<InMemoryStateView>>,
+    executor_service: Arc<ShardedExecutorService<RemoteStateViewClient>>,
 }
 
 impl ExecutorService {

--- a/execution/executor-service/src/remote_state_view.rs
+++ b/execution/executor-service/src/remote_state_view.rs
@@ -1,0 +1,218 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use crate::{RemoteKVRequest, RemoteKVResponse};
+use aptos_secure_net::network_controller::{Message, NetworkController};
+use aptos_types::state_store::state_key::StateKey;
+use aptos_vm::sharded_block_executor::remote_state_value::RemoteStateValue;
+use crossbeam_channel::{Receiver, Sender};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+    thread,
+};
+
+extern crate itertools;
+use anyhow::Result;
+use aptos_logger::trace;
+use aptos_state_view::TStateView;
+use aptos_types::{
+    block_executor::partitioner::ShardId,
+    state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
+};
+use dashmap::DashMap;
+
+pub static REMOTE_STATE_KEY_BATCH_SIZE: usize = 50000;
+
+pub struct RemoteStateView {
+    state_values: DashMap<StateKey, RemoteStateValue>,
+}
+
+impl RemoteStateView {
+    pub fn new() -> Self {
+        Self {
+            state_values: DashMap::new(),
+        }
+    }
+
+    pub fn has_state_key(&self, state_key: &StateKey) -> bool {
+        self.state_values.contains_key(state_key)
+    }
+
+    pub fn set_state_value(&self, state_key: &StateKey, state_value: Option<StateValue>) {
+        self.state_values
+            .get(state_key)
+            .unwrap()
+            .set_value(state_value);
+    }
+
+    pub fn insert_state_key(&self, state_key: StateKey) {
+        self.state_values
+            .entry(state_key)
+            .or_insert(RemoteStateValue::waiting());
+    }
+
+    pub fn get_state_value(&self, state_key: &StateKey) -> Result<Option<StateValue>> {
+        if let Some(value) = self.state_values.get(state_key) {
+            let value_clone = value.clone();
+            // It is possible that the value is not ready yet and the get_value call blocks. In that
+            // case we explicitly drop the value to relinquish the read lock on the value. Cloning the
+            // value should be in expensive as this is just cloning the underlying Arc.
+            drop(value);
+            return Ok(value_clone.get_value());
+        }
+        Ok(None)
+    }
+}
+
+pub struct RemoteStateViewClient {
+    shard_id: ShardId,
+    kv_tx: Arc<Sender<Message>>,
+    state_view: Arc<RwLock<RemoteStateView>>,
+    thread_pool: Arc<rayon::ThreadPool>,
+    _join_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl RemoteStateViewClient {
+    pub fn new(
+        shard_id: ShardId,
+        controller: &mut NetworkController,
+        coordinator_address: SocketAddr,
+    ) -> Self {
+        let thread_pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .thread_name(move |index| format!("remote-state-view-shard-{}-{}", shard_id, index))
+                .num_threads(num_cpus::get())
+                .build()
+                .unwrap(),
+        );
+        let kv_request_type = "remote_kv_request";
+        let kv_response_type = "remote_kv_response";
+        let result_rx = controller.create_inbound_channel(kv_response_type.to_string());
+        let command_tx =
+            controller.create_outbound_channel(coordinator_address, kv_request_type.to_string());
+        let state_view = Arc::new(RwLock::new(RemoteStateView::new()));
+        let state_value_receiver = RemoteStateValueReceiver::new(
+            shard_id,
+            state_view.clone(),
+            result_rx,
+            thread_pool.clone(),
+        );
+
+        let join_handle = thread::Builder::new()
+            .name(format!("remote-kv-receiver-{}", shard_id))
+            .spawn(move || state_value_receiver.start())
+            .unwrap();
+
+        Self {
+            shard_id,
+            kv_tx: Arc::new(command_tx),
+            state_view,
+            thread_pool,
+            _join_handle: Some(join_handle),
+        }
+    }
+
+    pub fn init_for_block(&self, state_keys: Vec<StateKey>) {
+        *self.state_view.write().unwrap() = RemoteStateView::new();
+        self.pre_fetch_state_values(state_keys);
+    }
+
+    fn pre_fetch_state_values(&self, state_keys: Vec<StateKey>) {
+        state_keys
+            .chunks(REMOTE_STATE_KEY_BATCH_SIZE)
+            .map(|state_keys_chunk| state_keys_chunk.to_vec())
+            .for_each(|state_keys| {
+                let sender = self.kv_tx.clone();
+                let shard_id = self.shard_id;
+                self.thread_pool.spawn(move || {
+                    Self::send_state_value_request(shard_id, sender, state_keys);
+                });
+            });
+        state_keys.into_iter().for_each(|state_key| {
+            self.state_view.read().unwrap().insert_state_key(state_key);
+        });
+    }
+
+    fn send_state_value_request(
+        shard_id: ShardId,
+        sender: Arc<Sender<Message>>,
+        state_keys: Vec<StateKey>,
+    ) {
+        let request = RemoteKVRequest::new(shard_id, state_keys);
+        let request_message = bcs::to_bytes(&request).unwrap();
+        sender.send(Message::new(request_message)).unwrap();
+    }
+}
+
+impl TStateView for RemoteStateViewClient {
+    type Key = StateKey;
+
+    fn get_state_value(&self, state_key: &StateKey) -> Result<Option<StateValue>> {
+        let state_view_reader = self.state_view.read().unwrap();
+        if state_view_reader.has_state_key(state_key) {
+            // If the key is already in the cache then we return it.
+            return state_view_reader.get_state_value(state_key);
+        }
+        // If the value is not already in the cache then we pre-fetch it and wait for it to arrive.
+        self.pre_fetch_state_values(vec![state_key.clone()]);
+        state_view_reader.get_state_value(state_key)
+    }
+
+    fn get_usage(&self) -> Result<StateStorageUsage> {
+        unimplemented!("get_usage is not implemented for RemoteStateView")
+    }
+}
+
+struct RemoteStateValueReceiver {
+    shard_id: ShardId,
+    state_view: Arc<RwLock<RemoteStateView>>,
+    kv_rx: Receiver<Message>,
+    thread_pool: Arc<rayon::ThreadPool>,
+}
+
+impl RemoteStateValueReceiver {
+    fn new(
+        shard_id: ShardId,
+        state_view: Arc<RwLock<RemoteStateView>>,
+        kv_rx: Receiver<Message>,
+        thread_pool: Arc<rayon::ThreadPool>,
+    ) -> Self {
+        Self {
+            shard_id,
+            state_view,
+            kv_rx,
+            thread_pool,
+        }
+    }
+
+    fn start(&self) {
+        loop {
+            let message = self.kv_rx.recv().unwrap();
+            let state_view = self.state_view.clone();
+            let shard_id = self.shard_id;
+            self.thread_pool.spawn(move || {
+                Self::handle_message(shard_id, message, state_view);
+            });
+        }
+    }
+
+    fn handle_message(
+        shard_id: ShardId,
+        message: Message,
+        state_view: Arc<RwLock<RemoteStateView>>,
+    ) {
+        let response: RemoteKVResponse = bcs::from_bytes(&message.data).unwrap();
+        let state_view_lock = state_view.read().unwrap();
+        trace!(
+            "Received state values for shard {} with size {}",
+            shard_id,
+            response.inner.len()
+        );
+        response
+            .inner
+            .into_iter()
+            .for_each(|(state_key, state_value)| {
+                state_view_lock.set_state_value(&state_key, state_value);
+            });
+    }
+}

--- a/execution/executor-service/src/remote_state_view_service.rs
+++ b/execution/executor-service/src/remote_state_view_service.rs
@@ -1,0 +1,105 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use crate::{RemoteKVRequest, RemoteKVResponse};
+use aptos_secure_net::network_controller::{Message, NetworkController};
+use crossbeam_channel::{Receiver, Sender};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+};
+
+extern crate itertools;
+use aptos_logger::trace;
+use aptos_state_view::{StateView, TStateView};
+use itertools::Itertools;
+
+pub struct RemoteStateViewService<S: StateView + Sync + Send + 'static> {
+    kv_rx: Receiver<Message>,
+    kv_tx: Arc<Vec<Sender<Message>>>,
+    thread_pool: Arc<rayon::ThreadPool>,
+    state_view: Arc<RwLock<Option<Arc<S>>>>,
+}
+
+impl<S: StateView + Sync + Send + 'static> RemoteStateViewService<S> {
+    pub fn new(
+        controller: &mut NetworkController,
+        remote_shard_addresses: Vec<SocketAddr>,
+        num_threads: Option<usize>,
+    ) -> Self {
+        let num_threads = num_threads.unwrap_or_else(num_cpus::get);
+        let thread_pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .unwrap(),
+        );
+        let kv_request_type = "remote_kv_request";
+        let kv_response_type = "remote_kv_response";
+        let result_rx = controller.create_inbound_channel(kv_request_type.to_string());
+        let command_txs = remote_shard_addresses
+            .iter()
+            .map(|address| {
+                controller.create_outbound_channel(*address, kv_response_type.to_string())
+            })
+            .collect_vec();
+        Self {
+            kv_rx: result_rx,
+            kv_tx: Arc::new(command_txs),
+            thread_pool,
+            state_view: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub fn set_state_view(&self, state_view: Arc<S>) {
+        let mut state_view_lock = self.state_view.write().unwrap();
+        *state_view_lock = Some(state_view);
+    }
+
+    pub fn start(&self) {
+        loop {
+            let message = self.kv_rx.recv().unwrap();
+            let state_view = self.state_view.clone();
+            let kv_txs = self.kv_tx.clone();
+            self.thread_pool.spawn(move || {
+                Self::handle_message(message, state_view, kv_txs);
+            });
+        }
+    }
+
+    pub fn handle_message(
+        message: Message,
+        state_view: Arc<RwLock<Option<Arc<S>>>>,
+        kv_tx: Arc<Vec<Sender<Message>>>,
+    ) {
+        let req: RemoteKVRequest = bcs::from_bytes(&message.data).unwrap();
+        let (shard_id, state_keys) = req.into();
+        trace!(
+            "remote state view service - received request for shard {} with {} keys",
+            shard_id,
+            state_keys.len()
+        );
+        let resp = state_keys
+            .into_iter()
+            .map(|state_key| {
+                let state_value = state_view
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .unwrap()
+                    .get_state_value(&state_key)
+                    .unwrap();
+                (state_key, state_value)
+            })
+            .collect_vec();
+        let len = resp.len();
+        let resp = RemoteKVResponse::new(resp);
+        let resp = bcs::to_bytes(&resp).unwrap();
+        trace!(
+            "remote state view service - sending response for shard {} with {} keys",
+            shard_id,
+            len
+        );
+        let message = Message::new(resp);
+        kv_tx[shard_id].send(message).unwrap();
+    }
+}

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -95,7 +95,7 @@ pub fn compare_txn_outputs(
 pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>(
     sharded_block_executor: ShardedBlockExecutor<FakeDataStore, E>,
 ) {
-    let num_txns = 400;
+    let num_txns = 10;
     let num_shards = sharded_block_executor.num_shards();
     let mut executor = FakeExecutor::from_head_genesis();
     let mut transactions = Vec::new();

--- a/secure/net/src/network_controller/inbound_handler.rs
+++ b/secure/net/src/network_controller/inbound_handler.rs
@@ -4,7 +4,7 @@ use crate::{
     network_controller::{error::Error, Message, MessageType, NetworkMessage},
     NetworkServer,
 };
-use aptos_logger::error;
+use aptos_logger::{error, warn};
 use crossbeam_channel::Sender;
 use std::{
     collections::HashMap,
@@ -70,7 +70,7 @@ impl InboundHandler {
             // Send the message to the registered handler
             handler.send(message).unwrap();
         } else {
-            println!("No handler registered for message type: {:?}", message_type);
+            warn!("No handler registered for message type: {:?}", message_type);
         }
     }
 
@@ -90,7 +90,10 @@ impl InboundHandler {
             // Send the message to the registered handler
             handler.send(msg)?;
         } else {
-            println!("No handler registered for sender: {:?}", sender);
+            warn!(
+                "No handler registered for sender: {:?} and msg type {:?}",
+                sender, message_type
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
### Description

Adding support for remote executor and remote storage service. This is still not fully functional as the underlying network context is not reliable and drops messages. When we switch to gRPC, this should work. Adding this change before gRPC support as we would have interfaces ready to be implemented in gRPC. 

### Test Plan

Added a test with no cross shard conflict. With cross shard conflict, this doesn't work because of unreliable network context. 
