### PR TITLE
[SDK V2] Implement memoize and memoizeAsync high order functions

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/utils/memoize.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/memoize.ts
@@ -1,0 +1,64 @@
+/**
+ * The global cache Map
+ */
+const cache = new Map<string, { value: any; timestamp: number }>();
+
+/**
+ * A memoize high order function to cache async function response
+ *
+ * @param func An async function to cache the result of
+ * @param key The provided cache key
+ * @param ttlMs time-to-live in milliseconds for cached data
+ * @returns
+ */
+export function memoizeAsync<T>(
+  func: (...args: any[]) => Promise<T>,
+  key: string,
+  ttlMs?: number,
+): (...args: any[]) => Promise<T> {
+  return async (...args: any[]) => {
+    // Check if the cached result exists and is within TTL
+    if (cache.has(key)) {
+      const { value, timestamp } = cache.get(key)!;
+      if (ttlMs === undefined || Date.now() - timestamp <= ttlMs) {
+        return value;
+      }
+    }
+
+    // If not cached or TTL expired, compute the result
+    const result = await func(...args);
+
+    // Cache the result with a timestamp
+    cache.set(key, { value: result, timestamp: Date.now() });
+
+    return result;
+  };
+}
+
+/**
+ * A memoize high order function to cache function response
+ *
+ * @param func A function to cache the result of
+ * @param key The provided cache key
+ * @param ttlMs time-to-live in milliseconds for cached data
+ * @returns
+ */
+export function memoize<T>(func: (...args: any[]) => T, key: string, ttlMs?: number): (...args: any[]) => T {
+  return (...args: any[]) => {
+    // Check if the cached result exists and is within TTL
+    if (cache.has(key)) {
+      const { value, timestamp } = cache.get(key)!;
+      if (ttlMs === undefined || Date.now() - timestamp <= ttlMs) {
+        return value;
+      }
+    }
+
+    // If not cached or TTL expired, compute the result
+    const result = func(...args);
+
+    // Cache the result with a timestamp
+    cache.set(key, { value: result, timestamp: Date.now() });
+
+    return result;
+  };
+}

