### PR TITLE
assert no slot allocation after epilogue

### DIFF
--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -373,4 +373,10 @@ impl VMChangeSet {
 
         checker.check_change_set(self)
     }
+
+    pub fn has_creation(&self) -> bool {
+        use WriteOp::*;
+        self.write_set_iter()
+            .any(|(_key, op)| matches!(op, Creation(..) | CreationWithMetadata { .. }))
+    }
 }


### PR DESCRIPTION
### Description
To defend against an potential vulnerability (read commit for detail).

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
