### PR TITLE
Fix issue 9410 by removing special-case hack to suppress unknown attribute warnings on aptos_stdlib

### DIFF
--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
@@ -1,3 +1,15 @@
+warning[W02016]: unknown attribute
+  ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:7
+  │
+4 │     #[a, a(x = 0)]
+  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+
+warning[W02016]: unknown attribute
+  ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:10
+  │
+4 │     #[a, a(x = 0)]
+  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:10
   │
@@ -5,6 +17,18 @@ error[E02001]: duplicate declaration, item, or annotation
   │       -  ^^^^^^^^ Duplicate attribute 'a' attached to the same item
   │       │   
   │       Attribute previously given here
+
+warning[W02016]: unknown attribute
+  ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:7:7
+  │
+7 │     #[testonly]
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+
+warning[W02016]: unknown attribute
+  ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:8:7
+  │
+8 │     #[b(a, a = 0, a(x = 1))]
+  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:8:12

--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
@@ -1,0 +1,6 @@
+warning[W02016]: unknown attribute
+  ┌─ tests/move_check/parser/aptos_stdlib_attributes2.move:4:7
+  │
+4 │     #[testonly]
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+


### PR DESCRIPTION
### Description

[PR 9229](https://github.com/aptos-labs/aptos-core/pull/9229) introduced warnings on unknown attributes, but suppressed them for aptos_stdlib to avoid user consternation about problems in the Aptos codebase.  It also removed those attributes from the codebase, so now that it is released it becomes safe to Fix i[ssue 9410](https://github.com/aptos-labs/aptos-core/issues/9410) and remove the special-case for the aptos_stdlib.

### Test Plan
Existing test cases, new test outputs.
