### PR TITLE
[TS SDK V2] Add `General` api class

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/api/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/account.ts
@@ -11,6 +11,9 @@ import {
 } from "../types";
 import { getInfo, getModule, getModules, getResource, getResources, getTransactions } from "../internal/account";
 
+/**
+ * A class to query all `Account` related queries on Aptos.
+ */
 export class Account {
   readonly config: AptosConfig;
 

--- a/ecosystem/typescript/sdk_v2/src/api/aptos.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/aptos.ts
@@ -58,3 +58,4 @@ function applyMixin(targetClass: any, baseClass: any, baseClassProp: string) {
 }
 
 applyMixin(Aptos, Account, "account");
+applyMixin(Aptos, General, "general");

--- a/ecosystem/typescript/sdk_v2/src/api/aptos.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/aptos.ts
@@ -1,10 +1,13 @@
 import { Account } from "./account";
 import { AptosConfig } from "./aptos_config";
+import { General } from "./general";
 
 export class Aptos {
   readonly config: AptosConfig;
 
   readonly account: Account;
+
+  readonly general: General;
 
   /**
    * This class is the main entry point into Aptos's
@@ -26,10 +29,12 @@ export class Aptos {
   constructor(settings?: AptosConfig) {
     this.config = new AptosConfig(settings);
     this.account = new Account(this.config);
+    this.general = new General(this.config);
   }
 }
 
 export interface Aptos extends Account {}
+export interface Aptos extends General {}
 
 /**
 In TypeScript, we can’t inherit or extend from more than one class,

--- a/ecosystem/typescript/sdk_v2/src/api/general.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/general.ts
@@ -1,7 +1,10 @@
-import { getLedgerInfo } from "../internal/general";
-import { LedgerInfo } from "../types";
+import { getBlockByHeight, getBlockByVersion, getLedgerInfo, getTableItem, view } from "../internal/general";
+import { Block, LedgerInfo, LedgerVersion, MoveValue, TableItemRequest, ViewRequest } from "../types";
 import { AptosConfig } from "./aptos_config";
 
+/**
+ * A class to query all `General` Aptos related queries
+ */
 export class General {
   readonly config: AptosConfig;
 
@@ -9,13 +12,103 @@ export class General {
     this.config = config;
   }
 
+  /**
+   * Queries for the Aptos ledger info
+   *
+   * @returns Aptos Ledger Info
+   *
+   * @example An example of the returned data
+   * ```
+   * {
+   * "chain_id": 4,
+   * "epoch": "8",
+   * "ledger_version": "714",
+   * "oldest_ledger_version": "0",
+   * "ledger_timestamp": "1694695496521775",
+   * "node_role": "validator",
+   * "oldest_block_height": "0",
+   * "block_height": "359",
+   * "git_hash": "c82193f36f4e185fed9f68c4ad21f6c6dd390c6e"
+   * }
+   * ```
+   */
   async getLedgerInfo(): Promise<LedgerInfo> {
     const data = await getLedgerInfo({ aptosConfig: this.config });
     return data;
   }
 
+  /**
+   * Queries for the chain id
+   *
+   * @returns The chain id
+   */
   async getChainId(): Promise<number> {
     const result = await this.getLedgerInfo();
     return result.chain_id;
+  }
+
+  /**
+   * Queries for block by transaction version
+   *
+   * @param version Ledger version to lookup block information for
+   * @param options.withTransactions If set to true, include all transactions in the block
+   *
+   * @returns Block
+   */
+  async getBlockByVersion(args: { blockVersion: number; options?: { withTransactions?: boolean } }): Promise<Block> {
+    const block = await getBlockByVersion({ aptosConfig: this.config, ...args });
+    return block;
+  }
+
+  /**
+   * Get block by block height
+   *
+   * @param blockHeight Block height to lookup.  Starts at 0
+   * @param options.withTransactions If set to true, include all transactions in the block
+   *
+   * @returns Block
+   */
+  async getBlockByHeight(args: { blockHeight: number; options?: { withTransactions?: boolean } }): Promise<Block> {
+    const block = await getBlockByHeight({ aptosConfig: this.config, ...args });
+    return block;
+  }
+
+  /**
+   * Queries for a table item for a table identified by the handle and the key for the item.
+   * Key and value types need to be passed in to help with key serialization and value deserialization.
+   * @param handle A pointer to where that table is stored
+   * @param data Object that describes table item
+   *
+   * @example https://fullnode.devnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::coin::CoinInfo%3C0x1::aptos_coin::AptosCoin%3E
+   * {
+   *  data.key_type = "address" // Move type of table key
+   *  data.value_type = "u128" // Move type of table value
+   *  data.key = "0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935" // Value of table key
+   * }
+   *
+   * @returns Table item value rendered in JSON
+   */
+  async getTableItem(args: { handle: string; data: TableItemRequest; options?: LedgerVersion }): Promise<any> {
+    const item = await getTableItem({ aptosConfig: this.config, ...args });
+    return item;
+  }
+
+  /**
+   * Queries for a Move view function
+   * @param payload ViewRequest payload
+   * @example
+   * `
+   * const payload: ViewRequest = {
+   *  function: "0x1::coin::balance",
+   *  type_arguments: ["0x1::aptos_coin::AptosCoin"],
+   *  arguments: [accountAddress],
+   * };
+   * `
+   *
+   * @returns a Move value
+   */
+  async view(args: { payload: ViewRequest; options?: LedgerVersion }): Promise<MoveValue> {
+    const data = await view({ aptosConfig: this.config, ...args });
+    return data[0];
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/api/general.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/general.ts
@@ -1,0 +1,21 @@
+import { getLedgerInfo } from "../internal/general";
+import { LedgerInfo } from "../types";
+import { AptosConfig } from "./aptos_config";
+
+export class General {
+  readonly config: AptosConfig;
+
+  constructor(config: AptosConfig) {
+    this.config = config;
+  }
+
+  async getLedgerInfo(): Promise<LedgerInfo> {
+    const data = await getLedgerInfo({ aptosConfig: this.config });
+    return data;
+  }
+
+  async getChainId(): Promise<number> {
+    const result = await this.getLedgerInfo();
+    return result.chain_id;
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/internal/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/internal/account.ts
@@ -1,3 +1,10 @@
+/**
+ * This file contains the underlying implementations for exposed API surface in
+ * the {@link api/account}. By moving the methods out into a separate file,
+ * other namespaces and processes can access these methods without depending on the entire
+ * account namespace and without having a dependency cycle error.
+ */
+
 import { AptosConfig } from "../api/aptos_config";
 import {
   AccountData,
@@ -13,13 +20,6 @@ import { get } from "../client";
 import { paginateWithCursor } from "../utils/paginate_with_cursor";
 import { AccountAddress } from "../core";
 import { AptosApiType } from "../utils/const";
-
-/**
- * This file contains the underlying implementations for exposed API surface in
- * the {@link api/account}. By moving the methods out into a separate file,
- * other namespaces and processes can access these methods without depending on the entire
- * account namespace and without having a dependency cycle error.
- */
 
 export async function getInfo(args: { aptosConfig: AptosConfig; accountAddress: HexInput }): Promise<AccountData> {
   const { aptosConfig, accountAddress } = args;

--- a/ecosystem/typescript/sdk_v2/src/internal/general.ts
+++ b/ecosystem/typescript/sdk_v2/src/internal/general.ts
@@ -1,14 +1,88 @@
+/**
+ * This file contains the underlying implementations for exposed API surface in
+ * the {@link api/general}. By moving the methods out into a separate file,
+ * other namespaces and processes can access these methods without depending on the entire
+ * general namespace and without having a dependency cycle error.
+ */
+
 import { AptosConfig } from "../api";
-import { get } from "../client";
-import { LedgerInfo } from "../types";
+import { get, post } from "../client";
+import { Block, LedgerInfo, LedgerVersion, MoveValue, TableItemRequest, ViewRequest } from "../types";
 import { AptosApiType } from "../utils/const";
 
 export async function getLedgerInfo(args: { aptosConfig: AptosConfig }): Promise<LedgerInfo> {
   const { aptosConfig } = args;
   const { data } = await get<{}, LedgerInfo>({
     url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
-    endpoint: `/`,
+    endpoint: "",
     originMethod: "getLedgerInfo",
+    overrides: { ...aptosConfig.clientConfig },
+  });
+  return data;
+}
+
+export async function getBlockByVersion(args: {
+  aptosConfig: AptosConfig;
+  blockVersion: number;
+  options?: { withTransactions?: boolean };
+}): Promise<Block> {
+  const { aptosConfig, blockVersion, options } = args;
+  const { data } = await get<{}, Block>({
+    url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
+    endpoint: `blocks/by_version/${blockVersion}`,
+    originMethod: "getBlockByVersion",
+    params: { with_transactions: options?.withTransactions },
+    overrides: { ...aptosConfig.clientConfig },
+  });
+  return data;
+}
+
+export async function getBlockByHeight(args: {
+  aptosConfig: AptosConfig;
+  blockHeight: number;
+  options?: { withTransactions?: boolean };
+}): Promise<Block> {
+  const { aptosConfig, blockHeight, options } = args;
+  const { data } = await get<{}, Block>({
+    url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
+    endpoint: `blocks/by_height/${blockHeight}`,
+    originMethod: "getBlockByHeight",
+    params: { with_transactions: options?.withTransactions },
+    overrides: { ...aptosConfig.clientConfig },
+  });
+  return data;
+}
+
+export async function getTableItem(args: {
+  aptosConfig: AptosConfig;
+  handle: string;
+  data: TableItemRequest;
+  options?: LedgerVersion;
+}): Promise<any> {
+  const { aptosConfig, handle, data, options } = args;
+  const response = await post<TableItemRequest, any>({
+    url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
+    body: data,
+    endpoint: `tables/${handle}/item`,
+    originMethod: "getTableItem",
+    params: { ledger_version: options?.ledgerVersion },
+    overrides: { ...aptosConfig.clientConfig },
+  });
+  return response.data;
+}
+
+export async function view(args: {
+  aptosConfig: AptosConfig;
+  payload: ViewRequest;
+  options?: LedgerVersion;
+}): Promise<MoveValue[]> {
+  const { aptosConfig, payload, options } = args;
+  const { data } = await post<ViewRequest, MoveValue[]>({
+    url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
+    body: payload,
+    endpoint: "view",
+    originMethod: "view",
+    params: { ledger_version: options?.ledgerVersion },
     overrides: { ...aptosConfig.clientConfig },
   });
   return data;

--- a/ecosystem/typescript/sdk_v2/src/internal/general.ts
+++ b/ecosystem/typescript/sdk_v2/src/internal/general.ts
@@ -1,0 +1,15 @@
+import { AptosConfig } from "../api";
+import { get } from "../client";
+import { LedgerInfo } from "../types";
+import { AptosApiType } from "../utils/const";
+
+export async function getLedgerInfo(args: { aptosConfig: AptosConfig }): Promise<LedgerInfo> {
+  const { aptosConfig } = args;
+  const { data } = await get<{}, LedgerInfo>({
+    url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
+    endpoint: `/`,
+    originMethod: "getLedgerInfo",
+    overrides: { ...aptosConfig.clientConfig },
+  });
+  return data;
+}

--- a/ecosystem/typescript/sdk_v2/src/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/types/index.ts
@@ -513,9 +513,72 @@ export type Event = {
 };
 
 /**
+ * Map of Move types to local TypeScript types
+ */
+export type MoveUint8Type = number;
+export type MoveUint16Type = number;
+export type MoveUint32Type = number;
+export type MoveUint64Type = string;
+export type MoveUint128Type = string;
+export type MoveUint256Type = string;
+export type MoveAddressType = `0x${string}`;
+export type MoveObjectType = `0x${string}`;
+export type MoveStructType = `0x${string}::${string}::${string}`;
+export type MoveOptionType = MoveType | null | undefined;
+/**
  * String representation of a on-chain Move struct type.
  */
 export type MoveResourceType = `${string}::${string}::${string}`;
+
+export type MoveType =
+  | boolean
+  | string
+  | MoveUint8Type
+  | MoveUint16Type
+  | MoveUint32Type
+  | MoveUint64Type
+  | MoveUint128Type
+  | MoveUint256Type
+  | MoveAddressType
+  | MoveObjectType
+  | MoveStructType
+  | Array<MoveType>;
+
+/**
+ * Possible Move values acceptable by move functions (entry, view)
+ *
+ * `Bool -> boolean`
+ *
+ * `u8, u16, u32 -> number`
+ *
+ * `u64, u128, u256 -> string`
+ *
+ * `String -> string`
+ *
+ * `Address -> 0x${string}`
+ *
+ * `Struct - 0x${string}::${string}::${string}`
+ *
+ * `Object -> 0x${string}`
+ *
+ * `Vector -> Array<MoveValue>`
+ *
+ * `Option -> MoveValue | null | undefined`
+ */
+export type MoveValue =
+  | boolean
+  | string
+  | MoveUint8Type
+  | MoveUint16Type
+  | MoveUint32Type
+  | MoveUint64Type
+  | MoveUint128Type
+  | MoveUint256Type
+  | MoveAddressType
+  | MoveObjectType
+  | MoveStructType
+  | MoveOptionType
+  | Array<MoveValue>;
 
 /**
  * Move module id is a string representation of Move module.
@@ -650,4 +713,50 @@ export type LedgerInfo = {
    * software version used by the API endpoint.
    */
   git_hash?: string;
+};
+
+/**
+ * A Block type
+ */
+export type Block = {
+  block_height: string;
+  block_hash: `0x${string}`;
+  block_timestamp: string;
+  first_version: string;
+  last_version: string;
+  /**
+   * The transactions in the block in sequential order
+   */
+  transactions?: Array<TransactionResponse>;
+};
+
+/////// REQUEST TYPES ///////
+
+/**
+ * View request for the Move view function API
+ *
+ * `type MoveResourceType = ${string}::${string}::${string}`;
+ */
+export type ViewRequest = {
+  function: MoveResourceType;
+  /**
+   * Type arguments of the function
+   */
+  type_arguments: Array<MoveResourceType>;
+  /**
+   * Arguments of the function
+   */
+  arguments: Array<MoveValue>;
+};
+
+/**
+ * Table Item request for the GetTableItem API
+ */
+export type TableItemRequest = {
+  key_type: MoveValue;
+  value_type: MoveValue;
+  /**
+   * The value of the table item's key
+   */
+  key: any;
 };

--- a/ecosystem/typescript/sdk_v2/src/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/types/index.ts
@@ -627,3 +627,27 @@ export type MoveFunction = {
    */
   return: Array<string>;
 };
+
+export enum RoleType {
+  VALIDATOR = "validator",
+  FULL_NODE = "full_node",
+}
+
+export type LedgerInfo = {
+  /**
+   * Chain ID of the current chain
+   */
+  chain_id: number;
+  epoch: string;
+  ledger_version: string;
+  oldest_ledger_version: string;
+  ledger_timestamp: string;
+  node_role: RoleType;
+  oldest_block_height: string;
+  block_height: string;
+  /**
+   * Git hash of the build of the API endpoint.  Can be used to determine the exact
+   * software version used by the API endpoint.
+   */
+  git_hash?: string;
+};

--- a/ecosystem/typescript/sdk_v2/tests/e2e/api/account.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/e2e/api/account.test.ts
@@ -13,13 +13,15 @@ describe("account api", () => {
           await aptos.getAccountInfo({
             accountAddress: "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
           }),
-      ).rejects.toThrow();
+      ).rejects.toThrow("Hex string must start with a leading 0x.");
     });
 
     test("it throws when invalid account address", () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      expect(async () => await aptos.getAccountInfo({ accountAddress: "0x123" })).rejects.toThrow();
+      expect(async () => await aptos.getAccountInfo({ accountAddress: "0x123" })).rejects.toThrow(
+        "The given hex string 0x0000000000000000000000000000000000000000000000000000000000000123 is not a special address, it must be represented as 0x + 64 chars.",
+      );
     });
   });
 
@@ -72,6 +74,7 @@ describe("account api", () => {
         resourceType: "0x1::account::Account",
       });
       expect(data).toHaveProperty("type");
+      expect(data.type).toBe("0x1::account::Account");
     });
   });
 
