### PR TITLE
add MOVE_COMPILER_DEBUG and MOVE_TEST_DEBUG env vars to add more info…

### DIFF
--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -288,12 +288,10 @@ impl VMError {
     location: {location_string},
     indices: {indices},
     offsets: {offsets},
-    exec_state: {exec_state:?},
 }}",
                 major_status = self.major_status(),
                 sub_status = self.sub_status(),
                 location_string = location_string,
-                exec_state = self.exec_state(),
                 // TODO maybe include source map info?
                 indices = indices,
                 offsets = offsets,

--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -234,6 +234,53 @@ impl VMError {
             offsets,
         }))
     }
+
+    pub fn format_test_output(&self, verbose: bool, comparison_mode: bool) -> String {
+        let location_string = match &self.location() {
+            Location::Undefined => "undefined".to_owned(),
+            Location::Script => "script".to_owned(),
+            Location::Module(id) => {
+                format!("0x{}::{}", id.address().short_str_lossless(), id.name())
+            },
+        };
+        let message_str = if verbose {
+            match &self.message() {
+                Some(message_str) => message_str,
+                None => "None",
+            }
+        } else {
+            "redacted"
+        };
+        format!(
+            "{{
+    message: {message},
+    major_status: {major_status:?},
+    sub_status: {sub_status:?},
+    location: {location_string},
+    indices: {indices},
+    offsets: {offsets},
+    exec_state: {exec_state:?},
+}}",
+            message = message_str,
+            major_status = self.major_status(),
+            sub_status = self.sub_status(),
+            location_string = location_string,
+            exec_state = self.exec_state(),
+            // TODO maybe include source map info?
+            indices = if comparison_mode {
+                // During comparison testing, abstract this data.
+                "redacted".to_string()
+            } else {
+                format!("{:?}", self.indices())
+            },
+            offsets = if comparison_mode {
+                // During comparison testing, abstract this data.
+                "redacted".to_string()
+            } else {
+                format!("{:?}", self.offsets())
+            },
+        )
+    }
 }
 
 impl fmt::Debug for VMError {

--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -243,16 +243,26 @@ impl VMError {
                 format!("0x{}::{}", id.address().short_str_lossless(), id.name())
             },
         };
-        let message_str = if verbose {
-            match &self.message() {
+        let indices = if comparison_mode {
+            // During comparison testing, abstract this data.
+            "redacted".to_string()
+        } else {
+            format!("{:?}", self.indices())
+        };
+        let offsets = if comparison_mode {
+            // During comparison testing, abstract this data.
+            "redacted".to_string()
+        } else {
+            format!("{:?}", self.offsets())
+        };
+
+        if verbose {
+            let message_str = match &self.message() {
                 Some(message_str) => message_str,
                 None => "None",
-            }
-        } else {
-            "redacted"
-        };
-        format!(
-            "{{
+            };
+            format!(
+                "{{
     message: {message},
     major_status: {major_status:?},
     sub_status: {sub_status:?},
@@ -261,25 +271,34 @@ impl VMError {
     offsets: {offsets},
     exec_state: {exec_state:?},
 }}",
-            message = message_str,
-            major_status = self.major_status(),
-            sub_status = self.sub_status(),
-            location_string = location_string,
-            exec_state = self.exec_state(),
-            // TODO maybe include source map info?
-            indices = if comparison_mode {
-                // During comparison testing, abstract this data.
-                "redacted".to_string()
-            } else {
-                format!("{:?}", self.indices())
-            },
-            offsets = if comparison_mode {
-                // During comparison testing, abstract this data.
-                "redacted".to_string()
-            } else {
-                format!("{:?}", self.offsets())
-            },
-        )
+                message = message_str,
+                major_status = self.major_status(),
+                sub_status = self.sub_status(),
+                location_string = location_string,
+                exec_state = self.exec_state(),
+                // TODO maybe include source map info?
+                indices = indices,
+                offsets = offsets,
+            )
+        } else {
+            format!(
+                "{{
+    major_status: {major_status:?},
+    sub_status: {sub_status:?},
+    location: {location_string},
+    indices: {indices},
+    offsets: {offsets},
+    exec_state: {exec_state:?},
+}}",
+                major_status = self.major_status(),
+                sub_status = self.sub_status(),
+                location_string = location_string,
+                exec_state = self.exec_state(),
+                // TODO maybe include source map info?
+                indices = indices,
+                offsets = offsets,
+            )
+        }
     }
 }
 

