### PR TITLE
[Executor] CapturedReads component, Metadata and exists support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "dashmap",
+ "derivative",
  "itertools",
  "move-binary-format",
  "move-core-types",
@@ -601,6 +602,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
+ "test-case",
 ]
 
 [[package]]

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -22,31 +22,31 @@ pub trait TResourceView {
     ///   -  Err(...)         otherwise (e.g. storage error).
     fn get_resource_state_value(
         &self,
-        key: &Self::Key,
+        state_key: &Self::Key,
         maybe_layout: Option<&Self::Layout>,
     ) -> anyhow::Result<Option<StateValue>>;
 
     fn get_resource_bytes(
         &self,
-        key: &Self::Key,
+        state_key: &Self::Key,
         maybe_layout: Option<&Self::Layout>,
     ) -> anyhow::Result<Option<Bytes>> {
-        let maybe_state_value = self.get_resource_state_value(key, maybe_layout)?;
+        let maybe_state_value = self.get_resource_state_value(state_key, maybe_layout)?;
         Ok(maybe_state_value.map(|state_value| state_value.bytes().clone()))
     }
 
     fn get_resource_state_value_metadata(
         &self,
-        key: &Self::Key,
+        state_key: &Self::Key,
     ) -> anyhow::Result<Option<StateValueMetadataKind>> {
         // For metadata, layouts are not important.
-        let maybe_state_value = self.get_resource_state_value(key, None)?;
+        let maybe_state_value = self.get_resource_state_value(state_key, None)?;
         Ok(maybe_state_value.map(StateValue::into_metadata))
     }
 
-    fn resource_exists(&self, key: &Self::Key) -> anyhow::Result<bool> {
+    fn resource_exists(&self, state_key: &Self::Key) -> anyhow::Result<bool> {
         // For existence, layouts are not important.
-        self.get_resource_state_value(key, None)
+        self.get_resource_state_value(state_key, None)
             .map(|maybe_state_value| maybe_state_value.is_some())
     }
 }
@@ -57,7 +57,7 @@ pub trait TResourceGroupView {
 
     fn get_resource_from_group(
         &self,
-        _key: &Self::Key,
+        _state_key: &Self::Key,
         _resource_tag: &Self::Tag,
     ) -> anyhow::Result<Option<Bytes>> {
         unimplemented!("TResourceGroupView not yet implemented");
@@ -73,7 +73,7 @@ pub trait TResourceGroupView {
         unimplemented!("TResourceGroupView not yet implemented");
     }
 
-    fn resource_group_exists(&self, _key: &Self::Key) -> anyhow::Result<bool> {
+    fn resource_group_exists(&self, _state_key: &Self::Key) -> anyhow::Result<bool> {
         unimplemented!("TResourceGroupView not yet implemented");
     }
 
@@ -90,7 +90,7 @@ pub trait TResourceGroupView {
     /// the parallel execution setting, as a wrong value will be (later) caught by validation.
     /// Thus, R/W conflicts are avoided, as long as the estimates are correct (e.g. updating
     /// struct members of a fixed size).
-    fn resource_group_size(&self, _key: &Self::Key) -> anyhow::Result<u64> {
+    fn resource_group_size(&self, _state_key: &Self::Key) -> anyhow::Result<u64> {
         unimplemented!("TResourceGroupView not yet implemented");
     }
 
@@ -106,7 +106,7 @@ pub trait TResourceGroupView {
     /// which in the context of parallel execution does not cause a full R/W conflict.
     fn resource_exists_in_group(
         &self,
-        _key: &Self::Key,
+        _state_key: &Self::Key,
         _resource_tag: &Self::Tag,
     ) -> anyhow::Result<bool> {
         unimplemented!("TResourceGroupView not yet implemented");
@@ -121,23 +121,23 @@ pub trait TModuleView {
     ///   -  Ok(None)         if the module is not in storage,
     ///   -  Ok(Some(...))    if the module exists in storage,
     ///   -  Err(...)         otherwise (e.g. storage error).
-    fn get_module_state_value(&self, key: &Self::Key) -> anyhow::Result<Option<StateValue>>;
+    fn get_module_state_value(&self, state_key: &Self::Key) -> anyhow::Result<Option<StateValue>>;
 
-    fn get_module_bytes(&self, key: &Self::Key) -> anyhow::Result<Option<Bytes>> {
-        let maybe_state_value = self.get_module_state_value(key)?;
+    fn get_module_bytes(&self, state_key: &Self::Key) -> anyhow::Result<Option<Bytes>> {
+        let maybe_state_value = self.get_module_state_value(state_key)?;
         Ok(maybe_state_value.map(|state_value| state_value.bytes().clone()))
     }
 
     fn get_module_state_value_metadata(
         &self,
-        key: &Self::Key,
+        state_key: &Self::Key,
     ) -> anyhow::Result<Option<StateValueMetadataKind>> {
-        let maybe_state_value = self.get_module_state_value(key)?;
+        let maybe_state_value = self.get_module_state_value(state_key)?;
         Ok(maybe_state_value.map(StateValue::into_metadata))
     }
 
-    fn module_exists(&self, key: &Self::Key) -> anyhow::Result<bool> {
-        self.get_module_state_value(key)
+    fn module_exists(&self, state_key: &Self::Key) -> anyhow::Result<bool> {
+        self.get_module_state_value(state_key)
             .map(|maybe_state_value| maybe_state_value.is_some())
     }
 }

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -30,6 +30,7 @@ claims = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 dashmap = { workspace = true }
+derivative = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 num_cpus = { workspace = true }
@@ -47,6 +48,7 @@ itertools = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
+test-case = { workspace = true }
 
 [features]
 fuzzing = ["criterion", "proptest", "proptest-derive"]

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1,0 +1,866 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::task::Transaction;
+use anyhow::bail;
+use aptos_mvhashmap::{
+    types::{MVDataError, MVDataOutput, TxnIndex, Version},
+    versioned_data::VersionedData,
+    versioned_group_data::VersionedGroupData,
+};
+use aptos_types::{state_store::state_value::StateValueMetadataKind, write_set::TransactionWrite};
+use derivative::Derivative;
+use std::{
+    collections::{
+        hash_map::{
+            Entry,
+            Entry::{Occupied, Vacant},
+        },
+        HashMap,
+    },
+    sync::Arc,
+};
+
+/// The enum variants should not be re-ordered, as it defines a relation
+/// Existence < Metadata < Value.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ReadKind {
+    Exists,
+    Metadata,
+    Value,
+}
+
+/// The enum captures the state that the transaction execution extracted from
+/// a read callback to block executor, in order to be validated by Block-STM.
+/// The captured state is fine-grained, e.g. it distinguishes between reading
+/// a full value, and other kinds of reads that may access only the metadata
+/// information, or check whether data exists at a given key.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""), Debug(bound = ""), PartialEq(bound = ""))]
+pub(crate) enum DataRead<V> {
+    // Version supercedes V comparison.
+    Versioned(
+        Version,
+        // Currently, we are conservative and check the version for equality
+        // (version implies value equality, but not vice versa). TODO: when
+        // comparing the instances of V is cheaper, compare those instead.
+        #[derivative(PartialEq = "ignore", Debug = "ignore")] Arc<V>,
+    ),
+    Metadata(Option<StateValueMetadataKind>),
+    Exists(bool),
+    /// Read resolved an aggregatorV1 delta to a value. TODO: deprecate.
+    Resolved(u128),
+}
+
+// Represents the result of comparing DataReads ('self' and 'other').
+#[derive(Debug)]
+enum DataReadComparison {
+    // Information in 'self' DataRead contains information about the kind of the
+    // 'other' DataRead, and is consistent with 'other'.
+    Contains,
+    // Information in 'self' DataRead contains information about the kind of the
+    // 'other' DataRead, but is inconsistent with 'other'.
+    Inconsistent,
+    // All information about the kind of 'other' is not contained in 'self' kind.
+    // For example, exists does not provide enough information about metadata.
+    Insufficient,
+}
+
+impl<V: TransactionWrite> DataRead<V> {
+    // Assigns highest rank to Versioned / Resolved, then Metadata, then Exists.
+    // (e.g. versioned read implies metadata and existence information, and
+    // metadata information implies existence information).
+    fn get_kind(&self) -> ReadKind {
+        use DataRead::*;
+        match self {
+            Versioned(_, _) | Resolved(_) => ReadKind::Value,
+            Metadata(_) => ReadKind::Metadata,
+            Exists(_) => ReadKind::Exists,
+        }
+    }
+
+    // A convenience method, since the same key can be read in different modes, producing
+    // different DataRead / ReadKinds. Returns true if self has >= kind than other, i.e.
+    // contains more or equal information, and is consistent with the information in other.
+    fn contains(&self, other: &DataRead<V>) -> DataReadComparison {
+        let self_kind = self.get_kind();
+        let other_kind = other.get_kind();
+
+        if self_kind < other_kind {
+            DataReadComparison::Insufficient
+        } else {
+            let downcast_eq = if self_kind == other_kind {
+                // Optimization to avoid unnecessary clones (e.g. during validation).
+                self == other
+            } else {
+                self.downcast(other_kind)
+                    .expect("Downcast to lower kind must succeed")
+                    == *other
+            };
+
+            if downcast_eq {
+                DataReadComparison::Contains
+            } else {
+                DataReadComparison::Inconsistent
+            }
+        }
+    }
+
+    /// If the reads contains sufficient information, extract this information and generate
+    /// a new DataRead of the desired kind (e.g. Metadata kind from Value).
+    pub(crate) fn downcast(&self, kind: ReadKind) -> Option<DataRead<V>> {
+        let self_kind = self.get_kind();
+        if self_kind == kind {
+            return Some(self.clone());
+        }
+
+        (self_kind > kind).then(|| match (self, &kind) {
+            (DataRead::Versioned(_, v), ReadKind::Metadata) => {
+                // For deletion, as_state_value_metadata returns None, also asserted by tests.
+                DataRead::Metadata(v.as_state_value_metadata())
+            },
+            (DataRead::Versioned(_, v), ReadKind::Exists) => DataRead::Exists(!v.is_deletion()),
+            (DataRead::Resolved(_), ReadKind::Metadata) => DataRead::Metadata(Some(None)),
+            (DataRead::Resolved(_), ReadKind::Exists) => DataRead::Exists(true),
+            (DataRead::Metadata(maybe_metadata), ReadKind::Exists) => {
+                DataRead::Exists(maybe_metadata.is_some())
+            },
+            (_, _) => unreachable!("{:?}, {:?} must be covered", self_kind, kind),
+        })
+    }
+}
+
+/// Additional state regarding groups that may be provided to the VM during transaction
+/// execution and is captured. There may be a DataRead per tag within the group, and also
+/// the group size (also computed based on speculative information in MVHashMap).
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+struct GroupRead<T: Transaction> {
+    /// The size of the resource group can be read (used for gas charging).
+    speculative_size: Option<u64>,
+    /// Reads to individual resources in the group, keyed by a tag.
+    inner_reads: HashMap<T::Tag, DataRead<T::Value>>,
+}
+
+/// Serves as a "read-set" of a transaction execution, and provides APIs for capturing reads,
+/// resolving new reads based on already captured reads when possible, and for validation.
+///
+/// The intended use is that all reads should be attempted to be resolved from CapturedReads.
+/// If not possible, then after proper resolution from MVHashMap/storage, they should be
+/// captured. This enforces an invariant that 'capture_read' will never be called with a
+/// read that has a kind <= already captured read (for that key / tag).
+#[derive(Derivative)]
+#[derivative(Default(bound = "", new = "true"))]
+pub(crate) struct CapturedReads<T: Transaction> {
+    data_reads: HashMap<T::Key, DataRead<T::Value>>,
+    group_reads: HashMap<T::Key, GroupRead<T>>,
+    // Currently, we record paths for triggering module R/W fallback.
+    // TODO: implement a general functionality once the fallback is removed.
+    pub(crate) module_reads: Vec<T::Key>,
+
+    /// If there is a speculative failure (e.g. delta application failure, or an
+    /// observed inconsistency), the transaction output is irrelevant (must be
+    /// discarded and transaction re-executed). We have a global flag, as which
+    /// read observed the inconsistency is irrelevant (moreover, typically,
+    /// an error is returned to the VM to wrap up the ongoing execution).
+    speculative_failure: bool,
+    /// Set if the invarint on CapturedReads intended use is violated. Leads to an alert
+    /// and sequential execution fallback.
+    incorrect_use: bool,
+}
+
+#[derive(Debug)]
+enum UpdateResult {
+    Inserted,
+    Updated,
+    IncorrectUse(String),
+    Inconsistency(String),
+}
+
+impl<T: Transaction> CapturedReads<T> {
+    // Given a hashmap entry for a key, incorporate a new DataRead. This checks
+    // consistency and ensures that the most comprehensive read is recorded.
+    fn update_entry<K, V: TransactionWrite>(
+        entry: Entry<K, DataRead<V>>,
+        read: DataRead<V>,
+    ) -> UpdateResult {
+        match entry {
+            Vacant(e) => {
+                e.insert(read);
+                UpdateResult::Inserted
+            },
+            Occupied(mut e) => {
+                let existing_read = e.get_mut();
+                if read.get_kind() <= existing_read.get_kind() {
+                    UpdateResult::IncorrectUse(format!(
+                        "Incorrect use CaptureReads, read {:?}, existing {:?}",
+                        read, existing_read
+                    ))
+                } else {
+                    match read.contains(existing_read) {
+                        DataReadComparison::Contains => {
+                            *existing_read = read;
+                            UpdateResult::Updated
+                        },
+                        DataReadComparison::Inconsistent => UpdateResult::Inconsistency(format!(
+                            "Read {:?} must be consistent with the already stored read {:?}",
+                            read, existing_read
+                        )),
+                        DataReadComparison::Insufficient => unreachable!(
+                            "{:?} Insufficient for {:?}, but has higher kind",
+                            read, existing_read
+                        ),
+                    }
+                }
+            },
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn capture_group_size(
+        &mut self,
+        _state_key: T::Key,
+        _group_size: u64,
+    ) -> anyhow::Result<()> {
+        unimplemented!("Group size capturing not implemented");
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn group_size(&self, state_key: &T::Key) -> Option<u64> {
+        self.group_reads
+            .get(state_key)
+            .and_then(|group| group.speculative_size)
+    }
+
+    // Error means there was a inconsistency in information read (must be due to the
+    // speculative nature of reads).
+    pub(crate) fn capture_read(
+        &mut self,
+        state_key: T::Key,
+        maybe_tag: Option<T::Tag>,
+        read: DataRead<T::Value>,
+    ) -> anyhow::Result<()> {
+        let ret = match maybe_tag {
+            Some(tag) => {
+                let group = self.group_reads.entry(state_key).or_default();
+                Self::update_entry(group.inner_reads.entry(tag), read)
+            },
+            None => Self::update_entry(self.data_reads.entry(state_key), read),
+        };
+
+        match ret {
+            UpdateResult::IncorrectUse(m) => {
+                self.incorrect_use = true;
+                bail!(m);
+            },
+            UpdateResult::Inconsistency(m) => {
+                // Record speculative failure.
+                self.speculative_failure = true;
+                bail!(m);
+            },
+            UpdateResult::Updated | UpdateResult::Inserted => Ok(()),
+        }
+    }
+
+    // If maybe_tag is provided, then we check the group, otherwise, normal reads.
+    pub(crate) fn get_by_kind(
+        &self,
+        state_key: &T::Key,
+        maybe_tag: Option<&T::Tag>,
+        kind: ReadKind,
+    ) -> Option<DataRead<T::Value>> {
+        assert!(
+            kind != ReadKind::Metadata || maybe_tag.is_none(),
+            "May not request metadata of a group member"
+        );
+
+        match maybe_tag {
+            Some(tag) => self
+                .group_reads
+                .get(state_key)
+                .and_then(|group| group.inner_reads.get(tag).and_then(|r| r.downcast(kind))),
+            None => self
+                .data_reads
+                .get(state_key)
+                .and_then(|r| r.downcast(kind)),
+        }
+    }
+
+    pub(crate) fn validate_data_reads(
+        &self,
+        data_map: &VersionedData<T::Key, T::Value>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        if self.speculative_failure {
+            return false;
+        }
+
+        use MVDataError::*;
+        use MVDataOutput::*;
+        self.data_reads.iter().all(|(k, r)| {
+            match data_map.fetch_data(k, idx_to_validate) {
+                Ok(Versioned(version, v)) => {
+                    matches!(
+                        DataRead::Versioned(version, v).contains(r),
+                        DataReadComparison::Contains
+                    )
+                },
+                Ok(Resolved(value)) => matches!(
+                    DataRead::Resolved(value).contains(r),
+                    DataReadComparison::Contains
+                ),
+                // Dependency implies a validation failure, and if the original read were to
+                // observe an unresolved delta, it would set the aggregator base value in the
+                // multi-versioned data-structure, resolve, and record the resolved value.
+                Err(Dependency(_))
+                | Err(Unresolved(_))
+                | Err(DeltaApplicationFailure)
+                | Err(Uninitialized) => false,
+            }
+        })
+    }
+
+    pub(crate) fn validate_group_reads(
+        &self,
+        group_map: &VersionedGroupData<T::Key, T::Tag, T::Value>,
+        idx_to_validate: TxnIndex,
+    ) -> bool {
+        if self.speculative_failure {
+            return false;
+        }
+
+        self.group_reads.iter().all(|(key, group)| {
+            let mut ret = true;
+            if let Some(size) = group.speculative_size {
+                ret &= Ok(size) == group_map.get_group_size(key, idx_to_validate);
+            }
+
+            ret && group.inner_reads.iter().all(|(tag, r)| {
+                group_map
+                    .read_from_group(key, tag, idx_to_validate)
+                    .is_ok_and(|(version, v)| {
+                        matches!(
+                            DataRead::Versioned(version, v).contains(r),
+                            DataReadComparison::Contains
+                        )
+                    })
+            })
+        })
+    }
+
+    pub(crate) fn mark_failure(&mut self) {
+        self.speculative_failure = true;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        proptest_types::types::{KeyType, MockEvent, ValueType},
+        task::Transaction,
+    };
+    use aptos_mvhashmap::types::StorageVersion;
+    use aptos_types::{
+        on_chain_config::CurrentTimeMicroseconds, state_store::state_value::StateValueMetadata,
+    };
+    use claims::{assert_err, assert_gt, assert_matches, assert_none, assert_ok, assert_some_eq};
+    use test_case::test_case;
+
+    #[test]
+    fn data_read_kind() {
+        // Test the strict ordering of enum variants for the read kinds.
+        assert_gt!(ReadKind::Value, ReadKind::Metadata);
+        assert_gt!(ReadKind::Metadata, ReadKind::Exists);
+
+        // Test that get_kind returns the proper kind for data read instances.
+
+        assert_eq!(
+            DataRead::Versioned(
+                Err(StorageVersion),
+                Arc::new(ValueType::with_len_and_metadata(1, None))
+            )
+            .get_kind(),
+            ReadKind::Value
+        );
+        assert_eq!(
+            DataRead::Resolved::<ValueType>(200).get_kind(),
+            ReadKind::Value
+        );
+        assert_eq!(
+            DataRead::Metadata::<ValueType>(Some(None)).get_kind(),
+            ReadKind::Metadata
+        );
+        assert_eq!(
+            DataRead::Metadata::<ValueType>(None).get_kind(),
+            ReadKind::Metadata
+        );
+        assert_eq!(
+            DataRead::Exists::<ValueType>(true).get_kind(),
+            ReadKind::Exists
+        );
+        assert_eq!(
+            DataRead::Exists::<ValueType>(false).get_kind(),
+            ReadKind::Exists
+        );
+    }
+
+    macro_rules! assert_inconsistent_same_kind {
+        ($x:expr, $y:expr) => {{
+            assert_ne!($x, $y);
+            assert_ne!($y, $x);
+            assert_matches!($x.contains(&$y), DataReadComparison::Inconsistent);
+            assert_matches!($y.contains(&$x), DataReadComparison::Inconsistent);
+        }};
+    }
+
+    macro_rules! assert_inconsistent_downcast {
+        ($x:expr, $y:expr) => {{
+            assert_ne!($x, $y);
+            assert_ne!($y, $x);
+            assert_matches!($x.contains(&$y), DataReadComparison::Inconsistent);
+            assert_matches!($y.contains(&$x), DataReadComparison::Insufficient);
+        }};
+    }
+
+    macro_rules! assert_contains {
+        ($x:expr, $y:expr) => {{
+            assert_some_eq!($x.downcast($y.get_kind()), $y);
+            assert_matches!($x.contains(&$y), DataReadComparison::Contains);
+        }};
+    }
+
+    macro_rules! assert_insufficient {
+        ($x:expr, $y:expr) => {{
+            assert_none!($x.downcast($y.get_kind()));
+            assert_matches!($x.contains(&$y), DataReadComparison::Insufficient);
+        }};
+    }
+
+    #[test]
+    fn as_contained_kind() {
+        // Legacy state values do not have metadata.
+        let versioned_legacy = DataRead::Versioned(
+            Err(StorageVersion),
+            Arc::new(ValueType::with_len_and_metadata(1, None)),
+        );
+        let versioned_deletion = DataRead::Versioned(
+            Ok((5, 1)),
+            Arc::new(ValueType::with_len_and_metadata(0, None)),
+        );
+        let versioned_with_metadata = DataRead::Versioned(
+            Ok((7, 0)),
+            Arc::new(ValueType::with_len_and_metadata(2, raw_metadata())),
+        );
+        let resolved = DataRead::Resolved::<ValueType>(200);
+        let deletion_metadata = DataRead::Metadata(None);
+        let legacy_metadata = DataRead::Metadata(Some(None));
+        let metadata = DataRead::Metadata(Some(raw_metadata()));
+        let exists = DataRead::Exists(true);
+        let not_exists = DataRead::Exists(false);
+
+        // Test contains & downcast.
+        assert_contains!(versioned_legacy, legacy_metadata);
+        assert_contains!(resolved, legacy_metadata);
+        assert_contains!(versioned_legacy, exists);
+        assert_contains!(resolved, exists);
+        assert_contains!(legacy_metadata, exists);
+        // Same checks for deletion (Resolved cannot be a deletion).
+        assert_contains!(versioned_deletion, deletion_metadata);
+        assert_contains!(versioned_deletion, not_exists);
+        assert_contains!(deletion_metadata, not_exists);
+        // Same checks with real metadata.
+        assert_contains!(versioned_with_metadata, metadata);
+        assert_contains!(versioned_with_metadata, exists);
+        assert_contains!(metadata, exists);
+
+        // Test upcast.
+        assert_insufficient!(legacy_metadata, versioned_legacy);
+        assert_insufficient!(deletion_metadata, versioned_legacy);
+        assert_insufficient!(exists, versioned_legacy);
+        assert_insufficient!(not_exists, versioned_legacy);
+        assert_insufficient!(exists, legacy_metadata);
+        assert_insufficient!(not_exists, legacy_metadata);
+
+        // Test inconsistency at the same kind.
+        assert_inconsistent_same_kind!(exists, not_exists);
+        assert_inconsistent_same_kind!(deletion_metadata, legacy_metadata);
+        assert_inconsistent_same_kind!(deletion_metadata, metadata);
+        assert_inconsistent_same_kind!(legacy_metadata, metadata);
+        assert_inconsistent_same_kind!(versioned_legacy, versioned_with_metadata);
+        assert_inconsistent_same_kind!(versioned_legacy, versioned_deletion);
+        assert_inconsistent_same_kind!(versioned_legacy, resolved);
+        assert_inconsistent_same_kind!(versioned_with_metadata, versioned_deletion);
+        assert_inconsistent_same_kind!(versioned_with_metadata, resolved);
+        assert_inconsistent_same_kind!(versioned_deletion, resolved);
+        // Test inconsistency with downcast.
+        assert_inconsistent_downcast!(versioned_legacy, metadata);
+        assert_inconsistent_downcast!(versioned_legacy, deletion_metadata);
+        assert_inconsistent_downcast!(versioned_legacy, not_exists);
+        assert_inconsistent_downcast!(resolved, deletion_metadata);
+        assert_inconsistent_downcast!(resolved, metadata);
+        assert_inconsistent_downcast!(resolved, not_exists);
+        assert_inconsistent_downcast!(versioned_with_metadata, legacy_metadata);
+        assert_inconsistent_downcast!(versioned_with_metadata, deletion_metadata);
+        assert_inconsistent_downcast!(versioned_with_metadata, not_exists);
+        assert_inconsistent_downcast!(versioned_deletion, legacy_metadata);
+        assert_inconsistent_downcast!(versioned_deletion, metadata);
+        assert_inconsistent_downcast!(versioned_deletion, exists);
+        assert_inconsistent_downcast!(metadata, not_exists);
+        assert_inconsistent_downcast!(legacy_metadata, not_exists);
+        assert_inconsistent_downcast!(deletion_metadata, exists);
+
+        // Test that V is getting ignored in the comparison.
+        assert_eq!(
+            versioned_legacy,
+            DataRead::Versioned(
+                Err(StorageVersion),
+                Arc::new(ValueType::with_len_and_metadata(10, None))
+            )
+        );
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestTransactionType {}
+
+    impl Transaction for TestTransactionType {
+        type Event = MockEvent;
+        type Identifier = ();
+        type Key = KeyType<u32>;
+        type Tag = u32;
+        type Value = ValueType;
+    }
+
+    macro_rules! assert_update_incorrect_use {
+        ($m:expr, $x:expr, $y:expr) => {{
+            let original = $m.get(&$x).cloned().unwrap();
+            assert_matches!(
+                CapturedReads::<TestTransactionType>::update_entry($m.entry($x), $y.clone()),
+                UpdateResult::IncorrectUse(_)
+            );
+            assert_some_eq!($m.get(&$x), &original);
+        }};
+    }
+
+    macro_rules! assert_update_inconsistency {
+        ($m:expr, $x:expr, $y:expr) => {{
+            let original = $m.get(&$x).cloned().unwrap();
+            assert_matches!(
+                CapturedReads::<TestTransactionType>::update_entry($m.entry($x), $y.clone()),
+                UpdateResult::Inconsistency(_)
+            );
+            assert_some_eq!($m.get(&$x), &original);
+        }};
+    }
+
+    macro_rules! assert_update {
+        ($m:expr, $x:expr, $y:expr) => {{
+            assert_matches!(
+                CapturedReads::<TestTransactionType>::update_entry($m.entry($x), $y.clone()),
+                UpdateResult::Updated
+            );
+            assert_some_eq!($m.get(&$x), &$y);
+        }};
+    }
+
+    macro_rules! assert_insert {
+        ($m:expr, $x:expr, $y:expr) => {{
+            assert_matches!(
+                CapturedReads::<TestTransactionType>::update_entry($m.entry($x), $y.clone()),
+                UpdateResult::Inserted
+            );
+            assert_some_eq!($m.get(&$x), &$y);
+        }};
+    }
+
+    fn raw_metadata() -> StateValueMetadataKind {
+        Some(StateValueMetadata::new(5, &CurrentTimeMicroseconds {
+            microseconds: 7,
+        }))
+    }
+
+    #[test]
+    fn test_update_entry() {
+        // Legacy state values do not have metadata.
+        let versioned_legacy = DataRead::Versioned(
+            Err(StorageVersion),
+            Arc::new(ValueType::with_len_and_metadata(1, None)),
+        );
+        let versioned_deletion = DataRead::Versioned(
+            Ok((5, 1)),
+            Arc::new(ValueType::with_len_and_metadata(0, None)),
+        );
+        let versioned_with_metadata = DataRead::Versioned(
+            Ok((7, 0)),
+            Arc::new(ValueType::with_len_and_metadata(2, raw_metadata())),
+        );
+        let resolved = DataRead::Resolved::<ValueType>(200);
+        let deletion_metadata = DataRead::Metadata(None);
+        let legacy_metadata = DataRead::Metadata(Some(None));
+        let metadata = DataRead::Metadata(Some(raw_metadata()));
+        let exists = DataRead::Exists(true);
+        let not_exists = DataRead::Exists(false);
+
+        let mut map: HashMap<u32, DataRead<ValueType>> = HashMap::new();
+        assert_none!(map.get(&0));
+
+        // Populate the empty entry.
+        assert_insert!(map, 0, not_exists);
+        // Update to the same data is not correct use.
+        assert_update_incorrect_use!(map, 0, not_exists);
+        // Incorrect use (<= kind provided than already captured) takes precedence
+        // over inconsistency.
+        assert_update_incorrect_use!(map, 0, exists);
+
+        // Update to a consistent higher kind.
+        assert_update!(map, 0, deletion_metadata);
+        // Update w. consistent lower kind is not correct use.
+        assert_update_incorrect_use!(map, 0, not_exists);
+
+        // More of the above behavior, with different kinds.
+        assert_update_incorrect_use!(map, 0, deletion_metadata);
+
+        assert_update_incorrect_use!(map, 0, exists);
+        assert_update_inconsistency!(map, 0, resolved);
+        assert_update_incorrect_use!(map, 0, exists);
+        assert_update_inconsistency!(map, 0, versioned_with_metadata);
+        // Updated key 0 for the last time.
+        assert_update!(map, 0, versioned_deletion);
+        assert_update_incorrect_use!(map, 0, not_exists);
+        assert_update_incorrect_use!(map, 0, legacy_metadata);
+        assert_update_incorrect_use!(map, 0, metadata);
+        assert_update_incorrect_use!(map, 0, deletion_metadata);
+        assert_update_incorrect_use!(map, 0, versioned_legacy);
+
+        assert_none!(map.get(&1));
+        assert_insert!(map, 1, metadata);
+        assert_update_incorrect_use!(map, 1, legacy_metadata);
+        assert_update_inconsistency!(map, 1, versioned_legacy);
+        assert_update_incorrect_use!(map, 1, exists);
+        assert_update_inconsistency!(map, 1, versioned_deletion);
+        assert_update_incorrect_use!(map, 1, not_exists);
+        assert_update_incorrect_use!(map, 1, metadata);
+        assert_update_inconsistency!(map, 1, resolved);
+        assert_update!(map, 1, versioned_with_metadata);
+        assert_update_incorrect_use!(map, 1, metadata);
+        assert_update_incorrect_use!(map, 1, not_exists);
+        assert_update_incorrect_use!(map, 1, exists);
+        assert_update_incorrect_use!(map, 1, legacy_metadata);
+        assert_update_incorrect_use!(map, 1, versioned_deletion);
+
+        assert_none!(map.get(&2));
+        assert_insert!(map, 2, legacy_metadata);
+        assert_update!(map, 2, resolved);
+        assert_update_incorrect_use!(map, 2, versioned_legacy);
+        assert_update_incorrect_use!(map, 2, legacy_metadata);
+        assert_update_incorrect_use!(map, 2, versioned_deletion);
+        assert_update_incorrect_use!(map, 2, not_exists);
+        assert_update_incorrect_use!(map, 2, metadata);
+        assert_update_incorrect_use!(map, 2, exists);
+        assert_update_incorrect_use!(map, 2, versioned_with_metadata);
+        assert_update_incorrect_use!(map, 2, deletion_metadata);
+        assert_update_incorrect_use!(map, 2, resolved);
+    }
+
+    fn legacy_reads_by_kind() -> Vec<DataRead<ValueType>> {
+        let exists = DataRead::Exists(true);
+        let legacy_metadata = DataRead::Metadata(Some(None));
+        let versioned_legacy = DataRead::Versioned(
+            Err(StorageVersion),
+            Arc::new(ValueType::with_len_and_metadata(1, None)),
+        );
+        vec![exists, legacy_metadata, versioned_legacy]
+    }
+
+    fn deletion_reads_by_kind() -> Vec<DataRead<ValueType>> {
+        let versioned_deletion = DataRead::Versioned(
+            Ok((5, 1)),
+            Arc::new(ValueType::with_len_and_metadata(0, None)),
+        );
+        let deletion_metadata = DataRead::Metadata(None);
+        let not_exists = DataRead::Exists(false);
+        vec![not_exists, deletion_metadata, versioned_deletion]
+    }
+
+    fn with_metadata_reads_by_kind() -> Vec<DataRead<ValueType>> {
+        let versioned_with_metadata = DataRead::Versioned(
+            Ok((7, 0)),
+            Arc::new(ValueType::with_len_and_metadata(2, raw_metadata())),
+        );
+        let metadata = DataRead::Metadata(Some(raw_metadata()));
+        let exists = DataRead::Exists(true);
+        vec![exists, metadata, versioned_with_metadata]
+    }
+
+    macro_rules! assert_capture_get {
+        ($x:expr, $k:expr, $mt:expr, $y:expr) => {{
+            let read_kinds = vec![ReadKind::Exists, ReadKind::Metadata, ReadKind::Value];
+
+            for i in 0..3 {
+                if $mt.is_none() || i != 1 {
+                    // Do not request metadata of group member.
+                    assert_none!($x.get_by_kind(&$k, $mt.as_ref(), read_kinds[i].clone()));
+                }
+            }
+
+            for i in 0..3 {
+                assert_ok!($x.capture_read($k.clone(), $mt.clone(), $y[i].clone()));
+                for j in 0..i {
+                    if $mt.is_none() || j != 1 {
+                        // Do not request metadata of group member
+                        assert_some_eq!(
+                            $x.get_by_kind(&$k, $mt.as_ref(), read_kinds[j].clone()),
+                            $y[j]
+                        );
+                    }
+                }
+            }
+        }};
+    }
+
+    #[test_case(false)]
+    #[test_case(true)]
+    fn capture_and_get_by_kind(use_tag: bool) {
+        let mut captured_reads = CapturedReads::<TestTransactionType>::new();
+        let legacy_reads = legacy_reads_by_kind();
+        let deletion_reads = deletion_reads_by_kind();
+        let with_metadata_reads = with_metadata_reads_by_kind();
+
+        assert_capture_get!(
+            captured_reads,
+            KeyType::<u32>(10, false),
+            use_tag.then_some(30),
+            legacy_reads
+        );
+        assert_capture_get!(
+            captured_reads,
+            KeyType::<u32>(11, false),
+            use_tag.then_some(30),
+            deletion_reads
+        );
+        assert_capture_get!(
+            captured_reads,
+            KeyType::<u32>(15, false),
+            use_tag.then_some(30),
+            with_metadata_reads
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn metadata_for_group_member() {
+        let captured_reads = CapturedReads::<TestTransactionType>::new();
+        captured_reads.get_by_kind(&KeyType::<u32>(21, false), Some(&10), ReadKind::Metadata);
+    }
+
+    macro_rules! assert_incorrect_use {
+        ($x:expr, $k:expr, $mt:expr, $y:expr) => {{
+            assert!(!$x.incorrect_use);
+
+            for i in 0..3 {
+                assert_ok!($x.capture_read($k.clone(), $mt.clone(), $y[i].clone()));
+                for j in 0..(i + 1) {
+                    assert_err!($x.capture_read($k, $mt.clone(), $y[j].clone()));
+                    assert!($x.incorrect_use);
+                    $x.incorrect_use = false;
+                }
+            }
+        }};
+    }
+
+    #[test_case(false)]
+    #[test_case(true)]
+    fn incorrect_use_flag(use_tag: bool) {
+        let mut captured_reads = CapturedReads::<TestTransactionType>::new();
+        let legacy_reads = legacy_reads_by_kind();
+        let deletion_reads = deletion_reads_by_kind();
+        let with_metadata_reads = with_metadata_reads_by_kind();
+
+        let resolved = DataRead::Resolved::<ValueType>(200);
+        let mixed_reads = vec![
+            deletion_reads[0].clone(),
+            with_metadata_reads[1].clone(),
+            resolved,
+        ];
+
+        assert_incorrect_use!(
+            captured_reads,
+            KeyType::<u32>(10, false),
+            use_tag.then_some(30),
+            legacy_reads
+        );
+        assert_incorrect_use!(
+            captured_reads,
+            KeyType::<u32>(11, false),
+            use_tag.then_some(30),
+            deletion_reads
+        );
+        assert_incorrect_use!(
+            captured_reads,
+            KeyType::<u32>(15, false),
+            use_tag.then_some(30),
+            with_metadata_reads
+        );
+
+        // Test incorrect with with incompatible types.
+        assert!(!captured_reads.incorrect_use);
+
+        for i in 0..3 {
+            let key = KeyType::<u32>(20 + i, false);
+            assert_ok!(captured_reads.capture_read(
+                key,
+                use_tag.then_some(30),
+                mixed_reads[i as usize].clone()
+            ));
+            for j in 0..(i + 1) {
+                assert_err!(captured_reads.capture_read(
+                    key,
+                    use_tag.then_some(30),
+                    mixed_reads[j as usize].clone()
+                ));
+                assert!(captured_reads.incorrect_use);
+                captured_reads.incorrect_use = false;
+            }
+        }
+    }
+
+    #[test_case(false)]
+    #[test_case(true)]
+    fn speculative_failure_flag(use_tag: bool) {
+        let mut captured_reads = CapturedReads::<TestTransactionType>::new();
+        let versioned_legacy = DataRead::Versioned(
+            Err(StorageVersion),
+            Arc::new(ValueType::with_len_and_metadata(1, None)),
+        );
+        let resolved = DataRead::Resolved::<ValueType>(200);
+        let metadata = DataRead::Metadata(Some(raw_metadata()));
+        let deletion_metadata = DataRead::Metadata(None);
+        let exists = DataRead::Exists(true);
+
+        assert!(!captured_reads.speculative_failure);
+        let key = KeyType::<u32>(20, false);
+        assert_ok!(captured_reads.capture_read(key, use_tag.then_some(30), exists));
+        assert_err!(captured_reads.capture_read(
+            key,
+            use_tag.then_some(30),
+            deletion_metadata.clone()
+        ));
+        assert!(captured_reads.speculative_failure);
+
+        captured_reads.speculative_failure = false;
+        let key = KeyType::<u32>(21, false);
+        assert_ok!(captured_reads.capture_read(key, use_tag.then_some(30), deletion_metadata));
+        assert_err!(captured_reads.capture_read(key, use_tag.then_some(30), resolved));
+        assert!(captured_reads.speculative_failure);
+
+        captured_reads.speculative_failure = false;
+        let key = KeyType::<u32>(22, false);
+        assert_ok!(captured_reads.capture_read(key, use_tag.then_some(30), metadata));
+        assert_err!(captured_reads.capture_read(key, use_tag.then_some(30), versioned_legacy));
+        assert!(captured_reads.speculative_failure);
+
+        captured_reads.speculative_failure = false;
+        captured_reads.mark_failure();
+        assert!(captured_reads.speculative_failure);
+    }
+}

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -135,7 +135,8 @@ optimistically creating validation tasks for higher transactions in 2(b),
 and threads that perform these tasks can already detect validation failures
 due to the ESTIMATE markers on memory locations, instead of waiting for a
 subsequent incarnation to finish.
-**/
+ **/
+mod captured_reads;
 pub mod counters;
 pub mod errors;
 pub mod executor;

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -17,15 +17,15 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
 /// The execution result of a transaction
 #[derive(Debug)]
-pub enum ExecutionStatus<T, E> {
+pub enum ExecutionStatus<O, E> {
     /// Transaction was executed successfully.
-    Success(T),
+    Success(O),
     /// Transaction hit a none recoverable error during execution, halt the execution and propagate
     /// the error back to the caller.
     Abort(E),
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list
-    SkipRest(T),
+    SkipRest(O),
 }
 
 /// Trait that defines a transaction type that can be executed by the block executor. A transaction

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    captured_reads::CapturedReads,
     errors::Error,
     task::{ExecutionStatus, Transaction, TransactionOutput},
 };
 use anyhow::anyhow;
-use aptos_mvhashmap::types::{TxnIndex, Version};
-use aptos_types::{
-    access_path::AccessPath, executable::ModulePath, fee_statement::FeeStatement,
-    write_set::WriteOp,
-};
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::{fee_statement::FeeStatement, write_set::WriteOp};
 use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;
 use dashmap::DashSet;
 use std::{
+    collections::HashMap,
     fmt::Debug,
     iter::{empty, Iterator},
     sync::{
@@ -23,119 +22,41 @@ use std::{
     },
 };
 
-type TxnInput<K> = Vec<ReadDescriptor<K>>;
+type TxnInput<T> = CapturedReads<T>;
+
 // When a transaction is committed, the output delta writes must be populated by
 // the WriteOps corresponding to the deltas in the corresponding outputs.
 #[derive(Debug)]
-pub(crate) struct TxnOutput<T: TransactionOutput, E: Debug> {
-    output_status: ExecutionStatus<T, Error<E>>,
+pub(crate) struct TxnOutput<O: TransactionOutput, E: Debug> {
+    output_status: ExecutionStatus<O, Error<E>>,
 }
 
-impl<T: TransactionOutput, E: Debug> TxnOutput<T, E> {
-    pub fn from_output_status(output_status: ExecutionStatus<T, Error<E>>) -> Self {
+impl<O: TransactionOutput, E: Debug> TxnOutput<O, E> {
+    pub fn from_output_status(output_status: ExecutionStatus<O, Error<E>>) -> Self {
         Self { output_status }
     }
 
-    pub fn output_status(&self) -> &ExecutionStatus<T, Error<E>> {
+    pub fn output_status(&self) -> &ExecutionStatus<O, Error<E>> {
         &self.output_status
     }
 }
 
-/// Information about the read which is used by validation.
-#[derive(Debug, Clone, PartialEq)]
-enum ReadKind {
-    /// Read returned a value from the multi-version data-structure, with index
-    /// and incarnation number of the execution associated with the write of
-    /// that entry.
-    Versioned(Version),
-    /// Read resolved a delta.
-    Resolved(u128),
-    /// Speculative inconsistency failure.
-    SpeculativeFailure,
-    /// Module read. TODO: Design a better representation once more meaningfully separated.
-    Module,
-}
+pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug> {
+    inputs: Vec<CachePadded<ArcSwapOption<TxnInput<T>>>>, // txn_idx -> input.
 
-#[derive(Debug, Clone)]
-pub struct ReadDescriptor<K> {
-    access_path: K,
-    kind: ReadKind,
-}
-
-impl<K: Debug + ModulePath> ReadDescriptor<K> {
-    pub fn from_versioned(access_path: K, version: Version) -> Self {
-        Self {
-            access_path,
-            kind: ReadKind::Versioned(version),
-        }
-    }
-
-    pub fn from_resolved(access_path: K, value: u128) -> Self {
-        Self {
-            access_path,
-            kind: ReadKind::Resolved(value),
-        }
-    }
-
-    pub fn from_module(access_path: K) -> Self {
-        Self {
-            access_path,
-            kind: ReadKind::Module,
-        }
-    }
-
-    pub fn from_speculative_failure(access_path: K) -> Self {
-        Self {
-            access_path,
-            kind: ReadKind::SpeculativeFailure,
-        }
-    }
-
-    fn module_path(&self) -> Option<AccessPath> {
-        self.access_path.module_path()
-    }
-
-    pub fn path(&self) -> &K {
-        &self.access_path
-    }
-
-    // Does the read descriptor describe a read from MVHashMap w. a specified version.
-    pub fn validate_versioned(&self, version: Version) -> bool {
-        self.kind == ReadKind::Versioned(version)
-    }
-
-    // Does the read descriptor describe a read from MVHashMap w. a resolved delta.
-    pub fn validate_resolved(&self, value: u128) -> bool {
-        self.kind == ReadKind::Resolved(value)
-    }
-
-    // Does the read descriptor describe a read from MVHashMap w. a resolved delta.
-    pub fn validate_module(&self) -> bool {
-        self.kind == ReadKind::Module
-    }
-
-    // Does the read descriptor describe to a read with a delta application failure.
-    pub fn is_speculative_failure(&self) -> bool {
-        self.kind == ReadKind::SpeculativeFailure
-    }
-}
-
-pub struct TxnLastInputOutput<K, T: TransactionOutput, E: Debug> {
-    inputs: Vec<CachePadded<ArcSwapOption<TxnInput<K>>>>, // txn_idx -> input.
-
-    outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<T, E>>>>, // txn_idx -> output.
+    outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<O, E>>>>, // txn_idx -> output.
 
     // Record all writes and reads to access paths corresponding to modules (code) in any
     // (speculative) executions. Used to avoid a potential race with module publishing and
     // Move-VM loader cache - see 'record' function comment for more information.
-    module_writes: DashSet<AccessPath>,
-    module_reads: DashSet<AccessPath>,
+    module_writes: DashSet<T::Key>,
+    module_reads: DashSet<T::Key>,
 
     module_read_write_intersection: AtomicBool,
 }
 
-impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
-    TxnLastInputOutput<K, T, E>
+impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
+    TxnLastInputOutput<T, O, E>
 {
     pub fn new(num_txns: TxnIndex) -> Self {
         Self {
@@ -151,16 +72,16 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
         }
     }
 
-    fn append_and_check(
-        paths: Vec<AccessPath>,
-        set_to_append: &DashSet<AccessPath>,
-        set_to_check: &DashSet<AccessPath>,
+    fn append_and_check<'a>(
+        paths: impl Iterator<Item = &'a T::Key>,
+        set_to_append: &DashSet<T::Key>,
+        set_to_check: &DashSet<T::Key>,
     ) -> bool {
         for path in paths {
             // Standard flags, first show, then look.
             set_to_append.insert(path.clone());
 
-            if set_to_check.contains(&path) {
+            if set_to_check.contains(path) {
                 return true;
             }
         }
@@ -182,36 +103,27 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
     pub(crate) fn record(
         &self,
         txn_idx: TxnIndex,
-        input: Vec<ReadDescriptor<K>>,
-        output: ExecutionStatus<T, Error<E>>,
+        input: CapturedReads<T>,
+        output: ExecutionStatus<O, Error<E>>,
     ) -> anyhow::Result<()> {
-        let read_modules: Vec<AccessPath> = input
-            .iter()
-            .filter_map(|desc| {
-                matches!(desc.kind, ReadKind::Module).then(|| {
-                    desc.module_path()
-                        .unwrap_or_else(|| panic!("Module path guaranteed to exist {:?}", desc))
-                })
-            })
-            .collect();
-        let written_modules: Vec<AccessPath> = match &output {
-            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => output
-                .module_write_set()
-                .keys()
-                .map(|k| {
-                    k.module_path().unwrap_or_else(|| {
-                        panic!("Unexpected non-module key found in putput: {:?}", k)
-                    })
-                })
-                .collect(),
-            ExecutionStatus::Abort(_) => Vec::new(),
+        let written_modules = match &output {
+            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                output.module_write_set()
+            },
+            ExecutionStatus::Abort(_) => HashMap::new(),
         };
 
         if !self.module_read_write_intersection.load(Ordering::Relaxed) {
             // Check if adding new read & write modules leads to intersections.
-            if Self::append_and_check(read_modules, &self.module_reads, &self.module_writes)
-                || Self::append_and_check(written_modules, &self.module_writes, &self.module_reads)
-            {
+            if Self::append_and_check(
+                input.module_reads.iter(),
+                &self.module_reads,
+                &self.module_writes,
+            ) || Self::append_and_check(
+                written_modules.keys(),
+                &self.module_writes,
+                &self.module_reads,
+            ) {
                 self.module_read_write_intersection
                     .store(true, Ordering::Release);
                 return Err(anyhow!(
@@ -230,7 +142,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
         self.module_read_write_intersection.load(Ordering::Acquire)
     }
 
-    pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<Vec<ReadDescriptor<K>>>> {
+    pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<CapturedReads<T>>> {
         self.inputs[txn_idx as usize].load_full()
     }
 
@@ -269,7 +181,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
         }
     }
 
-    pub(crate) fn txn_output(&self, txn_idx: TxnIndex) -> Option<Arc<TxnOutput<T, E>>> {
+    pub(crate) fn txn_output(&self, txn_idx: TxnIndex) -> Option<Arc<TxnOutput<O, E>>> {
         self.outputs[txn_idx as usize].load_full()
     }
 
@@ -278,8 +190,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
     pub(crate) fn modified_keys(
         &self,
         txn_idx: TxnIndex,
-    ) -> Option<impl Iterator<Item = (<<T as TransactionOutput>::Txn as Transaction>::Key, bool)>>
-    {
+    ) -> Option<impl Iterator<Item = (T::Key, bool)>> {
         self.outputs[txn_idx as usize]
             .load_full()
             .and_then(|txn_output| match &txn_output.output_status {
@@ -295,10 +206,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
             })
     }
 
-    pub(crate) fn delta_keys(
-        &self,
-        txn_idx: TxnIndex,
-    ) -> Vec<<<T as TransactionOutput>::Txn as Transaction>::Key> {
+    pub(crate) fn delta_keys(&self, txn_idx: TxnIndex) -> Vec<T::Key> {
         self.outputs[txn_idx as usize].load().as_ref().map_or(
             vec![],
             |txn_output| match &txn_output.output_status {
@@ -310,20 +218,15 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
         )
     }
 
-    pub(crate) fn events(
-        &self,
-        txn_idx: TxnIndex,
-    ) -> Box<dyn Iterator<Item = <<T as TransactionOutput>::Txn as Transaction>::Event>> {
+    pub(crate) fn events(&self, txn_idx: TxnIndex) -> Box<dyn Iterator<Item = T::Event>> {
         self.outputs[txn_idx as usize].load().as_ref().map_or(
-            Box::new(empty::<<<T as TransactionOutput>::Txn as Transaction>::Event>()),
+            Box::new(empty::<T::Event>()),
             |txn_output| match &txn_output.output_status {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
                     let events = t.get_events();
                     Box::new(events.into_iter())
                 },
-                ExecutionStatus::Abort(_) => {
-                    Box::new(empty::<<<T as TransactionOutput>::Txn as Transaction>::Event>())
-                },
+                ExecutionStatus::Abort(_) => Box::new(empty::<T::Event>()),
             },
         )
     }
@@ -333,7 +236,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
     pub(crate) fn record_delta_writes(
         &self,
         txn_idx: TxnIndex,
-        delta_writes: Vec<(<<T as TransactionOutput>::Txn as Transaction>::Key, WriteOp)>,
+        delta_writes: Vec<(T::Key, WriteOp)>,
     ) {
         match &self.outputs[txn_idx as usize]
             .load_full()
@@ -349,7 +252,7 @@ impl<K: Debug + ModulePath, T: TransactionOutput, E: Debug + Send + Clone>
 
     // Must be executed after parallel execution is done, grabs outputs. Will panic if
     // other outstanding references to the recorded outputs exist.
-    pub(crate) fn take_output(&self, txn_idx: TxnIndex) -> ExecutionStatus<T, Error<E>> {
+    pub(crate) fn take_output(&self, txn_idx: TxnIndex) -> ExecutionStatus<O, Error<E>> {
         let owning_ptr = self.outputs[txn_idx as usize]
             .swap(None)
             .expect("[BlockSTM]: Output must be recorded after execution");

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    captured_reads::{CapturedReads, DataRead, ReadKind},
     counters,
     scheduler::{DependencyResult, DependencyStatus, Scheduler},
     task::Transaction,
-    txn_last_input_output::ReadDescriptor,
 };
 use aptos_aggregator::{
     delta_change_set::serialize,
@@ -20,7 +20,10 @@ use aptos_mvhashmap::{
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
     executable::{Executable, ModulePath},
-    state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
+    state_store::{
+        state_storage_usage::StateStorageUsage,
+        state_value::{StateValue, StateValueMetadataKind},
+    },
     write_set::TransactionWrite,
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
@@ -29,34 +32,41 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::{StatusCode, VMStatus},
 };
-use std::{
-    cell::RefCell,
-    fmt::Debug,
-    sync::{atomic::AtomicU32, Arc},
-};
+use std::{cell::RefCell, fmt::Debug, sync::atomic::AtomicU32};
 
 /// A struct which describes the result of the read from the proxy. The client
 /// can interpret these types to further resolve the reads.
 #[derive(Debug)]
-pub(crate) enum ReadResult<V> {
-    // Successful read of a value.
-    Value(Arc<V>),
-    // Similar to above, but the value was aggregated and is an integer.
-    U128(u128),
-    // Read did not return anything.
+pub(crate) enum ReadResult {
+    Value(Option<StateValue>),
+    Metadata(Option<StateValueMetadataKind>),
+    Exists(bool),
     Uninitialized,
-    // Must half the execution of the calling transaction. This might be because
+    // Must halt the execution of the calling transaction. This might be because
     // there was an inconsistency in observed speculative state, or dependency
     // waiting indicated that the parallel execution had been halted. The String
     // parameter provides more context (error description / message).
     HaltSpeculativeExecution(String),
 }
 
+impl ReadResult {
+    fn from_data_read<V: TransactionWrite>(data: DataRead<V>) -> Self {
+        match data {
+            DataRead::Versioned(_, v) => ReadResult::Value(v.as_state_value()),
+            DataRead::Resolved(v) => {
+                ReadResult::Value(Some(StateValue::new_legacy(serialize(&v).into())))
+            },
+            DataRead::Metadata(maybe_metadata) => ReadResult::Metadata(maybe_metadata),
+            DataRead::Exists(exists) => ReadResult::Exists(exists),
+        }
+    }
+}
+
 pub(crate) struct ParallelState<'a, T: Transaction, X: Executable> {
     versioned_map: &'a MVHashMap<T::Key, T::Tag, T::Value, X>,
     scheduler: &'a Scheduler,
     _counter: &'a AtomicU32,
-    captured_reads: RefCell<Vec<ReadDescriptor<T::Key>>>,
+    captured_reads: RefCell<CapturedReads<T>>,
 }
 
 impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
@@ -69,7 +79,7 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
             versioned_map: shared_map,
             scheduler: shared_scheduler,
             _counter: shared_counter,
-            captured_reads: RefCell::new(Vec::new()),
+            captured_reads: RefCell::new(CapturedReads::new()),
         }
     }
 
@@ -79,33 +89,107 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
         key: &T::Key,
         txn_idx: TxnIndex,
     ) -> anyhow::Result<MVModulesOutput<T::Value, X>, MVModulesError> {
-        // Register a fake read for the read / write path intersection fallback for modules.
+        // Record for the R/W path intersection fallback for modules.
         self.captured_reads
             .borrow_mut()
-            .push(ReadDescriptor::from_module(key.clone()));
+            .module_reads
+            .push(key.clone());
 
         self.versioned_map.modules().fetch_module(key, txn_idx)
     }
 
+    // txn_idx is estimated to have a r/w dependency on dep_idx.
+    // Returns after the dependency has been resolved, the returned indicator is true if
+    // it is safe to continue, and false if the execution has been halted.
+    fn wait_for_dependency(&self, txn_idx: TxnIndex, dep_idx: TxnIndex) -> bool {
+        match self.scheduler.wait_for_dependency(txn_idx, dep_idx) {
+            DependencyResult::Dependency(dep_condition) => {
+                let _timer = counters::DEPENDENCY_WAIT_SECONDS.start_timer();
+                // Wait on a condition variable corresponding to the encountered
+                // read dependency. Once the dep_idx finishes re-execution, scheduler
+                // will mark the dependency as resolved, and then the txn_idx will be
+                // scheduled for re-execution, which will re-awaken cvar here.
+                // A deadlock is not possible due to these condition variables:
+                // suppose all threads are waiting on read dependency, and consider
+                // one with lowest txn_idx. It observed a dependency, so some thread
+                // aborted dep_idx. If that abort returned execution task, by
+                // minimality (lower transactions aren't waiting), that thread would
+                // finish execution unblock txn_idx, contradiction. Otherwise,
+                // execution_idx in scheduler was lower at a time when at least the
+                // thread that aborted dep_idx was alive, and again, since lower txns
+                // than txn_idx are not blocked, so the execution of dep_idx will
+                // eventually finish and lead to unblocking txn_idx, contradiction.
+                let (lock, cvar) = &*dep_condition;
+                let mut dep_resolved = lock.lock();
+                while let DependencyStatus::Unresolved = *dep_resolved {
+                    dep_resolved = cvar.wait(dep_resolved).unwrap();
+                }
+                // dep resolved status is either resolved or execution halted.
+                matches!(*dep_resolved, DependencyStatus::Resolved)
+            },
+            DependencyResult::ExecutionHalted => false,
+            DependencyResult::Resolved => true,
+        }
+    }
+
     /// Captures a read from the VM execution, but not unresolved deltas, as in this case it is the
     /// callers responsibility to set the aggregator's base value and call fetch_data again.
-    fn fetch_data(&self, key: &T::Key, txn_idx: TxnIndex) -> ReadResult<T::Value> {
+    fn read_data_by_kind(
+        &self,
+        key: &T::Key,
+        txn_idx: TxnIndex,
+        target_kind: ReadKind,
+    ) -> ReadResult {
         use MVDataError::*;
         use MVDataOutput::*;
+
+        if let Some(data) = self
+            .captured_reads
+            .borrow()
+            .get_by_kind(key, None, target_kind.clone())
+        {
+            return ReadResult::from_data_read(data);
+        }
 
         loop {
             match self.versioned_map.data().fetch_data(key, txn_idx) {
                 Ok(Versioned(version, v)) => {
-                    self.captured_reads
+                    let data_read = DataRead::Versioned(version, v.clone())
+                        .downcast(target_kind)
+                        .expect("Downcast from Versioned must succeed");
+
+                    if self
+                        .captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_versioned(key.clone(), version));
-                    return ReadResult::Value(v);
+                        .capture_read(key.clone(), None, data_read.clone())
+                        .is_err()
+                    {
+                        // Inconsistency in recorded reads.
+                        return ReadResult::HaltSpeculativeExecution(
+                            "Inconsistency in reads (must be due to speculation)".to_string(),
+                        );
+                    }
+
+                    return ReadResult::from_data_read(data_read);
                 },
                 Ok(Resolved(value)) => {
-                    self.captured_reads
+                    let data_read = DataRead::Resolved(value)
+                        .downcast(target_kind)
+                        .expect("Downcast from Resolved must succeed");
+
+                    if self
+                        .captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_resolved(key.clone(), value));
-                    return ReadResult::U128(value);
+                        .capture_read(key.clone(), None, data_read.clone())
+                        .is_err()
+                    {
+                        // Inconsistency in recorded reads.
+                        return ReadResult::HaltSpeculativeExecution(
+                            "Inconsistency in reads (must be due to speculation)".to_string(),
+                        );
+                    }
+
+                    return ReadResult::from_data_read(data_read);
                 },
                 Err(Uninitialized) | Err(Unresolved(_)) => {
                     // The underlying assumption here for not recording anything about the read is
@@ -115,52 +199,14 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
                     return ReadResult::Uninitialized;
                 },
                 Err(Dependency(dep_idx)) => {
-                    // `self.txn_idx` estimated to depend on a write from `dep_idx`.
-                    match self.scheduler.wait_for_dependency(txn_idx, dep_idx) {
-                        DependencyResult::Dependency(dep_condition) => {
-                            let _timer = counters::DEPENDENCY_WAIT_SECONDS.start_timer();
-                            // Wait on a condition variable corresponding to the encountered
-                            // read dependency. Once the dep_idx finishes re-execution, scheduler
-                            // will mark the dependency as resolved, and then the txn_idx will be
-                            // scheduled for re-execution, which will re-awaken cvar here.
-                            // A deadlock is not possible due to these condition variables:
-                            // suppose all threads are waiting on read dependency, and consider
-                            // one with lowest txn_idx. It observed a dependency, so some thread
-                            // aborted dep_idx. If that abort returned execution task, by
-                            // minimality (lower transactions aren't waiting), that thread would
-                            // finish execution unblock txn_idx, contradiction. Otherwise,
-                            // execution_idx in scheduler was lower at a time when at least the
-                            // thread that aborted dep_idx was alive, and again, since lower txns
-                            // than txn_idx are not blocked, so the execution of dep_idx will
-                            // eventually finish and lead to unblocking txn_idx, contradiction.
-                            let (lock, cvar) = &*dep_condition;
-                            let mut dep_resolved = lock.lock();
-                            while let DependencyStatus::Unresolved = *dep_resolved {
-                                dep_resolved = cvar.wait(dep_resolved).unwrap();
-                            }
-                            if let DependencyStatus::ExecutionHalted = *dep_resolved {
-                                return ReadResult::HaltSpeculativeExecution(
-                                    "Speculative error to halt BlockSTM early.".to_string(),
-                                );
-                            }
-                        },
-                        DependencyResult::ExecutionHalted => {
-                            return ReadResult::HaltSpeculativeExecution(
-                                "Speculative error to halt BlockSTM early.".to_string(),
-                            );
-                        },
-                        DependencyResult::Resolved => continue,
+                    if !self.wait_for_dependency(txn_idx, dep_idx) {
+                        return ReadResult::HaltSpeculativeExecution(
+                            "Interrupted as block execution was halted".to_string(),
+                        );
                     }
                 },
                 Err(DeltaApplicationFailure) => {
-                    // Delta application failure currently should never happen. Here, we assume it
-                    // happened because of speculation and return 0 to the Move-VM. Validation will
-                    // ensure the transaction re-executes if 0 wasn't the right number.
-
-                    self.captured_reads
-                        .borrow_mut()
-                        .push(ReadDescriptor::from_speculative_failure(key.clone()));
-
+                    self.captured_reads.borrow_mut().mark_failure();
                     return ReadResult::HaltSpeculativeExecution(
                         "Delta application failure (must be speculative)".to_string(),
                     );
@@ -205,7 +251,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
     }
 
     /// Drains the captured reads.
-    pub(crate) fn take_reads(&self) -> Vec<ReadDescriptor<T::Key>> {
+    pub(crate) fn take_reads(&self) -> CapturedReads<T> {
         match &self.latest_view {
             ViewState::Sync(state) => state.captured_reads.take(),
             ViewState::Unsync(_) => {
@@ -227,7 +273,65 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                 state_key
             );
         }
+
+        // TODO: AggregatorID in V2 can be replaced here.
         ret
+    }
+
+    fn get_resource_state_value_impl(
+        &self,
+        state_key: &T::Key,
+        kind: ReadKind,
+    ) -> anyhow::Result<ReadResult> {
+        debug_assert!(
+            state_key.module_path().is_none(),
+            "Reading a module {:?} using ResourceView",
+            state_key,
+        );
+
+        match &self.latest_view {
+            ViewState::Sync(state) => {
+                let mut ret = state.read_data_by_kind(state_key, self.txn_idx, kind.clone());
+
+                if matches!(ret, ReadResult::Uninitialized) {
+                    let from_storage = self.get_base_value(state_key)?;
+                    state.versioned_map.data().provide_base_value(
+                        state_key.clone(),
+                        TransactionWrite::from_state_value(from_storage),
+                    );
+
+                    ret = state.read_data_by_kind(state_key, self.txn_idx, kind);
+                }
+
+                match ret {
+                    // ExecutionHalted indicates that the parallel execution is halted.
+                    // The read should return immediately and log the error.
+                    // For now we use STORAGE_ERROR as the VM will not log the speculative eror,
+                    // so no actual error will be logged once the execution is halted and
+                    // the speculative logging is flushed.
+                    ReadResult::HaltSpeculativeExecution(msg) => Err(anyhow::Error::new(
+                        VMStatus::error(StatusCode::STORAGE_ERROR, Some(msg)),
+                    )),
+                    ReadResult::Uninitialized => {
+                        unreachable!("base value must already be recorded in the MV data structure")
+                    },
+                    _ => Ok(ret),
+                }
+            },
+            ViewState::Unsync(state) => {
+                let ret = state.unsync_map.fetch_data(state_key).map_or_else(
+                    || self.get_base_value(state_key),
+                    |v| Ok(v.as_state_value()),
+                );
+                ret.map(|maybe_state_value| match kind {
+                    ReadKind::Value => ReadResult::Value(maybe_state_value),
+                    ReadKind::Metadata => {
+                        ReadResult::Metadata(maybe_state_value.map(StateValue::into_metadata))
+                    },
+                    ReadKind::Exists => ReadResult::Exists(maybe_state_value.is_some()),
+                })
+            },
+        }
     }
 }
 
@@ -242,56 +346,40 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceVi
         state_key: &Self::Key,
         _maybe_layout: Option<&Self::Layout>,
     ) -> anyhow::Result<Option<StateValue>> {
-        debug_assert!(
-            state_key.module_path().is_none(),
-            "Reading a module {:?} using ResourceView",
-            state_key,
-        );
-
-        match &self.latest_view {
-            ViewState::Sync(state) => {
-                let mut mv_value = state.fetch_data(state_key, self.txn_idx);
-
-                if matches!(mv_value, ReadResult::Uninitialized) {
-                    let from_storage = self.base_view.get_state_value(state_key)?;
-
-                    // This base value can also be used to resolve AggregatorV1 directly from
-                    // the versioned data-structure (without more storage calls).
-                    state.versioned_map.data().provide_base_value(
-                        state_key.clone(),
-                        TransactionWrite::from_state_value(from_storage),
-                    );
-
-                    mv_value = state.fetch_data(state_key, self.txn_idx);
+        self.get_resource_state_value_impl(state_key, ReadKind::Value)
+            .map(|res| {
+                if let ReadResult::Value(v) = res {
+                    v
+                } else {
+                    unreachable!("Read result must be Value kind")
                 }
-
-                match mv_value {
-                    ReadResult::Value(v) => Ok(v.as_state_value()),
-                    ReadResult::U128(v) => Ok(Some(StateValue::new_legacy(serialize(&v).into()))),
-                    // ExecutionHalted indicates that the parallel execution is halted.
-                    // The read should return immediately and log the error.
-                    // For now we use STORAGE_ERROR as the VM will not log the speculative eror,
-                    // so no actual error will be logged once the execution is halted and
-                    // the speculative logging is flushed.
-                    ReadResult::HaltSpeculativeExecution(msg) => Err(anyhow::Error::new(
-                        VMStatus::error(StatusCode::STORAGE_ERROR, Some(msg)),
-                    )),
-                    ReadResult::Uninitialized => {
-                        unreachable!("base value must already be recorded in the MV data structure")
-                    },
-                }
-            },
-            ViewState::Unsync(state) => state.unsync_map.fetch_data(state_key).map_or_else(
-                || {
-                    // TODO: AggregatorV2 ID for sequential must be replaced in this flow.
-                    self.get_base_value(state_key)
-                },
-                |v| Ok(v.as_state_value()),
-            ),
-        }
+            })
     }
 
-    // TODO: implement here fn get_resource_state_value_metadata & resource_exists.
+    fn get_resource_state_value_metadata(
+        &self,
+        state_key: &Self::Key,
+    ) -> anyhow::Result<Option<StateValueMetadataKind>> {
+        self.get_resource_state_value_impl(state_key, ReadKind::Metadata)
+            .map(|res| {
+                if let ReadResult::Metadata(v) = res {
+                    v
+                } else {
+                    unreachable!("Read result must be Metadata kind")
+                }
+            })
+    }
+
+    fn resource_exists(&self, state_key: &Self::Key) -> anyhow::Result<bool> {
+        self.get_resource_state_value_impl(state_key, ReadKind::Exists)
+            .map(|res| {
+                if let ReadResult::Exists(v) = res {
+                    v
+                } else {
+                    unreachable!("Read result must be Exists kind")
+                }
+            })
+    }
 }
 
 impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TModuleView

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -271,10 +271,10 @@ where
                             if test_group {
                                 match map.group_data().read_from_group(
                                     &KeyType(key.clone()),
-                                    idx as TxnIndex,
                                     &5,
+                                    idx as TxnIndex,
                                 ) {
-                                    Ok((v, _)) => {
+                                    Ok((_, v)) => {
                                         assert_value(v);
                                         break;
                                     },

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -7,7 +7,7 @@
 
 use crate::state_store::{
     state_key::StateKey,
-    state_value::{StateValue, StateValueMetadata},
+    state_value::{StateValue, StateValueMetadata, StateValueMetadataKind},
 };
 use anyhow::{bail, Result};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -170,7 +170,16 @@ impl WriteOp {
 pub trait TransactionWrite {
     fn bytes(&self) -> Option<&Bytes>;
 
+    // Returns state value that would be observed by a read following the 'self' write.
     fn as_state_value(&self) -> Option<StateValue>;
+
+    // Returns metadata that would be observed by a read following the 'self' write.
+    // Provided as a separate method to avoid the clone in as_state_value method
+    // (although default implementation below does just that).
+    fn as_state_value_metadata(&self) -> Option<StateValueMetadataKind> {
+        self.as_state_value()
+            .map(|state_value| state_value.into_metadata())
+    }
 
     // Often, the contents of W:TransactionWrite are converted to Option<StateValue>, e.g.
     // to emulate reading from storage after W has been applied. However, in some contexts,
@@ -210,6 +219,12 @@ impl TransactionWrite for WriteOp {
             None => StateValue::new_legacy(bytes.clone()),
             Some(metadata) => StateValue::new_with_metadata(bytes.clone(), metadata.clone()),
         })
+    }
+
+    // Note that even if WriteOp is DeletionWithMetadata, the method returns None, as a later
+    // read would not read the metadata of the deletion op.
+    fn as_state_value_metadata(&self) -> Option<StateValueMetadataKind> {
+        self.bytes().map(|_| self.metadata().cloned())
     }
 
     fn from_state_value(maybe_state_value: Option<StateValue>) -> Self {


### PR DESCRIPTION
Create a component that exclusively deals with capturing reads from transaction execution, and validating them
- Incorporate new functionality to distinguish between reading a full value, just metadata, or only checking for existence. For now, the callers don't take full benefit of it, but resource groups will (for metadata, and it will have its own existence check for resources in the group too - functionality also implemented in CapturedReads).
- Test the component extensively.

Besides being important for getting the performance improvements for resource groups (o.w. we would get R/W conflicts on metadata), this greatly simplifies validation and code extensibility for the future, also gives us infrastructure to avoid many R/W conflicts in the future.

CapturedReads has comprehensive unit test suite. Metadata and exists reading will be integrated into proptests in a follow up PR.