### PR TITLE
[Aptos Data Client] Small cleanups and refactors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "aptos-storage-service-types",
  "aptos-time-service",
  "aptos-types",
+ "arc-swap",
  "async-trait",
  "bcs 0.1.4",
  "claims",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "claims",
+ "dashmap",
  "futures",
  "itertools",
  "maplit",

--- a/state-sync/aptos-data-client/Cargo.toml
+++ b/state-sync/aptos-data-client/Cargo.toml
@@ -28,6 +28,7 @@ aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }

--- a/state-sync/aptos-data-client/Cargo.toml
+++ b/state-sync/aptos-data-client/Cargo.toml
@@ -26,6 +26,7 @@ aptos-storage-service-client = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -21,7 +21,7 @@ use aptos_config::{
     network_id::PeerNetworkId,
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
-use aptos_infallible::{Mutex, RwLock};
+use aptos_infallible::Mutex;
 use aptos_logger::{debug, info, sample, sample::SampleRate, trace, warn};
 use aptos_network::{application::interface::NetworkClient, protocols::network::RpcError};
 use aptos_storage_interface::DbReader;
@@ -77,13 +77,13 @@ const PEER_LOG_FREQ_SECS: u64 = 10;
 #[derive(Clone, Debug)]
 pub struct AptosDataClient {
     /// Config for AptosNet data client.
-    data_client_config: AptosDataClientConfig,
+    data_client_config: Arc<AptosDataClientConfig>,
     /// The underlying AptosNet storage service client.
     storage_service_client: StorageServiceClient<NetworkClient<StorageServiceMessage>>,
     /// The state of the active subscription stream.
     active_subscription_state: Arc<Mutex<Option<SubscriptionState>>>,
     /// All of the data-client specific data we have on each network peer.
-    peer_states: Arc<RwLock<PeerStates>>,
+    peer_states: Arc<PeerStates>,
     /// A cached, aggregate data summary of all unbanned peers' data summaries.
     global_summary_cache: Arc<ArcSwap<GlobalDataSummary>>,
     /// Used for generating the next request/response id.
@@ -101,16 +101,20 @@ impl AptosDataClient {
         storage_service_client: StorageServiceClient<NetworkClient<StorageServiceMessage>>,
         runtime: Option<Handle>,
     ) -> (Self, DataSummaryPoller) {
+        // Wrap the configs in an Arc (to be shared across components)
+        let base_config = Arc::new(base_config);
+        let data_client_config = Arc::new(data_client_config);
+
         // Create the data client
         let data_client = Self {
-            data_client_config,
+            data_client_config: data_client_config.clone(),
             storage_service_client: storage_service_client.clone(),
             active_subscription_state: Arc::new(Mutex::new(None)),
-            peer_states: Arc::new(RwLock::new(PeerStates::new(
+            peer_states: Arc::new(PeerStates::new(
                 base_config,
-                data_client_config,
+                data_client_config.clone(),
                 storage_service_client.get_peers_and_metadata(),
-            ))),
+            )),
             global_summary_cache: Arc::new(ArcSwap::from(Arc::new(GlobalDataSummary::empty()))),
             response_id_generator: Arc::new(U64IdGenerator::new()),
             time_service: time_service.clone(),
@@ -151,7 +155,7 @@ impl AptosDataClient {
 
     /// Update a peer's data summary.
     pub fn update_summary(&self, peer: PeerNetworkId, summary: StorageServerSummary) {
-        self.peer_states.write().update_summary(peer, summary)
+        self.peer_states.update_summary(peer, summary)
     }
 
     /// Recompute and update the global data summary cache
@@ -161,7 +165,7 @@ impl AptosDataClient {
         self.garbage_collect_peer_states()?;
 
         // Calculate the global data summary
-        let global_data_summary = self.peer_states.read().calculate_global_data_summary();
+        let global_data_summary = self.peer_states.calculate_global_data_summary();
 
         // Update the cached data summary
         self.global_summary_cache
@@ -177,7 +181,6 @@ impl AptosDataClient {
 
         // Garbage collect the disconnected peers
         self.peer_states
-            .write()
             .garbage_collect_peer_states(all_connected_peers);
 
         Ok(())
@@ -285,11 +288,8 @@ impl AptosDataClient {
         prospective_peers
             .into_iter()
             .filter(|peer| {
-                self.peer_states.read().can_service_request(
-                    peer,
-                    self.time_service.clone(),
-                    request,
-                )
+                self.peer_states
+                    .can_service_request(peer, self.time_service.clone(), request)
             })
             .collect::<Vec<_>>()
     }
@@ -299,7 +299,7 @@ impl AptosDataClient {
         &self,
     ) -> crate::error::Result<Option<PeerNetworkId>, Error> {
         // Fetch the number of in-flight polls and update the metrics
-        let num_in_flight_polls = self.peer_states.read().num_in_flight_priority_polls();
+        let num_in_flight_polls = self.peer_states.num_in_flight_priority_polls();
         update_in_flight_metrics(PRIORITIZED_PEER, num_in_flight_polls);
 
         // Ensure we don't go over the maximum number of in-flight polls
@@ -315,7 +315,7 @@ impl AptosDataClient {
     /// Fetches the next regular peer to poll
     pub fn fetch_regular_peer_to_poll(&self) -> crate::error::Result<Option<PeerNetworkId>, Error> {
         // Fetch the number of in-flight polls and update the metrics
-        let num_in_flight_polls = self.peer_states.read().num_in_flight_regular_polls();
+        let num_in_flight_polls = self.peer_states.num_in_flight_regular_polls();
         update_in_flight_metrics(REGULAR_PEER, num_in_flight_polls);
 
         // Ensure we don't go over the maximum number of in-flight polls
@@ -334,7 +334,7 @@ impl AptosDataClient {
         mut peers: Vec<PeerNetworkId>,
     ) -> crate::error::Result<Option<PeerNetworkId>, Error> {
         // Identify the peers who do not already have in-flight requests.
-        peers.retain(|peer| !self.peer_states.read().existing_in_flight_request(peer));
+        peers.retain(|peer| !self.peer_states.existing_in_flight_request(peer));
 
         // Select a peer at random for polling
         let peer_to_poll = peers.choose(&mut rand::thread_rng());
@@ -343,14 +343,12 @@ impl AptosDataClient {
 
     /// Marks the given peers as having an in-flight poll request
     pub fn in_flight_request_started(&self, peer: &PeerNetworkId) {
-        self.peer_states.write().new_in_flight_request(peer);
+        self.peer_states.new_in_flight_request(peer);
     }
 
     /// Marks the given peers as polled
     pub fn in_flight_request_complete(&self, peer: &PeerNetworkId) {
-        self.peer_states
-            .write()
-            .mark_in_flight_request_complete(peer);
+        self.peer_states.mark_in_flight_request_complete(peer);
     }
 
     /// Returns all peers connected to us
@@ -376,7 +374,7 @@ impl AptosDataClient {
         let mut priority_peers = vec![];
         let mut regular_peers = vec![];
         for peer in all_connected_peers {
-            if self.peer_states.read().is_priority_peer(&peer) {
+            if self.peer_states.is_priority_peer(&peer) {
                 priority_peers.push(peer);
             } else {
                 regular_peers.push(peer);
@@ -504,7 +502,7 @@ impl AptosDataClient {
                 // On the one hand, scoring dynamics are simpler when each request
                 // is successful or failed but not both; on the other hand, this
                 // feels simpler for the consumer.
-                self.peer_states.write().update_score_success(peer);
+                self.peer_states.update_score_success(peer);
 
                 // Package up all of the context needed to fully report an error
                 // with this RPC.
@@ -569,9 +567,7 @@ impl AptosDataClient {
         _request: &StorageServiceRequest,
         error_type: ErrorType,
     ) {
-        self.peer_states
-            .write()
-            .update_score_error(peer, error_type);
+        self.peer_states.update_score_error(peer, error_type);
     }
 
     /// Creates a storage service request using the given data request
@@ -592,8 +588,8 @@ impl AptosDataClient {
 
     /// Returns a copy of the peer states for testing
     #[cfg(test)]
-    pub(crate) fn get_peer_states(&self) -> PeerStates {
-        self.peer_states.read().clone()
+    pub(crate) fn get_peer_states(&self) -> Arc<PeerStates> {
+        self.peer_states.clone()
     }
 }
 

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -35,7 +35,7 @@ pub struct LatencyMonitor {
 
 impl LatencyMonitor {
     pub fn new(
-        data_client_config: AptosDataClientConfig,
+        data_client_config: Arc<AptosDataClientConfig>,
         data_client: Arc<dyn AptosDataClientInterface + Send + Sync>,
         storage: Arc<dyn DbReader>,
         time_service: TimeService,
@@ -318,7 +318,7 @@ mod tests {
     };
     use aptos_config::config::AptosDataClientConfig;
     use aptos_time_service::{TimeService, TimeServiceTrait};
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     #[test]
     fn test_calculate_duration_from_proposal() {
@@ -626,7 +626,7 @@ mod tests {
 
     /// Creates a latency monitor for testing
     fn create_latency_monitor() -> (TimeService, LatencyMonitor) {
-        let data_client_config = AptosDataClientConfig::default();
+        let data_client_config = Arc::new(AptosDataClientConfig::default());
         let data_client = create_mock_data_client();
         let storage = create_mock_db_reader();
         let time_service = TimeService::mock();

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -306,7 +306,7 @@ impl PeerStates {
     }
 
     /// Calculates a global data summary using all known storage summaries
-    pub fn calculate_aggregate_summary(&self) -> GlobalDataSummary {
+    pub fn calculate_global_data_summary(&self) -> GlobalDataSummary {
         // Only include likely-not-malicious peers in the data summary aggregation
         let summaries: Vec<StorageServerSummary> = self
             .peer_to_state

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -17,12 +17,9 @@ use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServerSummary,
 };
 use aptos_time_service::TimeService;
+use dashmap::{DashMap, DashSet};
 use itertools::Itertools;
-use std::{
-    cmp::min,
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{cmp::min, sync::Arc};
 
 /// Scores for peer rankings based on preferences and behavior.
 const MAX_SCORE: f64 = 100.0;
@@ -82,7 +79,7 @@ impl PeerState {
     }
 
     /// Returns the storage summary iff the peer is not below the ignore threshold
-    fn storage_summary_if_not_ignored(&self) -> Option<&StorageServerSummary> {
+    fn get_storage_summary_if_not_ignored(&self) -> Option<&StorageServerSummary> {
         if self.score <= IGNORE_PEER_THRESHOLD {
             None
         } else {
@@ -109,26 +106,26 @@ impl PeerState {
 /// advertisements and data-client internal metadata for scoring.
 #[derive(Clone, Debug)]
 pub(crate) struct PeerStates {
-    base_config: BaseConfig,
-    data_client_config: AptosDataClientConfig,
-    peer_to_state: HashMap<PeerNetworkId, PeerState>,
-    in_flight_priority_polls: HashSet<PeerNetworkId>, // The priority peers with in-flight polls
-    in_flight_regular_polls: HashSet<PeerNetworkId>,  // The regular peers with in-flight polls
+    base_config: Arc<BaseConfig>,
+    data_client_config: Arc<AptosDataClientConfig>,
+    peer_to_state: DashMap<PeerNetworkId, PeerState>,
+    in_flight_priority_polls: DashSet<PeerNetworkId>, // The priority peers with in-flight polls
+    in_flight_regular_polls: DashSet<PeerNetworkId>,  // The regular peers with in-flight polls
     peers_and_metadata: Arc<PeersAndMetadata>,
 }
 
 impl PeerStates {
     pub fn new(
-        base_config: BaseConfig,
-        data_client_config: AptosDataClientConfig,
+        base_config: Arc<BaseConfig>,
+        data_client_config: Arc<AptosDataClientConfig>,
         peers_and_metadata: Arc<PeersAndMetadata>,
     ) -> Self {
         Self {
             base_config,
             data_client_config,
-            peer_to_state: HashMap::new(),
-            in_flight_priority_polls: HashSet::new(),
-            in_flight_regular_polls: HashSet::new(),
+            peer_to_state: DashMap::new(),
+            in_flight_priority_polls: DashSet::new(),
+            in_flight_regular_polls: DashSet::new(),
             peers_and_metadata,
         }
     }
@@ -151,46 +148,60 @@ impl PeerStates {
         }
 
         // Check if the peer can service the request
-        self.peer_to_state
-            .get(peer)
-            .and_then(PeerState::storage_summary_if_not_ignored)
-            .map(|summary| summary.can_service(&self.data_client_config, time_service, request))
-            .unwrap_or(false)
+        if let Some(peer_state) = self.peer_to_state.get(peer) {
+            return match peer_state.get_storage_summary_if_not_ignored() {
+                Some(storage_summary) => {
+                    storage_summary.can_service(&self.data_client_config, time_service, request)
+                },
+                None => false, // The peer is temporarily ignored
+            };
+        }
+
+        // Otherwise, the request cannot be serviced
+        false
     }
 
     /// Updates the score of the peer according to a successful operation
-    pub fn update_score_success(&mut self, peer: PeerNetworkId) {
-        let old_score = self.peer_to_state.entry(peer).or_default().score;
-        self.peer_to_state
-            .entry(peer)
-            .or_default()
-            .update_score_success();
-        let new_score = self.peer_to_state.entry(peer).or_default().score;
-        if old_score <= IGNORE_PEER_THRESHOLD && new_score > IGNORE_PEER_THRESHOLD {
-            info!(
-                (LogSchema::new(LogEntry::PeerStates)
-                    .event(LogEvent::PeerNoLongerIgnored)
-                    .message("Peer will no longer be ignored")
-                    .peer(&peer))
-            );
+    pub fn update_score_success(&self, peer: PeerNetworkId) {
+        if let Some(mut entry) = self.peer_to_state.get_mut(&peer) {
+            // Get the peer's old score
+            let old_score = entry.score;
+
+            // Update the peer's score with a successful operation
+            entry.update_score_success();
+
+            // Log if the peer is no longer ignored
+            let new_score = entry.score;
+            if old_score <= IGNORE_PEER_THRESHOLD && new_score > IGNORE_PEER_THRESHOLD {
+                info!(
+                    (LogSchema::new(LogEntry::PeerStates)
+                        .event(LogEvent::PeerNoLongerIgnored)
+                        .message("Peer will no longer be ignored")
+                        .peer(&peer))
+                );
+            }
         }
     }
 
     /// Updates the score of the peer according to an error
-    pub fn update_score_error(&mut self, peer: PeerNetworkId, error: ErrorType) {
-        let old_score = self.peer_to_state.entry(peer).or_default().score;
-        self.peer_to_state
-            .entry(peer)
-            .or_default()
-            .update_score_error(error);
-        let new_score = self.peer_to_state.entry(peer).or_default().score;
-        if old_score > IGNORE_PEER_THRESHOLD && new_score <= IGNORE_PEER_THRESHOLD {
-            info!(
-                (LogSchema::new(LogEntry::PeerStates)
-                    .event(LogEvent::PeerIgnored)
-                    .message("Peer will be ignored")
-                    .peer(&peer))
-            );
+    pub fn update_score_error(&self, peer: PeerNetworkId, error: ErrorType) {
+        if let Some(mut entry) = self.peer_to_state.get_mut(&peer) {
+            // Get the peer's old score
+            let old_score = entry.score;
+
+            // Update the peer's score with an error
+            entry.update_score_error(error);
+
+            // Log if the peer is now ignored
+            let new_score = entry.score;
+            if old_score > IGNORE_PEER_THRESHOLD && new_score <= IGNORE_PEER_THRESHOLD {
+                info!(
+                    (LogSchema::new(LogEntry::PeerStates)
+                        .event(LogEvent::PeerIgnored)
+                        .message("Peer will be ignored")
+                        .peer(&peer))
+                );
+            }
         }
     }
 
@@ -210,13 +221,13 @@ impl PeerStates {
     }
 
     /// Marks an in-flight request as started for the specified peer
-    pub fn new_in_flight_request(&mut self, peer: &PeerNetworkId) {
+    pub fn new_in_flight_request(&self, peer: &PeerNetworkId) {
         // Get the current in-flight polls
         let is_priority_peer = self.is_priority_peer(peer);
         let in_flight_polls = if is_priority_peer {
-            &mut self.in_flight_priority_polls
+            &self.in_flight_priority_polls
         } else {
-            &mut self.in_flight_regular_polls
+            &self.in_flight_regular_polls
         };
 
         // Insert the new peer
@@ -234,11 +245,12 @@ impl PeerStates {
     }
 
     /// Marks the pending in-flight request as complete for the specified peer
-    pub fn mark_in_flight_request_complete(&mut self, peer: &PeerNetworkId) {
+    pub fn mark_in_flight_request_complete(&self, peer: &PeerNetworkId) {
         // The priority of the peer might have changed since we
         // last polled it, so we attempt to remove it from both
         // the regular and priority in-flight requests.
-        if !self.in_flight_priority_polls.remove(peer) && !self.in_flight_regular_polls.remove(peer)
+        if self.in_flight_priority_polls.remove(peer).is_none()
+            && self.in_flight_regular_polls.remove(peer).is_none()
         {
             error!(
                 (LogSchema::new(LogEntry::PeerStates)
@@ -292,7 +304,7 @@ impl PeerStates {
     }
 
     /// Updates the storage summary for the given peer
-    pub fn update_summary(&mut self, peer: PeerNetworkId, summary: StorageServerSummary) {
+    pub fn update_summary(&self, peer: PeerNetworkId, summary: StorageServerSummary) {
         self.peer_to_state
             .entry(peer)
             .or_default()
@@ -300,23 +312,27 @@ impl PeerStates {
     }
 
     /// Garbage collects the peer states to remove data for disconnected peers
-    pub fn garbage_collect_peer_states(&mut self, connected_peers: Vec<PeerNetworkId>) {
+    pub fn garbage_collect_peer_states(&self, connected_peers: Vec<PeerNetworkId>) {
         self.peer_to_state
             .retain(|peer_network_id, _| connected_peers.contains(peer_network_id));
     }
 
     /// Calculates a global data summary using all known storage summaries
     pub fn calculate_global_data_summary(&self) -> GlobalDataSummary {
-        // Only include likely-not-malicious peers in the data summary aggregation
-        let summaries: Vec<StorageServerSummary> = self
+        // Gather all storage summaries, but exclude peers that are ignored
+        let storage_summaries: Vec<StorageServerSummary> = self
             .peer_to_state
-            .values()
-            .filter_map(PeerState::storage_summary_if_not_ignored)
-            .cloned()
+            .iter()
+            .filter_map(|peer_state| {
+                peer_state
+                    .value()
+                    .get_storage_summary_if_not_ignored()
+                    .cloned()
+            })
             .collect();
 
         // If we have no peers, return an empty global summary
-        if summaries.is_empty() {
+        if storage_summaries.is_empty() {
             return GlobalDataSummary::empty();
         }
 
@@ -326,7 +342,7 @@ impl PeerStates {
         let mut max_state_chunk_sizes = vec![];
         let mut max_transaction_chunk_sizes = vec![];
         let mut max_transaction_output_chunk_sizes = vec![];
-        for summary in summaries {
+        for summary in storage_summaries {
             // Collect aggregate data advertisements
             if let Some(epoch_ending_ledger_infos) = summary.data_summary.epoch_ending_ledger_infos
             {
@@ -375,7 +391,7 @@ impl PeerStates {
 
     #[cfg(test)]
     /// Returns a copy of the peer to states map for test purposes
-    pub fn get_peer_to_states(&self) -> HashMap<PeerNetworkId, PeerState> {
+    pub fn get_peer_to_states(&self) -> DashMap<PeerNetworkId, PeerState> {
         self.peer_to_state.clone()
     }
 }

--- a/state-sync/aptos-data-client/src/poller.rs
+++ b/state-sync/aptos-data-client/src/poller.rs
@@ -32,9 +32,9 @@ const REGULAR_PEER_SAMPLE_FREQ: u64 = 3;
 /// A poller for storage summaries that is responsible for periodically refreshing
 /// the view of advertised data in the network.
 pub struct DataSummaryPoller {
-    data_client_config: AptosDataClientConfig, // The configuration for the data client
-    data_client: AptosDataClient,              // The data client through which to poll peers
-    poll_loop_interval: Duration,              // The interval between polling loop executions
+    data_client_config: Arc<AptosDataClientConfig>, // The configuration for the data client
+    data_client: AptosDataClient,                   // The data client through which to poll peers
+    poll_loop_interval: Duration,                   // The interval between polling loop executions
     runtime: Option<Handle>, // An optional runtime on which to spawn the poller threads
     storage: Arc<dyn DbReader>, // The reader interface to storage
     time_service: TimeService, // The service to monitor elapsed time
@@ -42,7 +42,7 @@ pub struct DataSummaryPoller {
 
 impl DataSummaryPoller {
     pub fn new(
-        data_client_config: AptosDataClientConfig,
+        data_client_config: Arc<AptosDataClientConfig>,
         data_client: AptosDataClient,
         poll_loop_interval: Duration,
         runtime: Option<Handle>,
@@ -63,7 +63,7 @@ impl DataSummaryPoller {
     pub async fn start_poller(self) {
         // Create and start the latency monitor
         start_latency_monitor(
-            self.data_client_config,
+            self.data_client_config.clone(),
             self.data_client.clone(),
             self.storage.clone(),
             self.time_service.clone(),
@@ -248,7 +248,7 @@ pub(crate) fn poll_peer(
 
 /// Spawns the dedicated latency monitor
 fn start_latency_monitor(
-    data_client_config: AptosDataClientConfig,
+    data_client_config: Arc<AptosDataClientConfig>,
     data_client: AptosDataClient,
     storage: Arc<dyn DbReader>,
     time_service: TimeService,


### PR DESCRIPTION
### Description
This PR offers two small cleanups and refactors to the Aptos Data Client:
1. Replace `Arc<RwLock<T>>` with `Arc<ArcSwap<T>>` for the global summary cache. This should [reduce](https://docs.rs/arc-swap/latest/arc_swap/) lock contention.
2. Remove the global `RwLock` around `PeerStates` and use `DashMap` and `DashSet` internally, to reduce lock contention.

Nothing else should change 😄 

### Test Plan
Existing test infrastructure.