### PR TITLE
[TS-SDK v2] Updating the `Deserializable` interface and making `Serializable` an abstract class

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -5,7 +5,13 @@
 import { MAX_U32_NUMBER } from "./consts";
 import { Uint128, Uint16, Uint256, Uint32, Uint64, Uint8 } from "../types";
 
-export interface Deserializable<T> {
+// Since Typescript doesn't have abstract static methods, we use this interface to
+// require a static deserialize method for a Deserializable class.
+// It is not exported because it's not intended to be used, only to define
+// what types are allowed to be deserialized with the `Deserializer.deserializer(...)` function.
+// If you use it with a class like `MyClass implements Deserializable<T>`, Typescript will require
+// that you implement a non-static deserialize(), and we only want a static deserialize().
+interface Deserializable<T> {
   deserialize(deserializer: Deserializer): T;
 }
 
@@ -190,8 +196,9 @@ export class Deserializer {
   }
 
   /**
-   * This function deserializes a Deserializable value. The bytes must be loaded into the Serializer already.
-   * Note that it does not take in the value, it takes in the class type of the value that implements Serializable.
+   * Deserializes a BCS Deserializable value.
+   *
+   * The serialized bytes must already be in the Deserializer buffer.
    *
    * The process of using this function is as follows:
    * 1. Serialize the value of class type T using its `serialize` function.
@@ -200,61 +207,11 @@ export class Deserializer {
    *
    * @param cls The Deserializable class to deserialize the buffered bytes into.
    *
-   * @example
-   * // Define the MoveStruct class that implements the Deserializable interface
-   *  class MoveStruct implements Serializable {
-   *    constructor(
-   *      public name: string,
-   *      public description: string,
-   *      public enabled: boolean,
-   *      public vectorU8: Array<number>,
-   *    ) {}
-   *
-   *    serialize(serializer: Serializer): void {
-   *      serializer.serializeStr(this.name);
-   *      serializer.serializeStr(this.description);
-   *      serializer.serializeBool(this.enabled);
-   *      serializer.serializeU32AsUleb128(this.vectorU8.length);
-   *      this.vectorU8.forEach((n) => serializer.serializeU8(n));
-   *    }
-   *
-   *    static deserialize(deserializer: Deserializer): MoveStruct {
-   *      const name = deserializer.deserializeStr();
-   *      const description = deserializer.deserializeStr();
-   *      const enabled = deserializer.deserializeBool();
-   *      const length = deserializer.deserializeUleb128AsU32();
-   *      const vectorU8 = new Array<number>();
-   *      for (let i = 0; i < length; i++) {
-   *        vectorU8.push(deserializer.deserializeU8());
-   *      }
-   *      return new MoveStruct(name, description, enabled, vectorU8);
-   *    }
-   *  }
-   *
-   * // Construct a MoveStruct
-   * const moveStruct = new MoveStruct("abc", "123", false, [1, 2, 3, 4]);
-   *
-   * // Serialize a MoveStruct instance.
-   * const serializer = new Serializer();
-   * serializer.serialize(moveStruct);
-   * const moveStructBcsBytes = serializer.toUint8Array();
-   *
-   * // Load the bytes into the Deserializer buffer
-   * const deserializer = new Deserializer(moveStructBcsBytes);
-   *
-   * // Deserialize the buffered bytes into an instance of MoveStruct
-   * const deserializedMoveStruct = deserializer.deserialize(MoveStruct);
-   * assert(deserializedMoveStruct.name === moveStruct.name);
-   * assert(deserializedMoveStruct.description === moveStruct.description);
-   * assert(deserializedMoveStruct.enabled === moveStruct.enabled);
-   * assert(deserializedMoveStruct.vectorU8.length === moveStruct.vectorU8.length);
-   * deserializeMoveStruct.vectorU8.forEach((n, i) => assert(n === moveStruct.vectorU8[i]));
-   *
    * @returns the deserialized value of class type T
    */
   deserialize<T>(cls: Deserializable<T>): T {
-    // NOTE: The `deserialize` method called by `cls` is defined in the `cls`'s
-    // Deserializable interface, not the one defined in this class.
+    // NOTE: `deserialize` in `cls.deserialize(this)` here is a static method defined in `cls`,
+    // It is separate from the `deserialize` instance method defined here in Deserializer.
     return cls.deserialize(this);
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -5,12 +5,11 @@
 import { MAX_U32_NUMBER } from "./consts";
 import { Uint128, Uint16, Uint256, Uint32, Uint64, Uint8 } from "../types";
 
-// Since Typescript doesn't have abstract static methods, we use this interface to
-// require a static deserialize method for a Deserializable class.
-// It is not exported because it's not intended to be used, only to define
-// what types are allowed to be deserialized with the `Deserializer.deserializer(...)` function.
-// If you use it with a class like `MyClass implements Deserializable<T>`, Typescript will require
-// that you implement a non-static deserialize(), and we only want a static deserialize().
+/**
+ * This interface exists solely for the `deserialize` function in the `Deserializer` class.
+ * It is not exported because exporting it results in more typing errors than it prevents
+ * due to Typescript's lack of support for static methods in abstract classes and interfaces.
+ */
 interface Deserializable<T> {
   deserialize(deserializer: Deserializer): T;
 }
@@ -196,16 +195,15 @@ export class Deserializer {
   }
 
   /**
-   * Deserializes a BCS Deserializable value.
+   * Helper function that primarily exists to support alternative syntax for deserialization.
+   * That is, if we have a `const deserializer: new Deserializer(...)`, instead of having to use
+   * `MyClass.deserialize(deserializer)`, we can call `deserializer.deserialize(MyClass)`.
    *
-   * The serialized bytes must already be in the Deserializer buffer.
-   *
-   * The process of using this function is as follows:
-   * 1. Serialize the value of class type T using its `serialize` function.
-   * 2. Get the serialized bytes and pass them into the Deserializer constructor.
-   * 3. Call this function with your newly constructed Deserializer, as `deserializer.deserialize(ClassType)`
-   *
-   * @param cls The Deserializable class to deserialize the buffered bytes into.
+   * @example const deserializer = new Deserializer(new Uint8Array([1, 2, 3]));
+   * const value = deserializer.deserialize(MyClass); // where MyClass has a `deserialize` function
+   * // value is now an instance of MyClass
+   * // equivalent to `const value = MyClass.deserialize(deserializer)`
+   * @param cls The BCS-deserializable class to deserialize the buffered bytes into.
    *
    * @returns the deserialized value of class type T
    */

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -12,8 +12,23 @@ import {
 } from "./consts";
 import { AnyNumber, Uint16, Uint32, Uint8 } from "../types";
 
-export interface Serializable {
-  serialize(serializer: Serializer): void;
+// This class is intended to be used as a base class for all serializable types.
+// It can be used to facilitate composable serialization of a complex type and
+// in general to serialize a type to its BCS representation.
+export abstract class Serializable {
+  abstract serialize(serializer: Serializer): void;
+
+  /**
+   * Serializes a `Serializable` value to its BCS representation.
+   * This function is the Typescript SDK equivalent of `bcs::to_bytes` in Move.
+   * @param value The Serializable value to serialize
+   * @returns the byte buffer BCS representation of the value
+   */
+  bcsToBytes(): Uint8Array {
+    const serializer = new Serializer();
+    this.serialize(serializer);
+    return serializer.toUint8Array();
+  }
 }
 
 export class Serializer {
@@ -235,9 +250,9 @@ export class Serializer {
    *
    * @example
    * // Define the MoveStruct class that implements the Serializable interface
-   * class MoveStruct implements Serializable {
+   * class MoveStruct extends Serializable {
    *     constructor(
-   *         public creatorAddress: AccountAddress, // where AccountAddress implements Serializable
+   *         public creatorAddress: AccountAddress, // where AccountAddress extends Serializable
    *         public collectionName: string,
    *         public tokenName: string
    *     ) {}

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -21,8 +21,7 @@ export abstract class Serializable {
   /**
    * Serializes a `Serializable` value to its BCS representation.
    * This function is the Typescript SDK equivalent of `bcs::to_bytes` in Move.
-   * @param value The Serializable value to serialize
-   * @returns the byte buffer BCS representation of the value
+   * @returns the BCS representation of the Serializable instance as a byte buffer
    */
   bcsToBytes(): Uint8Array {
     const serializer = new Serializer();

--- a/ecosystem/typescript/sdk_v2/src/core/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account_address.ts
@@ -4,6 +4,7 @@
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { HexInput } from "../types";
 import { ParsingError, ParsingResult } from "./common";
+import { Deserializer, Serializable, Serializer } from "../bcs";
 
 /**
  * This enum is used to explain why an address was invalid.
@@ -34,7 +35,7 @@ export enum AddressInvalidReason {
  * The comments in this class make frequent reference to the LONG and SHORT formats,
  * as well as "special" addresses. To learn what these refer to see AIP-40.
  */
-export class AccountAddress {
+export class AccountAddress extends Serializable {
   /*
    * This is the internal representation of an account address.
    */
@@ -64,6 +65,7 @@ export class AccountAddress {
    * @param args.data A Uint8Array representing an account address.
    */
   constructor(args: { data: Uint8Array }) {
+    super();
     if (args.data.length !== AccountAddress.LENGTH) {
       throw new ParsingError(
         "AccountAddress data should be exactly 32 bytes long",
@@ -162,6 +164,36 @@ export class AccountAddress {
    */
   toUint8Array(): Uint8Array {
     return this.data;
+  }
+
+  /**
+   * Serialize the AccountAddress to a Serializer instance's data buffer.
+   * @param serializer The serializer to serialize the AccountAddress to.
+   * @returns void
+   * @example
+   * const serializer = new Serializer();
+   * const address = AccountAddress.fromString({ input: "0x1" });
+   * address.serialize(serializer);
+   * const bytes = serializer.toUint8Array();
+   * // `bytes` is now the BCS-serialized address.
+   */
+  serialize(serializer: Serializer): void {
+    serializer.serializeFixedBytes(this.data);
+  }
+
+  /**
+   * Deserialize an AccountAddress from the byte buffer in a Deserializer instance.
+   * @param deserializer The deserializer to deserialize the AccountAddress from.
+   * @returns An instance of AccountAddress.
+   * @example
+   * const bytes = hexToBytes("0x0102030405060708091011121314151617181920212223242526272829303132");
+   * const deserializer = new Deserializer(bytes);
+   * const address = AccountAddress.deserialize(deserializer);
+   * // `address` is now an instance of AccountAddress.
+   */
+  static deserialize(deserializer: Deserializer): AccountAddress {
+    const bytes = deserializer.deserializeFixedBytes(AccountAddress.LENGTH);
+    return new AccountAddress({ data: bytes });
   }
 
   // ===

--- a/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
@@ -28,8 +28,15 @@ export abstract class PublicKey extends Serializable {
   abstract serialize(serializer: Serializer): void;
 }
 
+/**
+ * An abstract representation of a private key.  This is used to sign transactions and
+ * derive the public key associated.
+ */
 export abstract class PrivateKey extends Serializable {
-  // Sign the given message with the private key.
+  /**
+   * Sign a message with the key
+   * @param args
+   */
   abstract sign(args: { message: HexInput }): Signature;
 
   /**
@@ -50,8 +57,14 @@ export abstract class PrivateKey extends Serializable {
   abstract publicKey(): PublicKey;
 }
 
+/**
+ * An abstract representation of a signature.  This is the product of signing a
+ * message and can be used with the PublicKey to verify the signature.
+ */
 export abstract class Signature extends Serializable {
-  // Convert the signature to bytes or Uint8Array.
+  /**
+   * Get the raw signature bytes
+   */
   abstract toUint8Array(): Uint8Array;
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/asymmetric_crypto.ts
@@ -1,14 +1,14 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializable, Deserializer, Serializable, Serializer } from "../bcs";
+import { Serializable, Serializer } from "../bcs";
 import { HexInput } from "../types";
 
 /**
  * An abstract representation of a public key.  All Asymmetric key pairs will use this to
  * verify signatures and for authentication keys.
  */
-export abstract class PublicKey implements Serializable, Deserializable<PublicKey> {
+export abstract class PublicKey extends Serializable {
   /**
    * Verifies that the private key associated with this public key signed the message with the given signature.
    * @param args
@@ -25,21 +25,11 @@ export abstract class PublicKey implements Serializable, Deserializable<PublicKe
    */
   abstract toString(): string;
 
-  // TODO: This should be a static method.
-  abstract deserialize(deserializer: Deserializer): PublicKey;
-
   abstract serialize(serializer: Serializer): void;
 }
 
-/**
- * An abstract representation of a private key.  This is used to sign transactions and
- * derive the public key associated.
- */
-export abstract class PrivateKey implements Serializable, Deserializable<PrivateKey> {
-  /**
-   * Sign a message with the key
-   * @param args
-   */
+export abstract class PrivateKey extends Serializable {
+  // Sign the given message with the private key.
   abstract sign(args: { message: HexInput }): Signature;
 
   /**
@@ -52,9 +42,6 @@ export abstract class PrivateKey implements Serializable, Deserializable<Private
    */
   abstract toString(): string;
 
-  // TODO: This should be a static method.
-  abstract deserialize(deserializer: Deserializer): PrivateKey;
-
   abstract serialize(serializer: Serializer): void;
 
   /**
@@ -63,23 +50,14 @@ export abstract class PrivateKey implements Serializable, Deserializable<Private
   abstract publicKey(): PublicKey;
 }
 
-/**
- * An abstract representation of a signature.  This is the product of signing a
- * message and can be used with the PublicKey to verify the signature.
- */
-export abstract class Signature implements Serializable, Deserializable<Signature> {
-  /**
-   * Get the raw signature bytes
-   */
+export abstract class Signature extends Serializable {
+  // Convert the signature to bytes or Uint8Array.
   abstract toUint8Array(): Uint8Array;
 
   /**
    * Get the signature as a hex string with a 0x prefix e.g. 0x123456...
    */
   abstract toString(): string;
-
-  // TODO: This should be a static method.
-  abstract deserialize(deserializer: Deserializer): Signature;
 
   abstract serialize(serializer: Serializer): void;
 }

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -76,11 +76,6 @@ export class Ed25519PublicKey extends PublicKey {
     const bytes = deserializer.deserializeBytes();
     return new Ed25519PublicKey({ hexInput: bytes });
   }
-
-  // eslint-disable-next-line class-methods-use-this,@typescript-eslint/no-unused-vars
-  deserialize(deserializer: Deserializer): PublicKey {
-    throw new Error("Not implemented");
-  }
 }
 
 /**
@@ -150,11 +145,6 @@ export class Ed25519PrivateKey extends PrivateKey {
     serializer.serializeBytes(this.toUint8Array());
   }
 
-  // TODO: Update this in interface to be static, then remove this method
-  deserialize(deserializer: Deserializer): Ed25519PrivateKey {
-    throw new Error("Method not implemented.");
-  }
-
   static deserialize(deserializer: Deserializer): Ed25519PrivateKey {
     const bytes = deserializer.deserializeBytes();
     return new Ed25519PrivateKey({ hexInput: bytes });
@@ -221,11 +211,6 @@ export class Ed25519Signature extends Signature {
 
   serialize(serializer: Serializer): void {
     serializer.serializeBytes(this.data.toUint8Array());
-  }
-
-  // TODO: Update this in interface to be static, then remove this method
-  deserialize(deserializer: Deserializer): Ed25519Signature {
-    throw new Error("Method not implemented.");
   }
 
   static deserialize(deserializer: Deserializer): Ed25519Signature {

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -97,11 +97,6 @@ export class MultiEd25519PublicKey extends PublicKey {
     serializer.serializeBytes(this.toUint8Array());
   }
 
-  // TODO: Update this in interface to be static, then remove this method
-  deserialize(deserializer: Deserializer): PublicKey {
-    throw new Error("Method not implemented.");
-  }
-
   static deserialize(deserializer: Deserializer): MultiEd25519PublicKey {
     const bytes = deserializer.deserializeBytes();
     const threshold = bytes[bytes.length - 1];
@@ -238,11 +233,6 @@ export class MultiEd25519Signature extends Signature {
 
   serialize(serializer: Serializer): void {
     serializer.serializeBytes(this.toUint8Array());
-  }
-
-  // TODO: Update this in interface to be static, then remove this method
-  deserialize(deserializer: Deserializer): Signature {
-    throw new Error("Method not implemented.");
   }
 
   static deserialize(deserializer: Deserializer): MultiEd25519Signature {

--- a/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Serializable, Serializer, Deserializer, Deserializable } from "../../src/bcs";
+import { Serializable, Serializer, Deserializer } from "../../src/bcs";
 
 describe("BCS Deserializer", () => {
   it("deserializes a non-empty string", () => {
@@ -132,13 +132,15 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a single deserializable class", () => {
     // Define the MoveStruct class that implements the Deserializable interface
-    class MoveStruct implements Serializable {
+    class MoveStruct extends Serializable {
       constructor(
         public name: string,
         public description: string,
         public enabled: boolean,
         public vectorU8: Array<number>,
-      ) {}
+      ) {
+        super();
+      }
 
       serialize(serializer: Serializer): void {
         serializer.serializeStr(this.name);
@@ -177,7 +179,7 @@ describe("BCS Deserializer", () => {
   });
 
   it("deserializes and composes an abstract Deserializable class instance from composed deserialize calls", () => {
-    abstract class MoveStruct {
+    abstract class MoveStruct extends Serializable {
       abstract serialize(serializer: Serializer): void;
 
       static deserialize(deserializer: Deserializer): MoveStruct {
@@ -193,27 +195,15 @@ describe("BCS Deserializer", () => {
       }
     }
 
-    class MoveStructs implements Serializable {
-      constructor(public moveStruct1: MoveStruct, public moveStruct2: MoveStruct) {}
-
-      serialize(serializer: Serializer): void {
-        serializer.serialize(this.moveStruct1);
-        serializer.serialize(this.moveStruct2);
-      }
-
-      // deserialize two MoveStructs, potentially either MoveStructA or MoveStructB
-      static deserialize(deserializer: Deserializer): MoveStructs {
-        return new MoveStructs(MoveStruct.deserialize(deserializer), MoveStruct.deserialize(deserializer));
-      }
-    }
-
-    class MoveStructA implements Serializable {
+    class MoveStructA extends Serializable {
       constructor(
         public name: string,
         public description: string,
         public enabled: boolean,
         public vectorU8: Array<number>,
-      ) {}
+      ) {
+        super();
+      }
 
       serialize(serializer: Serializer): void {
         // enum variant index for the abstract MoveStruct class
@@ -237,13 +227,15 @@ describe("BCS Deserializer", () => {
         return new MoveStructA(name, description, enabled, vectorU8);
       }
     }
-    class MoveStructB implements Serializable {
+    class MoveStructB extends Serializable {
       constructor(
         public moveStructA: MoveStructA,
         public name: string,
         public description: string,
         public vectorU8: Array<number>,
-      ) {}
+      ) {
+        super();
+      }
 
       serialize(serializer: Serializer): void {
         // enum variant index for the abstract MoveStruct class

--- a/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
@@ -171,7 +171,7 @@ describe("BCS Deserializer", () => {
     // Load the bytes into the Deserializer buffer
     const deserializer = new Deserializer(moveStructBcsBytes);
     // Deserialize the buffered bytes into an instance of MoveStruct
-    const deserializedMoveStruct = deserializer.deserialize(MoveStruct);
+    const deserializedMoveStruct = MoveStruct.deserialize(deserializer);
     expect(deserializedMoveStruct.name).toEqual(moveStruct.name);
     expect(deserializedMoveStruct.description).toEqual(moveStruct.description);
     expect(deserializedMoveStruct.enabled).toEqual(moveStruct.enabled);

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -119,12 +119,12 @@ describe("MultiSignature", () => {
   it("should throws exception when creating a bitmap with wrong bits", async () => {
     expect(() => {
       MultiEd25519Signature.createBitmap({ bits: [32] });
-    }).toThrow("Cannot have a signature larger than 31");
+    }).toThrow("Cannot have a signature larger than 31.");
   });
 
   it("should throws exception when creating a bitmap with duplicate bits", async () => {
     expect(() => {
       MultiEd25519Signature.createBitmap({ bits: [2, 2] });
-    }).toThrow("Duplicate bits detected");
+    }).toThrow("Duplicate bits detected.");
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -119,12 +119,12 @@ describe("MultiSignature", () => {
   it("should throws exception when creating a bitmap with wrong bits", async () => {
     expect(() => {
       MultiEd25519Signature.createBitmap({ bits: [32] });
-    }).toThrow("Cannot have a signature larger than 31.");
+    }).toThrow("Cannot have a signature larger than 31");
   });
 
   it("should throws exception when creating a bitmap with duplicate bits", async () => {
     expect(() => {
       MultiEd25519Signature.createBitmap({ bits: [2, 2] });
-    }).toThrow("Duplicate bits detected.");
+    }).toThrow("Duplicate bits detected");
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
@@ -225,13 +225,15 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes multiple Serializable values", () => {
-    class MoveStructA implements Serializable {
+    class MoveStructA extends Serializable {
       constructor(
         public name: string,
         public description: string,
         public enabled: boolean,
         public vectorU8: Array<number>,
-      ) {}
+      ) {
+        super();
+      }
 
       serialize(serializer: Serializer): void {
         serializer.serializeStr(this.name);
@@ -241,13 +243,15 @@ describe("BCS Serializer", () => {
         this.vectorU8.forEach((n) => serializer.serializeU8(n));
       }
     }
-    class MoveStructB implements Serializable {
+    class MoveStructB extends Serializable {
       constructor(
         public moveStructA: MoveStructA,
         public name: string,
         public description: string,
         public vectorU8: Array<number>,
-      ) {}
+      ) {
+        super();
+      }
 
       serialize(serializer: Serializer): void {
         serializer.serialize(this.moveStructA);


### PR DESCRIPTION
### Description

1. I've removed the export from `Deserializable` in order to facilitate using static `deserialize` methods with Deserializable values.

Typescript doesn't let us use `abstract static` methods, nor does it let us use `static` methods with interfaces, so this is the only solution I could come up with that's simple enough. Note that `Deserializable` is really only meant to facilitate the `Deserializer` instance method `deserialize()`, so it's fine if it's purely used as an interface to describe an object as opposed to being explicitly extended.

2. I also changed `Serializable` to a class instead of an interface and added the `bcsToBytes()` function to it, that way whenever a class `extends Serializable` you can just call `classInstance.bcsToBytes()` on the instance to serialize it and get the bcs serialized bytes.

3. I also removed the abstract `deserialize` functions from the public/private key classes, because you can't declare an `abstract static` method, so it wouldn't work anyway. Unfortunately typescript has quite a few limitations in this regard.

4. Also updated some documentation

### Test Plan
`pnpm jest`