### PR TITLE
Revert "Remove Bulletproofs feature flag"

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -50,6 +50,16 @@ proposals:
               sender_aware_v2: 32
             block_gas_limit: 35000
             transaction_deduper_type: txn_hash_and_authenticator_v1
+  - name: enable_bulletproofs
+    metadata:
+      title: "Enable Bulletproofs Module"
+      description: "AIP-46: New modules for ElGamal, Pedersen and Bulletproofs over Ristretto255"
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/222"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - bulletproofs_natives
   - name: enable_storage_deletion_refund
     metadata:
       title: "Enable Storage Deletion Refund"


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#10137

We've re-evaluated the feature, and agreed that this is now ready to ship.