### PR TITLE
[Framework] Create storage account

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -46,6 +46,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::staking_contract`](staking_contract.md#0x1_staking_contract)
 -  [`0x1::staking_proxy`](staking_proxy.md#0x1_staking_proxy)
 -  [`0x1::state_storage`](state_storage.md#0x1_state_storage)
+-  [`0x1::storage_account`](storage_account.md#0x1_storage_account)
 -  [`0x1::storage_gas`](storage_gas.md#0x1_storage_gas)
 -  [`0x1::system_addresses`](system_addresses.md#0x1_system_addresses)
 -  [`0x1::timestamp`](timestamp.md#0x1_timestamp)

--- a/aptos-move/framework/aptos-framework/doc/storage_account.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_account.md
@@ -1,0 +1,155 @@
+
+<a name="0x1_storage_account"></a>
+
+# Module `0x1::storage_account`
+
+A storage account is a lightweight way to allocate global storage:
+- Cheaper than using a table since no handle generation/hashing.
+- Cheaper than a resource account, which allocates an Account too.
+- Cheaper than creating an object & immediately deleting ObjectCore.
+
+
+-  [Struct `SignerCapability`](#0x1_storage_account_SignerCapability)
+-  [Function `create_storage_account`](#0x1_storage_account_create_storage_account)
+-  [Function `create_storage_account_and_capability`](#0x1_storage_account_create_storage_account_and_capability)
+-  [Function `get_signer_capability_address`](#0x1_storage_account_get_signer_capability_address)
+-  [Function `create_signer_with_capability`](#0x1_storage_account_create_signer_with_capability)
+
+
+<pre><code><b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
+<b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
+</code></pre>
+
+
+
+<a name="0x1_storage_account_SignerCapability"></a>
+
+## Struct `SignerCapability`
+
+
+
+<pre><code><b>struct</b> <a href="storage_account.md#0x1_storage_account_SignerCapability">SignerCapability</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="account.md#0x1_account">account</a>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_storage_account_create_storage_account"></a>
+
+## Function `create_storage_account`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_storage_account">create_storage_account</a>(): (<b>address</b>, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_storage_account">create_storage_account</a>(): (<b>address</b>, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>let</b> storage_addr = <a href="transaction_context.md#0x1_transaction_context_generate_auid_address">transaction_context::generate_auid_address</a>();
+    (storage_addr, <a href="create_signer.md#0x1_create_signer">create_signer</a>(storage_addr))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_storage_account_create_storage_account_and_capability"></a>
+
+## Function `create_storage_account_and_capability`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_storage_account_and_capability">create_storage_account_and_capability</a>(): (<b>address</b>, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="storage_account.md#0x1_storage_account_SignerCapability">storage_account::SignerCapability</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_storage_account_and_capability">create_storage_account_and_capability</a>(): (
+    <b>address</b>,
+    <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="storage_account.md#0x1_storage_account_SignerCapability">SignerCapability</a>,
+) {
+    <b>let</b> addr = <a href="transaction_context.md#0x1_transaction_context_generate_auid_address">transaction_context::generate_auid_address</a>();
+    (addr, <a href="create_signer.md#0x1_create_signer">create_signer</a>(addr), <a href="storage_account.md#0x1_storage_account_SignerCapability">SignerCapability</a> { <a href="account.md#0x1_account">account</a>: addr })
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_storage_account_get_signer_capability_address"></a>
+
+## Function `get_signer_capability_address`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_get_signer_capability_address">get_signer_capability_address</a>(cap: &<a href="storage_account.md#0x1_storage_account_SignerCapability">storage_account::SignerCapability</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_get_signer_capability_address">get_signer_capability_address</a>(cap: &<a href="storage_account.md#0x1_storage_account_SignerCapability">SignerCapability</a>): <b>address</b> {
+    cap.<a href="account.md#0x1_account">account</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_storage_account_create_signer_with_capability"></a>
+
+## Function `create_signer_with_capability`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_signer_with_capability">create_signer_with_capability</a>(cap: &<a href="storage_account.md#0x1_storage_account_SignerCapability">storage_account::SignerCapability</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_account.md#0x1_storage_account_create_signer_with_capability">create_signer_with_capability</a>(cap: &<a href="storage_account.md#0x1_storage_account_SignerCapability">SignerCapability</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <a href="create_signer.md#0x1_create_signer">create_signer</a>(cap.<a href="account.md#0x1_account">account</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/sources/create_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/create_signer.move
@@ -14,6 +14,7 @@ module aptos_framework::create_signer {
     friend aptos_framework::genesis;
     friend aptos_framework::multisig_account;
     friend aptos_framework::object;
+    friend aptos_framework::storage_account;
 
     public(friend) native fun create_signer(addr: address): signer;
 }

--- a/aptos-move/framework/aptos-framework/sources/storage_account.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_account.move
@@ -3,8 +3,8 @@
 /// - Cheaper than a resource account, which allocates an Account too.
 /// - Cheaper than creating an object & immediately deleting ObjectCore.
 module aptos_framework::storage_account {
-    use aptos_framework::transaction_context;
     use aptos_framework::create_signer::create_signer;
+    use aptos_framework::transaction_context;
 
     struct SignerCapability has copy, drop, store { account: address }
 
@@ -55,7 +55,7 @@ module aptos_framework::storage_account {
     const FREE_WRITE_BYTES_QUOTA: u64 = 1024;
 
     #[test_only]
-    const DATA: vector<u8> = b"I can store so much data in a storage account because it has no overhead: no object::ObjectCore, no account::Account, just the data I need. When I need to access my state I don't need to do any expensive hashing against a table handle, rather, I simply borrow out of global storage. Then when I'm done, I simply deallocate from memory using move_from(). Neat! Wow, I sure do have a lot of extra space I can fit into here, so how about some more ASCII characters? Here you go! 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    const DATA: vector<u8> = b"I can store so much data in a storage account because it has no overhead: no object::ObjectCore, no account::Account, just the data I need. When I need to access my state I don't need to do any expensive hashing against a table handle. Rather, I simply borrow out of global storage. Then when I'm done, I simply deallocate from memory using move_from(). Neat! Wow, I sure do have a lot of extra space I can fit into here, so how about some more ASCII characters? Here you go! 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
     #[test(features = @std, tree_creator = @0xace)]
     fun test_end_to_end(

--- a/aptos-move/framework/aptos-framework/sources/storage_account.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_account.move
@@ -1,0 +1,92 @@
+/// A storage account is a lightweight way to allocate global storage:
+/// - Cheaper than using a table since no handle generation/hashing.
+/// - Cheaper than a resource account, which allocates an Account too.
+/// - Cheaper than creating an object & immediately deleting ObjectCore.
+module aptos_framework::storage_account {
+    use aptos_framework::transaction_context;
+    use aptos_framework::create_signer::create_signer;
+
+    struct SignerCapability has copy, drop, store { account: address }
+
+    public fun create_storage_account(): (address, signer) {
+        let storage_addr = transaction_context::generate_auid_address();
+        (storage_addr, create_signer(storage_addr))
+    }
+
+    public fun create_storage_account_and_capability(): (
+        address,
+        signer,
+        SignerCapability,
+    ) {
+        let addr = transaction_context::generate_auid_address();
+        (addr, create_signer(addr), SignerCapability { account: addr })
+    }
+
+    public fun get_signer_capability_address(cap: &SignerCapability): address {
+        cap.account
+    }
+
+    public fun create_signer_with_capability(cap: &SignerCapability): signer {
+        create_signer(cap.account)
+    }
+
+    #[test_only]
+    use aptos_framework::type_info;
+    #[test_only]
+    use std::features;
+    #[test_only]
+    use std::option::{Self, Option};
+    #[test_only]
+    use std::signer;
+
+    #[test_only]
+    struct TreeRoot has key {
+        node: Option<address>,
+    }
+
+    #[test_only]
+    struct LeafNode has key, drop {
+        data: vector<u8>,
+    }
+
+    #[test_only]
+    /// From gas schedule `transaction.rs`
+    /// Ideally this value would be queryable during runtime.
+    const FREE_WRITE_BYTES_QUOTA: u64 = 1024;
+
+    #[test_only]
+    const DATA: vector<u8> = b"I can store so much data in a storage account because it has no overhead: no object::ObjectCore, no account::Account, just the data I need. When I need to access my state I don't need to do any expensive hashing against a table handle, rather, I simply borrow out of global storage. Then when I'm done, I simply deallocate from memory using move_from(). Neat! Wow, I sure do have a lot of extra space I can fit into here, so how about some more ASCII characters? Here you go! 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test(features = @std, tree_creator = @0xace)]
+    fun test_end_to_end(
+        features: &signer,
+        tree_creator: &signer,
+    ) acquires TreeRoot, LeafNode {
+        // Enable AUID generation for testing.
+        let feature = features::get_auids();
+        features::change_feature_flags(features, vector[feature], vector[]);
+        // Create an empty tree.
+        let tree_creator_address = signer::address_of(tree_creator);
+        move_to(tree_creator, TreeRoot { node: option::none() });
+        // Allocate a new leaf node under a storage account.
+        let (storage_addr, storage_account) = create_storage_account();
+        move_to(&storage_account, LeafNode { data: DATA });
+        let root_ref_mut = borrow_global_mut<TreeRoot>(tree_creator_address);
+        root_ref_mut.node = option::some(storage_addr);
+        // Check the size of the allocated leaf node.
+        let node_ref = borrow_global<LeafNode>(storage_addr);
+        let storage_size = type_info::size_of_val(node_ref);
+        assert!(storage_size == FREE_WRITE_BYTES_QUOTA, 0);
+        // Perform an arbitrary node operation.
+        let leaf_ref_mut = borrow_global_mut<LeafNode>(storage_addr);
+        leaf_ref_mut.data = b"I sure do like storage accounts!";
+        // Delete the node.
+        root_ref_mut.node = option::none();
+        move_from<LeafNode>(storage_addr);
+        // Verify capability functionality.
+        let (addr, account, cap) = create_storage_account_and_capability();
+        assert!(addr == get_signer_capability_address(&cap), 0);
+        assert!(account == create_signer_with_capability(&cap), 0);
+    }
+
+}


### PR DESCRIPTION
@davidiw @junkil-park @lightmark @movekevin @msmouse  @vgao1996

This PR adds storage account functionality, analogous to `malloc` in C.

Presently, global storage allocation can be done in one of several ways, which all have limitations:

1. Using a table requires expensive handle creation and hashing operations during lookup, and looking up data in the REST API is difficult with nested table handles.
2. Using a resource account requires the allocation of an `aptos_framework::account::Account`, which does not have a global resource group and thus leads to two global storage item creations during allocation.
3. Using an object requires creating an `aptos_framework::object::ObjectCore`, which can be incorporated in a resource group but which occupies almost 100 bytes. The `ObjectCore` can be deleted, but it requires several operations:
    - `object::create_object()`
    - `object::generate_signer()`
    - `move_to<ApplicationDataResource>` using the object account (AUID) signer, under the `ObjectGroup` resource group (to avoid having two global storage item creations)
    - `object::generate_delete_ref()`
    - `object::delete()`

Like during object creation, the proposed storage account functionality relies on an AUID, but is much more straightforward than the above process required for object-based storage allocation.

