### PR TITLE
Propagating MoveTypeLayout for resources to BlockSTM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "claims",
  "crossbeam",
  "dashmap",
+ "move-core-types",
  "proptest",
  "proptest-derive",
  "rayon",
@@ -3489,6 +3490,7 @@ dependencies = [
  "aptos-native-interface",
  "aptos-types",
  "better_any",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-table-extension",
@@ -9735,6 +9737,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "better_any",
+ "bytes",
  "clap 4.3.21",
  "codespan-reporting",
  "colored",

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -160,9 +160,12 @@ pub trait AptosGasMeter: MoveGasMeter {
 
             write_fee += slot_fee + bytes_fee
         }
-        let event_fee = change_set.events().iter().fold(Fee::new(0), |acc, event| {
-            acc + self.storage_fee_per_event(event)
-        });
+        let event_fee = change_set
+            .events()
+            .iter()
+            .fold(Fee::new(0), |acc, (event, _)| {
+                acc + self.storage_fee_per_event(event)
+            });
         let event_discount = self.storage_discount_for_events(event_fee);
         let event_net_fee = event_fee
             .checked_sub(event_discount)

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -559,7 +559,7 @@ where
         // Events
         let mut event_fee = Fee::new(0);
         let mut event_fees = vec![];
-        for event in change_set.events().iter() {
+        for (event, _) in change_set.events().iter() {
             let fee = self.storage_fee_per_event(event);
             event_fees.push(EventStorage {
                 ty: event.type_tag().clone(),

--- a/aptos-move/aptos-vm-types/src/storage.rs
+++ b/aptos-move/aptos-vm-types/src/storage.rs
@@ -378,7 +378,7 @@ impl CheckChangeSet for ChangeSetConfigs {
         }
 
         let mut total_event_size = 0;
-        for event in change_set.events() {
+        for (event, _) in change_set.events() {
             let size = event.event_data().len() as u64;
             if size > self.max_bytes_per_event {
                 return Err(VMStatus::error(ERR, None));

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -4,7 +4,8 @@
 use crate::{
     change_set::VMChangeSet,
     tests::utils::{
-        build_change_set, mock_add, mock_create, mock_delete, mock_modify, MockChangeSetChecker,
+        build_change_set, mock_add, mock_create, mock_create_with_layout, mock_delete,
+        mock_delete_with_layout, mock_modify, mock_modify_with_layout, MockChangeSetChecker,
     },
 };
 use aptos_types::{
@@ -57,7 +58,22 @@ use std::collections::HashMap;
 /// *--------------*----------------*----------------*-----------------*
 /// ```
 
-macro_rules! write_set_1 {
+macro_rules! resource_write_set_1 {
+    ($d:ident) => {
+        vec![
+            mock_create_with_layout(format!("0{}", $d), 0, None),
+            mock_modify_with_layout(format!("1{}", $d), 1, None),
+            mock_delete_with_layout(format!("2{}", $d)),
+            mock_create_with_layout(format!("7{}", $d), 7, None),
+            mock_create_with_layout(format!("8{}", $d), 8, None),
+            mock_modify_with_layout(format!("10{}", $d), 10, None),
+            mock_modify_with_layout(format!("11{}", $d), 11, None),
+            mock_delete_with_layout(format!("12{}", $d)),
+        ]
+    };
+}
+
+macro_rules! module_write_set_1 {
     ($d:ident) => {
         vec![
             mock_create(format!("0{}", $d), 0),
@@ -72,7 +88,22 @@ macro_rules! write_set_1 {
     };
 }
 
-macro_rules! write_set_2 {
+macro_rules! resource_write_set_2 {
+    ($d:ident) => {
+        vec![
+            mock_create_with_layout(format!("3{}", $d), 103, None),
+            mock_modify_with_layout(format!("4{}", $d), 104, None),
+            mock_delete_with_layout(format!("5{}", $d)),
+            mock_modify_with_layout(format!("7{}", $d), 107, None),
+            mock_delete_with_layout(format!("8{}", $d)),
+            mock_modify_with_layout(format!("10{}", $d), 110, None),
+            mock_delete_with_layout(format!("11{}", $d)),
+            mock_create_with_layout(format!("12{}", $d), 112, None),
+        ]
+    };
+}
+
+macro_rules! module_write_set_2 {
     ($d:ident) => {
         vec![
             mock_create(format!("3{}", $d), 103),
@@ -86,8 +117,24 @@ macro_rules! write_set_2 {
         ]
     };
 }
+macro_rules! expected_resource_write_set {
+    ($d:ident) => {
+        HashMap::from([
+            mock_create_with_layout(format!("0{}", $d), 0, None),
+            mock_modify_with_layout(format!("1{}", $d), 1, None),
+            mock_delete_with_layout(format!("2{}", $d)),
+            mock_create_with_layout(format!("3{}", $d), 103, None),
+            mock_modify_with_layout(format!("4{}", $d), 104, None),
+            mock_delete_with_layout(format!("5{}", $d)),
+            mock_create_with_layout(format!("7{}", $d), 107, None),
+            mock_modify_with_layout(format!("10{}", $d), 110, None),
+            mock_delete_with_layout(format!("11{}", $d)),
+            mock_modify_with_layout(format!("12{}", $d), 112, None),
+        ])
+    };
+}
 
-macro_rules! expected_write_set {
+macro_rules! expected_module_write_set {
     ($d:ident) => {
         HashMap::from([
             mock_create(format!("0{}", $d), 0),
@@ -108,9 +155,9 @@ macro_rules! expected_write_set {
 // errors because we test them separately.
 fn build_change_sets_for_test() -> (VMChangeSet, VMChangeSet) {
     let mut descriptor = "r";
-    let resource_write_set_1 = write_set_1!(descriptor);
+    let resource_write_set_1 = resource_write_set_1!(descriptor);
     descriptor = "m";
-    let module_write_set_1 = write_set_1!(descriptor);
+    let module_write_set_1 = module_write_set_1!(descriptor);
     let aggregator_write_set_1 = vec![mock_create("18a", 18), mock_modify("19a", 19)];
     let aggregator_delta_set_1 = vec![
         mock_add("15a", 15),
@@ -127,9 +174,9 @@ fn build_change_sets_for_test() -> (VMChangeSet, VMChangeSet) {
     );
 
     descriptor = "r";
-    let resource_write_set_2 = write_set_2!(descriptor);
+    let resource_write_set_2 = resource_write_set_2!(descriptor);
     descriptor = "m";
-    let module_write_set_2 = write_set_2!(descriptor);
+    let module_write_set_2 = module_write_set_2!(descriptor);
     let aggregator_write_set_2 = vec![mock_modify("22a", 122), mock_delete("23a")];
     let aggregator_delta_set_2 = vec![
         mock_add("16a", 116),
@@ -158,12 +205,12 @@ fn test_successful_squash() {
     let mut descriptor = "r";
     assert_eq!(
         change_set.resource_write_set(),
-        &expected_write_set!(descriptor)
+        &expected_resource_write_set!(descriptor)
     );
     descriptor = "m";
     assert_eq!(
         change_set.module_write_set(),
-        &expected_write_set!(descriptor)
+        &expected_module_write_set!(descriptor)
     );
 
     let expected_aggregator_write_set = HashMap::from([
@@ -188,7 +235,7 @@ fn test_successful_squash() {
 }
 
 macro_rules! assert_invariant_violation {
-    ($w1:ident, $w2:ident) => {
+    ($w1:ident, $w2:ident, $w3:ident, $w4:ident) => {
         let check = |res: anyhow::Result<(), VMStatus>| {
             assert_matches!(
                 res,
@@ -204,12 +251,12 @@ macro_rules! assert_invariant_violation {
         let cs2 = build_change_set($w2.clone(), vec![], vec![], vec![], vec![]);
         let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
         check(res);
-        let mut cs1 = build_change_set(vec![], $w1.clone(), vec![], vec![], vec![]);
-        let cs2 = build_change_set(vec![], $w2.clone(), vec![], vec![], vec![]);
+        let mut cs1 = build_change_set(vec![], $w3.clone(), vec![], vec![], vec![]);
+        let cs2 = build_change_set(vec![], $w4.clone(), vec![], vec![], vec![]);
         let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
         check(res);
-        let mut cs1 = build_change_set(vec![], vec![], $w1.clone(), vec![], vec![]);
-        let cs2 = build_change_set(vec![], vec![], $w2.clone(), vec![], vec![]);
+        let mut cs1 = build_change_set(vec![], vec![], $w3.clone(), vec![], vec![]);
+        let cs2 = build_change_set(vec![], vec![], $w4.clone(), vec![], vec![]);
         let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
         check(res);
     };
@@ -218,33 +265,41 @@ macro_rules! assert_invariant_violation {
 #[test]
 fn test_unsuccessful_squash_create_create() {
     // create 6 + create 106 throws an error
-    let write_set_1 = vec![mock_create("6", 6)];
-    let write_set_2 = vec![mock_create("6", 106)];
-    assert_invariant_violation!(write_set_1, write_set_2);
+    let write_set_1 = vec![mock_create_with_layout("6", 6, None)];
+    let write_set_2 = vec![mock_create_with_layout("6", 106, None)];
+    let write_set_3 = vec![mock_create("6", 6)];
+    let write_set_4 = vec![mock_create("6", 106)];
+    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
 }
 
 #[test]
 fn test_unsuccessful_squash_modify_create() {
     // modify 9 + create 109 throws an error
-    let write_set_1 = vec![mock_modify("9", 9)];
-    let write_set_2 = vec![mock_create("9", 109)];
-    assert_invariant_violation!(write_set_1, write_set_2);
+    let write_set_1 = vec![mock_modify_with_layout("9", 9, None)];
+    let write_set_2 = vec![mock_create_with_layout("9", 109, None)];
+    let write_set_3 = vec![mock_modify("9", 9)];
+    let write_set_4 = vec![mock_create("9", 109)];
+    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
 }
 
 #[test]
 fn test_unsuccessful_squash_delete_modify() {
     // delete + modify 113 throws an error
-    let write_set_1 = vec![mock_delete("13")];
-    let write_set_2 = vec![mock_modify("13", 113)];
-    assert_invariant_violation!(write_set_1, write_set_2);
+    let write_set_1 = vec![mock_delete_with_layout("13")];
+    let write_set_2 = vec![mock_modify_with_layout("13", 113, None)];
+    let write_set_3 = vec![mock_delete("13")];
+    let write_set_4 = vec![mock_modify("13", 113)];
+    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
 }
 
 #[test]
 fn test_unsuccessful_squash_delete_delete() {
     // delete + delete throws an error
-    let write_set_1 = vec![mock_delete("14")];
-    let write_set_2 = vec![mock_delete("14")];
-    assert_invariant_violation!(write_set_1, write_set_2);
+    let write_set_1 = vec![mock_delete_with_layout("14")];
+    let write_set_2 = vec![mock_delete_with_layout("14")];
+    let write_set_3 = vec![mock_delete("14")];
+    let write_set_4 = vec![mock_delete("14")];
+    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
 }
 
 #[test]
@@ -319,7 +374,7 @@ fn test_roundtrip_to_storage_change_set() {
 
 #[test]
 fn test_failed_conversion_to_change_set() {
-    let resource_write_set = vec![mock_delete("a")];
+    let resource_write_set = vec![mock_delete_with_layout("a")];
     let aggregator_delta_set = vec![mock_add("b", 100)];
     let change_set = build_change_set(
         resource_write_set,

--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     output::VMOutput,
-    tests::utils::{as_state_key, build_vm_output, mock_add, mock_create, mock_modify},
+    tests::utils::{as_state_key, build_vm_output, mock_add, mock_create_with_layout, mock_modify},
 };
 use aptos_aggregator::delta_change_set::serialize;
 use aptos_language_e2e_tests::data_store::FakeDataStore;
@@ -36,7 +36,7 @@ fn test_ok_output_equality_no_deltas() {
     let state_view = FakeDataStore::default();
     let executor_view = state_view.as_executor_view();
     let vm_output = build_vm_output(
-        vec![mock_create("0", 0)],
+        vec![mock_create_with_layout("0", 0, None)],
         vec![mock_modify("1", 1)],
         vec![mock_modify("2", 2)],
         vec![],
@@ -71,7 +71,7 @@ fn test_ok_output_equality_with_deltas() {
     let executor_view = state_view.as_executor_view();
 
     let vm_output = build_vm_output(
-        vec![mock_create("0", 0)],
+        vec![mock_create_with_layout("0", 0, None)],
         vec![mock_modify("1", 1)],
         vec![mock_modify("2", 2)],
         vec![mock_add(delta_key, 300)],

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -13,8 +13,8 @@ use aptos_types::{
     transaction::{ExecutionStatus, TransactionStatus},
     write_set::WriteOp,
 };
-use move_core_types::vm_status::VMStatus;
-use std::collections::HashMap;
+use move_core_types::{value::MoveTypeLayout, vm_status::VMStatus};
+use std::{collections::HashMap, sync::Arc};
 
 pub(crate) struct MockChangeSetChecker;
 
@@ -49,13 +49,41 @@ pub(crate) fn mock_delete(k: impl ToString) -> (StateKey, WriteOp) {
     (as_state_key!(k), WriteOp::Deletion)
 }
 
+pub(crate) fn mock_create_with_layout(
+    k: impl ToString,
+    v: u128,
+    layout: Option<Arc<MoveTypeLayout>>,
+) -> (StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>)) {
+    (
+        as_state_key!(k),
+        (WriteOp::Creation(as_bytes!(v).into()), layout),
+    )
+}
+
+pub(crate) fn mock_modify_with_layout(
+    k: impl ToString,
+    v: u128,
+    layout: Option<Arc<MoveTypeLayout>>,
+) -> (StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>)) {
+    (
+        as_state_key!(k),
+        (WriteOp::Modification(as_bytes!(v).into()), layout),
+    )
+}
+
+pub(crate) fn mock_delete_with_layout(
+    k: impl ToString,
+) -> (StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>)) {
+    (as_state_key!(k), (WriteOp::Deletion, None))
+}
+
 pub(crate) fn mock_add(k: impl ToString, v: u128) -> (StateKey, DeltaOp) {
     const DUMMY_LIMIT: u128 = 1000;
     (as_state_key!(k), delta_add(v, DUMMY_LIMIT))
 }
 
 pub(crate) fn build_change_set(
-    resource_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
+    resource_write_set: impl IntoIterator<Item = (StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>))>,
     module_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
     aggregator_v1_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
     aggregator_v1_delta_set: impl IntoIterator<Item = (StateKey, DeltaOp)>,
@@ -75,7 +103,7 @@ pub(crate) fn build_change_set(
 
 // For testing, output has always a success execution status and uses 100 gas units.
 pub(crate) fn build_vm_output(
-    resource_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
+    resource_write_set: impl IntoIterator<Item = (StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>))>,
     module_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
     aggregator_v1_write_set: impl IntoIterator<Item = (StateKey, WriteOp)>,
     aggregator_v1_delta_set: impl IntoIterator<Item = (StateKey, DeltaOp)>,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1300,11 +1300,11 @@ impl AptosVM {
         let has_new_block_event = change_set
             .events()
             .iter()
-            .any(|e| e.event_key() == Some(&new_block_event_key()));
+            .any(|(e, _)| e.event_key() == Some(&new_block_event_key()));
         let has_new_epoch_event = change_set
             .events()
             .iter()
-            .any(|e| e.event_key() == Some(&new_epoch_event_key()));
+            .any(|(e, _)| e.event_key() == Some(&new_epoch_event_key()));
         if has_new_block_event && has_new_epoch_event {
             Ok(())
         } else {
@@ -1687,7 +1687,7 @@ impl VMAdapter for AptosVM {
             .change_set()
             .events()
             .iter()
-            .any(|event| event.event_key() == Some(&new_epoch_event_key))
+            .any(|(event, _)| event.event_key() == Some(&new_epoch_event_key))
     }
 
     fn execute_single_transaction(

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -35,7 +35,7 @@ use aptos_types::{
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::output::VMOutput;
-use move_core_types::{language_storage::StructTag, vm_status::VMStatus};
+use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::{prelude::*, ThreadPool};
 use std::{collections::HashMap, sync::Arc};
@@ -92,7 +92,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn resource_write_set(&self) -> HashMap<StateKey, WriteOp> {
+    fn resource_write_set(&self) -> HashMap<StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>)> {
         self.vm_output
             .lock()
             .as_ref()
@@ -140,7 +140,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn get_events(&self) -> Vec<ContractEvent> {
+    fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
         self.vm_output
             .lock()
             .as_ref()

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -149,7 +149,7 @@ impl<'r> TResourceView for ExecutorViewWithChangeSet<'r> {
         maybe_layout: Option<&Self::Layout>,
     ) -> anyhow::Result<Option<StateValue>> {
         match self.change_set.resource_write_set().get(state_key) {
-            Some(write_op) => Ok(write_op.as_state_value()),
+            Some((write_op, _)) => Ok(write_op.as_state_value()),
             None => self.base.get_resource_state_value(state_key, maybe_layout),
         }
     }
@@ -231,8 +231,8 @@ mod test {
         state_view.set_legacy(key("aggregator_delta_set"), serialize(&70));
 
         let resource_write_set = HashMap::from([
-            (key("resource_both"), write(80)),
-            (key("resource_write_set"), write(90)),
+            (key("resource_both"), (write(80), None)),
+            (key("resource_write_set"), (write(90), None)),
         ]);
 
         let module_write_set = HashMap::from([

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -21,20 +21,26 @@ use aptos_types::{
 };
 use aptos_vm_types::{change_set::VMChangeSet, storage::ChangeSetConfigs};
 use bytes::Bytes;
-use move_binary_format::errors::{Location, PartialVMError, VMResult};
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    effects::{AccountChangeSet, ChangeSet as MoveChangeSet, Op as MoveStorageOp},
+    effects::{AccountChanges, Changes, Op as MoveStorageOp},
     language_storage::{ModuleId, StructTag},
+    value::MoveTypeLayout,
     vm_status::{StatusCode, VMStatus},
 };
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
+use move_vm_types::values::Value;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
+
+type AccountChangeSet = AccountChanges<Bytes, BytesWithResourceLayout>;
+type ChangeSet = Changes<Bytes, BytesWithResourceLayout>;
+pub type BytesWithResourceLayout = (Bytes, Option<Arc<MoveTypeLayout>>);
 
 #[derive(BCSCryptoHash, CryptoHasher, Deserialize, Serialize)]
 pub enum SessionId {
@@ -146,7 +152,23 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         configs: &ChangeSetConfigs,
     ) -> VMResult<VMChangeSet> {
         let move_vm = self.inner.get_move_vm();
-        let (change_set, mut extensions) = self.inner.finish_with_extensions()?;
+
+        let resource_converter = |value: Value,
+                                  layout: MoveTypeLayout,
+                                  has_aggregator_lifting: bool|
+         -> PartialVMResult<BytesWithResourceLayout> {
+            value
+                .simple_serialize(&layout)
+                .map(Into::into)
+                .map(|bytes| (bytes, has_aggregator_lifting.then_some(Arc::new(layout))))
+                .ok_or_else(|| {
+                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                        .with_message(format!("Error when serializing resource {}.", value))
+                })
+        };
+        let (change_set, mut extensions) = self
+            .inner
+            .finish_with_extensions_with_custom_effects(&resource_converter)?;
 
         let (change_set, resource_group_change_set) =
             Self::split_and_merge_resource_groups(move_vm, self.remote, change_set, ap_cache)?;
@@ -205,12 +227,16 @@ impl<'r, 'l> SessionExt<'r, 'l> {
     ///   * If group or data does't exist, Unreachable
     ///   * If elements remain, Modify
     ///   * Otherwise delete
+    /// TODO: Resource groups are currently not handled correctly in terms of propagating MoveTypeLayout
     fn split_and_merge_resource_groups<C: AccessPathCache>(
         runtime: &MoveVM,
         remote: &dyn AptosMoveResolver,
-        change_set: MoveChangeSet,
+        change_set: ChangeSet,
         ap_cache: &mut C,
-    ) -> VMResult<(MoveChangeSet, HashMap<StateKey, MoveStorageOp<Bytes>>)> {
+    ) -> VMResult<(
+        ChangeSet,
+        HashMap<StateKey, MoveStorageOp<BytesWithResourceLayout>>,
+    )> {
         // The use of this implies that we could theoretically call unwrap with no consequences,
         // but using unwrap means the code panics if someone can come up with an attack.
         let common_error = || {
@@ -218,7 +244,7 @@ impl<'r, 'l> SessionExt<'r, 'l> {
                 .with_message("split_and_merge_resource_groups error".to_string())
                 .finish(Location::Undefined)
         };
-        let mut change_set_filtered = MoveChangeSet::new();
+        let mut change_set_filtered = ChangeSet::new();
 
         let mut resource_group_change_set = HashMap::new();
         let mut resource_group_cache = remote.release_resource_group_cache();
@@ -264,11 +290,11 @@ impl<'r, 'l> SessionExt<'r, 'l> {
                         MoveStorageOp::Delete => {
                             source_data.remove(&struct_tag).ok_or_else(common_error)?;
                         },
-                        MoveStorageOp::Modify(new_data) => {
+                        MoveStorageOp::Modify((new_data, _)) => {
                             let data = source_data.get_mut(&struct_tag).ok_or_else(common_error)?;
                             *data = new_data;
                         },
-                        MoveStorageOp::New(data) => {
+                        MoveStorageOp::New((data, _)) => {
                             let data = source_data.insert(struct_tag, data);
                             if data.is_some() {
                                 return Err(common_error());
@@ -280,17 +306,19 @@ impl<'r, 'l> SessionExt<'r, 'l> {
                 let op = if source_data.is_empty() {
                     MoveStorageOp::Delete
                 } else if create {
-                    MoveStorageOp::New(
+                    MoveStorageOp::New((
                         bcs::to_bytes(&source_data)
                             .map_err(|_| common_error())?
                             .into(),
-                    )
+                        None,
+                    ))
                 } else {
-                    MoveStorageOp::Modify(
+                    MoveStorageOp::Modify((
                         bcs::to_bytes(&source_data)
                             .map_err(|_| common_error())?
                             .into(),
-                    )
+                        None,
+                    ))
                 };
                 resource_group_change_set.insert(state_key, op);
             }
@@ -301,9 +329,9 @@ impl<'r, 'l> SessionExt<'r, 'l> {
 
     pub(crate) fn convert_change_set<C: AccessPathCache>(
         woc: &WriteOpConverter,
-        change_set: MoveChangeSet,
-        resource_group_change_set: HashMap<StateKey, MoveStorageOp<Bytes>>,
-        events: Vec<ContractEvent>,
+        change_set: ChangeSet,
+        resource_group_change_set: HashMap<StateKey, MoveStorageOp<BytesWithResourceLayout>>,
+        events: Vec<(ContractEvent, Option<MoveTypeLayout>)>,
         table_change_set: TableChangeSet,
         aggregator_change_set: AggregatorChangeSet,
         ap_cache: &mut C,
@@ -317,11 +345,11 @@ impl<'r, 'l> SessionExt<'r, 'l> {
 
         for (addr, account_changeset) in change_set.into_inner() {
             let (modules, resources) = account_changeset.into_inner();
-            for (struct_tag, blob_op) in resources {
+            for (struct_tag, blob_and_layout_op) in resources {
                 let state_key = StateKey::access_path(ap_cache.get_resource_path(addr, struct_tag));
                 let op = woc.convert_resource(
                     &state_key,
-                    blob_op,
+                    blob_and_layout_op,
                     configs.legacy_resource_creation_as_modification(),
                 )?;
 

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -603,11 +603,15 @@ where
 {
     type Txn = MockTransaction<K, V, E>;
 
-    fn resource_write_set(&self) -> HashMap<K, V> {
+    // TODO: Assigning MoveTypeLayout as None for all the writes for now. That means, the
+    // the resources do not have any aggregators embededded in them. Change it to test
+    // resources with aggregators as well.
+    fn resource_write_set(&self) -> HashMap<K, (V, Option<Arc<MoveTypeLayout>>)> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_none())
             .cloned()
+            .map(|(k, v)| (k, (v, None)))
             .collect()
     }
 
@@ -629,8 +633,10 @@ where
         self.deltas.iter().cloned().collect()
     }
 
-    fn get_events(&self) -> Vec<E> {
-        self.events.clone()
+    // TODO: Currently, appending None to all events, which means none of the
+    // events have aggregators. Test it with aggregators as well.
+    fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
+        self.events.iter().map(|e| (e.clone(), None)).collect()
     }
 
     fn skip_output() -> Self {

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -13,7 +13,7 @@ use aptos_types::{
 use aptos_vm_types::resolver::TExecutorView;
 use move_core_types::value::MoveTypeLayout;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
+use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -100,7 +100,13 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// aggregator_v1.
     fn resource_write_set(
         &self,
-    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+    ) -> HashMap<
+        <Self::Txn as Transaction>::Key,
+        (
+            <Self::Txn as Transaction>::Value,
+            Option<Arc<MoveTypeLayout>>,
+        ),
+    >;
 
     fn module_write_set(
         &self,
@@ -114,7 +120,7 @@ pub trait TransactionOutput: Send + Sync + Debug {
     fn aggregator_v1_delta_set(&self) -> HashMap<<Self::Txn as Transaction>::Key, DeltaOp>;
 
     /// Get the events of a transaction from its output.
-    fn get_events(&self) -> Vec<<Self::Txn as Transaction>::Event>;
+    fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
 
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -40,7 +40,7 @@ use std::{
 #[derive(Debug)]
 pub(crate) enum ReadResult<V> {
     // Successful read of a value.
-    Value(Arc<V>),
+    Value(Arc<V>, Option<Arc<MoveTypeLayout>>),
     // Similar to above, but the value was aggregated and is an integer.
     U128(u128),
     // Read did not return anything.
@@ -95,11 +95,11 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
 
         loop {
             match self.versioned_map.data().fetch_data(key, txn_idx) {
-                Ok(Versioned(version, v)) => {
+                Ok(Versioned(version, v, layout)) => {
                     self.captured_reads
                         .borrow_mut()
                         .push(ReadDescriptor::from_versioned(key.clone(), version));
-                    return ReadResult::Value(v);
+                    return ReadResult::Value(v, layout);
                 },
                 Ok(Resolved(value)) => {
                     self.captured_reads
@@ -266,7 +266,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceVi
                 }
 
                 match mv_value {
-                    ReadResult::Value(v) => Ok(v.as_state_value()),
+                    ReadResult::Value(v, _) => Ok(v.as_ref().as_state_value()),
                     ReadResult::U128(v) => Ok(Some(StateValue::new_legacy(serialize(&v).into()))),
                     // ExecutionHalted indicates that the parallel execution is halted.
                     // The read should return immediately and log the error.

--- a/aptos-move/framework/table-natives/Cargo.toml
+++ b/aptos-move/framework/table-natives/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 aptos-gas-schedule = { workspace = true } 
 aptos-native-interface = { workspace = true }
 better_any = { workspace = true }
+bytes = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
 

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -23,6 +23,7 @@ bytes = { workspace = true }
 claims = { workspace = true }
 crossbeam = { workspace = true }
 dashmap = { workspace = true }
+move-core-types = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -4,6 +4,7 @@
 use aptos_aggregator::delta_change_set::DeltaOp;
 use aptos_crypto::hash::HashValue;
 use aptos_types::executable::ExecutableDescriptor;
+use move_core_types::value::MoveTypeLayout;
 use std::sync::{atomic::AtomicU32, Arc};
 
 pub type AtomicTxnIndex = AtomicU32;
@@ -67,7 +68,7 @@ pub enum MVDataOutput<V> {
     Resolved(u128),
     /// Information from the last versioned-write. Note that the version is returned
     /// and not the data to avoid copying big values around.
-    Versioned(Version, Arc<V>),
+    Versioned(Version, Arc<V>, Option<Arc<MoveTypeLayout>>),
 }
 
 /// Returned as Ok(..) when read successfully from the multi-version data-structure.

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -44,6 +44,7 @@ enum ExpectedOutput<V: Debug + Clone + PartialEq> {
     Failure,
 }
 
+#[derive(Debug, Clone)]
 struct Value<V> {
     maybe_value: Option<V>,
     maybe_bytes: Option<Bytes>,
@@ -233,7 +234,7 @@ where
                 .write(key.clone(), idx, 0, vec![(5, value)]);
             map.group_data().mark_estimate(&key, idx);
         } else {
-            map.data().write(key.clone(), idx, 0, value);
+            map.data().write(key.clone(), idx, 0, (value, None));
             map.data().mark_estimate(&key, idx);
         }
     }
@@ -290,7 +291,7 @@ where
                                     .data()
                                     .fetch_data(&KeyType(key.clone()), idx as TxnIndex)
                                 {
-                                    Ok(Versioned(_, v)) => {
+                                    Ok(Versioned(_, v, _)) => {
                                         assert_value(v);
                                         break;
                                     },
@@ -337,7 +338,7 @@ where
                             map.group_data()
                                 .write(key, idx as TxnIndex, 1, vec![(5, value)]);
                         } else {
-                            map.data().write(key, idx as TxnIndex, 1, value);
+                            map.data().write(key, idx as TxnIndex, 1, (value, None));
                         }
                     },
                     Operator::Insert(v) => {
@@ -347,7 +348,7 @@ where
                             map.group_data()
                                 .write(key, idx as TxnIndex, 1, vec![(5, value)]);
                         } else {
-                            map.data().write(key, idx as TxnIndex, 1, value);
+                            map.data().write(key, idx as TxnIndex, 1, (value, None));
                         }
                     },
                     Operator::Update(delta) => {

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -36,7 +36,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    value::{serialize_values, MoveValue},
+    value::{serialize_values, MoveTypeLayout, MoveValue},
 };
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
@@ -641,10 +641,10 @@ fn emit_new_block_and_epoch_event(session: &mut SessionExt) {
 }
 
 /// Verify the consistency of the genesis `WriteSet`
-fn verify_genesis_write_set(events: &[ContractEvent]) {
+fn verify_genesis_write_set(events: &[(ContractEvent, Option<MoveTypeLayout>)]) {
     let new_epoch_events: Vec<&ContractEventV1> = events
         .iter()
-        .filter_map(|e| {
+        .filter_map(|(e, _)| {
             if e.event_key() == Some(&NewEpochEvent::event_key()) {
                 Some(e.v1().unwrap())
             } else {

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -60,7 +60,7 @@ pub enum MoveValue {
 }
 
 /// A layout associated with a named field
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(arbitrary::Arbitrary))]
 pub struct MoveFieldLayout {
     pub name: Identifier,
@@ -73,7 +73,7 @@ impl MoveFieldLayout {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(arbitrary::Arbitrary))]
 pub enum MoveStructLayout {
     /// The representation used by the MoveVM
@@ -87,7 +87,7 @@ pub enum MoveStructLayout {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(arbitrary::Arbitrary))]
 pub enum LayoutTag {
     /// The current type corresponds to an aggregator or a snapshot values
@@ -95,7 +95,7 @@ pub enum LayoutTag {
     AggregatorLifting,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(arbitrary::Arbitrary))]
 pub enum MoveTypeLayout {
     #[serde(rename(serialize = "bool", deserialize = "bool"))]

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -23,7 +23,9 @@ use move_vm_types::{
 use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
-    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue)>,
+    // The bool flag in the `data_map` indicates whether the resource contains
+    // an aggregator or snapshot.
+    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue, bool)>,
     module_map: BTreeMap<Identifier, (Bytes, bool)>,
 }
 
@@ -69,15 +71,16 @@ impl<'r> TransactionDataCache<'r> {
     ///
     /// Gives all proper guarantees on lifetime of global data as well.
     pub(crate) fn into_effects(self, loader: &Loader) -> PartialVMResult<ChangeSet> {
-        let resource_converter = |value: Value, layout: MoveTypeLayout| -> PartialVMResult<Bytes> {
-            value
-                .simple_serialize(&layout)
-                .map(Into::into)
-                .ok_or_else(|| {
-                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
-                        .with_message(format!("Error when serializing resource {}.", value))
-                })
-        };
+        let resource_converter =
+            |value: Value, layout: MoveTypeLayout, _: bool| -> PartialVMResult<Bytes> {
+                value
+                    .simple_serialize(&layout)
+                    .map(Into::into)
+                    .ok_or_else(|| {
+                        PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                            .with_message(format!("Error when serializing resource {}.", value))
+                    })
+            };
         self.into_custom_effects(&resource_converter, loader)
     }
 
@@ -85,10 +88,10 @@ impl<'r> TransactionDataCache<'r> {
     /// produced effects for resources.
     pub(crate) fn into_custom_effects<Resource>(
         self,
-        resource_converter: &dyn Fn(Value, MoveTypeLayout) -> PartialVMResult<Resource>,
+        resource_converter: &dyn Fn(Value, MoveTypeLayout, bool) -> PartialVMResult<Resource>,
         loader: &Loader,
     ) -> PartialVMResult<Changes<Bytes, Resource>> {
-        let mut change_set = Changes::new();
+        let mut change_set = Changes::<Bytes, Resource>::new();
         for (addr, account_data_cache) in self.account_map.into_iter() {
             let mut modules = BTreeMap::new();
             for (module_name, (module_blob, is_republishing)) in account_data_cache.module_map {
@@ -101,7 +104,7 @@ impl<'r> TransactionDataCache<'r> {
             }
 
             let mut resources = BTreeMap::new();
-            for (ty, (layout, gv)) in account_data_cache.data_map {
+            for (ty, (layout, gv, has_aggregator_lifting)) in account_data_cache.data_map {
                 if let Some(op) = gv.into_effect_with_layout(layout) {
                     let struct_tag = match loader.type_to_type_tag(&ty)? {
                         TypeTag::Struct(struct_tag) => *struct_tag,
@@ -109,7 +112,9 @@ impl<'r> TransactionDataCache<'r> {
                     };
                     resources.insert(
                         struct_tag,
-                        op.and_then(|(value, layout)| resource_converter(value, layout))?,
+                        op.and_then(|(value, layout)| {
+                            resource_converter(value, layout, has_aggregator_lifting)
+                        })?,
                     );
                 }
             }
@@ -130,7 +135,7 @@ impl<'r> TransactionDataCache<'r> {
         // The sender's account will always be mutated.
         let mut total_mutated_accounts: u64 = 1;
         for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v)| v.is_mutated()) {
+            if addr != sender && entry.data_map.values().any(|(_, v, _)| v.is_mutated()) {
                 total_mutated_accounts += 1;
             }
         }
@@ -218,14 +223,16 @@ impl<'r> TransactionDataCache<'r> {
                 None => GlobalValue::none(),
             };
 
-            account_cache.data_map.insert(ty.clone(), (ty_layout, gv));
+            account_cache
+                .data_map
+                .insert(ty.clone(), (ty_layout, gv, has_aggregator_lifting));
         }
 
         Ok((
             account_cache
                 .data_map
                 .get_mut(ty)
-                .map(|(_ty_layout, gv)| gv)
+                .map(|(_ty_layout, gv, _has_aggregator_lifting)| gv)
                 .expect("global value must exist"),
             load_res,
         ))

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -265,7 +265,7 @@ impl<'r, 'l> Session<'r, 'l> {
 
     pub fn finish_with_custom_effects<Resource>(
         self,
-        resource_converter: &dyn Fn(Value, MoveTypeLayout) -> PartialVMResult<Resource>,
+        resource_converter: &dyn Fn(Value, MoveTypeLayout, bool) -> PartialVMResult<Resource>,
     ) -> VMResult<Changes<Bytes, Resource>> {
         self.data_cache
             .into_custom_effects(resource_converter, self.move_vm.runtime.loader())
@@ -287,7 +287,7 @@ impl<'r, 'l> Session<'r, 'l> {
 
     pub fn finish_with_extensions_with_custom_effects<Resource>(
         self,
-        resource_converter: &dyn Fn(Value, MoveTypeLayout) -> PartialVMResult<Resource>,
+        resource_converter: &dyn Fn(Value, MoveTypeLayout, bool) -> PartialVMResult<Resource>,
     ) -> VMResult<(Changes<Bytes, Resource>, NativeContextExtensions<'r>)> {
         let Session {
             data_cache,

--- a/third_party/move/tools/move-unit-test/Cargo.toml
+++ b/third_party/move/tools/move-unit-test/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 better_any = "0.1.1"
+bytes = { version = "1.4.0" }
 clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.0"


### PR DESCRIPTION
### Description

Propagating MoveTypeLayout for resources to BlockSTM.
Modify `VMChangeSet.resource_write_set` to `HashMap<StateKey, (WriteOp, Option<MoveTypeLayout>)`.