### PR TITLE
[draft][gas] introduce dummy gas parameters

### DIFF
--- a/aptos-move/aptos-gas-calibration/src/measurements.rs
+++ b/aptos-move/aptos-gas-calibration/src/measurements.rs
@@ -53,6 +53,7 @@ fn compile_and_run_samples(
     for dir_path in dir_paths {
         // configure and build Move package
         let build_options = BuildOptions {
+            dev: true,
             with_srcs: true,
             with_abis: true,
             with_source_maps: true,

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -214,3 +214,12 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [string_utils_per_byte: InternalGasPerByte, { 8.. =>"string_utils.format.per_byte" }, 20],
     ]
 );
+
+crate::gas_schedule::macros::define_dummy_gas_parameters!(
+    bls12381_test_only_sign_base: InternalGas,
+    bls12381_test_only_sign_per_byte_msg: InternalGasPerByte,
+
+    bls12381_test_only_generate_keys: InternalGas,
+
+    bls12381_test_only_generate_proof_of_possession: InternalGas,
+);

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/mod.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/mod.rs
@@ -27,7 +27,9 @@ pub mod gas_params {
 
     pub mod natives {
         use super::*;
-        pub use aptos_framework::gas_params as aptos_framework;
+        pub mod aptos_framework {
+            pub use super::super::aptos_framework::{dummy_gas_params::*, gas_params::*};
+        }
         pub use move_stdlib::gas_params as move_stdlib;
         pub use table::gas_params as table;
     }


### PR DESCRIPTION
This introduces dummy gas parameters that can be used to model abstract costs of the test-only natives, allowing them to be used in the gas calibration tool.