### PR TITLE
[consensus] introduce CommitSignerProvider trait

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -13,6 +13,7 @@ use crate::{
         buffer_manager::{OrderedBlocks, ResetRequest},
         decoupled_execution_utils::prepare_phases_and_buffer_manager,
         ordering_state_computer::OrderingStateComputer,
+        signing_phase::CommitSignerProvider,
     },
     liveness::{
         cached_proposer_election::CachedProposerElection,
@@ -483,7 +484,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     /// it sets `self.commit_msg_tx` to a new aptos_channel::Sender and returns an OrderingStateComputer
     fn spawn_decoupled_execution(
         &mut self,
-        safety_rules_container: Arc<Mutex<MetricsSafetyRules>>,
+        commit_signer_provider: Arc<dyn CommitSignerProvider>,
         verifier: ValidatorVerifier,
     ) -> OrderingStateComputer {
         let network_sender = NetworkSender::new(
@@ -510,7 +511,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             prepare_phases_and_buffer_manager(
                 self.author,
                 self.commit_state_computer.clone(),
-                safety_rules_container,
+                commit_signer_provider,
                 network_sender,
                 commit_msg_rx,
                 self.commit_state_computer.clone(),

--- a/consensus/src/experimental/decoupled_execution_utils.rs
+++ b/consensus/src/experimental/decoupled_execution_utils.rs
@@ -8,7 +8,7 @@ use crate::{
         execution_phase::{ExecutionPhase, ExecutionRequest, ExecutionResponse},
         persisting_phase::{PersistingPhase, PersistingRequest},
         pipeline_phase::{CountedRequest, PipelinePhase},
-        signing_phase::{SigningPhase, SigningRequest, SigningResponse},
+        signing_phase::{CommitSignerProvider, SigningPhase, SigningRequest, SigningResponse},
     },
     network::{IncomingCommitRequest, NetworkSender},
     state_replication::StateComputer,
@@ -18,8 +18,6 @@ use aptos_consensus_types::common::Author;
 use aptos_types::{account_address::AccountAddress, validator_verifier::ValidatorVerifier};
 use futures::channel::mpsc::UnboundedReceiver;
 use std::sync::{atomic::AtomicU64, Arc};
-
-use super::signing_phase::CommitSignerProvider;
 
 /// build channels and return phases and buffer manager
 pub fn prepare_phases_and_buffer_manager(

--- a/consensus/src/experimental/decoupled_execution_utils.rs
+++ b/consensus/src/experimental/decoupled_execution_utils.rs
@@ -10,22 +10,22 @@ use crate::{
         pipeline_phase::{CountedRequest, PipelinePhase},
         signing_phase::{SigningPhase, SigningRequest, SigningResponse},
     },
-    metrics_safety_rules::MetricsSafetyRules,
     network::{IncomingCommitRequest, NetworkSender},
     state_replication::StateComputer,
 };
 use aptos_channels::aptos_channel::Receiver;
 use aptos_consensus_types::common::Author;
-use aptos_infallible::Mutex;
 use aptos_types::{account_address::AccountAddress, validator_verifier::ValidatorVerifier};
 use futures::channel::mpsc::UnboundedReceiver;
 use std::sync::{atomic::AtomicU64, Arc};
+
+use super::signing_phase::CommitSignerProvider;
 
 /// build channels and return phases and buffer manager
 pub fn prepare_phases_and_buffer_manager(
     author: Author,
     execution_proxy: Arc<dyn StateComputer>,
-    safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+    safety_rules: Arc<dyn CommitSignerProvider>,
     commit_msg_tx: NetworkSender,
     commit_msg_rx: Receiver<AccountAddress, IncomingCommitRequest>,
     persisting_proxy: Arc<dyn StateComputer>,

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -2,7 +2,10 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{monitor, persistent_liveness_storage::PersistentLivenessStorage};
+use crate::{
+    experimental::signing_phase::CommitSignerProvider, monitor,
+    persistent_liveness_storage::PersistentLivenessStorage,
+};
 use aptos_consensus_types::{
     block_data::BlockData,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
@@ -10,6 +13,7 @@ use aptos_consensus_types::{
     vote_proposal::VoteProposal,
 };
 use aptos_crypto::bls12381;
+use aptos_infallible::Mutex;
 use aptos_logger::prelude::info;
 use aptos_safety_rules::{ConsensusState, Error, TSafetyRules};
 use aptos_types::{
@@ -130,6 +134,16 @@ impl TSafetyRules for MetricsSafetyRules {
                 inner.sign_commit_vote(ledger_info.clone(), new_ledger_info.clone())
             )
         })
+    }
+}
+
+impl CommitSignerProvider for Mutex<MetricsSafetyRules> {
+    fn sign_commit_vote(
+        &self,
+        ledger_info: LedgerInfoWithSignatures,
+        new_ledger_info: LedgerInfo,
+    ) -> Result<bls12381::Signature, Error> {
+        self.lock().sign_commit_vote(ledger_info, new_ledger_info)
     }
 }
 


### PR DESCRIPTION
### Description

This PR introduces a commit signer trait that allows signing post-execution ledger info in the decoupled execution pipeline. MetricsSafetyRules implements this trait so the compatibility remains intact for current consensus implementation.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
