### PR TITLE
[aptos-logger] truncate long log messages and field values

### DIFF
--- a/crates/aptos-logger/src/event.rs
+++ b/crates/aptos-logger/src/event.rs
@@ -15,7 +15,7 @@ pub struct Event<'a> {
 }
 
 impl<'a> Event<'a> {
-    fn new(
+    pub(crate) fn new(
         metadata: &'a Metadata,
         message: Option<fmt::Arguments<'a>>,
         keys_and_values: &'a [&'a dyn Schema],


### PR DESCRIPTION
### Description

Avoid printing too much.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Unit test.
