### PR TITLE
[aggregator_v2] Fixes found through testing

### DIFF
--- a/aptos-move/aptos-aggregator/src/aggregator_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/aggregator_change_set.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use move_binary_format::errors::PartialVMResult;
 
+// TODO To be renamed to DelayedApplyChange
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AggregatorApplyChange<I: Clone> {
     AggregatorDelta {
@@ -27,6 +28,7 @@ pub enum AggregatorApplyChange<I: Clone> {
     },
 }
 
+// TODO To be renamed to DelayedChange
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AggregatorChange<I: Clone> {
     Create(AggregatorValue),

--- a/aptos-move/aptos-aggregator/src/bounded_math.rs
+++ b/aptos-move/aptos-aggregator/src/bounded_math.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_logger::error;
-use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_binary_format::errors::PartialVMError;
 use move_core_types::vm_status::StatusCode;
 
 // When bounded math operation overflows
@@ -80,7 +80,7 @@ pub fn ok_underflow<T>(value: BoundedMathResult<T>) -> BoundedMathResult<Option<
     }
 }
 
-pub fn expect_ok<T>(value: BoundedMathResult<T>) -> PartialVMResult<T> {
+pub fn expect_ok<V, E: std::fmt::Debug>(value: Result<V, E>) -> Result<V, PartialVMError> {
     value.map_err(code_invariant_error)
 }
 

--- a/aptos-move/aptos-aggregator/src/types.rs
+++ b/aptos-move/aptos-aggregator/src/types.rs
@@ -45,6 +45,7 @@ pub enum AggregatorError {
     WrongVersionID,
 }
 
+// TODO To be renamed to DelayedFieldID
 /// Ephemeral identifier type used by aggregators V2.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AggregatorID(u64);
@@ -149,10 +150,12 @@ impl TryFrom<AggregatorVersionedID> for StateKey {
     }
 }
 
+// TODO To be renamed to DelayedFieldValue
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AggregatorValue {
     Aggregator(u128),
     Snapshot(u128),
+    // TODO probably change to Derived(Arc<Vec<u8>>) to make copying predictably costly
     Derived(Vec<u8>),
 }
 
@@ -304,4 +307,9 @@ impl SnapshotToStringFormula {
             },
         }
     }
+}
+
+pub enum ReadPosition {
+    BeforeCurrentTxn,
+    AfterCurrentTxn,
 }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -146,7 +146,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get deltas")
+            .expect("Output to be set to aggregator change set")
             .change_set()
             .aggregator_v2_change_set()
             .clone()

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -146,7 +146,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to aggregator change set")
+            .expect("Output to be set to get aggregator change set")
             .change_set()
             .aggregator_v2_change_set()
             .clone()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -760,7 +760,6 @@ where
                             .unwrap(),
                         );
                     }
