### PR TITLE
[move-model] fix internal assertion violation in definition analysis

### DIFF
--- a/third_party/move/move-prover/tests/sources/functional/duplicate_function_declarations.exp
+++ b/third_party/move/move-prover/tests/sources/functional/duplicate_function_declarations.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with model building errors
+error: duplicate declaration of `double`
+   ┌─ tests/sources/functional/duplicate_function_declarations.move:11:9
+   │
+11 │     fun double(x: u8): u8 {
+   │         ^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/duplicate_function_declarations.move
+++ b/third_party/move/move-prover/tests/sources/functional/duplicate_function_declarations.move
@@ -1,0 +1,15 @@
+module 0x42::DuplicateFunction {
+    struct R0 { x: u8 }
+
+    spec R0 {
+        fun double(x: u8): u8 {
+            x * 2
+        }
+        invariant x > 0;
+    }
+
+    fun double(x: u8): u8 {
+        x * 2
+    }
+    spec double (x: u8) : u8 {}
+}


### PR DESCRIPTION
### Description

Fix failing internal assert in move-model #9064. The assert is triggered because of duplicate declarations of a function name during definition analysis. This is fixed by raising an error explaining the duplicate declaration instead of an assertion violation. Close #9064 

### Test Plan
`move-prover/tests/sources/functional/duplicate_function_declarations.move`