### PR TITLE
fix that db-restore can not run concurrently in tests

### DIFF
--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -14,7 +14,6 @@ use aptos_temppath::TempPath;
 use async_trait::async_trait;
 use clap::Parser;
 use futures::stream::poll_fn;
-use once_cell::sync::Lazy;
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -26,13 +25,6 @@ use tokio::{
     io::{AsyncRead, AsyncReadExt},
 };
 use tokio_stream::StreamExt;
-
-static TEMP_METADATA_CACHE_DIR: Lazy<TempPath> = Lazy::new(|| {
-    let dir = TempPath::new();
-    dir.create_as_dir()
-        .expect("Temp metadata dir should create.");
-    dir
-});
 
 #[derive(Clone, Parser)]
 pub struct MetadataCacheOpt {
@@ -60,7 +52,7 @@ impl MetadataCacheOpt {
     pub(crate) fn cache_dir(&self) -> PathBuf {
         self.dir
             .clone()
-            .unwrap_or_else(|| TEMP_METADATA_CACHE_DIR.path().to_path_buf())
+            .unwrap_or_else(|| TempPath::new().path().to_path_buf())
             .join(Self::SUB_DIR)
     }
 }


### PR DESCRIPTION
It's wrong to use the same temp dir for the whole process

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
