### PR TITLE
[indexer] Local development improvement(docs + code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ aptos-move/move-examples/scripts/minter/build/Minter/*
 # Docker incremental build temporary files and directories
 target-out-docker
 **/Dockerfile.tmp
+# Indexer grpc temporary certificates.
+docker/compose/indexer-grpc/data-service-grpc-server.crt
+docker/compose/indexer-grpc/data-service-grpc-server.key
+
 
 # Doc generation output
 *.md.old

--- a/developer-docs-site/docs/indexer/txn-stream/local-development.md
+++ b/developer-docs-site/docs/indexer/txn-stream/local-development.md
@@ -31,6 +31,7 @@ In order to use the local development script you must have the following install
 docker-compose version --short
 ```
 - grpcurl: [Installation Guide](https://github.com/fullstorydev/grpcurl#installation)
+- OpenSSL
 
 ## Preparation
 Clone the aptos-core repo:
@@ -108,3 +109,11 @@ Try setting the following environment variable before running the script:
 ```bash
 export REDIS_IMAGE_REPO=arm64v8/redis
 ```
+
+### Cache worker is crashlooping or `Redis latest version update failed.` in log
+Wipe the data:
+```bash
+poetry run python indexer_grpc_local.py wipe
+```
+
+This means historical data will be lost.

--- a/developer-docs-site/scripts/additional_dict.txt
+++ b/developer-docs-site/scripts/additional_dict.txt
@@ -224,6 +224,7 @@ Octa
 Octas
 Ohlone
 OpenAPI
+OpenSSL
 OptionalAggregator
 PFN
 PFNs

--- a/docker/builder/indexer-grpc.Dockerfile
+++ b/docker/builder/indexer-grpc.Dockerfile
@@ -22,9 +22,9 @@ COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-post-processor /
 # The health check port
 EXPOSE 8080
 # The gRPC non-TLS port
-EXPOSE 50051
-# The gRPC TLS port
 EXPOSE 50052
+# The gRPC TLS port
+EXPOSE 50053
 
 ENV RUST_LOG_FORMAT=json
 

--- a/docker/compose/indexer-grpc/data-service-config.yaml
+++ b/docker/compose/indexer-grpc/data-service-config.yaml
@@ -3,6 +3,10 @@ health_check_port: 8084
 server_config:
   data_service_grpc_non_tls_config:
       data_service_grpc_listen_address: 0.0.0.0:50052
+  data_service_grpc_tls_config:
+      data_service_grpc_listen_address: 0.0.0.0:50053
+      cert_path: /opt/aptos/certs/data-service-grpc-server.crt
+      key_path: /opt/aptos/certs/data-service-grpc-server.key
   whitelisted_auth_tokens: ["dummy_token"]
   file_store_config:
     file_store_type: LocalFileStore

--- a/docker/compose/indexer-grpc/docker-compose.yaml
+++ b/docker/compose/indexer-grpc/docker-compose.yaml
@@ -14,7 +14,8 @@
 version: "3.8"
 services:
   redis:
-    image: ${REDIS_IMAGE_REPO:-redis}:6.2
+    image: ${REDIS_IMAGE_REPO:-redis}:7.2
+    command: redis-server --appendonly yes
     networks:
       shared:
         ipv4_address:  172.16.1.12
@@ -25,7 +26,7 @@ services:
       - 6379:6379
 
   redis-replica:
-    image: ${REDIS_IMAGE_REPO:-redis}:6.2
+    image: ${REDIS_IMAGE_REPO:-redis}:7.2
     command: redis-server --replicaof redis 6379
     networks:
       shared:
@@ -89,12 +90,19 @@ services:
       - type: bind
         source: ./data-service-config.yaml
         target: /opt/aptos/data-service-config.yaml
+      - type: bind
+        source: ./data-service-grpc-server.key
+        target: /opt/aptos/certs/data-service-grpc-server.key
+      - type: bind
+        source: ./data-service-grpc-server.crt
+        target: /opt/aptos/certs/data-service-grpc-server.crt
     command:
       - '/usr/local/bin/aptos-indexer-grpc-data-service'
       - '--config-path'
       - '/opt/aptos/data-service-config.yaml'
     ports:
-      - "50052:50052" # GRPC
+      - "50052:50052" # GRPC non-secure
+      - "50053:50053" # GRPC secure
       - "18084:8084" # health
     depends_on:
       - indexer-grpc-cache-worker


### PR DESCRIPTION
### Description

* Allow the local development to setup both tls and non-tls endpoints.
* update the redis to version 7(i noticed some segfault on version 6). 

![image](https://github.com/aptos-labs/aptos-core/assets/112209412/87bf2089-9048-47cc-af2d-421d86313a7f)


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

* non-TLS
`grpcurl  -plaintext -d  '{ "starting_version": 0 }' -H "x-aptos-data-authorization:dummy_token" localhost:50052 aptos.indexer.v1.RawData/GetTransactions`
* TLS
`grpcurl  -insecure -d  '{ "starting_version": 0 }' -H "x-aptos-data-authorization:dummy_token" localhost:50053 aptos.indexer.v1.RawData/GetTransactions`


