### PR TITLE
replay-verify workflow tunings

### DIFF
--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
       - uses: actions/checkout@v3
-      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+      - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
@@ -51,7 +51,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' && (inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all')
     needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
+    uses: ./.github/workflows/workflow-run-replay-verify.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
@@ -71,7 +71,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' && (inputs.CHAIN_NAME == 'mainnet' || inputs.CHAIN_NAME == 'all' )
     needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
+    uses: ./.github/workflows/workflow-run-replay-verify.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
@@ -88,7 +88,7 @@ jobs:
   test-replay:
     if: ${{ github.event_name == 'pull_request' }}
     needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
+    uses: ./.github/workflows/workflow-run-replay-verify.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -81,6 +81,7 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 720 }}
     runs-on: ${{ inputs.RUNS_ON }}
     strategy:
+        fail-fast: false
         matrix:
           number: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] # runner number
     steps:


### PR DESCRIPTION
### Description
1. not reference workflows by @main
2.  not cancel other sub-jobs on first failure

### Test Plan
manually scheduled https://github.com/aptos-labs/aptos-core/actions/runs/6341570151?pr=10281

-- sub-job failure didn't cancel other sub-jobs.