### PR TITLE
[NFT Metadata Crawler] Trim URIs before making request

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/lib.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/lib.rs
@@ -16,7 +16,7 @@ pub async fn get_uri_metadata(url: String) -> anyhow::Result<(String, u32)> {
         .timeout(Duration::from_secs(MAX_HEAD_REQUEST_RETRY_SECONDS))
         .build()
         .context("Failed to build reqwest client")?;
-    let request = client.head(&url);
+    let request = client.head(url.trim());
     let response = request.send().await?;
     let headers = response.headers();
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -53,7 +53,7 @@ impl ImageOptimizer {
                     .context("Failed to build reqwest client")?;
 
                 let response = client
-                    .get(&uri)
+                    .get(uri.trim())
                     .send()
                     .await
                     .context("Failed to get image")?;

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
@@ -57,7 +57,7 @@ impl JSONParser {
                     .context("Failed to build reqwest client")?;
 
                 let response = client
-                    .get(&uri)
+                    .get(uri.trim())
                     .send()
                     .await
                     .context("Failed to get JSON")?;


### PR DESCRIPTION
### Description
Some of the token and collection URIs have a new line character at the end. This change trims the provided URIs before making the request. 