### PR TITLE
[move unit tests] Run extended checker as part of unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9068,6 +9068,7 @@ dependencies = [
  "move-docgen",
  "move-errmapgen",
  "move-ir-types",
+ "move-model",
  "move-package",
  "move-prover",
  "move-resource-viewer",

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -53,6 +53,7 @@ log = { workspace = true }
 lru = { workspace = true }
 merlin = { workspace = true }
 move-binary-format = { workspace = true }
+move-cli = { workspace = true }
 move-command-line-common = { workspace = true }
 move-compiler = { workspace = true }
 move-core-types = { workspace = true }

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -121,6 +121,7 @@ impl ReleaseTarget {
                 bytecode_version: None,
                 compiler_version: None,
                 skip_attribute_checks: false,
+                check_test_code: false,
                 known_attributes: extended_checks::get_all_attribute_names().clone(),
             },
             packages: packages.iter().map(|(path, _)| path.to_owned()).collect(),

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -72,6 +72,8 @@ pub struct BuildOptions {
     pub compiler_version: Option<CompilerVersion>,
     #[clap(long)]
     pub skip_attribute_checks: bool,
+    #[clap(long)]
+    pub check_test_code: bool,
     #[clap(skip)]
     pub known_attributes: BTreeSet<String>,
 }
@@ -96,6 +98,7 @@ impl Default for BuildOptions {
             bytecode_version: None,
             compiler_version: None,
             skip_attribute_checks: false,
+            check_test_code: false,
             known_attributes: extended_checks::get_all_attribute_names().clone(),
         }
     }
