### PR TITLE
[forge] Split duration more usefully, for more reliable stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,6 +3635,7 @@ dependencies = [
  "aptos-sdk",
  "aptos-temppath",
  "aptos-types",
+ "assert_approx_eq",
  "bcs 0.1.4",
  "csv",
  "futures",

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -869,7 +869,7 @@ fn realistic_env_sweep_wrap(
 fn realistic_env_load_sweep_test() -> ForgeConfig {
     realistic_env_sweep_wrap(20, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(&[10, 100, 1000, 3000, 5000]),
+        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
         criteria: [
             (9, 1.5, 3., 4.),
             (95, 1.5, 3., 4.),
@@ -893,7 +893,7 @@ fn realistic_env_load_sweep_test() -> ForgeConfig {
 fn realistic_env_workload_sweep_test() -> ForgeConfig {
     realistic_env_sweep_wrap(7, 3, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TRANSACTIONS(&[
+        workloads: Workloads::TRANSACTIONS(vec![
             TransactionWorkload {
                 transaction_type: TransactionTypeArg::CoinTransfer,
                 num_modules: 1,
@@ -964,7 +964,7 @@ fn load_vs_perf_benchmark() -> ForgeConfig {
         .with_initial_fullnode_count(10)
         .add_network_test(LoadVsPerfBenchmark {
             test: Box::new(PerformanceBenchmark),
-            workloads: Workloads::TPS(&[
+            workloads: Workloads::TPS(vec![
                 200, 1000, 3000, 5000, 7000, 7500, 8000, 9000, 10000, 12000, 15000,
             ]),
             criteria: Vec::new(),
@@ -993,7 +993,7 @@ fn workload_vs_perf_benchmark() -> ForgeConfig {
         }))
         .add_network_test(LoadVsPerfBenchmark {
             test: Box::new(PerformanceBenchmark),
-            workloads: Workloads::TRANSACTIONS(&[
+            workloads: Workloads::TRANSACTIONS(vec![
                 TransactionWorkload {
                     transaction_type: TransactionTypeArg::NoOp,
                     num_modules: 1,

--- a/testsuite/testcases/Cargo.toml
+++ b/testsuite/testcases/Cargo.toml
@@ -38,6 +38,9 @@ reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+assert_approx_eq = { workspace = true }
+
 [[test]]
 name = "forge-local-compatibility"
 harness = false


### PR DESCRIPTION
We have a sweep of tests, with some being in 1 phase and some in 2. Previously, each test would get ~5 minutes, giving it 2.5 minutes per phase.

With this, we make all phases equal, i.e. ~4 minutes, so we get similarly stable results for each phase, as we get for full runs, without needing to extend runtime.

(this is for workload sweep test)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
