### PR TITLE
[dag] commit signer

### DIFF
--- a/consensus/src/dag/commit_signer.rs
+++ b/consensus/src/dag/commit_signer.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 use crate::experimental::signing_phase::CommitSignerProvider;
 use aptos_crypto::bls12381;
 use aptos_types::validator_signer::ValidatorSigner;

--- a/consensus/src/dag/commit_signer.rs
+++ b/consensus/src/dag/commit_signer.rs
@@ -1,0 +1,28 @@
+use crate::experimental::signing_phase::CommitSignerProvider;
+use aptos_crypto::bls12381;
+use aptos_types::validator_signer::ValidatorSigner;
+
+pub struct DagCommitSigner {
+    signer: ValidatorSigner,
+}
+
+impl DagCommitSigner {
+    pub fn new(signer: ValidatorSigner) -> Self {
+        Self { signer }
+    }
+}
+
+impl CommitSignerProvider for DagCommitSigner {
+    fn sign_commit_vote(
+        &self,
+        _ledger_info: aptos_types::ledger_info::LedgerInfoWithSignatures,
+        new_ledger_info: aptos_types::ledger_info::LedgerInfo,
+    ) -> Result<bls12381::Signature, aptos_safety_rules::Error> {
+        let signature = self
+            .signer
+            .sign(&new_ledger_info)
+            .map_err(|err| aptos_safety_rules::Error::SerializationError(err.to_string()))?;
+
+        Ok(signature)
+    }
+}

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -5,6 +5,7 @@
 mod adapter;
 mod anchor_election;
 mod bootstrap;
+mod commit_signer;
 mod dag_driver;
 mod dag_fetcher;
 mod dag_handler;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1201,10 +1201,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     }
 }
 
-fn new_signer_from_storage(
-    author: Author,
-    backend: &SecureBackend,
-) -> aptos_types::validator_signer::ValidatorSigner {
+fn new_signer_from_storage(author: Author, backend: &SecureBackend) -> Arc<ValidatorSigner> {
     let storage: Storage = backend.try_into().expect("Unable to initialize storage");
     if let Err(error) = storage.available() {
         panic!("Storage is not available: {:?}", error);
@@ -1213,5 +1210,5 @@ fn new_signer_from_storage(
         .get(CONSENSUS_KEY)
         .map(|v| v.value)
         .expect("Unable to get private key");
-    ValidatorSigner::new(author, private_key)
+    Arc::new(ValidatorSigner::new(author, private_key))
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -55,17 +55,19 @@ use crate::{
 use anyhow::{bail, ensure, Context};
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
-use aptos_config::config::{ConsensusConfig, NodeConfig};
+use aptos_config::config::{ConsensusConfig, NodeConfig, SecureBackend};
 use aptos_consensus_types::{
     common::{Author, Round},
     epoch_retrieval::EpochRetrievalRequest,
 };
 use aptos_event_notifications::ReconfigNotificationListener;
+use aptos_global_constants::CONSENSUS_KEY;
 use aptos_infallible::{duration_since_epoch, Mutex};
 use aptos_logger::prelude::*;
 use aptos_mempool::QuorumStoreRequest;
 use aptos_network::{application::interface::NetworkClient, protocols::network::Event};
 use aptos_safety_rules::SafetyRulesManager;
+use aptos_secure_storage::{KVStorage, Storage};
 use aptos_types::{
     account_address::AccountAddress,
     epoch_change::EpochChangeProof,
@@ -74,6 +76,7 @@ use aptos_types::{
         LeaderReputationType, OnChainConfigPayload, OnChainConfigProvider, OnChainConsensusConfig,
         OnChainExecutionConfig, ProposerElectionType, ValidatorSet,
     },
+    validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
 use fail::fail_point;
@@ -1196,4 +1199,19 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 .set(duration_since_epoch().as_millis() as i64);
         }
     }
+}
+
+fn new_signer_from_storage(
+    author: Author,
+    backend: &SecureBackend,
+) -> aptos_types::validator_signer::ValidatorSigner {
+    let storage: Storage = backend.try_into().expect("Unable to initialize storage");
+    if let Err(error) = storage.available() {
+        panic!("Storage is not available: {:?}", error);
+    }
+    let private_key = storage
+        .get(CONSENSUS_KEY)
+        .map(|v| v.value)
+        .expect("Unable to get private key");
+    ValidatorSigner::new(author, private_key)
 }


### PR DESCRIPTION
### Description

This PR introduces a commit signer struct that implements CommitSignerProvider to sign buffer manager commit proofs for DAG produced blocks.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