@@ -126,6 +129,7 @@ pub fn build_model(
         generate_abis: false,
         generate_docs: false,
         generate_move_model: false,
+        full_model_generation: false,
         install_dir: None,
         test_mode: false,
         force_recompilation: false,
@@ -160,6 +164,7 @@ impl BuiltPackage {
             generate_abis: options.with_abis,
             generate_docs: false,
             generate_move_model: true,
+            full_model_generation: options.check_test_code,
             install_dir: options.install_dir.clone(),
             test_mode: false,
             force_recompilation: false,
@@ -177,8 +182,7 @@ impl BuiltPackage {
         let (mut package, model_opt) =
             build_config.compile_package_no_exit(&package_path, &mut stderr())?;
 
-        // Build the Move model for extra processing and run extended checks as well derive
-        // runtime metadata
+        // Run extended checks as well derive runtime metadata
         let model = &model_opt.expect("move model");
         let runtime_metadata = extended_checks::run_extended_checks(model);
         if model.diag_count(Severity::Warning) > 0 {

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -3,6 +3,7 @@
 
 use crate::{KnownAttribute, RuntimeModuleMetadataV1};
 use move_binary_format::file_format::{Ability, AbilitySet, Visibility};
+use move_cli::base::test_validation;
 use move_compiler::shared::known_attributes;
 use move_core_types::{
     account_address::AccountAddress,
@@ -75,6 +76,14 @@ pub fn run_extended_checks(env: &GlobalEnv) -> BTreeMap<ModuleId, RuntimeModuleM
     let mut checker = ExtendedChecker::new(env);
     checker.run();
     checker.output
+}
+
+/// Configures the move-cli unit test validation hook to run the extended checker.
+pub fn configure_extended_checks_for_unit_test() {
+    fn validate(env: &GlobalEnv) {
+        run_extended_checks(env);
+    }
+    test_validation::set_validation_hook(Box::new(validate));
 }
 
 #[derive(Debug)]

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -41,6 +41,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
 pub fn aptos_test_natives() -> NativeFunctionTable {
     // By side effect, configure for unit tests
     natives::configure_for_unit_test();
+    extended_checks::configure_extended_checks_for_unit_test();
     // move_stdlib has the testing feature enabled to include debug native functions
     natives::aptos_natives(
         LATEST_GAS_FEATURE_VERSION,

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -56,6 +56,7 @@ pub fn run_tests_for_pkg(
 
 pub fn aptos_test_natives() -> NativeFunctionTable {
     natives::configure_for_unit_test();
+    extended_checks::configure_extended_checks_for_unit_test();
     natives::aptos_natives(
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1125,6 +1125,12 @@ pub struct MovePackageDir {
     /// Do not complain about unknown attributes in Move code.
     #[clap(long)]
     pub skip_attribute_checks: bool,
+
+    /// Do apply extended checks for Aptos (e.g. `#[view]` attribute) also on test code.
+    /// NOTE: this behavior will become the default in the future.
+    /// See https://github.com/aptos-labs/aptos-core/issues/10335
+    #[clap(long, env = "APTOS_CHECK_TEST_CODE")]
+    pub check_test_code: bool,
 }
 
 impl MovePackageDir {
@@ -1138,6 +1144,7 @@ impl MovePackageDir {
             bytecode_version: None,
             compiler_version: None,
             skip_attribute_checks: false,
+            check_test_code: false,
         }
     }
 

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -998,6 +998,7 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             move_options.bytecode_version,
             move_options.compiler_version,
             move_options.skip_attribute_checks,
+            move_options.check_test_code,
         );
         let package = BuiltPackage::build(package_path, options)?;
         let release = ReleasePackage::new(package)?;

--- a/crates/aptos/src/move_tool/aptos_debug_natives.rs
+++ b/crates/aptos/src/move_tool/aptos_debug_natives.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_framework::extended_checks;
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
@@ -13,6 +14,7 @@ pub fn aptos_debug_natives(
 ) -> NativeFunctionTable {
     // As a side effect, also configure for unit testing
     natives::configure_for_unit_test();
+    extended_checks::configure_extended_checks_for_unit_test();
     // Return all natives -- build with the 'testing' feature, therefore containing
     // debug related functions.
     natives::aptos_natives(

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -33,8 +33,8 @@ use crate::{
 };
 use aptos_crypto::HashValue;
 use aptos_framework::{
-    build_model, docgen::DocgenOptions, extended_checks, natives::code::UpgradePolicy,
-    prover::ProverOptions, BuildOptions, BuiltPackage,
+    docgen::DocgenOptions, extended_checks, natives::code::UpgradePolicy, prover::ProverOptions,
+    BuildOptions, BuiltPackage,
 };
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters};
 use aptos_rest_client::aptos_api_types::{
@@ -46,10 +46,6 @@ use aptos_types::{
 };
 use async_trait::async_trait;
 use clap::{Parser, Subcommand, ValueEnum};
-use codespan_reporting::{
-    diagnostic::Severity,
-    term::termcolor::{ColorChoice, StandardStream},
-};
 use itertools::Itertools;
 use move_cli::{self, base::test::UnitTestResult};
 use move_command_line_common::env::MOVE_HOME;
@@ -317,6 +313,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
                     self.move_options.bytecode_version,
                     self.move_options.compiler_version,
                     self.move_options.skip_attribute_checks,
+                    self.move_options.check_test_code,
                 )
         };
         let pack = BuiltPackage::build(self.move_options.get_package_path()?, build_options)
@@ -378,6 +375,7 @@ impl CompileScript {
                 self.move_options.bytecode_version,
                 self.move_options.compiler_version,
                 self.move_options.skip_attribute_checks,
+                self.move_options.check_test_code,
             )
         };
         let package_dir = self.move_options.get_package_path()?;
@@ -455,6 +453,7 @@ impl CliCommand<&'static str> for TestPackage {
             dev_mode: self.move_options.dev,
             additional_named_addresses: self.move_options.named_addresses(),
             test_mode: true,
+            full_model_generation: self.move_options.check_test_code,
             install_dir: self.move_options.output_dir.clone(),
             skip_fetch_latest_git_deps: self.move_options.skip_fetch_latest_git_deps,
             compiler_config: CompilerConfig {
@@ -465,27 +464,6 @@ impl CliCommand<&'static str> for TestPackage {
             ..Default::default()
         };
 
-        // Build the Move model for extended checks
-        let model = &build_model(
-            self.move_options.dev,
-            self.move_options.get_package_path()?.as_path(),
-            self.move_options.named_addresses(),
-            None,
-            self.move_options.bytecode_version,
-            self.move_options.compiler_version,
-            self.move_options.skip_attribute_checks,
-            known_attributes.clone(),
-        )?;
-        let _ = extended_checks::run_extended_checks(model);
-        if model.diag_count(Severity::Warning) > 0 {
-            let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
-            model.report_diag(&mut error_writer, Severity::Warning);
-            if model.has_errors() {
-                return Err(CliError::MoveCompilationError(
-                    "extended checks failed".to_string(),
-                ));
-            }
-        }
         let path = self.move_options.get_package_path()?;
         let result = move_cli::base::test::run_move_unit_tests(
             path.as_path(),
@@ -611,6 +589,7 @@ impl CliCommand<&'static str> for DocumentPackage {
             bytecode_version: move_options.bytecode_version,
             compiler_version: move_options.compiler_version,
             skip_attribute_checks: move_options.skip_attribute_checks,
+            check_test_code: move_options.check_test_code,
             known_attributes: extended_checks::get_all_attribute_names().clone(),
         };
         BuiltPackage::build(move_options.get_package_path()?, build_options)?;
@@ -679,6 +658,7 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
                 self.move_options.bytecode_version,
                 self.move_options.compiler_version,
                 self.move_options.skip_attribute_checks,
+                self.move_options.check_test_code,
             );
         let package = BuiltPackage::build(package_path, options)
             .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
@@ -748,6 +728,7 @@ impl IncludedArtifacts {
         bytecode_version: Option<u32>,
         compiler_version: Option<CompilerVersion>,
         skip_attribute_checks: bool,
+        check_test_code: bool,
     ) -> BuildOptions {
         use IncludedArtifacts::*;
         match self {
@@ -763,6 +744,7 @@ impl IncludedArtifacts {
                 bytecode_version,
                 compiler_version,
                 skip_attribute_checks,
+                check_test_code,
                 known_attributes: extended_checks::get_all_attribute_names().clone(),
                 ..BuildOptions::default()
             },
@@ -777,6 +759,7 @@ impl IncludedArtifacts {
                 bytecode_version,
                 compiler_version,
                 skip_attribute_checks,
+                check_test_code,
                 known_attributes: extended_checks::get_all_attribute_names().clone(),
                 ..BuildOptions::default()
             },
@@ -791,6 +774,7 @@ impl IncludedArtifacts {
                 bytecode_version,
                 compiler_version,
                 skip_attribute_checks,
+                check_test_code,
                 known_attributes: extended_checks::get_all_attribute_names().clone(),
                 ..BuildOptions::default()
             },
@@ -935,6 +919,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
             move_options.bytecode_version,
             move_options.compiler_version,
             move_options.skip_attribute_checks,
+            move_options.check_test_code,
         );
         let package = BuiltPackage::build(package_path, options)?;
         let compiled_units = package.extract_code();
@@ -1074,6 +1059,7 @@ impl CliCommand<&'static str> for VerifyPackage {
                 self.move_options.bytecode_version,
                 self.move_options.compiler_version,
                 self.move_options.skip_attribute_checks,
+                self.move_options.check_test_code,
             )
         };
         let pack = BuiltPackage::build(self.move_options.get_package_path()?, build_options)

--- a/crates/aptos/src/move_tool/show.rs
+++ b/crates/aptos/src/move_tool/show.rs
@@ -66,6 +66,7 @@ impl CliCommand<Vec<EntryABI>> for ShowAbi {
                     self.move_options.bytecode_version,
                     self.move_options.compiler_version,
                     self.move_options.skip_attribute_checks,
+                    self.move_options.check_test_code,
                 )
         };
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1048,6 +1048,7 @@ impl CliTestFramework {
             bytecode_version: None,
             compiler_version: None,
             skip_attribute_checks: false,
+            check_test_code: false,
         }
     }
 

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -379,6 +379,19 @@ impl Flags {
         }
     }
 
+    pub fn all_functions() -> Self {
+        Self {
+            test: true,
+            verify: true,
+            shadow: false,
+            flavor: "".to_string(),
+            bytecode_version: None,
+            keep_testing_functions: false,
+            skip_attribute_checks: false,
+            debug: debug_compiler_env_var(),
+        }
+    }
+
     pub fn verification() -> Self {
         Self {
             test: false,

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -73,6 +73,18 @@ pub enum Attribute {
     Assign(NodeId, Symbol, AttributeValue),
 }
 
+impl Attribute {
+    pub fn name(&self) -> Symbol {
+        match self {
+            Attribute::Assign(_, s, _) | Attribute::Apply(_, s, _) => *s,
+        }
+    }
+
+    pub fn has(attrs: &[Attribute], pred: impl Fn(&Attribute) -> bool) -> bool {
+        attrs.iter().any(pred)
+    }
+}
+
 // =================================================================================================
 /// # Conditions
 

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -2,10 +2,23 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Names of well-known functions.
+//! Names of well-known functions or attributes.
 //!
 //! This currently only contains those declarations used somewhere, not all well-known
 //! declarations. It can be extended on the go.
+//!
+
+/// Function identifying the name of an attribute which declares an
+/// item to be part of test.
+pub fn is_test_only_attribute_name(s: &str) -> bool {
+    s == "test" || s == "test_only "
+}
+
+/// Function identifying the name of an attribute which declares an
+/// item to be part of verification only.
+pub fn is_verify_only_attribute_name(s: &str) -> bool {
+    s == "verify_only"
+}
 
 pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";

--- a/third_party/move/move-prover/move-docgen/src/docgen.rs
+++ b/third_party/move/move-prover/move-docgen/src/docgen.rs
@@ -671,6 +671,7 @@ impl<'env> Docgen<'env> {
         if !module_env.get_structs().count() > 0 {
             for s in module_env
                 .get_structs()
+                .filter(|s| !s.is_test_only())
                 .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
             {
                 self.gen_struct(&spec_block_map, &s);
@@ -684,7 +685,7 @@ impl<'env> Docgen<'env> {
 
         let funs = module_env
             .get_functions()
-            .filter(|f| self.options.include_private_fun || f.is_exposed())
+            .filter(|f| (self.options.include_private_fun || f.is_exposed()) && !f.is_test_only())
             .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
             .collect_vec();
         if !funs.is_empty() {
@@ -1338,6 +1339,7 @@ impl<'env> Docgen<'env> {
         self.gen_spec_blocks(module_env, "", &SpecBlockTarget::Module, spec_block_map);
         for struct_env in module_env
             .get_structs()
+            .filter(|s| !s.is_test_only())
             .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
         {
             let target =
@@ -1355,6 +1357,7 @@ impl<'env> Docgen<'env> {
         }
         for func_env in module_env
             .get_functions()
+            .filter(|f| !f.is_test_only())
             .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
         {
             let target = SpecBlockTarget::Function(func_env.module_env.get_id(), func_env.get_id());
@@ -1869,7 +1872,11 @@ impl<'env> Docgen<'env> {
                 ))
                 .unwrap_or("");
             let newl_at = source_before.rfind('\n').unwrap_or(0);
-            let mut indent = source_before.len() - newl_at - 1;
+            let mut indent = if source_before.len() > newl_at {
+                source_before.len() - newl_at - 1
+            } else {
+                0
+            };
             if indent >= 4 && source_before.ends_with("spec ") {
                 // Special case for `spec define` and similar constructs.
                 indent -= 4;

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -41,6 +41,7 @@ move-disassembler = { path = "../move-disassembler" }
 move-docgen = { path = "../../move-prover/move-docgen" }
 move-errmapgen = { path = "../../move-prover/move-errmapgen" }
 move-ir-types = { path = "../../move-ir/types" }
+move-model = { path = "../../move-model" }
 move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }

--- a/third_party/move/tools/move-cli/src/base/mod.rs
+++ b/third_party/move/tools/move-cli/src/base/mod.rs
@@ -11,6 +11,7 @@ pub mod movey_upload;
 pub mod new;
 pub mod prove;
 pub mod test;
+pub mod test_validation;
 
 use move_package::source_package::layout::SourcePackageLayout;
 use std::path::PathBuf;

--- a/third_party/move/tools/move-cli/src/base/test_validation.rs
+++ b/third_party/move/tools/move-cli/src/base/test_validation.rs
@@ -1,0 +1,33 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module manages validation of the unit tests, in addition to standard compiler
+//! checking.
+
+use move_model::model::GlobalEnv;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static VALIDATION_HOOK: Lazy<Mutex<Option<Box<dyn Fn(&GlobalEnv) + Send + Sync>>>> =
+    Lazy::new(|| Mutex::new(None));
+
+/// Sets a hook which is called to validate the tested modules. The hook gets
+/// passed the model containing the unit tests. Any errors during validation
+/// should be attached to the model.
+pub fn set_validation_hook(p: Box<dyn Fn(&GlobalEnv) + Send + Sync>) {
+    *VALIDATION_HOOK.lock().unwrap() = Some(p)
+}
+
+/// Returns true if validation is needed. This should be called to avoid building
+/// a model unless needed.
+pub fn needs_validation() -> bool {
+    VALIDATION_HOOK.lock().unwrap().is_some()
+}
+
+/// Validates the modules in the env.
+pub(crate) fn validate(env: &GlobalEnv) {
+    if let Some(h) = &*VALIDATION_HOOK.lock().unwrap() {
+        (*h)(env)
+    }
+}

--- a/third_party/move/tools/move-package/src/compilation/build_plan.rs
+++ b/third_party/move/tools/move-package/src/compilation/build_plan.rs
@@ -17,7 +17,7 @@ use move_compiler::{
     diagnostics::{report_diagnostics_to_color_buffer, report_warnings, FilesSourceText},
     Compiler,
 };
-use move_model::model::GlobalEnv;
+use move_model::model;
 use petgraph::algo::toposort;
 use std::{collections::BTreeSet, io::Write, path::Path};
 #[cfg(feature = "evm-backend")]
@@ -127,7 +127,7 @@ impl BuildPlan {
         &self,
         config: &CompilerConfig,
         writer: &mut W,
-    ) -> Result<(CompiledPackage, Option<GlobalEnv>)> {
+    ) -> Result<(CompiledPackage, Option<model::GlobalEnv>)> {
         self.compile_with_driver(
             writer,
             config,
@@ -158,7 +158,7 @@ impl BuildPlan {
         config: &CompilerConfig,
         compiler_driver_v1: impl FnMut(Compiler) -> CompilerDriverResult,
         compiler_driver_v2: impl FnMut(move_compiler_v2::Options) -> CompilerDriverResult,
-    ) -> Result<(CompiledPackage, Option<GlobalEnv>)> {
+    ) -> Result<(CompiledPackage, Option<model::GlobalEnv>)> {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {
             Some(under_path) => under_path.clone(),

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -114,6 +114,10 @@ pub struct BuildConfig {
     #[clap(name = "generate-abis", long = "abi", global = true)]
     pub generate_abis: bool,
 
+    /// Whether to generate a move model
+    #[clap(skip)]
+    pub generate_move_model: bool,
+
     /// Installation directory for compiled artifacts. Defaults to current directory.
     #[clap(long = "install-dir", value_parser, global = true)]
     pub install_dir: Option<PathBuf>,
@@ -199,7 +203,7 @@ impl BuildConfig {
         self,
         path: &Path,
         writer: &mut W,
-    ) -> Result<CompiledPackage> {
+    ) -> Result<(CompiledPackage, Option<GlobalEnv>)> {
         let config = self.compiler_config.clone(); // Need clone because of mut self
         let resolved_graph = self.resolution_graph_for_package(path, writer)?;
         let mutx = PackageLock::lock();

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -23,7 +23,7 @@ use move_compiler::{
     command_line::SKIP_ATTRIBUTE_CHECKS, shared::known_attributes::KnownAttribute,
 };
 use move_core_types::account_address::AccountAddress;
-use move_model::model::GlobalEnv;
+use move_model::model;
 use serde::{Deserialize, Serialize};
 use source_package::layout::SourcePackageLayout;
 use std::{
@@ -114,9 +114,13 @@ pub struct BuildConfig {
     #[clap(name = "generate-abis", long = "abi", global = true)]
     pub generate_abis: bool,
 
-    /// Whether to generate a move model
+    /// Whether to generate a move model. Used programmatically only.
     #[clap(skip)]
     pub generate_move_model: bool,
+
+    /// Whether the generated model shall contain all functions, including test-only ones.
+    #[clap(skip)]
+    pub full_model_generation: bool,
 
     /// Installation directory for compiled artifacts. Defaults to current directory.
     #[clap(long = "install-dir", value_parser, global = true)]
@@ -203,7 +207,7 @@ impl BuildConfig {
         self,
         path: &Path,
         writer: &mut W,
-    ) -> Result<(CompiledPackage, Option<GlobalEnv>)> {
+    ) -> Result<(CompiledPackage, Option<model::GlobalEnv>)> {
         let config = self.compiler_config.clone(); // Need clone because of mut self
         let resolved_graph = self.resolution_graph_for_package(path, writer)?;
         let mutx = PackageLock::lock();
@@ -232,7 +236,7 @@ impl BuildConfig {
         self,
         path: &Path,
         model_config: ModelConfig,
-    ) -> Result<GlobalEnv> {
+    ) -> Result<model::GlobalEnv> {
         // resolution graph diagnostics are only needed for CLI commands so ignore them by passing a
         // vector as the writer
         let resolved_graph = self.resolution_graph_for_package(path, &mut Vec::new())?;

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -9,6 +9,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -12,6 +12,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -12,6 +12,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -13,6 +13,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -13,6 +13,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -11,6 +11,8 @@ CompiledPackageInfo {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -5,6 +5,8 @@ ResolutionGraph {
         test_mode: false,
         generate_docs: false,
         generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
         install_dir: Some(
             "ELIDED_FOR_TEST",
         ),


### PR DESCRIPTION
### Summary

Closes #9251

This runs the extended checker as part of Aptos unit tests (either our own Rust integrated tests or from the CLI). It uses the same technique as we already used for native extensions specific to Aptos: a hook is defined where additional, move-model based validations can be run. This is hook is then connected to the extended checker when running Aptos tests.

The implementation also optimizes the construction of the move model: if that one is already needed by abi generation (which is the default), it is not constructed a 2nd time for the extended checker -- both  for the existing build step and the new test step. This should avoid one full additional compilation (source -> bytecode -> model run).

Addendum: Extended checks until now excluded test code, leading to wrong usage of entry functions and attributes marked as test-only. Because fixing this is a breaking change, this PR adds the behavior to check test code via a new CLI option `--check-test-code`. This flag should eventually become default behavior.

### Test Plan

Manual