### PR TITLE
[marketplace / framework] Fix divide by zero and marketplace royalty edge conditions

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -40,18 +40,9 @@ Standard math utilities missing in the Move Language.
 ## Constants
 
 
-<a name="0x1_math128_EDIVISION_BY_ZERO"></a>
-
-
-
-<pre><code><b>const</b> <a href="math128.md#0x1_math128_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 2;
-</code></pre>
-
-
-
 <a name="0x1_math128_EINVALID_ARG_FLOOR_LOG2"></a>
 
-Abort value when an invalid argument is provided.
+Cannot log2 the value 0
 
 
 <pre><code><b>const</b> <a href="math128.md#0x1_math128_EINVALID_ARG_FLOOR_LOG2">EINVALID_ARG_FLOOR_LOG2</a>: u64 = 1;
@@ -142,7 +133,7 @@ Return the average of two.
 
 ## Function `mul_div`
 
-Returns a * b / c going through u128 to prevent intermediate overflow
+Returns a * b / c going through u256 to prevent intermediate overflow
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_mul_div">mul_div</a>(a: u128, b: u128, c: u128): u128
@@ -155,6 +146,8 @@ Returns a * b / c going through u128 to prevent intermediate overflow
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_mul_div">mul_div</a>(a: u128, b: u128, c: u128): u128 {
+    // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
+    <b>assert</b>!(c != 0, std::error::invalid_argument(4));
     (((a <b>as</b> u256) * (b <b>as</b> u256) / (c <b>as</b> u256)) <b>as</b> u128)
 }
 </code></pre>
@@ -404,7 +397,8 @@ Returns square root of x, precisely floor(sqrt(x))
     // <a href="math128.md#0x1_math128_ceil_div">ceil_div</a>(x, y) = floor((x + y - 1) / y) = floor((x - 1) / y) + 1
     // (x + y - 1) could spuriously overflow. so we <b>use</b> the later version
     <b>if</b> (x == 0) {
-        <b>assert</b>!(y != 0, <a href="math128.md#0x1_math128_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>);
+        // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
+        <b>assert</b>!(y != 0, std::error::invalid_argument(4));
         0
     }
     <b>else</b> (x - 1) / y + 1

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -38,18 +38,9 @@ Standard math utilities missing in the Move Language.
 ## Constants
 
 
-<a name="0x1_math64_EDIVISION_BY_ZERO"></a>
-
-
-
-<pre><code><b>const</b> <a href="math64.md#0x1_math64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 1;
-</code></pre>
-
-
-
 <a name="0x1_math64_EINVALID_ARG_FLOOR_LOG2"></a>
 
-Abort value when an invalid argument is provided.
+Cannot log2 the value 0
 
 
 <pre><code><b>const</b> <a href="math64.md#0x1_math64_EINVALID_ARG_FLOOR_LOG2">EINVALID_ARG_FLOOR_LOG2</a>: u64 = 1;
@@ -153,6 +144,8 @@ Returns a * b / c going through u128 to prevent intermediate overflow
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_mul_div">mul_div</a>(a: u64, b: u64, c: u64): u64 {
+    // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
+    <b>assert</b>!(c != 0, std::error::invalid_argument(4));
     (((a <b>as</b> u128) * (b <b>as</b> u128) / (c <b>as</b> u128)) <b>as</b> u64)
 }
 </code></pre>
@@ -359,7 +352,8 @@ Returns square root of x, precisely floor(sqrt(x))
     // <a href="math64.md#0x1_math64_ceil_div">ceil_div</a>(x, y) = floor((x + y - 1) / y) = floor((x - 1) / y) + 1
     // (x + y - 1) could spuriously overflow. so we <b>use</b> the later version
     <b>if</b> (x == 0) {
-        <b>assert</b>!(y != 0, <a href="math64.md#0x1_math64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>);
+        // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
+        <b>assert</b>!(y != 0, std::error::invalid_argument(4));
         0
     }
     <b>else</b> (x - 1) / y + 1
@@ -373,22 +367,6 @@ Returns square root of x, precisely floor(sqrt(x))
 <a name="@Specification_1"></a>
 
 ## Specification
-
-
-
-<a name="0x1_math64_spec_pow"></a>
-
-
-<pre><code><b>fun</b> <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n: u64, e: u64): u64 {
-   <b>if</b> (e == 0) {
-       1
-   }
-   <b>else</b> {
-       n * <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n, e-1)
-   }
-}
-</code></pre>
-
 
 
 <a name="@Specification_1_max"></a>