-                    println!("Updates : {:?}", updates);
                     for (id, value) in updates.into_iter() {
                         data_map.write_aggregator(id, value);
                     }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -648,7 +648,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIden
         let id = T::Identifier::try_from_move_value(layout, identifier_value, &())
             .map_err(|e| TransformationError(e.to_string()))?;
         match &self.latest_view {
-            // TODO are we at this point always supposed to read a value this transaction committed (i.e. AfterCurrentTxn)?
             ViewState::Sync(state) => Ok(state
                 .read_aggregator_v2_last_committed_value(
                     id,

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
@@ -5,7 +5,7 @@ use crate::natives::aggregator_natives::{
     helpers_v1::{aggregator_info, unpack_aggregator_struct},
     NativeAggregatorContext,
 };
-use aptos_aggregator::types::AggregatorVersionedID;
+use aptos_aggregator::types::{AggregatorVersionedID, ReadPosition};
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
@@ -41,7 +41,7 @@ fn native_add(
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
     let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id, limit)?;
-    aggregator.try_add(aggregator_context.resolver, value)?;
+    aggregator.try_add(value, aggregator_context.resolver)?;
     Ok(smallvec![])
 }
 
@@ -68,7 +68,10 @@ fn native_read(
     let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id.clone(), limit)?;
 
-    let value = aggregator.read_aggregated_aggregator_value(aggregator_context.resolver)?;
+    let value = aggregator.read_aggregated_aggregator_value(
+        aggregator_context.resolver,
+        ReadPosition::AfterCurrentTxn,
+    )?;
 
     Ok(smallvec![Value::u128(value)])
 }
@@ -97,7 +100,7 @@ fn native_sub(
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
     let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id, limit)?;
-    aggregator.try_sub(aggregator_context.resolver, value)?;
+    aggregator.try_sub(value, aggregator_context.resolver)?;
     Ok(smallvec![])
 }
 

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -16,7 +16,7 @@ use aptos_aggregator::{
     aggregator_extension::AggregatorData,
     bounded_math::BoundedMath,
     resolver::AggregatorResolver,
-    types::{AggregatorVersionedID, SnapshotToStringFormula, SnapshotValue},
+    types::{AggregatorVersionedID, ReadPosition, SnapshotToStringFormula, SnapshotValue},
     utils::{string_to_bytes, to_utf8_bytes, u128_to_u64},
 };
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
@@ -243,7 +243,7 @@ fn native_try_add(
         let (resolver, mut aggregator_data) = get_context_data(context);
         let id = AggregatorVersionedID::V2(aggregator_value_field_as_id(agg_value)?);
         let aggregator = aggregator_data.get_aggregator(id, agg_max_value)?;
-        aggregator.try_add(resolver, input)?
+        aggregator.try_add(input, resolver)?
     } else {
         let math = BoundedMath::new(agg_max_value);
         match math.unsigned_add(agg_value, input) {
@@ -277,7 +277,7 @@ fn native_try_sub(
         let (resolver, mut aggregator_data) = get_context_data(context);
         let id = AggregatorVersionedID::V2(aggregator_value_field_as_id(agg_value)?);
         let aggregator = aggregator_data.get_aggregator(id, agg_max_value)?;
-        aggregator.try_sub(resolver, input)?
+        aggregator.try_sub(input, resolver)?
     } else {
         let math = BoundedMath::new(agg_max_value);
         match math.unsigned_subtract(agg_value, input) {
@@ -310,7 +310,7 @@ fn native_read(
         let (resolver, mut aggregator_data) = get_context_data(context);
         let id = AggregatorVersionedID::V2(aggregator_value_field_as_id(agg_value)?);
         let aggregator = aggregator_data.get_aggregator(id, agg_max_value)?;
-        aggregator.read_aggregated_aggregator_value(resolver)?
+        aggregator.read_aggregated_aggregator_value(resolver, ReadPosition::AfterCurrentTxn)?
     } else {
         agg_value
     };
@@ -494,7 +494,7 @@ fn native_string_concat(
         let aggregator_id = aggregator_value_field_as_id(snapshot_value)?;
         SnapshotValue::Integer(
             aggregator_data
-                .string_concat(aggregator_id, resolver, prefix, suffix)
+                .string_concat(aggregator_id, prefix, suffix, resolver)
                 .as_u64() as u128,
         )
     } else {

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -213,17 +213,17 @@ mod test {
         assert!(aggregator_data
             .get_aggregator(aggregator_v1_id_for_test(500), 500)
             .unwrap()
-            .try_add(context.resolver, 150)
+            .try_add(150, context.resolver)
             .unwrap());
         assert!(aggregator_data
             .get_aggregator(aggregator_v1_id_for_test(600), 600)
             .unwrap()
-            .try_add(context.resolver, 100)
+            .try_add(100, context.resolver)
             .unwrap());
         assert!(aggregator_data
             .get_aggregator(aggregator_v1_id_for_test(700), 700)
             .unwrap()
-            .try_add(context.resolver, 200)
+            .try_add(200, context.resolver)
             .unwrap());
 
         aggregator_data.remove_aggregator_v1(aggregator_v1_id_for_test(100));
@@ -322,7 +322,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(900), 900)
                 .unwrap()
-                .try_add(context.resolver, 200),
+                .try_add(200, context.resolver),
             true
         );
 
@@ -330,7 +330,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(900), 900)
                 .unwrap()
-                .try_sub(context.resolver, 501),
+                .try_sub(501, context.resolver),
             false
         );
 
@@ -348,7 +348,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(900), 900)
                 .unwrap()
-                .try_add(context.resolver, 300),
+                .try_add(300, context.resolver),
             true
         );
 
@@ -361,7 +361,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(900), 900)
                 .unwrap()
-                .try_add(context.resolver, 100),
+                .try_add(100, context.resolver),
             true
         );
 
