### PR TITLE
[version] update aptos-node version to 1.7.2

### DIFF
--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-node"
 description = "Aptos node"
-version = "1.6.0"
+version = "1.7.2"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
aptos-node version has not been changed in Cargo.toml