### PR TITLE
trivial: avoid StateValue::from() in production

### DIFF
--- a/aptos-move/aptos-vm/src/sharded_block_executor/aggr_overridden_state_view.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/aggr_overridden_state_view.rs
@@ -26,8 +26,10 @@ impl<'a, S: StateView + Sync + Send> AggregatorOverriddenStateView<'a, S> {
     }
 
     fn total_supply_base_view_override(&self) -> Result<Option<StateValue>> {
-        Ok(Some(StateValue::from(
-            bcs::to_bytes(&self.total_supply_aggr_base_val).unwrap(),
+        Ok(Some(StateValue::new_legacy(
+            bcs::to_bytes(&self.total_supply_aggr_base_val)
+                .unwrap()
+                .into(),
         )))
     }
 }


### PR DESCRIPTION
### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
