### PR TITLE
[ts-sdk-v2] Add .npmrc to ensure pnpm lockfile is consistent

### DIFF
--- a/ecosystem/typescript/sdk_v2/.npmrc
+++ b/ecosystem/typescript/sdk_v2/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true


### PR DESCRIPTION
### Description
I kept getting differing lockfiles, because pnpm is configured differently for me than whoever has been submitting commits.  This fixes that issue.

### Test Plan
Ran `pnpm install` and my lockfile didn't change format version