@@ -132,6 +135,7 @@ describe("account api", () => {
         resourceType: "0x1::account::Account",
       });
       expect(data).toHaveProperty("type");
+      expect(data.type).toBe("0x1::account::Account");
     });
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/e2e/api/general.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/e2e/api/general.test.ts
@@ -1,0 +1,81 @@
+import { AptosConfig, Aptos } from "../../../src";
+import { ViewRequest } from "../../../src/types";
+import { Network } from "../../../src/utils/api-endpoints";
+
+describe("general api", () => {
+  test("it fetches ledger info", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+    const ledgerInfo = await aptos.getLedgerInfo();
+    expect(ledgerInfo.chain_id).toBe(4);
+  });
+
+  test("it fetches chain id", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+    const chainId = await aptos.getChainId();
+    expect(chainId).toBe(4);
+  });
+
+  test("it fetches block data by block height", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+    const blockHeight = 100;
+    const blockData = await aptos.getBlockByHeight({ blockHeight });
+    expect(blockData.block_height).toBe(blockHeight.toString());
+  });
+
+  test("it fetches block data by block version", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+    const blockVersion = 1;
+    const blockData = await aptos.getBlockByVersion({ blockVersion });
+    expect(blockData.block_height).toBe(blockVersion.toString());
+  });
+
+  test("it fetches view function data", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+
+    const payload: ViewRequest = {
+      function: "0x1::chain_id::get",
+      type_arguments: [],
+      arguments: [],
+    };
+
+    const chainId = await aptos.view({ payload });
+
+    expect(chainId).toBe(4);
+  });
+
+  test("it fetches table item data", async () => {
+    const config = new AptosConfig({ network: Network.LOCAL });
+    const aptos = new Aptos(config);
+    const resource = await aptos.getAccountResource({
+      accountAddress: "0x1",
+      resourceType: "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
+    });
+
+    const {
+      supply: {
+        vec: [
+          {
+            aggregator: {
+              vec: [{ handle, key }],
+            },
+          },
+        ],
+      },
+    } = resource.data as any;
+
+    const supply = await aptos.getTableItem({
+      handle,
+      data: {
+        key_type: "address",
+        value_type: "u128",
+        key: key,
+      },
+    });
+    expect(parseInt(supply)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
### Description
Add `General` api class that holds chain general queries.
- getLedgerInfo
- getChainId
- getBlockByVersion
- getBlockByHeight
- getTableItem
- view

note: events is missing, there is an on going discussion on what this API should look like

### Test Plan
```
  ✓ it fetches ledger info (22 ms)
  ✓ it fetches chain id (2 ms)
  ✓ it fetches block data by block height (3 ms)
  ✓ it fetches block data by block version (2 ms)
  ✓ it fetches view function data (61 ms)
  ✓ it fetches table item data (6 ms)
```
