### PR TITLE
[Execution][Block-STM] Create the final block-stm output in parallel

### DIFF
--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -104,6 +104,17 @@ pub static RAYON_EXECUTION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static PARALLEL_EXECUTOR_FINAL_RESULT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "aptos_parallel_executor_final_result_seconds",
+        // metric description
+        "The time spent in constructing the final result in parallel execution",
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
+    )
+    .unwrap()
+});
+
 pub static VM_INIT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         // metric name

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -636,7 +636,7 @@ where
                                     *skip_index = Some(idx);
                                 }
                                 output
-                            }
+                            },
                             Some(ExecutionStatus::Abort(err)) => {
                                 *maybe_err.lock().unwrap() = Some(err);
                                 E::Output::skip_output()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -609,60 +609,103 @@ where
         ret
     }
 
+    fn set_error_if_needed(
+        maybe_err: &Arc<Mutex<Option<Error<E::Error>>>>,
+        min_error_index: &Arc<Mutex<Option<usize>>>,
+        err: Error<E::Error>,
+        idx: usize,
+    ) {
+        let mut min_error_index = min_error_index.lock().unwrap();
+        if let Some(existing_index) = *min_error_index {
+            if idx < existing_index {
+                *maybe_err.lock().unwrap() = Some(err);
+                *min_error_index = Some(idx);
+            }
+        } else {
+            *min_error_index = Some(idx);
+            *maybe_err.lock().unwrap() = Some(err);
+        }
+    }
+
+    fn set_skip_index_if_needed(skip_rest_index: &Arc<Mutex<Option<usize>>>, idx: usize) {
+        let mut skip_index = skip_rest_index.lock().unwrap();
+        if let Some(existing_index) = *skip_index {
+            *skip_index = Some(std::cmp::min(existing_index, idx));
+        } else {
+            *skip_index = Some(idx);
+        }
+    }
+
+    // This function processes the transaction output in parallel and returns the final result.
+    // Following semantic is guaranteed to ensure the output of the parallel result collection is
+    // deterministic and is same as sequential result collection
+    // 1. If there is an error in any of the transaction and no transaction is skipped, then the
+    //    error is returned.
+    // 2. If there is no error in any of the transaction and some transaction is skipped, then the
+    // the all transaction output after the skipped transaction is set to skip.
+    // 3. If there is error in any of the transaction and some transaction is skipped, then the
+    // we check the minimum index of the error and skipped transaction. If the error transaction
+    // index is less than the skipped transaction index, then the error is returned. Otherwise,
+    // the all transaction output after the skipped transaction is set to skip.
     fn make_final_result_in_parallel(
         &self,
         last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
         num_txns: usize,
     ) -> Result<Vec<E::Output>, E::Error> {
         let _timer = PARALLEL_EXECUTOR_FINAL_RESULT_SECONDS.start_timer();
-        let skip_rest_index = Arc::new(Mutex::new(None));
-        let maybe_err = Arc::new(Mutex::new(None));
-        let mut final_results = if last_input_output.module_publishing_may_race() {
+        if last_input_output.module_publishing_may_race() {
             counters::MODULE_PUBLISHING_FALLBACK_COUNT.inc();
-            *maybe_err.lock().unwrap() = Some(Error::ModulePathReadWrite);
-            vec![]
-        } else {
-            self.executor_thread_pool.scope(|_| {
-                (0..num_txns)
-                    .into_par_iter()
-                    .map(
-                        |idx| match last_input_output.try_take_output(idx as TxnIndex) {
-                            Some(ExecutionStatus::Success(output)) => output,
-                            Some(ExecutionStatus::SkipRest(output)) => {
-                                let mut skip_index = skip_rest_index.lock().unwrap();
-                                if let Some(existing_index) = *skip_index {
-                                    *skip_index = Some(std::cmp::min(existing_index, idx));
-                                } else {
-                                    *skip_index = Some(idx);
-                                }
-                                output
-                            },
-                            Some(ExecutionStatus::Abort(err)) => {
-                                *maybe_err.lock().unwrap() = Some(err);
-                                E::Output::skip_output()
-                            },
-                            None => {
-                                // This is the case when there is an error or txn is skipped by the scheduler.
-                                E::Output::skip_output()
-                            },
+            return Err(Error::ModulePathReadWrite);
+        }
+        let skip_rest_index = Arc::new(Mutex::new(None));
+        let min_error_index = Arc::new(Mutex::new(None));
+        let maybe_err = Arc::new(Mutex::new(None));
+
+        let mut final_results: Vec<E::Output> = self.executor_thread_pool.scope(|_| {
+            (0..num_txns)
+                .into_par_iter()
+                .map(
+                    |idx| match last_input_output.try_take_output(idx as TxnIndex) {
+                        Some(ExecutionStatus::Success(output)) => output,
+                        Some(ExecutionStatus::SkipRest(output)) => {
+                            Self::set_skip_index_if_needed(&skip_rest_index, idx);
+                            output
                         },
-                    )
-                    .collect()
-            })
-        };
+                        Some(ExecutionStatus::Abort(err)) => {
+                            Self::set_error_if_needed(&maybe_err, &min_error_index, err, idx);
+                            E::Output::skip_output()
+                        },
+                        None => {
+                            // This is the case when there is an error or txn is skipped by the scheduler.
+                            E::Output::skip_output()
+                        },
+                    },
+                )
+                .collect()
+        });
 
         let maybe_err = maybe_err.lock().unwrap().take();
-        match maybe_err {
-            Some(err) => Err(err),
-            None => {
-                if let Some(skip_index) = *skip_rest_index.lock().unwrap() {
-                    final_results[skip_index..].iter_mut().for_each(|t| {
-                        *t = E::Output::skip_output();
-                    });
+        let maybe_skip_index = skip_rest_index.lock().unwrap().take();
+        let maybe_err_index = min_error_index.lock().unwrap().take();
+
+        if let Some(err_index) = maybe_err_index {
+            if let Some(skip_index) = maybe_skip_index {
+                if skip_index > err_index {
+                    return Err(maybe_err.unwrap());
                 }
-                Ok(final_results)
-            },
+            } else {
+                return Err(maybe_err.unwrap());
+            }
         }
+        if let Some(skip_index) = maybe_skip_index {
+            // Everything after skip_index is skipped.
+            final_results[skip_index + 1..]
+                .iter_mut()
+                .for_each(|output| {
+                    *output = E::Output::skip_output();
+                });
+        }
+        Ok(final_results)
     }
 
     pub(crate) fn execute_transactions_sequential(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -5,8 +5,9 @@
 use crate::{
     counters,
     counters::{
-        PARALLEL_EXECUTION_SECONDS, RAYON_EXECUTION_SECONDS, TASK_EXECUTE_SECONDS,
-        TASK_VALIDATE_SECONDS, VM_INIT_SECONDS, WORK_WITH_TASK_SECONDS,
+        PARALLEL_EXECUTION_SECONDS, PARALLEL_EXECUTOR_FINAL_RESULT_SECONDS,
+        RAYON_EXECUTION_SECONDS, TASK_EXECUTE_SECONDS, TASK_VALIDATE_SECONDS, VM_INIT_SECONDS,
+        WORK_WITH_TASK_SECONDS,
     },
     errors::*,
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
@@ -30,7 +31,10 @@ use aptos_types::{
 };
 use aptos_vm_logging::{clear_speculative_txn_logs, init_speculative_logs};
 use num_cpus;
-use rayon::ThreadPool;
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    ThreadPool,
+};
 use std::{
     collections::HashMap,
     marker::PhantomData,
@@ -38,7 +42,7 @@ use std::{
         atomic::AtomicU32,
         mpsc,
         mpsc::{Receiver, Sender},
-        Arc,
+        Arc, Mutex,
     },
 };
 
@@ -592,29 +596,8 @@ where
         drop(timer);
 
         let num_txns = num_txns as usize;
-        // TODO: for large block sizes and many cores, extract outputs in parallel.
-        let mut final_results = Vec::with_capacity(num_txns);
 
-        let maybe_err = if last_input_output.module_publishing_may_race() {
-            counters::MODULE_PUBLISHING_FALLBACK_COUNT.inc();
-            Some(Error::ModulePathReadWrite)
-        } else {
-            let mut ret = None;
-            for idx in 0..num_txns {
-                match last_input_output.take_output(idx as TxnIndex) {
-                    ExecutionStatus::Success(t) => final_results.push(t),
-                    ExecutionStatus::SkipRest(t) => {
-                        final_results.push(t);
-                        break;
-                    },
-                    ExecutionStatus::Abort(err) => {
-                        ret = Some(err);
-                        break;
-                    },
-                };
-            }
-            ret
-        };
+        let ret = self.make_final_result_in_parallel(&last_input_output, num_txns);
 
         self.executor_thread_pool.spawn(move || {
             // Explicit async drops.
@@ -623,11 +606,60 @@ where
             // TODO: re-use the code cache.
             drop(versioned_cache);
         });
+        ret
+    }
 
+    fn make_final_result_in_parallel(
+        &self,
+        last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
+        num_txns: usize,
+    ) -> Result<Vec<E::Output>, E::Error> {
+        let _timer = PARALLEL_EXECUTOR_FINAL_RESULT_SECONDS.start_timer();
+        let skip_rest_index = Arc::new(Mutex::new(None));
+        let maybe_err = Arc::new(Mutex::new(None));
+        let mut final_results = if last_input_output.module_publishing_may_race() {
+            counters::MODULE_PUBLISHING_FALLBACK_COUNT.inc();
+            *maybe_err.lock().unwrap() = Some(Error::ModulePathReadWrite);
+            vec![]
+        } else {
+            self.executor_thread_pool.scope(|_| {
+                (0..num_txns)
+                    .into_par_iter()
+                    .map(
+                        |idx| match last_input_output.try_take_output(idx as TxnIndex) {
+                            Some(ExecutionStatus::Success(output)) => output,
+                            Some(ExecutionStatus::SkipRest(output)) => {
+                                let mut skip_index = skip_rest_index.lock().unwrap();
+                                if let Some(existing_index) = *skip_index {
+                                    *skip_index = Some(std::cmp::min(existing_index, idx));
+                                } else {
+                                    *skip_index = Some(idx);
+                                }
+                                output
+                            }
+                            Some(ExecutionStatus::Abort(err)) => {
+                                *maybe_err.lock().unwrap() = Some(err);
+                                E::Output::skip_output()
+                            },
+                            None => {
+                                // This is the case when there is an error or txn is skipped by the scheduler.
+                                E::Output::skip_output()
+                            },
+                        },
+                    )
+                    .collect()
+            })
+        };
+
+        let maybe_err = maybe_err.lock().unwrap().take();
         match maybe_err {
             Some(err) => Err(err),
             None => {
-                final_results.resize_with(num_txns, E::Output::skip_output);
+                if let Some(skip_index) = *skip_rest_index.lock().unwrap() {
+                    final_results[skip_index..].iter_mut().for_each(|t| {
+                        *t = E::Output::skip_output();
+                    });
+                }
                 Ok(final_results)
             },
         }


### PR DESCRIPTION
### Description

Profiling the execution code, we figured that the output creation which is currently being done in serial, consumes around 10% of the time for larger block size of ~20k. This change makes the output creation parallel.

### Test Plan
Existing UTs. 

Ran the single node performance benchmark on t2d-standard-60 machine and it gives us overall 4% TPS boost. The TPS goes from 31500 to 32800. 

Command - 

```
cargo run --profile performance -p aptos-executor-benchmark  -- --execution-threads 48 --generate-then-execute --transactions-per-sender 1 --block-size 25000 --split-ledger-db --use-sharded-state-merkle-db --skip-index-and-usage run-executor  --main-signer-accounts 100000  --data-dir ~/data/db2 --checkpoint-dir ~/data/chk --blocks 50
```


