### PR TITLE
[dag] state sync refactor and notifier reinit

### DIFF
--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -33,26 +33,29 @@ use async_trait::async_trait;
 use futures_channel::mpsc::UnboundedSender;
 use std::{collections::HashMap, sync::Arc};
 
-#[async_trait]
-pub trait Notifier: Send + Sync {
+pub trait OrderedNotifier: Send + Sync {
     fn send_ordered_nodes(
         &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         failed_author: Vec<(Round, Author)>,
     ) -> anyhow::Result<()>;
+}
 
+#[async_trait]
+pub trait ProofNotifier: Send + Sync {
     async fn send_epoch_change(&self, proof: EpochChangeProof);
 
     async fn send_commit_proof(&self, ledger_info: LedgerInfoWithSignatures);
 }
-pub struct NotifierAdapter {
+
+pub struct OrderedNotifierAdapter {
     executor_channel: UnboundedSender<OrderedBlocks>,
     storage: Arc<dyn DAGStorage>,
     parent_block_info: Arc<RwLock<BlockInfo>>,
     epoch_state: Arc<EpochState>,
 }
 
-impl NotifierAdapter {
+impl OrderedNotifierAdapter {
     pub fn new(
         executor_channel: UnboundedSender<OrderedBlocks>,
         storage: Arc<dyn DAGStorage>,
@@ -87,8 +90,7 @@ impl NotifierAdapter {
     }
 }
 
-#[async_trait]
-impl Notifier for NotifierAdapter {
+impl OrderedNotifier for OrderedNotifierAdapter {
     fn send_ordered_nodes(
         &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
@@ -156,14 +158,6 @@ impl Notifier for NotifierAdapter {
                 },
             ),
         })?)
-    }
-
-    async fn send_epoch_change(&self, _proof: EpochChangeProof) {
-        todo!()
-    }
-
-    async fn send_commit_proof(&self, _ledger_info: LedgerInfoWithSignatures) {
-        todo!()
     }
 }
 

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 
 use super::{
-    adapter::Notifier,
+    adapter::{OrderedNotifier, OrderedNotifierAdapter},
     anchor_election::RoundRobinAnchorElection,
     dag_driver::DagDriver,
     dag_fetcher::{DagFetcher, DagFetcherService, FetchRequestHandler},
@@ -12,10 +12,11 @@ use super::{
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
     storage::DAGStorage,
-    types::{CertifiedNodeMessage, DAGMessage},
+    types::DAGMessage,
+    ProofNotifier,
 };
 use crate::{
-    dag::{adapter::NotifierAdapter, dag_state_sync::StateSyncStatus},
+    dag::dag_state_sync::StateSyncStatus,
     experimental::buffer_manager::OrderedBlocks,
     network::IncomingDAGRequest,
     state_replication::{PayloadClient, StateComputer},
@@ -51,6 +52,7 @@ struct DagBootstrapper {
     storage: Arc<dyn DAGStorage>,
     rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
     dag_network_sender: Arc<dyn TDAGNetworkSender>,
+    proof_notifier: Arc<dyn ProofNotifier>,
     time_service: aptos_time_service::TimeService,
     payload_client: Arc<dyn PayloadClient>,
     state_computer: Arc<dyn StateComputer>,
@@ -64,6 +66,7 @@ impl DagBootstrapper {
         storage: Arc<dyn DAGStorage>,
         rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
         dag_network_sender: Arc<dyn TDAGNetworkSender>,
+        proof_notifier: Arc<dyn ProofNotifier>,
         time_service: aptos_time_service::TimeService,
         payload_client: Arc<dyn PayloadClient>,
         state_computer: Arc<dyn StateComputer>,
@@ -75,6 +78,7 @@ impl DagBootstrapper {
             storage,
             rb_network_sender,
             dag_network_sender,
+            proof_notifier,
             time_service,
             payload_client,
             state_computer,
@@ -84,7 +88,7 @@ impl DagBootstrapper {
     fn bootstrap_dag_store(
         &self,
         latest_ledger_info: LedgerInfo,
-        notifier: Arc<dyn Notifier>,
+        notifier: Arc<dyn OrderedNotifier>,
     ) -> (Arc<RwLock<Dag>>, OrderRule) {
         let dag = Arc::new(RwLock::new(Dag::new(
             self.epoch_state.clone(),
@@ -189,7 +193,7 @@ impl DagBootstrapper {
         );
 
         loop {
-            let adapter = Arc::new(NotifierAdapter::new(
+            let adapter = Arc::new(OrderedNotifierAdapter::new(
                 ordered_nodes_tx.clone(),
                 self.storage.clone(),
             ));
@@ -197,7 +201,8 @@ impl DagBootstrapper {
             let (dag_store, order_rule) =
                 self.bootstrap_dag_store(ledger_info.ledger_info().clone(), adapter.clone());
 
-            let state_sync_trigger = StateSyncTrigger::new(dag_store.clone(), adapter);
+            let state_sync_trigger =
+                StateSyncTrigger::new(dag_store.clone(), self.proof_notifier.clone());
 
             let (handler, fetch_service) =
                 self.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);
@@ -247,6 +252,7 @@ pub(super) fn bootstrap_dag_for_test(
     storage: Arc<dyn DAGStorage>,
     rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
     dag_network_sender: Arc<dyn TDAGNetworkSender>,
+    proof_notifier: Arc<dyn ProofNotifier>,
     time_service: aptos_time_service::TimeService,
     payload_client: Arc<dyn PayloadClient>,
     state_computer: Arc<dyn StateComputer>,
@@ -263,23 +269,23 @@ pub(super) fn bootstrap_dag_for_test(
         storage.clone(),
         rb_network_sender,
         dag_network_sender,
+        proof_notifier.clone(),
         time_service,
         payload_client,
         state_computer,
     );
 
     let (ordered_nodes_tx, ordered_nodes_rx) = futures_channel::mpsc::unbounded();
-    let adapter = Arc::new(NotifierAdapter::new(
+    let adapter = Arc::new(OrderedNotifierAdapter::new(
         ordered_nodes_tx,
         storage.clone(),
-        epoch_state,
     ));
     let (dag_rpc_tx, dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 64, None);
 
     let (dag_store, order_rule) =
         bootstraper.bootstrap_dag_store(latest_ledger_info, adapter.clone());
 
-    let state_sync_trigger = StateSyncTrigger::new(dag_store.clone(), adapter.clone());
+    let state_sync_trigger = StateSyncTrigger::new(dag_store.clone(), proof_notifier.clone());
 
     let (handler, fetch_service) =
         bootstraper.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -196,13 +196,17 @@ impl DagBootstrapper {
             let adapter = Arc::new(OrderedNotifierAdapter::new(
                 ordered_nodes_tx.clone(),
                 self.storage.clone(),
+                self.epoch_state.clone(),
             ));
 
             let (dag_store, order_rule) =
                 self.bootstrap_dag_store(ledger_info.ledger_info().clone(), adapter.clone());
 
-            let state_sync_trigger =
-                StateSyncTrigger::new(dag_store.clone(), self.proof_notifier.clone());
+            let state_sync_trigger = StateSyncTrigger::new(
+                self.epoch_state.clone(),
+                dag_store.clone(),
+                self.proof_notifier.clone(),
+            );
 
             let (handler, fetch_service) =
                 self.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);
@@ -279,13 +283,15 @@ pub(super) fn bootstrap_dag_for_test(
     let adapter = Arc::new(OrderedNotifierAdapter::new(
         ordered_nodes_tx,
         storage.clone(),
+        epoch_state.clone(),
     ));
     let (dag_rpc_tx, dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 64, None);
 
     let (dag_store, order_rule) =
         bootstraper.bootstrap_dag_store(latest_ledger_info, adapter.clone());
 
-    let state_sync_trigger = StateSyncTrigger::new(dag_store.clone(), proof_notifier.clone());
+    let state_sync_trigger =
+        StateSyncTrigger::new(epoch_state, dag_store.clone(), proof_notifier.clone());
 
     let (handler, fetch_service) =
         bootstraper.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -3,11 +3,8 @@
 use super::{
     dag_driver::DagDriver,
     dag_fetcher::{FetchRequestHandler, FetchWaiter},
-    dag_state_sync::{
-        StateSyncStatus,
-        StateSyncTrigger,
-    },
-    types::{CertifiedNodeMessage, TDAGMessage},
+    dag_state_sync::{StateSyncStatus, StateSyncTrigger},
+    types::TDAGMessage,
     CertifiedNode, Node,
 };
 use crate::{
@@ -133,7 +130,7 @@ impl NetworkHandler {
                         self.node_receiver.process(node).await.map(|r| r.into())
                     },
                     DAGMessage::CertifiedNodeMsg(certified_node_msg) => {
-                        match self.state_sync_trigger.check(certified_node_msg).await {
+                        match self.state_sync_trigger.check(certified_node_msg).await? {
                             StateSyncStatus::Synced(Some(certified_node_msg)) => self
                                 .dag_driver
                                 .process(certified_node_msg.certified_node())

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -1,11 +1,11 @@
 // Copyright © Aptos Foundation
 
 use super::{
-    adapter::Notifier,
     dag_fetcher::TDagFetcher,
     dag_store::Dag,
     storage::DAGStorage,
     types::{CertifiedNodeMessage, RemoteFetchRequest},
+    ProofNotifier,
 };
 use crate::state_replication::StateComputer;
 use aptos_consensus_types::common::Round;
@@ -31,11 +31,11 @@ pub enum StateSyncStatus {
 
 pub(super) struct StateSyncTrigger {
     dag_store: Arc<RwLock<Dag>>,
-    proof_notifier: Arc<dyn Notifier>,
+    proof_notifier: Arc<dyn ProofNotifier>,
 }
 
 impl StateSyncTrigger {
-    pub(super) fn new(dag_store: Arc<RwLock<Dag>>, proof_notifier: Arc<dyn Notifier>) -> Self {
+    pub(super) fn new(dag_store: Arc<RwLock<Dag>>, proof_notifier: Arc<dyn ProofNotifier>) -> Self {
         Self {
             dag_store,
             proof_notifier,

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -21,3 +21,4 @@ mod types;
 
 pub use dag_network::{RpcHandler, RpcWithFallback, TDAGNetworkSender};
 pub use types::{CertifiedNode, DAGMessage, DAGNetworkMessage, Extensions, Node, NodeId, Vote};
+pub use adapter::ProofNotifier;

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -19,6 +19,6 @@ mod storage;
 mod tests;
 mod types;
 
+pub use adapter::ProofNotifier;
 pub use dag_network::{RpcHandler, RpcWithFallback, TDAGNetworkSender};
 pub use types::{CertifiedNode, DAGMessage, DAGNetworkMessage, Extensions, Node, NodeId, Vote};
-pub use adapter::ProofNotifier;

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::dag::{
-    adapter::Notifier,
+    adapter::OrderedNotifier,
     anchor_election::AnchorElection,
     dag_state_sync::DAG_WINDOW,
     dag_store::{Dag, NodeStatus},
@@ -21,7 +21,7 @@ pub struct OrderRule {
     lowest_unordered_anchor_round: Round,
     dag: Arc<RwLock<Dag>>,
     anchor_election: Box<dyn AnchorElection>,
-    notifier: Arc<dyn Notifier>,
+    notifier: Arc<dyn OrderedNotifier>,
     storage: Arc<dyn DAGStorage>,
 }
 
@@ -31,7 +31,7 @@ impl OrderRule {
         latest_ledger_info: LedgerInfo,
         dag: Arc<RwLock<Dag>>,
         mut anchor_election: Box<dyn AnchorElection>,
-        notifier: Arc<dyn Notifier>,
+        notifier: Arc<dyn OrderedNotifier>,
         storage: Arc<dyn DAGStorage>,
     ) -> Self {
         let committed_round = if latest_ledger_info.ends_epoch() {

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -21,7 +21,6 @@ use aptos_time_service::TimeService;
 use aptos_types::{
     aggregate_signature::AggregateSignature,
     block_info::BlockInfo,
-    epoch_change::EpochChangeProof,
     epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_verifier::random_validator_verifier,
@@ -113,12 +112,7 @@ fn setup(epoch_state: Arc<EpochState>, storage: Arc<dyn DAGStorage>) -> DagState
     let time_service = TimeService::mock();
     let state_computer = Arc::new(EmptyStateComputer {});
 
-    DagStateSynchronizer::new(
-        epoch_state,
-        time_service,
-        state_computer,
-        storage,
-    )
+    DagStateSynchronizer::new(epoch_state, time_service, state_computer, storage)
 }
 
 #[tokio::test]

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -116,11 +116,9 @@ impl Notifier for MockNotifier {
 fn setup(epoch_state: Arc<EpochState>, storage: Arc<dyn DAGStorage>) -> DagStateSynchronizer {
     let time_service = TimeService::mock();
     let state_computer = Arc::new(EmptyStateComputer {});
-    let downstream_notifier = Arc::new(MockNotifier {});
 
     DagStateSynchronizer::new(
         epoch_state,
-        downstream_notifier,
         time_service,
         state_computer,
         storage,

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     dag::{
-        adapter::Notifier,
+        adapter::OrderedNotifier,
         dag_fetcher::{FetchRequestHandler, TDagFetcher},
         dag_state_sync::{DagStateSynchronizer, DAG_WINDOW},
         dag_store::Dag,
@@ -99,7 +99,7 @@ impl TDagFetcher for MockDagFetcher {
 struct MockNotifier {}
 
 #[async_trait]
-impl Notifier for MockNotifier {
+impl OrderedNotifier for MockNotifier {
     fn send_ordered_nodes(
         &self,
         _ordered_nodes: Vec<Arc<CertifiedNode>>,
@@ -107,10 +107,6 @@ impl Notifier for MockNotifier {
     ) -> anyhow::Result<()> {
         Ok(())
     }
-
-    async fn send_epoch_change(&self, _proof: EpochChangeProof) {}
-
-    async fn send_commit_proof(&self, _ledger_info: LedgerInfoWithSignatures) {}
 }
 
 fn setup(epoch_state: Arc<EpochState>, storage: Arc<dyn DAGStorage>) -> DagStateSynchronizer {

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -86,6 +86,7 @@ impl DagBootstrapUnit {
                 Arc::new(dag_storage),
                 network.clone(),
                 network.clone(),
+                network.clone(),
                 time_service,
                 payload_client,
                 state_computer,

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -2,7 +2,10 @@
 
 use super::dag_test;
 use crate::{
-    dag::{bootstrap::bootstrap_dag_for_test, types::CertifiedNodeMessage},
+    dag::{
+        bootstrap::bootstrap_dag_for_test, dag_state_sync::StateSyncStatus,
+        types::CertifiedNodeMessage,
+    },
     experimental::buffer_manager::OrderedBlocks,
     network::{IncomingDAGRequest, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
@@ -41,7 +44,7 @@ use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 struct DagBootstrapUnit {
-    nh_task_handle: JoinHandle<CertifiedNodeMessage>,
+    nh_task_handle: JoinHandle<StateSyncStatus>,
     df_task_handle: JoinHandle<()>,
     dag_rpc_tx: aptos_channel::Sender<Author, IncomingDAGRequest>,
     network_events:

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -2,10 +2,7 @@
 
 use super::dag_test;
 use crate::{
-    dag::{
-        bootstrap::bootstrap_dag_for_test, dag_state_sync::StateSyncStatus,
-        types::CertifiedNodeMessage,
-    },
+    dag::{bootstrap::bootstrap_dag_for_test, dag_state_sync::StateSyncStatus},
     experimental::buffer_manager::OrderedBlocks,
     network::{IncomingDAGRequest, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -16,10 +16,7 @@ use crate::{
 };
 use aptos_consensus_types::common::{Author, Round};
 use aptos_infallible::{Mutex, RwLock};
-use aptos_types::{
-    epoch_change::EpochChangeProof, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    validator_verifier::random_validator_verifier,
-};
+use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
 use async_trait::async_trait;
 use futures_channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use proptest::prelude::*;

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     dag::{
-        adapter::Notifier,
+        adapter::OrderedNotifier,
         anchor_election::RoundRobinAnchorElection,
         dag_state_sync::DAG_WINDOW,
         dag_store::Dag,
@@ -85,21 +85,13 @@ pub struct TestNotifier {
 }
 
 #[async_trait]
-impl Notifier for TestNotifier {
+impl OrderedNotifier for TestNotifier {
     fn send_ordered_nodes(
         &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         _failed_authors: Vec<(Round, Author)>,
     ) -> anyhow::Result<()> {
         Ok(self.tx.unbounded_send(ordered_nodes)?)
-    }
-
-    async fn send_epoch_change(&self, _proof: EpochChangeProof) {
-        unimplemented!()
-    }
-
-    async fn send_commit_proof(&self, _ledger_info: LedgerInfoWithSignatures) {
-        unimplemented!()
     }
 }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1207,6 +1207,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     }
 }
 
+#[allow(dead_code)]
 fn new_signer_from_storage(author: Author, backend: &SecureBackend) -> Arc<ValidatorSigner> {
     let storage: Storage = backend.try_into().expect("Unable to initialize storage");
     if let Err(error) = storage.available() {

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -141,8 +141,6 @@ impl ExecutionPipeline {
     }
 }
 
-const PIPELINE_DEPTH: usize = 8;
-
 struct ExecuteBlockCommand {
     block: ExecutableBlock,
     parent_block_id: HashValue,

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -142,6 +142,7 @@ pub struct DagStateSyncComputer {
 }
 
 impl DagStateSyncComputer {
+    #[allow(dead_code)]
     pub fn new(
         state_computer_for_sync: Arc<dyn StateComputer>,
         reset_event_channel_tx: UnboundedSender<ResetRequest>,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -5,7 +5,7 @@
 use crate::{
     block_storage::tracing::{observe_block, BlockStage},
     counters,
-    dag::{DAGMessage, DAGNetworkMessage, RpcWithFallback, TDAGNetworkSender, ProofNotifier},
+    dag::{DAGMessage, DAGNetworkMessage, ProofNotifier, RpcWithFallback, TDAGNetworkSender},
     experimental::commit_reliable_broadcast::CommitMessage,
     logging::LogEvent,
     monitor,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -5,7 +5,7 @@
 use crate::{
     block_storage::tracing::{observe_block, BlockStage},
     counters,
-    dag::{DAGMessage, DAGNetworkMessage, RpcWithFallback, TDAGNetworkSender},
+    dag::{DAGMessage, DAGNetworkMessage, RpcWithFallback, TDAGNetworkSender, ProofNotifier},
     experimental::commit_reliable_broadcast::CommitMessage,
     logging::LogEvent,
     monitor,
@@ -489,6 +489,17 @@ impl RBNetworkSender<DAGMessage> for NetworkSender {
             .await
             .map_err(|e| anyhow!("invalid rpc response: {}", e))
             .and_then(TConsensusMsg::from_network_message)
+    }
+}
+
+#[async_trait]
+impl ProofNotifier for NetworkSender {
+    async fn send_epoch_change(&self, proof: EpochChangeProof) {
+        self.send_epoch_change(proof).await
+    }
+
+    async fn send_commit_proof(&self, ledger_info: LedgerInfoWithSignatures) {
+        self.send_commit_proof(ledger_info).await
     }
 }
 


### PR DESCRIPTION
### Description

This PR splits the notifier into OrderedNotifier and ProofNotifier. 

- Cleans up some code to make sure ordered notifier adapter is re-instantiated after each state sync, so that the parent block info is accurate. To do so, it moves the epoch change notification logic from state sync manager to state sync notifier.
- Also, cleans up some StateSyncStatus logic and makes sure that DAG doesn't reinit when an epoch change is required.
- NetworkSender implements ProofNotifier. This makes a clean abstraction and keeps all epoch manager/buffer manager related components (including messages) outside of the DAG.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
