### PR TITLE
[CLI] Set runtime timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bcs 0.1.4",
+ "bollard",
  "chrono",
  "clap 4.3.21",
  "clap_complete",
@@ -4925,6 +4926,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+dependencies = [
+ "base64 0.21.2",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.3",
+ "url",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.43.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,7 +5251,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -6391,6 +6432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "erased-serde"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7435,7 +7482,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.3",
@@ -7837,6 +7884,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8026,6 +8086,18 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -8070,7 +8142,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap",
+ "indexmap 1.9.3",
  "is-terminal",
  "itoa",
  "log",
@@ -9142,7 +9214,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "backtrace",
- "indexmap",
+ "indexmap 1.9.3",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -10834,7 +10906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset 0.2.0",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -10844,7 +10916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -11105,7 +11177,7 @@ checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
 dependencies = [
  "darling",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "mime",
  "proc-macro-crate",
  "proc-macro2 1.0.64",
@@ -12622,9 +12694,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
 dependencies = [
  "serde_derive",
 ]
@@ -12698,13 +12770,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",
- "syn 1.0.105",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -12713,7 +12785,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -12773,12 +12845,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.1",
+ "serde",
+ "serde_json",
+ "time 0.3.24",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
@@ -12790,7 +12878,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -14015,7 +14103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
  "combine",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "serde",
 ]
@@ -14026,7 +14114,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -14151,7 +14239,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project 1.0.12",
  "pin-project-lite",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -446,6 +446,7 @@ bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"
 blst = "0.3.7"
+bollard = "0.15"
 bulletproofs = { version = "4.0.0" }
 byteorder = "1.4.3"
 bytes = { version = "1.4.0", features = ["serde"] }
@@ -591,7 +592,7 @@ sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 siphasher = "0.3.10"
 # pin to 1.0.149 because the latest version fails analyze_serde_formats
-serde = { version = "=1.0.149", features = ["derive", "rc"] }
+serde = { version = "=1.0.157", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order", "arbitrary_precision"] } # Note: arbitrary_precision is required to parse u256 in JSON
 serde_repr = "0.1"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -49,6 +49,7 @@ aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
+bollard = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env", "unstable-styles"] }
 clap_complete = { workspace = true }

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -11,16 +11,26 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use aptos::{move_tool, Tool};
 use clap::Parser;
-use std::process::exit;
+use std::{process::exit, time::Duration};
 
-#[tokio::main]
-async fn main() {
-    // Register hooks
+fn main() {
+    // Register hooks.
     move_tool::register_package_hooks();
-    // Run the corresponding tools
-    let result = Tool::parse().execute().await;
 
-    // At this point, we'll want to print and determine whether to exit for an error code
+    // Create a runtime.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Run the corresponding tool.
+    let result = runtime.block_on(Tool::parse().execute());
+
+    // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
+    // here waiting forever waiting for tasks that sometimes don't want to exit on
+    // their own (e.g. telemetry, containers spawned by the local testnet, etc).
+    runtime.shutdown_timeout(Duration::from_millis(100));
+
     match result {
         Ok(inner) => println!("{}", inner),
         Err(inner) => {

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -46,6 +46,7 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
+        let name_clone = name.to_string();
         let future = async move {
             for health_checker in self.get_prerequisite_health_checkers() {
                 health_checker
@@ -56,7 +57,10 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
             self.run_service()
                 .await
                 .context("Service ended with an error")?;
-            warn!("Service ended unexpectedly without any error");
+            warn!(
+                "Service {} ended unexpectedly without any error",
+                name_clone
+            );
             Ok(())
         };
         tokio::spawn(future.map(move |result: Result<()>| {

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -4,9 +4,7 @@
 use super::health_checker::HealthChecker;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::FutureExt;
 use std::{collections::HashSet, fmt::Debug};
-use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[async_trait]
@@ -40,32 +38,28 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
     fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker>;
 
     /// This is the function we use from the outside to start the service. It makes
-    /// sure all the prerequisite services have started and then spawns a tokio task to
-    /// run the service. The user should never need to override this implementation.
-    fn run(self: Box<Self>) -> JoinHandle<()> {
+    /// sure all the prerequisite services have started and then calls the inner
+    /// function to run the service. The user should never need to override this
+    /// implementation.
+    async fn run(self: Box<Self>) -> Result<()> {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
         let name_clone = name.to_string();
-        let future = async move {
-            for health_checker in self.get_prerequisite_health_checkers() {
-                health_checker
-                    .wait(Some(&self.get_name()))
-                    .await
-                    .context("Prerequisite service did not start up successfully")?;
-            }
-            self.run_service()
+        for health_checker in self.get_prerequisite_health_checkers() {
+            health_checker
+                .wait(Some(&self.get_name()))
                 .await
-                .context("Service ended with an error")?;
-            warn!(
-                "Service {} ended unexpectedly without any error",
-                name_clone
-            );
-            Ok(())
-        };
-        tokio::spawn(future.map(move |result: Result<()>| {
-            warn!("{} stopped unexpectedly {:#?}", name, result);
-        }))
+                .context("Prerequisite service did not start up successfully")?;
+        }
+        self.run_service()
+            .await
+            .context("Service ended with an error")?;
+        warn!(
+            "Service {} ended unexpectedly without any error",
+            name_clone
+        );
+        Ok(())
     }
 
     /// The ServiceManager may return PostHealthySteps. The tool will run these after

--- a/crates/aptos/src/node/local_testnet/utils.rs
+++ b/crates/aptos/src/node/local_testnet/utils.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::traits::ShutdownStep;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
+use bollard::{container::RemoveContainerOptions, image::CreateImageOptions, Docker};
+use futures::TryStreamExt;
 use reqwest::Url;
-use std::{fs::create_dir_all, net::SocketAddr, path::Path, process::Stdio};
-use tokio::process::Command;
+use std::{fs::create_dir_all, net::SocketAddr, path::Path};
 use tracing::info;
 
 pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url> {
@@ -18,22 +19,18 @@ pub fn socket_addr_to_url(socket_addr: &SocketAddr, scheme: &str) -> Result<Url>
     Ok(Url::parse(&full_url)?)
 }
 
+pub fn get_docker() -> Result<Docker> {
+    let docker = Docker::connect_with_local_defaults()
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
+    Ok(docker)
+}
+
 pub async fn confirm_docker_available() -> Result<()> {
-    let status = Command::new("docker")
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+    let docker = get_docker()?;
+    docker
+        .info()
         .await
-        .context("Failed to check if Docker is available")?;
-
-    if !status.success() {
-        bail!(
-            "Docker is not available, confirm it is installed and running: {:?}",
-            status
-        );
-    }
-
+        .context("Docker is not available, confirm it is installed and running: {:?}")?;
     Ok(())
 }
 
@@ -44,18 +41,15 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
         container_name
     );
 
-    let _ = Command::new("docker")
-        .arg("rm")
-        .arg("-f")
-        .arg(container_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context(format!(
-            "Failed to remove existing container with name {}",
-            container_name
-        ))?;
+    let docker = get_docker()?;
+
+    let options = Some(RemoveContainerOptions {
+        force: true,
+        ..Default::default()
+    });
+
+    // Ignore any error, it'll be because the container doesn't exist.
+    let _ = docker.remove_container(container_name, options).await;
 
     info!(
         "Removed any existing postgres container with name {}",
@@ -67,19 +61,28 @@ pub async fn delete_container(container_name: &str) -> Result<()> {
 
 pub async fn pull_docker_image(image_name: &str) -> Result<()> {
     info!("Pulling docker image {}", image_name);
-    let status = Command::new("docker")
-        .arg("pull")
-        .arg(image_name)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .context("Failed to pull postgres image")?;
-    info!("Pulled docker image {}", image_name);
 
-    if !status.success() {
-        bail!("Failed to pull postgres image: {:?}", status);
-    }
+    let docker = get_docker()?;
+
+    let options = Some(CreateImageOptions {
+        from_image: image_name,
+        ..Default::default()
+    });
+
+    // Check if the image is there. If not, print that we'll pull it.
+    if docker.inspect_image(image_name).await.is_err() {
+        eprintln!("Image {} not found, pulling it now", image_name);
+    };
+
+    // The docker pull CLI command is just sugar around this API.
+    docker
+        .create_image(options, None, None)
+        // Just wait for the whole stream, we don't need to do other things in parallel.
+        .try_collect::<Vec<_>>()
+        .await
+        .with_context(|| format!("Failed to pull image {}", image_name))?;
+
+    info!("Pulled docker image {}", image_name);
 
     Ok(())
 }
@@ -88,11 +91,7 @@ pub async fn pull_docker_image(image_name: &str) -> Result<()> {
 /// file called README.md that tells the user where to go to see logs. We do this since
 /// having the user use `docker logs` is the preferred approach. To help debug any
 /// potential startup failures however, we also create files for the command to write to.
-pub fn setup_docker_logging(
-    test_dir: &Path,
-    dir_name: &str,
-    container_name: &str,
-) -> Result<(Stdio, Stdio)> {
+pub fn setup_docker_logging(test_dir: &Path, dir_name: &str, container_name: &str) -> Result<()> {
     // Create dir.
     let log_dir = test_dir.join(dir_name);
     create_dir_all(log_dir.as_path()).context(format!("Failed to create {}", log_dir.display()))?;
@@ -104,25 +103,7 @@ pub fn setup_docker_logging(
     );
     std::fs::write(log_dir.join("README.md"), data).context("Unable to write README file")?;
 
-    // Create file for stdout.
-    let path = log_dir.join("stdout.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stdout = Stdio::from(file);
-
-    // Create file for stderr.
-    let path = log_dir.join("stderr.log");
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .open(path.clone())
-        .context(format!("Failed to create {}", path.display()))?;
-    let stderr = Stdio::from(file);
-
-    Ok((stdout, stderr))
+    Ok(())
 }
 
 /// This shutdown step forcibly kills a container with the given name. If no container


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/10255/
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/10333

### Description
Some tokio tasks don't like to go away, e.g. if they're blocking on some synchronous code and spawn_blocking wasn't used. This is pretty common with the local testnet. Since it now intercepts ctrl+C, this phenomenon is now visible, so we need to set a timeout on the runtime.

### Test Plan
See https://github.com/aptos-labs/aptos-core/pull/10311. All the testing on that PR was actually using this one.
