### PR TITLE
module metadata cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,6 +1597,7 @@ dependencies = [
  "itertools",
  "libsecp256k1",
  "log",
+ "lru 0.7.8",
  "merlin",
  "move-binary-format",
  "move-cli",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1440,7 +1440,7 @@ impl AptosVM {
             arguments,
             func_name.as_ident_str(),
             &func_inst,
-            metadata.as_ref(),
+            metadata.as_ref().map(Arc::as_ref),
             vm.0.get_features()
                 .is_enabled(FeatureFlag::STRUCT_CONSTRUCTORS),
         )?;

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -637,7 +637,7 @@ impl AptosVMImpl {
     pub(crate) fn extract_module_metadata(
         &self,
         module: &ModuleId,
-    ) -> Option<RuntimeModuleMetadataV1> {
+    ) -> Option<Arc<RuntimeModuleMetadataV1>> {
         if self.features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) {
             aptos_framework::get_vm_metadata(&self.move_vm, module)
         } else {

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -50,6 +50,7 @@ include_dir = { workspace = true }
 itertools = { workspace = true }
 libsecp256k1 = { workspace = true }
 log = { workspace = true }
+lru = { workspace = true }
 merlin = { workspace = true }
 move-binary-format = { workspace = true }
 move-command-line-common = { workspace = true }

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -6,6 +6,7 @@ use aptos_types::{
     on_chain_config::{FeatureFlag, Features, TimedFeatures},
     transaction::AbortInfo,
 };
+use lru::LruCache;
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
@@ -23,7 +24,7 @@ use move_core_types::{
 };
 use move_vm_runtime::move_vm::MoveVM;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, env, sync::Arc};
+use std::{cell::RefCell, collections::BTreeMap, env, sync::Arc};
 use thiserror::Error;
 
 /// The minimal file format version from which the V1 metadata is supported
@@ -148,12 +149,29 @@ impl KnownAttribute {
     }
 }
 
+const METADATA_CACHE_SIZE: usize = 1024;
+
+thread_local! {
+    static V1_METADATA_CACHE: RefCell<LruCache<Vec<u8>, Option<Arc<RuntimeModuleMetadataV1>>>> = RefCell::new(LruCache::new(METADATA_CACHE_SIZE));
+
+    static V0_METADATA_CACHE: RefCell<LruCache<Vec<u8>, Option<Arc<RuntimeModuleMetadataV1>>>> = RefCell::new(LruCache::new(METADATA_CACHE_SIZE));
+}
+
 /// Extract metadata from the VM, upgrading V0 to V1 representation as needed
 pub fn get_metadata(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> {
     if let Some(data) = md.iter().find(|md| md.key == APTOS_METADATA_KEY_V1) {
-        bcs::from_bytes::<RuntimeModuleMetadataV1>(&data.value)
-            .ok()
-            .map(Arc::new)
+        V1_METADATA_CACHE.with(|ref_cell| {
+            let mut cache = ref_cell.borrow_mut();
+            if let Some(meta) = cache.get(&data.value) {
+                meta.clone()
+            } else {
+                let meta = bcs::from_bytes::<RuntimeModuleMetadataV1>(&data.value)
+                    .ok()
+                    .map(Arc::new);
+                cache.put(data.value.clone(), meta.clone());
+                meta
+            }
+        })
     } else {
         get_metadata_v0(md)
     }
@@ -161,8 +179,19 @@ pub fn get_metadata(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> {
 
 pub fn get_metadata_v0(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> {
     if let Some(data) = md.iter().find(|md| md.key == APTOS_METADATA_KEY) {
-        let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
-        Some(Arc::new(data_v0.upgrade()))
+        V0_METADATA_CACHE.with(|ref_cell| {
+            let mut cache = ref_cell.borrow_mut();
+            if let Some(meta) = cache.get(&data.value) {
+                meta.clone()
+            } else {
+                let meta = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value)
+                    .ok()
+                    .map(RuntimeModuleMetadata::upgrade)
+                    .map(Arc::new);
+                cache.put(data.value.clone(), meta.clone());
+                meta
+            }
+        })
     } else {
         None
     }

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -48,26 +48,26 @@ class RunGroupConfig:
 # Local machine numbers will be higher.
 # fmt: off
 TESTS = [
-    RunGroupConfig(expected_tps=20500, key=RunGroupKey("no-op"), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=24000, key=RunGroupKey("no-op"), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=3000, key=RunGroupKey("no-op", module_working_set_size=1000), included_in=Flow.LAND_BLOCKING),
-    RunGroupConfig(expected_tps=14500, key=RunGroupKey("coin-transfer"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=16000, key=RunGroupKey("coin-transfer"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=30300, key=RunGroupKey("coin-transfer", executor_type="native"), included_in=Flow.LAND_BLOCKING),
-    RunGroupConfig(expected_tps=12500, key=RunGroupKey("account-generation"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=14000, key=RunGroupKey("account-generation"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=26500, key=RunGroupKey("account-generation", executor_type="native"), included_in=Flow.CONTINUOUS),
-    RunGroupConfig(expected_tps=18500, key=RunGroupKey("account-resource32-b"), included_in=Flow.LAND_BLOCKING),
-    RunGroupConfig(expected_tps=3550, key=RunGroupKey("modify-global-resource"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
-    RunGroupConfig(expected_tps=11500, key=RunGroupKey("modify-global-resource", module_working_set_size=10), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=20500, key=RunGroupKey("account-resource32-b"), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=4200, key=RunGroupKey("modify-global-resource"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=12500, key=RunGroupKey("modify-global-resource", module_working_set_size=10), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=130, key=RunGroupKey("publish-package"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
-    RunGroupConfig(expected_tps=2350, key=RunGroupKey(
+    RunGroupConfig(expected_tps=2650, key=RunGroupKey(
         "mix_publish_transfer",
         transaction_type_override="publish-package coin-transfer",
         transaction_weights_override="1 500",
     ), included_in=Flow.LAND_BLOCKING, waived=True),
-    RunGroupConfig(expected_tps=400, key=RunGroupKey("batch100-transfer"), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=430, key=RunGroupKey("batch100-transfer"), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=940, key=RunGroupKey("batch100-transfer", executor_type="native"), included_in=Flow.CONTINUOUS),
 
-    RunGroupConfig(expected_tps=1680, key=RunGroupKey("token-v1ft-mint-and-transfer"), included_in=Flow.LAND_BLOCKING),
-    RunGroupConfig(expected_tps=8200, key=RunGroupKey("token-v1ft-mint-and-transfer", module_working_set_size=20), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=1980, key=RunGroupKey("token-v1ft-mint-and-transfer"), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=9300, key=RunGroupKey("token-v1ft-mint-and-transfer", module_working_set_size=20), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=1000, key=RunGroupKey("token-v1nft-mint-and-transfer-sequential"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(expected_tps=5150, key=RunGroupKey("token-v1nft-mint-and-transfer-sequential", module_working_set_size=20), included_in=Flow.CONTINUOUS),
     RunGroupConfig(expected_tps=1300, key=RunGroupKey("token-v1nft-mint-and-transfer-parallel"), included_in=Flow.CONTINUOUS),
@@ -80,8 +80,8 @@ TESTS = [
     RunGroupConfig(expected_tps=18000, key=RunGroupKey("no-op2-signers"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(expected_tps=18000, key=RunGroupKey("no-op5-signers"), included_in=Flow.CONTINUOUS),
    
-    RunGroupConfig(expected_tps=1580, key=RunGroupKey("token-v2-ambassador-mint"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
-    RunGroupConfig(expected_tps=5700, key=RunGroupKey("token-v2-ambassador-mint", module_working_set_size=20), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=1820, key=RunGroupKey("token-v2-ambassador-mint"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=6250, key=RunGroupKey("token-v2-ambassador-mint", module_working_set_size=20), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
 
     RunGroupConfig(expected_tps=50000, key=RunGroupKey("coin_transfer_connected_components", executor_type="sharded", sharding_traffic_flags="--connected-tx-grps 5000", transaction_type_override=""), included_in=Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=50000, key=RunGroupKey("coin_transfer_hotspot", executor_type="sharded", sharding_traffic_flags="--hotspot-probability 0.8", transaction_type_override=""), included_in=Flow.REPRESENTATIVE),


### PR DESCRIPTION
### Description

3% gain for this comand (32k TPS -> 33k TPS)
```
cargo run -p aptos-executor-benchmark --profile performance -- --block-size 50000  --split-ledger-db  --skip-index-and-usage --use-sharded-state-merkle-db --execution-threads 48 --connected-tx-grps 5000 --shuffle-connected-txns --generate-then-execute run-executor  --data-dir /home/msmouse/work/data/temp/$DB --checkpoint-dir /home/msmouse/work/data/temp/ck --blocks 50 --main-signer-accounts $SIGNERS
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