--- a/ecosystem/typescript/sdk_v2/tests/unit/memoize.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/memoize.test.ts
@@ -1,0 +1,203 @@
+import { memoizeAsync, memoize } from "../../src/utils/memoize";
+
+describe("memoize", () => {
+  describe("memoizeAsync", () => {
+    // Define an asynchronous function to mock
+    const asyncFunction = jest.fn(async (arg) => {
+      // Simulate some asynchronous operation to be resolved after 100 ms
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return arg;
+    });
+
+    beforeEach(() => {
+      // needed because of a weird bug with jest https://github.com/jestjs/jest/pull/12572
+      jest.useFakeTimers({ doNotFake: ["setTimeout", "performance"] });
+    });
+
+    afterEach(() => {
+      // Restore real timers and clear all timers after each test
+      jest.useRealTimers();
+      jest.clearAllTimers();
+      asyncFunction.mockClear();
+    });
+
+    test("it does not execute function again before TTL has passed", async () => {
+      // Create a memoized version of the async function with a TTL of 200 milliseconds
+      const memoizedAsyncFunction = memoizeAsync(asyncFunction, "asyncFunction1", 200);
+
+      // Call the memoized function with an argument
+      const result1 = await memoizedAsyncFunction("arg1");
+
+      // Advance the timers by 50 milliseconds (before the TTL)
+      jest.advanceTimersByTime(50);
+
+      // Call the memoized function again with the same argument
+      const result2 = await memoizedAsyncFunction("arg2");
+
+      // Ensure the function was not executed again before TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg1"); // Result from the memoized cache
+
+      // Ensure the async function was called only once
+      expect(asyncFunction).toHaveBeenCalledTimes(1);
+    });
+
+    test("it executes function again after TTL has passed", async () => {
+      // Create a memoized version of the async function with a TTL of 200 milliseconds
+      const memoizedAsyncFunction = memoizeAsync(asyncFunction, "asyncFunction2", 200);
+
+      // Call the memoized function with an argument
+      const result1 = await memoizedAsyncFunction("arg1");
+
+      // Advance the timers by 250 milliseconds (beyond the TTL)
+      jest.advanceTimersByTime(250);
+
+      // Call the memoized function again with the same argument
+      const result2 = await memoizedAsyncFunction("arg2");
+
+      // Ensure the function was executed again after TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg2"); // Result from the second call
+
+      // Ensure the async function was called twice (once initially, once after TTL)
+      expect(asyncFunction).toHaveBeenCalledTimes(2);
+    });
+
+    test("it does not execute function again when TTL is not provided", async () => {
+      const memoizedAsyncFunction = memoizeAsync(asyncFunction, "asyncFunction3");
+
+      // Call the memoized function with an argument
+      const result1 = await memoizedAsyncFunction("arg1");
+
+      // Advance the timers by 250 milliseconds (beyond the TTL)
+      jest.advanceTimersByTime(250);
+
+      // Call the memoized function again with the same argument
+      const result2 = await memoizedAsyncFunction("arg2");
+
+      // Ensure the function was executed again after TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg1"); // Result from the memoized cache
+
+      // Ensure the async function was called only once
+      expect(asyncFunction).toHaveBeenCalledTimes(1);
+    });
+
+    test("it returns the expected response based on the provided cache key", async () => {
+      const memoizedAsyncFunction4 = memoizeAsync(asyncFunction, "asyncFunction4");
+      const memoizedAsyncFunction5 = memoizeAsync(asyncFunction, "asyncFunction5");
+
+      // Call memoized function with an argument
+      const result1 = await memoizedAsyncFunction4("arg1");
+
+      // Call another memoized function with an argument
+      const result2 = await memoizedAsyncFunction5("arg2");
+
+      // Ensure the function was executed twice
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg2"); // Result from the second call
+
+      // Ensure the async function was called twice (once for each cache key)
+      expect(asyncFunction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("memoize", () => {
+    // Define a function to mock
+    const func = jest.fn((arg) => {
+      return arg;
+    });
+
+    beforeEach(() => {
+      // needed because of a weird bug with jest https://github.com/jestjs/jest/pull/12572
+      jest.useFakeTimers({ doNotFake: ["performance"] });
+    });
+
+    afterEach(() => {
+      // Restore real timers and clear all timers after each test
+      jest.useRealTimers();
+      jest.clearAllTimers();
+      func.mockClear();
+    });
+
+    test("it does not execute function again before TTL has passed", () => {
+      // Create a memoized version of the async function with a TTL of 200 milliseconds
+      const memoizedFunction = memoize(func, "function1", 200);
+
+      // Call the memoized function with an argument
+      const result1 = memoizedFunction("arg1");
+
+      // Advance the timers by 50 milliseconds (before the TTL)
+      jest.advanceTimersByTime(50);
+
+      // Call the memoized function again with the same argument
+      const result2 = memoizedFunction("arg2");
+
+      // Ensure the function was not executed again before TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg1"); // Result from the memoized cache
+
+      // Ensure the async function was called only once
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    test("it executes function again after TTL has passed", () => {
+      // Create a memoized version of the async function with a TTL of 200 milliseconds
+      const memoizedFunction = memoize(func, "function2", 200);
+
+      // Call the memoized function with an argument
+      const result1 = memoizedFunction("arg1");
+
+      // Advance the timers by 250 milliseconds (beyond the TTL)
+      jest.advanceTimersByTime(250);
+
+      // Call the memoized function again with the same argument
+      const result2 = memoizedFunction("arg2");
+
+      // Ensure the function was executed again after TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg2"); // Result from the second call
+
+      // Ensure the async function was called twice (once initially, once after TTL)
+      expect(func).toHaveBeenCalledTimes(2);
+    });
+
+    test("it does not execute function again when TTL is not provided", () => {
+      const memoizedFunction = memoize(func, "function3");
+
+      // Call the memoized function with an argument
+      const result1 = memoizedFunction("arg1");
+
+      // Advance the timers by 250 milliseconds (beyond the TTL)
+      jest.advanceTimersByTime(250);
+
+      // Call the memoized function again with the same argument
+      const result2 = memoizedFunction("arg2");
+
+      // Ensure the function was executed again after TTL
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg1"); // Result from the memoized cache
+
+      // Ensure the async function was called only once
+      expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    test("it returns the expected response based on the provided cache key", () => {
+      const memoizedFunction4 = memoize(func, "function4");
+      const memoizedFunction5 = memoize(func, "function5");
+
+      // Call memoized function with an argument
+      const result1 = memoizedFunction4("arg1");
+
+      // Call another memoized function with an argument
+      const result2 = memoizedFunction5("arg2");
+
+      // Ensure the function was executed twice
+      expect(result1).toBe("arg1"); // Result from the first call
+      expect(result2).toBe("arg2"); // Result from the second call
+
+      // Ensure the async function was called twice (once for each cache key)
+      expect(func).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
### Description
Implementation of a `memoize` and `memoizeAsync` high order functions that later can be used to cache function response.

- `memoize` - a high order function to memoize a pure function response (for example, class methods)
```
authKey(): HexString {
 const memoizedAuthKey = memoize(() => {
     const pubKey = new Ed25519PublicKey(this.signingKey.publicKey);
     const authKey = AuthenticationKey.fromEd25519PublicKey(pubKey);
     return authKey.derivedAddress();
    }, `authKey`);
  return memoizedAuthKey();
}
```
- `memoizeAsync` - a high order function to memoize an async function response (for example, api calls)
```
export async function getModules(args: {
  aptosConfig: AptosConfig;
  accountAddress: HexInput;
}): Promise<MoveModuleBytecode[]> {
  const memoizedGetModules = memoizeAsync(
    async (args: {
      aptosConfig: AptosConfig;
      accountAddress: HexInput;
      options?: PaginationArgs & LedgerVersion;
    }): Promise<MoveModuleBytecode[]> => {
      const { aptosConfig, accountAddress, options } = args;
      const data = await paginateWithCursor<{}, MoveModuleBytecode[]>({
        url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
        endpoint: `accounts/${AccountAddress.fromHexInput({ input: accountAddress }).toString()}/modules`,
        params: { ledger_version: options?.ledgerVersion, start: options?.start, limit: options?.limit ?? 1000 },
        originMethod: "getModules",
        overrides: { ...aptosConfig.clientConfig },
      });
      return data;
    },
    `getAccountModules_${args.accountAddress}`,
    600000, // 10 Minutes
  );

  return memoizedGetModules(args);
}
```

Note: current sdk version uses decorators. Decided to use high order function for some reasons:
1. Decorators is not that common in the JS world but high order functions are everywhere (filter, map, reduce, etc...).
2. Decorators can only be applied on class methods and not pure functions which doesn't conform with our new sdk design.
3. For now the memoize functions are pretty simple, can extend them as we need and think is right.

### Test Plan
```
npx jest -- tests/unit/memoize.test.ts              
 PASS  tests/unit/memoize.test.ts
  memoize
    memoizeAsync
      ✓ it does not execute function again before TTL has passed (103 ms)
      ✓ it executes function again after TTL has passed (204 ms)
      ✓ it does not execute function again when TTL is not provided (105 ms)
      ✓ it returns the expected response based on the provided cache key (206 ms)
    memoize
      ✓ it does not execute function again before TTL has passed (1 ms)
      ✓ it executes function again after TTL has passed
      ✓ it does not execute function again when TTL is not provided (1 ms)
      ✓ it returns the expected response based on the provided cache key
```