@@ -369,7 +369,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(900), 900)
                 .unwrap()
-                .try_add(context.resolver, 51),
+                .try_add(51, context.resolver),
             false
         );
 
@@ -378,7 +378,7 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(2000), 2000)
                 .unwrap()
-                .try_add(context.resolver, 500),
+                .try_add(500, context.resolver),
             true
         );
 
@@ -390,9 +390,9 @@ mod test {
         assert_eq!(
             aggregator_data.string_concat(
                 AggregatorID::new(2200),
-                context.resolver,
                 "prefix".as_bytes().to_vec(),
-                "suffix".as_bytes().to_vec()
+                "suffix".as_bytes().to_vec(),
+                context.resolver,
             ),
             AggregatorID::new(4)
         );
@@ -401,14 +401,14 @@ mod test {
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(2000), 2000)
                 .unwrap()
-                .try_add(context.resolver, 1700),
+                .try_add(1700, context.resolver),
             false
         );
         assert_ok_eq!(
             aggregator_data
                 .get_aggregator(AggregatorVersionedID::v2(2000), 2000)
                 .unwrap()
-                .try_sub(context.resolver, 501),
+                .try_sub(501, context.resolver),
             false
         );
     }

--- a/aptos-move/mvhashmap/src/versioned_aggregators.rs
+++ b/aptos-move/mvhashmap/src/versioned_aggregators.rs
@@ -3,8 +3,8 @@
 
 use crate::types::{AtomicTxnIndex, MVAggregatorsError, TxnIndex};
 use aptos_aggregator::{
-    aggregator_change_set::{AggregatorApplyChange, ApplyBase},
-    types::AggregatorValue,
+    aggregator_change_set::{AggregatorApplyChange, AggregatorChange, ApplyBase},
+    types::{AggregatorValue, ReadPosition},
 };
 use claims::{assert_matches, assert_none};
 use crossbeam::utils::CachePadded;
@@ -313,6 +313,8 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
     }
 }
 
+// TODO To be renamed to VersionedDelayedFields
+//
 /// Maps each ID (access path) to an internal VersionedValue, managing versioned updates to the
 /// specified aggregator (which handles both Aggregator, and AggregatorSnapshot).
 ///
@@ -366,7 +368,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
 
     /// Must be called when an aggregator creation with a given ID and initial value is observed
     /// in the outputs of txn_idx.
-    pub fn create_aggregator(&self, id: K, txn_idx: TxnIndex, value: AggregatorValue) {
+    pub fn initialize_delayed_field(&self, id: K, txn_idx: TxnIndex, value: AggregatorValue) {
         let mut created = VersionedValue::new(None);
         created.insert(txn_idx, VersionEntry::Value(value, None));
 
@@ -374,6 +376,43 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
             self.values.insert(id, created),
             "VerionedValue when creating aggregator ID may not already exist"
         );
+    }
+
+    /// Must be called when a snapshot (delta or derived) creation with a given ID
+    /// and initial apply is observed.
+    /// This should be only called when apply applies on top of different ID.
+    pub fn initialize_dependent_delayed_field(
+        &self,
+        id: K,
+        txn_idx: TxnIndex,
+        apply: AggregatorApplyChange<K>,
+    ) {
+        let mut created = VersionedValue::new(None);
+        created.insert(txn_idx, VersionEntry::Apply(apply));
+
+        assert_none!(
+            self.values.insert(id, created),
+            "VerionedValue when creating aggregator ID may not already exist"
+        );
+    }
+
+    pub fn record_change(&self, id: K, txn_idx: TxnIndex, change: AggregatorChange<K>) {
+        match change {
+            AggregatorChange::Create(value) => self.initialize_delayed_field(id, txn_idx, value),
+            AggregatorChange::Apply(apply) => match &apply {
+                AggregatorApplyChange::AggregatorDelta { .. } => {
+                    self.values
+                        .get_mut(&id)
+                        // TODO we probably cannot panic here any more (i.e. in V2 this might not be guaranteed)
+                        .expect("VersionedValue for an (resolved) ID must already exist")
+                        .insert(txn_idx, VersionEntry::Apply(apply))
+                },
+                AggregatorApplyChange::SnapshotDelta { .. }
+                | AggregatorApplyChange::SnapshotDerived { .. } => {
+                    self.initialize_dependent_delayed_field(id, txn_idx, apply)
+                },
+            },
+        };
     }
 
     /// The caller must maintain the invariant that prior to calling the methods below w.