--- a/third_party/move/move-compiler/src/command_line/compiler.rs
+++ b/third_party/move/move-compiler/src/command_line/compiler.rs
@@ -17,8 +17,12 @@ use crate::{
     },
     to_bytecode, typing, unit_test, verification,
 };
-use move_command_line_common::files::{
-    extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
+use move_command_line_common::{
+    env::read_bool_env_var,
+    files::{
+        extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+        SOURCE_MAP_EXTENSION,
+    },
 };
 use move_core_types::language_storage::ModuleId as CompiledModuleId;
 use move_symbol_pool::Symbol;
@@ -54,13 +58,7 @@ pub struct SteppedCompiler<'a, const P: Pass> {
 }
 
 pub fn debug_compiler() -> bool {
-    static DEBUG_COMPILER: Lazy<bool> = Lazy::new(|| match std::env::var("MOVE_COMPILER_DEBUG") {
-        Ok(s) => {
-            let s = s.to_lowercase();
-            s != "0" && s != "false" && s != "no"
-        },
-        Err(_) => true,
-    });
+    static DEBUG_COMPILER: Lazy<bool> = Lazy::new(|| read_bool_env_var("MOVE_COMPILER_DEBUG"));
     *DEBUG_COMPILER
 }
 

--- a/third_party/move/move-compiler/src/command_line/mod.rs
+++ b/third_party/move/move-compiler/src/command_line/mod.rs
@@ -37,3 +37,7 @@ pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 pub const MOVE_COMPILED_INTERFACES_DIR: &str = "mv_interfaces";
 
 pub const COMPILED_NAMED_ADDRESS_MAPPING: &str = "compiled-module-address-name";
+
+pub const MOVE_COMPILER_DEBUG_ENV_VAR: &str = "MOVE_COMPILER_DEBUG";
+
+pub const DEBUG_FLAG: &str = "debug";

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -11,7 +11,6 @@ use clap::*;
 use move_command_line_common::env::read_bool_env_var;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
-
 use once_cell::sync::Lazy;
 use petgraph::{algo::astar as petgraph_astar, graphmap::DiGraphMap};
 use std::{
@@ -114,13 +113,13 @@ pub fn shortest_cycle<'a, T: Ord + Hash>(
             );
             match (shortest_path, path_opt) {
                 (p, None) | (None, p) => p,
-                (Some((acc_len, acc_path)), Some((cur_len, cur_path))) => {
-                    Some(if cur_len < acc_len {
+                (Some((acc_len, acc_path)), Some((cur_len, cur_path))) => Some(
+                    if cur_len < acc_len {
                         (cur_len, cur_path)
                     } else {
                         (acc_len, acc_path)
-                    })
-                },
+                    },
+                ),
             }
         });
     let (_, mut path) = shortest_path.unwrap();

