### PR TITLE
[TSSDKv2][3/n] Account and AuthenticationKey Classes

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/core/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account.ts
@@ -1,0 +1,150 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import nacl from "tweetnacl";
+import * as bip39 from "@scure/bip39";
+import { AccountAddress } from "./account_address";
+import { Hex } from "./hex";
+import { bytesToHex } from "@noble/hashes/utils";
+import { HexInput } from "../types";
+import { PrivateKey, PublicKey, Signature } from "../crypto/ed25519";
+import { derivePath } from "../utils/hd-key";
+import { AuthenticationKey } from "../crypto/authentication_key";
+
+/**
+ * Class for creating and managing account on Aptos network
+ *
+ * Use this class to create accounts, sign transactions, and more.
+ * Note: Creating an account instance does not create the account onchain.
+ */
+export class Account {
+  /**
+   * A private key and public key, associated with the given account
+   */
+  readonly publicKey: PublicKey;
+  readonly privateKey: PrivateKey;
+
+  /**
+   * Account address associated with the account
+   */
+  readonly accountAddress: AccountAddress;
+
+  /**
+   * constructor for Account
+   *
+   * @param args.privateKey PrivateKey - private key of the account
+   * @param args.address AccountAddress - address of the account
+   *
+   * This method is private because it should only be called by the factory static methods.
+   * @returns Account
+   */
+  private constructor(args: { privateKey: PrivateKey; address: AccountAddress }) {
+    const { privateKey, address } = args;
+
+    // Derive the public key from the private key
+    const keyPair = nacl.sign.keyPair.fromSeed(privateKey.toUint8Array().slice(0, 32));
+    this.publicKey = new PublicKey({ hexInput: keyPair.publicKey });
+
+    this.privateKey = privateKey;
+    this.accountAddress = address;
+  }
+
+  /**
+   * Generate a new account with random private key and address
+   *
+   * @returns Account
+   */
+  static generate(): Account {
+    const keyPair = nacl.sign.keyPair();
+    const privateKey = new PrivateKey({ value: keyPair.secretKey.slice(0, 32) });
+    const address = new AccountAddress({ data: Account.authKey({ publicKey: keyPair.publicKey }).toUint8Array() });
+    return new Account({ privateKey, address });
+  }
+
+  /**
+   * Creates new account with provided private key
+   *
+   * @param args.privateKey Hex - private key of the account
+   * @returns Account
+   */
+  static fromPrivateKey(args: { privateKey: HexInput }): Account {
+    const privatekeyHex = Hex.fromHexInput({ hexInput: args.privateKey });
+    const keyPair = nacl.sign.keyPair.fromSeed(privatekeyHex.toUint8Array().slice(0, 32));
+    const privateKey = new PrivateKey({ value: keyPair.secretKey.slice(0, 32) });
+    const address = new AccountAddress({ data: Account.authKey({ publicKey: keyPair.publicKey }).toUint8Array() });
+    return new Account({ privateKey, address });
+  }
+
+  /**
+   * Creates new account with provided private key and address
+   * This is intended to be used for account that has it's key rotated
+   *
+   * @param args.privateKey Hex - private key of the account
+   * @param args.address AccountAddress - address of the account
+   * @returns Account
+   */
+  static fromPrivateKeyAndAddress(args: { privateKey: HexInput; address: AccountAddress }): Account {
+    const privatekeyHex = Hex.fromHexInput({ hexInput: args.privateKey });
+    const signingKey = nacl.sign.keyPair.fromSeed(privatekeyHex.toUint8Array().slice(0, 32));
+    const privateKey = new PrivateKey({ value: signingKey.secretKey.slice(0, 32) });
+    return new Account({ privateKey, address: args.address });
+  }
+
+  /**
+   * Creates new account with bip44 path and mnemonics,
+   * @param path. (e.g. m/44'/637'/0'/0'/0')
+   * Detailed description: {@link https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki}
+   * @param mnemonics.
+   * @returns AptosAccount
+   */
+  static fromDerivationPath(args: { path: string; mnemonic: string }): Account {
+    const { path, mnemonic } = args;
+    if (!Account.isValidPath({ path })) {
+      throw new Error("Invalid derivation path");
+    }
+
+    const normalizeMnemonics = mnemonic
+      .trim()
+      .split(/\s+/)
+      .map((part) => part.toLowerCase())
+      .join(" ");
+
+    const { key } = derivePath(path, bytesToHex(bip39.mnemonicToSeedSync(normalizeMnemonics)));
+
+    const signingKey = nacl.sign.keyPair.fromSeed(key.slice(0, 32));
+    const privateKey = new PrivateKey({ value: signingKey.secretKey.slice(0, 32) });
+    const address = new AccountAddress({ data: Account.authKey({ publicKey: signingKey.publicKey }).toUint8Array() });
+
+    return new Account({ privateKey, address });
+  }
+
+  /**
+   * Check's if the derive path is valid
+   */
+  static isValidPath(args: { path: string }): boolean {
+    return /^m\/44'\/637'\/[0-9]+'\/[0-9]+'\/[0-9]+'+$/.test(args.path);
+  }
+
+  /**
+   * This key enables account owners to rotate their private key(s)
+   * associated with the account without changing the address that hosts their account.
+   * See here for more info: {@link https://aptos.dev/concepts/accounts#single-signer-authentication}
+   * @returns Authentication key for the associated account
+   */
+  static authKey(args: { publicKey: HexInput }): Hex {
+    const publicKey = new PublicKey({ hexInput: args.publicKey });
+    const authKey = AuthenticationKey.fromPublicKey({ publicKey });
+    return authKey.data;
+  }
+
+  sign(data: HexInput): Signature {
+    const signature = this.privateKey.sign({ message: data });
+    return signature;
+  }
+
+  verifySignature(message: HexInput, signature: HexInput): boolean {
+    const rawMessage = Hex.fromHexInput({ hexInput: message }).toUint8Array();
+    const rawSignature = Hex.fromHexInput({ hexInput: signature }).toUint8Array();
+    return this.publicKey.verifySignature({ data: rawMessage, signature: rawSignature });
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/core/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account.ts
@@ -32,7 +32,7 @@ export class Account {
 
   /**
    * constructor for Account
-   * 
+   *
    * TODO: This constructor uses the nacl library directly, which only works with ed25519 keys.
    * Need to update this to use the new crypto library if new schemes are added.
    *
@@ -54,7 +54,7 @@ export class Account {
   }
 
   /**
-   * Generate a new account with random private key and address
+   * Derives an account with random private key and address
    *
    * @returns Account
    */
@@ -66,7 +66,7 @@ export class Account {
   }
 
   /**
-   * Creates new account with provided private key
+   * Derives an account with provided private key
    *
    * @param args.privateKey Hex - private key of the account
    * @returns Account
@@ -80,7 +80,7 @@ export class Account {
   }
 
   /**
-   * Creates new account with provided private key and address
+   * Derives an account with provided private key and address
    * This is intended to be used for account that has it's key rotated
    *
    * @param args.privateKey Hex - private key of the account
@@ -95,7 +95,8 @@ export class Account {
   }
 
   /**
-   * Creates new account with bip44 path and mnemonics,
+   * Derives an account with bip44 path and mnemonics,
+   *
    * @param path. (e.g. m/44'/637'/0'/0'/0')
    * Detailed description: {@link https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki}
    * @param mnemonics.
@@ -141,14 +142,27 @@ export class Account {
     return authKey.data;
   }
 
-  sign(data: HexInput): Signature {
-    const signature = this.privateKey.sign({ message: data });
+  /**
+   * Sign the given message with the private key.
+   *
+   * @param args.data in HexInput format
+   * @returns Signature
+   */
+  sign(args: { data: HexInput }): Signature {
+    const signature = this.privateKey.sign({ message: args.data });
     return signature;
   }
 
-  verifySignature(message: HexInput, signature: HexInput): boolean {
+  /**
+   * Verify the given message and signature with the public key.
+   *
+   * @param args.message raw message data in HexInput format
+   * @param args.signature signed message Signature
+   * @returns
+   */
+  verifySignature(args: { message: HexInput; signature: Signature }): boolean {
+    const { message, signature } = args;
     const rawMessage = Hex.fromHexInput({ hexInput: message }).toUint8Array();
-    const rawSignature = Hex.fromHexInput({ hexInput: signature }).toUint8Array();
-    return this.publicKey.verifySignature({ data: rawMessage, signature: new Ed25519Signature({ data: rawSignature }) });
+    return this.publicKey.verifySignature({ data: rawMessage, signature });
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
@@ -8,6 +8,12 @@ export abstract class PublicKey implements Serializable, Deserializable<PublicKe
   // Verify the given message with the public key and signature.
   abstract verifySignature(args: { data: HexInput; signature: Signature }): boolean;
 
+  // Convert the public key to bytes or Uint8Array.
+  abstract toUint8Array(): Uint8Array;
+
+  // Convert the public key to a hex string with the 0x prefix.
+  abstract toString(): string;
+
   // TODO: This should be a static method.
   abstract deserialize(deserializer: Deserializer): PublicKey;
   abstract serialize(serializer: Serializer): void;
@@ -17,12 +23,24 @@ export abstract class PrivateKey implements Serializable, Deserializable<Private
   // Sign the given message with the private key.
   abstract sign(args: { message: HexInput }): Signature;
 
+  // Convert the private key to bytes or Uint8Array.
+  abstract toUint8Array(): Uint8Array;
+
+  // Convert the private key to a hex string with the 0x prefix.
+  abstract toString(): string;
+
   // TODO: This should be a static method.
   abstract deserialize(deserializer: Deserializer): PrivateKey;
   abstract serialize(serializer: Serializer): void;
 }
 
 export abstract class Signature implements Serializable, Deserializable<Signature> {
+  // Convert the signature to bytes or Uint8Array.
+  abstract toUint8Array(): Uint8Array;
+
+  // Convert the signature to a hex string with the 0x prefix.
+  abstract toString(): string;
+
   // TODO: This should be a static method.
   abstract deserialize(deserializer: Deserializer): Signature;
   abstract serialize(serializer: Serializer): void;

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -1,0 +1,102 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
+import { AccountAddress, Hex } from "../core";
+import { HexInput } from "../types";
+import { MultiPublicKey } from "./multi_ed25519";
+import { PublicKey } from "./ed25519";
+
+/**
+ * Each account stores an authentication key. Authentication key enables account owners to rotate
+ * their private key(s) associated with the account without changing the address that hosts their account.
+ * @see {@link * https://aptos.dev/concepts/accounts | Account Basics}
+ *
+ * Account addresses can be derived from AuthenticationKey
+ */
+export class AuthenticationKey {
+  // Length of AuthenticationKey in bytes(Uint8Array)
+  static readonly LENGTH: number = 32;
+
+  // Scheme identifier for MultiEd25519 signatures used to derive authentication keys for MultiEd25519 public keys
+  static readonly MULTI_ED25519_SCHEME: number = 1;
+
+  // Scheme identifier for Ed25519 signatures used to derive authentication key for MultiEd25519 public key
+  static readonly ED25519_SCHEME: number = 0;
+
+  // Scheme identifier used when hashing an account's address together with a seed to derive the address (not the
+  // authentication key) of a resource account.
+  static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
+
+  // Actual data of AuthenticationKey, in Hex format
+  public readonly data: Hex;
+
+  constructor(args: { data: HexInput }) {
+    const { data } = args;
+    const hex = Hex.fromHexInput({ hexInput: data });
+    if (hex.toUint8Array().length !== AuthenticationKey.LENGTH) {
+      throw new Error(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
+    }
+    this.data = hex;
+  }
+
+  toString(): string {
+    return this.data.toString();
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.data.toUint8Array();
+  }
+
+  /**
+   * Converts a K-of-N MultiEd25519PublicKey to AuthenticationKey with:
+   * `auth_key = sha3-256(p_1 | … | p_n | K | 0x01)`. `K` represents the K-of-N required for
+   * authenticating the transaction. `0x01` is the 1-byte scheme for multisig.
+   *
+   * @param multiPublicKey A K-of-N MultiPublicKey
+   * @returns AuthenticationKey
+   */
+  static fromMultiPublicKey(args: { multiPublicKey: MultiPublicKey }): AuthenticationKey {
+    const { multiPublicKey } = args;
+    const multiPubKeyBytes = multiPublicKey.toUint8Array();
+
+    const bytes = new Uint8Array(multiPubKeyBytes.length + 1);
+    bytes.set(multiPubKeyBytes);
+    bytes.set([AuthenticationKey.MULTI_ED25519_SCHEME], multiPubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey({ data: hash.digest() });
+  }
+
+  /**
+   * Converts a PublicKey to AuthenticationKey
+   *
+   * @param publicKey
+   * @returns AuthenticationKey
+   */
+  static fromPublicKey(args: { publicKey: PublicKey }): AuthenticationKey {
+    const { publicKey } = args;
+    const pubKeyBytes = publicKey.toUint8Array();
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey({ data: hash.digest() });
+  }
+
+  /**
+   * Derives an account address from AuthenticationKey. Since current AccountAddress is 32 bytes,
+   * AuthenticationKey bytes are directly translated to AccountAddress.
+   *
+   * @returns AccountAddress
+   */
+  derivedAddress(): AccountAddress {
+    return new AccountAddress({ data: this.data.toUint8Array() });
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -4,13 +4,15 @@
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { AccountAddress, Hex } from "../core";
 import { HexInput } from "../types";
-import { MultiPublicKey } from "./multi_ed25519";
-import { PublicKey } from "./ed25519";
+import { MultiEd25519PublicKey } from "./multi_ed25519";
+import { PublicKey } from "./asymmetric_crypto";
 
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
  * their private key(s) associated with the account without changing the address that hosts their account.
  * @see {@link * https://aptos.dev/concepts/accounts | Account Basics}
+ * 
+ * Note: AuthenticationKey only supports Ed25519 and MultiEd25519 public keys for now.
  *
  * Account addresses can be derived from AuthenticationKey
  */
@@ -56,7 +58,7 @@ export class AuthenticationKey {
    * @param multiPublicKey A K-of-N MultiPublicKey
    * @returns AuthenticationKey
    */
-  static fromMultiPublicKey(args: { multiPublicKey: MultiPublicKey }): AuthenticationKey {
+  static fromMultiPublicKey(args: { multiPublicKey: MultiEd25519PublicKey }): AuthenticationKey {
     const { multiPublicKey } = args;
     const multiPubKeyBytes = multiPublicKey.toUint8Array();
 
@@ -71,7 +73,7 @@ export class AuthenticationKey {
   }
 
   /**
-   * Converts a PublicKey to AuthenticationKey
+   * Converts a PublicKey(s) to AuthenticationKey
    *
    * @param publicKey
    * @returns AuthenticationKey

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -10,7 +10,7 @@ import { PublicKey } from "./asymmetric_crypto";
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
  * their private key(s) associated with the account without changing the address that hosts their account.
- * @see {@link * https://aptos.dev/concepts/accounts | Account Basics}
+ * @see {@link https://aptos.dev/concepts/accounts | Account Basics}
  * 
  * Note: AuthenticationKey only supports Ed25519 and MultiEd25519 public keys for now.
  *

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -149,7 +149,7 @@ export class Ed25519PrivateKey extends PrivateKey {
   /**
    * Generate a new random private key.
    *
-   * @returns
+   * @returns Ed25519PrivateKey
    */
   static generate(): Ed25519PrivateKey {
     const keyPair = nacl.sign.keyPair();

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -155,16 +155,6 @@ export class Ed25519PrivateKey extends PrivateKey {
     const keyPair = nacl.sign.keyPair();
     return new Ed25519PrivateKey({ value: keyPair.secretKey.slice(0, Ed25519PrivateKey.LENGTH) });
   }
-
-  /**
-   * Generate a new random private key.
-   *
-   * @returns
-   */
-  static generate(): PrivateKey {
-    const keyPair = nacl.sign.keyPair();
-    return new PrivateKey({ value: keyPair.secretKey.slice(0, PrivateKey.LENGTH) });
-  }
 }
 
 /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -163,7 +163,7 @@ export class Ed25519PrivateKey extends PrivateKey {
    */
   static generate(): PrivateKey {
     const keyPair = nacl.sign.keyPair();
-    return new PrivateKey({ value: keyPair.secretKey.slice(0, 32) });
+    return new PrivateKey({ value: keyPair.secretKey.slice(0, PrivateKey.LENGTH) });
   }
 }
 

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -155,6 +155,16 @@ export class Ed25519PrivateKey extends PrivateKey {
     const keyPair = nacl.sign.keyPair();
     return new Ed25519PrivateKey({ value: keyPair.secretKey.slice(0, Ed25519PrivateKey.LENGTH) });
   }
+
+  /**
+   * Generate a new random private key.
+   *
+   * @returns
+   */
+  static generate(): PrivateKey {
+    const keyPair = nacl.sign.keyPair();
+    return new PrivateKey({ value: keyPair.secretKey.slice(0, 32) });
+  }
 }
 
 /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -135,6 +135,10 @@ export class MultiEd25519Signature extends Signature {
       );
     }
 
+    if (signatures.length > MultiSignature.MAX_SIGNATURES_SUPPORTED) {
+      throw new Error(`The number of signatures cannot be greater than ${MultiSignature.MAX_SIGNATURES_SUPPORTED}`);
+    }
+
     this.signatures = signatures;
     this.bitmap = bitmap;
   }

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -6,6 +6,7 @@ import { Serializer } from "../bcs/serializer";
 import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
 import { PublicKey, Signature } from "./asymmetric_crypto";
 import { HexInput } from "../types";
+import { Hex } from "../core/hex";
 
 export class MultiEd25519PublicKey extends PublicKey {
   // Maximum number of public keys supported
@@ -69,6 +70,10 @@ export class MultiEd25519PublicKey extends PublicKey {
     bytes[this.publicKeys.length * Ed25519PublicKey.LENGTH] = this.threshold;
 
     return bytes;
+  }
+
+  toString(): string {
+    return Hex.fromHexInput({ hexInput: this.toUint8Array() }).toString();
   }
 
   verifySignature(args: { data: HexInput; signature: MultiEd25519Signature }): boolean {
@@ -135,8 +140,8 @@ export class MultiEd25519Signature extends Signature {
       );
     }
 
-    if (signatures.length > MultiSignature.MAX_SIGNATURES_SUPPORTED) {
-      throw new Error(`The number of signatures cannot be greater than ${MultiSignature.MAX_SIGNATURES_SUPPORTED}`);
+    if (signatures.length > MultiEd25519Signature.MAX_SIGNATURES_SUPPORTED) {
+      throw new Error(`The number of signatures cannot be greater than ${MultiEd25519Signature.MAX_SIGNATURES_SUPPORTED}`);
     }
 
     this.signatures = signatures;
@@ -155,6 +160,10 @@ export class MultiEd25519Signature extends Signature {
     bytes.set(this.bitmap, this.signatures.length * Ed25519Signature.LENGTH);
 
     return bytes;
+  }
+
+  toString(): string {
+    return Hex.fromHexInput({ hexInput: this.toUint8Array() }).toString();
   }
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/utils/hd-key.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/hd-key.ts
@@ -1,0 +1,76 @@
+import nacl from "tweetnacl";
+import { hmac } from "@noble/hashes/hmac";
+import { sha512 } from "@noble/hashes/sha512";
+import { hexToBytes } from "@noble/hashes/utils";
+
+export type Keys = {
+  key: Uint8Array;
+  chainCode: Uint8Array;
+};
+
+const pathRegex = /^m(\/[0-9]+')+$/;
+
+const replaceDerive = (val: string): string => val.replace("'", "");
+
+const HMAC_KEY = "ed25519 seed";
+const HARDENED_OFFSET = 0x80000000;
+
+export const getMasterKeyFromSeed = (seed: string): Keys => {
+  const h = hmac.create(sha512, HMAC_KEY);
+  const I = h.update(hexToBytes(seed)).digest();
+  const IL = I.slice(0, 32);
+  const IR = I.slice(32);
+  return {
+    key: IL,
+    chainCode: IR,
+  };
+};
+
+export const CKDPriv = ({ key, chainCode }: Keys, index: number): Keys => {
+  const buffer = new ArrayBuffer(4);
+  new DataView(buffer).setUint32(0, index);
+  const indexBytes = new Uint8Array(buffer);
+  const zero = new Uint8Array([0]);
+  const data = new Uint8Array([...zero, ...key, ...indexBytes]);
+
+  const I = hmac.create(sha512, chainCode).update(data).digest();
+  const IL = I.slice(0, 32);
+  const IR = I.slice(32);
+  return {
+    key: IL,
+    chainCode: IR,
+  };
+};
+
+export const getPublicKey = (privateKey: Uint8Array, withZeroByte = true): Uint8Array => {
+  const keyPair = nacl.sign.keyPair.fromSeed(privateKey);
+  const signPk = keyPair.secretKey.subarray(32);
+  const zero = new Uint8Array([0]);
+  return withZeroByte ? new Uint8Array([...zero, ...signPk]) : signPk;
+};
+
+export const isValidPath = (path: string): boolean => {
+  if (!pathRegex.test(path)) {
+    return false;
+  }
+  return !path
+    .split("/")
+    .slice(1)
+    .map(replaceDerive)
+    .some(Number.isNaN as any);
+};
+
+export const derivePath = (path: string, seed: string, offset = HARDENED_OFFSET): Keys => {
+  if (!isValidPath(path)) {
+    throw new Error("Invalid derivation path");
+  }
+
+  const { key, chainCode } = getMasterKeyFromSeed(seed);
+  const segments = path
+    .split("/")
+    .slice(1)
+    .map(replaceDerive)
+    .map((el) => parseInt(el, 10));
+
+  return segments.reduce((parentKeys, segment) => CKDPriv(parentKeys, segment + offset), { key, chainCode });
+};

--- a/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
@@ -4,6 +4,7 @@
 import { Account } from "../../src/core/account";
 import { AccountAddress } from "../../src/core/account_address";
 import { Hex } from "../../src/core/hex";
+import { Ed25519Signature } from "../../src/crypto/ed25519";
 import { ed25519 } from "./helper";
 
 describe("Account", () => {
@@ -61,7 +62,10 @@ describe("Account", () => {
       privateKey,
       address: AccountAddress.fromString({ input: address }),
     });
-    expect(account.sign(message).toString()).toEqual(signedMessage);
-    expect(account.verifySignature(message, signedMessage)).toBe(true);
+    expect(account.sign({ data: message }).toString()).toEqual(signedMessage);
+
+    // Verify the signature
+    const signature = new Ed25519Signature({ data: signedMessage });
+    expect(account.verifySignature({ message, signature })).toBe(true);
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
@@ -1,0 +1,67 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Account } from "../../src/core/account";
+import { AccountAddress } from "../../src/core/account_address";
+import { Hex } from "../../src/core/hex";
+import { ed25519 } from "./helper";
+
+describe("Account", () => {
+  it("should create an instance of Account correctly without error", () => {
+    const account = Account.generate();
+    expect(account).toBeInstanceOf(Account);
+  });
+
+  it("should create a new account from a provided private key", () => {
+    const { privateKey, publicKey, address } = ed25519;
+    const newAccount = Account.fromPrivateKey({ privateKey });
+    expect(newAccount).toBeInstanceOf(Account);
+    expect(newAccount.privateKey.toString()).toEqual(privateKey);
+    expect(newAccount.publicKey.toString()).toEqual(publicKey);
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should create a new account from a provided private key and address", () => {
+    const { privateKey, publicKey, address } = ed25519;
+    const newAccount = Account.fromPrivateKeyAndAddress({
+      privateKey,
+      address: AccountAddress.fromString({ input: address }),
+    });
+    expect(newAccount).toBeInstanceOf(Account);
+    expect(newAccount.privateKey.toString()).toEqual(privateKey);
+    expect(newAccount.publicKey.toString()).toEqual(publicKey);
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should create a new account from a bip44 path and mnemonics", () => {
+    const { mnemonic } = ed25519;
+    const address = "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30";
+    const path = "m/44'/637'/0'/0'/0'";
+    const newAccount = Account.fromDerivationPath({ path, mnemonic });
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should check if a derivation path is valid", () => {
+    const validPath = "m/44'/637'/0'/0'/0'"; // Valid path
+    const invalidPath = "invalid/path"; // Invalid path
+    expect(Account.isValidPath({ path: validPath })).toBe(true);
+    expect(Account.isValidPath({ path: invalidPath })).toBe(false);
+  });
+
+  it("should return the authentication key for a public key", () => {
+    const { publicKey, address } = ed25519;
+    const authKey = Account.authKey({ publicKey });
+    expect(authKey).toBeInstanceOf(Hex);
+    expect(authKey.toString()).toEqual(address);
+  });
+
+  it("should sign data, return a Hex signature, and verify", () => {
+    const { privateKey, address, message, signedMessage } = ed25519;
+    const account = Account.fromPrivateKeyAndAddress({
+      privateKey,
+      address: AccountAddress.fromString({ input: address }),
+    });
+    expect(account.sign(message).toString()).toEqual(signedMessage);
+    expect(account.verifySignature(message, signedMessage)).toBe(true);
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -1,6 +1,6 @@
 import { AuthenticationKey } from "../../src/crypto/authentication_key";
-import { PublicKey } from "../../src/crypto/ed25519";
-import { MultiPublicKey } from "../../src/crypto/multi_ed25519";
+import { Ed25519PublicKey } from "../../src/crypto/ed25519";
+import { MultiEd25519PublicKey } from "../../src/crypto/multi_ed25519";
 import { ed25519, multiEd25519PkTestObject } from "./helper";
 
 describe("AuthenticationKey", () => {
@@ -17,8 +17,8 @@ describe("AuthenticationKey", () => {
     );
   });
 
-  it("should create AuthenticationKey from PublicKey", () => {
-    const publicKey = new PublicKey({ hexInput: ed25519.publicKey });
+  it("should create AuthenticationKey from Ed25519PublicKey", () => {
+    const publicKey = new Ed25519PublicKey({ hexInput: ed25519.publicKey });
     const authKey = AuthenticationKey.fromPublicKey({ publicKey });
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(ed25519.authKey);
@@ -28,10 +28,10 @@ describe("AuthenticationKey", () => {
     // create the MultiPublicKey
     let edPksArray = [];
     for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
-      edPksArray.push(new PublicKey({ hexInput: multiEd25519PkTestObject.public_keys[i] }));
+      edPksArray.push(new Ed25519PublicKey({ hexInput: multiEd25519PkTestObject.public_keys[i] }));
     }
 
-    const pubKeyMultiSig = new MultiPublicKey({
+    const pubKeyMultiSig = new MultiEd25519PublicKey({
       publicKeys: edPksArray,
       threshold: multiEd25519PkTestObject.threshold,
     });

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -1,0 +1,49 @@
+import { AuthenticationKey } from "../../src/crypto/authentication_key";
+import { PublicKey } from "../../src/crypto/ed25519";
+import { MultiPublicKey } from "../../src/crypto/multi_ed25519";
+import { ed25519, multiEd25519PkTestObject } from "./helper";
+
+describe("AuthenticationKey", () => {
+  it("should create an instance with save the hexinput correctly", () => {
+    const authKey = new AuthenticationKey({ data: ed25519.authKey });
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual(ed25519.authKey);
+  });
+
+  it("should throw an error with invalid hex input length", () => {
+    const invalidHexInput = "0123456789abcdef"; // Invalid length
+    expect(() => new AuthenticationKey({ data: invalidHexInput })).toThrowError(
+      "Authentication Key length should be 32",
+    );
+  });
+
+  it("should create AuthenticationKey from PublicKey", () => {
+    const publicKey = new PublicKey({ hexInput: ed25519.publicKey });
+    const authKey = AuthenticationKey.fromPublicKey({ publicKey });
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual(ed25519.authKey);
+  });
+
+  it("should create AuthenticationKey from MultiPublicKey", () => {
+    // create the MultiPublicKey
+    let edPksArray = [];
+    for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
+      edPksArray.push(new PublicKey({ hexInput: multiEd25519PkTestObject.public_keys[i] }));
+    }
+
+    const pubKeyMultiSig = new MultiPublicKey({
+      publicKeys: edPksArray,
+      threshold: multiEd25519PkTestObject.threshold,
+    });
+
+    const authKey = AuthenticationKey.fromMultiPublicKey({ multiPublicKey: pubKeyMultiSig });
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual("0xa81cfac3df59920593ff417b45fc347ead3d88f8e25112c0488d34d7c9eb20af");
+  });
+
+  it("should derive an AccountAddress from AuthenticationKey with same string", () => {
+    const authKey = new AuthenticationKey({ data: ed25519.authKey });
+    const accountAddress = authKey.derivedAddress();
+    expect(accountAddress.toString()).toEqual(ed25519.authKey);
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
@@ -4,6 +4,9 @@
 export const ed25519 = {
   privateKey: "0xc5338cd251c22daa8c9c9cc94f498cc8a5c7e1d2e75287a5dda91096fe64efa5",
   publicKey: "0xde19e5d1880cac87d57484ce9ed2e84cf0f9599f12e7cc3a52e4e7657a763f2c",
+  authKey: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
+  address: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
+  mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
   message: "0x7777",
   // eslint-disable-next-line max-len
   signedMessage:


### PR DESCRIPTION
### Description

Note: This is the `3rd` stack of the whole work. Previous stack here -> #10186

This PR adds the Account and AuthenticationKey classes. Most of the thing stays the same as v1, but with some modification.

1. Account now holds the actual `PublicKey` and `PrivateKey` objects
2. `Verify` and `Sign` relies on the method the corresponding key
3. Using object as param

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Run all tests and make sure they all passes
