### PR TITLE
[refactor] Separate function for changing genesis stake

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -261,7 +261,7 @@ where
 
         // Build genesis and the validator node
         let builder = aptos_genesis::builder::Builder::new(&test_dir, framework.clone())?
-            .with_init_config(Some(Arc::new(move |_, config, _| {
+            .with_init_config(Some(Arc::new(move |_, config| {
                 *config = node_config.clone();
             })))
             .with_init_genesis_config(Some(Arc::new(|genesis_config| {

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -6,7 +6,7 @@ use crate::{Factory, GenesisConfig, GenesisConfigFn, NodeConfigFn, Result, Swarm
 use anyhow::{bail, Context};
 use aptos_config::config::NodeConfig;
 use aptos_framework::ReleaseBundle;
-use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn};
+use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn, InitGenesisStakeFn};
 use aptos_infallible::Mutex;
 use rand::rngs::StdRng;
 use std::{
@@ -122,6 +122,7 @@ impl LocalFactory {
         genesis_framework: Option<ReleaseBundle>,
         init_config: Option<InitConfigFn>,
         vfn_config: Option<NodeConfig>,
+        init_genesis_stake: Option<InitGenesisStakeFn>,
         init_genesis_config: Option<InitGenesisConfigFn>,
         guard: ActiveNodesGuard,
     ) -> Result<LocalSwarm>
@@ -136,6 +137,7 @@ impl LocalFactory {
             self.versions.clone(),
             Some(version.clone()),
             init_config,
+            init_genesis_stake,
             init_genesis_config,
             swarmdir,
             genesis_framework,
@@ -206,6 +208,7 @@ impl Factory for LocalFactory {
                 num_fullnodes,
                 version,
                 framework,
+                None,
                 None,
                 None,
                 None,

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -44,7 +44,7 @@ use std::{
 async fn test_analyze_validators() {
     let (mut swarm, cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_i, _conf, genesis_stake_amount| {
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
             *genesis_stake_amount = 100000;
         }))
         .build_with_cli(0)
@@ -188,7 +188,7 @@ async fn check_vote_to_elected(swarm: &mut LocalSwarm) -> (Option<u64>, Option<u
 #[ignore]
 async fn test_onchain_config_change() {
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 400;
             conf.consensus.quorum_store_poll_time_ms = 100;
@@ -540,7 +540,7 @@ async fn test_large_total_stake() {
     // just barelly below u64::MAX
     const BASE: u64 = 10_000_000_000_000_000_000;
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
-        .with_init_config(Arc::new(|_, _, genesis_stake_amount| {
+        .with_init_genesis_stake(Arc::new(|_, genesis_stake_amount| {
             // make sure we have quorum
             *genesis_stake_amount = BASE;
         }))
@@ -606,12 +606,13 @@ async fn test_nodes_rewards() {
     const BASE: u64 = 3600u64 * 24 * 365 * 10 * 100;
 
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
-        .with_init_config(Arc::new(|i, conf, genesis_stake_amount| {
+        .with_init_config(Arc::new(|_, conf| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 200;
             conf.consensus.quorum_store_poll_time_ms = 100;
             conf.api.failpoints_enabled = true;
-
+        }))
+        .with_init_genesis_stake(Arc::new(|i, genesis_stake_amount| {
             // make sure we have quorum
             *genesis_stake_amount = if i < 2 { 10 * BASE } else { BASE };
         }))
@@ -1035,10 +1036,12 @@ async fn test_register_and_update_validator() {
 async fn test_join_and_leave_validator() {
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_i, conf, genesis_stake_amount| {
+        .with_init_config(Arc::new(|_i, conf| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 200;
             conf.consensus.quorum_store_poll_time_ms = 100;
+        }))
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
             *genesis_stake_amount = 100000;
         }))
         .with_init_genesis_config(Arc::new(|genesis_config| {
@@ -1197,10 +1200,12 @@ async fn test_join_and_leave_validator() {
 async fn test_owner_create_and_delegate_flow() {
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_i, conf, genesis_stake_amount| {
+        .with_init_config(Arc::new(|_i, conf| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 200;
             conf.consensus.quorum_store_poll_time_ms = 100;
+        }))
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
             // enough for quorum
             *genesis_stake_amount = 5000000;
         }))

--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -23,7 +23,7 @@ use std::{
 
 pub async fn create_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
     let swarm = SwarmBuilder::new_local(num_nodes)
-        .with_init_config(Arc::new(move |_, config, _| {
+        .with_init_config(Arc::new(move |_, config| {
             config.api.failpoints_enabled = true;
             config.consensus.max_sending_block_txns = max_block_txns;
             config

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -180,7 +180,7 @@ async fn test_onchain_config_quorum_store_enabled_and_disabled() {
 async fn test_remote_batch_reads() {
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             conf.api.failpoints_enabled = true;
         }))
         // TODO: remove when quorum store becomes the in-code default
@@ -315,7 +315,7 @@ async fn test_batch_id_on_restart_wiped_db() {
 async fn test_swarm_with_bad_non_qs_node() {
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             conf.api.failpoints_enabled = true;
         }))
         // TODO: remove when quorum store becomes the in-code default

--- a/testsuite/smoke-test/src/indexer.rs
+++ b/testsuite/smoke-test/src/indexer.rs
@@ -100,7 +100,7 @@ async fn test_old_indexer() {
 
     let mut swarm = crate::smoke_test_environment::SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.storage.enable_indexer = true;
 
             config.indexer.enabled = true;

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -175,7 +175,7 @@ async fn test_file_discovery() {
     let discovery_file_for_closure = discovery_file.clone();
     let swarm = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(move |_, config, _| {
+        .with_init_config(Arc::new(move |_, config| {
             let discovery_file_for_closure2 = discovery_file_for_closure.clone();
             modify_network_config(config, &NetworkId::Validator, move |network| {
                 network.discovery_method = DiscoveryMethod::None;
@@ -210,7 +210,7 @@ async fn test_peer_monitoring_service_enabled() {
     // Create a swarm of 4 validators with peer monitoring enabled
     let swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.peer_monitoring_service.enable_peer_monitoring_client = true;
         }))
         .build()
@@ -227,7 +227,7 @@ async fn test_network_performance_monitoring() {
     // Create a swarm of 4 validators with peer monitoring enabled
     let swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.peer_monitoring_service.enable_peer_monitoring_client = true;
             config
                 .peer_monitoring_service

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -174,7 +174,7 @@ async fn test_gas_estimation_inner(swarm: &mut LocalSwarm) {
 #[tokio::test]
 async fn test_gas_estimation_txns_limit() {
     let mut swarm = SwarmBuilder::new_local(1)
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             let max_block_txns = 3;
             conf.api.gas_estimation.enabled = true;
             // Use a small full block threshold to make gas estimates update sooner.
@@ -213,7 +213,7 @@ async fn test_gas_estimation_gas_used_limit() {
                 block_gas_limit: Some(1),
             });
         }))
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             let max_block_txns = 3;
             conf.api.gas_estimation.enabled = true;
             // The full block threshold will never be hit

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -63,7 +63,7 @@ async fn setup_simple_test(
     JoinHandle<anyhow::Result<()>>,
     RosettaClient,
 ) {
-    setup_test(num_accounts, Arc::new(|_, _, _| {})).await
+    setup_test(num_accounts, Arc::new(|_, _| {})).await
 }
 
 async fn setup_test(
@@ -128,7 +128,7 @@ async fn test_block_transactions() {
 
     let (swarm, cli, _faucet, rosetta_client) = setup_test(
         2,
-        Arc::new(|_, config, _| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
+        Arc::new(|_, config| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
     )
     .await;
 
@@ -2478,7 +2478,7 @@ async fn test_delegation_pool_operations() {
 
     let (mut swarm, cli, _, rosetta_client) = setup_test(
         2,
-        Arc::new(|_, config, _| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
+        Arc::new(|_, config| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
     )
     .await;
 

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -8,7 +8,7 @@ use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
 use aptos_forge::{ActiveNodesGuard, Factory, LocalFactory, LocalSwarm, Node};
 use aptos_framework::ReleaseBundle;
-use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn};
+use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn, InitGenesisStakeFn};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::chain_id::ChainId;
@@ -27,6 +27,7 @@ pub struct SwarmBuilder {
     genesis_framework: Option<ReleaseBundle>,
     init_config: Option<InitConfigFn>,
     vfn_config: Option<NodeConfig>,
+    init_genesis_stake: Option<InitGenesisStakeFn>,
     init_genesis_config: Option<InitGenesisConfigFn>,
 }
 
@@ -39,6 +40,7 @@ impl SwarmBuilder {
             genesis_framework: None,
             init_config: None,
             vfn_config: None,
+            init_genesis_stake: None,
             init_genesis_config: None,
         }
     }
@@ -64,6 +66,11 @@ impl SwarmBuilder {
 
     pub fn with_vfn_config(mut self, config: NodeConfig) -> Self {
         self.vfn_config = Some(config);
+        self
+    }
+
+    pub fn with_init_genesis_stake(mut self, init_genesis_stake: InitGenesisStakeFn) -> Self {
+        self.init_genesis_stake = Some(init_genesis_stake);
         self
     }
 
@@ -105,6 +112,7 @@ impl SwarmBuilder {
                 builder.genesis_framework,
                 builder.init_config,
                 builder.vfn_config,
+                builder.init_genesis_stake,
                 Some(Arc::new(move |genesis_config| {
                     if let Some(init_genesis_config) = &init_genesis_config {
                         (init_genesis_config)(genesis_config);

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -103,7 +103,7 @@ async fn test_full_node_bootstrap_transactions_or_outputs() {
     // Create a validator swarm of 1 validator node with a small network limit
     let mut swarm = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.storage_service.max_network_chunk_bytes = 5 * 1024;
         }))
         .build()
@@ -135,7 +135,7 @@ async fn test_full_node_bootstrap_snapshot_transactions_or_outputs() {
     // Create a validator swarm of 1 validator node with a small network limit
     let mut swarm = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.storage_service.max_network_chunk_bytes = 500 * 1024;
         }))
         .build()
@@ -294,7 +294,7 @@ async fn test_validator_bootstrap_outputs() {
     // Create a swarm of 4 validators using output syncing
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -325,7 +325,7 @@ async fn test_validator_bootstrap_outputs_network_limit() {
     // Create a swarm of 4 validators using output syncing and an aggressive network limit
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -346,7 +346,7 @@ async fn test_validator_bootstrap_outputs_network_limit_tiny() {
     // This forces all chunks to be of size 1.
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -365,7 +365,7 @@ async fn test_validator_bootstrap_state_snapshot_no_compression() {
     // Create a swarm of 4 validators using state snapshot syncing
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -385,7 +385,7 @@ async fn test_validator_bootstrap_state_snapshot_network_limit() {
     // Create a swarm of 4 validators using state snapshot syncing and an aggressive network limit
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -406,7 +406,7 @@ async fn test_validator_bootstrap_state_snapshot_network_limit_tiny() {
     // This forces all chunks to be of size 1.
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -439,7 +439,7 @@ async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators using transaction syncing
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -457,7 +457,7 @@ async fn test_validator_bootstrap_transactions_or_outputs() {
     // Create a swarm of 4 validators using transaction or output syncing
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteOrApplyFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -482,7 +482,7 @@ async fn test_validator_bootstrap_transactions_network_limit() {
     // Create a swarm of 4 validators using transaction syncing and an aggressive network limit
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -503,7 +503,7 @@ async fn test_validator_bootstrap_transactions_network_limit_tiny() {
     // This forces all chunks to be of size 1.
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -522,7 +522,7 @@ async fn test_validator_bootstrap_outputs_network_exponential_backoff() {
     // Create a swarm of 4 validators using output syncing and a small response timeout
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -541,7 +541,7 @@ async fn test_validator_bootstrap_transactions_no_compression() {
     // Create a swarm of 4 validators using transaction syncing and no compression
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -562,7 +562,7 @@ async fn perform_full_node_bootstrap_state_snapshot(epoch_changes: bool) {
     // Create a swarm with 2 validators
     let mut swarm = SwarmBuilder::new_local(2)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
         }))
@@ -611,7 +611,7 @@ async fn perform_validator_bootstrap_state_snapshot(epoch_changes: bool) {
     // Create a swarm of 4 validators using snapshot (fast) syncing and a chunk size = 30
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.storage_service.max_state_chunk_size = 30;
@@ -648,7 +648,7 @@ async fn perform_validator_bootstrap_state_snapshot_exponential_backoff(epoch_ch
     // Create a swarm of 4 validators using state snapshot syncing and a small response timeout
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -726,7 +726,7 @@ async fn test_validator_failure_bootstrap_outputs() {
     // Create a swarm of 4 validators with state snapshot bootstrapping and output syncing
     let swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
@@ -747,7 +747,7 @@ async fn test_validator_failure_bootstrap_execution() {
     // Create a swarm of 4 validators with state snapshot bootstrapping and transaction syncing
     let swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
+        .with_init_config(Arc::new(|_, config| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =

--- a/testsuite/smoke-test/src/test_smoke_tests.rs
+++ b/testsuite/smoke-test/src/test_smoke_tests.rs
@@ -20,7 +20,7 @@ use std::{
 async fn test_aptos_node_after_get_bin() {
     let mut swarm = SwarmBuilder::new_local(1)
         .with_aptos()
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             conf.api.failpoints_enabled = true;
         }))
         .build()

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -21,7 +21,7 @@ use std::{
 async fn test_txn_broadcast() {
     let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
-        .with_init_config(Arc::new(|_, conf, _| {
+        .with_init_config(Arc::new(|_, conf| {
             conf.api.failpoints_enabled = true;
         }))
         .build()

--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -217,7 +217,7 @@ async fn test_upgrade_flow() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_release_validate_tool_multi_step() {
     let (mut env, _, _) = SwarmBuilder::new_local(1)
-        .with_init_config(Arc::new(|_, _, genesis_stake_amount| {
+        .with_init_genesis_stake(Arc::new(|_, genesis_stake_amount| {
             // make sure we have quorum
             *genesis_stake_amount = 2000000000000000;
         }))


### PR DESCRIPTION
### Description

Remove stake parameter from `InitConfigFn` and create a separate `InitGenesisStakeFn`. This is a noop, but refactors the two separate parts of logic. Motivation is clarity and to make a future larger change more clear.

### Test Plan

Run existing tests. Nothing is expected to change.
