### PR TITLE
[Forge] Add a netbench test

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -44,6 +44,7 @@ pub use indexer_grpc_config::*;
 pub use inspection_service_config::*;
 pub use logger_config::*;
 pub use mempool_config::*;
+pub use netbench::*;
 pub use network_config::*;
 pub use node_config::*;
 pub use node_config_loader::sanitize_node_config;

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1370,13 +1370,13 @@ fn netbench_config_100_megabytes_per_s() -> NetbenchConfig {
     }
 }
 
-fn netbench_config_20_megabytes_per_s() -> NetbenchConfig {
+fn netbench_config_2_megabytes_per_s() -> NetbenchConfig {
     NetbenchConfig {
         enabled: true,
         max_network_channel_size: 1000,
         enable_direct_send_testing: true,
         direct_send_data_size: 100000,
-        direct_send_per_second: 200,
+        direct_send_per_second: 20,
         ..Default::default()
     }
 }
@@ -1396,7 +1396,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
         .with_initial_validator_count(NonZeroUsize::new(2).unwrap())
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             // Not using 100 MBps here, as it will lead to throughput collapse
-            config.netbench = Some(netbench_config_20_megabytes_per_s());
+            config.netbench = Some(netbench_config_2_megabytes_per_s());
         }))
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -526,7 +526,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => net_bench(), // TODO: remove this before landing
-        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
+        "realistic_env_max_load" => net_bench(), // TODO: remove this before landing
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/testcases/src/data/two_region_link_stats.csv
+++ b/testsuite/testcases/src/data/two_region_link_stats.csv
@@ -1,0 +1,3 @@
+sending_region,receiving_region,bitrate_bps,avgrtt
+aws--sa-east-1,aws--ap-northeast-1,32505856,255.289
+aws--ap-northeast-1,aws--sa-east-1,32243712,255.323

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -11,17 +11,16 @@ use std::collections::BTreeMap;
 /// The link stats are obtained from https://github.com/doitintl/intercloud-throughput/blob/master/results_202202/results.csv
 /// The four regions were hand-picked from the dataset to simulate a multi-region setup
 /// with high latencies and low bandwidth.
-macro_rules! FOUR_REGION_LINK_STATS_CSV {
+macro_rules! TWO_REGION_LINK_STATS_CSV {
     () => {
-        "data/four_region_link_stats.csv"
+        "data/two_region_link_stats.csv"
     };
 }
 
 fn get_link_stats_table() -> BTreeMap<String, BTreeMap<String, (u64, f64)>> {
     let mut stats_table = BTreeMap::new();
 
-    let mut rdr =
-        csv::Reader::from_reader(include_bytes!(FOUR_REGION_LINK_STATS_CSV!()).as_slice());
+    let mut rdr = csv::Reader::from_reader(include_bytes!(TWO_REGION_LINK_STATS_CSV!()).as_slice());
     rdr.deserialize()
         .for_each(|result: Result<(String, String, u64, f64), _>| {
             if let Ok((from, to, bitrate, latency)) = result {

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -8,7 +8,11 @@ use aptos_types::PeerId;
 use itertools::{self, EitherOrBoth, Itertools};
 use std::collections::BTreeMap;
 
+/// The link stats are obtained from https://github.com/doitintl/intercloud-throughput/blob/master/results_202202/results.csv
+/// The four regions were hand-picked from the dataset to simulate a multi-region setup
+/// with high latencies and low bandwidth.
 const FOUR_REGION_LINK_STATS: &[u8] = include_bytes!("data/four_region_link_stats.csv");
+/// The two regions were chosen as the most distant regions among the four regions set.
 const TWO_REGION_LINK_STATS: &[u8] = include_bytes!("data/two_region_link_stats.csv");
 
 fn get_link_stats_table(csv: &[u8]) -> BTreeMap<String, BTreeMap<String, (u64, f64)>> {


### PR DESCRIPTION
### Description

Create netbench tests across a pair of nodes, one colocated and the other emulated on a high-latency (and low bandwidth) network.

For now there is no success criteria, but we should be able to add one based on throughput when needed.

### Test Plan

Run the tests in forge.