--- a/third_party/move/move-compiler/src/to_bytecode/translate.rs
+++ b/third_party/move/move-compiler/src/to_bytecode/translate.rs
@@ -119,9 +119,6 @@ pub fn program(
     let mut units = vec![];
 
     let (orderings, sdecls, fdecls) = extract_decls(compilation_env, pre_compiled_lib, &prog);
-    if compilation_env.flags().debug() {
-        eprintln!("Bytecode: = {:?}", prog);
-    }
     let G::Program {
         modules: gmodules,
         scripts: gscripts,

--- a/third_party/move/move-compiler/src/to_bytecode/translate.rs
+++ b/third_party/move/move-compiler/src/to_bytecode/translate.rs
@@ -119,6 +119,9 @@ pub fn program(
     let mut units = vec![];
 
     let (orderings, sdecls, fdecls) = extract_decls(compilation_env, pre_compiled_lib, &prog);
+    if compilation_env.flags().debug() {
+        eprintln!("Bytecode: = {:?}", prog);
+    }
     let G::Program {
         modules: gmodules,
         scripts: gscripts,

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -210,6 +210,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
 
         let id = module.self_id();
         let sender = *id.address();
+        let verbose = extra_args.verbose;
         match self.perform_session_action(
             gas_budget,
             |session, gas_status| {
@@ -232,10 +233,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             Err(vm_error) => Err(anyhow!(
                 "Unable to publish module '{}'. Got VMError: {}",
                 module.self_id(),
-                vm_error.format_test_output(
-                    move_test_debug() || extra_args.verbose,
-                    self.comparison_mode
-                )
+                vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
             )),
         }
     }
@@ -267,6 +265,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map(|a| MoveValue::Signer(*a).simple_serialize().unwrap())
             .chain(args)
             .collect();
+        let verbose = extra_args.verbose;
         let serialized_return_values = self
             .perform_session_action(
                 gas_budget,
@@ -278,10 +277,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Script execution failed with VMError: {}",
-                    vm_error.format_test_output(
-                        move_test_debug() || extra_args.verbose,
-                        self.comparison_mode
-                    )
+                    vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
                 )
             })?;
         Ok((None, serialized_return_values))
@@ -312,6 +308,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map(|a| MoveValue::Signer(*a).simple_serialize().unwrap())
             .chain(args)
             .collect();
+        let verbose = extra_args.verbose;
         let serialized_return_values = self
             .perform_session_action(
                 gas_budget,
@@ -325,10 +322,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Function execution failed with VMError: {}",
-                    vm_error.format_test_output(
-                        move_test_debug() || extra_args.verbose,
-                        self.comparison_mode
-                    )
+                    vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
                 )
             })?;
         Ok((None, serialized_return_values))

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -88,12 +88,18 @@ pub struct AdapterPublishArgs {
     #[clap(long)]
     /// is skip the check friend link, if true, treat `friend` as `private`
     pub skip_check_friend_linking: bool,
+    /// print more complete information for VMErrors on publish
+    #[clap(long)]
+    pub verbose: bool,
 }
 
 #[derive(Debug, Parser)]
 pub struct AdapterExecuteArgs {
     #[clap(long)]
     pub check_runtime_types: bool,
+    /// print more complete information for VMErrors on run
+    #[clap(long)]
+    pub verbose: bool,
 }
 
 fn move_test_debug() -> bool {
@@ -226,7 +232,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             Err(vm_error) => Err(anyhow!(
                 "Unable to publish module '{}'. Got VMError: {}",
                 module.self_id(),
-                vm_error.format_test_output(move_test_debug(), self.comparison_mode)
+                vm_error.format_test_output(
+                    move_test_debug() || extra_args.verbose,
+                    self.comparison_mode
+                )
             )),
         }
     }
@@ -269,7 +278,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Script execution failed with VMError: {}",
-                    vm_error.format_test_output(move_test_debug(), self.comparison_mode)
+                    vm_error.format_test_output(
+                        move_test_debug() || extra_args.verbose,
+                        self.comparison_mode
+                    )
                 )
             })?;
         Ok((None, serialized_return_values))
