### PR TITLE
[CLI] Add print-metadata to the download subcommand

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Added an option `--print-metadata` to the command `aptos move download` to print out the metadata of the package to be downloaded.
+  - Example: `aptos move download  --account 0x1 --package AptosFramework --url https://mainnet.aptoslabs.com/v1 --print-metadata`
 
 ## [2.1.0] - 2023/08/24
 ### Updated

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -992,6 +992,9 @@ pub struct DownloadPackage {
     pub(crate) rest_options: RestOptions,
     #[clap(flatten)]
     pub(crate) profile_options: ProfileOptions,
+    /// Print metadata of the package
+    #[clap(long)]
+    pub print_metadata: bool,
 }
 
 #[async_trait]
@@ -1015,6 +1018,9 @@ impl CliCommand<&'static str> for DownloadPackage {
                 since it is not safe to depend on such packages."
                     .to_owned(),
             ));
+        }
+        if self.print_metadata {
+            println!("{}", package);
         }
         let package_path = output_dir.join(package.name());
         package

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -10,7 +10,7 @@ use aptos_rest_client::Client;
 use aptos_types::account_address::AccountAddress;
 use move_package::compilation::package_layout::CompiledPackageLayout;
 use reqwest::Url;
-use std::{fs, path::Path};
+use std::{fmt, fs, path::Path};
 
 // TODO: this is a first naive implementation of the package registry. Before mainnet
 // we need to use tables for the package registry.
@@ -28,6 +28,13 @@ pub struct CachedPackageMetadata<'a> {
 /// Represents the package metadata found in an registry.
 pub struct CachedModuleMetadata<'a> {
     metadata: &'a ModuleMetadata,
+}
+
+impl fmt::Display for CachedPackageMetadata<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.metadata)?;
+        Ok(())
+    }
 }
 
 impl CachedPackageRegistry {

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -889,6 +889,7 @@ impl CliTestFramework {
             account: self.account_id(index),
             package,
             output_dir: Some(output_dir),
+            print_metadata: false,
         }
         .execute()
         .await


### PR DESCRIPTION
### Description

This PR adds an option `--print-metadata` to the command `aptos move download` to print out the metadata of the package to be downloaded. Close #10131

### Test Plan

`aptos move download  --account 0x1 --package AptosFramework --url https://mainnet.aptoslabs.com/v1 --print-metadata`