### PR TITLE
Update doc for FeeStatement on-chain struct

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_fee.md
@@ -152,7 +152,23 @@ collected when executing the block.
 
 ## Struct `FeeStatement`
 
-Summary of the fees charged and refunds issued for a transaction.
+Breakdown of fee charge and refund for a transaction.
+The structure is:
+
+- Net charge or refund (not in the statement)
+- total charge: total_charge_gas_units, matches <code>gas_used</code> in the on-chain <code>TransactionInfo</code>.
+This is the sum of the sub-items below. Notice that there's potential precision loss when
+the conversion between internal and external gas units and between native token and gas
+units, so it's possible that the numbers don't add up exactly. -- This number is the final
+charge, while the break down is merely informational.
+- gas charge for execution (CPU time): <code>execution_gas_units</code>
+- gas charge for IO (storage random access): <code>io_gas_units</code>
+- storage fee charge (storage space): <code>storage_fee_octas</code>, to be included in
+<code>total_charge_gas_unit</code>, this number is converted to gas units according to the user
+specified <code>gas_unit_price</code> on the transaction.
+- storage deletion refund: <code>storage_fee_refund_octas</code>, this is not included in <code>gas_used</code> or
+<code>total_charge_gas_units</code>, the net charge / refund is calculated by
+<code>total_charge_gas_units</code> * <code>gas_unit_price</code> - <code>storage_fee_refund_octas</code>.
 
 This is meant to emitted as a module event.
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -39,7 +39,23 @@ module aptos_framework::transaction_fee {
     }
 
     #[event]
-    /// Summary of the fees charged and refunds issued for a transaction.
+    /// Breakdown of fee charge and refund for a transaction.
+    /// The structure is:
+    ///
+    /// - Net charge or refund (not in the statement)
+    ///    - total charge: total_charge_gas_units, matches `gas_used` in the on-chain `TransactionInfo`.
+    ///      This is the sum of the sub-items below. Notice that there's potential precision loss when
+    ///      the conversion between internal and external gas units and between native token and gas
+    ///      units, so it's possible that the numbers don't add up exactly. -- This number is the final
+    ///      charge, while the break down is merely informational.
+    ///        - gas charge for execution (CPU time): `execution_gas_units`
+    ///        - gas charge for IO (storage random access): `io_gas_units`
+    ///        - storage fee charge (storage space): `storage_fee_octas`, to be included in
+    ///          `total_charge_gas_unit`, this number is converted to gas units according to the user
+    ///          specified `gas_unit_price` on the transaction.
+    ///    - storage deletion refund: `storage_fee_refund_octas`, this is not included in `gas_used` or
+    ///      `total_charge_gas_units`, the net charge / refund is calculated by
+    ///      `total_charge_gas_units` * `gas_unit_price` - `storage_fee_refund_octas`.
     ///
     /// This is meant to emitted as a module event.
     struct FeeStatement has drop, store {

--- a/types/src/fee_statement.rs
+++ b/types/src/fee_statement.rs
@@ -7,14 +7,26 @@ use serde::{Deserialize, Serialize};
 /// The structure is:
 ///
 /// - Net charge or refund (not in the statement)
-///   - total charge: total_charge_gas_units, matches `gas_used` in the on-chain `TransactionInfo`.
-///     - gas charge for execution (CPU time): execution_gas_units
-///     - gas charge for IO (storage random access): io_gas_units
-///     - storage fee charge (storage space): storage_fee_octas, when included in total_charge, this number is converted to gas units according to the user specified gas unit price.
-///   - storage deletion refund: storage_fee_refund_octas, this is not included in `gas_used` or `total_charge_gas_units`, the net charge / refund is calculated by total_charge_gas_units * gas_unit_price - storage_fee_refund_octas.
+///    - total charge: total_charge_gas_units, matches `gas_used` in the on-chain `TransactionInfo`.
+///      This is the sum of the sub-items below. Notice that there's potential precision loss when
+///      the conversion between internal and external gas units and between native token and gas
+///      units, so it's possible that the numbers don't add up exactly. -- This number is the final
+///      charge, while the break down is merely informational.
+///        - gas charge for execution (CPU time): `execution_gas_units`
+///        - gas charge for IO (storage random access): `io_gas_units`
+///        - storage fee charge (storage space): `storage_fee_octas`, to be included in
+///          `total_charge_gas_unit`, this number is converted to gas units according to the user
+///          specified `gas_unit_price` on the transaction.
+///    - storage deletion refund: `storage_fee_refund_octas`, this is not included in `gas_used` or
+///      `total_charge_gas_units`, the net charge / refund is calculated by
+///      `total_charge_gas_units` * `gas_unit_price` - `storage_fee_refund_octas`.
+///
+/// This is meant to emitted as a module event.
+///
+/// (keep this doc in sync with the `struct FeeStatement` in Move.)
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FeeStatement {
-    /// Total gas charge, not including
+    /// Total gas charge.
     total_charge_gas_units: u64,
     /// Execution gas charge.
     execution_gas_units: u64,


### PR DESCRIPTION
### Description
Just realized the fancier version of the doc on FeeStatement was put on top of the Rust struct instead of the Move counterpart.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
