### PR TITLE
[CLI] Add support for running standard indexer processors to the local testnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@
 !aptos-move/framework/
 !aptos-move/move-examples/hello_blockchain/
 !crates/aptos/src/move_tool/*.bpl
+!crates/aptos/src/node/local_testnet/hasura_metadata.json
 !crates/aptos-faucet/doc/
 !api/doc/
 !crates/indexer/migrations/**/*.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "move-vm-runtime",
  "once_cell",
  "poem",
+ "processor",
  "rand 0.7.3",
  "regex",
  "reqwest",
@@ -288,6 +289,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "server-framework",
  "shadow-rs",
  "tempfile",
  "termcolor",
@@ -522,7 +524,7 @@ dependencies = [
  "move-bytecode-verifier",
  "num_cpus",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.12",
  "proptest",
  "rand 0.7.3",
  "regex",
@@ -1899,7 +1901,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-protos",
  "aptos-runtimes",
  "async-trait",
@@ -1931,7 +1933,7 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-protos",
  "aptos-runtimes",
  "async-trait",
@@ -1960,7 +1962,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-runtimes",
  "async-trait",
  "clap 4.3.21",
@@ -1996,7 +1998,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-proptest-helpers",
  "aptos-protos",
  "aptos-runtimes",
@@ -2155,6 +2157,18 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "warp",
+]
+
+[[package]]
+name = "aptos-indexer-protos"
+version = "1.0.9"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "pbjson",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "serde",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -2463,6 +2477,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-moving-average"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
 dependencies = [
@@ -2508,7 +2530,7 @@ dependencies = [
  "aptos-types",
  "bytes",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "serde",
  "tokio",
  "tokio-util 0.7.3",
@@ -2549,7 +2571,7 @@ dependencies = [
  "itertools",
  "maplit",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.12",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -2986,7 +3008,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "tokio",
  "tokio-util 0.7.3",
 ]
@@ -3656,7 +3678,7 @@ dependencies = [
  "aptos-infallible",
  "enum_dispatch",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -4279,6 +4301,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,6 +4670,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bb8"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot 0.12.1",
+ "tokio",
 ]
 
 [[package]]
@@ -6033,11 +6081,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
 dependencies = [
  "async-trait",
+ "bb8",
  "diesel",
  "futures-util",
  "scoped-futures",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_async_migrations"
+version = "0.11.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "diesel",
+ "diesel-async",
+ "macros",
+ "scoped-futures",
+ "tracing",
 ]
 
 [[package]]
@@ -6790,7 +6851,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "pin-project",
+ "pin-project 1.0.12",
  "spin 0.9.4",
 ]
 
@@ -6985,6 +7046,49 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
+name = "gcemeta"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d460327b24cc34c86d53d60a90e9e6044817f7906ebd9baa5c3d0ee13e1ecf"
+dependencies = [
+ "bytes",
+ "hyper",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a24376e7850e7864bb326debc5765a1dda4fc47603c22e2bc0ebf30ff59141b"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "gcemeta",
+ "hyper",
+ "jsonwebtoken 8.1.1",
+ "once_cell",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "reqwest",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic 0.9.2",
+ "tower",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "gcp-bigquery-client"
@@ -8249,7 +8353,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 1.1.0",
- "pin-project",
+ "pin-project 1.0.12",
  "rustls 0.20.6",
  "rustls-pemfile 0.2.1",
  "serde",
@@ -8711,6 +8815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macros"
+version = "0.1.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
 ]
 
 [[package]]
@@ -10790,11 +10903,31 @@ checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.12",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -11267,6 +11400,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "processor"
+version = "1.0.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "anyhow",
+ "aptos-indexer-protos",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5)",
+ "async-trait",
+ "base64 0.13.0",
+ "bcs 0.1.4",
+ "bigdecimal",
+ "chrono",
+ "clap 4.3.21",
+ "diesel",
+ "diesel-async",
+ "diesel_async_migrations",
+ "diesel_migrations",
+ "enum_dispatch",
+ "field_count",
+ "futures",
+ "futures-util",
+ "gcloud-sdk",
+ "google-cloud-googleapis",
+ "google-cloud-pubsub",
+ "hex",
+ "once_cell",
+ "prometheus",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "serde",
+ "serde_json",
+ "server-framework",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
+ "strum",
+ "tokio",
+ "tonic 0.9.2",
+ "tracing",
+ "unescape",
+ "url",
 ]
 
 [[package]]
@@ -11842,6 +12019,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes",
  "cookie",
@@ -12360,6 +12538,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f8cfb86d2019f64a4cfb49e499f401f406fbec946c1ffeea9d0504284347de"
+dependencies = [
+ "prost 0.12.1",
+ "prost-types 0.12.1",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12614,6 +12805,27 @@ dependencies = [
  "move-core-types",
  "proptest",
  "proptest-derive",
+]
+
+[[package]]
+name = "server-framework"
+version = "1.0.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backtrace",
+ "clap 4.3.21",
+ "futures",
+ "prometheus",
+ "serde",
+ "serde_yaml 0.8.26",
+ "tempfile",
+ "tokio",
+ "toml 0.7.4",
+ "tracing",
+ "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]
@@ -13137,6 +13349,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -13672,7 +13887,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.12",
  "rand 0.8.5",
  "tokio",
 ]
@@ -13837,7 +14052,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.11.9",
  "prost-derive 0.11.9",
  "tokio",
@@ -13870,8 +14085,9 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.11.9",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.1",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -13901,7 +14117,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.12.1",
  "rustls-native-certs",
  "rustls-pemfile 1.0.1",
@@ -13936,7 +14152,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project",
+ "pin-project 1.0.12",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -13999,6 +14215,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
+
+[[package]]
 name = "trace"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14011,9 +14239,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -14024,13 +14252,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",