@@ -313,7 +325,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Function execution failed with VMError: {}",
-                    vm_error.format_test_output(move_test_debug(), self.comparison_mode)
+                    vm_error.format_test_output(
+                        move_test_debug() || extra_args.verbose,
+                        self.comparison_mode
+                    )
                 )
             })?;
         Ok((None, serialized_return_values))

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -9,10 +9,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use move_binary_format::{
-    compatibility::Compatibility,
-    errors::{Location, VMError, VMResult},
-    file_format::CompiledScript,
-    CompiledModule,
+    compatibility::Compatibility, errors::VMResult, file_format::CompiledScript, CompiledModule,
 };
 use move_command_line_common::{
     address::ParsedAddress, env::read_bool_env_var, files::verify_and_create_named_address_mapping,

--- a/third_party/move/tools/move-unit-test/src/test_reporter.rs
+++ b/third_party/move/tools/move-unit-test/src/test_reporter.rs
@@ -377,8 +377,10 @@ impl TestFailure {
         };
 
         static MOVE_TEST_DEBUG: Lazy<bool> = Lazy::new(|| read_bool_env_var("MOVE_TEST_DEBUG"));
-        let full_vm_error_description = vm_error.format_test_output(*MOVE_TEST_DEBUG, false);
-        diags = diags + &full_vm_error_description;
+        if *MOVE_TEST_DEBUG {
+            let full_vm_error_description = vm_error.format_test_output(*MOVE_TEST_DEBUG, false);
+            diags = diags + &full_vm_error_description;
+        }
 
         match vm_error.exec_state() {
             None => diags,

--- a/third_party/move/tools/move-unit-test/src/test_reporter.rs
+++ b/third_party/move/tools/move-unit-test/src/test_reporter.rs
@@ -9,7 +9,7 @@ use move_binary_format::{
     access::ModuleAccess,
     errors::{ExecutionState, Location, VMError, VMResult},
 };
-use move_command_line_common::files::FileHash;
+use move_command_line_common::{env::read_bool_env_var, files::FileHash};
 pub use move_compiler::unit_test::ExpectedMoveError as MoveError;
 use move_compiler::{
     diagnostics::{self, Diagnostic, Diagnostics},
@@ -18,6 +18,7 @@ use move_compiler::{
 use move_core_types::{effects::ChangeSet, language_storage::ModuleId, vm_status::StatusType};
 use move_ir_types::location::Loc;
 use move_symbol_pool::Symbol;
+use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     io::{Result, Write},
@@ -344,7 +345,7 @@ impl TestFailure {
             Some(vm_error) => vm_error,
         };
 
-        let diags = match vm_error.location() {
+        let mut diags = match vm_error.location() {
             Location::Module(module_id) => {
                 let diag_opt = vm_error.offsets().first().and_then(|(fdef_idx, offset)| {
                     let function_source_map = test_plan
@@ -374,6 +375,10 @@ impl TestFailure {
             },
             _ => base_message,
         };
+
+        static MOVE_TEST_DEBUG: Lazy<bool> = Lazy::new(|| read_bool_env_var("MOVE_TEST_DEBUG"));
+        let full_vm_error_description = vm_error.format_test_output(*MOVE_TEST_DEBUG, false);
+        diags = diags + &full_vm_error_description;
 
         match vm_error.exec_state() {
             None => diags,


### PR DESCRIPTION
add MOVE_COMPILER_DEBUG and MOVE_TEST_DEBUG env vars to add more info to outputs for debugging

### Description

VMError outputs are deliberately suppressed in unit and transactional tests to make comparison with "golden" expected outputs easier.  But for debugging an unexpectedly failing test, the full VMError output is useful to see.  By setting the environment variable MOVE_TEST_DEBUG=1, the developer can see the full test output.  If RUST_BACKTRACE=1 is also set, then this should include the VM or Loader stack for better debugging.  At Runtian's suggestion, this is also now available by adding --verbose to the publish command in transactional tests, see https://github.com/aptos-labs/aptos-core/pull/10000/.

To debug the Move Compiler, it is most useful to see the compiler IR between passes.  By setting the envronment variable MOVE_COMPILER_DEBUG=1 when running the compiler (or full build), the developer can see that IR after each pass.  Note that this will be too verbose to be useful unless just a small program is being compiled.

### Test Plan
Testing that without these environment variables set, nothing changes.  Manual testing for useful output with environment variables set.

