### PR TITLE
[dag] async message handler support

### DIFF
--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -16,18 +16,19 @@ use crate::{
     },
     state_replication::PayloadClient,
 };
-use anyhow::{bail, Ok};
-use aptos_consensus_types::common::{Author, Payload};
+use anyhow::bail;
+use aptos_consensus_types::common::{Author, PayloadFilter};
 use aptos_infallible::RwLock;
-use aptos_logger::error;
+use aptos_logger::{debug, error};
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{block_info::Round, epoch_state::EpochState};
+use async_trait::async_trait;
 use futures::{
     future::{AbortHandle, Abortable},
-    FutureExt,
+    FutureExt, executor::block_on,
 };
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use thiserror::Error as ThisError;
 use tokio_retry::strategy::ExponentialBackoff;
 
@@ -71,6 +72,9 @@ impl DagDriver {
             .read()
             .get_strong_links_for_round(highest_round, &epoch_state.verifier)
             .map_or_else(|| highest_round.saturating_sub(1), |_| highest_round);
+
+        debug!("highest_round: {}, current_round: {}", highest_round, current_round);
+
         let mut driver = Self {
             author,
             epoch_state,
@@ -96,34 +100,40 @@ impl DagDriver {
                 .read()
                 .get_strong_links_for_round(current_round, &driver.epoch_state.verifier)
                 .unwrap_or(vec![]);
-            driver.enter_new_round(current_round + 1, strong_links);
+            block_on(driver.enter_new_round(current_round + 1, strong_links));
         }
         driver
     }
 
-    pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
-        let mut dag_writer = self.dag.write();
-        let round = node.metadata().round();
+    pub async fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
+        let maybe_strong_links = {
+            let mut dag_writer = self.dag.write();
+            let round = node.metadata().round();
 
-        if !dag_writer.all_exists(node.parents_metadata()) {
-            if let Err(err) = self.fetch_requester.request_for_certified_node(node) {
-                error!("request to fetch failed: {}", err);
+            if !dag_writer.all_exists(node.parents_metadata()) {
+                if let Err(err) = self.fetch_requester.request_for_certified_node(node) {
+                    error!("request to fetch failed: {}", err);
+                }
+                bail!(DagDriverError::MissingParents);
             }
-            bail!(DagDriverError::MissingParents);
-        }
 
-        dag_writer.add_node(node)?;
-        if self.current_round == round {
-            let maybe_strong_links = dag_writer
-                .get_strong_links_for_round(self.current_round, &self.epoch_state.verifier);
-            drop(dag_writer);
-            if let Some(strong_links) = maybe_strong_links {
-                self.enter_new_round(self.current_round + 1, strong_links);
+            dag_writer.add_node(node)?;
+            if self.current_round == round {
+                dag_writer
+                    .get_strong_links_for_round(self.current_round, &self.epoch_state.verifier)
+            } else {
+                None
             }
+        };
+
+        if let Some(strong_links) = maybe_strong_links {
+            self.enter_new_round(self.current_round + 1, strong_links)
+                .await;
         }
         Ok(())
     }
 
+    pub async fn enter_new_round(&mut self, new_round: Round, strong_links: Vec<NodeCertificate>) {
     pub fn enter_new_round(&mut self, new_round: Round, strong_links: Vec<NodeCertificate>) {
         // TODO: support pulling payload
         let payload = Payload::empty(false);
@@ -171,11 +181,12 @@ impl DagDriver {
     }
 }
 
+#[async_trait]
 impl RpcHandler for DagDriver {
     type Request = CertifiedNode;
     type Response = CertifiedAck;
 
-    fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
+    async fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
         let epoch = node.metadata().epoch();
         {
             let dag_reader = self.dag.read();
@@ -186,6 +197,7 @@ impl RpcHandler for DagDriver {
 
         let node_metadata = node.metadata().clone();
         self.add_node(node)
+            .await
             .map(|_| self.order_rule.process_new_node(&node_metadata))?;
 
         Ok(CertifiedAck::new(epoch))

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -25,8 +25,9 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{block_info::Round, epoch_state::EpochState};
 use async_trait::async_trait;
 use futures::{
+    executor::block_on,
     future::{AbortHandle, Abortable},
-    FutureExt, executor::block_on,
+    FutureExt,
 };
 use std::{sync::Arc, time::Duration};
 use thiserror::Error as ThisError;
@@ -73,7 +74,10 @@ impl DagDriver {
             .get_strong_links_for_round(highest_round, &epoch_state.verifier)
             .map_or_else(|| highest_round.saturating_sub(1), |_| highest_round);
 
-        debug!("highest_round: {}, current_round: {}", highest_round, current_round);
+        debug!(
+            "highest_round: {}, current_round: {}",
+            highest_round, current_round
+        );
 
         let mut driver = Self {
             author,

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -303,11 +303,12 @@ impl FetchRequestHandler {
     }
 }
 
+#[async_trait]
 impl RpcHandler for FetchRequestHandler {
     type Request = RemoteFetchRequest;
     type Response = FetchResponse;
 
-    fn process(&mut self, message: Self::Request) -> anyhow::Result<Self::Response> {
+    async fn process(&mut self, message: Self::Request) -> anyhow::Result<Self::Response> {
         let dag_reader = self.dag.read();
 
         // `Certified Node`: In the good case, there should exist at least one honest validator that

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -76,16 +76,42 @@ impl NetworkHandler {
                     }
                 },
                 Some(res) = self.node_fetch_waiter.next() => {
-                    if let Err(e) = res.map_err(|e| anyhow::anyhow!("recv error: {}", e)).and_then(|node| self.node_receiver.process(node)) {
+                    match res {
+                        Ok(node) => if let Err(e) = self.node_receiver.process(node).await {
                         warn!(error = ?e, "error processing node fetch notification");
-                    }
+                        },
+                        Err(e) => {
+                            debug!("sender dropped channel: {}", e);
+                        },
+                    };
                 },
                 Some(res) = self.certified_node_fetch_waiter.next() => {
-                    if let Err(e) = res.map_err(|e| anyhow::anyhow!("recv error: {}", e)).and_then(|certified_node| self.dag_driver.process(certified_node)) {
-                        warn!(error = ?e, "error processing certified node fetch notification");
-                    }
+                    match res {
+                        Ok(certified_node) => if let Err(e) = self.dag_driver.process(certified_node).await {
+                            warn!(error = ?e, "error processing certified node fetch notification");                        },
+                        Err(e) => {
+                            debug!("sender dropped channel: {}", e);
+                        },
+                    };
                 }
             }
+        }
+    }
+
+    fn verify_incoming_rpc(&self, dag_message: &DAGMessage) -> Result<(), anyhow::Error> {
+        match dag_message {
+            DAGMessage::NodeMsg(node) => node.verify(&self.epoch_state.verifier),
+            DAGMessage::CertifiedNodeMsg(certified_node) => {
+                certified_node.verify(&self.epoch_state.verifier)
+            },
+            DAGMessage::FetchRequest(request) => request.verify(&self.epoch_state.verifier),
+            _ => {
+                error!(
+                    "unknown rpc message {:?}",
+                    std::mem::discriminant(dag_message)
+                );
+                Err(anyhow::anyhow!("unexpected rpc message"))
+            },
         }
     }
 
@@ -102,32 +128,30 @@ impl NetworkHandler {
             bail!("message author and network author mismatch");
         }
 
-        let response: anyhow::Result<DAGMessage> = match dag_message {
-            DAGMessage::NodeMsg(node) => node
-                .verify(&self.epoch_state.verifier)
-                .and_then(|_| self.node_receiver.process(node))
-                .map(|r| r.into()),
+        let response: anyhow::Result<DAGMessage> = {
+            match self.verify_incoming_rpc(&dag_message) {
+                Ok(_) => match dag_message {
+                    DAGMessage::NodeMsg(node) => {
+                        self.node_receiver.process(node).await.map(|r| r.into())
+                    },
             DAGMessage::CertifiedNodeMsg(certified_node_msg) => {
-                match certified_node_msg.verify(&self.epoch_state.verifier) {
-                    Ok(_) => match self.state_sync_trigger.check(certified_node_msg).await {
+                        match self.state_sync_trigger.check(certified_node_msg).await {
                         ret @ (NeedsSync(_), None) => return Ok(ret.0),
                         (Synced, Some(certified_node_msg)) => self
                             .dag_driver
                             .process(certified_node_msg.certified_node())
+                                .await
                             .map(|r| r.into()),
                         _ => unreachable!(),
+                        }
+            },
+                    DAGMessage::FetchRequest(request) => {
+                        self.fetch_receiver.process(request).await.map(|r| r.into())
                     },
-                    Err(e) => Err(e),
-                }
-            },
-            DAGMessage::FetchRequest(request) => request
-                .verify(&self.epoch_state.verifier)
-                .and_then(|_| self.fetch_receiver.process(request))
-                .map(|r| r.into()),
-            _ => {
-                error!("unknown rpc message {:?}", dag_message);
-                Err(anyhow::anyhow!("unknown rpc message"))
-            },
+                    _ => unreachable!("verification must catch this error"),
+                },
+                Err(err) => Err(err),
+            }
         };
 
         let response = response

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -17,7 +17,7 @@ use crate::{
 use anyhow::bail;
 use aptos_channels::aptos_channel;
 use aptos_consensus_types::common::Author;
-use aptos_logger::{error, warn};
+use aptos_logger::{debug, warn};
 use aptos_network::protocols::network::RpcError;
 use aptos_types::epoch_state::EpochState;
 use bytes::Bytes;
@@ -78,7 +78,7 @@ impl NetworkHandler {
                 Some(res) = self.node_fetch_waiter.next() => {
                     match res {
                         Ok(node) => if let Err(e) = self.node_receiver.process(node).await {
-                        warn!(error = ?e, "error processing node fetch notification");
+                            warn!(error = ?e, "error processing node fetch notification");
                         },
                         Err(e) => {
                             debug!("sender dropped channel: {}", e);
@@ -105,13 +105,10 @@ impl NetworkHandler {
                 certified_node.verify(&self.epoch_state.verifier)
             },
             DAGMessage::FetchRequest(request) => request.verify(&self.epoch_state.verifier),
-            _ => {
-                error!(
-                    "unknown rpc message {:?}",
-                    std::mem::discriminant(dag_message)
-                );
-                Err(anyhow::anyhow!("unexpected rpc message"))
-            },
+            _ => Err(anyhow::anyhow!(
+                "unexpected rpc message{:?}",
+                std::mem::discriminant(dag_message)
+            )),
         }
     }
 
@@ -129,22 +126,23 @@ impl NetworkHandler {
         }
 
         let response: anyhow::Result<DAGMessage> = {
-            match self.verify_incoming_rpc(&dag_message) {
+            let verification_result = self.verify_incoming_rpc(&dag_message);
+            match verification_result {
                 Ok(_) => match dag_message {
                     DAGMessage::NodeMsg(node) => {
                         self.node_receiver.process(node).await.map(|r| r.into())
                     },
-            DAGMessage::CertifiedNodeMsg(certified_node_msg) => {
+                    DAGMessage::CertifiedNodeMsg(certified_node_msg) => {
                         match self.state_sync_trigger.check(certified_node_msg).await {
-                        ret @ (NeedsSync(_), None) => return Ok(ret.0),
-                        (Synced, Some(certified_node_msg)) => self
-                            .dag_driver
-                            .process(certified_node_msg.certified_node())
+                            ret @ (NeedsSync(_), None) => return Ok(ret.0),
+                            (Synced, Some(certified_node_msg)) => self
+                                .dag_driver
+                                .process(certified_node_msg.certified_node())
                                 .await
-                            .map(|r| r.into()),
-                        _ => unreachable!(),
+                                .map(|r| r.into()),
+                            _ => unreachable!(),
                         }
-            },
+                    },
                     DAGMessage::FetchRequest(request) => {
                         self.fetch_receiver.process(request).await.map(|r| r.into())
                     },

--- a/consensus/src/dag/dag_network.rs
+++ b/consensus/src/dag/dag_network.rs
@@ -17,11 +17,12 @@ use std::{
     time::Duration,
 };
 
+#[async_trait]
 pub trait RpcHandler {
     type Request;
     type Response;
 
-    fn process(&mut self, message: Self::Request) -> anyhow::Result<Self::Response>;
+    async fn process(&mut self, message: Self::Request) -> anyhow::Result<Self::Response>;
 }
 
 #[async_trait]

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -42,8 +42,7 @@ impl StateSyncTrigger {
     }
 
     /// This method checks if a state sync is required, and if so,
-    /// notifies the bootstraper and yields the current task infinitely,
-    /// to let the bootstraper can abort this task.
+    /// notifies the bootstraper, to let the bootstraper can abort this task.
     pub(super) async fn check(
         &self,
         node: CertifiedNodeMessage,

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -12,6 +12,7 @@ use aptos_consensus_types::common::{Author, Round};
 use aptos_infallible::RwLock;
 use aptos_logger::error;
 use aptos_types::{epoch_state::EpochState, validator_signer::ValidatorSigner};
+use async_trait::async_trait;
 use std::{collections::BTreeMap, mem, sync::Arc};
 use thiserror::Error as ThisError;
 
@@ -140,11 +141,12 @@ fn read_votes_from_storage(
     votes_by_round_peer
 }
 
+#[async_trait]
 impl RpcHandler for NodeBroadcastHandler {
     type Request = Node;
     type Response = Vote;
 
-    fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
+    async fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
         let node = self.validate(node)?;
 
         let votes_by_peer = self

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -130,14 +130,14 @@ async fn test_certified_node_handler() {
 
     let first_round_node = new_certified_node(1, signers[0].author(), vec![]);
     // expect an ack for a valid message
-    assert_ok!(driver.process(first_round_node.clone()));
+    assert_ok!(driver.process(first_round_node.clone()).await);
     // expect an ack if the same message is sent again
-    assert_ok_eq!(driver.process(first_round_node), CertifiedAck::new(1));
+    assert_ok_eq!(driver.process(first_round_node).await, CertifiedAck::new(1));
 
     let parent_node = new_certified_node(1, signers[1].author(), vec![]);
     let invalid_node = new_certified_node(2, signers[0].author(), vec![parent_node.certificate()]);
     assert_eq!(
-        driver.process(invalid_node).unwrap_err().to_string(),
+        driver.process(invalid_node).await.unwrap_err().to_string(),
         DagDriverError::MissingParents.to_string()
     );
 }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -83,6 +83,7 @@ impl TDagFetcher for MockDagFetcher {
     ) -> anyhow::Result<()> {
         let response = FetchRequestHandler::new(self.target_dag.clone(), self.epoch_state.clone())
             .process(remote_request)
+            .await
             .unwrap();
 
         let mut new_dag_writer = new_dag.write();

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -14,8 +14,8 @@ use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_
 use claims::assert_ok_eq;
 use std::sync::Arc;
 
-#[test]
-fn test_dag_fetcher_receiver() {
+#[tokio::test]
+async fn test_dag_fetcher_receiver() {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
@@ -56,7 +56,7 @@ fn test_dag_fetcher_receiver() {
         DagSnapshotBitmask::new(1, vec![vec![true, false]]),
     );
     assert_ok_eq!(
-        fetcher.process(request),
+        fetcher.process(request).await,
         FetchResponse::new(1, vec![first_round_nodes[1].clone()])
     );
 }

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -70,7 +70,10 @@ async fn test_node_broadcast_receiver_succeed() {
     // expect an ack for a valid message
     assert_ok_eq!(rb_receiver.process(wellformed_node).await, expected_result);
     // expect the original ack for any future message from same author
-    assert_ok_eq!(rb_receiver.process(equivocating_node).await, expected_result);
+    assert_ok_eq!(
+        rb_receiver.process(equivocating_node).await,
+        expected_result
+    );
 }
 
 // TODO: Unit test node broad receiver with a pruned DAG store. Possibly need a validator verifier trait.

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -17,6 +17,7 @@ use aptos_types::{
     validator_verifier::random_validator_verifier,
 };
 use claims::{assert_ok, assert_ok_eq};
+use futures::executor::block_on;
 use std::{collections::BTreeMap, sync::Arc};
 
 struct MockFetchRequester {}
@@ -67,9 +68,9 @@ async fn test_node_broadcast_receiver_succeed() {
         wellformed_node.sign_vote(&signers[3]).unwrap(),
     );
     // expect an ack for a valid message
-    assert_ok_eq!(rb_receiver.process(wellformed_node), expected_result);
+    assert_ok_eq!(rb_receiver.process(wellformed_node).await, expected_result);
     // expect the original ack for any future message from same author
-    assert_ok_eq!(rb_receiver.process(equivocating_node), expected_result);
+    assert_ok_eq!(rb_receiver.process(equivocating_node).await, expected_result);
 }
 
 // TODO: Unit test node broad receiver with a pruned DAG store. Possibly need a validator verifier trait.
@@ -106,7 +107,7 @@ async fn test_node_broadcast_receiver_failure() {
 
     // Round 1
     let node = new_node(1, 10, signers[0].author(), vec![]);
-    let vote = rb_receivers[1].process(node.clone()).unwrap();
+    let vote = rb_receivers[1].process(node.clone()).await.unwrap();
 
     // Round 2 with invalid parent
     let partial_sigs = PartialSignatures::new(BTreeMap::from([(
@@ -121,7 +122,7 @@ async fn test_node_broadcast_receiver_failure() {
     );
     let node = new_node(2, 20, signers[0].author(), vec![node_cert]);
     assert_eq!(
-        rb_receivers[1].process(node).unwrap_err().to_string(),
+        rb_receivers[1].process(node).await.unwrap_err().to_string(),
         NodeBroadcastHandleError::InvalidParent.to_string(),
     );
 
@@ -135,7 +136,7 @@ async fn test_node_broadcast_receiver_failure() {
                 .iter_mut()
                 .zip(&signers)
                 .for_each(|(rb_receiver, signer)| {
-                    let sig = rb_receiver.process(node.clone()).unwrap();
+                    let sig = block_on(rb_receiver.process(node.clone())).unwrap();
                     partial_sigs.add_signature(signer.author(), sig.signature().clone())
                 });
             NodeCertificate::new(
@@ -150,13 +151,13 @@ async fn test_node_broadcast_receiver_failure() {
     // Add Round 2 node with proper certificates
     let node = new_node(2, 20, signers[0].author(), node_certificates);
     assert_eq!(
-        rb_receivers[0].process(node).unwrap_err().to_string(),
+        rb_receivers[0].process(node).await.unwrap_err().to_string(),
         NodeBroadcastHandleError::MissingParents.to_string()
     );
 }
 
-#[test]
-fn test_node_broadcast_receiver_storage() {
+#[tokio::test]
+async fn test_node_broadcast_receiver_storage() {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let signers: Vec<_> = signers.into_iter().map(Arc::new).collect();
     let epoch_state = Arc::new(EpochState {
@@ -181,7 +182,7 @@ fn test_node_broadcast_receiver_storage() {
         storage.clone(),
         Arc::new(MockFetchRequester {}),
     );
-    let sig = rb_receiver.process(node).expect("must succeed");
+    let sig = rb_receiver.process(node).await.expect("must succeed");
 
     assert_ok_eq!(storage.get_votes(), vec![(
         NodeId::new(0, 1, signers[0].author()),


### PR DESCRIPTION
### Description

This PR makes RpcHandler trait handler method async so any implementations can call other async methods. This is necessary to support pulling payload in Dag Driver.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
