### PR TITLE
[TS SDK] Add `burnObject` transaction support

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Add current objects queries support - `getAccountOwnedObjects`
+- Add `burnObject` transaction support in `AptosToken`
 
 ## 1.19.0 (2023-08-24)
 

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -549,4 +549,31 @@ export class AptosToken {
     );
     return txnHash;
   }
+
+  /**
+   * Burn an object by the object owner
+   * @param owner The object owner account
+   * @param objectId The object address
+   * @optional objectType. The object type, default to "0x1::object::ObjectCore"
+   * @returns The hash of the transaction submitted to the API
+   */
+  async burnObject(
+    owner: AptosAccount,
+    objectId: MaybeHexString,
+    objectType?: string,
+    extraArgs?: OptionalTransactionArgs,
+  ): Promise<string> {
+    const builder = new TransactionBuilderRemoteABI(this.provider, {
+      sender: owner.address(),
+      ...extraArgs,
+    });
+    const rawTxn = await builder.build(
+      "0x1::object::burn",
+      [objectType || "0x1::object::ObjectCore"],
+      [HexString.ensure(objectId).hex()],
+    );
+    const bcsTxn = AptosClient.generateBCSTransaction(owner, rawTxn);
+    const pendingTransaction = await this.provider.submitSignedBCSTransaction(bcsTxn);
+    return pendingTransaction.hash;
+  }
 }

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
@@ -1,5 +1,5 @@
 import { AptosAccount } from "../../account";
-import { UserTransaction } from "../../generated";
+import { UserTransaction, WriteResource, WriteSetChange_WriteResource } from "../../generated";
 import { AptosToken } from "../../plugins";
 import { Provider } from "../../providers";
 import { PROVIDER_LOCAL_NETWORK_CONFIG, getFaucetClient, longTestTimeout } from "../unit/test_helper.test";
@@ -14,6 +14,7 @@ const bob = new AptosAccount();
 const collectionName = "AliceCollection";
 const tokenName = "Alice Token";
 let tokenAddress = "";
+let collectionAddress = "";
 
 describe("token objects", () => {
   beforeAll(async () => {
@@ -25,10 +26,14 @@ describe("token objects", () => {
   test(
     "create collection",
     async () => {
-      await provider.waitForTransaction(
+      const txn = await provider.waitForTransactionWithResult(
         await aptosToken.createCollection(alice, "Alice's simple collection", collectionName, "https://aptos.dev", 5),
         { checkSuccess: true },
       );
+      const objectCore = (txn as UserTransaction).changes.find(
+        (change) => (change as WriteResource).data.type === "0x1::object::ObjectCore",
+      );
+      collectionAddress = (objectCore as WriteSetChange_WriteResource).address;
     },
     longTestTimeout,
   );
@@ -238,6 +243,14 @@ describe("token objects", () => {
     "burn token",
     async () => {
       await provider.waitForTransaction(await aptosToken.burnToken(alice, tokenAddress), { checkSuccess: true });
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "burn object",
+    async () => {
+      await provider.waitForTransaction(await aptosToken.burnObject(alice, collectionAddress), { checkSuccess: true });
     },
     longTestTimeout,
   );


### PR DESCRIPTION
### Description
following [AIP-45](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-45.md) adding `burnObject` transaction support
### Test Plan
tests are passing
