### PR TITLE
Provide router_signer address when deploying ans

### DIFF
--- a/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
+++ b/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
@@ -55,6 +55,18 @@ try {
     repoDir = tempDir;
   }
 
+  // Derive the router signer address.
+  const ROUTER_SIGNER = `0x${
+    JSON.parse(
+      execSync(
+        `${cliInvocation} account derive-resource-account-address --address ${ANS_TEST_ACCOUNT_ADDRESS} --seed "ANS ROUTER" --seed-encoding utf8`,
+        {
+          encoding: "utf8",
+        },
+      ),
+    ).Result
+  }`;
+
   // 2. Fund ANS account.
   console.log("---funding account---");
   execSync(
@@ -65,7 +77,7 @@ try {
   // 3. Publish the ANS modules under the ANS account.
   console.log("---publishing ans modules---");
   execSync(
-    `${cliInvocation} move publish --package-dir ${repoDir}/core --assume-yes --private-key=${ANS_TEST_ACCOUNT_PRIVATE_KEY} --named-addresses aptos_names=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_admin=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_funds=${ANS_TEST_ACCOUNT_ADDRESS} --url=${APTOS_NODE_URL}`,
+    `${cliInvocation} move publish --package-dir ${repoDir}/core --assume-yes --private-key=${ANS_TEST_ACCOUNT_PRIVATE_KEY} --named-addresses aptos_names=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_admin=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_funds=${ANS_TEST_ACCOUNT_ADDRESS},router_signer=${ROUTER_SIGNER} --url=${APTOS_NODE_URL}`,
     { stdio: "inherit" },
   );
   console.log("---module published---");


### PR DESCRIPTION
### Description
The latest ANS v1 requires an additional `router_signer` named address. The `router_signer` is a resource account that is created by the `ANS v1` contract with the seed `ANS ROUTER`.


### Test Plan

Tested locally

```
[nix-shell:~/aptos/aptos-core/ecosystem/typescript/sdk]$ pnpm run publish-ans-contract

> aptos@1.19.0 publish-ans-contract /Users/brianli/aptos/aptos-core/ecosystem/typescript/sdk
> ts-node ./scripts/publish_ans_contract.ts

---creating temporary directory for ANS code---
---cloning ANS repository to /tmp/tmp.zkYimE2DEw---
Cloning into '/tmp/tmp.zkYimE2DEw'...
---running CLI using local binary---
---funding account---
{
  "Result": "Added 100000000 Octas to account 585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82"
}
---publishing ans modules---
Compiling, may take a little while to download git dependencies...
FETCHING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY AptosToken
INCLUDING DEPENDENCY MoveStdlib
BUILDING aptos_names
package size 36923 bytes
{
  "Result": {
    "transaction_hash": "0x1177a936984f76356d1d816fdfbd428cdf4d55e76b2212489c1422a44ca21f8c",
    "gas_used": 30909,
    "gas_unit_price": 100,
    "sender": "585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1694183126651292,
    "version": 85,
    "vm_status": "Executed successfully"
  }
}
---module published---
```