@@ -402,46 +441,26 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
         }
     }
 
-    /// This method is intended to be called during transaction execution (e.g. for getting
-    /// a rough value of an aggregator cheaply for branch prediction). Hence, the 'calling'
-    /// transaction may not be committed yet, and there is no reason to provide txn_idx.
+    /// Returns the committed value from largest transaction index that is
+    /// strictly smaller than the given current_txn_idx.
     pub fn read_latest_committed_value(
         &self,
         id: K,
+        current_txn_idx: TxnIndex,
+        read_position: ReadPosition,
     ) -> Result<AggregatorValue, MVAggregatorsError> {
         self.values
             .get_mut(&id)
-            .expect("VersionedValue for an (resolved) ID must already exist")
-            .read_latest_committed_value(self.next_idx_to_commit.load(Ordering::Relaxed))
-    }
-
-    /// If a value was derived from applying delta to a speculatively read value, we also
-    /// provide a delta. This is useful for the optimization where if the txn aborts and
-    /// the entry is marked as an estimate, reads may be able to bypass the Estimate entry
-    /// by optimistically applying the previous delta.
-    ///
-    /// Record value can also be used to finalize committed values in the data-structure,
-    /// in order to avoid potentially costly delta traversals in reads. Due to a use in
-    /// read_latest_committed_value, called frequently (as a part of aggregator implementation),
-    /// Upon commit Snapshot and Delta entries are all required to be replaced with Values.
-    pub fn record_value(
-        &self,
-        id: K,
-        txn_idx: TxnIndex,
-        value: AggregatorValue,
-        maybe_apply: Option<AggregatorApplyChange<K>>,
-    ) {
-        self.values
-            .get_mut(&id)
-            .expect("VersionedValue for an (resolved) ID must already exist")
-            .insert(txn_idx, VersionEntry::Value(value, maybe_apply));
-    }
-
-    pub fn record_apply(&self, id: K, txn_idx: TxnIndex, apply: AggregatorApplyChange<K>) {
-        self.values
-            .get_mut(&id)
-            .expect("VersionedValue for an (resolved) ID must already exist")
-            .insert(txn_idx, VersionEntry::Apply(apply));
+            .ok_or(MVAggregatorsError::NotFound)
+            .and_then(|v| {
+                v.read_latest_committed_value(
+                    match read_position {
+                        ReadPosition::BeforeCurrentTxn => current_txn_idx,
+                        ReadPosition::AfterCurrentTxn => current_txn_idx + 1,
+                    }
+                    .min(self.next_idx_to_commit.load(Ordering::Relaxed)),
+                )
+            })
     }
 
     pub fn mark_estimate(&self, id: K, txn_idx: TxnIndex) {

--- a/aptos-move/mvhashmap/src/versioned_aggregators.rs
+++ b/aptos-move/mvhashmap/src/versioned_aggregators.rs
@@ -374,7 +374,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
 
         assert_none!(
             self.values.insert(id, created),
-            "VerionedValue when creating aggregator ID may not already exist"
+            "VersionedValue when creating aggregator ID may not already exist"
         );
     }
 
@@ -392,7 +392,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
 
         assert_none!(
             self.values.insert(id, created),
-            "VerionedValue when creating aggregator ID may not already exist"
+            "VersionedValue when creating aggregator ID may not already exist"
         );
     }
 
@@ -442,7 +442,8 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedAggregators<K> {
     }
 
     /// Returns the committed value from largest transaction index that is
-    /// strictly smaller than the given current_txn_idx.
+    /// smaller than the given current_txn_idx (read_position defined whether
+    /// inclusively or exclusively from the current transaction itself).
     pub fn read_latest_committed_value(
         &self,
         id: K,


### PR DESCRIPTION
with these sequential execution works (excluding exchange/materialization)

- some changes in CapturedReads (not all, there are followup)
- introducing ReadPosition (BeforeCurrentTxn, AfterCurrentTxn) for calls that we need to distinguish whether we want including with current transaction or not), so it’s harder to have bugs
- validation/try commit logic in coordinator_commit_hook
- sequential execution update to state (no exchanges yet)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
