### PR TITLE
[forge] Make it possible to run forge.py locally

### DIFF
--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -7,4 +7,5 @@
 
 echo "Warning: run_forge.sh is deprecated. Please use forge.py instead."
 echo "Executing python testsuite/forge.py test $@"
+poetry --directory testsuite install 
 exec python3 testsuite/forge.py test "$@"

--- a/testsuite/test_framework/shell.py
+++ b/testsuite/test_framework/shell.py
@@ -69,6 +69,7 @@ class LocalShell(Shell):
         for line in iter(process.stdout.readline, b""):
             if stream_output:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
             output += line
             if timeout_secs and time.time() - start_time > timeout_secs:
                 process.kill()


### PR DESCRIPTION
In the pursuit of a repro for a failing forge test I hit a bunch of problems just trying to run forge locally

I hit aws auth error... even though we are not using aws for forge anymore
I hit problems trying to find cluster (because we do not set the gcloud project)
I hit problems trying to find image (because of crane dependency)
I hit problems trying to find image (because we dont guarantee that forge image is built for every validator-testing image)

This should make it much easier to just run forge

Changes:

Deprecate S3 config, implement google storage config
Use gcloud instead of crane to test for image tags
Use forge image instead of validator testing for finding images

Test Plan:

running things locally, also forge run on PR

You can now run forge easily locally!

```
cd testsuite
poetry run python forge.py test framework_upgrade
```
