### PR TITLE
[Fuzzing] Add AptosVM fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7402,9 +7402,11 @@ version = "0.1.0"
 name = "fuzzer-fuzz"
 version = "0.0.0"
 dependencies = [
- "aptos-consensus",
- "aptos-consensus-types",
+ "aptos-framework",
+ "aptos-language-e2e-tests",
  "aptos-types",
+ "aptos-vm",
+ "aptos-vm-genesis",
  "arbitrary",
  "bcs 0.1.4",
  "libfuzzer-sys",
@@ -7414,6 +7416,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -6293,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",

--- a/testsuite/fuzzer/.cargo/config.toml
+++ b/testsuite/fuzzer/.cargo/config.toml
@@ -1,0 +1,7 @@
+target-applies-to-host = false
+
+[host]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
+
+[host.x86_64-unknown-linux-gnu]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -8,7 +8,11 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
+aptos-framework = { workspace = true }
+aptos-language-e2e-tests = { workspace = true }
 aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+aptos-vm-genesis = { workspace = true }
 arbitrary = "1.3.2"
 bcs = { workspace = true }
 libfuzzer-sys = "0.4"
@@ -18,10 +22,6 @@ move-core-types = { workspace = true, features = ["fuzzing"] }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
-aptos-language-e2e-tests = { workspace = true }
-aptos-vm = { workspace = true }
-aptos-framework = { workspace = true }
-aptos-vm-genesis = { workspace = true }
 once_cell = { workspace = true }
 
 [[bin]]

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 aptos-types = { workspace = true }
-arbitrary = "1.3.1"
+arbitrary = "1.3.2"
 bcs = { workspace = true }
 libfuzzer-sys = "0.4"
 move-binary-format = { workspace = true, features = ["fuzzing"] }

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -20,6 +20,11 @@ move-core-types = { workspace = true, features = ["fuzzing"] }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
+aptos-language-e2e-tests = { workspace = true }
+aptos-vm = { workspace = true }
+aptos-framework = { workspace = true }
+aptos-vm-genesis = { workspace = true }
+once_cell = { workspace = true }
 
 [[bin]]
 name = "move_bytecode_verifier_code_unit"
@@ -60,5 +65,11 @@ doc = false
 [[bin]]
 name = "signed_transaction_deserialize"
 path = "fuzz_targets/signed_transaction_deserialize.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "move_aptosvm_publish_and_run"
+path = "fuzz_targets/move/aptosvm_publish_and_run.rs"
 test = false
 doc = false

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-aptos-consensus = { workspace = true, features = ["fuzzing"] }
-aptos-consensus-types = { workspace = true, features = ["fuzzing"] }
 aptos-types = { workspace = true }
 arbitrary = "1.3.1"
 bcs = { workspace = true }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -1,0 +1,307 @@
+#![no_main]
+
+// Copyright © Aptos Foundation
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    convert::TryInto,
+};
+
+use aptos_language_e2e_tests::{data_store::GENESIS_CHANGE_SET_HEAD, executor::FakeExecutor};
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::Corpus;
+use move_binary_format::{
+    access::ModuleAccess,
+    file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
+};
+
+use aptos_types::{
+    chain_id::ChainId,
+    transaction::{EntryFunction, ModuleBundle, Script, TransactionArgument, TransactionPayload, TransactionStatus, ExecutionStatus},
+    write_set::WriteSet,
+};
+
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, TypeTag},
+    value::MoveValue,
+    vm_status::{StatusType, VMStatus},
+};
+use once_cell::sync::Lazy;
+
+#[derive(Debug, Arbitrary, Eq, PartialEq)]
+pub enum ExecVariant {
+    Script {
+        script: CompiledScript,
+        type_args: Vec<TypeTag>,
+        args: Vec<MoveValue>,
+    },
+    CallFunction {
+        module: ModuleId,
+        function: FunctionDefinitionIndex,
+        type_args: Vec<TypeTag>,
+        args: Vec<Vec<u8>>,
+    },
+}
+
+#[derive(Debug, Arbitrary, Eq, PartialEq)]
+pub struct RunnableState {
+    pub dep_modules: Vec<CompiledModule>,
+    pub exec_variant: ExecVariant,
+}
+
+// genesis write set generated once for each fuzzing session
+static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
+
+// small debug macro which can be enabled or disabled
+const DEBUG: bool = false;
+macro_rules! tdbg {
+    () => {
+        ()
+    };
+    ($val:expr $(,)?) => {
+        if DEBUG {
+            dbg!($val)
+        } else {
+            ($val)
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        if DEBUG {
+            dbg!($(($val)),+,)
+        } else {
+            dbg!($(($val)),+,)
+        }
+    };
+}
+
+// used for ordering modules topologically
+fn sort_by_deps(
+    map: &BTreeMap<ModuleId, CompiledModule>,
+    order: &mut Vec<ModuleId>,
+    id: ModuleId,
+    visited: &mut HashSet<ModuleId>,
+) -> Result<(), Corpus> {
+    if visited.contains(&id) {
+        return Err(Corpus::Keep);
+    }
+    visited.insert(id.clone());
+    if order.contains(&id) {
+        return Ok(());
+    }
+    let compiled = &map.get(&id).unwrap();
+    for dep in compiled.immediate_dependencies() {
+        // Only consider deps which are actually in this package. Deps for outside
+        // packages are considered fine because of package deployment order. Note
+        // that because of this detail, we can't use existing topsort from Move utils.
+        if map.contains_key(&dep) {
+            sort_by_deps(map, order, dep, visited)?;
+        }
+    }
+    order.push(id);
+    return Ok(());
+}
+
+// panic to catch invariant violations
+fn check_for_invariant_violation(e: VMStatus) {
+    if e.status_type() == StatusType::InvariantViolation {
+        // known false positive
+        if e.message() != Some(&"moving container with dangling references".to_string()) {
+            panic!("invariant violation {:?}", e);
+        }
+    }
+}
+
+fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
+    tdbg!(&input);
+    let mut vm = FakeExecutor::from_genesis(&VM, ChainId::mainnet()).set_not_parallel();
+
+    for m in input.dep_modules.iter_mut() {
+        // m.metadata = vec![]; // we could optimize metadata to only contain aptos metadata
+        m.version = 6; // others don't matter
+    }
+    for module in input.dep_modules.iter() {
+        // reject bad modules fast
+        move_bytecode_verifier::verify_module(&module).map_err(|_| Corpus::Keep)?;
+    }
+
+    // check no duplicates
+    let mset: HashSet<_> = input.dep_modules.iter().map(|m| m.self_id()).collect();
+    if mset.len() != input.dep_modules.len() {
+        return Err(Corpus::Keep);
+    }
+
+    // topologically order modules {
+    let all_modules = std::mem::take(&mut input.dep_modules);
+    let mut map = all_modules
+        .into_iter()
+        .map(|m| (m.self_id(), m))
+        .collect::<BTreeMap<_, _>>();
+    let mut order = vec![];
+    for id in map.keys() {
+        let mut visited = HashSet::new();
+        sort_by_deps(&map, &mut order, id.clone(), &mut visited)?;
+    }
+    // }
+
+    // group same address modules in packages. keep local ordering.
+    let mut packages = vec![];
+    for cur_package_id in order.iter() {
+        let mut cur = vec![];
+        if !map.contains_key(cur_package_id) {
+            continue;
+        }
+        // this makes sure we keep the order in packages
+        for id in order.iter() {
+            // check if part of current package
+            if id.address() == cur_package_id.address() {
+                if let Some(module) = map.remove(&cur_package_id) {
+                    cur.push(module);
+                }
+            }
+        }
+        packages.push(cur)
+    }
+
+    // publish all packages
+    for group in packages {
+        let sender = *group[0].address();
+        let serialized_modules: Vec<Vec<u8>> = group
+            .iter()
+            .map(|m| {
+                let mut b = vec![];
+                m.serialize(&mut b).map(|_| b)
+            })
+            .collect::<Result<Vec<Vec<u8>>, _>>()
+            .map_err(|_| Corpus::Keep)?;
+
+        // deprecated but easiest way to publish modules
+        let mb = ModuleBundle::new(serialized_modules);
+        let acc = vm.new_account_at(sender);
+        let tx = acc
+            .transaction()
+            .gas_unit_price(100)
+            .sequence_number(0)
+            .payload(TransactionPayload::ModuleBundle(mb))
+            .sign();
+        tdbg!("publishing");
+        let res = vm
+            .execute_block(vec![tx])
+            .map_err(|e| {
+                check_for_invariant_violation(e);
+                Corpus::Keep
+            })?
+            .pop()
+            .expect("expected 1 output");
+        // if error exit gracefully
+        let status = match tdbg!(res.status()) {
+            TransactionStatus::Keep(status) => status,
+            _ => return Err(Corpus::Keep),
+        };
+        match tdbg!(status) {
+            ExecutionStatus::Success => (),
+            _ => return Err(Corpus::Keep),
+        };
+        tdbg!("published");
+    }
+
+    let acc = vm.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    // build tx
+    let tx = match input.exec_variant {
+        ExecVariant::Script {
+            script,
+            type_args,
+            args,
+        } => {
+            let mut script_bytes = vec![];
+            script
+                .serialize(&mut script_bytes)
+                .map_err(|_| Corpus::Keep)?;
+            acc.transaction()
+                .gas_unit_price(100)
+                .max_gas_amount(1000)
+                .sequence_number(0)
+                .payload(TransactionPayload::Script(Script::new(
+                    script_bytes,
+                    type_args,
+                    args.into_iter()
+                        .map(|x| x.try_into())
+                        .collect::<Result<Vec<TransactionArgument>, _>>()
+                        .map_err(|_| Corpus::Keep)?,
+                )))
+        },
+        ExecVariant::CallFunction {
+            module,
+            function,
+            type_args,
+            args,
+        } => {
+            // convert FunctionDefinitionIndex to function name... {
+            let cm = input
+                .dep_modules
+                .iter()
+                .find(|m| m.self_id() == module)
+                .ok_or(Corpus::Keep)?;
+            let fhi = cm
+                .function_defs
+                .get(function.0 as usize)
+                .ok_or(Corpus::Keep)?
+                .function;
+            let function_identifier_index = cm
+                .function_handles
+                .get(fhi.0 as usize)
+                .ok_or(Corpus::Keep)?
+                .name;
+            let function_name = cm
+                .identifiers
+                .get(function_identifier_index.0 as usize)
+                .ok_or(Corpus::Keep)?
+                .clone();
+            // }
+            acc.transaction()
+                .gas_unit_price(100)
+                .max_gas_amount(1000)
+                .sequence_number(0)
+                .payload(TransactionPayload::EntryFunction(EntryFunction::new(
+                    module,
+                    function_name,
+                    type_args,
+                    args,
+                )))
+        },
+    };
+    let tx = tx
+        .raw()
+        .sign(&acc.privkey, acc.pubkey)
+        .map_err(|_| Corpus::Keep)?
+        .into_inner();
+
+    // exec tx
+    tdbg!("exec start");
+    let res = vm
+        .execute_block(vec![tx])
+        .map_err(|e| {
+            check_for_invariant_violation(e);
+            Corpus::Keep
+        })?
+        .pop()
+        .expect("expect 1 output");
+    tdbg!("exec end");
+
+    // if error exit gracefully
+    let status = match tdbg!(res.status()) {
+        TransactionStatus::Keep(status) => status,
+        _ => return Err(Corpus::Keep),
+    };
+    match tdbg!(status) {
+        ExecutionStatus::Success => (),
+        _ => return Err(Corpus::Keep),
+    };
+
+    Ok(())
+}
+
+fuzz_target!(|fuzz_data: RunnableState| -> Corpus {
+    run_case(fuzz_data).err().unwrap_or(Corpus::Keep)
+});

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -2,21 +2,7 @@
 
 // Copyright © Aptos Foundation
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    convert::TryInto,
-};
-
 use aptos_language_e2e_tests::{data_store::GENESIS_CHANGE_SET_HEAD, executor::FakeExecutor};
