### PR TITLE
[Node Configs] Update sanitizer to be read-only and migrate indexer ops.

### DIFF
--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -135,7 +135,7 @@ impl ApiConfig {
 
 impl ConfigSanitizer for ApiConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn test_sanitize_disabled_api() {
         // Create a node config with the API disabled
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             api: ApiConfig {
                 enabled: false,
                 failpoints_enabled: true,
@@ -186,13 +186,13 @@ mod tests {
         };
 
         // Sanitize the config and verify that it succeeds
-        ApiConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet()).unwrap();
+        ApiConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet()).unwrap();
     }
 
     #[test]
     fn test_sanitize_failpoints_on_mainnet() {
         // Create a node config with failpoints enabled
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             api: ApiConfig {
                 enabled: true,
                 failpoints_enabled: true,
@@ -203,15 +203,15 @@ mod tests {
 
         // Sanitize the config and verify that it fails because
         // failpoints are not supported on mainnet.
-        let error = ApiConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
-            .unwrap_err();
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet()).unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
 
     #[test]
     fn test_sanitize_invalid_workers() {
         // Create a node config with failpoints enabled
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             api: ApiConfig {
                 enabled: true,
                 max_runtime_workers: None,
@@ -223,8 +223,8 @@ mod tests {
 
         // Sanitize the config and verify that it fails because
         // the runtime worker multiplier is invalid.
-        let error = ApiConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
-            .unwrap_err();
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet()).unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
 }

--- a/config/src/config/base_config.rs
+++ b/config/src/config/base_config.rs
@@ -34,7 +34,7 @@ impl Default for BaseConfig {
 
 impl ConfigSanitizer for BaseConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -179,7 +179,7 @@ mod test {
     #[test]
     fn test_sanitize_valid_base_config() {
         // Create a node config with a waypoint
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             base: BaseConfig {
                 waypoint: WaypointConfig::FromConfig(Waypoint::default()),
                 ..Default::default()
@@ -188,13 +188,13 @@ mod test {
         };
 
         // Sanitize the config and verify that it passes
-        BaseConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet()).unwrap();
+        BaseConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet()).unwrap();
     }
 
     #[test]
     fn test_sanitize_missing_waypoint() {
         // Create a node config with a missing waypoint
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             base: BaseConfig {
                 waypoint: WaypointConfig::None,
                 ..Default::default()
@@ -203,7 +203,7 @@ mod test {
         };
 
         // Sanitize the config and verify that it fails because of the missing waypoint
-        let error = BaseConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+        let error = BaseConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
             .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }

--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     config::{
-        node_config_loader::NodeType, utils::get_config_name, Error, InspectionServiceConfig,
-        LoggerConfig, MempoolConfig, NodeConfig, Peer, PeerMonitoringServiceConfig, PeerRole,
-        PeerSet, StateSyncConfig,
+        node_config_loader::NodeType, utils::get_config_name, Error, IndexerConfig,
+        InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig, Peer,
+        PeerMonitoringServiceConfig, PeerRole, PeerSet, StateSyncConfig,
     },
     network_id::NetworkId,
 };
@@ -17,6 +17,7 @@ use std::{collections::HashMap, str::FromStr};
 
 // Useful optimizer constants
 const OPTIMIZER_STRING: &str = "Optimizer";
+const ALL_NETWORKS_OPTIMIZER_NAME: &str = "AllNetworkConfigOptimizer";
 const PUBLIC_NETWORK_OPTIMIZER_NAME: &str = "PublicNetworkConfigOptimizer";
 const VALIDATOR_NETWORK_OPTIMIZER_NAME: &str = "ValidatorNetworkConfigOptimizer";
 
@@ -96,6 +97,9 @@ impl ConfigOptimizer for NodeConfig {
     ) -> Result<bool, Error> {
         // Optimize only the relevant sub-configs
         let mut optimizers_with_modifications = vec![];
+        if IndexerConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(IndexerConfig::get_optimizer_name());
+        }
         if InspectionServiceConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(InspectionServiceConfig::get_optimizer_name());
         }
@@ -116,6 +120,9 @@ impl ConfigOptimizer for NodeConfig {
         if StateSyncConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(StateSyncConfig::get_optimizer_name());
         }
+        if optimize_all_network_configs(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(ALL_NETWORKS_OPTIMIZER_NAME.to_string());
+        }
         if optimize_public_network_config(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(PUBLIC_NETWORK_OPTIMIZER_NAME.to_string());
         }
@@ -126,6 +133,30 @@ impl ConfigOptimizer for NodeConfig {
         // Return true iff any config modifications were made
         Ok(!optimizers_with_modifications.is_empty())
     }
+}
+
+/// Optimizes all network configs according to the node type and chain ID
+fn optimize_all_network_configs(
+    node_config: &mut NodeConfig,
+    _local_config_yaml: &Value,
+    _node_type: NodeType,
+    _chain_id: ChainId,
+) -> Result<bool, Error> {
+    let mut modified_config = false;
+
+    // Set the listener address and prepare the node identities for the validator network
+    if let Some(validator_network) = &mut node_config.validator_network {
+        validator_network.set_listen_address_and_prepare_identity()?;
+        modified_config = true;
+    }
+
+    // Set the listener address and prepare the node identities for the fullnode networks
+    for fullnode_network in &mut node_config.full_node_networks {
+        fullnode_network.set_listen_address_and_prepare_identity()?;
+        modified_config = true;
+    }
+
+    Ok(modified_config)
 }
 
 /// Optimize the public network config according to the node type and chain ID

--- a/config/src/config/config_sanitizer.rs
+++ b/config/src/config/config_sanitizer.rs
@@ -4,9 +4,9 @@
 use crate::config::{
     node_config_loader::NodeType,
     utils::{are_failpoints_enabled, get_config_name},
-    ApiConfig, BaseConfig, ConsensusConfig, Error, ExecutionConfig, IndexerConfig,
-    IndexerGrpcConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig,
-    PeerMonitoringServiceConfig, StateSyncConfig, StorageConfig,
+    ApiConfig, BaseConfig, ConsensusConfig, Error, ExecutionConfig, IndexerGrpcConfig,
+    InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig, PeerMonitoringServiceConfig,
+    StateSyncConfig, StorageConfig,
 };
 use aptos_types::chain_id::ChainId;
 use std::collections::HashSet;
@@ -27,7 +27,7 @@ pub trait ConfigSanitizer {
 
     /// Validate and process the config according to the given node type and chain ID
     fn sanitize(
-        _node_config: &mut NodeConfig,
+        _node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -37,7 +37,7 @@ pub trait ConfigSanitizer {
 
 impl ConfigSanitizer for NodeConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -48,7 +48,6 @@ impl ConfigSanitizer for NodeConfig {
         ExecutionConfig::sanitize(node_config, node_type, chain_id)?;
         sanitize_failpoints_config(node_config, node_type, chain_id)?;
         sanitize_fullnode_network_configs(node_config, node_type, chain_id)?;
-        IndexerConfig::sanitize(node_config, node_type, chain_id)?;
         IndexerGrpcConfig::sanitize(node_config, node_type, chain_id)?;
         InspectionServiceConfig::sanitize(node_config, node_type, chain_id)?;
         LoggerConfig::sanitize(node_config, node_type, chain_id)?;
@@ -64,7 +63,7 @@ impl ConfigSanitizer for NodeConfig {
 
 /// Sanitize the failpoints config according to the node role and chain ID
 fn sanitize_failpoints_config(
-    node_config: &mut NodeConfig,
+    node_config: &NodeConfig,
     _node_type: NodeType,
     chain_id: ChainId,
 ) -> Result<(), Error> {
@@ -100,12 +99,12 @@ fn sanitize_failpoints_config(
 
 /// Sanitize the fullnode network configs according to the node role and chain ID
 fn sanitize_fullnode_network_configs(
-    node_config: &mut NodeConfig,
+    node_config: &NodeConfig,
     node_type: NodeType,
     _chain_id: ChainId,
 ) -> Result<(), Error> {
     let sanitizer_name = FULLNODE_NETWORKS_SANITIZER_NAME.to_string();
-    let fullnode_networks = &mut node_config.full_node_networks;
+    let fullnode_networks = &node_config.full_node_networks;
 
     // Verify that the fullnode network configs are not empty for fullnodes
     if fullnode_networks.is_empty() && !node_type.is_validator() {
@@ -138,9 +137,6 @@ fn sanitize_fullnode_network_configs(
                 ),
             ));
         }
-
-        // Prepare the network id
-        fullnode_network_config.set_listen_address_and_prepare_identity()?;
     }
 
     Ok(())
@@ -148,12 +144,12 @@ fn sanitize_fullnode_network_configs(
 
 /// Sanitize the validator network config according to the node role and chain ID
 fn sanitize_validator_network_config(
-    node_config: &mut NodeConfig,
+    node_config: &NodeConfig,
     node_type: NodeType,
     _chain_id: ChainId,
 ) -> Result<(), Error> {
     let sanitizer_name = VALIDATOR_NETWORK_SANITIZER_NAME.to_string();
-    let validator_network = &mut node_config.validator_network;
+    let validator_network = &node_config.validator_network;
 
     // Verify that the validator network config is not empty for validators
     if validator_network.is_none() && node_type.is_validator() {
@@ -188,9 +184,6 @@ fn sanitize_validator_network_config(
                 "Mutual authentication must be enabled for the validator network!".into(),
             ));
         }
-
-        // Prepare the network id
-        validator_network_config.set_listen_address_and_prepare_identity()?;
     }
 
     Ok(())
@@ -204,14 +197,14 @@ mod tests {
     #[test]
     fn test_sanitize_missing_pfn_network_configs() {
         // Create a PFN config with empty fullnode network configs
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             full_node_networks: vec![],
             ..Default::default()
         };
 
         // Sanitize the config and verify that it fails
         let error = sanitize_fullnode_network_configs(
-            &mut node_config,
+            &node_config,
             NodeType::PublicFullnode,
             ChainId::mainnet(),
         )
@@ -222,14 +215,14 @@ mod tests {
     #[test]
     fn test_sanitize_missing_vfn_network_configs() {
         // Create a VFN config with empty fullnode network configs
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             full_node_networks: vec![],
             ..Default::default()
         };
 
         // Sanitize the PFN config and verify that it fails
         let error = sanitize_fullnode_network_configs(
-            &mut node_config,
+            &node_config,
             NodeType::ValidatorFullnode,
             ChainId::testnet(),
         )
@@ -240,7 +233,7 @@ mod tests {
     #[test]
     fn test_sanitize_validator_network_for_fullnode() {
         // Create a fullnode config that includes a validator network
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             full_node_networks: vec![NetworkConfig {
                 network_id: NetworkId::Validator,
                 ..Default::default()
@@ -250,7 +243,7 @@ mod tests {
 
         // Sanitize the config and verify that it fails
         let error = sanitize_fullnode_network_configs(
-            &mut node_config,
+            &node_config,
             NodeType::PublicFullnode,
             ChainId::testnet(),
         )
@@ -261,7 +254,7 @@ mod tests {
     #[test]
     fn test_sanitize_duplicate_fullnode_network_configs() {
         // Create a node config with multiple fullnode network configs with the same network id
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             full_node_networks: vec![
                 NetworkConfig {
                     network_id: NetworkId::Public,
@@ -277,7 +270,7 @@ mod tests {
 
         // Sanitize the config and verify that it fails
         let error = sanitize_fullnode_network_configs(
-            &mut node_config,
+            &node_config,
             NodeType::ValidatorFullnode,
             ChainId::testnet(),
         )
@@ -288,14 +281,14 @@ mod tests {
     #[test]
     fn test_sanitize_missing_validator_network_config() {
         // Create a node config with an empty validator network config
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             validator_network: None,
             ..Default::default()
         };
 
         // Sanitize the config and verify that it fails
         let error = sanitize_validator_network_config(
-            &mut node_config,
+            &node_config,
             NodeType::Validator,
             ChainId::testnet(),
         )
@@ -306,7 +299,7 @@ mod tests {
     #[test]
     fn test_sanitize_validator_network_fullnode() {
         // Create a validator network config
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             validator_network: Some(NetworkConfig {
                 network_id: NetworkId::Validator,
                 mutual_authentication: true,
@@ -317,7 +310,7 @@ mod tests {
 
         // Sanitize the config (for a fullnode) and verify that it fails
         let error = sanitize_validator_network_config(
-            &mut node_config,
+            &node_config,
             NodeType::PublicFullnode,
             ChainId::testnet(),
         )
@@ -328,7 +321,7 @@ mod tests {
     #[test]
     fn test_sanitize_validator_disabled_authentication() {
         // Create a validator config with disabled mutual authentication
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             validator_network: Some(NetworkConfig {
                 network_id: NetworkId::Validator,
                 mutual_authentication: false,
@@ -339,7 +332,7 @@ mod tests {
 
         // Sanitize the config and verify that it fails
         let error = sanitize_validator_network_config(
-            &mut node_config,
+            &node_config,
             NodeType::Validator,
             ChainId::testnet(),
         )
@@ -350,7 +343,7 @@ mod tests {
     #[test]
     fn test_sanitize_validator_incorrect_network_id() {
         // Create a validator config with the wrong network ID
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             validator_network: Some(NetworkConfig {
                 network_id: NetworkId::Public,
                 ..Default::default()
@@ -360,7 +353,7 @@ mod tests {
 
         // Sanitize the config and verify that it fails
         let error = sanitize_validator_network_config(
-            &mut node_config,
+            &node_config,
             NodeType::Validator,
             ChainId::testnet(),
         )

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -351,7 +351,7 @@ impl ConsensusConfig {
 
 impl ConfigSanitizer for ConsensusConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -127,7 +127,7 @@ impl ExecutionConfig {
 
 impl ConfigSanitizer for ExecutionConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -166,7 +166,7 @@ mod test {
     #[test]
     fn test_sanitize_valid_execution_config() {
         // Create a node config with a valid execution config
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             execution: ExecutionConfig {
                 paranoid_hot_potato_verification: true,
                 paranoid_type_verification: true,
@@ -176,14 +176,13 @@ mod test {
         };
 
         // Sanitize the config and verify that it succeeds
-        ExecutionConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
-            .unwrap();
+        ExecutionConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet()).unwrap();
     }
 
     #[test]
     fn test_sanitize_hot_potato_mainnet() {
         // Create a node config with missing paranoid_hot_potato_verification on mainnet
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             execution: ExecutionConfig {
                 paranoid_hot_potato_verification: false,
                 paranoid_type_verification: true,
@@ -194,7 +193,7 @@ mod test {
 
         // Sanitize the config and verify that it fails
         let error =
-            ExecutionConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            ExecutionConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
@@ -202,7 +201,7 @@ mod test {
     #[test]
     fn test_sanitize_paranoid_type_mainnet() {
         // Create a node config with missing paranoid_type_verification on mainnet
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             execution: ExecutionConfig {
                 paranoid_hot_potato_verification: true,
                 paranoid_type_verification: false,
@@ -213,7 +212,7 @@ mod test {
 
         // Sanitize the config and verify that it fails
         let error =
-            ExecutionConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            ExecutionConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -50,7 +50,7 @@ impl Default for GasEstimationConfig {
 
 impl ConfigSanitizer for GasEstimationConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/indexer_config.rs
+++ b/config/src/config/indexer_config.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, Error, NodeConfig,
+    config_optimizer::ConfigOptimizer, node_config_loader::NodeType, Error, NodeConfig,
 };
 use aptos_logger::warn;
 use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::fmt::{Debug, Formatter};
 
 // Useful indexer environment variables
@@ -115,20 +116,25 @@ impl Debug for IndexerConfig {
     }
 }
 
-impl ConfigSanitizer for IndexerConfig {
-    fn sanitize(
+impl ConfigOptimizer for IndexerConfig {
+    fn optimize(
         node_config: &mut NodeConfig,
+        _local_config_yaml: &Value,
         _node_type: NodeType,
         _chain_id: ChainId,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
+        // If the indexer is not enabled, there's nothing to do
         let indexer_config = &mut node_config.indexer;
-
-        // If the indexer is not enabled, there's nothing to validate
         if !indexer_config.enabled {
-            return Ok(());
+            return Ok(false);
         }
 
-        // Verify the postgres uri
+        // TODO: we really shouldn't be overriding the configs if they are
+        // specified in the local node config file. This optimizer should
+        // migrate to the pattern used by other optimizers, but for now, we'll
+        // just keep the legacy behaviour to avoid breaking anything.
+
+        // Verify and set the postgres uri
         indexer_config.postgres_uri = env_var_or_default(
             INDEXER_DATABASE_URL,
             indexer_config.postgres_uri.clone(),
@@ -138,7 +144,7 @@ impl ConfigSanitizer for IndexerConfig {
             )),
         );
 
-        // Verify the processor
+        // Verify and set the processor
         indexer_config.processor = env_var_or_default(
             PROCESSOR_NAME,
             indexer_config
@@ -148,7 +154,7 @@ impl ConfigSanitizer for IndexerConfig {
             None,
         );
 
-        // Verify the starting version
+        // Verify and set the starting version
         indexer_config.starting_version = match std::env::var(STARTING_VERSION).ok() {
             None => indexer_config.starting_version,
             Some(starting_version) => match starting_version.parse::<u64>() {
@@ -189,7 +195,7 @@ impl ConfigSanitizer for IndexerConfig {
             None,
         );
 
-        Ok(())
+        Ok(true)
     }
 }
 

--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -59,7 +59,7 @@ impl Default for IndexerGrpcConfig {
 
 impl ConfigSanitizer for IndexerGrpcConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/inspection_service_config.rs
+++ b/config/src/config/inspection_service_config.rs
@@ -42,7 +42,7 @@ impl InspectionServiceConfig {
 
 impl ConfigSanitizer for InspectionServiceConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn test_sanitize_valid_service_config() {
         // Create an inspection service config with the configuration endpoint enabled
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             inspection_service: InspectionServiceConfig {
                 expose_configuration: true,
                 ..Default::default()
@@ -199,7 +199,7 @@ mod tests {
 
         // Verify that the configuration is sanitized successfully
         InspectionServiceConfig::sanitize(
-            &mut node_config,
+            &node_config,
             NodeType::PublicFullnode,
             ChainId::mainnet(),
         )
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_sanitize_config_mainnet() {
         // Create an inspection service config with the configuration endpoint enabled
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             inspection_service: InspectionServiceConfig {
                 expose_configuration: true,
                 ..Default::default()
@@ -219,7 +219,7 @@ mod tests {
 
         // Verify that sanitization fails for mainnet
         let error = InspectionServiceConfig::sanitize(
-            &mut node_config,
+            &node_config,
             NodeType::Validator,
             ChainId::mainnet(),
         )

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -69,7 +69,7 @@ impl LoggerConfig {
 
 impl ConfigSanitizer for LoggerConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_sanitize_missing_feature() {
         // Create a logger config with the tokio console port set
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             logger: LoggerConfig {
                 tokio_console_port: Some(100),
                 ..Default::default()
@@ -197,9 +197,8 @@ mod tests {
         };
 
         // Verify that the config fails sanitization (the tokio-console feature is missing!)
-        let error =
-            LoggerConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::testnet())
-                .unwrap_err();
+        let error = LoggerConfig::sanitize(&node_config, NodeType::Validator, ChainId::testnet())
+            .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
 }

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -83,7 +83,7 @@ impl Default for MempoolConfig {
 
 impl ConfigSanitizer for MempoolConfig {
     fn sanitize(
-        _node_config: &mut NodeConfig,
+        _node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -127,7 +127,7 @@ impl Default for NodeMonitoringConfig {
 
 impl ConfigSanitizer for PeerMonitoringServiceConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -138,7 +138,7 @@ impl ConfigSanitizer for PeerMonitoringServiceConfig {
 
 impl ConfigSanitizer for PerformanceMonitoringConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -184,7 +184,7 @@ impl QuorumStoreConfig {
 
 impl ConfigSanitizer for QuorumStoreConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -70,7 +70,7 @@ impl SafetyRulesConfig {
 
 impl ConfigSanitizer for SafetyRulesConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn test_sanitize_invalid_backend_for_mainnet() {
         // Create a node config with an invalid backend for mainnet
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             consensus: ConsensusConfig {
                 safety_rules: SafetyRulesConfig {
                     backend: SecureBackend::InMemoryStorage,
@@ -245,7 +245,7 @@ mod tests {
 
         // Verify that the config sanitizer fails
         let error =
-            SafetyRulesConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            SafetyRulesConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_sanitize_backend_for_mainnet_fullnodes() {
         // Create a node config with an invalid backend for mainnet validators
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             consensus: ConsensusConfig {
                 safety_rules: SafetyRulesConfig {
                     backend: SecureBackend::InMemoryStorage,
@@ -265,18 +265,14 @@ mod tests {
         };
 
         // Verify that the config sanitizer passes because the node is a fullnode
-        SafetyRulesConfig::sanitize(
-            &mut node_config,
-            NodeType::PublicFullnode,
-            ChainId::mainnet(),
-        )
-        .unwrap();
+        SafetyRulesConfig::sanitize(&node_config, NodeType::PublicFullnode, ChainId::mainnet())
+            .unwrap();
     }
 
     #[test]
     fn test_sanitize_invalid_service_for_mainnet() {
         // Create a node config with a non-local service
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             consensus: ConsensusConfig {
                 safety_rules: SafetyRulesConfig {
                     service: SafetyRulesService::Serializer,
@@ -289,7 +285,7 @@ mod tests {
 
         // Verify that the config sanitizer fails
         let error =
-            SafetyRulesConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            SafetyRulesConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
@@ -297,7 +293,7 @@ mod tests {
     #[test]
     fn test_sanitize_test_config_on_mainnet() {
         // Create a node config with a test config
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             consensus: ConsensusConfig {
                 safety_rules: SafetyRulesConfig {
                     test: Some(SafetyRulesTestConfig::new(PeerId::random())),
@@ -310,7 +306,7 @@ mod tests {
 
         // Verify that the config sanitizer fails
         let error =
-            SafetyRulesConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            SafetyRulesConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
@@ -318,7 +314,7 @@ mod tests {
     #[test]
     fn test_sanitize_missing_initial_safety_rules() {
         // Create a node config with a test config
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             consensus: ConsensusConfig {
                 safety_rules: SafetyRulesConfig {
                     test: Some(SafetyRulesTestConfig::new(PeerId::random())),
@@ -331,7 +327,7 @@ mod tests {
 
         // Verify that the config sanitizer fails
         let error =
-            SafetyRulesConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::mainnet())
+            SafetyRulesConfig::sanitize(&node_config, NodeType::Validator, ChainId::mainnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -315,7 +315,7 @@ impl Default for AptosDataClientConfig {
 
 impl ConfigSanitizer for StateSyncConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         node_type: NodeType,
         chain_id: ChainId,
     ) -> Result<(), Error> {
@@ -326,12 +326,12 @@ impl ConfigSanitizer for StateSyncConfig {
 
 impl ConfigSanitizer for StateSyncDriverConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {
         let sanitizer_name = Self::get_sanitizer_name();
-        let state_sync_driver_config = &mut node_config.state_sync.state_sync_driver;
+        let state_sync_driver_config = &node_config.state_sync.state_sync_driver;
 
         // Verify that auto-bootstrapping is not enabled for
         // nodes that are fast syncing.
@@ -627,7 +627,7 @@ mod tests {
     fn test_sanitize_auto_bootstrapping_fast_sync() {
         // Create a node config with fast sync and
         // auto bootstrapping enabled.
-        let mut node_config = NodeConfig {
+        let node_config = NodeConfig {
             state_sync: StateSyncConfig {
                 state_sync_driver: StateSyncDriverConfig {
                     bootstrapping_mode: BootstrappingMode::DownloadLatestStates,
@@ -641,7 +641,7 @@ mod tests {
 
         // Verify that sanitization fails
         let error =
-            StateSyncConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::testnet())
+            StateSyncConfig::sanitize(&node_config, NodeType::Validator, ChainId::testnet())
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -292,7 +292,7 @@ impl StorageConfig {
 
 impl ConfigSanitizer for StorageConfig {
     fn sanitize(
-        node_config: &mut NodeConfig,
+        node_config: &NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {


### PR DESCRIPTION
### Description
This PR:
1. Updates the `ConfigSanitizer` to take in an immutable `NodeConfig` reference. This should help to make it obvious that the sanitizer is responsible only for sanitizing/checking configs and not modifying them. Modifications should happen in the `ConfigOptimizer` step.
2. Migrates any existing `sanitize()` methods to `optimize()` if they need to modify the configs. To avoid breaking anything, I've kept the behaviour the same and added a comment about the requirements for the optimizers to not change values if specified by the node config file. This can be dealt with in a follow-up PR.

### Test Plan
Existing test infrastructure.