### PR TITLE
[TS SDK] Add indexer `events` query to also support events v2

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 - Add current objects queries support - `getAccountOwnedObjects`
 - Add `burnObject` transaction support in `AptosToken`
+- Add `getEvents` query on `IndexerClient` for a better support
 
 ## 1.19.0 (2023-08-24)
 

--- a/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
@@ -96,6 +96,16 @@ export type GetDelegatedStakingActivitiesQueryVariables = Types.Exact<{
 
 export type GetDelegatedStakingActivitiesQuery = { __typename?: 'query_root', delegated_staking_activities: Array<{ __typename?: 'delegated_staking_activities', amount: any, delegator_address: string, event_index: any, event_type: string, pool_address: string, transaction_version: any }> };
 
+export type GetEventsQueryVariables = Types.Exact<{
+  where_condition?: Types.InputMaybe<Types.Events_Bool_Exp>;
+  offset?: Types.InputMaybe<Types.Scalars['Int']>;
+  limit?: Types.InputMaybe<Types.Scalars['Int']>;
+  order_by?: Types.InputMaybe<Array<Types.Events_Order_By> | Types.Events_Order_By>;
+}>;
+
+
+export type GetEventsQuery = { __typename?: 'query_root', events: Array<{ __typename?: 'events', account_address: string, creation_number: any, data: any, event_index?: any | null, sequence_number: any, transaction_block_height: any, transaction_version: any, type: string }> };
+
 export type GetIndexerLedgerInfoQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 

--- a/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
@@ -286,6 +286,25 @@ export const GetDelegatedStakingActivities = `
   }
 }
     `;
+export const GetEvents = `
+    query getEvents($where_condition: events_bool_exp, $offset: Int, $limit: Int, $order_by: [events_order_by!]) {
+  events(
+    where: $where_condition
+    offset: $offset
+    limit: $limit
+    order_by: $order_by
+  ) {
+    account_address
+    creation_number
+    data
+    event_index
+    sequence_number
+    transaction_block_height
+    transaction_version
+    type
+  }
+}
+    `;
 export const GetIndexerLedgerInfo = `
     query getIndexerLedgerInfo {
   ledger_infos {
@@ -481,6 +500,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     getDelegatedStakingActivities(variables?: Types.GetDelegatedStakingActivitiesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetDelegatedStakingActivitiesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetDelegatedStakingActivitiesQuery>(GetDelegatedStakingActivities, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getDelegatedStakingActivities', 'query');
+    },
+    getEvents(variables?: Types.GetEventsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetEventsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<Types.GetEventsQuery>(GetEvents, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getEvents', 'query');
     },
     getIndexerLedgerInfo(variables?: Types.GetIndexerLedgerInfoQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetIndexerLedgerInfoQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetIndexerLedgerInfoQuery>(GetIndexerLedgerInfo, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getIndexerLedgerInfo', 'query');

--- a/ecosystem/typescript/sdk/src/indexer/queries/getEvents.graphql
+++ b/ecosystem/typescript/sdk/src/indexer/queries/getEvents.graphql
@@ -1,0 +1,12 @@
+query getEvents($where_condition: events_bool_exp, $offset: Int, $limit: Int, $order_by: [events_order_by!]) {
+  events(where: $where_condition, offset: $offset, limit: $limit, order_by: $order_by) {
+    account_address
+    creation_number
+    data
+    event_index
+    sequence_number
+    transaction_block_height
+    transaction_version
+    type
+  }
+}

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -410,6 +410,8 @@ export class AptosClient {
   }
 
   /**
+   * NOTE: for a better events query support, consider using IndexerClient.getEvents() query
+   *
    * Event types are globally identifiable by an account `address` and
    * monotonically increasing `creation_number`, one per event type emitted
    * to the given account. This API returns events corresponding to that
@@ -437,6 +439,8 @@ export class AptosClient {
   }
 
   /**
+   * NOTE: for a better events query support, consider using IndexerClient.getEvents() query
+   *
    * This API uses the given account `address`, `eventHandle`, and `fieldName`
    * to build a key that can globally identify an event types. It then uses this
    * key to return events emitted to the given account matching that event type.

--- a/ecosystem/typescript/sdk/src/providers/indexer.ts
+++ b/ecosystem/typescript/sdk/src/providers/indexer.ts
@@ -23,6 +23,7 @@ import {
   GetOwnedTokensByTokenDataQuery,
   GetAccountCoinsDataCountQuery,
   GetCurrentObjectsQuery,
+  GetEventsQuery,
 } from "../indexer/generated/operations";
 import {
   GetAccountTokensCount,
@@ -47,6 +48,7 @@ import {
   GetOwnedTokensByTokenData,
   GetAccountCoinsDataCount,
   GetCurrentObjects,
+  GetEvents,
 } from "../indexer/generated/queries";
 import { ClientConfig, post } from "../client";
 import { ApiError } from "./aptos_client";
@@ -61,6 +63,8 @@ import {
   Token_Activities_V2_Order_By,
   User_Transactions_Order_By,
   Current_Objects_Order_By,
+  Events_Order_By,
+  Events_Bool_Exp,
 } from "../indexer/generated/types";
 
 /**
@@ -900,6 +904,42 @@ export class IndexerClient {
       query: GetCurrentObjects,
       variables: {
         where_condition: whereCondition,
+        offset: extraArgs?.options?.offset,
+        limit: extraArgs?.options?.limit,
+        order_by: extraArgs?.orderBy,
+      },
+    };
+    return this.queryIndexer(graphqlQuery);
+  }
+
+  // EVENTS //
+
+  /**
+   * Queries for events
+   *
+   * An optional `where` can be passed in to filter out the response.
+   *
+   * @example
+   * ```
+   * { where:
+   *  {
+   *   type: { _eq: "0x1::block::NewBlockEvent" },
+   *   account_address: { _eq: "0x123" }
+   *  }
+   * }
+   * ```
+   *
+   * @returns GetEventsQuery response type
+   */
+  async getEvents(extraArgs?: {
+    where?: Events_Bool_Exp;
+    options?: IndexerPaginationArgs;
+    orderBy?: IndexerSortBy<Events_Order_By>[];
+  }): Promise<GetEventsQuery> {
+    const graphqlQuery = {
+      query: GetEvents,
+      variables: {
+        where_condition: extraArgs?.where,
         offset: extraArgs?.options?.offset,
         limit: extraArgs?.options?.limit,
         order_by: extraArgs?.orderBy,

--- a/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
@@ -379,6 +379,41 @@ describe("Indexer", () => {
       longTestTimeout,
     );
 
+    // EVENTS //
+
+    it(
+      "gets events",
+      async () => {
+        const events = await indexerClient.getEvents();
+        expect(events.events.length).toBeGreaterThan(0);
+      },
+      longTestTimeout,
+    );
+
+    it("gets events by type", async () => {
+      const events = await indexerClient.getEvents({
+        where: {
+          type: { _eq: "0x1::block::NewBlockEvent" },
+        },
+      });
+      expect(events.events.length).toBeGreaterThan(0);
+      expect(events.events[0].type).toBe("0x1::block::NewBlockEvent");
+    });
+
+    it("gets events by type and account address", async () => {
+      const events = await indexerClient.getEvents({
+        where: {
+          type: { _eq: "0x1::block::NewBlockEvent" },
+          account_address: { _eq: "0x0000000000000000000000000000000000000000000000000000000000000001" },
+        },
+      });
+      expect(events.events.length).toBeGreaterThan(0);
+      expect(events.events[0].type).toBe("0x1::block::NewBlockEvent");
+      expect(events.events[0].account_address).toBe(
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+      );
+    });
+
     // TOKEN STANDARD FILTER //
 
     it("gets account owned tokens with a specified token standard", async () => {


### PR DESCRIPTION
### Description
Add `getEvents()` function in `IndexerClient` for a better events query support (includes events v2).

note: we might want to structure a better dev exp when filtering graphql/indexer queries - probably will be part of sdk v2
### Test Plan
```
✓ gets events (1196 ms)
✓ gets events by type (1164 ms)
✓ gets events by type and account address (1154 ms)
```
