### PR TITLE
Fixing issue #7306

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -194,10 +194,17 @@ impl BuiltPackage {
                 bail!("extended checks failed")
             }
         }
+
+        let compiled_pkg_path = package
+            .compiled_package_info
+            .build_flags
+            .install_dir
+            .as_ref()
+            .unwrap_or(&package_path)
+            .join(CompiledPackageLayout::Root.path())
+            .join(package.compiled_package_info.package_name.as_str());
         inject_runtime_metadata(
-            package_path
-                .join(CompiledPackageLayout::Root.path())
-                .join(package.compiled_package_info.package_name.as_str()),
+            compiled_pkg_path,
             &mut package,
             runtime_metadata,
             bytecode_version,


### PR DESCRIPTION
### Description

See issue #7306 for more details on the problem being fixed.

When using `aptos move compile --output-dir`, the function `inject_runtime_metadata` was erroneously using the default path for the `.mv` file, instead of the path in the specified directory. We now use the specified path if one is provided, or else use the default.

### Test Plan

I manually tested that we pick the right directory. It is not clear what sort of automated test makes sense in this scenario.
