### PR TITLE
[ts-sdk] fix async queue promise dequeue and cancellation

### DIFF
--- a/ecosystem/typescript/sdk/src/transactions/async_queue.ts
+++ b/ecosystem/typescript/sdk/src/transactions/async_queue.ts
@@ -6,32 +6,37 @@
  * it does not guarantee ordering for those that call into and await on enqueue.
  */
 
+interface PendingDequeue<T> {
+  resolve: (value: T) => void;
+  reject: (reason?: AsyncQueueCancelledError) => void;
+}
+
 export class AsyncQueue<T> {
   readonly queue: T[] = [];
 
-  // The resolveMap is used to handle the resolution of promises when items are enqueued and dequeued.
-  private resolveMap: Map<number, (value: T) => void> = new Map();
-
-  private counter: number = 0;
+  // The pendingDequeue is used to handle the resolution of promises when items are enqueued and dequeued.
+  private pendingDequeue: PendingDequeue<T>[] = [];
 
   private cancelled: boolean = false;
 
   /**
    * The enqueue method adds an item to the queue. If there are pending dequeued promises,
-   * in the resolveMap, it resolves the oldest promise with the enqueued item immediately.
+   * in the pendingDequeue, it resolves the oldest promise with the enqueued item immediately.
    * Otherwise, it adds the item to the queue.
    *
    * @param item T
    */
   enqueue(item: T): void {
-    if (this.resolveMap.size > 0) {
-      const resolve = this.resolveMap.get(0);
-      if (resolve) {
-        this.resolveMap.delete(0);
-        resolve(item);
-        return;
-      }
+    this.cancelled = false;
+
+    if (this.pendingDequeue.length > 0) {
+      const promise = this.pendingDequeue.shift();
+
+      promise?.resolve(item);
+
+      return;
     }
+
     this.queue.push(item);
   }
 
@@ -39,7 +44,7 @@ export class AsyncQueue<T> {
    * The dequeue method returns a promise that resolves to the next item in the queue.
    * If the queue is not empty, it resolves the promise immediately with the next item.
    * Otherwise, it creates a new promise. The promise's resolve function is stored
-   * in the resolveMap with a unique counter value as the key.
+   * in the pendingDequeue with a unique counter value as the key.
    * The newly created promise is then returned, and it will be resolved later when an item is enqueued.
    *
    * @returns Promise<T>
@@ -48,11 +53,10 @@ export class AsyncQueue<T> {
     if (this.queue.length > 0) {
       return Promise.resolve(this.queue.shift()!);
     }
-    const promise = new Promise<T>((resolve) => {
-      this.counter += 1;
-      this.resolveMap.set(this.counter, resolve);
+
+    return new Promise<T>((resolve, reject) => {
+      this.pendingDequeue.push({ resolve, reject });
     });
-    return promise;
   }
 
   /**
@@ -71,10 +75,13 @@ export class AsyncQueue<T> {
    */
   cancel(): void {
     this.cancelled = true;
-    this.resolveMap.forEach(async (resolve) => {
-      resolve(await Promise.reject(new AsyncQueueCancelledError("Task cancelled")));
+
+    this.pendingDequeue.forEach(async ({ reject }) => {
+      reject(new AsyncQueueCancelledError("Task cancelled"));
     });
-    this.resolveMap.clear();
+
+    this.pendingDequeue = [];
+
     this.queue.length = 0;
   }
 
@@ -86,11 +93,15 @@ export class AsyncQueue<T> {
   isCancelled(): boolean {
     return this.cancelled;
   }
-}
 
-export class AsyncQueueCancelledError extends Error {
-  /* eslint-disable @typescript-eslint/no-useless-constructor */
-  constructor(message: string) {
-    super(message);
+  /**
+   * The pendingDequeueLength method returns the length of the pendingDequeue.
+   *
+   * @returns number
+   */
+  pendingDequeueLength(): number {
+    return this.pendingDequeue.length;
   }
 }
+
+export class AsyncQueueCancelledError extends Error {}

--- a/ecosystem/typescript/sdk/src/transactions/tests/async_queue.test.ts
+++ b/ecosystem/typescript/sdk/src/transactions/tests/async_queue.test.ts
@@ -1,0 +1,88 @@
+import { AsyncQueue, AsyncQueueCancelledError } from "../async_queue";
+
+describe("asyncQueue", () => {
+  it("should enqueue and dequeue items", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    asyncQueue.enqueue(1);
+
+    const item1 = await asyncQueue.dequeue();
+
+    asyncQueue.enqueue(2);
+    asyncQueue.enqueue(3);
+
+    const item2 = await asyncQueue.dequeue();
+    const item3 = await asyncQueue.dequeue();
+
+    expect(item1).toBe(1);
+    expect(item2).toBe(2);
+    expect(item3).toBe(3);
+  });
+
+  it("should handle dequeue before queue", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    const itemPromise1 = asyncQueue.dequeue();
+    const itemPromise2 = asyncQueue.dequeue();
+
+    expect(asyncQueue.pendingDequeueLength()).toBe(2);
+
+    asyncQueue.enqueue(1);
+    asyncQueue.enqueue(2);
+
+    const item1 = await itemPromise1;
+    const item2 = await itemPromise2;
+
+    expect(item1).toBe(1);
+    expect(item2).toBe(2);
+
+    expect(asyncQueue.pendingDequeueLength()).toBe(0);
+  });
+
+  it("should handle cancellation", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    const itemPromise1 = asyncQueue.dequeue();
+    const itemPromise2 = asyncQueue.dequeue();
+
+    expect(asyncQueue.pendingDequeueLength()).toBe(2);
+
+    asyncQueue.cancel();
+
+    await expect(itemPromise1).rejects.toThrow(AsyncQueueCancelledError);
+    await expect(itemPromise2).rejects.toThrow(AsyncQueueCancelledError);
+
+    expect(asyncQueue.isCancelled()).toBe(true);
+
+    expect(asyncQueue.pendingDequeueLength()).toBe(0);
+  });
+
+  it("should handle cancellation without errors if queue is empty", () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    asyncQueue.cancel();
+
+    expect(asyncQueue.isCancelled()).toBe(true);
+  });
+
+  it("should check if the queue is empty", () => {
+    const asyncQueue = new AsyncQueue<number>();
+    expect(asyncQueue.isEmpty()).toBe(true);
+
+    asyncQueue.enqueue(1);
+
+    expect(asyncQueue.isEmpty()).toBe(false);
+  });
+
+  it("should remove cancelled status after a new enqueue", () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    asyncQueue.cancel();
+
+    expect(asyncQueue.isCancelled()).toBe(true);
+
+    asyncQueue.enqueue(1);
+
+    expect(asyncQueue.isCancelled()).toBe(false);
+  });
+});


### PR DESCRIPTION
### Description

The AsyncQueue is utilized by the TransactionWorker and exhibited a bug when initiated with an empty transactions queue. To address this issue, I could just increase the counter *after* setting the resolveMap. Additionally, the cancellation behavior was enhanced to throw an AsyncQueueCancelledError instead of resolving to it. Furthermore, an unusual behavior was identified where the cancellation status persisted indefinitely. In addition to these fixes, several opinionated changes have been made to enhance the overall functionality and maintainability of the code.

### Test Plan

These implemented tests not only validate the existing functionality but also ensure that recent fixes and enhancements are working as expected.

- **Enqueue and Dequeue**: Verify that items can be enqueued and dequeued as expected, maintaining the queue's order.

- **Handle Dequeue Before Queue**: Ensure that the AsyncQueue can handle dequeuing items even before they are enqueued.

- **Cancellation**: Confirm that the cancel method correctly rejects promises with AsyncQueueCancelledError and updates the cancellation status.

- **Cancellation with Empty Queue**: Verify that cancellation does not cause errors when the queue is empty.

- **Check Queue Emptiness**: Validate the isEmpty method's accuracy in determining whether the queue is empty.

- **Remove Cancelled Status**: Check if the cancelled status is reset after a new item is enqueued.