### PR TITLE
[gha][forge] require git sha to checkout and test, not dependent on gha environment

### DIFF
--- a/.github/workflows/adhoc-forge.yaml
+++ b/.github/workflows/adhoc-forge.yaml
@@ -2,14 +2,18 @@ name: "Ad-hoc Forge Run"
 on:
   workflow_dispatch:
     inputs:
+      GIT_SHA:
+        required: true
+        type: string
+        description: The git SHA1 to checkout and test
       IMAGE_TAG:
-        required: true
+        required: false
         type: string
-        description: The docker image tag to test. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
+        description: The docker image tag to test. If not specified, falls back on GIT_SHA
       FORGE_IMAGE_TAG:
-        required: true
+        required: false
         type: string
-        description: The docker image tag to use for forge runner. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
+        description: The docker image tag to use for forge runner. If not specified, falls back on GIT_SHA
       FORGE_RUNNER_DURATION_SECS:
         required: false
         type: string
@@ -25,9 +29,6 @@ on:
         type: string
         description: The Forge k8s cluster to be used for test
 
-env:
-  GIT_SHA: ${{ github.sha }}
-
 permissions:
   contents: read
   id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
@@ -40,14 +41,14 @@ jobs:
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
+          echo "GIT_SHA: ${{ inputs.GIT_SHA }}"
           echo "IMAGE_TAG: ${{ inputs.IMAGE_TAG }}"
           echo "FORGE_IMAGE_TAG: ${{ inputs.FORGE_IMAGE_TAG }}"
           echo "FORGE_RUNNER_DURATION_SECS: ${{ inputs.FORGE_RUNNER_DURATION_SECS }}"
           echo "FORGE_TEST_SUITE: ${{ inputs.FORGE_TEST_SUITE }}"
           echo "FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}"
     outputs:
-      gitSha: ${{ env.GIT_SHA }}
+      gitSha: ${{ inputs.GIT_SHA }}
       imageTag: ${{ inputs.IMAGE_TAG }}
       forgeImageTag: ${{ inputs.FORGE_IMAGE_TAG }}
       forgeRunnerDurationSecs: ${{ inputs.FORGE_RUNNER_DURATION_SECS }}


### PR DESCRIPTION
### Description

Previously, `adhoc-forge.yaml` workflow tested using a min Forge (and swarm) version based on a user provided `IMAGE_TAG` variable. However, it would also calculate an `UPGRADE_IMAGE_TAG` (for multi-version Forge swarms) based on the current checked-out git ref and its children. Often times, this would mean a scenario where:
* The specified `IMAGE_TAG` is the correct version under test
* When you want to spin up a new node and do something like `swarm().versions().max()`, such as from [public_fullnode_performance](https://github.com/aptos-labs/aptos-core/blob/main/testsuite/testcases/src/public_fullnode_performance.rs#L170), you'd actually get the the other image tag, which would be likely from `main`. 

The scenarios where you'd want to test multi-version Forge is actually not too common. So this minimizes the chance of running a test with a configuration not intended by the user, and also makes Forge workflows less dependent on the environment they run in.

Now, the user is only required to specify `GIT_SHA`, which is the git commit sha1 to check out and test (the image is assumed to be built on this commit already). The values for the image tags etc are then derived from this. If a user wishes to use different versions for the Forge test runner and the nodes, then they could specify:
* `IMAGE_TAG`: the node version
* `FORGE_IMAGE_TAG`: the forge test runner version

### Test Plan

Trigger `adhoc-forge.yaml` workflow manually, and check the checked out versions.
Specify only `GIT_SHA: 97f32902cd30eef6e310c02aa2eb6cf97e17a941`. Then check the forge job output, which specifies a run of this configuration:

```
[Fri, 15 Sep 2023 16:33:06] INFO [forge.py.test:1448] Using the following image tags:
[Fri, 15 Sep 2023 16:33:06] INFO [forge.py.test:1449] 	forge:  97f32902cd30eef6e310c02aa2eb6cf97e17a941
[Fri, 15 Sep 2023 16:33:06] INFO [forge.py.test:1450] 	swarm:  97f32902cd30eef6e310c02aa2eb6cf97e17a941
[Fri, 15 Sep 2023 16:33:06] INFO [forge.py.test:1451] 	swarm upgrade (if applicable):  97f32902cd30eef6e310c02aa2eb6cf97e17a941
```

https://github.com/aptos-labs/aptos-core/actions/runs/6200528534/job/16835402954

<!-- Please provide us with clear details for verifying that your changes work. -->
