### PR TITLE
[move] fix dumping the bytecode for smart contracts containing inline functions (#9065)

### DIFF
--- a/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
+++ b/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
@@ -524,6 +524,9 @@ impl FunctionTargetPipeline {
                             // check for fixedpoint in summaries
                             for fid in scc {
                                 let func_env = env.get_function(*fid);
+                                if func_env.is_inline() {
+                                    continue;
+                                }
                                 for (_, target) in targets.get_targets(&func_env) {
                                     if !target.data.annotations.reached_fixedpoint() {
                                         continue 'fixedpoint;

--- a/third_party/move/move-model/bytecode/src/usage_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/usage_analysis.rs
@@ -369,6 +369,9 @@ impl FunctionTargetProcessor for UsageProcessor {
                 continue;
             }
             for fun in module.get_functions() {
+                if fun.is_inline() {
+                    continue;
+                }
                 for (_, ref target) in targets.get_targets(&fun) {
                     let usage = get_memory_usage(target);
                     writeln!(

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -64,6 +64,9 @@ impl NumberOperationProcessor {
             match item {
                 Either::Left(fid) => {
                     let func_env = env.get_function(*fid);
+                    if func_env.is_inline() {
+                        continue;
+                    }
                     for (_, target) in targets.get_targets(&func_env) {
                         if target.data.code.is_empty() {
                             continue;
@@ -74,6 +77,9 @@ impl NumberOperationProcessor {
                 Either::Right(scc) => {
                     for fid in scc {
                         let func_env = env.get_function(*fid);
+                        if func_env.is_inline() {
+                            continue;
+                        }
                         for (_, target) in targets.get_targets(&func_env) {
                             if target.data.code.is_empty() {
                                 continue;

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -154,6 +154,9 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
                 continue;
             }
             for ref fun in module.get_functions() {
+                if fun.is_inline() {
+                    continue;
+                }
                 for (variant, target) in targets.get_targets(fun) {
                     let spec = &*target.get_spec();
                     if !spec.conditions.is_empty() {


### PR DESCRIPTION
### Description

Update dumping functions to ignore inline function environments. Close #9065