### PR TITLE
[dag] store parent block info in adapter

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -210,9 +210,10 @@ impl Block {
         payload: Payload,
         author: Author,
         failed_authors: Vec<(Round, Author)>,
+        parent_block_info: BlockInfo,
     ) -> anyhow::Result<Self> {
         let block_data =
-            BlockData::new_for_dag(epoch, round, timestamp, payload, author, failed_authors);
+            BlockData::new_for_dag(epoch, round, timestamp, payload, author, failed_authors, parent_block_info);
         Self::new_proposal_from_block_data(block_data, &ValidatorSigner::from_int(0))
     }
 

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -212,8 +212,15 @@ impl Block {
         failed_authors: Vec<(Round, Author)>,
         parent_block_info: BlockInfo,
     ) -> anyhow::Result<Self> {
-        let block_data =
-            BlockData::new_for_dag(epoch, round, timestamp, payload, author, failed_authors, parent_block_info);
+        let block_data = BlockData::new_for_dag(
+            epoch,
+            round,
+            timestamp,
+            payload,
+            author,
+            failed_authors,
+            parent_block_info,
+        );
         Self::new_proposal_from_block_data(block_data, &ValidatorSigner::from_int(0))
     }
 

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -218,13 +218,14 @@ impl BlockData {
         payload: Payload,
         author: Author,
         failed_authors: Vec<(Round, Author)>,
+        parent_block_info: BlockInfo
     ) -> Self {
         Self {
             epoch,
             round,
             timestamp_usecs,
             quorum_cert: QuorumCert::new(
-                VoteData::new(BlockInfo::empty(), BlockInfo::empty()),
+                VoteData::new(parent_block_info, BlockInfo::empty()),
                 LedgerInfoWithSignatures::new(
                     LedgerInfo::new(BlockInfo::empty(), HashValue::zero()),
                     AggregateSignature::empty(),

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -218,7 +218,7 @@ impl BlockData {
         payload: Payload,
         author: Author,
         failed_authors: Vec<(Round, Author)>,
-        parent_block_info: BlockInfo
+        parent_block_info: BlockInfo,
     ) -> Self {
         Self {
             epoch,


### PR DESCRIPTION
### Description

This PR introduces the ability to cache parent block info in adapter, so they can be included in the block before pushing to execution. Execution requires that the block info refer to a valid parent block info.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
