### PR TITLE
Remove expensive counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "byteorder",
  "once_cell",
  "proptest",
+ "rand 0.7.3",
  "rocksdb",
 ]
 

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -148,17 +148,6 @@ pub static TASK_EXECUTE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static GET_NEXT_TASK_SECONDS: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        // metric name
-        "aptos_execution_get_next_task_seconds",
-        // metric description
-        "The time spent in seconds for getting next task from the scheduler",
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
-    )
-    .unwrap()
-});
-
 pub static DEPENDENCY_WAIT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "aptos_execution_dependency_wait",

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -2,7 +2,6 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::counters::GET_NEXT_TASK_SECONDS;
 use aptos_infallible::Mutex;
 use aptos_mvhashmap::types::{Incarnation, TxnIndex};
 use crossbeam::utils::CachePadded;
@@ -343,7 +342,6 @@ impl Scheduler {
 
     /// Return the next task for the thread.
     pub fn next_task(&self, committing: bool) -> SchedulerTask {
-        let _timer = GET_NEXT_TASK_SECONDS.start_timer();
         loop {
             if self.done() {
                 // No more tasks.

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -19,6 +19,7 @@ aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
+rand = { workspace = true }
 rocksdb = { workspace = true }
 
 [dev-dependencies]

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -22,8 +22,8 @@ pub mod iterator;
 use crate::{
     metrics::{
         APTOS_SCHEMADB_BATCH_COMMIT_BYTES, APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS,
-        APTOS_SCHEMADB_DELETES, APTOS_SCHEMADB_GET_BYTES, APTOS_SCHEMADB_GET_LATENCY_SECONDS,
-        APTOS_SCHEMADB_ITER_BYTES, APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES,
+        APTOS_SCHEMADB_DELETES_SAMPLED, APTOS_SCHEMADB_GET_BYTES, APTOS_SCHEMADB_GET_LATENCY_SECONDS,
+        APTOS_SCHEMADB_ITER_BYTES, APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES_SAMPLED,
         APTOS_SCHEMADB_SEEK_LATENCY_SECONDS,
     },
     schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec},
@@ -257,12 +257,12 @@ impl DB {
                 for write_op in rows {
                     match write_op {
                         WriteOp::Value { key, value } => {
-                            APTOS_SCHEMADB_PUT_BYTES
+                            APTOS_SCHEMADB_PUT_BYTES_SAMPLED
                                 .with_label_values(&[cf_name])
                                 .observe((key.len() + value.len()) as f64);
                         },
                         WriteOp::Deletion { key: _ } => {
-                            APTOS_SCHEMADB_DELETES.with_label_values(&[cf_name]).inc();
+                            APTOS_SCHEMADB_DELETES_SAMPLED.with_label_values(&[cf_name]).inc();
                         },
                     }
                 }

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -22,8 +22,9 @@ pub mod iterator;
 use crate::{
     metrics::{
         APTOS_SCHEMADB_BATCH_COMMIT_BYTES, APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS,
-        APTOS_SCHEMADB_DELETES_SAMPLED, APTOS_SCHEMADB_GET_BYTES, APTOS_SCHEMADB_GET_LATENCY_SECONDS,
-        APTOS_SCHEMADB_ITER_BYTES, APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES_SAMPLED,
+        APTOS_SCHEMADB_DELETES_SAMPLED, APTOS_SCHEMADB_GET_BYTES,
+        APTOS_SCHEMADB_GET_LATENCY_SECONDS, APTOS_SCHEMADB_ITER_BYTES,
+        APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES_SAMPLED,
         APTOS_SCHEMADB_SEEK_LATENCY_SECONDS,
     },
     schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec},
@@ -262,7 +263,9 @@ impl DB {
                                 .observe((key.len() + value.len()) as f64);
                         },
                         WriteOp::Deletion { key: _ } => {
-                            APTOS_SCHEMADB_DELETES_SAMPLED.with_label_values(&[cf_name]).inc();
+                            APTOS_SCHEMADB_DELETES_SAMPLED
+                                .with_label_values(&[cf_name])
+                                .inc();
                         },
                     }
                 }

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -22,9 +22,8 @@ pub mod iterator;
 use crate::{
     metrics::{
         APTOS_SCHEMADB_BATCH_COMMIT_BYTES, APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS,
-        APTOS_SCHEMADB_BATCH_PUT_LATENCY_SECONDS, APTOS_SCHEMADB_DELETES, APTOS_SCHEMADB_GET_BYTES,
-        APTOS_SCHEMADB_GET_LATENCY_SECONDS, APTOS_SCHEMADB_ITER_BYTES,
-        APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES,
+        APTOS_SCHEMADB_DELETES, APTOS_SCHEMADB_GET_BYTES, APTOS_SCHEMADB_GET_LATENCY_SECONDS,
+        APTOS_SCHEMADB_ITER_BYTES, APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_PUT_BYTES,
         APTOS_SCHEMADB_SEEK_LATENCY_SECONDS,
     },
     schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec},
@@ -33,6 +32,7 @@ use anyhow::{format_err, Result};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use iterator::{ScanDirection, SchemaIterator};
+use rand::Rng;
 /// Type alias to `rocksdb::ReadOptions`. See [`rocksdb doc`](https://github.com/pingcap/rust-rocksdb/blob/master/src/rocksdb_options.rs)
 pub use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Options, ReadOptions,
@@ -71,9 +71,6 @@ impl SchemaBatch {
 
     /// Adds an insert/update operation to the batch.
     pub fn put<S: Schema>(&self, key: &S::Key, value: &S::Value) -> Result<()> {
-        let _timer = APTOS_SCHEMADB_BATCH_PUT_LATENCY_SECONDS
-            .with_label_values(&["unknown"])
-            .start_timer();
         let key = <S::Key as KeyCodec<S>>::encode_key(key)?;
         let value = <S::Value as ValueCodec<S>>::encode_value(value)?;
         self.rows
@@ -224,10 +221,21 @@ impl DB {
 
     /// Writes a group of records wrapped in a [`SchemaBatch`].
     pub fn write_schemas(&self, batch: SchemaBatch) -> Result<()> {
+        // Function to determine if the counter should be sampled based on a sampling percentage
+        fn should_sample(sampling_percentage: usize) -> bool {
+            // Generate a random number between 0 and 100
+            let random_value = rand::thread_rng().gen_range(0, 100);
+
+            // Sample the counter if the random value is less than the sampling percentage
+            random_value <= sampling_percentage
+        }
+
         let _timer = APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS
             .with_label_values(&[&self.name])
             .start_timer();
         let rows_locked = batch.rows.lock();
+        let sampling_rate_pct = 1;
+        let sampled_kv_bytes = should_sample(sampling_rate_pct);
 
         let mut db_batch = rocksdb::WriteBatch::default();
         for (cf_name, rows) in rows_locked.iter() {
@@ -244,20 +252,23 @@ impl DB {
         self.inner.write_opt(db_batch, &default_write_options())?;
 
         // Bump counters only after DB write succeeds.
-        for (cf_name, rows) in rows_locked.iter() {
-            for write_op in rows {
-                match write_op {
-                    WriteOp::Value { key, value } => {
-                        APTOS_SCHEMADB_PUT_BYTES
-                            .with_label_values(&[cf_name])
-                            .observe((key.len() + value.len()) as f64);
-                    },
-                    WriteOp::Deletion { key: _ } => {
-                        APTOS_SCHEMADB_DELETES.with_label_values(&[cf_name]).inc();
-                    },
+        if sampled_kv_bytes {
+            for (cf_name, rows) in rows_locked.iter() {
+                for write_op in rows {
+                    match write_op {
+                        WriteOp::Value { key, value } => {
+                            APTOS_SCHEMADB_PUT_BYTES
+                                .with_label_values(&[cf_name])
+                                .observe((key.len() + value.len()) as f64);
+                        },
+                        WriteOp::Deletion { key: _ } => {
+                            APTOS_SCHEMADB_DELETES.with_label_values(&[cf_name]).inc();
+                        },
+                    }
                 }
             }
         }
+
         APTOS_SCHEMADB_BATCH_COMMIT_BYTES
             .with_label_values(&[&self.name])
             .observe(serialized_size as f64);

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -109,8 +109,10 @@ pub static APTOS_SCHEMADB_PUT_BYTES_SAMPLED: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 pub static APTOS_SCHEMADB_DELETES_SAMPLED: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("aptos_storage_deletes_sampled", "Aptos storage delete calls (sampled)", &[
-        "cf_name"
-    ])
+    register_int_counter_vec!(
+        "aptos_storage_deletes_sampled",
+        "Aptos storage delete calls (sampled)",
+        &["cf_name"]
+    )
     .unwrap()
 });

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -96,20 +96,20 @@ pub static APTOS_SCHEMADB_BATCH_COMMIT_BYTES: Lazy<HistogramVec> = Lazy::new(|| 
     .unwrap()
 });
 
-pub static APTOS_SCHEMADB_PUT_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+pub static APTOS_SCHEMADB_PUT_BYTES_SAMPLED: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
-        "aptos_schemadb_put_bytes",
+        "aptos_schemadb_put_bytes_sampled",
         // metric description
-        "Aptos schemadb put call puts data size in bytes",
+        "Aptos schemadb put call puts data size in bytes (sampled)",
         // metric labels (dimensions)
         &["cf_name"]
     )
     .unwrap()
 });
 
-pub static APTOS_SCHEMADB_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("aptos_storage_deletes", "Aptos storage delete calls", &[
+pub static APTOS_SCHEMADB_DELETES_SAMPLED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!("aptos_storage_deletes_sampled", "Aptos storage delete calls (sampled)", &[
         "cf_name"
     ])
     .unwrap()

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -114,16 +114,3 @@ pub static APTOS_SCHEMADB_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
     ])
     .unwrap()
 });
-
-pub static APTOS_SCHEMADB_BATCH_PUT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_batch_put_latency_seconds",
-        // metric description
-        "Aptos schemadb schema batch put latency in seconds",
-        // metric labels (dimensions)
-        &["db_name"],
-        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
-    )
-    .unwrap()
-});

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -51,7 +51,7 @@ TESTS = [
     RunGroupConfig(expected_tps=22700, key=RunGroupKey("no-op"), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=3200, key=RunGroupKey("no-op", module_working_set_size=1000), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=15000, key=RunGroupKey("coin-transfer"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
-    RunGroupConfig(expected_tps=26300, key=RunGroupKey("coin-transfer", executor_type="native"), included_in=Flow.LAND_BLOCKING),
+    RunGroupConfig(expected_tps=29000, key=RunGroupKey("coin-transfer", executor_type="native"), included_in=Flow.LAND_BLOCKING),
     RunGroupConfig(expected_tps=12700, key=RunGroupKey("account-generation"), included_in=Flow.LAND_BLOCKING | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=26500, key=RunGroupKey("account-generation", executor_type="native"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(expected_tps=20000, key=RunGroupKey("account-resource32-b"), included_in=Flow.LAND_BLOCKING),


### PR DESCRIPTION
### Description

From the CPU flamegraph, we could observe that these counters are consuming 5-6% of the CPU. Removing few of them and changing some to sampled counter instead. 

### Test Plan

Ran the executor benchmark and observed around 4% TPS gain. 
