### PR TITLE
[e2e-move-tests][harness] Cache module building across tests

### DIFF
--- a/aptos-move/e2e-move-tests/src/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator.rs
@@ -12,7 +12,7 @@ pub fn initialize(path: PathBuf) -> (MoveHarness, Account) {
 
     let mut harness = MoveHarness::new_with_executor(executor);
     let account = harness.new_account_at(AccountAddress::ONE);
-    assert_success!(harness.publish_package(&account, &path));
+    assert_success!(harness.publish_package_cache_building(&account, &path));
     assert_success!(harness.run_entry_function(
         &account,
         str::parse("0x1::aggregator_test::initialize").unwrap(),

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -15,7 +15,7 @@ pub fn initialize(path: PathBuf) -> (MoveHarness, Account) {
     let mut harness = MoveHarness::new_with_executor(executor);
     harness.enable_features(vec![FeatureFlag::AGGREGATOR_SNAPSHOTS], vec![]);
     let account = harness.new_account_at(AccountAddress::ONE);
-    assert_success!(harness.publish_package(&account, &path));
+    assert_success!(harness.publish_package_cache_building(&account, &path));
     (harness, account)
 }
 

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.rs
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.rs
@@ -56,7 +56,7 @@ fn setup(harness: &mut MoveHarness) -> Account {
 
     let account = harness.new_account_at(AccountAddress::ONE);
 
-    assert_success!(harness.publish_package(&account, &path));
+    assert_success!(harness.publish_package_cache_building(&account, &path));
 
     account
 }

--- a/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
@@ -41,7 +41,10 @@ fn success_generic(
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("constructor_args.data/pack")));
+    assert_success!(h.publish_package_cache_building(
+        &acc,
+        &common::test_dir_path("constructor_args.data/pack")
+    ));
 
     // Check in initial state, resource does not exist.
     assert!(!h.exists_resource(acc.address(), module_data()));
@@ -72,7 +75,10 @@ fn success_generic_view(
 ) {
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("constructor_args.data/pack")));
+    assert_success!(h.publish_package_cache_building(
+        &acc,
+        &common::test_dir_path("constructor_args.data/pack")
+    ));
 
     // Check in initial state, resource does not exist.
     assert!(!h.exists_resource(acc.address(), module_data()));
@@ -97,7 +103,10 @@ fn fail_generic(ty_args: Vec<TypeTag>, tests: Vec<(&str, Vec<Vec<u8>>, Closure)>
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("constructor_args.data/pack")));
+    assert_success!(h.publish_package_cache_building(
+        &acc,
+        &common::test_dir_path("constructor_args.data/pack")
+    ));
 
     // Check in initial state, resource does not exist.
     assert!(!h.exists_resource(acc.address(), module_data()));

--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -224,7 +224,9 @@ fn test_normal_tx_with_signer_with_fee_payer() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
+    );
 
     let fun: MemberId = str::parse("0xcafe::test::hi").unwrap();
     let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![bcs::to_bytes(
@@ -264,7 +266,9 @@ fn test_normal_tx_without_signer_with_fee_payer() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
+    );
 
     let fun: MemberId = str::parse("0xcafe::test::nothing").unwrap();
     let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![]);
@@ -298,7 +302,9 @@ fn test_normal_tx_with_fee_payer_insufficient_funds() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
+    );
 
     let fun: MemberId = str::parse("0xcafe::test::nothing").unwrap();
     let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![]);

--- a/aptos-move/e2e-move-tests/src/tests/infinite_loop.rs
+++ b/aptos-move/e2e-move-tests/src/tests/infinite_loop.rs
@@ -17,7 +17,7 @@ fn empty_while_loop() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
-    assert_success!(h.publish_package(
+    assert_success!(h.publish_package_cache_building(
         &acc,
         &common::test_dir_path("infinite_loop.data/empty_loop"),
     ));

--- a/aptos-move/e2e-move-tests/src/tests/init_module.rs
+++ b/aptos-move/e2e-move-tests/src/tests/init_module.rs
@@ -19,7 +19,9 @@ fn init_module() {
 
     // Load the code
     let acc = h.aptos_framework_account();
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("init_module.data/pack"))
+    );
 
     // Verify that init_module was called.
     let module_data = parse_struct_tag("0x1::test::ModuleData").unwrap();
@@ -32,7 +34,9 @@ fn init_module() {
 
     // Republish to show that init_module is not called again. If init_module would be called again,
     // we would get an abort here because the first time, it used move_to for initialization.
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("init_module.data/pack"))
+    );
     assert_eq!(
         h.read_resource::<ModuleData>(acc.address(), module_data)
             .unwrap()
@@ -47,13 +51,15 @@ fn init_module_when_republishing_package() {
 
     // Deploy a package that initially does not have the module that has the init_module function.
     let acc = h.aptos_framework_account();
-    assert_success!(h.publish_package(
+    assert_success!(h.publish_package_cache_building(
         &acc,
         &common::test_dir_path("init_module.data/pack_initial")
     ));
 
     // Now republish the package with the new module that has init_module.
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("init_module.data/pack"))
+    );
 
     // Verify that init_module was called.
     let module_data = parse_struct_tag("0x1::test::ModuleData").unwrap();

--- a/aptos-move/e2e-move-tests/src/tests/per_category_gas_limits.rs
+++ b/aptos-move/e2e-move-tests/src/tests/per_category_gas_limits.rs
@@ -19,7 +19,7 @@ fn execution_limit_reached() {
 
     // Publish the infinite loop module.
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
-    assert_success!(h.publish_package(
+    assert_success!(h.publish_package_cache_building(
         &acc,
         &common::test_dir_path("infinite_loop.data/empty_loop"),
     ));
@@ -58,7 +58,7 @@ fn io_limit_reached() {
 
     // Publish the test module.
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("execution_limit.data/test"),));
+    assert_success!(h.publish_package_cache_building(&acc, &common::test_dir_path("execution_limit.data/test"),));
 
     // Lower the max io gas to lower than a single load_resource
     h.modify_gas_schedule(|gas_params| {
@@ -81,7 +81,7 @@ fn storage_limit_reached() {
 
     // Publish the test module.
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("execution_limit.data/test"),));
+    assert_success!(h.publish_package_cache_building(&acc, &common::test_dir_path("execution_limit.data/test"),));
 
     // Lower the max storage fee to 10 Octa.
     h.modify_gas_schedule(|gas_params| gas_params.vm.txn.max_storage_fee = Fee::new(10));

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -29,7 +29,9 @@ fn success_generic(ty_args: Vec<TypeTag>, tests: Vec<(&str, Vec<(Vec<Vec<u8>>, &
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
+    );
 
     let mut module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
     let string_struct = StructTag {
@@ -90,7 +92,9 @@ fn fail_generic(
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
+    assert_success!(
+        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
+    );
 
     let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
 


### PR DESCRIPTION
We have multiple tests using the same move code in data folders, causing them to be rebuilt over and over. Adding to harness methods that cache building, so it can be reused.

Haven't changed the default methods to do the caching, as caller can decide to modify the files, and then rebuilding is needed - so it is up to the caller to decide if it wants caching or not.

This speeds up e2e-move-tests on my machine from 80s to 50s:
RUST_BACKTRACE=1 RUST_MIN_STACK=104857600 cargo test --profile ci --package e2e-move-tests --lib

Before:
test result: ok. 113 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 79.58s

After:
test result: ok. 113 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 54.51s

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