- "syn 1.0.105",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -14049,7 +14277,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.12",
  "tracing",
 ]
 
@@ -14227,6 +14455,12 @@ checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unic-char-property"
@@ -14532,7 +14766,7 @@ dependencies = [
  "mime_guess",
  "multer",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "rustls-pemfile 1.0.1",
  "scoped-tls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bcs 0.1.4",
+ "bollard",
  "chrono",
  "clap 4.3.21",
  "clap_complete",
@@ -4925,6 +4926,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+dependencies = [
+ "base64 0.21.2",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.3",
+ "url",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.43.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,7 +5251,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -6391,6 +6432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "erased-serde"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7435,7 +7482,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.3",
@@ -7837,6 +7884,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8026,6 +8086,18 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -8070,7 +8142,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap",
+ "indexmap 1.9.3",
  "is-terminal",
  "itoa",
  "log",
@@ -9142,7 +9214,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "backtrace",
- "indexmap",
+ "indexmap 1.9.3",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -10834,7 +10906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset 0.2.0",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -10844,7 +10916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -11105,7 +11177,7 @@ checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
 dependencies = [
  "darling",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "mime",
  "proc-macro-crate",
  "proc-macro2 1.0.64",
@@ -12622,9 +12694,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
 dependencies = [
  "serde_derive",
 ]
@@ -12698,13 +12770,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",
- "syn 1.0.105",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -12713,7 +12785,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -12773,12 +12845,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.1",
+ "serde",
+ "serde_json",
+ "time 0.3.24",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
@@ -12790,7 +12878,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -14015,7 +14103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
  "combine",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "serde",
 ]
@@ -14026,7 +14114,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14151,7 +14239,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project 1.0.12",
  "pin-project-lite",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,6 +446,7 @@ bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"
 blst = "0.3.7"
+bollard = "0.15"
 bulletproofs = { version = "4.0.0" }
 byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
@@ -591,7 +592,7 @@ sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 siphasher = "0.3.10"
 # pin to 1.0.149 because the latest version fails analyze_serde_formats
-serde = { version = "=1.0.149", features = ["derive", "rc"] }
+serde = { version = "=1.0.157", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order", "arbitrary_precision"] } # Note: arbitrary_precision is required to parse u256 in JSON
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,7 +617,7 @@ thiserror = "1.0.37"
 time = { version = "0.3.24", features = ["serde"] }
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
-tracing = "0.1.34"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.80"
 tokio = { version = "1.21.0", features = ["full"] }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -49,6 +49,7 @@ aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
+bollard = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env", "unstable-styles"] }
 clap_complete = { workspace = true }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -78,6 +78,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -85,6 +86,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1246,6 +1246,11 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
     /// Returns a name for logging purposes
     fn command_name(&self) -> &'static str;
 
+    /// Returns whether the error should be JSONifyed.
+    fn jsonify_error_output(&self) -> bool {
+        true
+    }
+
     /// Executes the command, returning a command specific type
     async fn execute(self) -> CliTypedResult<T>;
 
@@ -1260,14 +1265,28 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
         let command_name = self.command_name();
         start_logger(level);
         let start_time = Instant::now();
-        to_common_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 
     /// Same as execute serialized without setting up logging
     async fn execute_serialized_without_logger(self) -> CliResult {
         let command_name = self.command_name();
         let start_time = Instant::now();
-        to_common_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 
     /// Executes the command, and throws away Ok(result) for the string Success
@@ -1275,7 +1294,14 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
         start_logger(Level::Warn);
         let command_name = self.command_name();
         let start_time = Instant::now();
-        to_common_success_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_success_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 }
 

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -11,16 +11,26 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use aptos::{move_tool, Tool};
 use clap::Parser;
-use std::process::exit;
+use std::{process::exit, time::Duration};
 
-#[tokio::main]
-async fn main() {
-    // Register hooks
+fn main() {
+    // Register hooks.
     move_tool::register_package_hooks();
-    // Run the corresponding tools
-    let result = Tool::parse().execute().await;
 
-    // At this point, we'll want to print and determine whether to exit for an error code
+    // Create a runtime.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Run the corresponding tool.
+    let result = runtime.block_on(Tool::parse().execute());
+
+    // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
+    // here waiting forever waiting for tasks that sometimes don't want to exit on
+    // their own (e.g. telemetry, containers spawned by the local testnet, etc).
+    runtime.shutdown_timeout(Duration::from_millis(100));
+
     match result {
         Ok(inner) => println!("{}", inner),
         Err(inner) => {

--- a/crates/aptos/src/node/local_testnet/hasura_metadata.json
+++ b/crates/aptos/src/node/local_testnet/hasura_metadata.json
@@ -1,0 +1,2036 @@
+{
+  "resource_version": 340,
+  "metadata": {
+    "version": 3,
+    "sources": [
+      {
+        "name": "indexer-v2",
+        "kind": "postgres",
+        "tables": [
+          {
+            "table": {
+              "name": "account_transactions",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "fungible_asset_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["account_address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_events_summary",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "block_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "min_block_height": "block_height"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "block_metadata_transactions",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "min_block_height",
+                    "num_distinct_versions",
+                    "account_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_events",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["account_address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_move_resources",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "block_metadata_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "epoch",
+                    "failed_proposer_indices",
+                    "id",
+                    "previous_block_votes_bitvec",
+                    "proposer",
+                    "round",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type": "coin_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "activity_type",
+                    "amount",
+                    "block_height",
+                    "coin_type",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "storage_refund_amount",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "coin_type_hash",
+                    "owner_address",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "creator_address",
+                    "decimals",
+                    "name",
+                    "supply_aggregator_table_handle",
+                    "supply_aggregator_table_key",
+                    "symbol",
+                    "transaction_created_timestamp",
+                    "transaction_version_created"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_supply",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "supply",
+                    "transaction_epoch",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_ans_lookup",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "all_token_ownerships",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "domain",
+                    "expiration_timestamp",
+                    "is_deleted",
+                    "last_transaction_version",
+                    "registered_address",
+                    "subdomain",
+                    "token_name"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_aptos_names",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "is_primary",
+                    "domain",
+                    "registered_address",
+                    "subdomain",
+                    "expiration_timestamp",
+                    "token_name",
+                    "last_transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_coin_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type_hash": "coin_type_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "coin_type_hash",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_ownership_v2_view",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "distinct_tokens",
+                    "last_transaction_version",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "owner_address",
+                    "collection_uri",
+                    "single_token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collections_v2",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "current_supply",
+                    "description",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "max_supply",
+                    "mutable_description",
+                    "mutable_uri",
+                    "table_handle_v1",
+                    "token_standard",
+                    "total_minted_v2",
+                    "uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_staking_pool_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "active_table_handle",
+                    "inactive_table_handle",
+                    "last_transaction_version",
+                    "operator_commission_percentage",
+                    "staking_pool_address",
+                    "total_coins",
+                    "total_shares"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_voter",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "delegation_pool_address",
+                    "delegator_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "pending_voter",
+                    "table_handle",
+                    "voter"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegator_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "delegator_address",
+                    "last_transaction_version",
+                    "parent_table_handle",
+                    "pool_address",
+                    "pool_type",
+                    "shares",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_fungible_asset_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "is_frozen",
+                    "is_primary",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "storage_id",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_objects",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "allow_ungated_transfer",
+                    "is_deleted",
+                    "last_guid_creation_num",
+                    "last_transaction_version",
+                    "object_address",
+                    "owner_address",
+                    "state_key_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_staking_pool_voter",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "operator_aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "operator_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "last_transaction_version",
+                    "operator_address",
+                    "staking_pool_address",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "is_deleted",
+                    "key",
+                    "key_hash",
+                    "last_transaction_version",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "largest_property_version",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "description",
+                    "is_fungible_v2",
+                    "largest_property_version_v1",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "supply",
+                    "token_data_id",
+                    "token_name",
+                    "token_properties",
+                    "token_standard",
+                    "token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_type",
+                    "token_data_id_hash",
+                    "token_properties"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "composed_nfts",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "owner_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "is_fungible_v2",
+                    "is_soulbound_v2",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "property_version_v1",
+                    "storage_id",
+                    "table_type_v1",
+                    "token_data_id",
+                    "token_properties_mutated_v1",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_pending_claims",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "last_transaction_version": "transaction_version",
+                      "property_version": "property_version",
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "tokens",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "from_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "property_version",
+                    "table_handle",
+                    "to_address",
+                    "token_data_id",
+                    "token_data_id_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_activities",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "delegator_address",
+                    "event_index",
+                    "event_type",
+                    "pool_address",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_pools",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_staking_pool",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "staking_pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "first_transaction_version",
+                    "staking_pool_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegator_distinct_pool",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["delegator_address", "pool_address"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "events",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "account_address",
+                    "creation_number",
+                    "data",
+                    "event_index",
+                    "sequence_number",
+                    "transaction_block_height",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "owner_aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "block_height",
+                    "entry_function_id_str",
+                    "event_index",
+                    "gas_fee_payer_address",
+                    "is_frozen",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "storage_id",
+                    "storage_refund_amount",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_metadata",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "asset_type",
+                    "creator_address",
+                    "decimals",
+                    "icon_uri",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "project_uri",
+                    "supply_aggregator_table_handle_v1",
+                    "supply_aggregator_table_key_v1",
+                    "symbol",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "indexer_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["db", "is_indexer_up"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "ledger_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["chain_id"],
+                  "filter": {}
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "move_resources",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "num_active_delegator_per_pool",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["num_active_delegator", "pool_address"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "processor_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "last_success_version",
+                    "last_updated",
+                    "processor"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "proposal_votes",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "num_votes",
+                    "proposal_id",
+                    "should_pass",
+                    "staking_pool_address",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "key",
+                    "table_handle",
+                    "transaction_version",
+                    "write_set_change_index"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_metadatas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["handle", "key_type", "value_type"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_owner",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "event_account_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_amount",
+                    "coin_type",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "from_address",
+                    "name",
+                    "property_version",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "transfer_type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_from",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "from_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "after_value",
+                    "before_value",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_index",
+                    "from_address",
+                    "is_fungible_v2",
+                    "property_version_v1",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "largest_property_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_ownerships",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_handle",
+                    "table_type",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "tokens",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "name",
+                    "property_version",
+                    "token_data_id_hash",
+                    "token_properties",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "user_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "entry_function_id_str",
+                    "epoch",
+                    "expiration_timestamp_secs",
+                    "gas_unit_price",
+                    "max_gas_amount",
+                    "parent_signature_type",
+                    "sender",
+                    "sequence_number",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          }
+        ],
+        "configuration": {
+          "connection_info": {
+            "database_url": {
+              "from_env": "INDEXER_V2_POSTGRES_URL"
+            },
+            "isolation_level": "read-committed",
+            "use_prepared_statements": false
+          }
+        }
+      }
+    ],
+    "query_collections": [
+      {
+        "name": "allowed-queries",
+        "definition": {
+          "queries": [
+            {
+              "name": "Latest Processor Status",
+              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n  }\n}"
+            }
+          ]
+        }
+      }
+    ],
+    "allowlist": [
+      {
+        "collection": "allowed-queries",
+        "scope": {
+          "global": true
+        }
+      }
+    ],
+    "rest_endpoints": [
+      {
+        "comment": "",
+        "definition": {
+          "query": {
+            "collection_name": "allowed-queries",
+            "query_name": "Latest Processor Status"
+          }
+        },
+        "methods": ["GET"],
+        "name": "Latest Processor Status",
+        "url": "get_lastest_processor_status"
+      }
+    ],
+    "api_limits": {
+      "depth_limit": {
+        "global": 4,
+        "per_role": {}
+      },
+      "disabled": false,
+      "time_limit": {
+        "global": 10,
+        "per_role": {}
+      }
+    },
+    "metrics_config": {
+      "analyze_query_variables": true,
+      "analyze_response_body": true
+    }
+  }
+}

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use std::time::Duration;
 use tokio::time::Instant;
 
-const MAX_WAIT_S: u64 = 35;
-const WAIT_INTERVAL_MS: u64 = 150;
+const MAX_WAIT_S: u64 = 60;
+const WAIT_INTERVAL_MS: u64 = 200;
 
 /// This provides a single place to define a variety of different healthchecks.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -1,7 +1,35 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{
+    health_checker::HealthChecker,
+    traits::{PostHealthyStep, ServiceManager, ShutdownStep},
+    utils::{confirm_docker_available, delete_container, pull_docker_image},
+    RunLocalTestnet,
+};
+use crate::node::local_testnet::utils::{setup_docker_logging, KillContainerShutdownStep};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use clap::Parser;
+use maplit::hashset;
+use reqwest::Url;
+use std::{collections::HashSet, path::PathBuf, process::Stdio};
+use tokio::process::Command;
+use tracing::info;
+
+const INDEXER_API_CONTAINER_NAME: &str = "indexer-api";
+const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.33.0";
+
+/// This Hasura metadata origintes from the aptos-indexer-processors repo.
+///
+/// This metadata is from revision: 1b8e14d9669258f797403e2b38da9ea5aea29e35.
+///
+/// The metadata file is not taken verbatim, it is currently edited by hand to remove
+/// any references to tables that aren't created by the Rust processor migrations.
+/// This works fine today since all the key processors you'd need in a local testnet
+/// are in the set of processors written in Rust. If this changes, we can explore
+/// alternatives, e.g. running processors in other languages using containers.
+const HASURA_METADATA: &str = include_str!("hasura_metadata.json");
 
 /// Args related to running an indexer API for the local testnet.
 #[derive(Debug, Parser)]
@@ -13,4 +41,230 @@ pub struct IndexerApiArgs {
     /// Docker to be installed in the host system.
     #[clap(long, conflicts_with = "no_txn_stream")]
     pub with_indexer_api: bool,
+
+    /// The port at which to run the indexer API.
+    #[clap(long, default_value_t = 8090)]
+    pub indexer_api_port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerApiManager {
+    indexer_api_port: u16,
+    prerequisite_health_checkers: HashSet<HealthChecker>,
+    test_dir: PathBuf,
+    postgres_connection_string: String,
+}
+
+impl IndexerApiManager {
+    pub fn new(
+        args: &RunLocalTestnet,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        test_dir: PathBuf,
+        postgres_connection_string: String,
+    ) -> Result<Self> {
+        Ok(Self {
+            indexer_api_port: args.indexer_api_args.indexer_api_port,
+            prerequisite_health_checkers,
+            test_dir,
+            postgres_connection_string,
+        })
+    }
+}
+
+#[async_trait]
+impl ServiceManager for IndexerApiManager {
+    fn get_name(&self) -> String {
+        "Indexer API".to_string()
+    }
+
+    async fn pre_run(&self) -> Result<()> {
+        // Confirm Docker is available.
+        confirm_docker_available().await?;
+
+        // Delete any existing indexer API container we find.
+        delete_container(INDEXER_API_CONTAINER_NAME).await?;
+
+        // Pull the image here so it is not subject to the 30 second startup timeout.
+        pull_docker_image(HASURA_IMAGE).await?;
+
+        // Warn the user about DOCKER_DEFAULT_PLATFORM.
+        if let Ok(var) = std::env::var("DOCKER_DEFAULT_PLATFORM") {
+            eprintln!(
+                "WARNING: DOCKER_DEFAULT_PLATFORM is set to {}. This may cause problems \
+                with running the indexer API. If it fails to start up, try unsetting \
+                this env var.\n",
+                var
+            );
+        }
+
+        Ok(())
+    }
+
+    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+        hashset! {HealthChecker::Http(
+            Url::parse(&format!("http://127.0.0.1:{}", self.indexer_api_port)).unwrap(),
+            self.get_name(),
+        )}
+    }
+
+    fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
+        self.prerequisite_health_checkers.iter().collect()
+    }
+
+    async fn run_service(self: Box<Self>) -> Result<()> {
+        let (stdout, stderr) =
+            setup_docker_logging(&self.test_dir, "indexer-api", INDEXER_API_CONTAINER_NAME)?;
+
+        // If we're on Mac, replace 127.0.0.1 with host.docker.internal.
+        // https://stackoverflow.com/a/24326540/3846032
+        let postgres_connection_string = if cfg!(target_os = "macos") {
+            self.postgres_connection_string
+                .replace("127.0.0.1", "host.docker.internal")
+        } else {
+            self.postgres_connection_string.to_string()
+        };
+
+        // https://stackoverflow.com/q/77171786/3846032
+        let mut command = Command::new("docker");
+        command
+            .arg("run")
+            .arg("-q")
+            .arg("--rm")
+            .arg("--tty")
+            .arg("--no-healthcheck")
+            .arg("--name")
+            .arg(INDEXER_API_CONTAINER_NAME)
+            .arg("-p")
+            .arg(format!(
+                "{}:{}",
+                self.indexer_api_port, self.indexer_api_port
+            ))
+            .arg("-e")
+            .arg(format!("PG_DATABASE_URL={}", postgres_connection_string))
+            .arg("-e")
+            .arg(format!(
+                "HASURA_GRAPHQL_METADATA_DATABASE_URL={}",
+                postgres_connection_string
+            ))
+            .arg("-e")
+            .arg(format!(
+                "INDEXER_V2_POSTGRES_URL={}",
+                postgres_connection_string
+            ))
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_DEV_MODE=true")
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_ENABLE_CONSOLE=true")
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_CONSOLE_ASSETS_DIR=/srv/console-assets")
+            .arg("-e")
+            .arg(format!(
+                "HASURA_GRAPHQL_SERVER_PORT={}",
+                self.indexer_api_port
+            ))
+            .arg(HASURA_IMAGE)
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr);
+
+        info!("Running command: {:?}", command);
+
+        let child = command
+            .spawn()
+            .context("Failed to start indexer API container")?;
+
+        // When sigint is received the container can error out, which we don't want to
+        // show to the user, so we log instead.
+        match child.wait_with_output().await {
+            Ok(output) => {
+                info!("Indexer API stopped with output: {:?}", output);
+            },
+            Err(err) => {
+                info!("Indexer API stopped unexpectedly with error: {}", err);
+            },
+        }
+
+        Ok(())
+    }
+
+    fn get_post_healthy_steps(&self) -> Vec<Box<dyn PostHealthyStep>> {
+        /// There is no good way to apply Hasura metadata (the JSON format, anyway) to
+        /// an instance of Hasura in a container at startup:
+        ///
+        /// https://github.com/hasura/graphql-engine/issues/8423
+        ///
+        /// As such, the only way to do it is to apply it via the API after startup.
+        /// That is what this post healthy step does.
+        #[derive(Debug)]
+        struct PostMetdataPostHealthyStep {
+            pub indexer_api_port: u16,
+        }
+
+        #[async_trait]
+        impl PostHealthyStep for PostMetdataPostHealthyStep {
+            async fn run(self: Box<Self>) -> Result<()> {
+                post_metadata(HASURA_METADATA, self.indexer_api_port)
+                    .await
+                    .context("Failed to apply Hasura metadata for Indexer API")?;
+                Ok(())
+            }
+        }
+
+        vec![Box::new(PostMetdataPostHealthyStep {
+            indexer_api_port: self.indexer_api_port,
+        })]
+    }
+
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        // Unfortunately the Hasura container does not shut down when the CLI does and
+        // there doesn't seem to be a good way to make it do so. To work around this,
+        // we register a step that will delete the container on shutdown.
+        // Read more here: https://stackoverflow.com/q/77171786/3846032.
+        vec![Box::new(KillContainerShutdownStep::new(
+            INDEXER_API_CONTAINER_NAME,
+        ))]
+    }
+}
+
+/// This submits a POST request to apply metadata to a Hasura API.
+async fn post_metadata(metadata_content: &str, port: u16) -> Result<()> {
+    let url = format!("http://127.0.0.1:{}/v1/metadata", port);
+    let client = reqwest::Client::new();
+
+    // Parse the metadata content as JSON.
+    let metadata_json: serde_json::Value = serde_json::from_str(metadata_content)?;
+
+    // Construct the payload.
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "type".to_string(),
+        serde_json::Value::String("replace_metadata".to_string()),
+    );
+    payload.insert("args".to_string(), metadata_json);
+
+    // Send the POST request.
+    let response = client.post(url).json(&payload).send().await?;
+
+    // Check that `is_consistent` is true in the response.
+    let json = response.json().await?;
+    check_is_consistent(&json)?;
+
+    Ok(())
+}
+
+/// This checks the response from the API to confirm the metadata was applied
+/// successfully.
+fn check_is_consistent(json: &serde_json::Value) -> Result<()> {
+    if let Some(obj) = json.as_object() {
+        if let Some(is_consistent_val) = obj.get("is_consistent") {
+            if is_consistent_val.as_bool() == Some(true) {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Something went wrong applying the Hasura metadata, perhaps it is not consistent with the DB. Response: {:#?}",
+        json
+    ))
 }

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -102,6 +102,10 @@ impl NodeManager {
     pub fn get_node_api_url(&self) -> Url {
         socket_addr_to_url(&self.config.api.address, "http").unwrap()
     }
+
+    pub fn get_data_service_url(&self) -> Url {
+        socket_addr_to_url(&self.config.indexer_grpc.address, "http").unwrap()
+    }
 }
 
 #[async_trait]

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -3,11 +3,11 @@
 
 use super::{
     health_checker::HealthChecker,
-    traits::ServiceManager,
+    traits::{ServiceManager, ShutdownStep},
     utils::{confirm_docker_available, delete_container, pull_docker_image},
     RunLocalTestnet,
 };
-use crate::node::local_testnet::utils::setup_docker_logging;
+use crate::node::local_testnet::utils::{setup_docker_logging, KillContainerShutdownStep};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
@@ -226,5 +226,12 @@ impl ServiceManager for PostgresManager {
         }
 
         Ok(())
+    }
+
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        // Shutdown the postgres container, if any.
+        vec![Box::new(KillContainerShutdownStep::new(
+            POSTGRES_CONTAINER_NAME,
+        ))]
     }
 }

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -1,0 +1,193 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use clap::Parser;
+use diesel_async::{pg::AsyncPgConnection, AsyncConnection};
+use maplit::hashset;
+use processor::{
+    processors::{token_processor::TokenProcessorConfig, ProcessorConfig, ProcessorName},
+    utils::database::run_pending_migrations,
+    IndexerGrpcProcessorConfig,
+};
+use reqwest::Url;
+use server_framework::{run_server_with_config, GenericConfig};
+use std::collections::HashSet;
+use tokio::sync::OnceCell;
+use tracing::info;
+
+static RUN_MIGRATIONS_ONCE: OnceCell<bool> = OnceCell::const_new();
+
+/// This struct is used to parse the command line arguments for the processors.
+#[derive(Debug, Parser)]
+pub struct ProcessorArgs {
+    /// The value of this flag determines which processors we will run if
+    /// --with-indexer-api is set. Note that some processors are not supported in the
+    /// local testnet (e.g. ANS). If you try to set those, an error will be thrown
+    /// immediately.
+    #[clap(
+        long,
+        value_enum,
+        default_values_t = vec![
+            ProcessorName::AccountTransactionsProcessor,
+            ProcessorName::CoinProcessor,
+            ProcessorName::DefaultProcessor,
+            ProcessorName::EventsProcessor,
+            ProcessorName::FungibleAssetProcessor,
+            ProcessorName::StakeProcessor,
+            ProcessorName::TokenProcessor,
+            ProcessorName::TokenV2Processor,
+            ProcessorName::UserTransactionProcessor,
+        ],
+        requires = "with_indexer_api"
+    )]
+    processors: Vec<ProcessorName>,
+}
+
+#[derive(Debug)]
+pub struct ProcessorManager {
+    config: GenericConfig<IndexerGrpcProcessorConfig>,
+    prerequisite_health_checkers: HashSet<HealthChecker>,
+}
+
+impl ProcessorManager {
+    fn new(
+        processor_name: &ProcessorName,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        health_check_port: u16,
+        data_service_url: Url,
+        postgres_connection_string: String,
+    ) -> Result<Self> {
+        let processor_config = match processor_name {
+            ProcessorName::AccountTransactionsProcessor => {
+                ProcessorConfig::AccountTransactionsProcessor
+            },
+            ProcessorName::AnsProcessor => {
+                bail!("ANS processor is not supported in the local testnet")
+            },
+            ProcessorName::CoinProcessor => ProcessorConfig::CoinProcessor,
+            ProcessorName::DefaultProcessor => ProcessorConfig::DefaultProcessor,
+            ProcessorName::EventsProcessor => ProcessorConfig::EventsProcessor,
+            ProcessorName::FungibleAssetProcessor => ProcessorConfig::FungibleAssetProcessor,
+            ProcessorName::NftMetadataProcessor => {
+                bail!("NFT Metadata processor is not supported in the local testnet")
+            },
+            ProcessorName::StakeProcessor => ProcessorConfig::StakeProcessor,
+            ProcessorName::TokenProcessor => {
+                ProcessorConfig::TokenProcessor(TokenProcessorConfig {
+                    // This NFT points thing doesn't exist on local testnets.
+                    nft_points_contract: None,
+                })
+            },
+            ProcessorName::TokenV2Processor => ProcessorConfig::TokenV2Processor,
+            ProcessorName::UserTransactionProcessor => ProcessorConfig::UserTransactionProcessor,
+        };
+        let server_config = IndexerGrpcProcessorConfig {
+            processor_config,
+            postgres_connection_string,
+            indexer_grpc_data_service_address: data_service_url,
+            auth_token: "notused".to_string(),
+            grpc_http2_config: Default::default(),
+            starting_version: None,
+            ending_version: None,
+            number_concurrent_processing_tasks: None,
+        };
+        let config = GenericConfig {
+            server_config,
+            health_check_port,
+        };
+        let manager = Self {
+            config,
+            prerequisite_health_checkers,
+        };
+        Ok(manager)
+    }
+
+    /// This function returns many new ProcessorManagers, one for each processor.
+    pub fn many_new(
+        args: &RunLocalTestnet,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        data_service_url: Url,
+        postgres_connection_string: String,
+    ) -> Result<Vec<Self>> {
+        if args.processor_args.processors.is_empty() {
+            bail!("Must specify at least one processor to run");
+        }
+        let mut managers = Vec::new();
+        let mut health_check_port = 43234;
+        for processor_name in &args.processor_args.processors {
+            managers.push(Self::new(
+                processor_name,
+                prerequisite_health_checkers.clone(),
+                health_check_port,
+                data_service_url.clone(),
+                postgres_connection_string.clone(),
+            )?);
+            health_check_port += 1;
+        }
+        Ok(managers)
+    }
+
+    /// Ccreate the necessary tables in the DB for the processors to work.
+    async fn run_migrations(&self) -> Result<()> {
+        let connection_string = &self.config.server_config.postgres_connection_string;
+        let mut connection = AsyncPgConnection::establish(connection_string)
+            .await
+            .with_context(|| format!("Failed to connect to postgres at {}", connection_string))?;
+        run_pending_migrations(&mut connection).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ServiceManager for ProcessorManager {
+    fn get_name(&self) -> String {
+        format!(
+            "processor_{}",
+            self.config.server_config.processor_config.name()
+        )
+    }
+
+    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+        hashset![HealthChecker::Http(
+            Url::parse(&format!(
+                "http://127.0.0.1:{}",
+                self.config.health_check_port
+            ))
+            .unwrap(),
+            self.get_name(),
+        )]
+    }
+
+    fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
+        self.prerequisite_health_checkers.iter().collect()
+    }
+
+    async fn run_service(self: Box<Self>) -> Result<()> {
+        // By default, when a processor starts up (specifically in Worker.run) it runs
+        // any pending migrations. Unfortunately, if you start multiple processors at
+        // the same time, they can sometimes clash with errors like this:
+        //
+        // https://stackoverflow.com/q/54351783/3846032
+        //
+        // To fix this, we run the migrations ourselves here in the CLI first. We use
+        // std::sync::Once to make sure we only run the migration once even though we
+        // call all the processor service managers get to this point. This is safer
+        // than relying on coordiation outside of this manager.
+        RUN_MIGRATIONS_ONCE
+            .get_or_init(|| async {
+                info!("Running DB migrations for the indexer processors");
+                self.run_migrations()
+                    .await
+                    .expect("Failed to run DB migrations");
+                info!("Ran DB migrations for the indexer processors");
+                true
+            })
+            .await;
+
+        // Run the processor.
+        run_server_with_config(self.config, tokio::runtime::Handle::current()).await
+    }
+}

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -46,6 +46,7 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
+        let name_clone = name.to_string();
         let future = async move {
             for health_checker in self.get_prerequisite_health_checkers() {
                 health_checker
@@ -56,7 +57,10 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
             self.run_service()
                 .await
                 .context("Service ended with an error")?;
-            warn!("Service ended unexpectedly without any error");
+            warn!(
+                "Service {} ended unexpectedly without any error",
+                name_clone
+            );
             Ok(())
         };
         tokio::spawn(future.map(move |result: Result<()>| {

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -75,6 +75,15 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
         vec![]
     }
 
+    /// The ServiceManager may return ShutdownSteps. The tool will run these on shutdown.
+    /// This is best effort, there is nothing we can do if part of the code aborts or
+    /// the process receives something like SIGKILL.
+    ///
+    /// See `ShutdownStep` for more information.
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        vec![]
+    }
+
     /// This function is responsible for running the service. It should return an error
     /// if the service ends unexpectedly. It gets called by `run`.
     async fn run_service(self: Box<Self>) -> Result<()>;
@@ -82,9 +91,18 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
 
 /// If a service wants to do something after it is healthy, it can define a struct,
 /// implement this trait for it, and return an instance of it.
-//
-// For more information see `get_post_healthy_steps` in `ServiceManager`.
+///
+/// For more information see `get_post_healthy_steps` in `ServiceManager`.
 #[async_trait]
 pub trait PostHealthyStep: Debug + Send + Sync + 'static {
+    async fn run(self: Box<Self>) -> Result<()>;
+}
+
+/// If a service wants to do something on shutdown, it can define a struct,
+/// implement this trait for it, and return an instance of it.
+///
+/// For more information see `get_shutdown_steps` in `ServiceManager`.
+#[async_trait]
+pub trait ShutdownStep: Debug + Send + Sync + 'static {
     async fn run(self: Box<Self>) -> Result<()>;
 }

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -4,9 +4,7 @@
 use super::health_checker::HealthChecker;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::FutureExt;
 use std::{collections::HashSet, fmt::Debug};
-use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[async_trait]
@@ -40,32 +38,28 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
     fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker>;
 
     /// This is the function we use from the outside to start the service. It makes
-    /// sure all the prerequisite services have started and then spawns a tokio task to
-    /// run the service. The user should never need to override this implementation.
-    fn run(self: Box<Self>) -> JoinHandle<()> {
+    /// sure all the prerequisite services have started and then calls the inner
+    /// function to run the service. The user should never need to override this
+    /// implementation.
+    async fn run(self: Box<Self>) -> Result<()> {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
         let name_clone = name.to_string();
-        let future = async move {
-            for health_checker in self.get_prerequisite_health_checkers() {
-                health_checker
-                    .wait(Some(&self.get_name()))
-                    .await
-                    .context("Prerequisite service did not start up successfully")?;
-            }
-            self.run_service()
+        for health_checker in self.get_prerequisite_health_checkers() {
+            health_checker
+                .wait(Some(&self.get_name()))
                 .await
-                .context("Service ended with an error")?;
-            warn!(
-                "Service {} ended unexpectedly without any error",
-                name_clone
-            );
-            Ok(())
-        };
-        tokio::spawn(future.map(move |result: Result<()>| {
-            warn!("{} stopped unexpectedly {:#?}", name, result);
-        }))
+                .context("Prerequisite service did not start up successfully")?;
+        }
+        self.run_service()
+            .await
+            .context("Service ended with an error")?;
+        warn!(
+            "Service {} ended unexpectedly without any error",
+            name_clone
+        );
+        Ok(())
     }
 
     /// The ServiceManager may return PostHealthySteps. The tool will run these after

--- a/crates/aptos/src/node/local_testnet/utils.rs
+++ b/crates/aptos/src/node/local_testnet/utils.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::traits::ShutdownStep;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
+use bollard::{container::RemoveContainerOptions, image::CreateImageOptions, Docker};
+use futures::TryStreamExt;
 use reqwest::Url;
-use std::{fs::create_dir_all, net::SocketAddr, path::Path, process::Stdio};
-use tokio::process::Command;
+use std::{fs::create_dir_all, net::SocketAddr, path::Path};
 use tracing::info;
 
 pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url> {
@@ -18,22 +19,18 @@ pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url>
     Ok(Url::parse(&full_url)?)
 }
 
+pub fn get_docker() -> Result<Docker> {
+    let docker = Docker::connect_with_local_defaults()
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
+    Ok(docker)
+}
+
 pub async fn confirm_docker_available() -> Result<()> {
-    let status = Command::new("docker")
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+    let docker = get_docker()?;
+    docker
+        .info()
         .await
-        .context("Failed to check if Docker is available")?;
-
-    if !status.success() {
-        bail!(
-            "Docker is not available, confirm it is installed and running: {:?}",
-            status
-        );
-    }
-
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
     Ok(())
 }
 
@@ -44,18 +41,15 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
         container_name
     );
 
-    let _ = Command::new("docker")
-        .arg("rm")
-        .arg("-f")
-        .arg(container_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context(format!(
-            "Failed to remove existing container with name {}",
-            container_name
-        ))?;
+    let docker = get_docker()?;
+
+    let options = Some(RemoveContainerOptions {
+        force: true,
+        ..Default::default()
+    });
+
+    // Ignore any error, it'll be because the container doesn't exist.
+    let _ = docker.remove_container(container_name, options).await;
 
     info!(
         "Removed any existing postgres container with name {}",
@@ -67,19 +61,28 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
 
 pub async fn pull_docker_image(image_name: &str) -> Result<()> {
     info!("Pulling docker image {}", image_name);
-    let status = Command::new("docker")
-        .arg("pull")
-        .arg(image_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context("Failed to pull postgres image")?;
-    info!("Pulled docker image {}", image_name);
 
-    if !status.success() {
-        bail!("Failed to pull postgres image: {:?}", status);
-    }
+    let docker = get_docker()?;
+
+    let options = Some(CreateImageOptions {
+        from_image: image_name,
+        ..Default::default()
+    });
+
+    // Check if the image is there. If not, print that we'll pull it.
+    if docker.inspect_image(image_name).await.is_err() {
+        eprintln!("Image {} not found, pulling it now", image_name);
+    };
+
+    // The docker pull CLI command is just sugar around this API.
+    docker
+        .create_image(options, None, None)
+        // Just wait for the whole stream, we don't need to do other things in parallel.
+        .try_collect::<Vec<_>>()
+        .await
+        .with_context(|| format!("Failed to pull image {}", image_name))?;
+
+    info!("Pulled docker image {}", image_name);
 
     Ok(())
 }
@@ -88,11 +91,7 @@ pub async fn pull_docker_image(image_name: &str) -> Result<()> {
 /// file called README.md that tells the user where to go to see logs. We do this since
 /// having the user use `docker logs` is the preferred approach. To help debug any
 /// potential startup failures however, we also create files for the command to write to.
-pub fn setup_docker_logging(
-    test_dir: &Path,
-    dir_name: &str,
-    container_name: &str,
-) -> Result<(Stdio, Stdio)> {
+pub fn setup_docker_logging(test_dir: &Path, dir_name: &str, container_name: &str) -> Result<()> {
     // Create dir.
     let log_dir = test_dir.join(dir_name);
     create_dir_all(log_dir.as_path()).context(format!("Failed to create {}", log_dir.display()))?;
@@ -104,25 +103,7 @@ pub fn setup_docker_logging(
     );
     std::fs::write(log_dir.join("README.md"), data).context("Unable to write README file")?;
 
-    // Create file for stdout.
-    let path = log_dir.join("stdout.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stdout = Stdio::from(file);
-
-    // Create file for stderr.
-    let path = log_dir.join("stderr.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stderr = Stdio::from(file);
-
-    Ok((stdout, stderr))
+    Ok(())
 }
 
 /// This shutdown step forcibly kills a container with the given name. If no container

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -100,7 +100,10 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
-            RunLocalTestnet(tool) => tool.execute_serialized_without_logger().await,
+            RunLocalTestnet(tool) => tool
+                .execute_serialized_without_logger()
+                .await
+                .map(|_| "".to_string()),
             UpdateConsensusKey(tool) => tool.execute_serialized().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
         }


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/10271
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/10310

### Description
This PR adds support for running indexer processors to the local testnet. The processors you run is configurable with `--processors`, which uses the new `ProcessorName` enum.

Note: I will update the dependency from that branch to a specific rev later.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api
```
```
Readiness endpoint: http://0.0.0.0:8070/

Postgres is starting, please wait...
Transaction stream is starting, please wait...
Node API is starting, please wait...
Faucet is starting, please wait...

Completed generating configuration:
        Log file: "/Users/dport/.aptos/testnet/validator.log"
        Test dir: "/Users/dport/.aptos/testnet"
        Aptos root key path: "/Users/dport/.aptos/testnet/mint.key"
        Waypoint: 0:2cc2b83a3435b6b38f5f8ef84afe96aef2458c524445d3d72cd55b0459e627c5
        ChainId: 4
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9101/metrics
        Aptosnet fullnode network endpoint: /ip4/0.0.0.0/tcp/6181
        Indexer gRPC node stream endpoint: 0.0.0.0:50051

Aptos is running, press ctrl-c to exit

Node API is ready. Endpoint: http://0.0.0.0:8080/
Postgres is ready. Endpoint: postgres://postgres@127.0.0.1:5433/local_testnet
Transaction stream is ready. Endpoint: http://0.0.0.0:50051/
Faucet is ready. Endpoint: http://127.0.0.1:8081/

Applying post startup steps...

Setup is complete, you can now use the local testnet!
```

```
local_testnet-# \x
Expanded display is on.
local_testnet-# select * from events limit 1;
ERROR:  syntax error at or near "select"
LINE 2: select * from events limit 1
        ^
local_testnet=# select * from events limit 1;
-[ RECORD 1 ]------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
sequence_number          | 3
creation_number          | 3
account_address          | 0x0000000000000000000000000000000000000000000000000000000000000001
transaction_version      | 4
transaction_block_height | 3
type                     | 0x1::block::NewBlockEvent
data                     | {"hash": "0x1cce75abaf027f116439ef26040f64f6d5337f6a04f0b093bed08a51b3da5981", "epoch": "2", "round": "2", "height": "3", "proposer": "0xa03f668876e2ec4d37d3b7f33ad29b5d01c777a189c2dfc0b03d67046c19c7d9", "time_microseconds": "1695901972557097", "failed_proposer_indices": [], "previous_block_votes_bitvec": "0x80"}
inserted_at              | 2023-09-28 11:52:53.356014
event_index              | 0

local_testnet=#
```

I also tested that works when using `--with-host-postgres`:
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api --postgres-user $USER --use-host-postgres
```