-use aptos_vm::AptosVM;
-use arbitrary::Arbitrary;
-use libfuzzer_sys::fuzz_target;
-use libfuzzer_sys::Corpus;
-use move_binary_format::{
-    access::ModuleAccess,
-    file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
-};
-
 use aptos_types::{
     chain_id::ChainId,
     transaction::{
@@ -25,7 +11,13 @@ use aptos_types::{
     },
     write_set::WriteSet,
 };
-
+use aptos_vm::AptosVM;
+use arbitrary::Arbitrary;
+use libfuzzer_sys::{fuzz_target, Corpus};
+use move_binary_format::{
+    access::ModuleAccess,
+    file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
+};
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, TypeTag},
@@ -33,6 +25,10 @@ use move_core_types::{
     vm_status::{StatusType, VMStatus},
 };
 use once_cell::sync::Lazy;
+use std::{
+    collections::{BTreeMap, HashSet},
+    convert::TryInto,
+};
 
 #[derive(Debug, Arbitrary, Eq, PartialEq, Clone)]
 pub enum ExecVariant {
@@ -104,7 +100,7 @@ fn sort_by_deps(
         }
     }
     order.push(id);
-    return Ok(());
+    Ok(())
 }
 
 // panic to catch invariant violations
@@ -128,7 +124,7 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     }
     for module in input.dep_modules.iter() {
         // reject bad modules fast
-        move_bytecode_verifier::verify_module(&module).map_err(|_| Corpus::Keep)?;
+        move_bytecode_verifier::verify_module(module).map_err(|_| Corpus::Keep)?;
     }
 
     // check no duplicates
