### PR TITLE
ChunkExecutor: Split out ledger update to a separate stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-experimental-runtimes",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
@@ -3757,6 +3758,7 @@ dependencies = [
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
+ "aptos-experimental-runtimes",
  "arr_macro",
  "bcs 0.1.4",
  "bytes",

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -7,7 +7,7 @@ use aptos_crypto::hash::{TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_H
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_types::{
     epoch_state::EpochState,
-    proof::{accumulator::InMemoryAccumulator, AccumulatorExtensionProof},
+    proof::{accumulator::InMemoryTransactionAccumulator, AccumulatorExtensionProof},
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -73,7 +73,7 @@ impl VoteProposal {
     /// Attention: this function itself does not verify the proof.
     fn vote_data_with_extension_proof(
         &self,
-        new_tree: &InMemoryAccumulator<TransactionAccumulatorHasher>,
+        new_tree: &InMemoryTransactionAccumulator,
     ) -> VoteData {
         VoteData::new(
             self.block().gen_block_info(

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -4,149 +4,100 @@
 
 #![forbid(unsafe_code)]
 
-use anyhow::{bail, ensure, Result};
-use aptos_storage_interface::ExecutedTrees;
+use crate::{ChunkCommitNotification, LedgerUpdateOutput};
+use aptos_storage_interface::{state_delta::StateDelta, ExecutedTrees};
 use aptos_types::{
-    contract_event::ContractEvent,
-    epoch_state::EpochState,
-    ledger_info::LedgerInfoWithSignatures,
-    transaction::{Transaction, TransactionInfo, TransactionStatus, TransactionToCommit},
+    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    state_store::combine_or_add_sharded_state_updates, transaction::TransactionToCommit,
 };
-use itertools::zip_eq;
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct ExecutedChunk {
-    pub status: Vec<TransactionStatus>,
-    pub to_commit: Vec<TransactionToCommit>,
-    pub result_view: ExecutedTrees,
+    pub result_state: StateDelta,
+    pub ledger_info: Option<LedgerInfoWithSignatures>,
     /// If set, this is the new epoch info that should be changed to if this is committed.
     pub next_epoch_state: Option<EpochState>,
-    pub ledger_info: Option<LedgerInfoWithSignatures>,
+    pub ledger_update_output: LedgerUpdateOutput,
 }
 
 impl ExecutedChunk {
-    pub fn new_empty(result_view: ExecutedTrees) -> Self {
-        Self {
-            result_view,
-            ..Default::default()
-        }
-    }
-
     pub fn reconfig_suffix(&self) -> Self {
         assert!(self.next_epoch_state.is_some());
         Self {
-            result_view: self.result_view.clone(),
+            result_state: self.result_state.clone(),
+            ledger_info: None,
             next_epoch_state: self.next_epoch_state.clone(),
-            ..Default::default()
+            ledger_update_output: self.ledger_update_output.reconfig_suffix(),
         }
     }
 
     pub fn transactions_to_commit(&self) -> &Vec<TransactionToCommit> {
-        &self.to_commit
-    }
-
-    pub fn transactions(&self) -> Vec<Transaction> {
-        self.to_commit
-            .iter()
-            .map(|txn_to_commit| txn_to_commit.transaction())
-            .cloned()
-            .collect()
-    }
-
-    pub fn events_to_commit(&self) -> Vec<ContractEvent> {
-        self.to_commit
-            .iter()
-            .flat_map(|txn_to_commit| txn_to_commit.events())
-            .cloned()
-            .collect()
+        &self.ledger_update_output.to_commit
     }
 
     pub fn has_reconfiguration(&self) -> bool {
         self.next_epoch_state.is_some()
     }
 
-    pub fn ensure_transaction_infos_match(
-        &self,
-        transaction_infos: &[TransactionInfo],
-    ) -> Result<()> {
-        ensure!(
-            self.to_commit.len() == transaction_infos.len(),
-            "Lengths don't match. {} vs {}",
-            self.to_commit.len(),
-            transaction_infos.len(),
-        );
-
-        let start_version =
-            self.result_view.txn_accumulator().version() + 1 - self.to_commit.len() as u64;
-        zip_eq(self.to_commit.iter(), transaction_infos.iter())
-            .enumerate()
-            .try_for_each(|(idx, (txn_to_commit, expected_txn_info))| {
-                let txn_info = txn_to_commit.transaction_info();
-                if txn_info != expected_txn_info {
-                    bail!(
-                        "Transaction infos don't match. version: {}, txn_info:{txn_info}, expected_txn_info:{expected_txn_info}",
-                        start_version + idx as u64
-                    );
-                }
-                Ok(())
-            })
-    }
-
-    pub fn maybe_select_chunk_ending_ledger_info(
-        &self,
-        verified_target_li: &LedgerInfoWithSignatures,
-        epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<Option<LedgerInfoWithSignatures>> {
-        let result_accumulator = self.result_view.txn_accumulator();
-
-        if verified_target_li.ledger_info().version() + 1 == result_accumulator.num_leaves() {
-            // If the chunk corresponds to the target LI, the target LI can be added to storage.
-            ensure!(
-                verified_target_li
-                    .ledger_info()
-                    .transaction_accumulator_hash()
-                    == result_accumulator.root_hash(),
-                "Root hash in target ledger info does not match local computation. {:?} != {:?}",
-                verified_target_li,
-                result_accumulator
-            );
-            Ok(Some(verified_target_li.clone()))
-        } else if let Some(epoch_change_li) = epoch_change_li {
-            // If the epoch change LI is present, it must match the version of the chunk:
-
-            // Verify that the given ledger info corresponds to the new accumulator.
-            ensure!(
-                epoch_change_li.ledger_info().transaction_accumulator_hash()
-                    == result_accumulator.root_hash(),
-                "Root hash of a given epoch LI does not match local computation."
-            );
-            ensure!(
-                epoch_change_li.ledger_info().version() + 1 == result_accumulator.num_leaves(),
-                "Version of a given epoch LI does not match local computation."
-            );
-            ensure!(
-                epoch_change_li.ledger_info().ends_epoch(),
-                "Epoch change LI does not carry validator set"
-            );
-            ensure!(
-                epoch_change_li.ledger_info().next_epoch_state() == self.next_epoch_state.as_ref(),
-                "New validator set of a given epoch LI does not match local computation"
-            );
-            Ok(Some(epoch_change_li.clone()))
-        } else {
-            ensure!(
-                self.next_epoch_state.is_none(),
-                "End of epoch chunk based on local computation but no EoE LedgerInfo provided."
-            );
-            Ok(None)
-        }
-    }
-
     pub fn combine(&mut self, rhs: Self) {
-        self.to_commit.extend(rhs.to_commit);
-        self.status.extend(rhs.status);
-        self.result_view = rhs.result_view;
-        self.next_epoch_state = rhs.next_epoch_state;
-        self.ledger_info = rhs.ledger_info;
+        assert_eq!(
+            self.ledger_update_output.next_version(),
+            rhs.ledger_update_output.first_version(),
+            "Chunks to be combined are not consecutive.",
+        );
+        let Self {
+            result_state,
+            ledger_info,
+            next_epoch_state,
+            ledger_update_output,
+        } = rhs;
+
+        let old_result_state = self.result_state.replace_with(result_state);
+        // TODO(aldenhu): This is very unfortunate. Will revisit soon by remodeling the state diff.
+        if self.result_state.base_version > old_result_state.base_version
+            && old_result_state.base_version != old_result_state.current_version
+        {
+            combine_or_add_sharded_state_updates(
+                &mut self
+                    .ledger_update_output
+                    .state_updates_until_last_checkpoint,
+                old_result_state.updates_since_base,
+            )
+        }
+
+        self.ledger_info = ledger_info;
+        self.next_epoch_state = next_epoch_state;
+        self.ledger_update_output.combine(ledger_update_output)
+    }
+
+    pub fn result_view(&self) -> ExecutedTrees {
+        ExecutedTrees::new(
+            self.result_state.clone(),
+            self.ledger_update_output.transaction_accumulator.clone(),
+        )
+    }
+
+    pub fn into_chunk_commit_notification(self) -> ChunkCommitNotification {
+        let reconfiguration_occurred = self.has_reconfiguration();
+
+        let mut committed_transactions =
+            Vec::with_capacity(self.ledger_update_output.to_commit.len());
+        let mut committed_events =
+            Vec::with_capacity(self.ledger_update_output.to_commit.len() * 2);
+        for txn_to_commit in self.ledger_update_output.to_commit {
+            let TransactionToCommit {
+                transaction,
+                events,
+                ..
+            } = txn_to_commit;
+            committed_transactions.push(transaction);
+            committed_events.extend(events);
+        }
+
+        ChunkCommitNotification {
+            committed_transactions,
+            committed_events,
+            reconfiguration_occurred,
+        }
     }
 }

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -74,18 +74,11 @@ impl InMemoryStateCalculator {
             updates_since_base,
         } = base.clone();
 
-        // TODO(grao): Rethink the strategy for state sync, and optimize this.
-        let state_cache = sharded_state_cache
-            .iter()
-            .flatten()
-            .map(|entry| (entry.key().clone(), entry.value().1.clone()))
-            .collect();
-
         Self {
             _frozen_base: frozen_base,
             proof_reader: ProofReader::new(proofs),
 
-            state_cache,
+            state_cache: sharded_state_cache.flatten(),
             next_version: current_version.map_or(0, |v| v + 1),
             updates_after_latest: create_empty_sharded_state_updates(),
             usage: current.usage(),

--- a/execution/executor-types/src/ledger_update_output.rs
+++ b/execution/executor-types/src/ledger_update_output.rs
@@ -5,12 +5,12 @@
 
 use crate::StateComputeResult;
 use anyhow::{ensure, Result};
-use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
+use aptos_crypto::HashValue;
 use aptos_storage_interface::cached_state_view::ShardedStateCache;
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
-    proof::accumulator::InMemoryAccumulator,
+    proof::accumulator::InMemoryTransactionAccumulator,
     state_store::ShardedStateUpdates,
     transaction::{Transaction, TransactionStatus, TransactionToCommit},
 };
@@ -26,13 +26,11 @@ pub struct LedgerUpdateOutput {
     pub sharded_state_cache: ShardedStateCache,
     /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
     /// `state_tree`.
-    pub transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+    pub transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
 }
 
 impl LedgerUpdateOutput {
-    pub fn new_empty(
-        transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
-    ) -> Self {
+    pub fn new_empty(transaction_accumulator: Arc<InMemoryTransactionAccumulator>) -> Self {
         Self {
             transaction_accumulator,
             ..Default::default()
@@ -46,7 +44,7 @@ impl LedgerUpdateOutput {
         }
     }
 
-    pub fn txn_accumulator(&self) -> &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>> {
+    pub fn txn_accumulator(&self) -> &Arc<InMemoryTransactionAccumulator> {
         &self.transaction_accumulator
     }
 
@@ -71,7 +69,7 @@ impl LedgerUpdateOutput {
 
     pub fn as_state_compute_result(
         &self,
-        parent_accumulator: &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+        parent_accumulator: &Arc<InMemoryTransactionAccumulator>,
         next_epoch_state: Option<EpochState>,
     ) -> StateComputeResult {
         let txn_accu = self.txn_accumulator();

--- a/execution/executor-types/src/ledger_update_output.rs
+++ b/execution/executor-types/src/ledger_update_output.rs
@@ -10,10 +10,12 @@ use aptos_storage_interface::cached_state_view::ShardedStateCache;
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
     proof::accumulator::InMemoryTransactionAccumulator,
-    state_store::ShardedStateUpdates,
-    transaction::{Transaction, TransactionStatus, TransactionToCommit},
+    state_store::{combine_or_add_sharded_state_updates, ShardedStateUpdates},
+    transaction::{Transaction, TransactionInfo, TransactionStatus, TransactionToCommit, Version},
 };
+use itertools::zip_eq;
 use std::sync::Arc;
 
 #[derive(Default, Debug)]
@@ -22,7 +24,7 @@ pub struct LedgerUpdateOutput {
     pub to_commit: Vec<TransactionToCommit>,
     pub reconfig_events: Vec<ContractEvent>,
     pub transaction_info_hashes: Vec<HashValue>,
-    pub state_updates_before_last_checkpoint: ShardedStateUpdates,
+    pub state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
     pub sharded_state_cache: ShardedStateCache,
     /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
     /// `state_tree`.
@@ -67,6 +69,93 @@ impl LedgerUpdateOutput {
         Ok(())
     }
 
+    pub fn maybe_select_chunk_ending_ledger_info(
+        &self,
+        verified_target_li: &LedgerInfoWithSignatures,
+        epoch_change_li: Option<&LedgerInfoWithSignatures>,
+        next_epoch_state: Option<&EpochState>,
+    ) -> Result<Option<LedgerInfoWithSignatures>> {
+        if verified_target_li.ledger_info().version() + 1
+            == self.transaction_accumulator.num_leaves()
+        {
+            // If the chunk corresponds to the target LI, the target LI can be added to storage.
+            ensure!(
+                verified_target_li
+                    .ledger_info()
+                    .transaction_accumulator_hash()
+                    == self.transaction_accumulator.root_hash(),
+                "Root hash in target ledger info does not match local computation. {:?} != {:?}",
+                verified_target_li,
+                self.transaction_accumulator,
+            );
+            Ok(Some(verified_target_li.clone()))
+        } else if let Some(epoch_change_li) = epoch_change_li {
+            // If the epoch change LI is present, it must match the version of the chunk:
+
+            // Verify that the given ledger info corresponds to the new accumulator.
+            ensure!(
+                epoch_change_li.ledger_info().transaction_accumulator_hash()
+                    == self.transaction_accumulator.root_hash(),
+                "Root hash of a given epoch LI does not match local computation. {:?} vs {:?}",
+                epoch_change_li,
+                self.transaction_accumulator,
+            );
+            ensure!(
+                epoch_change_li.ledger_info().version() + 1
+                    == self.transaction_accumulator.num_leaves(),
+                "Version of a given epoch LI does not match local computation. {:?} vs {:?}",
+                epoch_change_li,
+                self.transaction_accumulator,
+            );
+            ensure!(
+                epoch_change_li.ledger_info().ends_epoch(),
+                "Epoch change LI does not carry validator set. version:{}",
+                epoch_change_li.ledger_info().version(),
+            );
+            ensure!(
+                epoch_change_li.ledger_info().next_epoch_state() == next_epoch_state,
+                "New validator set of a given epoch LI does not match local computation. {:?} vs {:?}",
+                epoch_change_li.ledger_info().next_epoch_state(),
+                next_epoch_state,
+            );
+            Ok(Some(epoch_change_li.clone()))
+        } else {
+            ensure!(
+                next_epoch_state.is_none(),
+                "End of epoch chunk based on local computation but no EoE LedgerInfo provided. version: {:?}",
+                self.transaction_accumulator.num_leaves().checked_sub(1),
+            );
+            Ok(None)
+        }
+    }
+
+    pub fn ensure_transaction_infos_match(
+        &self,
+        transaction_infos: &[TransactionInfo],
+    ) -> Result<()> {
+        let first_version =
+            self.transaction_accumulator.version() + 1 - self.to_commit.len() as Version;
+        ensure!(
+            self.transactions_to_commit().len() == transaction_infos.len(),
+            "Lengths don't match. {} vs {}",
+            self.transactions_to_commit().len(),
+            transaction_infos.len(),
+        );
+
+        let mut version = first_version;
+        for (txn_to_commit, expected_txn_info) in
+            zip_eq(self.to_commit.iter(), transaction_infos.iter())
+        {
+            let txn_info = txn_to_commit.transaction_info();
+            ensure!(
+                txn_info == expected_txn_info,
+                "Transaction infos don't match. version:{version}, txn_info:{txn_info}, expected_txn_info:{expected_txn_info}",
+            );
+            version += 1;
+        }
+        Ok(())
+    }
+
     pub fn as_state_compute_result(
         &self,
         parent_accumulator: &Arc<InMemoryTransactionAccumulator>,
@@ -85,5 +174,39 @@ impl LedgerUpdateOutput {
             self.transaction_info_hashes.clone(),
             self.reconfig_events.clone(),
         )
+    }
+
+    pub fn combine(&mut self, rhs: Self) {
+        let Self {
+            status,
+            to_commit,
+            reconfig_events,
+            transaction_info_hashes,
+            state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
+            sharded_state_cache,
+            transaction_accumulator,
+        } = rhs;
+
+        if let Some(updates) = state_updates_before_last_checkpoint {
+            combine_or_add_sharded_state_updates(
+                &mut self.state_updates_until_last_checkpoint,
+                updates,
+            );
+        }
+
+        self.status.extend(status);
+        self.to_commit.extend(to_commit);
+        self.reconfig_events.extend(reconfig_events);
+        self.transaction_info_hashes.extend(transaction_info_hashes);
+        self.sharded_state_cache.combine(sharded_state_cache);
+        self.transaction_accumulator = transaction_accumulator;
+    }
+
+    pub fn next_version(&self) -> Version {
+        self.transaction_accumulator.num_leaves() as Version
+    }
+
+    pub fn first_version(&self) -> Version {
+        self.transaction_accumulator.num_leaves() - self.to_commit.len() as Version
     }
 }

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -58,7 +58,7 @@ pub struct StateCheckpointOutput {
     txns: TransactionsByStatus,
     per_version_state_updates: Vec<ShardedStateUpdates>,
     state_checkpoint_hashes: Vec<Option<HashValue>>,
-    state_updates_before_last_checkpoint: ShardedStateUpdates,
+    state_updates_before_last_checkpoint: Option<ShardedStateUpdates>,
     sharded_state_cache: ShardedStateCache,
 }
 
@@ -67,7 +67,7 @@ impl StateCheckpointOutput {
         txns: TransactionsByStatus,
         per_version_state_updates: Vec<ShardedStateUpdates>,
         state_checkpoint_hashes: Vec<Option<HashValue>>,
-        state_updates_before_last_checkpoint: ShardedStateUpdates,
+        state_updates_before_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: ShardedStateCache,
     ) -> Self {
         Self {
@@ -89,7 +89,7 @@ impl StateCheckpointOutput {
         TransactionsByStatus,
         Vec<ShardedStateUpdates>,
         Vec<Option<HashValue>>,
-        ShardedStateUpdates,
+        Option<ShardedStateUpdates>,
         ShardedStateCache,
     ) {
         (

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -404,7 +404,7 @@ where
             APTOS_EXECUTOR_TRANSACTIONS_SAVED.observe(to_commit as f64);
 
             let result_in_memory_state = block.output.state().clone();
-            self.db.writer.save_transaction_block(
+            self.db.writer.save_transactions(
                 txns_to_commit,
                 first_version,
                 committed_block.output.state().base_version,
@@ -419,9 +419,9 @@ where
                 block
                     .output
                     .get_ledger_update()
-                    .state_updates_before_last_checkpoint
+                    .state_updates_until_last_checkpoint
                     .clone(),
-                &block.output.get_ledger_update().sharded_state_cache,
+                Some(&block.output.get_ledger_update().sharded_state_cache),
             )?;
             first_version += txns_to_commit.len() as u64;
             committed_block = block.clone();

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -6,27 +6,29 @@
 
 use crate::{
     components::{
-        apply_chunk_output::{ensure_no_discard, ensure_no_retry},
-        chunk_commit_queue::ChunkCommitQueue,
+        apply_chunk_output::{ensure_no_discard, ensure_no_retry, ApplyChunkOutput},
+        chunk_commit_queue::{ChunkCommitQueue, ChunkToUpdateLedger},
         chunk_output::ChunkOutput,
     },
     logging::{LogEntry, LogSchema},
     metrics::{
         APTOS_EXECUTOR_APPLY_CHUNK_SECONDS, APTOS_EXECUTOR_COMMIT_CHUNK_SECONDS,
-        APTOS_EXECUTOR_EXECUTE_CHUNK_SECONDS, APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
+        APTOS_EXECUTOR_EXECUTE_CHUNK_SECONDS, APTOS_EXECUTOR_LEDGER_UPDATE_OTHER_SECONDS,
+        APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
     },
 };
-use anyhow::Result;
+use anyhow::{anyhow, ensure, Result};
 use aptos_executor_types::{
     ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, ParsedTransactionOutput,
     TransactionReplayer, VerifyExecutionMode,
 };
 use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
+use aptos_metrics_core::TimerHelper;
 use aptos_state_view::StateViewId;
 use aptos_storage_interface::{
-    async_proof_fetcher::AsyncProofFetcher, cached_state_view::CachedStateView, DbReaderWriter,
-    ExecutedTrees,
+    async_proof_fetcher::AsyncProofFetcher, cached_state_view::CachedStateView,
+    state_delta::StateDelta, DbReaderWriter, ExecutedTrees,
 };
 use aptos_types::{
     contract_event::ContractEvent,
@@ -77,7 +79,7 @@ impl<V: VMExecutor> ChunkExecutor<V> {
 }
 
 impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
-    fn execute_chunk(
+    fn enqueue_chunk_by_execution(
         &self,
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
@@ -88,20 +90,32 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
             .read()
             .as_ref()
             .expect("not reset")
-            .execute_chunk(txn_list_with_proof, verified_target_li, epoch_change_li)
+            .enqueue_chunk_by_execution(txn_list_with_proof, verified_target_li, epoch_change_li)
     }
 
-    fn apply_chunk(
+    fn enqueue_chunk_by_transaction_outputs(
         &self,
         txn_output_list_with_proof: TransactionOutputListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
-        self.inner.read().as_ref().expect("not reset").apply_chunk(
-            txn_output_list_with_proof,
-            verified_target_li,
-            epoch_change_li,
-        )
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .enqueue_chunk_by_transaction_outputs(
+                txn_output_list_with_proof,
+                verified_target_li,
+                epoch_change_li,
+            )
+    }
+
+    fn update_ledger(&self) -> Result<()> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .update_ledger()
     }
 
     fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
@@ -138,69 +152,48 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         })
     }
 
-    fn state_view(&self, latest_view: &ExecutedTrees) -> Result<CachedStateView> {
-        latest_view.verified_state_view(
-            StateViewId::ChunkExecution {
-                first_version: latest_view.txn_accumulator().num_leaves(),
-            },
-            Arc::clone(&self.db.reader),
+    fn latest_state_view(&self, latest_state: &StateDelta) -> Result<CachedStateView> {
+        let first_version = latest_state.next_version();
+        CachedStateView::new(
+            StateViewId::ChunkExecution { first_version },
+            self.db.reader.clone(),
+            first_version,
+            latest_state.current.clone(),
             Arc::new(AsyncProofFetcher::new(self.db.reader.clone())),
         )
     }
 
-    fn apply_chunk_output_for_state_sync(
-        verified_target_li: &LedgerInfoWithSignatures,
-        epoch_change_li: Option<&LedgerInfoWithSignatures>,
-        latest_view: &ExecutedTrees,
-        chunk_output: ChunkOutput,
-        transaction_infos: &[TransactionInfo],
-    ) -> Result<ExecutedChunk> {
-        let (mut executed_chunk, to_discard, to_retry) = chunk_output.apply_to_ledger(
-            latest_view,
-            Some(
-                transaction_infos
-                    .iter()
-                    .map(|txn_info| txn_info.state_checkpoint_hash())
-                    .collect(),
-            ),
-            None,
-        )?;
-        ensure_no_discard(to_discard)?;
-        ensure_no_retry(to_retry)?;
-        executed_chunk.ensure_transaction_infos_match(transaction_infos)?;
-        executed_chunk.ledger_info = executed_chunk
-            .maybe_select_chunk_ending_ledger_info(verified_target_li, epoch_change_li)?;
+    fn commit_chunk_impl(&self) -> Result<ExecutedChunk> {
+        let (persisted_state, chunk) = self.commit_queue.lock().next_chunk_to_commit()?;
 
-        Ok(executed_chunk)
-    }
-
-    fn commit_chunk_impl(&self) -> Result<Arc<ExecutedChunk>> {
-        let (base_view, to_commit) = self.commit_queue.lock().next_chunk_to_commit()?;
-        let txns_to_commit = to_commit.transactions_to_commit();
-        let ledger_info = to_commit.ledger_info.as_ref();
-        if ledger_info.is_some() || !txns_to_commit.is_empty() {
+        if chunk.ledger_info.is_some() || !chunk.transactions_to_commit().is_empty() {
             fail_point!("executor::commit_chunk", |_| {
                 Err(anyhow::anyhow!("Injected error in commit_chunk"))
             });
             self.db.writer.save_transactions(
-                txns_to_commit,
-                base_view.txn_accumulator().num_leaves(),
-                base_view.state().base_version,
-                ledger_info,
-                false, /* sync_commit */
-                to_commit.result_view.state().clone(),
+                chunk.transactions_to_commit(),
+                persisted_state.next_version(),
+                persisted_state.base_version,
+                chunk.ledger_info.as_ref(),
+                false, // sync_commit
+                chunk.result_state.clone(),
+                // TODO(aldenhu): avoid cloning
+                chunk
+                    .ledger_update_output
+                    .state_updates_until_last_checkpoint
+                    .clone(),
+                Some(&chunk.ledger_update_output.sharded_state_cache),
             )?;
         }
-
         self.commit_queue
             .lock()
-            .dequeue()
-            .expect("commit_queue.deque() failed.");
-        Ok(to_commit)
+            .dequeue_committed(chunk.result_state.clone())?;
+
+        Ok(chunk)
     }
 
-    // ************************* Block Executor Implementation *************************
-    fn execute_chunk(
+    // ************************* Chunk Executor Implementation *************************
+    fn enqueue_chunk_by_execution(
         &self,
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
@@ -209,16 +202,36 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let _timer = APTOS_EXECUTOR_EXECUTE_CHUNK_SECONDS.start_timer();
 
         let num_txns = txn_list_with_proof.transactions.len();
-        let first_version_in_request = txn_list_with_proof.first_transaction_version;
-        let (_persisted_view, latest_view) = self.commit_queue.lock().persisted_and_latest_view();
-
-        let (txn_info_list_with_proof, txns_to_skip, transactions) = verify_chunk(
-            txn_list_with_proof,
-            verified_target_li,
+        ensure!(num_txns != 0, "Empty transaction list!");
+        let first_version_in_request = txn_list_with_proof
+            .first_transaction_version
+            .ok_or_else(|| anyhow!("Non-empty chunk with first_version == None."))?;
+        let parent_state = self.commit_queue.lock().latest_state();
+        ensure!(
+            first_version_in_request == parent_state.next_version(),
+            "Unexpected chunk. version in request: {}, current_version: {:?}",
             first_version_in_request,
-            &latest_view,
-            num_txns,
+            parent_state.current_version,
+        );
+
+        verify_chunk(
+            &txn_list_with_proof,
+            verified_target_li,
+            Some(first_version_in_request),
         )?;
+        let TransactionListWithProof {
+            transactions,
+            events: _,
+            first_transaction_version: _,
+            proof: txn_infos_with_proof,
+        } = txn_list_with_proof;
+        let verified_target_li = verified_target_li.clone();
+        let epoch_change_li = epoch_change_li.cloned();
+        let known_state_checkpoints: Vec<_> = txn_infos_with_proof
+            .transaction_infos
+            .iter()
+            .map(|t| t.state_checkpoint_hash())
+            .collect();
 
         // TODO(skedia) In the chunk executor path, we ideally don't need to verify the signature
         // as only transactions with verified signatures are committed to the storage.
@@ -231,27 +244,38 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         });
 
         // Execute transactions.
-        let state_view = self.state_view(&latest_view)?;
+        let state_view = self.latest_state_view(&parent_state)?;
         let chunk_output = {
             let _timer = APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS.start_timer();
             // State sync executor shouldn't have block gas limit.
             ChunkOutput::by_transaction_execution::<V>(sig_verified_txns.into(), state_view, None)?
         };
-        let executed_chunk = Self::apply_chunk_output_for_state_sync(
-            verified_target_li,
-            epoch_change_li,
-            &latest_view,
-            chunk_output,
-            &txn_info_list_with_proof.transaction_infos[txns_to_skip..],
-        )?;
 
-        // Add result to commit queue.
-        self.commit_queue.lock().enqueue(executed_chunk);
+        // Calcualte state snapshot
+        let (result_state, next_epoch_state, state_checkpoint_output) =
+            ApplyChunkOutput::calculate_state_checkpoint(
+                chunk_output,
+                &self.commit_queue.lock().latest_state(),
+                None, // append_state_checkpoint_to_block
+                Some(known_state_checkpoints),
+                false, // is_block
+            )?;
+
+        // Enqueue for next stage.
+        self.commit_queue
+            .lock()
+            .enqueue_for_ledger_update(ChunkToUpdateLedger {
+                result_state,
+                state_checkpoint_output,
+                next_epoch_state,
+                verified_target_li,
+                epoch_change_li,
+                txn_infos_with_proof,
+            })?;
 
         info!(
             LogSchema::new(LogEntry::ChunkExecutor)
-                .local_synced_version(latest_view.version().unwrap_or(0))
-                .first_version_in_request(first_version_in_request)
+                .first_version_in_request(Some(first_version_in_request))
                 .num_txns_in_request(num_txns),
             "Executed transaction chunk!",
         );
@@ -259,7 +283,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         Ok(())
     }
 
-    fn apply_chunk(
+    fn enqueue_chunk_by_transaction_outputs(
         &self,
         txn_output_list_with_proof: TransactionOutputListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
@@ -268,40 +292,66 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let _timer = APTOS_EXECUTOR_APPLY_CHUNK_SECONDS.start_timer();
 
         let num_txns = txn_output_list_with_proof.transactions_and_outputs.len();
-        let first_version_in_request = txn_output_list_with_proof.first_transaction_output_version;
-        let (_persisted_view, latest_view) = self.commit_queue.lock().persisted_and_latest_view();
+        ensure!(num_txns != 0, "Empty transaction list!");
+        let first_version_in_request = txn_output_list_with_proof
+            .first_transaction_output_version
+            .ok_or_else(|| anyhow!("Non-empty chunk with first_version == None."))?;
+        let parent_state = self.commit_queue.lock().latest_state();
+        ensure!(
+            first_version_in_request == parent_state.next_version(),
+            "Unexpected chunk. version in request: {}, current_version: {:?}",
+            first_version_in_request,
+            parent_state.current_version,
+        );
 
         // Verify input transaction list.
-        txn_output_list_with_proof
-            .verify(verified_target_li.ledger_info(), first_version_in_request)?;
-
-        // Skip transactions already in ledger.
-        let txns_to_skip = txn_output_list_with_proof.proof.verify_extends_ledger(
-            latest_view.txn_accumulator().num_leaves(),
-            latest_view.txn_accumulator().root_hash(),
-            first_version_in_request,
+        txn_output_list_with_proof.verify(
+            verified_target_li.ledger_info(),
+            Some(first_version_in_request),
         )?;
-        let mut txns_and_outputs = txn_output_list_with_proof.transactions_and_outputs;
-        txns_and_outputs.drain(..txns_to_skip);
+        let TransactionOutputListWithProof {
+            transactions_and_outputs,
+            first_transaction_output_version: _,
+            proof: txn_infos_with_proof,
+        } = txn_output_list_with_proof;
+        let verified_target_li = verified_target_li.clone();
+        let epoch_change_li = epoch_change_li.cloned();
+        let known_state_checkpoints: Vec<_> = txn_infos_with_proof
+            .transaction_infos
+            .iter()
+            .map(|t| t.state_checkpoint_hash())
+            .collect();
 
         // Apply transaction outputs.
-        let state_view = self.state_view(&latest_view)?;
-        let chunk_output = ChunkOutput::by_transaction_output(txns_and_outputs, state_view)?;
-        let executed_chunk = Self::apply_chunk_output_for_state_sync(
-            verified_target_li,
-            epoch_change_li,
-            &latest_view,
-            chunk_output,
-            &txn_output_list_with_proof.proof.transaction_infos[txns_to_skip..],
-        )?;
+        let state_view = self.latest_state_view(&parent_state)?;
+        let chunk_output =
+            ChunkOutput::by_transaction_output(transactions_and_outputs, state_view)?;
 
-        // Add result to commit queue.
-        self.commit_queue.lock().enqueue(executed_chunk);
+        // Calculate state snapshot
+        let (result_state, next_epoch_state, state_checkpoint_output) =
+            ApplyChunkOutput::calculate_state_checkpoint(
+                chunk_output,
+                &self.commit_queue.lock().latest_state(),
+                None, // append_state_checkpoint_to_block
+                Some(known_state_checkpoints),
+                false, // is_block
+            )?;
+
+        // Enqueue for next stage.
+        self.commit_queue
+            .lock()
+            .enqueue_for_ledger_update(ChunkToUpdateLedger {
+                result_state,
+                state_checkpoint_output,
+                next_epoch_state,
+                verified_target_li,
+                epoch_change_li,
+                txn_infos_with_proof,
+            })?;
 
         info!(
             LogSchema::new(LogEntry::ChunkExecutor)
-                .local_synced_version(latest_view.version().unwrap_or(0))
-                .first_version_in_request(first_version_in_request)
+                .first_version_in_request(Some(first_version_in_request))
                 .num_txns_in_request(num_txns),
             "Applied transaction output chunk!",
         );
@@ -309,14 +359,65 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         Ok(())
     }
 
+    pub fn update_ledger(&self) -> Result<()> {
+        let _timer =
+            APTOS_EXECUTOR_LEDGER_UPDATE_OTHER_SECONDS.timer_with(&["chunk_update_ledger_total"]);
+
+        let (parent_accumulator, chunk) = self.commit_queue.lock().next_chunk_to_update_ledger()?;
+        let ChunkToUpdateLedger {
+            result_state,
+            state_checkpoint_output,
+            next_epoch_state,
+            verified_target_li,
+            epoch_change_li,
+            txn_infos_with_proof,
+        } = chunk;
+
+        let first_version = parent_accumulator.num_leaves();
+        let num_overlap = txn_infos_with_proof.verify_extends_ledger(
+            first_version,
+            parent_accumulator.root_hash(),
+            Some(first_version),
+        )?;
+        assert_eq!(num_overlap, 0, "overlapped chunks");
+
+        let (ledger_update_output, to_discard, to_retry) =
+            ApplyChunkOutput::calculate_ledger_update(state_checkpoint_output, parent_accumulator)?;
+        ensure!(to_discard.is_empty(), "Unexpected discard.");
+        ensure!(to_retry.is_empty(), "Unexpected retry.");
+        ledger_update_output
+            .ensure_transaction_infos_match(&txn_infos_with_proof.transaction_infos)?;
+        let ledger_info_opt = ledger_update_output.maybe_select_chunk_ending_ledger_info(
+            &verified_target_li,
+            epoch_change_li.as_ref(),
+            next_epoch_state.as_ref(),
+        )?;
+
+        let executed_chunk = ExecutedChunk {
+            result_state,
+            ledger_info: ledger_info_opt,
+            next_epoch_state,
+            ledger_update_output,
+        };
+        let num_txns = executed_chunk.transactions_to_commit().len();
+
+        self.commit_queue
+            .lock()
+            .save_ledger_update_output(executed_chunk)?;
+        info!(
+            LogSchema::new(LogEntry::ChunkExecutor)
+                .first_version_in_request(Some(first_version))
+                .num_txns_in_request(num_txns),
+            "Calculated ledger update!",
+        );
+        Ok(())
+    }
+
     fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
         let _timer = APTOS_EXECUTOR_COMMIT_CHUNK_SECONDS.start_timer();
         let executed_chunk = self.commit_chunk_impl()?;
-        Ok(ChunkCommitNotification {
-            committed_events: executed_chunk.events_to_commit(),
-            committed_transactions: executed_chunk.transactions(),
-            reconfiguration_occurred: executed_chunk.has_reconfiguration(),
-        })
+
+        Ok(executed_chunk.into_chunk_commit_notification())
     }
 }
 
@@ -324,42 +425,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
 /// that are not already applied in the ledger.
 #[cfg(not(feature = "consensus-only-perf-test"))]
 fn verify_chunk(
-    txn_list_with_proof: TransactionListWithProof,
+    txn_list_with_proof: &TransactionListWithProof,
     verified_target_li: &LedgerInfoWithSignatures,
     first_version_in_request: Option<u64>,
-    latest_view: &ExecutedTrees,
-    num_txns: usize,
-) -> Result<
-    (
-        aptos_types::proof::TransactionInfoListWithProof,
-        usize,
-        Vec<Transaction>,
-    ),
-    anyhow::Error,
-> {
-    // Verify input transaction list
-    txn_list_with_proof.verify(verified_target_li.ledger_info(), first_version_in_request)?;
-
-    let txn_list = txn_list_with_proof.transactions;
-    let txn_info_with_proof = txn_list_with_proof.proof;
-
-    // Skip transactions already in ledger
-    let txns_to_skip = txn_info_with_proof.verify_extends_ledger(
-        latest_view.txn_accumulator().num_leaves(),
-        latest_view.txn_accumulator().root_hash(),
-        first_version_in_request,
-    )?;
-
-    let mut transactions = txn_list;
-    transactions.drain(..txns_to_skip);
-    if txns_to_skip == num_txns {
-        info!(
-            "Skipping all transactions in the given chunk! Num transactions: {:?}",
-            num_txns
-        );
-    }
-
-    Ok((txn_info_with_proof, txns_to_skip, transactions))
+) -> Result<()> {
+    txn_list_with_proof.verify(verified_target_li.ledger_info(), first_version_in_request)
 }
 
 /// In consensus-only mode, the [TransactionListWithProof](transaction list) is *not*
@@ -370,25 +440,12 @@ fn verify_chunk(
 /// already in the ledger, because it is not necessary as execution is disabled.
 #[cfg(feature = "consensus-only-perf-test")]
 fn verify_chunk(
-    txn_list_with_proof: TransactionListWithProof,
+    _txn_list_with_proof: &TransactionListWithProof,
     _verified_target_li: &LedgerInfoWithSignatures,
     _first_version_in_request: Option<u64>,
-    _latest_view: &ExecutedTrees,
-    _num_txns: usize,
-) -> Result<
-    (
-        aptos_types::proof::TransactionInfoListWithProof,
-        usize,
-        Vec<Transaction>,
-    ),
-    anyhow::Error,
-> {
+) -> Result<()> {
     // no-op: we do not verify the proof in consensus-only mode
-    Ok((
-        txn_list_with_proof.proof,
-        0,
-        txn_list_with_proof.transactions,
-    ))
+    Ok(())
 }
 
 impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
@@ -410,7 +467,7 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
         )
     }
 
-    fn commit(&self) -> Result<Arc<ExecutedChunk>> {
+    fn commit(&self) -> Result<ExecutedChunk> {
         self.inner.read().as_ref().expect("not reset").commit()
     }
 }
@@ -424,7 +481,7 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
         mut event_vecs: Vec<Vec<ContractEvent>>,
         verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<()> {
-        let (_parent_view, mut latest_view) = self.commit_queue.lock().persisted_and_latest_view();
+        let mut latest_view = self.commit_queue.lock().expect_latest_view()?;
         let chunk_begin = latest_view.num_transactions() as Version;
         let chunk_end = chunk_begin + transactions.len() as Version; // right-exclusive
 
@@ -444,7 +501,7 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
             epochs.push((epoch_begin, chunk_end));
         }
 
-        let mut executed_chunk = ExecutedChunk::default();
+        let mut executed_chunk = None;
         // Replay epoch by epoch.
         for (begin, end) in epochs {
             self.remove_and_replay_epoch(
@@ -460,11 +517,12 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
             )?;
         }
 
-        self.commit_queue.lock().enqueue(executed_chunk);
-        Ok(())
+        self.commit_queue
+            .lock()
+            .enqueue_chunk_to_commit_directly(executed_chunk.expect("Nothing to commit."))
     }
 
-    fn commit(&self) -> Result<Arc<ExecutedChunk>> {
+    fn commit(&self) -> Result<ExecutedChunk> {
         self.commit_chunk_impl()
     }
 }
@@ -475,7 +533,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
     /// Notice there can be known broken versions inside the range.
     fn remove_and_replay_epoch(
         &self,
-        executed_chunk: &mut ExecutedChunk,
+        executed_chunk: &mut Option<ExecutedChunk>,
         latest_view: &mut ExecutedTrees,
         transactions: &mut Vec<Transaction>,
         transaction_infos: &mut Vec<TransactionInfo>,
@@ -558,7 +616,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<Version> {
         // Execute transactions.
-        let state_view = self.state_view(latest_view)?;
+        let state_view = self.latest_state_view(latest_view.state())?;
         let txns = transactions
             .iter()
             .take((end_version - begin_version) as usize)
@@ -599,7 +657,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
     /// It's guaranteed that there's no known broken versions or epoch endings in the range.
     fn remove_and_apply(
         &self,
-        executed_chunk: &mut ExecutedChunk,
+        executed_chunk: &mut Option<ExecutedChunk>,
         latest_view: &mut ExecutedTrees,
         transactions: &mut Vec<Transaction>,
         transaction_infos: &mut Vec<TransactionInfo>,
@@ -629,7 +687,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         })
         .collect();
 
-        let state_view = self.state_view(latest_view)?;
+        let state_view = self.latest_state_view(latest_view.state())?;
         let chunk_output = ChunkOutput::by_transaction_output(txns_and_outputs, state_view)?;
         let (executed_batch, to_discard, to_retry) = chunk_output.apply_to_ledger(
             latest_view,
@@ -643,10 +701,15 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         )?;
         ensure_no_discard(to_discard)?;
         ensure_no_retry(to_retry)?;
-        executed_batch.ensure_transaction_infos_match(&txn_infos)?;
+        executed_batch
+            .ledger_update_output
+            .ensure_transaction_infos_match(&txn_infos)?;
 
-        executed_chunk.combine(executed_batch);
-        *latest_view = executed_chunk.result_view.clone();
+        match executed_chunk {
+            Some(chunk) => chunk.combine(executed_batch),
+            None => *executed_chunk = Some(executed_batch),
+        }
+        *latest_view = executed_chunk.as_ref().unwrap().result_view();
         Ok(())
     }
 }

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -12,10 +12,7 @@ use crate::{
     metrics::{APTOS_EXECUTOR_ERRORS, APTOS_EXECUTOR_OTHER_TIMERS_SECONDS},
 };
 use anyhow::{ensure, Result};
-use aptos_crypto::{
-    hash::{CryptoHash, EventAccumulatorHasher, TransactionAccumulatorHasher},
-    HashValue,
-};
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_executor_types::{
     parsed_transaction_output::TransactionsWithParsedOutput,
     state_checkpoint_output::{StateCheckpointOutput, TransactionsByStatus},
@@ -26,7 +23,7 @@ use aptos_storage_interface::{state_delta::StateDelta, ExecutedTrees};
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
-    proof::accumulator::InMemoryAccumulator,
+    proof::accumulator::{InMemoryEventAccumulator, InMemoryTransactionAccumulator},
     state_store::ShardedStateUpdates,
     transaction::{
         ExecutionStatus, Transaction, TransactionInfo, TransactionOutput, TransactionStatus,
@@ -105,7 +102,7 @@ impl ApplyChunkOutput {
 
     pub fn calculate_ledger_update(
         state_checkpoint_output: StateCheckpointOutput,
-        base_txn_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+        base_txn_accumulator: Arc<InMemoryTransactionAccumulator>,
     ) -> Result<(LedgerUpdateOutput, Vec<Transaction>, Vec<Transaction>)> {
         let (
             txns,
@@ -318,8 +315,7 @@ impl ApplyChunkOutput {
             .into_par_iter()
             .map(|(event_hashes, write_set_hash)| {
                 (
-                    InMemoryAccumulator::<EventAccumulatorHasher>::from_leaves(&event_hashes)
-                        .root_hash(),
+                    InMemoryEventAccumulator::from_leaves(&event_hashes).root_hash(),
                     write_set_hash,
                 )
             })

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -44,6 +44,7 @@ impl ApplyChunkOutput {
         chunk_output: ChunkOutput,
         parent_state: &StateDelta,
         append_state_checkpoint_to_block: Option<HashValue>,
+        known_state_checkpoints: Option<Vec<Option<HashValue>>>,
         is_block: bool,
     ) -> Result<(StateDelta, Option<EpochState>, StateCheckpointOutput)> {
         let ChunkOutput {
@@ -72,7 +73,7 @@ impl ApplyChunkOutput {
             state_checkpoint_hashes,
             result_state,
             next_epoch_state,
-            block_state_updates,
+            state_updates_before_last_checkpoint,
             sharded_state_cache,
         ) = {
             let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
@@ -87,17 +88,24 @@ impl ApplyChunkOutput {
             )?
         };
 
-        Ok((
-            result_state,
-            next_epoch_state,
-            StateCheckpointOutput::new(
-                TransactionsByStatus::new(status, to_keep, to_discard, to_retry),
-                state_updates_vec,
-                state_checkpoint_hashes,
-                block_state_updates,
-                sharded_state_cache,
-            ),
-        ))
+        let mut state_checkpoint_output = StateCheckpointOutput::new(
+            TransactionsByStatus::new(status, to_keep, to_discard, to_retry),
+            state_updates_vec,
+            state_checkpoint_hashes,
+            state_updates_before_last_checkpoint,
+            sharded_state_cache,
+        );
+
+        // On state sync/replay, we generate state checkpoints only periodically, for the
+        // last state checkpoint of each chunk.
+        // A mismatch in the SMT will be detected at that occasion too. Here we just copy
+        // in the state root from the TxnInfo in the proof.
+        if let Some(state_checkpoint_hashes) = known_state_checkpoints {
+            state_checkpoint_output
+                .check_and_update_state_checkpoint_hashes(state_checkpoint_hashes)?;
+        }
+
+        Ok((result_state, next_epoch_state, state_checkpoint_output))
     }
 
     pub fn calculate_ledger_update(
@@ -141,7 +149,7 @@ impl ApplyChunkOutput {
                 to_commit,
                 reconfig_events,
                 transaction_info_hashes,
-                state_updates_before_last_checkpoint,
+                state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
                 sharded_state_cache,
                 transaction_accumulator,
             },
@@ -153,26 +161,17 @@ impl ApplyChunkOutput {
     pub fn apply_chunk(
         chunk_output: ChunkOutput,
         base_view: &ExecutedTrees,
-        state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
+        known_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
         append_state_checkpoint_to_block: Option<HashValue>,
     ) -> Result<(ExecutedChunk, Vec<Transaction>, Vec<Transaction>)> {
-        let (result_state, next_epoch_state, mut state_checkpoint_output) =
+        let (result_state, next_epoch_state, state_checkpoint_output) =
             Self::calculate_state_checkpoint(
                 chunk_output,
                 base_view.state(),
                 append_state_checkpoint_to_block,
+                known_state_checkpoint_hashes,
                 /*is_block=*/ false,
             )?;
-
-        // On state sync/replay, we generate state checkpoints only periodically, for the
-        // last state checkpoint of each chunk.
-        // A mismatch in the SMT will be detected at that occasion too. Here we just copy
-        // in the state root from the TxnInfo in the proof.
-        if let Some(state_checkpoint_hashes) = state_checkpoint_hashes {
-            state_checkpoint_output
-                .check_and_update_state_checkpoint_hashes(state_checkpoint_hashes)?;
-        }
-
         let (ledger_update_output, to_discard, to_retry) = Self::calculate_ledger_update(
             state_checkpoint_output,
             base_view.txn_accumulator().clone(),
@@ -180,14 +179,10 @@ impl ApplyChunkOutput {
 
         Ok((
             ExecutedChunk {
-                status: ledger_update_output.status,
-                to_commit: ledger_update_output.to_commit,
-                result_view: ExecutedTrees::new(
-                    result_state,
-                    ledger_update_output.transaction_accumulator,
-                ),
-                next_epoch_state,
+                result_state,
                 ledger_info: None,
+                next_epoch_state,
+                ledger_update_output,
             },
             to_discard,
             to_retry,
@@ -395,6 +390,9 @@ pub fn ensure_no_discard(to_discard: Vec<Transaction>) -> Result<()> {
 }
 
 pub fn ensure_no_retry(to_retry: Vec<Transaction>) -> Result<()> {
-    ensure!(to_retry.is_empty(), "Chunk crosses epoch boundary.",);
+    ensure!(
+        to_retry.is_empty(),
+        "Seeing retries when syncing, did it crosses epoch boundary?",
+    );
     Ok(())
 }

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -4,60 +4,146 @@
 
 #![forbid(unsafe_code)]
 
-use anyhow::{anyhow, Result};
-use aptos_executor_types::ExecutedChunk;
-use aptos_storage_interface::{DbReader, ExecutedTrees};
+use anyhow::{anyhow, ensure, Result};
+use aptos_executor_types::{state_checkpoint_output::StateCheckpointOutput, ExecutedChunk};
+use aptos_storage_interface::{state_delta::StateDelta, DbReader, ExecutedTrees};
+use aptos_types::{
+    epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::{accumulator::InMemoryTransactionAccumulator, TransactionInfoListWithProof},
+};
 use std::{collections::VecDeque, sync::Arc};
 
+pub(crate) struct ChunkToUpdateLedger {
+    pub result_state: StateDelta,
+    /// transactions sorted by status, state roots, state updates
+    pub state_checkpoint_output: StateCheckpointOutput,
+    /// If set, this is the new epoch info that should be changed to if this is committed.
+    pub next_epoch_state: Option<EpochState>,
+    /// the below are from the input -- can be checked / used only after the transaction accumulator
+    /// is updated.
+    pub verified_target_li: LedgerInfoWithSignatures,
+    pub epoch_change_li: Option<LedgerInfoWithSignatures>,
+    pub txn_infos_with_proof: TransactionInfoListWithProof,
+}
+
+/// It's a two stage pipeline:
+///           (front)     (front)
+///          /           /
+///    ... | to_commit | to_update_ledger | ---> (txn version increases)
+///         \           \                \
+///          \           \                latest_state
+///           \           latest_txn_accumulator
+///            persisted_state
+///
 pub struct ChunkCommitQueue {
-    persisted_view: ExecutedTrees,
-    chunks_to_commit: VecDeque<Arc<ExecutedChunk>>,
+    persisted_state: StateDelta,
+    /// Notice that latest_state and latest_txn_accumulator are at different versions.
+    latest_state: StateDelta,
+    latest_txn_accumulator: Arc<InMemoryTransactionAccumulator>,
+    to_commit: VecDeque<Option<ExecutedChunk>>,
+    to_update_ledger: VecDeque<Option<ChunkToUpdateLedger>>,
 }
 
 impl ChunkCommitQueue {
-    pub fn new_from_db(db: &Arc<dyn DbReader>) -> Result<Self> {
-        let persisted_view = db.get_latest_executed_trees()?;
-        Ok(Self::new(persisted_view))
+    pub(crate) fn new_from_db(db: &Arc<dyn DbReader>) -> Result<Self> {
+        let ExecutedTrees {
+            state,
+            transaction_accumulator,
+        } = db.get_latest_executed_trees()?;
+        Ok(Self {
+            persisted_state: state.clone(),
+            latest_state: state,
+            latest_txn_accumulator: transaction_accumulator,
+            to_commit: VecDeque::new(),
+            to_update_ledger: VecDeque::new(),
+        })
     }
 
-    pub fn new(persisted_view: ExecutedTrees) -> Self {
-        Self {
-            persisted_view,
-            chunks_to_commit: VecDeque::new(),
-        }
+    pub(crate) fn latest_state(&self) -> StateDelta {
+        self.latest_state.clone()
     }
 
-    pub fn persisted_and_latest_view(&self) -> (ExecutedTrees, ExecutedTrees) {
-        (self.persisted_view.clone(), self.latest_view())
-    }
-
-    pub fn latest_view(&self) -> ExecutedTrees {
-        self.chunks_to_commit
-            .back()
-            .map(|chunk| chunk.result_view.clone())
-            .unwrap_or_else(|| self.persisted_view.clone())
-    }
-
-    pub fn next_chunk_to_commit(&self) -> Result<(ExecutedTrees, Arc<ExecutedChunk>)> {
-        Ok((
-            self.persisted_view.clone(),
-            self.chunks_to_commit
-                .front()
-                .ok_or_else(|| anyhow!("Commit queue is empty."))
-                .map(Arc::clone)?,
+    pub(crate) fn expect_latest_view(&self) -> Result<ExecutedTrees> {
+        ensure!(
+            self.to_update_ledger.is_empty(),
+            "Pending chunk to update_ledger, can't construct latest ExecutedTrees."
+        );
+        Ok(ExecutedTrees::new(
+            self.latest_state.clone(),
+            self.latest_txn_accumulator.clone(),
         ))
     }
 
-    pub fn enqueue(&mut self, chunk: ExecutedChunk) {
-        self.chunks_to_commit.push_back(Arc::new(chunk))
+    pub(crate) fn enqueue_for_ledger_update(
+        &mut self,
+        chunk_to_update_ledger: ChunkToUpdateLedger,
+    ) -> Result<()> {
+        self.latest_state = chunk_to_update_ledger.result_state.clone();
+        self.to_update_ledger
+            .push_back(Some(chunk_to_update_ledger));
+        Ok(())
     }
 
-    pub fn dequeue(&mut self) -> Result<()> {
-        let committed_chunk = self
-            .chunks_to_commit
-            .pop_front()
-            .ok_or_else(|| anyhow!("Commit queue is empty."))?;
-        self.persisted_view = committed_chunk.result_view.clone();
+    pub(crate) fn next_chunk_to_update_ledger(
+        &mut self,
+    ) -> Result<(Arc<InMemoryTransactionAccumulator>, ChunkToUpdateLedger)> {
+        let chunk_opt = self
+            .to_update_ledger
+            .front_mut()
+            .ok_or_else(|| anyhow!("No chunk to update ledger."))?;
+        let chunk = chunk_opt
+            .take()
+            .ok_or_else(|| anyhow!("Next chunk to update ledger has already been processed."))?;
+        Ok((self.latest_txn_accumulator.clone(), chunk))
+    }
+
+    pub(crate) fn save_ledger_update_output(&mut self, chunk: ExecutedChunk) -> Result<()> {
+        ensure!(
+            !self.to_update_ledger.is_empty(),
+            "to_update_ledger is empty."
+        );
+        ensure!(
+            self.to_update_ledger.front().unwrap().is_none(),
+            "Head of to_update_ledger has not been processed."
+        );
+        self.latest_txn_accumulator = chunk.ledger_update_output.transaction_accumulator.clone();
+        self.to_update_ledger.pop_front();
+        self.to_commit.push_back(Some(chunk));
+
+        Ok(())
+    }
+
+    pub(crate) fn next_chunk_to_commit(&mut self) -> Result<(StateDelta, ExecutedChunk)> {
+        let chunk_opt = self
+            .to_commit
+            .front_mut()
+            .ok_or_else(|| anyhow!("No chunk to commit."))?;
+        let chunk = chunk_opt
+            .take()
+            .ok_or_else(|| anyhow!("Next chunk to commit has already been processed."))?;
+        Ok((self.persisted_state.clone(), chunk))
+    }
+
+    pub(crate) fn enqueue_chunk_to_commit_directly(&mut self, chunk: ExecutedChunk) -> Result<()> {
+        ensure!(
+            self.to_update_ledger.is_empty(),
+            "Mixed usage of different modes."
+        );
+        self.latest_state = chunk.result_state.clone();
+        self.latest_txn_accumulator = chunk.ledger_update_output.transaction_accumulator.clone();
+        self.to_commit.push_back(Some(chunk));
+        Ok(())
+    }
+
+    pub(crate) fn dequeue_committed(&mut self, latest_state: StateDelta) -> Result<()> {
+        ensure!(!self.to_commit.is_empty(), "to_commit is empty.");
+        ensure!(
+            self.to_commit.front().unwrap().is_none(),
+            "Head of to_commit has not been processed."
+        );
+        self.to_commit.pop_front();
+        self.persisted_state = latest_state;
         Ok(())
     }
 }

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -147,7 +147,7 @@ impl ChunkOutput {
     pub fn apply_to_ledger(
         self,
         base_view: &ExecutedTrees,
-        state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
+        known_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
         append_state_checkpoint_to_block: Option<HashValue>,
     ) -> Result<(ExecutedChunk, Vec<Transaction>, Vec<Transaction>)> {
         fail_point!("executor::apply_to_ledger", |_| {
@@ -156,7 +156,7 @@ impl ChunkOutput {
         ApplyChunkOutput::apply_chunk(
             self,
             base_view,
-            state_checkpoint_hashes,
+            known_state_checkpoint_hashes,
             append_state_checkpoint_to_block,
         )
     }
@@ -171,12 +171,14 @@ impl ChunkOutput {
                 "Injected error in into_state_checkpoint_output."
             ))
         });
+
         // TODO(msmouse): If this code path is only used by block_executor, consider move it to the
         // caller side.
         ApplyChunkOutput::calculate_state_checkpoint(
             self,
             parent_state,
             append_state_checkpoint_to_block,
+            None,
             /*is_block=*/ true,
         )
     }

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -102,11 +102,20 @@ impl GenesisCommitter {
     pub fn commit(self) -> Result<()> {
         self.db.save_transactions(
             self.output.transactions_to_commit(),
-            self.output.result_view.txn_accumulator().version(),
+            self.output
+                .ledger_update_output
+                .transaction_accumulator
+                .num_leaves()
+                - 1,
             self.base_state_version,
             self.output.ledger_info.as_ref(),
             true, /* sync_commit */
-            self.output.result_view.state().clone(),
+            self.output.result_state.clone(),
+            self.output
+                .ledger_update_output
+                .state_updates_until_last_checkpoint
+                .clone(),
+            Some(&self.output.ledger_update_output.sharded_state_cache),
         )?;
         info!("Genesis commited.");
         // DB bootstrapped, avoid anything that could fail after this.
@@ -143,7 +152,7 @@ pub fn calculate_genesis<V: VMExecutor>(
     )?
     .apply_to_ledger(&executed_trees, None, None)?;
     ensure!(
-        !output.to_commit.is_empty(),
+        !output.transactions_to_commit().is_empty(),
         "Genesis txn execution failed."
     );
 
@@ -151,7 +160,7 @@ pub fn calculate_genesis<V: VMExecutor>(
         // TODO(aldenhu): fix existing tests before using real timestamp and check on-chain epoch.
         GENESIS_TIMESTAMP_USECS
     } else {
-        let state_view = output.result_view.verified_state_view(
+        let state_view = output.result_view().verified_state_view(
             StateViewId::Miscellaneous,
             Arc::clone(&db.reader),
             Arc::new(AsyncProofFetcher::new(db.reader.clone())),
@@ -176,7 +185,10 @@ pub fn calculate_genesis<V: VMExecutor>(
                 epoch,
                 GENESIS_ROUND,
                 genesis_block_id(),
-                output.result_view.txn_accumulator().root_hash(),
+                output
+                    .ledger_update_output
+                    .transaction_accumulator
+                    .root_hash(),
                 genesis_version,
                 timestamp_usecs,
                 output.next_epoch_state.clone(),

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -11,11 +11,14 @@ use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_state_view::StateView;
 use aptos_storage_interface::{
-    cached_state_view::CachedStateView, state_delta::StateDelta, DbReader, DbReaderWriter, DbWriter,
+    cached_state_view::{CachedStateView, ShardedStateCache},
+    state_delta::StateDelta,
+    DbReader, DbReaderWriter, DbWriter,
 };
 use aptos_types::{
     block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
     ledger_info::LedgerInfoWithSignatures,
+    state_store::ShardedStateUpdates,
     test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
     transaction::{
         signature_verified_transaction::{
@@ -120,6 +123,8 @@ impl DbWriter for FakeDb {
         _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         _sync_commit: bool,
         _in_memory_state: StateDelta,
+        _block_state_updates: Option<ShardedStateUpdates>,
+        _sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
         Ok(())
     }

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -18,7 +18,7 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::{block, BLOCK_GAS_LIMIT},
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof},
+    transaction::TransactionListWithProof,
 };
 use rand::Rng;
 
@@ -46,7 +46,7 @@ impl TestExecutor {
     }
 }
 
-fn execute_and_commit_chunk(
+fn execute_and_commit_chunks(
     chunks: Vec<TransactionListWithProof>,
     ledger_info: LedgerInfoWithSignatures,
     db: &DbReaderWriter,
@@ -70,24 +70,6 @@ fn execute_and_commit_chunk(
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
-    // Execute an empty chunk. After that we should still get the genesis ledger info from DB.
-    executor
-        .execute_chunk(TransactionListWithProof::new_empty(), &ledger_info, None)
-        .unwrap();
-    executor.commit_chunk().unwrap();
-    let li = db.reader.get_latest_ledger_info().unwrap();
-    assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
-
-    // Execute the second chunk again. After that we should still get the same thing.
-    executor
-        .execute_chunk(chunks[1].clone(), &ledger_info, None)
-        .unwrap();
-    executor.commit_chunk().unwrap();
-    let li = db.reader.get_latest_ledger_info().unwrap();
-    assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
-
     // Execute the third chunk. After that we should get the new ledger info.
     executor
         .execute_chunk(chunks[2].clone(), &ledger_info, None)
@@ -103,11 +85,10 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
     let first_batch_size = 30;
     let second_batch_size = 40;
     let third_batch_size = 20;
-    let overlapping_size = 5;
 
     let first_batch_start = 1;
     let second_batch_start = first_batch_start + first_batch_size;
-    let third_batch_start = second_batch_start + second_batch_size - overlapping_size;
+    let third_batch_start = second_batch_start + second_batch_size;
 
     let (chunks, ledger_info) = {
         tests::create_transaction_chunks(vec![
@@ -123,7 +104,7 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
             db,
             executor,
         } = TestExecutor::new();
-        execute_and_commit_chunk(chunks, ledger_info.clone(), &db, &executor);
+        execute_and_commit_chunks(chunks, ledger_info.clone(), &db, &executor);
 
         let ledger_version = db.reader.get_latest_version().unwrap();
         let output1 = db
@@ -158,28 +139,6 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
     assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
     // Execute the second chunk. After that we should still get the genesis ledger info from DB.
-    executor
-        .apply_chunk(chunks[1].clone(), &ledger_info, None)
-        .unwrap();
-    executor.commit_chunk().unwrap();
-    let li = db.reader.get_latest_ledger_info().unwrap();
-    assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
-
-    // Execute an empty chunk. After that we should still get the genesis ledger info from DB.
-    executor
-        .apply_chunk(
-            TransactionOutputListWithProof::new_empty(),
-            &ledger_info,
-            None,
-        )
-        .unwrap();
-    executor.commit_chunk().unwrap();
-    let li = db.reader.get_latest_ledger_info().unwrap();
-    assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
-
-    // Execute the second chunk again. After that we should still get the same thing.
     executor
         .apply_chunk(chunks[1].clone(), &ledger_info, None)
         .unwrap();
@@ -230,11 +189,13 @@ fn test_executor_execute_and_commit_chunk_restart() {
 
     // Then we restart executor and resume to the next chunk.
     {
+        println!("------------------------------------ CCC");
         let executor = ChunkExecutor::<MockVM>::new(db.clone());
 
         executor
             .execute_chunk(chunks[1].clone(), &ledger_info, None)
             .unwrap();
+        println!("------------------------------------ DDD");
         executor.commit_chunk().unwrap();
         let li = db.reader.get_latest_ledger_info().unwrap();
         assert_eq!(li, ledger_info);

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -14,7 +14,7 @@ use aptos_config::config::{
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_storage_interface::{DbReader, DbWriter, ExecutedTrees, Order};
+use aptos_storage_interface::{DbReader, ExecutedTrees, Order};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -218,7 +218,7 @@ pub fn test_state_merkle_pruning_impl(
     let mut snapshot_versions = vec![];
     for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
         test_helper::update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
-        db.save_transactions(
+        db.save_transactions_for_test(
             txns_to_commit,
             next_ver,                /* first_version */
             next_ver.checked_sub(1), /* base_state_version */

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -7,7 +7,6 @@ use crate::{
     AptosDB,
 };
 use anyhow::Result;
-use aptos_storage_interface::DbWriter;
 use aptos_temppath::TempPath;
 use aptos_types::transaction::Version;
 use proptest::prelude::*;
@@ -24,8 +23,15 @@ proptest! {
         let mut cur_ver: Version = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
             update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
-            db.save_transactions(txns_to_commit, cur_ver, cur_ver.checked_sub(1), Some(ledger_info_with_sigs), true, in_memory_state.clone())
-                .unwrap();
+            db.save_transactions_for_test(
+                txns_to_commit,
+                cur_ver,
+                cur_ver.checked_sub(1),
+                Some(ledger_info_with_sigs),
+                true, // sync commit
+                in_memory_state.clone(),
+            )
+            .unwrap();
             cur_ver += txns_to_commit.len() as u64;
         }
 

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -240,7 +240,7 @@ mod test {
         utils::truncation_helper::num_frozen_nodes_in_accumulator,
         AptosDB, NUM_STATE_SHARDS,
     };
-    use aptos_storage_interface::{DbReader, DbWriter};
+    use aptos_storage_interface::DbReader;
     use aptos_temppath::TempPath;
     use proptest::prelude::*;
 
@@ -262,7 +262,14 @@ mod test {
             let mut version = 0;
             for (txns_to_commit, ledger_info_with_sigs) in input.0.iter() {
                 update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
-                db.save_transactions(txns_to_commit, version, version.checked_sub(1), Some(ledger_info_with_sigs), true, in_memory_state.clone())
+                db.save_transactions_for_test(
+                    txns_to_commit,
+                    version,
+                    version.checked_sub(1),
+                    Some(ledger_info_with_sigs),
+                    true,
+                    in_memory_state.clone()
+                )
                     .unwrap();
                 version += txns_to_commit.len() as u64;
             }

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -162,6 +162,8 @@ impl DbWriter for FastSyncStorageWrapper {
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
+        state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
+        sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
         self.get_aptos_db_write_ref().save_transactions(
             txns_to_commit,
@@ -170,28 +172,7 @@ impl DbWriter for FastSyncStorageWrapper {
             ledger_info_with_sigs,
             sync_commit,
             latest_in_memory_state,
-        )
-    }
-
-    fn save_transaction_block(
-        &self,
-        txns_to_commit: &[TransactionToCommit],
-        first_version: Version,
-        base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-        sync_commit: bool,
-        latest_in_memory_state: StateDelta,
-        block_state_updates: ShardedStateUpdates,
-        sharded_state_cache: &ShardedStateCache,
-    ) -> Result<()> {
-        self.get_aptos_db_write_ref().save_transaction_block(
-            txns_to_commit,
-            first_version,
-            base_state_version,
-            ledger_info_with_sigs,
-            sync_commit,
-            latest_in_memory_state,
-            block_state_updates,
+            state_updates_until_last_checkpoint,
             sharded_state_cache,
         )
     }

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -10,10 +10,11 @@ use crate::{
 use anyhow::{ensure, Result};
 use aptos_logger::info;
 use aptos_storage_interface::state_delta::StateDelta;
-use aptos_types::{state_store::ShardedStateUpdates, transaction::Version};
-use itertools::zip_eq;
+use aptos_types::{
+    state_store::{combine_sharded_state_updates, ShardedStateUpdates},
+    transaction::Version,
+};
 use std::{
-    mem::swap,
     sync::{
         mpsc,
         mpsc::{Sender, SyncSender},
@@ -148,7 +149,7 @@ impl BufferedState {
     pub fn update(
         &mut self,
         updates_until_next_checkpoint_since_current_option: Option<ShardedStateUpdates>,
-        mut new_state_after_checkpoint: StateDelta,
+        new_state_after_checkpoint: StateDelta,
         sync_commit: bool,
     ) -> Result<()> {
         ensure!(
@@ -157,27 +158,28 @@ impl BufferedState {
         if let Some(updates_until_next_checkpoint_since_current) =
             updates_until_next_checkpoint_since_current_option
         {
-            zip_eq(
-                self.state_after_checkpoint.updates_since_base.iter_mut(),
+            ensure!(
+                new_state_after_checkpoint.base_version > self.state_after_checkpoint.base_version,
+                "Diff between base and latest checkpoints provided, while they are the same.",
+            );
+            combine_sharded_state_updates(
+                &mut self.state_after_checkpoint.updates_since_base,
                 updates_until_next_checkpoint_since_current,
-            )
-            .for_each(|(base, delta)| {
-                base.extend(delta);
-            });
+            );
             self.state_after_checkpoint.current = new_state_after_checkpoint.base.clone();
             self.state_after_checkpoint.current_version = new_state_after_checkpoint.base_version;
-            swap(
-                &mut self.state_after_checkpoint,
-                &mut new_state_after_checkpoint,
-            );
+            let state_after_checkpoint = self
+                .state_after_checkpoint
+                .replace_with(new_state_after_checkpoint);
             if let Some(ref mut delta) = self.state_until_checkpoint {
-                delta.merge(new_state_after_checkpoint);
+                delta.merge(state_after_checkpoint);
             } else {
-                self.state_until_checkpoint = Some(Box::new(new_state_after_checkpoint));
+                self.state_until_checkpoint = Some(Box::new(state_after_checkpoint));
             }
         } else {
             ensure!(
-                new_state_after_checkpoint.base_version == self.state_after_checkpoint.base_version
+                new_state_after_checkpoint.base_version == self.state_after_checkpoint.base_version,
+                "Diff between base and latest checkpoints not provided.",
             );
             self.state_after_checkpoint = new_state_after_checkpoint;
         }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -58,9 +58,7 @@ use aptos_types::{
     transaction::Version,
     write_set::{TransactionWrite, WriteSet},
 };
-use arr_macro::arr;
 use claims::{assert_ge, assert_le};
-use dashmap::DashMap;
 use rayon::prelude::*;
 use std::{collections::HashSet, ops::Deref, sync::Arc};
 
@@ -780,7 +778,7 @@ impl StateStore {
         let mut usage = self.get_usage(base_version)?;
         let base_version_usage = usage;
 
-        let mut state_cache_with_version = &arr![DashMap::new(); 16];
+        let mut state_cache_with_version = &ShardedStateCache::default();
         if let Some(base_version) = base_version {
             let _timer = OTHER_TIMERS_SECONDS
                 .with_label_values(&["put_stats_and_indices__total_get"])
@@ -798,7 +796,7 @@ impl StateStore {
                     .collect::<HashSet<_>>();
                 THREAD_MANAGER.get_io_pool().scope(|s| {
                     for key in key_set {
-                        let cache = &state_cache_with_version[key.get_shard_id() as usize];
+                        let cache = state_cache_with_version.shard(key.get_shard_id());
                         s.spawn(move |_| {
                             let _timer = OTHER_TIMERS_SECONDS
                                 .with_label_values(&["put_stats_and_indices__get_state_value"])

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -22,6 +22,7 @@ use aptos_types::{
     access_path::AccessPath, account_address::AccountAddress, nibble::nibble_path::NibblePath,
     state_store::state_key::StateKeyTag,
 };
+use arr_macro::arr;
 use proptest::{collection::hash_map, prelude::*};
 use std::collections::HashMap;
 

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -365,7 +365,7 @@ pub fn test_save_blocks_impl(
     let mut snapshot_versions = vec![];
     for (batch_idx, (txns_to_commit, ledger_info_with_sigs)) in input.iter().enumerate() {
         update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
-        db.save_transactions(
+        db.save_transactions_for_test(
             txns_to_commit,
             cur_ver,                /* first_version */
             cur_ver.checked_sub(1), /* base_state_version */
@@ -953,25 +953,36 @@ pub fn test_sync_transactions_impl(
         let batch1_len = txns_to_commit.len() / 2;
         let base_state_version = cur_ver.checked_sub(1);
         if batch1_len > 0 {
-            update_in_memory_state(&mut in_memory_state, &txns_to_commit[..batch1_len]);
+            let txns_to_commit_batch = &txns_to_commit[..batch1_len];
+            update_in_memory_state(&mut in_memory_state, txns_to_commit_batch);
             db.save_transactions(
-                &txns_to_commit[..batch1_len],
+                txns_to_commit_batch,
                 cur_ver, /* first_version */
                 base_state_version,
                 None,
                 false, /* sync_commit */
                 in_memory_state.clone(),
+                gather_state_updates_until_last_checkpoint(
+                    cur_ver,
+                    &in_memory_state,
+                    txns_to_commit_batch,
+                ),
+                None,
             )
             .unwrap();
         }
-        update_in_memory_state(&mut in_memory_state, &txns_to_commit[batch1_len..]);
+        let ver = cur_ver + batch1_len as Version;
+        let txns_to_commit_batch = &txns_to_commit[batch1_len..];
+        update_in_memory_state(&mut in_memory_state, txns_to_commit_batch);
         db.save_transactions(
-            &txns_to_commit[batch1_len..],
-            cur_ver + batch1_len as u64, /* first_version */
+            txns_to_commit_batch,
+            ver,
             base_state_version,
             Some(ledger_info_with_sigs),
             false, /* sync_commit */
             in_memory_state.clone(),
+            gather_state_updates_until_last_checkpoint(ver, &in_memory_state, txns_to_commit_batch),
+            None,
         )
         .unwrap();
 
@@ -1006,4 +1017,62 @@ pub fn test_sync_transactions_impl(
             .flat_map(|(txns_to_commit, _)| txns_to_commit.iter())
             .collect(),
     );
+}
+
+pub fn gather_state_updates_until_last_checkpoint(
+    first_version: Version,
+    latest_in_memory_state: &StateDelta,
+    txns_to_commit: &[TransactionToCommit],
+) -> Option<ShardedStateUpdates> {
+    if let Some(latest_checkpoint_version) = latest_in_memory_state.base_version {
+        if latest_checkpoint_version >= first_version {
+            let idx = (latest_checkpoint_version - first_version) as usize;
+            assert!(
+                    txns_to_commit[idx].is_state_checkpoint(),
+                    "The new latest snapshot version passed in {:?} does not match with the last checkpoint version in txns_to_commit {:?}",
+                    latest_checkpoint_version,
+                    first_version + idx as u64
+                );
+            let mut sharded_state_updates = create_empty_sharded_state_updates();
+            sharded_state_updates.par_iter_mut().enumerate().for_each(
+                |(shard_id, state_updates_shard)| {
+                    txns_to_commit[..=idx].iter().for_each(|txn_to_commit| {
+                        state_updates_shard.extend(txn_to_commit.state_updates()[shard_id].clone());
+                    })
+                },
+            );
+            return Some(sharded_state_updates);
+        }
+    }
+
+    None
+}
+
+/// Test only methods for the DB
+impl AptosDB {
+    pub fn save_transactions_for_test(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        sync_commit: bool,
+        latest_in_memory_state: StateDelta,
+    ) -> Result<()> {
+        let state_updates_until_last_checkpoint = gather_state_updates_until_last_checkpoint(
+            first_version,
+            &latest_in_memory_state,
+            txns_to_commit,
+        );
+        self.save_transactions(
+            txns_to_commit,
+            first_version,
+            base_state_version,
+            ledger_info_with_sigs,
+            sync_commit,
+            latest_in_memory_state,
+            state_updates_until_last_checkpoint,
+            None,
+        )
+    }
 }

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -630,7 +630,7 @@ impl TransactionRestoreBatchController {
                         .start_timer();
                     tokio::task::spawn_blocking(move || {
                         let committed_chunk = chunk_replayer.commit()?;
-                        let v = committed_chunk.result_view.version().unwrap_or(0);
+                        let v = committed_chunk.result_state.current_version.unwrap_or(0);
                         let total_replayed = v - first_version + 1;
                         TRANSACTION_REPLAY_VERSION.set(v as i64);
                         info!(

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -9,7 +9,6 @@ use aptos_db::{
     AptosDB,
 };
 use aptos_proptest_helpers::ValueGenerator;
-use aptos_storage_interface::DbWriter;
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -40,7 +39,7 @@ pub fn tmp_db_with_random_content() -> (
     let blocks = ValueGenerator::new().generate(arb_blocks_to_commit());
     for (txns_to_commit, ledger_info_with_sigs) in &blocks {
         update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
-        db.save_transactions(
+        db.save_transactions_for_test(
             txns_to_commit,
             cur_ver, /* first_version */
             cur_ver.checked_sub(1),

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-experimental-runtimes = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-scratchpad = { workspace = true }

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_scratchpad::{FrozenSparseMerkleTree, SparseMerkleTree, StateStoreStatus};
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
@@ -16,11 +17,11 @@ use aptos_types::{
     transaction::Version,
     write_set::WriteSet,
 };
-use arr_macro::arr;
 use core::fmt;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
@@ -35,11 +36,49 @@ static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
         .unwrap()
 });
 
+type StateCacheShard = DashMap<StateKey, (Option<Version>, Option<StateValue>)>;
+
 // Sharded by StateKey.get_shard_id(). The version in the value indicates there is an entry on that
 // version for the given StateKey, and the version is the maximum one which <= the base version. It
 // will be None if the value is None, or we found the value on the speculative tree (in that case
 // we don't know the maximum version).
-pub type ShardedStateCache = [DashMap<StateKey, (Option<Version>, Option<StateValue>)>; 16];
+#[derive(Debug, Default)]
+pub struct ShardedStateCache {
+    shards: [StateCacheShard; 16],
+}
+
+impl ShardedStateCache {
+    pub fn combine(&mut self, rhs: Self) {
+        use rayon::prelude::*;
+        THREAD_MANAGER.get_exe_cpu_pool().install(|| {
+            self.shards
+                .par_iter_mut()
+                .zip_eq(rhs.shards.into_par_iter())
+                .for_each(|(l, r)| {
+                    for (k, (ver, val)) in r.into_iter() {
+                        l.entry(k).or_insert((ver, val));
+                    }
+                })
+        });
+    }
+
+    pub fn shard(&self, shard_id: u8) -> &StateCacheShard {
+        &self.shards[shard_id as usize]
+    }
+
+    pub fn flatten(self) -> DashMap<StateKey, Option<StateValue>> {
+        // TODO(grao): Rethink the strategy for state sync, and optimize this.
+        self.shards
+            .into_iter()
+            .flatten()
+            .map(|(key, (_ver_opt, val_opt))| (key, val_opt))
+            .collect()
+    }
+
+    pub fn par_iter(&self) -> impl IndexedParallelIterator<Item = &StateCacheShard> {
+        self.shards.par_iter()
+    }
+}
 
 /// `CachedStateView` is like a snapshot of the global state comprised of state view at two
 /// levels, persistent storage and memory.
@@ -125,7 +164,7 @@ impl CachedStateView {
             id,
             snapshot,
             speculative_state,
-            sharded_state_cache: arr![DashMap::new(); 16],
+            sharded_state_cache: ShardedStateCache::default(),
             proof_fetcher,
         })
     }
@@ -205,8 +244,10 @@ impl TStateView for CachedStateView {
     fn get_state_value(&self, state_key: &StateKey) -> Result<Option<StateValue>> {
         let _timer = TIMER.with_label_values(&["get_state_value"]).start_timer();
         // First check if the cache has the state value.
-        if let Some(version_and_value_opt) =
-            self.sharded_state_cache[state_key.get_shard_id() as usize].get(state_key)
+        if let Some(version_and_value_opt) = self
+            .sharded_state_cache
+            .shard(state_key.get_shard_id())
+            .get(state_key)
         {
             // This can return None, which means the value has been deleted from the DB.
             let value_opt = &version_and_value_opt.1;
@@ -215,7 +256,9 @@ impl TStateView for CachedStateView {
         let version_and_state_value_option =
             self.get_version_and_state_value_internal(state_key)?;
         // Update the cache if still empty
-        let new_version_and_value = self.sharded_state_cache[state_key.get_shard_id() as usize]
+        let new_version_and_value = self
+            .sharded_state_cache
+            .shard(state_key.get_shard_id())
             .entry(state_key.clone())
             .or_insert(version_and_state_value_option);
         let value_opt = &new_version_and_value.1;

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -6,10 +6,11 @@ use crate::{
     state_delta::StateDelta, DbReader,
 };
 use anyhow::Result;
-use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
+use aptos_crypto::HashValue;
 use aptos_state_view::StateViewId;
 use aptos_types::{
-    proof::accumulator::InMemoryAccumulator, state_store::state_storage_usage::StateStorageUsage,
+    proof::accumulator::{InMemoryAccumulator, InMemoryTransactionAccumulator},
+    state_store::state_storage_usage::StateStorageUsage,
     transaction::Version,
 };
 use std::sync::Arc;
@@ -23,7 +24,7 @@ pub struct ExecutedTrees {
 
     /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
     /// `state_tree`.
-    transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+    transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
 }
 
 impl ExecutedTrees {
@@ -31,7 +32,7 @@ impl ExecutedTrees {
         &self.state
     }
 
-    pub fn txn_accumulator(&self) -> &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>> {
+    pub fn txn_accumulator(&self) -> &Arc<InMemoryTransactionAccumulator> {
         &self.transaction_accumulator
     }
 
@@ -49,7 +50,7 @@ impl ExecutedTrees {
 
     pub fn new(
         state: StateDelta,
-        transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+        transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
     ) -> Self {
         assert_eq!(
             state.current_version.map_or(0, |v| v + 1),

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -20,11 +20,11 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct ExecutedTrees {
     /// The in-memory representation of state after execution.
-    state: StateDelta,
+    pub state: StateDelta,
 
     /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
     /// `state_tree`.
-    transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
+    pub transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
 }
 
 impl ExecutedTrees {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -546,25 +546,8 @@ pub trait DbWriter: Send + Sync {
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
-    ) -> Result<()> {
-        unimplemented!()
-    }
-
-    /// Persist transactions for block.
-    /// See [`AptosDB::save_transaction_block`].
-    ///
-    /// [`AptosDB::save_transaction_block`]:
-    /// ../aptosdb/struct.AptosDB.html#method.save_transaction_block
-    fn save_transaction_block(
-        &self,
-        txns_to_commit: &[TransactionToCommit],
-        first_version: Version,
-        base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-        sync_commit: bool,
-        latest_in_memory_state: StateDelta,
-        block_state_updates: ShardedStateUpdates,
-        sharded_state_cache: &ShardedStateCache,
+        state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
+        sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -5,12 +5,11 @@ use aptos_crypto::HashValue;
 use aptos_scratchpad::SparseMerkleTree;
 use aptos_types::{
     state_store::{
-        create_empty_sharded_state_updates, state_storage_usage::StateStorageUsage,
-        state_value::StateValue, ShardedStateUpdates,
+        combine_sharded_state_updates, create_empty_sharded_state_updates,
+        state_storage_usage::StateStorageUsage, state_value::StateValue, ShardedStateUpdates,
     },
     transaction::Version,
 };
-use itertools::zip_eq;
 
 /// This represents two state sparse merkle trees at their versions in memory with the updates
 /// reflecting the difference of `current` on top of `base`.
@@ -74,11 +73,7 @@ impl StateDelta {
 
     pub fn merge(&mut self, other: StateDelta) {
         assert!(other.follow(self));
-        zip_eq(self.updates_since_base.iter_mut(), other.updates_since_base).for_each(
-            |(base, delta)| {
-                base.extend(delta);
-            },
-        );
+        combine_sharded_state_updates(&mut self.updates_since_base, other.updates_since_base);
 
         self.current = other.current;
         self.current_version = other.current_version;
@@ -99,5 +94,20 @@ impl StateDelta {
 
     pub fn root_hash(&self) -> HashValue {
         self.current.root_hash()
+    }
+
+    pub fn next_version(&self) -> Version {
+        self.current_version.map_or(0, |v| v + 1)
+    }
+
+    pub fn replace_with(&mut self, mut rhs: Self) -> Self {
+        std::mem::swap(self, &mut rhs);
+        rhs
+    }
+}
+
+impl Default for StateDelta {
+    fn default() -> Self {
+        Self::new_empty()
     }
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
+aptos-experimental-runtimes = { workspace = true }
 arr_macro = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -21,7 +21,10 @@ use super::MerkleTreeInternalNode;
 use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES};
 use anyhow::{ensure, format_err, Result};
 use aptos_crypto::{
-    hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
+    hash::{
+        CryptoHash, CryptoHasher, EventAccumulatorHasher, TransactionAccumulatorHasher,
+        ACCUMULATOR_PLACEHOLDER_HASH,
+    },
     HashValue,
 };
 use serde::{Deserialize, Serialize};
@@ -323,3 +326,7 @@ where
         Self::new(vec![], 0).expect("Constructing empty accumulator should work.")
     }
 }
+
+pub type InMemoryTransactionAccumulator = InMemoryAccumulator<TransactionAccumulatorHasher>;
+
+pub type InMemoryEventAccumulator = InMemoryAccumulator<EventAccumulatorHasher>;

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     ledger_info::LedgerInfo,
+    proof::accumulator::InMemoryTransactionAccumulator,
     transaction::{TransactionInfo, Version},
 };
 use anyhow::{bail, ensure, format_err, Context, Result};
@@ -382,10 +383,10 @@ impl SparseMerkleProof {
 /// attempt to extend their accumulator summary with an [`AccumulatorConsistencyProof`]
 /// to verifiably ratchet their trusted view of the accumulator to a newer state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct TransactionAccumulatorSummary(pub InMemoryAccumulator<TransactionAccumulatorHasher>);
+pub struct TransactionAccumulatorSummary(pub InMemoryTransactionAccumulator);
 
 impl TransactionAccumulatorSummary {
-    pub fn new(accumulator: InMemoryAccumulator<TransactionAccumulatorHasher>) -> Result<Self> {
+    pub fn new(accumulator: InMemoryTransactionAccumulator) -> Result<Self> {
         ensure!(
             !accumulator.is_empty(),
             "empty accumulator: we can't verify consistency proofs from an empty accumulator",
@@ -890,7 +891,7 @@ impl TransactionInfoListWithProof {
                 .rev()
                 .cloned()
                 .collect::<Vec<_>>();
-            let accu_from_proof = InMemoryAccumulator::<TransactionAccumulatorHasher>::new(
+            let accu_from_proof = InMemoryTransactionAccumulator::new(
                 frozen_subtree_roots_from_proof,
                 first_version,
             )?

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::state_store::{state_key::StateKey, state_value::StateValue};
+use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use arr_macro::arr;
 use std::collections::HashMap;
 
@@ -15,4 +16,27 @@ pub type ShardedStateUpdates = [HashMap<StateKey, Option<StateValue>>; 16];
 
 pub fn create_empty_sharded_state_updates() -> ShardedStateUpdates {
     arr![HashMap::new(); 16]
+}
+
+pub fn combine_or_add_sharded_state_updates(
+    lhs: &mut Option<ShardedStateUpdates>,
+    rhs: ShardedStateUpdates,
+) {
+    if let Some(lhs) = lhs {
+        combine_sharded_state_updates(lhs, rhs);
+    } else {
+        *lhs = Some(rhs);
+    }
+}
+
+pub fn combine_sharded_state_updates(lhs: &mut ShardedStateUpdates, rhs: ShardedStateUpdates) {
+    use rayon::prelude::*;
+
+    THREAD_MANAGER.get_exe_cpu_pool().install(|| {
+        lhs.par_iter_mut()
+            .zip_eq(rhs.into_par_iter())
+            .for_each(|(l, r)| {
+                l.extend(r);
+            })
+    })
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1376,12 +1376,12 @@ impl Display for TransactionInfo {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct TransactionToCommit {
-    transaction: Transaction,
-    transaction_info: TransactionInfo,
-    state_updates: ShardedStateUpdates,
-    write_set: WriteSet,
-    events: Vec<ContractEvent>,
-    is_reconfig: bool,
+    pub transaction: Transaction,
+    pub transaction_info: TransactionInfo,
+    pub state_updates: ShardedStateUpdates,
+    pub write_set: WriteSet,
+    pub events: Vec<ContractEvent>,
+    pub is_reconfig: bool,
 }
 
 impl TransactionToCommit {


### PR DESCRIPTION
### Description
1. `execute_chunk()` is now `enqueue_chunk_by_execution()` + `ledger_update()`; `apply_chunk()` is now `enqueue_chunk_by_transaction_outputs()` + `ledger_update()`
2. the sharded state updates and sharded state cache are passed down to the DB
3. `save_transactions()` and `save_transaction_block()` are unified to one.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

tests and 
replay mainnet to varify the chunk replayer https://github.com/aptos-labs/aptos-core/actions/runs/6477553053
