### PR TITLE
[GHA] Stop running unnecessary tests on release branch pushes.

### DIFF
--- a/.github/workflows/forge-pfn.yaml
+++ b/.github/workflows/forge-pfn.yaml
@@ -23,10 +23,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/forge-pfn.yaml"
-      - "testsuite/find_latest_image.py"
-  push:
-    branches:
-      - aptos-release-v* # The aptos release branches
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}

--- a/.github/workflows/forge-state-sync.yaml
+++ b/.github/workflows/forge-state-sync.yaml
@@ -23,10 +23,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/forge-state-sync.yaml"
-      - "testsuite/find_latest_image.py"
-  push:
-    branches:
-      - aptos-release-v* # The aptos release branches
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}

--- a/developer-docs-site/docs/guides/state-sync.md
+++ b/developer-docs-site/docs/guides/state-sync.md
@@ -124,7 +124,7 @@ node configuration file:
  state_sync:
      state_sync_driver:
          bootstrapping_mode: DownloadLatestStates
-         continuous_syncing_mode: ApplyTransactionOutputs
+         continuous_syncing_mode: ExecuteTransactionsOrApplyOutputs
 ```
 
 While your node is syncing, you'll be able to see the


### PR DESCRIPTION
### Description
This PR:
1. Avoids running the PFN and state sync performance tests on release branch pushes. These runs are not needed.
2. Replaces the continuous syncing mode for fast sync in the dev docs.

### Test Plan
Existing test infrastructure.