@@ -517,6 +495,22 @@ Returns square root of x, precisely floor(sqrt(x))
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] x &gt; 0 ==&gt; result * result &lt;= x;
 <b>ensures</b> [abstract] x &gt; 0 ==&gt; x &lt; (result+1) * (result+1);
+</code></pre>
+
+
+
+
+<a name="0x1_math64_spec_pow"></a>
+
+
+<pre><code><b>fun</b> <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n: u64, e: u64): u64 {
+   <b>if</b> (e == 0) {
+       1
+   }
+   <b>else</b> {
+       n * <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n, e-1)
+   }
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -4,9 +4,8 @@ module aptos_std::math64 {
     use std::fixed_point32::FixedPoint32;
     use std::fixed_point32;
 
-    /// Abort value when an invalid argument is provided.
+    /// Cannot log2 the value 0
     const EINVALID_ARG_FLOOR_LOG2: u64 = 1;
-    const EDIVISION_BY_ZERO: u64 = 1;
 
     /// Return the largest of two numbers.
     public fun max(a: u64, b: u64): u64 {
@@ -29,6 +28,8 @@ module aptos_std::math64 {
 
     /// Returns a * b / c going through u128 to prevent intermediate overflow
     public inline fun mul_div(a: u64, b: u64, c: u64): u64 {
+        // Inline functions cannot take constants, as then every module using it needs the constant
+        assert!(c != 0, std::error::invalid_argument(4));
         (((a as u128) * (b as u128) / (c as u128)) as u64)
     }
 
@@ -116,7 +117,8 @@ module aptos_std::math64 {
         // ceil_div(x, y) = floor((x + y - 1) / y) = floor((x - 1) / y) + 1
         // (x + y - 1) could spuriously overflow. so we use the later version
         if (x == 0) {
-            assert!(y != 0, EDIVISION_BY_ZERO);
+            // Inline functions cannot take constants, as then every module using it needs the constant
+            assert!(y != 0, std::error::invalid_argument(4));
             0
         }
         else (x - 1) / y + 1
@@ -187,6 +189,12 @@ module aptos_std::math64 {
         assert!(mul_div(tmp,5,5) == tmp, 0);
         // Note that ordering other way is imprecise.
         assert!((tmp / 5) * 5 != tmp, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0x10004, location = aptos_std::math64)]
+    public entry fun test_mul_div_by_zero() {
+        mul_div(1, 1, 0);
     }
 
     #[test]

--- a/aptos-move/move-examples/marketplace/sources/coin_listing.move
+++ b/aptos-move/move-examples/marketplace/sources/coin_listing.move
@@ -13,6 +13,7 @@ module coin_listing {
     use std::option::{Self, Option};
     use std::signer;
     use std::string::{Self, String};
+    use aptos_std::math64;
 
     use aptos_framework::coin::{Self, Coin};
     use aptos_framework::object::{Self, ConstructorRef, Object, ObjectCore};
@@ -494,15 +495,19 @@ module coin_listing {
         let (royalty_addr, royalty_charge) = listing::compute_royalty(object, price);
         let (seller, fee_schedule) = listing::close(completer, object, purchaser_addr);
 
-        let commission_charge = fee_schedule::commission(fee_schedule, price);
-        let commission = coin::extract(&mut coins, commission_charge);
-        aptos_account::deposit_coins(fee_schedule::fee_address(fee_schedule), commission);
-
+        // Take royalty first
         if (royalty_charge != 0) {
             let royalty = coin::extract(&mut coins, royalty_charge);
             aptos_account::deposit_coins(royalty_addr, royalty);
         };
 
+        // Take commission of what's left, creators get paid first
+        let commission_charge = fee_schedule::commission(fee_schedule, price);
+        let actual_commission_charge = math64::min(coin::value(&coins), commission_charge);
+        let commission = coin::extract(&mut coins, actual_commission_charge);
+        aptos_account::deposit_coins(fee_schedule::fee_address(fee_schedule), commission);
+
+        // Seller gets what is left
         aptos_account::deposit_coins(seller, coins);
 
         events::emit_listing_filled(
@@ -625,6 +630,7 @@ module listing_tests {
     use aptos_token::token as tokenv1;
 
     use aptos_token_objects::token::Token;
+    use marketplace::test_utils::{mint_tokenv2_with_collection_royalty, mint_tokenv1_additional_royalty, mint_tokenv1};
 
     use marketplace::coin_listing;
     use marketplace::fee_schedule::FeeSchedule;
@@ -654,6 +660,35 @@ module listing_tests {
         assert!(object::owner(token) == purchaser_addr, 0);
         assert!(coin::balance<AptosCoin>(marketplace_addr) == 6, 0);
         assert!(coin::balance<AptosCoin>(seller_addr) == 10494, 0);
+        assert!(coin::balance<AptosCoin>(purchaser_addr) == 9500, 0);
+    }
+
+    #[test(aptos_framework = @0x1, marketplace = @0x111, seller = @0x222, purchaser = @0x333)]
+    fun test_fixed_price_high_royalty(
+        aptos_framework: &signer,
+        marketplace: &signer,
+        seller: &signer,
+        purchaser: &signer,
+    ) {
+        let (marketplace_addr, seller_addr, purchaser_addr) =
+            test_utils::setup(aptos_framework, marketplace, seller, purchaser);
+        // TODO: add test that separates seller and creator
+        let (_collection, additional_token) = mint_tokenv2_with_collection_royalty(seller, 100, 100);
+        let (token, fee_schedule, listing) = fixed_price_listing_with_token(marketplace, seller, additional_token);
+
+        assert!(coin::balance<AptosCoin>(marketplace_addr) == 1, 0);
+        assert!(coin::balance<AptosCoin>(seller_addr) == 9999, 0);
+        assert!(listing::listed_object(listing) == object::convert(token), 0);
+        assert!(listing::fee_schedule(listing) == fee_schedule, 0);
+        assert!(coin_listing::price<AptosCoin>(listing) == option::some(500), 0);
+        assert!(!coin_listing::is_auction<AptosCoin>(listing), 0);
+
+        coin_listing::purchase<AptosCoin>(purchaser, listing);
+
+        assert!(object::owner(token) == purchaser_addr, 0);
+        // Because royalty is 100, no commission is taken just the listing fee
+        assert!(coin::balance<AptosCoin>(marketplace_addr) == 1, 0);
+        assert!(coin::balance<AptosCoin>(seller_addr) == 10499, 0);
         assert!(coin::balance<AptosCoin>(purchaser_addr) == 9500, 0);
     }
 
@@ -1024,6 +1059,14 @@ module listing_tests {
         seller: &signer,
     ): (Object<Token>, Object<FeeSchedule>, Object<Listing>) {
         let token = test_utils::mint_tokenv2(seller);
+        fixed_price_listing_with_token(marketplace, seller, token)
+    }
+
+    inline fun fixed_price_listing_with_token(
+        marketplace: &signer,
+        seller: &signer,
+        token: Object<Token>
+    ): (Object<Token>, Object<FeeSchedule>, Object<Listing>) {
         let fee_schedule = test_utils::fee_schedule(marketplace);
         let listing = coin_listing::init_fixed_price_internal<AptosCoin>(
             seller,
@@ -1034,6 +1077,7 @@ module listing_tests {
         );
         (token, fee_schedule, listing)
     }
+
 
     inline fun auction_listing(
         marketplace: &signer,
@@ -1071,6 +1115,45 @@ module listing_tests {
         let (token_id, _fee_schedule, listing) = fixed_price_listing_for_tokenv1(marketplace, seller);
         coin_listing::purchase<AptosCoin>(purchaser, listing);
         assert!(tokenv1::balance_of(purchaser_addr, token_id) == 1, 0);
+    }
+
+    #[test(aptos_framework = @0x1, marketplace = @0x111, seller = @0x222, purchaser = @0x333)]
+    fun test_fixed_price_for_token_v1_high_royalty(
+        aptos_framework: &signer,
+        marketplace: &signer,
+        seller: &signer,
+        purchaser: &signer,
+    ) {
+        let (_marketplace_addr, _seller_addr, purchaser_addr) =
+            test_utils::setup(aptos_framework, marketplace, seller, purchaser);
+        tokenv1::opt_in_direct_transfer(purchaser, true);
+        let _token = mint_tokenv1(seller);
+        let token_id = mint_tokenv1_additional_royalty(seller, 100, 100);
+
+        let (_fee_schedule, listing) = fixed_price_listing_for_tokenv1_with_token(marketplace, seller, &token_id);
+        coin_listing::purchase<AptosCoin>(purchaser, listing);
+        assert!(tokenv1::balance_of(purchaser_addr, token_id) == 1, 0);
+        // TODO balance checks
+    }
+
+    #[test(aptos_framework = @0x1, marketplace = @0x111, seller = @0x222, purchaser = @0x333)]
+    fun test_fixed_price_for_token_v1_bad_royalty(
+        aptos_framework: &signer,
+        marketplace: &signer,
+        seller: &signer,
+        purchaser: &signer,
+    ) {
+        let (_marketplace_addr, _seller_addr, purchaser_addr) =
+            test_utils::setup(aptos_framework, marketplace, seller, purchaser);
+        tokenv1::opt_in_direct_transfer(purchaser, true);
+        let _token = mint_tokenv1(seller);
+        let token_id = mint_tokenv1_additional_royalty(seller, 0, 0);
+
+        let (_fee_schedule, listing) = fixed_price_listing_for_tokenv1_with_token(marketplace, seller, &token_id);
+        // This should not fail, and no royalty is taken
+        coin_listing::purchase<AptosCoin>(purchaser, listing);
+        assert!(tokenv1::balance_of(purchaser_addr, token_id) == 1, 0);
+        // TODO balance checks
     }
 
     #[test(aptos_framework = @0x1, marketplace = @0x111, seller = @0x222, purchaser = @0x333)]
@@ -1128,8 +1211,17 @@ module listing_tests {
         seller: &signer,
     ): (tokenv1::TokenId, Object<FeeSchedule>, Object<Listing>) {
         let token_id = test_utils::mint_tokenv1(seller);
+        let (fee_schedule, listing) = fixed_price_listing_for_tokenv1_with_token(marketplace, seller, &token_id);
+        (token_id, fee_schedule, listing)
+    }
+
+    inline fun fixed_price_listing_for_tokenv1_with_token(
+        marketplace: &signer,
+        seller: &signer,
+        token_id: &tokenv1::TokenId,
+    ): (Object<FeeSchedule>, Object<Listing>) {
         let (creator_addr, collection_name, token_name, property_version) =
-            tokenv1::get_token_id_fields(&token_id);
+            tokenv1::get_token_id_fields(token_id);
         let fee_schedule = test_utils::fee_schedule(marketplace);
         let listing = coin_listing::init_fixed_price_for_tokenv1_internal<AptosCoin>(
             seller,
@@ -1141,7 +1233,7 @@ module listing_tests {
             timestamp::now_seconds(),
             500,
         );
-        (token_id, fee_schedule, listing)
+        (fee_schedule, listing)
     }
 
     inline fun auction_listing_for_tokenv1(

--- a/aptos-move/move-examples/marketplace/sources/collection_offer.move
+++ b/aptos-move/move-examples/marketplace/sources/collection_offer.move
@@ -11,6 +11,7 @@ module collection_offer {
     use std::option::{Self, Option};
     use std::signer;
     use std::string::String;
+    use aptos_std::math64;
 
     use aptos_framework::coin::{Self, Coin};
     use aptos_framework::object::{Self, DeleteRef, Object};
@@ -388,15 +389,19 @@ module collection_offer {
         let coin_offer = borrow_global_mut<CoinOffer<CoinType>>(collection_offer_addr);
         let coins = coin::extract(&mut coin_offer.coins, price);
 
-        let royalty_charge = price * royalty_numerator / royalty_denominator;
+        let royalty_charge = listing::bounded_percentage(price, royalty_numerator, royalty_denominator);
+
         let royalties = coin::extract(&mut coins, royalty_charge);
         aptos_account::deposit_coins(royalty_payee, royalties);
 
+        // Commission can only be of whatever is left
         let fee_schedule = collection_offer_obj.fee_schedule;
         let commission_charge = fee_schedule::commission(fee_schedule, price);
-        let commission = coin::extract(&mut coins, commission_charge);
+        let actual_commission_charge = math64::min(commission_charge, coin::value(&coins));
+        let commission = coin::extract(&mut coins, actual_commission_charge);
         aptos_account::deposit_coins(fee_schedule::fee_address(fee_schedule), commission);
 
+        // Seller gets what is left
         aptos_account::deposit_coins(seller, coins);
 
         events::emit_collection_offer_filled(
@@ -570,6 +575,43 @@ module collection_offer_tests {
         assert!(coin::balance<AptosCoin>(marketplace_addr) == 11, 0);
         assert!(coin::balance<AptosCoin>(purchaser_addr) == 9489, 0);
         assert!(coin::balance<AptosCoin>(seller_addr) == 10500, 0);
+        assert!(object::is_owner(token, purchaser_addr), 0);
+        assert!(!collection_offer::exists_at(collection_offer), 0);
+    }
+
+    #[test(aptos_framework = @0x1, marketplace = @0x111, seller = @0x222, purchaser = @0x333)]
+    fun test_token_v2_high_royalty(
+        aptos_framework: &signer,
+        marketplace: &signer,
+        seller: &signer,
+        purchaser: &signer,
+    ) {
+        let (marketplace_addr, seller_addr, purchaser_addr) =
+            test_utils::setup(aptos_framework, marketplace, seller, purchaser);
+        let (collection, token) = test_utils::mint_tokenv2_with_collection_royalty(seller, 1, 1);
+        assert!(object::is_owner(token, seller_addr), 0);
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
+            purchaser,
+            collection,
+            test_utils::fee_schedule(marketplace),
+            500,
+            2,
+            timestamp::now_seconds() + 200,
+        );
+        assert!(!collection_offer::expired(collection_offer), 0);
+        assert!(collection_offer::expiration_time(collection_offer) == timestamp::now_seconds() + 200, 0);
+        assert!(collection_offer::price(collection_offer) == 500, 0);
+
+        assert!(collection_offer::remaining(collection_offer) == 2, 0);
+        assert!(coin::balance<AptosCoin>(marketplace_addr) == 1, 0);
+        assert!(coin::balance<AptosCoin>(purchaser_addr) == 8999, 0);
+        assert!(coin::balance<AptosCoin>(seller_addr) == 10000, 0);
+
+        collection_offer::sell_tokenv2<AptosCoin>(seller, collection_offer, token);
+        assert!(object::is_owner(token, purchaser_addr), 0);
+        assert!(collection_offer::remaining(collection_offer) == 1, 0);
+
+        collection_offer::sell_tokenv2<AptosCoin>(purchaser, collection_offer, token);
         assert!(object::is_owner(token, purchaser_addr), 0);
         assert!(!collection_offer::exists_at(collection_offer), 0);
     }

--- a/aptos-move/move-examples/marketplace/sources/fee_schedule.move
+++ b/aptos-move/move-examples/marketplace/sources/fee_schedule.move
@@ -6,6 +6,7 @@ module marketplace::fee_schedule {
     use std::error;
     use std::signer;
     use std::string::{Self, String};
+    use aptos_std::math64;
 
     use aptos_std::type_info;
 
@@ -319,7 +320,7 @@ module marketplace::fee_schedule {
             borrow_global<FixedRateCommission>(fee_schedule_addr).commission
         } else if (exists<PercentageRateCommission>(fee_schedule_addr)) {
             let fees = borrow_global<PercentageRateCommission>(fee_schedule_addr);
-            ((price as u128) * (fees.numerator as u128) / (fees.denominator as u128) as u64)
+            math64::mul_div(price, fees.numerator, fees.denominator)
         } else {
             0
         }

--- a/aptos-move/move-examples/marketplace/sources/test_utils.move
+++ b/aptos-move/move-examples/marketplace/sources/test_utils.move
@@ -99,6 +99,45 @@ module marketplace::test_utils {
         (object::convert(collection_object), object::convert(aptos_token))
     }
 
+    public fun mint_tokenv2_with_collection_royalty(
+        seller: &signer,
+        royalty_numerator: u64,
+        royalty_denominator: u64
+    ): (Object<Collection>, Object<Token>) {
+        let collection_name = string::utf8(b"collection_name");
+
+        let collection_object = aptos_token::create_collection_object(
+            seller,
+            string::utf8(b"collection description"),
+            2,
+            collection_name,
+            string::utf8(b"collection uri"),
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            royalty_numerator,
+            royalty_denominator,
+        );
+
+        let aptos_token = aptos_token::mint_token_object(
+            seller,
+            collection_name,
+            string::utf8(b"description"),
+            string::utf8(b"token_name"),
+            string::utf8(b"uri"),
+            vector::empty(),
+            vector::empty(),
+            vector::empty(),
+        );
+        (object::convert(collection_object), object::convert(aptos_token))
+    }
+
     public fun mint_tokenv2(seller: &signer): Object<Token> {
         let (_collection, token) = mint_tokenv2_with_collection(seller);
         token
@@ -172,6 +211,38 @@ module marketplace::test_utils {
             signer::address_of(seller),
             100,
             1,
+            vector[true, true, true, true, true],
+            vector::empty(),
+            vector::empty(),
+            vector::empty(),
+        );
+
+        tokenv1::create_token_id_raw(
+            signer::address_of(seller),
+            collection_name,
+            token_name,
+            0,
+        )
+    }
+
+    public fun mint_tokenv1_additional_royalty(
+        seller: &signer,
+        royalty_numerator: u64,
+        royalty_denominator: u64
+    ): tokenv1::TokenId {
+        let collection_name = string::utf8(b"collection_name");
+        let token_name = string::utf8(b"token_name_2");
+        tokenv1::create_token_script(
+            seller,
+            collection_name,
+            token_name,
+            string::utf8(b"Hello, Token"),
+            1,
+            1,
+            string::utf8(b"https://aptos.dev"),
+            signer::address_of(seller),
+            royalty_denominator,
+            royalty_numerator,
             vector[true, true, true, true, true],
             vector::empty(),
             vector::empty(),


### PR DESCRIPTION
### Description
Adds an error message for a divide by zero error in the aptos stdlib and handles divide by 0 in royalties in the example marketplace contract.

Additionally, adds checks for royalty 100% or 0 denominator in the marketplace, and ensures that listings go through rather than get stuck with insufficient balance errors.

Choices in the marketplace were:
1. Take royalty and commission from full amount, then make one taken before the other (I chose this, where commission is taken second)
2. Take the commission first, then take the royalty percentage from the remaining amount
3. Take the royalty first then take the commission percentage / amount from the remaining amount

### Test Plan
See unit tests