### PR TITLE
[Aptos-release-builder] Add printing package metadata to the aptos-release-builder

### DIFF
--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -63,6 +63,8 @@ pub enum Commands {
         print_gas_schedule: bool,
     },
     /// Print out package metadata.
+    /// Usage: --endpoint '<URL>'
+    /// --package-address <ADDRESS> --package-name <PACKAGE_NAME> [--print-json]
     PrintPackageMetadata {
         /// Url endpoint for the desired network. e.g: https://fullnode.mainnet.aptoslabs.com/v1.
         #[clap(short, long)]
@@ -73,6 +75,9 @@ pub enum Commands {
         /// The name of the package
         #[clap(long)]
         package_name: String,
+        /// Whether to print the original data in json
+        #[clap(long)]
+        print_json: bool,
     },
 }
 
@@ -229,6 +234,7 @@ async fn main() -> anyhow::Result<()> {
             endpoint,
             package_address,
             package_name,
+            print_json,
         } => {
             let client = aptos_rest_client::Client::new(endpoint);
             let address = AccountAddress::from_str_strict(&package_address)?;
@@ -237,7 +243,12 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
             for package in packages.into_inner().packages {
                 if package.name == package_name {
-                    println!("PackageMetadata:\n{}", package);
+                    if print_json {
+                        println!("{}", serde_json::to_string(&package).unwrap());
+                    } else {
+                        println!("{}", package);
+                    }
+                    break;
                 }
             }
             Ok(())

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::natives::any::Any;
+use crate::{natives::any::Any, unzip_metadata_str};
 use anyhow::bail;
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
@@ -78,6 +78,28 @@ pub struct PackageMetadata {
     pub extension: MoveOption<Any>,
 }
 
+impl fmt::Display for PackageMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Package name:{}", self.name)?;
+        writeln!(f, "Upgrade policy:{}", self.upgrade_policy)?;
+        writeln!(f, "Upgrade number:{}", self.upgrade_number)?;
+        writeln!(f, "Source digest:{}", self.source_digest)?;
+        let manifest_str = unzip_metadata_str(&self.manifest).unwrap();
+        writeln!(f, "Manifest:")?;
+        writeln!(f, "{}", manifest_str)?;
+        writeln!(f, "Package Dependency:")?;
+        for dep in &self.deps {
+            writeln!(f, "{:?}", dep)?;
+        }
+        writeln!(f, "extension:{:?}", self.extension)?;
+        writeln!(f, "Modules:")?;
+        for module in &self.modules {
+            writeln!(f, "{}", module)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PackageDep {
     pub account: AccountAddress,
@@ -92,6 +114,24 @@ pub struct ModuleMetadata {
     #[serde(with = "serde_bytes")]
     pub source_map: Vec<u8>,
     pub extension: MoveOption<Any>,
+}
+
+impl fmt::Display for ModuleMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Module name:{}", self.name)?;
+        if !self.source.is_empty() {
+            writeln!(f, "Source code:")?;
+            let source = unzip_metadata_str(&self.source).unwrap();
+            writeln!(f, "{}", source)?;
+        }
+        if !self.source_map.is_empty() {
+            writeln!(f, "Source map:")?;
+            let source_map = unzip_metadata_str(&self.source_map).unwrap();
+            writeln!(f, "{}", source_map)?;
+        }
+        writeln!(f, "Module extension:{:?}", self.extension)?;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
### Description

This PR adds a new subcommand `print-package-metadata` to the aptos-release-builder to print out the package metadata given the package name and the account address.

Usage: aptos-release-builder print-package-metadata --endpoint '\<URL\>' --package-address \<ADDRESS\> --package-name <PACKAGE_NAME> [--print-json]

For instance, when executing the command `aptos-release-builder print-package-metadata --endpoint 'https://mainnet.aptoslabs.com/v1' --package-address 0x1 --package-name AptosFramework`, the output looks like this:

```PackageMetadata:
Package name:AptosFramework
Upgrade policy:compatible
Upgrade number:8
Source digest:DB1749CC57545C1CF4F3099837619D27A1397E7802EF926DE6E1576BC0CC7112
Manifest:
[package]
name = "AptosFramework"
version = "1.0.0"

[addresses]
std = "0x1"
aptos_std = "0x1"
aptos_framework = "0x1"
aptos_token = "0x3"
core_resources = "0xA550C18"
vm_reserved = "0x0"

[dependencies]
AptosStdlib = { local = "../aptos-stdlib" }
MoveStdlib = { local = "../move-stdlib" }

Package Dependency:
PackageDep { account: 0000000000000000000000000000000000000000000000000000000000000001, package_name: "AptosStdlib" }
PackageDep { account: 0000000000000000000000000000000000000000000000000000000000000001, package_name: "MoveStdlib" }
extension:MoveOption { value: [] }
Modules:
Module name:system_addresses
Source code:
...
```
Note that the metadata of each module will also be printed out and they are omitted here.