@@ -161,7 +157,7 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
         for id in order.iter() {
             // check if part of current package
             if id.address() == cur_package_id.address() {
-                if let Some(module) = map.remove(&cur_package_id) {
+                if let Some(module) = map.remove(cur_package_id) {
                     cur.push(module);
                 }
             }

--- a/testsuite/fuzzer/google-oss-fuzz/build.sh
+++ b/testsuite/fuzzer/google-oss-fuzz/build.sh
@@ -5,7 +5,7 @@ NIGHTLY_VERSION="nightly-2023-01-01"  # bitvec does not compile with latest nigh
 rustup install $NIGHTLY_VERSION
 cd testsuite/fuzzer
 
-RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable" cargo +$NIGHTLY_VERSION fuzz build -O -a
+RUSTFLAGS="$RUSTFLAGS --cfg tokio_unstable" cargo +$NIGHTLY_VERSION fuzz build -Ztarget-applies-to-host -Zhost-config move_value_deserialize -O -a
 for fuzzer in $(cat fuzz/Cargo.toml | grep "name = " | grep -v "fuzzer-fuzz" | cut -d'"' -f2); do
   cp ../../target/x86_64-unknown-linux-gnu/release/$fuzzer $OUT/
 done

--- a/testsuite/fuzzer/repro.sh
+++ b/testsuite/fuzzer/repro.sh
@@ -25,7 +25,7 @@ FUZZER_NAME="$2"
 TESTCASE="$3"
 
 # Common command prefix
-CMD_PREFIX="cargo +nightly fuzz"
+CMD_PREFIX="cargo +nightly fuzz -Ztarget-applies-to-host -Zhost-config move_value_deserialize"
 
 # Set environment variable
 export RUSTFLAGS="--cfg tokio_unstable"

--- a/testsuite/fuzzer/test-fuzzers.sh
+++ b/testsuite/fuzzer/test-fuzzers.sh
@@ -5,7 +5,7 @@ export RUNS="1000"
 
 for fuzzer in $(cargo +nightly fuzz list); do
     echo "[info] compiling and running ${fuzzer} ${RUNS} times"
-    cargo +nightly fuzz run -O -a $fuzzer -- -runs=$RUNS
+    cargo +nightly fuzz run -Ztarget-applies-to-host -Zhost-config move_value_deserialize -O -a $fuzzer -- -runs=$RUNS
     if [ "$?" -ne "0" ]; then
         echo "[error] failed to run ${fuzzer}"
         return -1

--- a/third_party/move/move-binary-format/Cargo.toml
+++ b/third_party/move/move-binary-format/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-arbitrary = { version = "1.3.1", optional = true, features = ["derive"] }
+arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 backtrace = { workspace = true }
 indexmap = "1.9.3"
 move-core-types = { path = "../move-core/types" }

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -1928,6 +1928,7 @@ impl Bytecode {
 /// A CompiledScript defines the constant pools (string, address, signatures, etc.), the handle
 /// tables (external code references) and it has a `main` definition.
 #[derive(Clone, Default, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CompiledScript {
     /// Version number found during deserialization
     pub version: u32,

--- a/third_party/move/move-bytecode-verifier/fuzz/Cargo.toml
+++ b/third_party/move/move-bytecode-verifier/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = "1.3.1"
+arbitrary = "1.3.2"
 libfuzzer-sys = "0.4"
 move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
 move-bytecode-verifier = { path = "../" }

--- a/third_party/move/move-core/types/Cargo.toml
+++ b/third_party/move/move-core/types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-arbitrary = { version = "1.3.1", features = [ "derive_arbitrary"], optional = true }
+arbitrary = { version = "1.3.2", features = [ "derive_arbitrary"], optional = true }
 bytes = { version = "1.4.0" }
 ethnum = "1.0.4"
 hex = "0.4.3"
@@ -30,7 +30,7 @@ uint = "0.9.4"
 bcs = { workspace = true }
 
 [dev-dependencies]
-arbitrary = { version = "1.3.1", features = [ "derive_arbitrary"] }
+arbitrary = { version = "1.3.2", features = [ "derive_arbitrary"] }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 regex = "1.5.5"

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -210,6 +210,7 @@ impl ResourceKey {
 /// Represents the initial key into global storage where we first index by the address, and then
 /// the struct tag
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct ModuleId {


### PR DESCRIPTION
### Description
Adds new AptosVM fuzzer

Features:
* Fuzzing transactions through AptosVM eliminates false positives. (e.g. argument types are properly checked)
* Possible to reach aptos-specific features and adapter code
* Supports multi-module/multi-package fuzzcases
* invariant violations are caught as panics, except for known false positives
* Supports executions with both, entry functions and `CompiledScript`
* `Corpus::Keep`s for various errors can be modified to make libfuzzer not store specific fuzzcases.

Drawbacks:
* More dependencies for the fuzzer, slower compilation
* large input space means harder to mutate inputs

### Test Plan
* `./test-fuzzer.sh` passes
