### PR TITLE
[CLI] Add support for running postgres in a container to the local testnet + rest of PRs in stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@
 !aptos-move/framework/
 !aptos-move/move-examples/hello_blockchain/
 !crates/aptos/src/move_tool/*.bpl
+!crates/aptos/src/node/local_testnet/hasura_metadata.json
 !crates/aptos-faucet/doc/
 !api/doc/
 !crates/indexer/migrations/**/*.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,8 @@ dependencies = [
  "clap_complete",
  "codespan-reporting",
  "dashmap",
+ "diesel",
+ "diesel-async",
  "dirs",
  "futures",
  "hex",
@@ -4324,7 +4326,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -5786,7 +5788,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2",
+ "socket2 0.4.9",
  "winapi 0.3.9",
 ]
 
@@ -6009,9 +6011,9 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "53c8a2cb22327206568569e5a45bb5a2c946455efdd76e24d15b7e82171af95e"
 dependencies = [
  "bigdecimal",
  "bitflags 2.4.0",
@@ -6028,10 +6030,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "diesel_derives"
-version = "2.1.0"
+name = "diesel-async"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+dependencies = [
+ "async-trait",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2 1.0.64",
@@ -6652,6 +6668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fallible_collections"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6711,6 +6733,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixed-hash"
@@ -7659,7 +7687,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -8734,6 +8762,15 @@ checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -11000,6 +11037,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64 0.21.2",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac 0.12.1",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "pprof"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12252,6 +12318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12930,6 +13006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12999,6 +13085,17 @@ dependencies = [
  "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -13497,7 +13594,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -13543,6 +13640,32 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.8.5",
+ "socket2 0.5.4",
+ "tokio",
+ "tokio-util 0.7.3",
+ "whoami",
 ]
 
 [[package]]
@@ -14605,9 +14728,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 dependencies = [
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "move-vm-runtime",
  "once_cell",
  "poem",
+ "processor",
  "rand 0.7.3",
  "regex",
  "reqwest",
@@ -288,6 +289,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "server-framework",
  "shadow-rs",
  "tempfile",
  "termcolor",
@@ -522,7 +524,7 @@ dependencies = [
  "move-bytecode-verifier",
  "num_cpus",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.12",
  "proptest",
  "rand 0.7.3",
  "regex",
@@ -1899,7 +1901,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-protos",
  "aptos-runtimes",
  "async-trait",
@@ -1931,7 +1933,7 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-protos",
  "aptos-runtimes",
  "async-trait",
@@ -1960,7 +1962,7 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-runtimes",
  "async-trait",
  "clap 4.3.21",
@@ -1996,7 +1998,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0",
  "aptos-proptest-helpers",
  "aptos-protos",
  "aptos-runtimes",
@@ -2155,6 +2157,18 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "warp",
+]
+
+[[package]]
+name = "aptos-indexer-protos"
+version = "1.0.9"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "pbjson",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "serde",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -2463,6 +2477,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-moving-average"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
 dependencies = [
@@ -2508,7 +2530,7 @@ dependencies = [
  "aptos-types",
  "bytes",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "serde",
  "tokio",
  "tokio-util 0.7.3",
@@ -2549,7 +2571,7 @@ dependencies = [
  "itertools",
  "maplit",
  "once_cell",
- "pin-project",
+ "pin-project 1.0.12",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -2986,7 +3008,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "tokio",
  "tokio-util 0.7.3",
 ]
@@ -3657,7 +3679,7 @@ dependencies = [
  "aptos-infallible",
  "enum_dispatch",
  "futures",
- "pin-project",
+ "pin-project 1.0.12",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -4282,6 +4304,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4638,6 +4673,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bb8"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot 0.12.1",
+ "tokio",
 ]
 
 [[package]]
@@ -6036,11 +6084,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
 dependencies = [
  "async-trait",
+ "bb8",
  "diesel",
  "futures-util",
  "scoped-futures",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_async_migrations"
+version = "0.11.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "diesel",
+ "diesel-async",
+ "macros",
+ "scoped-futures",
+ "tracing",
 ]
 
 [[package]]
@@ -6792,7 +6853,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "pin-project",
+ "pin-project 1.0.12",
  "spin 0.9.4",
 ]
 
@@ -6987,6 +7048,49 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+
+[[package]]
+name = "gcemeta"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d460327b24cc34c86d53d60a90e9e6044817f7906ebd9baa5c3d0ee13e1ecf"
+dependencies = [
+ "bytes",
+ "hyper",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a24376e7850e7864bb326debc5765a1dda4fc47603c22e2bc0ebf30ff59141b"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "gcemeta",
+ "hyper",
+ "jsonwebtoken 8.1.1",
+ "once_cell",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "reqwest",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic 0.9.2",
+ "tower",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "gcp-bigquery-client"
@@ -8251,7 +8355,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 1.1.0",
- "pin-project",
+ "pin-project 1.0.12",
  "rustls 0.20.6",
  "rustls-pemfile 0.2.1",
  "serde",
@@ -8713,6 +8817,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macros"
+version = "0.1.0"
+source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
 ]
 
 [[package]]
@@ -10792,11 +10905,31 @@ checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.12",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -11269,6 +11402,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "processor"
+version = "1.0.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "anyhow",
+ "aptos-indexer-protos",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5)",
+ "async-trait",
+ "base64 0.13.0",
+ "bcs 0.1.4",
+ "bigdecimal",
+ "chrono",
+ "clap 4.3.21",
+ "diesel",
+ "diesel-async",
+ "diesel_async_migrations",
+ "diesel_migrations",
+ "enum_dispatch",
+ "field_count",
+ "futures",
+ "futures-util",
+ "gcloud-sdk",
+ "google-cloud-googleapis",
+ "google-cloud-pubsub",
+ "hex",
+ "once_cell",
+ "prometheus",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "serde",
+ "serde_json",
+ "server-framework",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
+ "strum",
+ "tokio",
+ "tonic 0.9.2",
+ "tracing",
+ "unescape",
+ "url",
 ]
 
 [[package]]
@@ -11844,6 +12021,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes",
  "cookie",
@@ -12362,6 +12540,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f8cfb86d2019f64a4cfb49e499f401f406fbec946c1ffeea9d0504284347de"
+dependencies = [
+ "prost 0.12.1",
+ "prost-types 0.12.1",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12616,6 +12807,27 @@ dependencies = [
  "move-core-types",
  "proptest",
  "proptest-derive",
+]
+
+[[package]]
+name = "server-framework"
+version = "1.0.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backtrace",
+ "clap 4.3.21",
+ "futures",
+ "prometheus",
+ "serde",
+ "serde_yaml 0.8.26",
+ "tempfile",
+ "tokio",
+ "toml 0.7.4",
+ "tracing",
+ "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]
@@ -13139,6 +13351,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -13674,7 +13889,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.12",
  "rand 0.8.5",
  "tokio",
 ]
@@ -13839,7 +14054,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.11.9",
  "prost-derive 0.11.9",
  "tokio",
@@ -13872,8 +14087,9 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.11.9",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.1",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -13903,7 +14119,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "prost 0.12.1",
  "rustls-native-certs",
  "rustls-pemfile 1.0.1",
@@ -13938,7 +14154,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project",
+ "pin-project 1.0.12",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -14001,6 +14217,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
+
+[[package]]
 name = "trace"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14013,9 +14241,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -14026,13 +14254,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",
- "syn 1.0.105",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -14051,7 +14279,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.0.12",
  "tracing",
 ]
 
@@ -14229,6 +14457,12 @@ checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unic-char-property"
@@ -14534,7 +14768,7 @@ dependencies = [
  "mime_guess",
  "multer",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.0.12",
  "rustls-pemfile 1.0.1",
  "scoped-tls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bcs 0.1.4",
+ "bollard",
  "chrono",
  "clap 4.3.21",
  "clap_complete",
@@ -4928,6 +4929,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.15.0"
+source = "git+https://github.com/banool/bollard.git?rev=0bf0b43f736040bb3d4aacb20125fd2b4021733d#0bf0b43f736040bb3d4aacb20125fd2b4021733d"
+dependencies = [
+ "base64 0.21.2",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.3",
+ "url",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.43.0-rc.2"
+source = "git+https://github.com/banool/bollard.git?rev=0bf0b43f736040bb3d4aacb20125fd2b4021733d#0bf0b43f736040bb3d4aacb20125fd2b4021733d"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7839,6 +7878,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8028,6 +8080,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -12772,6 +12825,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "time 0.3.24",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6119,8 +6119,7 @@ dependencies = [
 [[package]]
 name = "diesel-async"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+source = "git+https://github.com/banool/diesel_async?rev=7115c8668b88d56029cb1471e84d2ea0234ff035#7115c8668b88d56029cb1471e84d2ea0234ff035"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,13 +472,8 @@ dashmap = "5.2.0"
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
-diesel = { version = "2.1.0", features = [
-    "chrono",
-    "postgres",
-    "r2d2",
-    "numeric",
-    "serde_json",
-] }
+diesel = "2.1.0"
+diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"
 dir-diff = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,7 +618,7 @@ threadpool = "1.8.1"
 time = { version = "0.3.24", features = ["serde"] }
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
-tracing = "0.1.34"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.80"
 tokio = { version = "1.21.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -594,6 +594,8 @@ sha2 = "0.9.3"
 sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 siphasher = "0.3.10"
+# For more information about why we are pinned to 1.0.149, see this issue:
+# https://github.com/aptos-labs/aptos-core/issues/10424
 serde = { version = "=1.0.149", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order", "arbitrary_precision"] } # Note: arbitrary_precision is required to parse u256 in JSON
@@ -730,3 +732,5 @@ debug = true
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
+# More context here: https://github.com/weiznich/diesel_async/pull/121.
+diesel-async = { git = "https://github.com/banool/diesel_async", rev = "7115c8668b88d56029cb1471e84d2ea0234ff035" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,6 +446,10 @@ bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"
 blst = "0.3.7"
+# We use a version of bollard where it relies on a lower version of serde_with.
+# Otherwise it imposes that we use serde 1.0.157, which we can't due to this issue:
+# https://github.com/aptos-labs/aptos-core/issues/10424
+bollard = { git = "https://github.com/banool/bollard.git", rev = "0bf0b43f736040bb3d4aacb20125fd2b4021733d" }
 bulletproofs = { version = "4.0.0" }
 byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
@@ -590,7 +594,6 @@ sha2 = "0.9.3"
 sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 siphasher = "0.3.10"
-# pin to 1.0.149 because the latest version fails analyze_serde_formats
 serde = { version = "=1.0.149", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order", "arbitrary_precision"] } # Note: arbitrary_precision is required to parse u256 in JSON

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -49,6 +49,7 @@ aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
+bollard = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env", "unstable-styles"] }
 clap_complete = { workspace = true }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -54,6 +54,10 @@ clap = { workspace = true, features = ["env", "unstable-styles"] }
 clap_complete = { workspace = true }
 codespan-reporting = { workspace = true }
 dashmap = { workspace = true }
+diesel = { workspace = true, features = [
+    "postgres_backend",
+] }
+diesel-async = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -78,6 +78,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -85,6 +86,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1246,6 +1246,11 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
     /// Returns a name for logging purposes
     fn command_name(&self) -> &'static str;
 
+    /// Returns whether the error should be JSONifyed.
+    fn jsonify_error_output(&self) -> bool {
+        true
+    }
+
     /// Executes the command, returning a command specific type
     async fn execute(self) -> CliTypedResult<T>;
 
@@ -1260,14 +1265,28 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
         let command_name = self.command_name();
         start_logger(level);
         let start_time = Instant::now();
-        to_common_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 
     /// Same as execute serialized without setting up logging
     async fn execute_serialized_without_logger(self) -> CliResult {
         let command_name = self.command_name();
         let start_time = Instant::now();
-        to_common_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 
     /// Executes the command, and throws away Ok(result) for the string Success
@@ -1275,7 +1294,14 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
         start_logger(Level::Warn);
         let command_name = self.command_name();
         let start_time = Instant::now();
-        to_common_success_result(command_name, start_time, self.execute().await).await
+        let jsonify_error_output = self.jsonify_error_output();
+        to_common_success_result(
+            command_name,
+            start_time,
+            self.execute().await,
+            jsonify_error_output,
+        )
+        .await
     }
 }
 

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -58,7 +58,7 @@ pub fn prompt_yes(prompt: &str) -> bool {
     result.unwrap()
 }
 
-/// Convert any successful response to Success. If there is an error, show as JSON
+/// Convert any successful response to Success. If there is an error, show it as JSON
 /// unless `jsonify_error` is false.
 pub async fn to_common_success_result<T>(
     command: &str,

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -58,23 +58,32 @@ pub fn prompt_yes(prompt: &str) -> bool {
     result.unwrap()
 }
 
-/// Convert any successful response to Success
+/// Convert any successful response to Success. If there is an error, show as JSON
+/// unless `jsonify_error` is false.
 pub async fn to_common_success_result<T>(
     command: &str,
     start_time: Instant,
     result: CliTypedResult<T>,
+    jsonify_error: bool,
 ) -> CliResult {
-    to_common_result(command, start_time, result.map(|_| "Success")).await
+    to_common_result(
+        command,
+        start_time,
+        result.map(|_| "Success"),
+        jsonify_error,
+    )
+    .await
 }
 
-/// For pretty printing outputs in JSON
+/// For pretty printing outputs in JSON. You can opt out of printing the error as
+/// JSON by setting `jsonify_error` to false.
 pub async fn to_common_result<T: Serialize>(
     command: &str,
     start_time: Instant,
     result: CliTypedResult<T>,
+    jsonify_error: bool,
 ) -> CliResult {
     let latency = start_time.elapsed();
-    let is_err = result.is_err();
 
     if !telemetry_is_disabled() {
         let error = if let Err(ref error) = result {
@@ -86,7 +95,7 @@ pub async fn to_common_result<T: Serialize>(
 
         if let Err(err) = timeout(
             Duration::from_millis(2000),
-            send_telemetry_event(command, latency, !is_err, error),
+            send_telemetry_event(command, latency, error),
         )
         .await
         {
@@ -94,6 +103,14 @@ pub async fn to_common_result<T: Serialize>(
         }
     }
 
+    // Return early with a non JSON error if requested.
+    if let Err(err) = &result {
+        if !jsonify_error {
+            return Err(format!("{:#}", err));
+        }
+    }
+
+    let is_err = result.is_err();
     let result = ResultWrapper::<T>::from(result);
     let string = serde_json::to_string_pretty(&result).unwrap();
     if is_err {
@@ -108,12 +125,7 @@ pub fn cli_build_information() -> BTreeMap<String, String> {
 }
 
 /// Sends a telemetry event about the CLI build, command and result
-async fn send_telemetry_event(
-    command: &str,
-    latency: Duration,
-    success: bool,
-    error: Option<&str>,
-) {
+async fn send_telemetry_event(command: &str, latency: Duration, error: Option<&str>) {
     // Collect the build information
     let build_information = cli_build_information();
 
@@ -122,7 +134,7 @@ async fn send_telemetry_event(
         build_information,
         command.into(),
         latency,
-        success,
+        error.is_none(),
         error,
     )
     .await;

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -11,16 +11,26 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use aptos::{move_tool, Tool};
 use clap::Parser;
-use std::process::exit;
+use std::{process::exit, time::Duration};
 
-#[tokio::main]
-async fn main() {
-    // Register hooks
+fn main() {
+    // Register hooks.
     move_tool::register_package_hooks();
-    // Run the corresponding tools
-    let result = Tool::parse().execute().await;
 
-    // At this point, we'll want to print and determine whether to exit for an error code
+    // Create a runtime.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Run the corresponding tool.
+    let result = runtime.block_on(Tool::parse().execute());
+
+    // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
+    // here waiting forever waiting for tasks that sometimes don't want to exit on
+    // their own (e.g. telemetry, containers spawned by the local testnet, etc).
+    runtime.shutdown_timeout(Duration::from_millis(100));
+
     match result {
         Ok(inner) => println!("{}", inner),
         Err(inner) => {

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
     // here waiting forever waiting for tasks that sometimes don't want to exit on
     // their own (e.g. telemetry, containers spawned by the local testnet, etc).
-    runtime.shutdown_timeout(Duration::from_millis(100));
+    runtime.shutdown_timeout(Duration::from_millis(50));
 
     match result {
         Ok(inner) => println!("{}", inner),

--- a/crates/aptos/src/node/local_testnet/faucet.rs
+++ b/crates/aptos/src/node/local_testnet/faucet.rs
@@ -70,7 +70,7 @@ impl ServiceManager for FaucetManager {
         "Faucet".to_string()
     }
 
-    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+    fn get_health_checkers(&self) -> HashSet<HealthChecker> {
         hashset! {HealthChecker::http_checker_from_port(
             self.config.server_config.listen_port,
             self.get_name(),

--- a/crates/aptos/src/node/local_testnet/hasura_metadata.json
+++ b/crates/aptos/src/node/local_testnet/hasura_metadata.json
@@ -1,0 +1,2036 @@
+{
+  "resource_version": 340,
+  "metadata": {
+    "version": 3,
+    "sources": [
+      {
+        "name": "indexer-v2",
+        "kind": "postgres",
+        "tables": [
+          {
+            "table": {
+              "name": "account_transactions",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "fungible_asset_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["account_address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_events_summary",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "block_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "min_block_height": "block_height"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "block_metadata_transactions",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "min_block_height",
+                    "num_distinct_versions",
+                    "account_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_events",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["account_address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "address_version_from_move_resources",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "coin_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "delegated_staking_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "delegated_staking_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token_activities_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "transaction_version": "transaction_version"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "token_activities_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "block_metadata_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "epoch",
+                    "failed_proposer_indices",
+                    "id",
+                    "previous_block_votes_bitvec",
+                    "proposer",
+                    "round",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type": "coin_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "activity_type",
+                    "amount",
+                    "block_height",
+                    "coin_type",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "storage_refund_amount",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "coin_type_hash",
+                    "owner_address",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "creator_address",
+                    "decimals",
+                    "name",
+                    "supply_aggregator_table_handle",
+                    "supply_aggregator_table_key",
+                    "symbol",
+                    "transaction_created_timestamp",
+                    "transaction_version_created"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "coin_supply",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_type",
+                    "coin_type_hash",
+                    "supply",
+                    "transaction_epoch",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_ans_lookup",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "all_token_ownerships",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "domain",
+                    "expiration_timestamp",
+                    "is_deleted",
+                    "last_transaction_version",
+                    "registered_address",
+                    "subdomain",
+                    "token_name"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_aptos_names",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "is_primary",
+                    "domain",
+                    "registered_address",
+                    "subdomain",
+                    "expiration_timestamp",
+                    "token_name",
+                    "last_transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_coin_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "coin_info",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "coin_type_hash": "coin_type_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "coin_infos",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "coin_type",
+                    "coin_type_hash",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "description",
+                    "description_mutable",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "supply",
+                    "table_handle",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collection_ownership_v2_view",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "distinct_tokens",
+                    "last_transaction_version",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "owner_address",
+                    "collection_uri",
+                    "single_token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_collections_v2",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "current_supply",
+                    "description",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "max_supply",
+                    "mutable_description",
+                    "mutable_uri",
+                    "table_handle_v1",
+                    "token_standard",
+                    "total_minted_v2",
+                    "uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_staking_pool_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "active_table_handle",
+                    "inactive_table_handle",
+                    "last_transaction_version",
+                    "operator_commission_percentage",
+                    "staking_pool_address",
+                    "total_coins",
+                    "total_shares"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegated_voter",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "delegation_pool_address",
+                    "delegator_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "pending_voter",
+                    "table_handle",
+                    "voter"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_delegator_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "delegator_address",
+                    "last_transaction_version",
+                    "parent_table_handle",
+                    "pool_address",
+                    "pool_type",
+                    "shares",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_fungible_asset_balances",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "is_frozen",
+                    "is_primary",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "storage_id",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_objects",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "allow_ungated_transfer",
+                    "is_deleted",
+                    "last_guid_creation_num",
+                    "last_transaction_version",
+                    "object_address",
+                    "owner_address",
+                    "state_key_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_staking_pool_voter",
+              "schema": "public"
+            },
+            "array_relationships": [
+              {
+                "name": "operator_aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "operator_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "last_transaction_version",
+                    "operator_address",
+                    "staking_pool_address",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "is_deleted",
+                    "key",
+                    "key_hash",
+                    "last_transaction_version",
+                    "table_handle"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "largest_property_version",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_datas_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_id",
+                    "description",
+                    "is_fungible_v2",
+                    "largest_property_version_v1",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "maximum",
+                    "supply",
+                    "token_data_id",
+                    "token_name",
+                    "token_properties",
+                    "token_standard",
+                    "token_uri"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "aptos_name",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "name": "token_name"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_type",
+                    "token_data_id_hash",
+                    "token_properties"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_ownerships_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "composed_nfts",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "owner_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_ownerships_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "is_fungible_v2",
+                    "is_soulbound_v2",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "owner_address",
+                    "property_version_v1",
+                    "storage_id",
+                    "table_type_v1",
+                    "token_data_id",
+                    "token_properties_mutated_v1",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "current_token_pending_claims",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_collection_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_data_id_hash": "collection_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collection_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_collection_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "collection_id": "collection_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_collections_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "current_token_data_v2",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "token",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "last_transaction_version": "transaction_version",
+                      "property_version": "property_version",
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "tokens",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_id",
+                    "collection_name",
+                    "creator_address",
+                    "from_address",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "property_version",
+                    "table_handle",
+                    "to_address",
+                    "token_data_id",
+                    "token_data_id_hash"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_activities",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "delegator_address",
+                    "event_index",
+                    "event_type",
+                    "pool_address",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegated_staking_pools",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_staking_pool",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "staking_pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "first_transaction_version",
+                    "staking_pool_address"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "delegator_distinct_pool",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_pool_balance",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_delegated_staking_pool_balances",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "staking_pool_metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "pool_address": "staking_pool_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_staking_pool_voter",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["delegator_address", "pool_address"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "events",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "account_address",
+                    "creation_number",
+                    "data",
+                    "event_index",
+                    "sequence_number",
+                    "transaction_block_height",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "metadata",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "asset_type": "asset_type"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "fungible_asset_metadata",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "owner_aptos_names",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "owner_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "asset_type",
+                    "block_height",
+                    "entry_function_id_str",
+                    "event_index",
+                    "gas_fee_payer_address",
+                    "is_frozen",
+                    "is_gas_fee",
+                    "is_transaction_success",
+                    "owner_address",
+                    "storage_id",
+                    "storage_refund_amount",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "fungible_asset_metadata",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "asset_type",
+                    "creator_address",
+                    "decimals",
+                    "icon_uri",
+                    "last_transaction_timestamp",
+                    "last_transaction_version",
+                    "name",
+                    "project_uri",
+                    "supply_aggregator_table_handle_v1",
+                    "supply_aggregator_table_key_v1",
+                    "symbol",
+                    "token_standard"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "indexer_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["db", "is_indexer_up"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "ledger_infos",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["chain_id"],
+                  "filter": {}
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "move_resources",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["address", "transaction_version"],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "num_active_delegator_per_pool",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["num_active_delegator", "pool_address"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "processor_status",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "last_success_version",
+                    "last_updated",
+                    "processor"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "proposal_votes",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "num_votes",
+                    "proposal_id",
+                    "should_pass",
+                    "staking_pool_address",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "voter_address"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_items",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "decoded_key",
+                    "decoded_value",
+                    "key",
+                    "table_handle",
+                    "transaction_version",
+                    "write_set_change_index"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "table_metadatas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": ["handle", "key_type", "value_type"],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id_hash": "token_data_id_hash"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_owner",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "event_account_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "coin_amount",
+                    "coin_type",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "event_account_address",
+                    "event_creation_number",
+                    "event_index",
+                    "event_sequence_number",
+                    "from_address",
+                    "name",
+                    "property_version",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "transfer_type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_activities_v2",
+              "schema": "public"
+            },
+            "object_relationships": [
+              {
+                "name": "current_token_data",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "token_data_id": "token_data_id"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_token_datas_v2",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "array_relationships": [
+              {
+                "name": "aptos_names_from",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "from_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "aptos_names_to",
+                "using": {
+                  "manual_configuration": {
+                    "column_mapping": {
+                      "to_address": "registered_address"
+                    },
+                    "insertion_order": null,
+                    "remote_table": {
+                      "name": "current_aptos_names",
+                      "schema": "public"
+                    }
+                  }
+                }
+              }
+            ],
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "after_value",
+                    "before_value",
+                    "entry_function_id_str",
+                    "event_account_address",
+                    "event_index",
+                    "from_address",
+                    "is_fungible_v2",
+                    "property_version_v1",
+                    "to_address",
+                    "token_amount",
+                    "token_data_id",
+                    "token_standard",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "type"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_datas",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "default_properties",
+                    "description",
+                    "description_mutable",
+                    "largest_property_version",
+                    "maximum",
+                    "maximum_mutable",
+                    "metadata_uri",
+                    "name",
+                    "payee_address",
+                    "properties_mutable",
+                    "royalty_mutable",
+                    "royalty_points_denominator",
+                    "royalty_points_numerator",
+                    "supply",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version",
+                    "uri_mutable"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "token_ownerships",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "amount",
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "name",
+                    "owner_address",
+                    "property_version",
+                    "table_handle",
+                    "table_type",
+                    "token_data_id_hash",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "tokens",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "collection_data_id_hash",
+                    "collection_name",
+                    "creator_address",
+                    "name",
+                    "property_version",
+                    "token_data_id_hash",
+                    "token_properties",
+                    "transaction_timestamp",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "name": "user_transactions",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "block_height",
+                    "entry_function_id_str",
+                    "epoch",
+                    "expiration_timestamp_secs",
+                    "gas_unit_price",
+                    "max_gas_amount",
+                    "parent_signature_type",
+                    "sender",
+                    "sequence_number",
+                    "timestamp",
+                    "version"
+                  ],
+                  "filter": {},
+                  "limit": 100
+                }
+              }
+            ]
+          }
+        ],
+        "configuration": {
+          "connection_info": {
+            "database_url": {
+              "from_env": "INDEXER_V2_POSTGRES_URL"
+            },
+            "isolation_level": "read-committed",
+            "use_prepared_statements": false
+          }
+        }
+      }
+    ],
+    "query_collections": [
+      {
+        "name": "allowed-queries",
+        "definition": {
+          "queries": [
+            {
+              "name": "Latest Processor Status",
+              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n  }\n}"
+            }
+          ]
+        }
+      }
+    ],
+    "allowlist": [
+      {
+        "collection": "allowed-queries",
+        "scope": {
+          "global": true
+        }
+      }
+    ],
+    "rest_endpoints": [
+      {
+        "comment": "",
+        "definition": {
+          "query": {
+            "collection_name": "allowed-queries",
+            "query_name": "Latest Processor Status"
+          }
+        },
+        "methods": ["GET"],
+        "name": "Latest Processor Status",
+        "url": "get_lastest_processor_status"
+      }
+    ],
+    "api_limits": {
+      "depth_limit": {
+        "global": 4,
+        "per_role": {}
+      },
+      "disabled": false,
+      "time_limit": {
+        "global": 10,
+        "per_role": {}
+      }
+    },
+    "metrics_config": {
+      "analyze_query_variables": true,
+      "analyze_response_body": true
+    }
+  }
+}

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use std::time::Duration;
 use tokio::time::Instant;
 
-const MAX_WAIT_S: u64 = 35;
-const WAIT_INTERVAL_MS: u64 = 150;
+const MAX_WAIT_S: u64 = 60;
+const WAIT_INTERVAL_MS: u64 = 200;
 
 /// This provides a single place to define a variety of different healthchecks.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -1,9 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliError, CliTypedResult};
-use anyhow::Context;
+use anyhow::{anyhow, Context, Result};
 use aptos_protos::indexer::v1::GetTransactionsRequest;
+use diesel_async::{pg::AsyncPgConnection, AsyncConnection};
 use futures::StreamExt;
 use reqwest::Url;
 use serde::Serialize;
@@ -23,10 +23,12 @@ pub enum HealthChecker {
     NodeApi(Url),
     /// Check that a data service GRPC stream is up.
     DataServiceGrpc(Url),
+    /// Check that a postgres instance is up.
+    Postgres(String),
 }
 
 impl HealthChecker {
-    pub async fn check(&self) -> CliTypedResult<()> {
+    pub async fn check(&self) -> Result<()> {
         match self {
             HealthChecker::Http(url, _) => {
                 reqwest::get(Url::clone(url))
@@ -54,19 +56,18 @@ impl HealthChecker {
                 client
                     .get_transactions(request)
                     .await
-                    .map_err(|err| {
-                        CliError::UnexpectedError(format!("GRPC connection error: {:#}", err))
-                    })?
+                    .context("GRPC connection error")?
                     .into_inner()
                     .next()
                     .await
                     .context("Did not receive init signal from data service GRPC stream")?
-                    .map_err(|err| {
-                        CliError::UnexpectedError(format!(
-                            "Error processing first message from GRPC stream: {:#}",
-                            err
-                        ))
-                    })?;
+                    .context("Error processing first message from GRPC stream")?;
+                Ok(())
+            },
+            HealthChecker::Postgres(connection_string) => {
+                AsyncPgConnection::establish(connection_string)
+                    .await
+                    .context("Failed to connect to postgres")?;
                 Ok(())
             },
         }
@@ -77,7 +78,7 @@ impl HealthChecker {
         &self,
         // The service, if any, waiting for this service to start up.
         waiting_service: Option<&str>,
-    ) -> CliTypedResult<()> {
+    ) -> Result<()> {
         let prefix = self.to_string();
         wait_for_startup(|| self.check(), match waiting_service {
             Some(waiting_service) => {
@@ -98,6 +99,7 @@ impl HealthChecker {
             HealthChecker::Http(url, _) => url.as_str(),
             HealthChecker::NodeApi(url) => url.as_str(),
             HealthChecker::DataServiceGrpc(url) => url.as_str(),
+            HealthChecker::Postgres(url) => url.as_str(),
         }
     }
 
@@ -116,14 +118,15 @@ impl std::fmt::Display for HealthChecker {
             HealthChecker::Http(_, name) => write!(f, "{}", name),
             HealthChecker::NodeApi(_) => write!(f, "Node API"),
             HealthChecker::DataServiceGrpc(_) => write!(f, "Transaction stream"),
+            HealthChecker::Postgres(_) => write!(f, "Postgres"),
         }
     }
 }
 
-async fn wait_for_startup<F, Fut>(check_fn: F, error_message: String) -> CliTypedResult<()>
+async fn wait_for_startup<F, Fut>(check_fn: F, error_message: String) -> Result<()>
 where
     F: Fn() -> Fut,
-    Fut: futures::Future<Output = CliTypedResult<()>>,
+    Fut: futures::Future<Output = Result<()>>,
 {
     let max_wait = Duration::from_secs(MAX_WAIT_S);
     let wait_interval = Duration::from_millis(WAIT_INTERVAL_MS);
@@ -150,7 +153,7 @@ where
             Some(last_error_message) => format!("{}: {}", error_message, last_error_message),
             None => error_message,
         };
-        return Err(CliError::UnexpectedError(error_message));
+        return Err(anyhow!(error_message));
     }
 
     Ok(())

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -1,7 +1,35 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{
+    health_checker::HealthChecker,
+    traits::{PostHealthyStep, ServiceManager, ShutdownStep},
+    utils::{confirm_docker_available, delete_container, pull_docker_image},
+    RunLocalTestnet,
+};
+use crate::node::local_testnet::utils::{setup_docker_logging, KillContainerShutdownStep};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use clap::Parser;
+use maplit::hashset;
+use reqwest::Url;
+use std::{collections::HashSet, path::PathBuf, process::Stdio};
+use tokio::process::Command;
+use tracing::info;
+
+const INDEXER_API_CONTAINER_NAME: &str = "indexer-api";
+const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.33.0";
+
+/// This Hasura metadata origintes from the aptos-indexer-processors repo.
+///
+/// This metadata is from revision: 1b8e14d9669258f797403e2b38da9ea5aea29e35.
+///
+/// The metadata file is not taken verbatim, it is currently edited by hand to remove
+/// any references to tables that aren't created by the Rust processor migrations.
+/// This works fine today since all the key processors you'd need in a local testnet
+/// are in the set of processors written in Rust. If this changes, we can explore
+/// alternatives, e.g. running processors in other languages using containers.
+const HASURA_METADATA: &str = include_str!("hasura_metadata.json");
 
 /// Args related to running an indexer API for the local testnet.
 #[derive(Debug, Parser)]
@@ -13,4 +41,230 @@ pub struct IndexerApiArgs {
     /// Docker to be installed in the host system.
     #[clap(long, conflicts_with = "no_txn_stream")]
     pub with_indexer_api: bool,
+
+    /// The port at which to run the indexer API.
+    #[clap(long, default_value_t = 8090)]
+    pub indexer_api_port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexerApiManager {
+    indexer_api_port: u16,
+    prerequisite_health_checkers: HashSet<HealthChecker>,
+    test_dir: PathBuf,
+    postgres_connection_string: String,
+}
+
+impl IndexerApiManager {
+    pub fn new(
+        args: &RunLocalTestnet,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        test_dir: PathBuf,
+        postgres_connection_string: String,
+    ) -> Result<Self> {
+        Ok(Self {
+            indexer_api_port: args.indexer_api_args.indexer_api_port,
+            prerequisite_health_checkers,
+            test_dir,
+            postgres_connection_string,
+        })
+    }
+}
+
+#[async_trait]
+impl ServiceManager for IndexerApiManager {
+    fn get_name(&self) -> String {
+        "Indexer API".to_string()
+    }
+
+    async fn pre_run(&self) -> Result<()> {
+        // Confirm Docker is available.
+        confirm_docker_available().await?;
+
+        // Delete any existing indexer API container we find.
+        delete_container(INDEXER_API_CONTAINER_NAME).await?;
+
+        // Pull the image here so it is not subject to the 30 second startup timeout.
+        pull_docker_image(HASURA_IMAGE).await?;
+
+        // Warn the user about DOCKER_DEFAULT_PLATFORM.
+        if let Ok(var) = std::env::var("DOCKER_DEFAULT_PLATFORM") {
+            eprintln!(
+                "WARNING: DOCKER_DEFAULT_PLATFORM is set to {}. This may cause problems \
+                with running the indexer API. If it fails to start up, try unsetting \
+                this env var.\n",
+                var
+            );
+        }
+
+        Ok(())
+    }
+
+    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+        hashset! {HealthChecker::Http(
+            Url::parse(&format!("http://127.0.0.1:{}", self.indexer_api_port)).unwrap(),
+            self.get_name(),
+        )}
+    }
+
+    fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
+        self.prerequisite_health_checkers.iter().collect()
+    }
+
+    async fn run_service(self: Box<Self>) -> Result<()> {
+        let (stdout, stderr) =
+            setup_docker_logging(&self.test_dir, "indexer-api", INDEXER_API_CONTAINER_NAME)?;
+
+        // If we're on Mac, replace 127.0.0.1 with host.docker.internal.
+        // https://stackoverflow.com/a/24326540/3846032
+        let postgres_connection_string = if cfg!(target_os = "macos") {
+            self.postgres_connection_string
+                .replace("127.0.0.1", "host.docker.internal")
+        } else {
+            self.postgres_connection_string.to_string()
+        };
+
+        // https://stackoverflow.com/q/77171786/3846032
+        let mut command = Command::new("docker");
+        command
+            .arg("run")
+            .arg("-q")
+            .arg("--rm")
+            .arg("--tty")
+            .arg("--no-healthcheck")
+            .arg("--name")
+            .arg(INDEXER_API_CONTAINER_NAME)
+            .arg("-p")
+            .arg(format!(
+                "{}:{}",
+                self.indexer_api_port, self.indexer_api_port
+            ))
+            .arg("-e")
+            .arg(format!("PG_DATABASE_URL={}", postgres_connection_string))
+            .arg("-e")
+            .arg(format!(
+                "HASURA_GRAPHQL_METADATA_DATABASE_URL={}",
+                postgres_connection_string
+            ))
+            .arg("-e")
+            .arg(format!(
+                "INDEXER_V2_POSTGRES_URL={}",
+                postgres_connection_string
+            ))
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_DEV_MODE=true")
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_ENABLE_CONSOLE=true")
+            .arg("-e")
+            .arg("HASURA_GRAPHQL_CONSOLE_ASSETS_DIR=/srv/console-assets")
+            .arg("-e")
+            .arg(format!(
+                "HASURA_GRAPHQL_SERVER_PORT={}",
+                self.indexer_api_port
+            ))
+            .arg(HASURA_IMAGE)
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr);
+
+        info!("Running command: {:?}", command);
+
+        let child = command
+            .spawn()
+            .context("Failed to start indexer API container")?;
+
+        // When sigint is received the container can error out, which we don't want to
+        // show to the user, so we log instead.
+        match child.wait_with_output().await {
+            Ok(output) => {
+                info!("Indexer API stopped with output: {:?}", output);
+            },
+            Err(err) => {
+                info!("Indexer API stopped unexpectedly with error: {}", err);
+            },
+        }
+
+        Ok(())
+    }
+
+    fn get_post_healthy_steps(&self) -> Vec<Box<dyn PostHealthyStep>> {
+        /// There is no good way to apply Hasura metadata (the JSON format, anyway) to
+        /// an instance of Hasura in a container at startup:
+        ///
+        /// https://github.com/hasura/graphql-engine/issues/8423
+        ///
+        /// As such, the only way to do it is to apply it via the API after startup.
+        /// That is what this post healthy step does.
+        #[derive(Debug)]
+        struct PostMetdataPostHealthyStep {
+            pub indexer_api_port: u16,
+        }
+
+        #[async_trait]
+        impl PostHealthyStep for PostMetdataPostHealthyStep {
+            async fn run(self: Box<Self>) -> Result<()> {
+                post_metadata(HASURA_METADATA, self.indexer_api_port)
+                    .await
+                    .context("Failed to apply Hasura metadata for Indexer API")?;
+                Ok(())
+            }
+        }
+
+        vec![Box::new(PostMetdataPostHealthyStep {
+            indexer_api_port: self.indexer_api_port,
+        })]
+    }
+
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        // Unfortunately the Hasura container does not shut down when the CLI does and
+        // there doesn't seem to be a good way to make it do so. To work around this,
+        // we register a step that will delete the container on shutdown.
+        // Read more here: https://stackoverflow.com/q/77171786/3846032.
+        vec![Box::new(KillContainerShutdownStep::new(
+            INDEXER_API_CONTAINER_NAME,
+        ))]
+    }
+}
+
+/// This submits a POST request to apply metadata to a Hasura API.
+async fn post_metadata(metadata_content: &str, port: u16) -> Result<()> {
+    let url = format!("http://127.0.0.1:{}/v1/metadata", port);
+    let client = reqwest::Client::new();
+
+    // Parse the metadata content as JSON.
+    let metadata_json: serde_json::Value = serde_json::from_str(metadata_content)?;
+
+    // Construct the payload.
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "type".to_string(),
+        serde_json::Value::String("replace_metadata".to_string()),
+    );
+    payload.insert("args".to_string(), metadata_json);
+
+    // Send the POST request.
+    let response = client.post(url).json(&payload).send().await?;
+
+    // Check that `is_consistent` is true in the response.
+    let json = response.json().await?;
+    check_is_consistent(&json)?;
+
+    Ok(())
+}
+
+/// This checks the response from the API to confirm the metadata was applied
+/// successfully.
+fn check_is_consistent(json: &serde_json::Value) -> Result<()> {
+    if let Some(obj) = json.as_object() {
+        if let Some(is_consistent_val) = obj.get("is_consistent") {
+            if is_consistent_val.as_bool() == Some(true) {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Something went wrong applying the Hasura metadata, perhaps it is not consistent with the DB. Response: {:#?}",
+        json
+    ))
 }

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -1,0 +1,16 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+
+/// Args related to running an indexer API for the local testnet.
+#[derive(Debug, Parser)]
+pub struct IndexerApiArgs {
+    /// If set, we will run a postgres DB using Docker (unless
+    /// --use-host-postgres is set), run the standard set of indexer processors (see
+    /// --processors) and configure them to write to this DB, and run an API that lets
+    /// you access the data they write to storage. This is opt in because it requires
+    /// Docker to be installed in the host system.
+    #[clap(long, conflicts_with = "no_txn_stream")]
+    pub with_indexer_api: bool,
+}

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -102,6 +102,10 @@ impl NodeManager {
     pub fn get_node_api_url(&self) -> Url {
         socket_addr_to_url(&self.config.api.address, "http").unwrap()
     }
+
+    pub fn get_data_service_url(&self) -> Url {
+        socket_addr_to_url(&self.config.indexer_grpc.address, "http").unwrap()
+    }
 }
 
 #[async_trait]

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -117,7 +117,7 @@ impl ServiceManager for NodeManager {
     /// We return health checkers for both the Node API and the txn stream (if enabled).
     /// As it is now, it is fine to make downstream services wait for both but if that
     /// changes we can refactor.
-    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+    fn get_health_checkers(&self) -> HashSet<HealthChecker> {
         let node_api_url = self.get_node_api_url();
         let mut checkers = HashSet::new();
         checkers.insert(HealthChecker::NodeApi(node_api_url));

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -7,18 +7,25 @@ use super::{
     utils::{confirm_docker_available, delete_container, pull_docker_image},
     RunLocalTestnet,
 };
-use crate::node::local_testnet::utils::{setup_docker_logging, KillContainerShutdownStep};
+use crate::node::local_testnet::utils::{
+    get_docker, setup_docker_logging, KillContainerShutdownStep,
+};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
+use bollard::{
+    container::{Config, CreateContainerOptions, StartContainerOptions, WaitContainerOptions},
+    models::{HostConfig, PortBinding},
+};
 use clap::Parser;
 use diesel_async::{pg::AsyncPgConnection, AsyncConnection, RunQueryDsl};
-use maplit::hashset;
-use std::{collections::HashSet, path::PathBuf, process::Stdio};
-use tokio::process::Command;
-use tracing::info;
+use futures::TryStreamExt;
+use maplit::{hashmap, hashset};
+use std::{collections::HashSet, path::PathBuf};
+use tracing::{info, warn};
 
 const POSTGRES_CONTAINER_NAME: &str = "local-testnet-postgres";
 const POSTGRES_IMAGE: &str = "postgres:14.9";
+const POSTGRES_DEFAULT_PORT: u16 = 5432;
 
 /// Args related to running postgres in the local testnet.
 #[derive(Clone, Debug, Parser)]
@@ -183,49 +190,61 @@ impl ServiceManager for PostgresManager {
         }
 
         // Let the user know where to go to see logs for postgres.
-        let (stdout, stderr) =
-            setup_docker_logging(&self.test_dir, "postgres", POSTGRES_CONTAINER_NAME)?;
+        setup_docker_logging(&self.test_dir, "postgres", POSTGRES_CONTAINER_NAME)?;
 
-        let port = self.args.get_postgres_port();
+        let options = Some(CreateContainerOptions {
+            name: POSTGRES_CONTAINER_NAME,
+            ..Default::default()
+        });
 
-        let mut command = Command::new("docker");
-        command
-            .arg("run")
-            .arg("-q")
-            .arg("--rm")
-            .arg("--tty")
-            .arg("--name")
-            .arg(POSTGRES_CONTAINER_NAME)
-            .arg("-p")
-            .arg(format!("127.0.0.1:{}:5432", port))
-            .arg("-e")
-            .arg("POSTGRES_HOST_AUTH_METHOD=trust")
-            .arg("-e")
-            .arg(format!("POSTGRES_USER={}", self.args.postgres_user))
-            .arg("-e")
-            .arg(format!("POSTGRES_DB={}", self.args.postgres_database))
-            .arg(POSTGRES_IMAGE)
-            .stdin(Stdio::null())
-            .stdout(stdout)
-            .stderr(stderr);
+        let port = self.args.get_postgres_port().to_string();
+        let exposed_ports = Some(hashmap! {POSTGRES_DEFAULT_PORT.to_string() => hashmap!{}});
+        let host_config = Some(HostConfig {
+            port_bindings: Some(hashmap! {
+                POSTGRES_DEFAULT_PORT.to_string() => Some(vec![PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some(port),
+                }]),
+            }),
+            ..Default::default()
+        });
 
-        info!("Running command: {:?}", command);
+        let config = Config {
+            image: Some(POSTGRES_IMAGE.to_string()),
+            tty: Some(true),
+            exposed_ports,
+            host_config,
+            env: Some(vec![
+                "POSTGRES_HOST_AUTH_METHOD=trust".to_string(),
+                format!("POSTGRES_USER={}", self.args.postgres_user),
+                format!("POSTGRES_DB={}", self.args.postgres_database),
+            ]),
+            ..Default::default()
+        };
 
-        let child = command
-            .spawn()
+        let docker = get_docker()?;
+
+        let id = docker.create_container(options, config).await?.id;
+
+        docker
+            .start_container(&id, None::<StartContainerOptions<&str>>)
+            .await
             .context("Failed to start postgres container")?;
 
-        // When sigint is received the container can error out, which we don't want to
-        // show to the user, so we log instead.
-        match child.wait_with_output().await {
-            Ok(output) => {
-                // Print nothing, this probably implies ctrl+C.
-                info!("Postgres stopped with output: {:?}", output);
-            },
-            Err(err) => {
-                info!("Postgres stopped unexpectedly with error: {}", err);
-            },
-        }
+        // Wait for the container to stop, which it never should unless we receive
+        // ctrl-c.
+        let wait = docker
+            .wait_container(
+                &id,
+                Some(WaitContainerOptions {
+                    condition: "not-running",
+                }),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .context("Failed to wait on postgres container")?;
+
+        warn!("Postgres container stopped: {:?}", wait.last());
 
         Ok(())
     }

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -1,0 +1,232 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    health_checker::HealthChecker,
+    traits::ServiceManager,
+    utils::{confirm_docker_available, delete_container, pull_docker_image},
+    RunLocalTestnet,
+};
+use crate::node::local_testnet::utils::setup_docker_logging;
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use clap::Parser;
+use diesel_async::{pg::AsyncPgConnection, AsyncConnection, RunQueryDsl};
+use maplit::hashset;
+use std::{collections::HashSet, path::PathBuf, process::Stdio};
+use tokio::process::Command;
+use tracing::info;
+
+const POSTGRES_CONTAINER_NAME: &str = "local-testnet-postgres";
+const POSTGRES_IMAGE: &str = "postgres:14.9";
+
+/// Args related to running postgres in the local testnet.
+#[derive(Clone, Debug, Parser)]
+pub struct PostgresArgs {
+    /// This is the database to connect to, both when --use-host-postgres is set
+    /// and when it is not (i.e. when postgres is running in a container).
+    #[clap(long, default_value = "local_testnet")]
+    pub postgres_database: String,
+
+    /// The user to connect as. If --use-host-postgres is set, we expect this user to
+    /// exist already.
+    #[clap(long, default_value = "postgres")]
+    pub postgres_user: String,
+
+    /// This is the port to use for the postgres instance when --use-host-postgres
+    /// is not set (i.e. we are running a postgres instance in a container).
+    #[clap(long, default_value_t = 5433)]
+    pub postgres_port: u16,
+
+    /// If set, connect to the postgres instance specified by the rest of the
+    /// `postgres_args` (e.g. --host-postgres-host, --host-postgres-user, etc) rather
+    /// than running a new one with Docker. This can be used to connect to an existing
+    /// postgres instance running on the host system. Do not include the database.
+    ///
+    /// WARNING: Any existing database it finds (based on --postgres-database) will be
+    /// dropped.
+    #[clap(long, requires = "with_indexer_api")]
+    pub use_host_postgres: bool,
+
+    /// When --use-host-postgres is set, this is the port to connect to.
+    #[clap(long, default_value_t = 5432)]
+    pub host_postgres_port: u16,
+
+    /// When --use-host-postgres is set, this is the password to connect with.
+    #[clap(long)]
+    pub host_postgres_password: Option<String>,
+}
+
+impl PostgresArgs {
+    pub fn get_postgres_port(&self) -> u16 {
+        match self.use_host_postgres {
+            true => self.host_postgres_port,
+            false => self.postgres_port,
+        }
+    }
+
+    /// Get the connection string for the postgres database. If `database` is specified
+    /// we will use that rather than `postgres_database`.
+    pub fn get_connection_string(&self, database: Option<&str>) -> String {
+        let password = match self.use_host_postgres {
+            true => match &self.host_postgres_password {
+                Some(password) => format!(":{}", password),
+                None => "".to_string(),
+            },
+            false => "".to_string(),
+        };
+        let port = self.get_postgres_port();
+        let database = match database {
+            Some(database) => database,
+            None => &self.postgres_database,
+        };
+        format!(
+            "postgres://{}{}@127.0.0.1:{}/{}",
+            self.postgres_user, password, port, database,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PostgresManager {
+    args: PostgresArgs,
+    test_dir: PathBuf,
+    force_restart: bool,
+}
+
+impl PostgresManager {
+    pub fn new(args: &RunLocalTestnet, test_dir: PathBuf) -> Result<Self> {
+        if args.postgres_args.use_host_postgres
+            && args.postgres_args.postgres_database == "postgres"
+        {
+            bail!("The postgres database cannot be named postgres if --use-host-postgres is set");
+        }
+        Ok(Self {
+            args: args.postgres_args.clone(),
+            test_dir,
+            force_restart: args.force_restart,
+        })
+    }
+
+    /// Drop and recreate the database specified by `self.args.postgres_database`.
+    /// This is only necessary when --force-restart and --use-host-postgres are set.
+    /// For this we connect to the `postgres` database so we can drop the database
+    /// we'll actually use (since you can't drop a database you're connected to).
+    async fn recreate_host_database(&self) -> Result<()> {
+        info!("Dropping database {}", self.args.postgres_database);
+        let connection_string = self.args.get_connection_string(Some("postgres"));
+
+        // Open a connection to the DB.
+        let mut connection = AsyncPgConnection::establish(&connection_string)
+            .await
+            .with_context(|| format!("Failed to connect to postgres at {}", connection_string))?;
+
+        // Drop the DB.
+        diesel::sql_query(format!(
+            "DROP DATABASE IF EXISTS {}",
+            self.args.postgres_database
+        ))
+        .execute(&mut connection)
+        .await?;
+        info!("Dropped database {}", self.args.postgres_database);
+
+        // Create DB again.
+        diesel::sql_query(format!("CREATE DATABASE {}", self.args.postgres_database))
+            .execute(&mut connection)
+            .await?;
+        info!("Created database {}", self.args.postgres_database);
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ServiceManager for PostgresManager {
+    fn get_name(&self) -> String {
+        "Postgres".to_string()
+    }
+
+    async fn pre_run(&self) -> Result<()> {
+        if self.force_restart {
+            if self.args.use_host_postgres {
+                // If we're using a DB outside of Docker, drop and recreate the database.
+                self.recreate_host_database().await?;
+            } else {
+                // Kill any existing container we find.
+                delete_container(POSTGRES_CONTAINER_NAME).await?;
+            }
+        }
+
+        // Confirm Docker is available.
+        confirm_docker_available().await?;
+
+        // Pull the image here so it is not subject to the 30 second startup timeout.
+        pull_docker_image(POSTGRES_IMAGE).await?;
+
+        Ok(())
+    }
+
+    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+        hashset! {HealthChecker::Postgres(
+            self.args.get_connection_string(None),
+        )}
+    }
+
+    fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
+        hashset! {}
+    }
+
+    async fn run_service(self: Box<Self>) -> Result<()> {
+        // If we're using postgres on the host just do nothing forever.
+        if self.args.use_host_postgres {
+            return std::future::pending().await;
+        }
+
+        // Let the user know where to go to see logs for postgres.
+        let (stdout, stderr) =
+            setup_docker_logging(&self.test_dir, "postgres", POSTGRES_CONTAINER_NAME)?;
+
+        let port = self.args.get_postgres_port();
+
+        let mut command = Command::new("docker");
+        command
+            .arg("run")
+            .arg("-q")
+            .arg("--rm")
+            .arg("--tty")
+            .arg("--name")
+            .arg(POSTGRES_CONTAINER_NAME)
+            .arg("-p")
+            .arg(format!("127.0.0.1:{}:5432", port))
+            .arg("-e")
+            .arg("POSTGRES_HOST_AUTH_METHOD=trust")
+            .arg("-e")
+            .arg(format!("POSTGRES_USER={}", self.args.postgres_user))
+            .arg("-e")
+            .arg(format!("POSTGRES_DB={}", self.args.postgres_database))
+            .arg(POSTGRES_IMAGE)
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr);
+
+        info!("Running command: {:?}", command);
+
+        let child = command
+            .spawn()
+            .context("Failed to start postgres container")?;
+
+        // When sigint is received the container can error out, which we don't want to
+        // show to the user, so we log instead.
+        match child.wait_with_output().await {
+            Ok(output) => {
+                // Print nothing, this probably implies ctrl+C.
+                info!("Postgres stopped with output: {:?}", output);
+            },
+            Err(err) => {
+                info!("Postgres stopped unexpectedly with error: {}", err);
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -3,11 +3,11 @@
 
 use super::{
     health_checker::HealthChecker,
-    traits::ServiceManager,
+    traits::{ServiceManager, ShutdownStep},
     utils::{confirm_docker_available, delete_container, pull_docker_image},
     RunLocalTestnet,
 };
-use crate::node::local_testnet::utils::setup_docker_logging;
+use crate::node::local_testnet::utils::{setup_docker_logging, KillContainerShutdownStep};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
@@ -228,5 +228,12 @@ impl ServiceManager for PostgresManager {
         }
 
         Ok(())
+    }
+
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        // Shutdown the postgres container, if any.
+        vec![Box::new(KillContainerShutdownStep::new(
+            POSTGRES_CONTAINER_NAME,
+        ))]
     }
 }

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -25,7 +25,7 @@ static RUN_MIGRATIONS_ONCE: OnceCell<bool> = OnceCell::const_new();
 pub struct ProcessorArgs {
     /// The value of this flag determines which processors we will run if
     /// --with-indexer-api is set. Note that some processors are not supported in the
-    /// local testnet (e.g. ANS). If you try to set those, an error will be thrown
+    /// local testnet (e.g. ANS). If you try to set those an error will be thrown
     /// immediately.
     #[clap(
         long,
@@ -77,7 +77,7 @@ impl ProcessorManager {
             ProcessorName::StakeProcessor => ProcessorConfig::StakeProcessor,
             ProcessorName::TokenProcessor => {
                 ProcessorConfig::TokenProcessor(TokenProcessorConfig {
-                    // This NFT points thing doesn't exist on local testnets.
+                    // This NFT points contract doesn't exist on local testnets.
                     nft_points_contract: None,
                 })
             },
@@ -150,7 +150,7 @@ impl ServiceManager for ProcessorManager {
         )
     }
 
-    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+    fn get_health_checkers(&self) -> HashSet<HealthChecker> {
         hashset![HealthChecker::Http(
             Url::parse(&format!(
                 "http://127.0.0.1:{}",
@@ -173,9 +173,10 @@ impl ServiceManager for ProcessorManager {
         // https://stackoverflow.com/q/54351783/3846032
         //
         // To fix this, we run the migrations ourselves here in the CLI first. We use
-        // std::sync::Once to make sure we only run the migration once even though we
-        // call all the processor service managers get to this point. This is safer
-        // than relying on coordiation outside of this manager.
+        // OnceCell to make sure we only run the migration once. When all the processor
+        // ServiceManagers reach this point, one of them will run the code and the rest
+        // will wait. Doing it at this point in the code is safer than relying on
+        // coordiation outside of this manager.
         RUN_MIGRATIONS_ONCE
             .get_or_init(|| async {
                 info!("Running DB migrations for the indexer processors");

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -1,0 +1,193 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use clap::Parser;
+use diesel_async::{pg::AsyncPgConnection, AsyncConnection};
+use maplit::hashset;
+use processor::{
+    processors::{token_processor::TokenProcessorConfig, ProcessorConfig, ProcessorName},
+    utils::database::run_pending_migrations,
+    IndexerGrpcProcessorConfig,
+};
+use reqwest::Url;
+use server_framework::{run_server_with_config, GenericConfig};
+use std::collections::HashSet;
+use tokio::sync::OnceCell;
+use tracing::info;
+
+static RUN_MIGRATIONS_ONCE: OnceCell<bool> = OnceCell::const_new();
+
+/// This struct is used to parse the command line arguments for the processors.
+#[derive(Debug, Parser)]
+pub struct ProcessorArgs {
+    /// The value of this flag determines which processors we will run if
+    /// --with-indexer-api is set. Note that some processors are not supported in the
+    /// local testnet (e.g. ANS). If you try to set those, an error will be thrown
+    /// immediately.
+    #[clap(
+        long,
+        value_enum,
+        default_values_t = vec![
+            ProcessorName::AccountTransactionsProcessor,
+            ProcessorName::CoinProcessor,
+            ProcessorName::DefaultProcessor,
+            ProcessorName::EventsProcessor,
+            ProcessorName::FungibleAssetProcessor,
+            ProcessorName::StakeProcessor,
+            ProcessorName::TokenProcessor,
+            ProcessorName::TokenV2Processor,
+            ProcessorName::UserTransactionProcessor,
+        ],
+        requires = "with_indexer_api"
+    )]
+    processors: Vec<ProcessorName>,
+}
+
+#[derive(Debug)]
+pub struct ProcessorManager {
+    config: GenericConfig<IndexerGrpcProcessorConfig>,
+    prerequisite_health_checkers: HashSet<HealthChecker>,
+}
+
+impl ProcessorManager {
+    fn new(
+        processor_name: &ProcessorName,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        health_check_port: u16,
+        data_service_url: Url,
+        postgres_connection_string: String,
+    ) -> Result<Self> {
+        let processor_config = match processor_name {
+            ProcessorName::AccountTransactionsProcessor => {
+                ProcessorConfig::AccountTransactionsProcessor
+            },
+            ProcessorName::AnsProcessor => {
+                bail!("ANS processor is not supported in the local testnet")
+            },
+            ProcessorName::CoinProcessor => ProcessorConfig::CoinProcessor,
+            ProcessorName::DefaultProcessor => ProcessorConfig::DefaultProcessor,
+            ProcessorName::EventsProcessor => ProcessorConfig::EventsProcessor,
+            ProcessorName::FungibleAssetProcessor => ProcessorConfig::FungibleAssetProcessor,
+            ProcessorName::NftMetadataProcessor => {
+                bail!("NFT Metadata processor is not supported in the local testnet")
+            },
+            ProcessorName::StakeProcessor => ProcessorConfig::StakeProcessor,
+            ProcessorName::TokenProcessor => {
+                ProcessorConfig::TokenProcessor(TokenProcessorConfig {
+                    // This NFT points thing doesn't exist on local testnets.
+                    nft_points_contract: None,
+                })
+            },
+            ProcessorName::TokenV2Processor => ProcessorConfig::TokenV2Processor,
+            ProcessorName::UserTransactionProcessor => ProcessorConfig::UserTransactionProcessor,
+        };
+        let server_config = IndexerGrpcProcessorConfig {
+            processor_config,
+            postgres_connection_string,
+            indexer_grpc_data_service_address: data_service_url,
+            auth_token: "notused".to_string(),
+            grpc_http2_config: Default::default(),
+            starting_version: None,
+            ending_version: None,
+            number_concurrent_processing_tasks: None,
+        };
+        let config = GenericConfig {
+            server_config,
+            health_check_port,
+        };
+        let manager = Self {
+            config,
+            prerequisite_health_checkers,
+        };
+        Ok(manager)
+    }
+
+    /// This function returns many new ProcessorManagers, one for each processor.
+    pub fn many_new(
+        args: &RunLocalTestnet,
+        prerequisite_health_checkers: HashSet<HealthChecker>,
+        data_service_url: Url,
+        postgres_connection_string: String,
+    ) -> Result<Vec<Self>> {
+        if args.processor_args.processors.is_empty() {
+            bail!("Must specify at least one processor to run");
+        }
+        let mut managers = Vec::new();
+        let mut health_check_port = 43234;
+        for processor_name in &args.processor_args.processors {
+            managers.push(Self::new(
+                processor_name,
+                prerequisite_health_checkers.clone(),
+                health_check_port,
+                data_service_url.clone(),
+                postgres_connection_string.clone(),
+            )?);
+            health_check_port += 1;
+        }
+        Ok(managers)
+    }
+
+    /// Ccreate the necessary tables in the DB for the processors to work.
+    async fn run_migrations(&self) -> Result<()> {
+        let connection_string = &self.config.server_config.postgres_connection_string;
+        let mut connection = AsyncPgConnection::establish(connection_string)
+            .await
+            .with_context(|| format!("Failed to connect to postgres at {}", connection_string))?;
+        run_pending_migrations(&mut connection).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ServiceManager for ProcessorManager {
+    fn get_name(&self) -> String {
+        format!(
+            "processor_{}",
+            self.config.server_config.processor_config.name()
+        )
+    }
+
+    fn get_healthchecks(&self) -> HashSet<HealthChecker> {
+        hashset![HealthChecker::Http(
+            Url::parse(&format!(
+                "http://127.0.0.1:{}",
+                self.config.health_check_port
+            ))
+            .unwrap(),
+            self.get_name(),
+        )]
+    }
+
+    fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
+        self.prerequisite_health_checkers.iter().collect()
+    }
+
+    async fn run_service(self: Box<Self>) -> Result<()> {
+        // By default, when a processor starts up (specifically in Worker.run) it runs
+        // any pending migrations. Unfortunately, if you start multiple processors at
+        // the same time, they can sometimes clash with errors like this:
+        //
+        // https://stackoverflow.com/q/54351783/3846032
+        //
+        // To fix this, we run the migrations ourselves here in the CLI first. We use
+        // std::sync::Once to make sure we only run the migration once even though we
+        // call all the processor service managers get to this point. This is safer
+        // than relying on coordiation outside of this manager.
+        RUN_MIGRATIONS_ONCE
+            .get_or_init(|| async {
+                info!("Running DB migrations for the indexer processors");
+                self.run_migrations()
+                    .await
+                    .expect("Failed to run DB migrations");
+                info!("Ran DB migrations for the indexer processors");
+                true
+            })
+            .await;
+
+        // Run the processor.
+        run_server_with_config(self.config, tokio::runtime::Handle::current()).await
+    }
+}

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -46,6 +46,7 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
+        let name_clone = name.to_string();
         let future = async move {
             for health_checker in self.get_prerequisite_health_checkers() {
                 health_checker
@@ -56,7 +57,10 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
             self.run_service()
                 .await
                 .context("Service ended with an error")?;
-            warn!("Service ended unexpectedly without any error");
+            warn!(
+                "Service {} ended unexpectedly without any error",
+                name_clone
+            );
             Ok(())
         };
         tokio::spawn(future.map(move |result: Result<()>| {

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -75,6 +75,15 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
         vec![]
     }
 
+    /// The ServiceManager may return ShutdownSteps. The tool will run these on shutdown.
+    /// This is best effort, there is nothing we can do if part of the code aborts or
+    /// the process receives something like SIGKILL.
+    ///
+    /// See `ShutdownStep` for more information.
+    fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
+        vec![]
+    }
+
     /// This function is responsible for running the service. It should return an error
     /// if the service ends unexpectedly. It gets called by `run`.
     async fn run_service(self: Box<Self>) -> Result<()>;
@@ -82,9 +91,18 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
 
 /// If a service wants to do something after it is healthy, it can define a struct,
 /// implement this trait for it, and return an instance of it.
-//
-// For more information see `get_post_healthy_steps` in `ServiceManager`.
+///
+/// For more information see `get_post_healthy_steps` in `ServiceManager`.
 #[async_trait]
 pub trait PostHealthyStep: Debug + Send + Sync + 'static {
+    async fn run(self: Box<Self>) -> Result<()>;
+}
+
+/// If a service wants to do something on shutdown, it can define a struct,
+/// implement this trait for it, and return an instance of it.
+///
+/// For more information see `get_shutdown_steps` in `ServiceManager`.
+#[async_trait]
+pub trait ShutdownStep: Debug + Send + Sync + 'static {
     async fn run(self: Box<Self>) -> Result<()>;
 }

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -4,9 +4,7 @@
 use super::health_checker::HealthChecker;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::FutureExt;
 use std::{collections::HashSet, fmt::Debug};
-use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[async_trait]
@@ -40,32 +38,28 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
     fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker>;
 
     /// This is the function we use from the outside to start the service. It makes
-    /// sure all the prerequisite services have started and then spawns a tokio task to
-    /// run the service. The user should never need to override this implementation.
-    fn run(self: Box<Self>) -> JoinHandle<()> {
+    /// sure all the prerequisite services have started and then calls the inner
+    /// function to run the service. The user should never need to override this
+    /// implementation.
+    async fn run(self: Box<Self>) -> Result<()> {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
         let name_clone = name.to_string();
-        let future = async move {
-            for health_checker in self.get_prerequisite_health_checkers() {
-                health_checker
-                    .wait(Some(&self.get_name()))
-                    .await
-                    .context("Prerequisite service did not start up successfully")?;
-            }
-            self.run_service()
+        for health_checker in self.get_prerequisite_health_checkers() {
+            health_checker
+                .wait(Some(&self.get_name()))
                 .await
-                .context("Service ended with an error")?;
-            warn!(
-                "Service {} ended unexpectedly without any error",
-                name_clone
-            );
-            Ok(())
-        };
-        tokio::spawn(future.map(move |result: Result<()>| {
-            warn!("{} stopped unexpectedly {:#?}", name, result);
-        }))
+                .context("Prerequisite service did not start up successfully")?;
+        }
+        self.run_service()
+            .await
+            .context("Service ended with an error")?;
+        warn!(
+            "Service {} ended unexpectedly without any error",
+            name_clone
+        );
+        Ok(())
     }
 
     /// The ServiceManager may return PostHealthySteps. The tool will run these after

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -23,10 +23,10 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
     /// can use to make sure prerequisite services have started. These are also used
     /// by the "ready server", a server that exposes a unified endpoint for checking
     /// if all services are ready.
-    fn get_healthchecks(&self) -> HashSet<HealthChecker>;
+    fn get_health_checkers(&self) -> HashSet<HealthChecker>;
 
-    /// Whereas get_healthchecks returns healthchecks that other downstream services can
-    /// use, this should return health checkers for services that this service is
+    /// Whereas get_health_checkers returns healthchecks that other downstream services
+    /// can use, this should return health checkers for services that this service is
     /// waiting to start.
     //
     // Note: If we were using an object oriented language, we'd just make the

--- a/crates/aptos/src/node/local_testnet/utils.rs
+++ b/crates/aptos/src/node/local_testnet/utils.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::traits::ShutdownStep;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
+use bollard::{container::RemoveContainerOptions, image::CreateImageOptions, Docker};
+use futures::TryStreamExt;
 use reqwest::Url;
-use std::{fs::create_dir_all, net::SocketAddr, path::Path, process::Stdio};
-use tokio::process::Command;
+use std::{fs::create_dir_all, net::SocketAddr, path::Path};
 use tracing::info;
 
 pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url> {
@@ -18,22 +19,18 @@ pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url>
     Ok(Url::parse(&full_url)?)
 }
 
+pub fn get_docker() -> Result<Docker> {
+    let docker = Docker::connect_with_local_defaults()
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
+    Ok(docker)
+}
+
 pub async fn confirm_docker_available() -> Result<()> {
-    let status = Command::new("docker")
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+    let docker = get_docker()?;
+    docker
+        .info()
         .await
-        .context("Failed to check if Docker is available")?;
-
-    if !status.success() {
-        bail!(
-            "Docker is not available, confirm it is installed and running: {:?}",
-            status
-        );
-    }
-
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
     Ok(())
 }
 
@@ -44,18 +41,15 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
         container_name
     );
 
-    let _ = Command::new("docker")
-        .arg("rm")
-        .arg("-f")
-        .arg(container_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context(format!(
-            "Failed to remove existing container with name {}",
-            container_name
-        ))?;
+    let docker = get_docker()?;
+
+    let options = Some(RemoveContainerOptions {
+        force: true,
+        ..Default::default()
+    });
+
+    // Ignore any error, it'll be because the container doesn't exist.
+    let _ = docker.remove_container(container_name, options).await;
 
     info!(
         "Removed any existing postgres container with name {}",
@@ -67,19 +61,28 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
 
 pub async fn pull_docker_image(image_name: &str) -> Result<()> {
     info!("Pulling docker image {}", image_name);
-    let status = Command::new("docker")
-        .arg("pull")
-        .arg(image_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context("Failed to pull postgres image")?;
-    info!("Pulled docker image {}", image_name);
 
-    if !status.success() {
-        bail!("Failed to pull postgres image: {:?}", status);
-    }
+    let docker = get_docker()?;
+
+    let options = Some(CreateImageOptions {
+        from_image: image_name,
+        ..Default::default()
+    });
+
+    // Check if the image is there. If not, print that we'll pull it.
+    if docker.inspect_image(image_name).await.is_err() {
+        eprintln!("Image {} not found, pulling it now", image_name);
+    };
+
+    // The docker pull CLI command is just sugar around this API.
+    docker
+        .create_image(options, None, None)
+        // Just wait for the whole stream, we don't need to do other things in parallel.
+        .try_collect::<Vec<_>>()
+        .await
+        .with_context(|| format!("Failed to pull image {}", image_name))?;
+
+    info!("Pulled docker image {}", image_name);
 
     Ok(())
 }
@@ -88,11 +91,7 @@ pub async fn pull_docker_image(image_name: &str) -> Result<()> {
 /// file called README.md that tells the user where to go to see logs. We do this since
 /// having the user use `docker logs` is the preferred approach. To help debug any
 /// potential startup failures however, we also create files for the command to write to.
-pub fn setup_docker_logging(
-    test_dir: &Path,
-    dir_name: &str,
-    container_name: &str,
-) -> Result<(Stdio, Stdio)> {
+pub fn setup_docker_logging(test_dir: &Path, dir_name: &str, container_name: &str) -> Result<()> {
     // Create dir.
     let log_dir = test_dir.join(dir_name);
     create_dir_all(log_dir.as_path()).context(format!("Failed to create {}", log_dir.display()))?;
@@ -104,25 +103,7 @@ pub fn setup_docker_logging(
     );
     std::fs::write(log_dir.join("README.md"), data).context("Unable to write README file")?;
 
-    // Create file for stdout.
-    let path = log_dir.join("stdout.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stdout = Stdio::from(file);
-
-    // Create file for stderr.
-    let path = log_dir.join("stderr.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stderr = Stdio::from(file);
-
-    Ok((stdout, stderr))
+    Ok(())
 }
 
 /// This shutdown step forcibly kills a container with the given name. If no container

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -100,7 +100,10 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
-            RunLocalTestnet(tool) => tool.execute_serialized_without_logger().await,
+            RunLocalTestnet(tool) => tool
+                .execute_serialized_without_logger()
+                .await
+                .map(|_| "".to_string()),
             UpdateConsensusKey(tool) => tool.execute_serialized().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
         }

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -30,7 +30,13 @@ bcs = { workspace = true }
 bigdecimal = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-diesel = { workspace = true }
+diesel = { workspace = true, features = [
+    "chrono",
+    "postgres",
+    "r2d2",
+    "numeric",
+    "serde_json",
+] }
 diesel_migrations = { workspace = true }
 field_count = { workspace = true }
 futures = { workspace = true }

--- a/ecosystem/nft-metadata-crawler-parser/Cargo.toml
+++ b/ecosystem/nft-metadata-crawler-parser/Cargo.toml
@@ -22,7 +22,13 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 csv = { workspace = true }
-diesel = { workspace = true }
+diesel = { workspace = true, features = [
+    "chrono",
+    "postgres",
+    "r2d2",
+    "numeric",
+    "serde_json",
+] }
 diesel_migrations = { workspace = true }
 field_count = { workspace = true }
 futures = { workspace = true }

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -40,7 +40,13 @@ aptos-vm = { workspace = true }
 aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
-diesel = { workspace = true }
+diesel = { workspace = true, features = [
+    "chrono",
+    "postgres",
+    "r2d2",
+    "numeric",
+    "serde_json",
+] }
 hex = { workspace = true }
 move-core-types = { workspace = true }
 proptest = { workspace = true }


### PR DESCRIPTION
## Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/10252
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/10254

## Description
This PR adds support for:
- Spinning up postgres in a container.
- Using postgres already running in the host system.

This is required to run indexer processors.

I still need to double check that this works on a fresh system, I have a suspicion that if postgres isn't installed things will fail with some error to the effect of "postgres shared library missing".

I also need to make sure I'm not reintroducing the OpenSSL dep.

This depends on https://github.com/aptos-labs/aptos-indexer-processors/pull/146.

Note: To avoid using undesired diesel features in the CLI I had to move the feature declarations from the workspace level to the crate level. Crate level feature declarations are additive, they don't replace the features used at the workspace level.

## Test Plan
### Postgres in a container
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api --postgres-user dport
```
```
Node API is ready. Endpoint: http://0.0.0.0:8080/
Postgres is ready. Endpoint: postgres://dport@127.0.0.1:5433/local_testnet
Transaction stream is ready. Endpoint: http://0.0.0.0:50051/
Faucet is ready. Endpoint: http://127.0.0.1:8081/
```
```
psql postgres://dport@127.0.0.1:5433/local_testnet
```
```
psql (14.9 (Homebrew))
Type "help" for help.

local_testnet=# \dn
List of schemas
  Name  | Owner
--------+-------
 public | dport
(1 row)
```

Once the CLI shuts down so does the postgres container.

### Host postgres
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api --postgres-user dport --use-host-postgres
```
```
Postgres is ready. Endpoint: postgres://dport@127.0.0.1:5432/local_testnet
```
```
psql postgres://dport@127.0.0.1:5433/local_testnet
```
```
psql (14.9 (Homebrew))
Type "help" for help.

local_testnet=# \dn
List of schemas
  Name  | Owner
--------+-------
 public | dport
(1 row)
```

## Further Testing
Now that I've rebased all the other PRs in the stack into this PR, I will do some additional testing. I'm using this invocation:
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api
```

Does it work on:
- ARM MacOS: Yes!!
- x86 Ubuntu 22: Yes!!
- x86 Windows (host system, NT, MSVC): Not working, but due to an unrelated error that occurs on main too: https://gist.github.com/banool/135ce49c0662832446778c6268b68d62.
- x86 Windows (Ubuntu 22 WSL): Yes!!
- CLI running inside container from x86 Linux tools image running on ARM MacOS: Yes!!

For the last of these, I ran it like this:
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run -it -v /var/run/docker.sock:/var/run/docker.sock --network host aptos-core/tools:from-local aptos node run-local-testnet --with-indexer-api
```