### PR TITLE
Use local testnet indexer for TS SDK tests

### DIFF
--- a/.github/actions/run-local-testnet/action.yaml
+++ b/.github/actions/run-local-testnet/action.yaml
@@ -8,6 +8,9 @@ inputs:
   GCP_DOCKER_ARTIFACT_REPO:
     description: "The GCP Docker artifact repository"
     required: true
+  WITH_INDEXER_API:
+    description: "If true, run an indexer API as well"
+    default: "false"
 
 runs:
   using: composite
@@ -18,9 +21,21 @@ runs:
       run: mkdir -p ${{ runner.temp }}/testnet
       shell: bash
 
-    # Run a local testnet. We mount in the testnet directory we just created.
-    - run: docker run -p 8080:8080 -p 8081:8081 -v ${{ runner.temp }}/testnet:/testnet --name=local-testnet-${{ inputs.IMAGE_TAG }} --detach ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.IMAGE_TAG }} aptos node run-local-testnet --with-faucet --test-dir /testnet
+    # Run a local testnet. We mount in the testnet directory we just created. We bind
+    # the Docker daemon Unix socket from the host into the container so the CLI inside
+    # the container can run containers on the host (e.g. postgres and the indexer API).
+    - run: |
+        docker run \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --network host \
+        -v ${{ runner.temp }}/testnet:/testnet \
+        --name=local-testnet-${{ inputs.IMAGE_TAG }} \
+        --detach ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.IMAGE_TAG }} \
+        aptos node run-local-testnet \
+        --test-dir /testnet \
+        ${{ inputs.WITH_INDEXER_API == 'true' && '--with-indexer-api' }}
       shell: bash
+
 
     # Install node + npm.
     - uses: actions/setup-node@v3
@@ -28,12 +43,11 @@ runs:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"
 
-    # Wait for the node API and faucet of the local testnet to start up.
+    # Wait for all the services of the local testnet to start up by waiting for the
+    # readiness endpoint to return 200.
     - run: npm install -g wait-on
       shell: bash
-    - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8080/v1
-      shell: bash
-    - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081
+    - run: wait-on -t 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
       shell: bash
 
     # Print the logs from the local testnet if the tests failed.

--- a/.github/actions/run-ts-sdk-e2e-tests/action.yaml
+++ b/.github/actions/run-ts-sdk-e2e-tests/action.yaml
@@ -53,8 +53,9 @@ runs:
       with:
         IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
         GCP_DOCKER_ARTIFACT_REPO: ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
+        WITH_INDEXER_API: "true"
 
-    # Run the TS SDK tests.
+    # Run the non indexer TS SDK tests.
     - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
       name: sdk-pnpm-test
       env:
@@ -66,3 +67,17 @@ runs:
         max_attempts: 3
         timeout_minutes: 25
         command: cd ./ecosystem/typescript/sdk && pnpm run test:ci
+
+
+    # Run the indexer TS SDK tests.
+    - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      name: ts-sdk-indexer-test
+      env:
+        # This is important, it ensures that the tempdir we create for cloning the ANS
+        # repo and mounting it into the CLI container is created in a location that
+        # actually supports mounting. Learn more here: https://stackoverflow.com/a/76523941/3846032.
+        TMPDIR: ${{ runner.temp }}
+      with:
+        max_attempts: 3
+        timeout_minutes: 20
+        command: cd ./ecosystem/typescript/sdk && pnpm run test:indexer

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -1,14 +1,13 @@
 # Each of these jobs runs the TS SDK E2E tests from this commit against a local testnet
-# built from one of the production release branches. In other words, we run the TS SDK
-# tests against a local devnet, testnet, and mainnet. We also run the TS SDK tests for
-# the indexer, though those run against the production indexer for now.
+# built from one of the aptos-core branches. Currently we only test against a local
+# testnet in a CLI built from main.
 
 env:
   GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-name: "TS SDK E2E Tests"
+name: "TS SDK E2E Tests YOOO"
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
@@ -44,7 +43,8 @@ jobs:
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
 
-  # This is a PR required job.
+  # This is a PR required job. This runs both the non-indexer and indexer TS SDK tests.
+  # Now that the latter runs against the local testnet too we make these land blocking.
   run-tests-main-branch:
     needs: [permission-check, file_change_determinator]
     runs-on: high-perf-docker
@@ -69,34 +69,3 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
       - run: echo "Skipping the tests on the main branch! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
-
-  # Run the TS SDK indexer tests. Note: Unlike the above tests where everything is self
-  # contained because we run a local testnet, these tests operate against the
-  # production indexer service. This service can be flaky so we don't want those tests
-  # to be land blocking for any PR on the aptos repo. This is why we run those tests
-  # separate from test-sdk-confirm-client-generated-publish.
-  run-indexer-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    needs: [permission-check]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ env.GIT_SHA }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .node-version
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@v2
-
-      # Run package install. If install fails, it probably means the lockfile
-      # was not included in the commit.
-      - run: cd ./ecosystem/typescript/sdk && pnpm install --frozen-lockfile
-
-      # Run indexer tests.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
-        name: ts-sdk-indexer-test
-        with:
-          max_attempts: 3
-          timeout_minutes: 20
-          command: cd ./ecosystem/typescript/sdk && pnpm run test:indexer

--- a/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
@@ -1,24 +1,19 @@
 import { AptosAccount } from "../../account/aptos_account";
 import { bcsSerializeBool } from "../../bcs";
-import { FaucetClient } from "../../plugins/faucet_client";
-import { IndexerClient } from "../../providers/indexer";
 import { TokenClient } from "../../plugins/token_client";
-import { FAUCET_AUTH_TOKEN, longTestTimeout } from "../unit/test_helper.test";
-import { Network, NetworkToIndexerAPI, sleep } from "../../utils";
+import { getFaucetClient, longTestTimeout } from "../unit/test_helper.test";
+import { Network, sleep } from "../../utils";
 import { Provider } from "../../providers";
 import { AptosToken } from "../../plugins";
 
-const provider = new Provider(Network.DEVNET);
-const aptosToken = new AptosToken(provider);
-const faucetClient = new FaucetClient("https://fullnode.devnet.aptoslabs.com", "https://faucet.devnet.aptoslabs.com", {
-  TOKEN: FAUCET_AUTH_TOKEN,
-});
+const provider = new Provider(Network.LOCAL);
+const faucetClient = getFaucetClient();
 const tokenClient = new TokenClient(provider.aptosClient);
+const aptosToken = new AptosToken(provider);
 const alice = new AptosAccount();
 const collectionName = "AliceCollection";
 const collectionNameV2 = "AliceCollection2";
 const tokenName = "Alice Token";
-const indexerClient = new IndexerClient(NetworkToIndexerAPI[Network.DEVNET]);
 
 let skipTest = false;
 let runTests = describe;
@@ -27,19 +22,19 @@ describe("Indexer", () => {
   it("should throw an error when account address is not valid", async () => {
     const address1 = "702ca08576f66393140967fef983bb6bf160dafeb73de9c4ddac4d2dc";
     expect(async () => {
-      await indexerClient.getOwnedTokens(address1);
+      await provider.getOwnedTokens(address1);
     }).rejects.toThrow(`${address1} is less than 66 chars long.`);
 
     const address2 = "0x702ca08576f66393140967fef983bb6bf160dafeb73de9c4ddac4d2dc";
     expect(async () => {
-      await indexerClient.getOwnedTokens(address2);
+      await provider.getOwnedTokens(address2);
     }).rejects.toThrow(`${address2} is less than 66 chars long.`);
   });
 
   it("should not throw an error when account address is missing 0x", async () => {
     const address = "790a34c702ca08576f66393140967fef983bb6bf160dafeb73de9c4ddac4d2dc";
     expect(async () => {
-      await indexerClient.getOwnedTokens(address);
+      await provider.getOwnedTokens(address);
     }).not.toThrow();
   });
 
@@ -48,15 +43,15 @@ describe("Indexer", () => {
     const fullNodeChainId = await provider.getChainId();
 
     console.log(
-      `\n devnet chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo.ledger_infos[0].chain_id}`,
+      `\n network chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo.ledger_infos[0].chain_id}`,
     );
 
     if (indexerLedgerInfo.ledger_infos[0].chain_id !== fullNodeChainId) {
-      console.log(`\n devnet chain id and indexer chain id are not synced, skipping rest of tests`);
+      console.log(`\n network chain id and indexer chain id are not synced, skipping rest of tests`);
       skipTest = true;
       runTests = describe.skip;
     } else {
-      console.log(`\n devnet chain id and indexer chain id are in synced, running tests`);
+      console.log(`\n network chain id and indexer chain id are in synced, running tests`);
     }
 
     if (!skipTest) {
@@ -125,7 +120,7 @@ describe("Indexer", () => {
     });
 
     it("gets indexer ledger info", async () => {
-      const ledgerInfo = await indexerClient.getIndexerLedgerInfo();
+      const ledgerInfo = await provider.getIndexerLedgerInfo();
       expect(ledgerInfo.ledger_infos[0].chain_id).toBeGreaterThan(1);
     });
 
@@ -134,7 +129,7 @@ describe("Indexer", () => {
     it(
       "gets account owned objects data",
       async () => {
-        const accountObjects = await indexerClient.getAccountOwnedObjects(alice.address().hex());
+        const accountObjects = await provider.getAccountOwnedObjects(alice.address().hex());
         expect(accountObjects.current_objects.length).toBe(2);
       },
       longTestTimeout,
@@ -145,10 +140,10 @@ describe("Indexer", () => {
     it(
       "gets token activities",
       async () => {
-        const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
+        const accountTokens = await provider.getOwnedTokens(alice.address().hex());
         expect(accountTokens.current_token_ownerships_v2).toHaveLength(2);
         // V1
-        const tokenActivityV1 = await indexerClient.getTokenActivities(
+        const tokenActivityV1 = await provider.getTokenActivities(
           accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
         );
         expect(tokenActivityV1.token_activities_v2).toHaveLength(2);
@@ -159,7 +154,7 @@ describe("Indexer", () => {
         expect(tokenActivityV1.token_activities_v2[1].token_standard).toEqual("v1");
         expect(tokenActivityV1.token_activities_v2[1].to_address).toEqual(alice.address().hex());
         // V2
-        const tokenActivityV2 = await indexerClient.getTokenActivities(
+        const tokenActivityV2 = await provider.getTokenActivities(
           accountTokens.current_token_ownerships_v2[1].current_token_data!.token_data_id,
         );
         expect(tokenActivityV2.token_activities_v2).toHaveLength(1);
@@ -172,16 +167,16 @@ describe("Indexer", () => {
     it(
       "gets token activities count",
       async () => {
-        const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex(), {
+        const accountTokens = await provider.getOwnedTokens(alice.address().hex(), {
           orderBy: [{ last_transaction_version: "desc" }],
         });
         expect(accountTokens.current_token_ownerships_v2[0].token_standard).toBe("v2");
         expect(accountTokens.current_token_ownerships_v2[1].token_standard).toBe("v1");
-        const tokenActivitiesV2Count = await indexerClient.getTokenActivitiesCount(
+        const tokenActivitiesV2Count = await provider.getTokenActivitiesCount(
           accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
         );
         expect(tokenActivitiesV2Count.token_activities_v2_aggregate.aggregate?.count).toBe(1);
-        const tokenActivitiesV1Count = await indexerClient.getTokenActivitiesCount(
+        const tokenActivitiesV1Count = await provider.getTokenActivitiesCount(
           accountTokens.current_token_ownerships_v2[1].current_token_data!.token_data_id,
         );
         expect(tokenActivitiesV1Count.token_activities_v2_aggregate.aggregate?.count).toBe(2);
@@ -192,7 +187,7 @@ describe("Indexer", () => {
     it(
       "gets account token count",
       async () => {
-        const accountTokenCount = await indexerClient.getAccountTokensCount(alice.address().hex());
+        const accountTokenCount = await provider.getAccountTokensCount(alice.address().hex());
         expect(accountTokenCount.current_token_ownerships_v2_aggregate.aggregate?.count).toEqual(2);
       },
       longTestTimeout,
@@ -201,8 +196,8 @@ describe("Indexer", () => {
     it(
       "gets token data",
       async () => {
-        const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
-        const tokenData = await indexerClient.getTokenData(
+        const accountTokens = await provider.getOwnedTokens(alice.address().hex());
+        const tokenData = await provider.getTokenData(
           accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
         );
         expect(tokenData.current_token_datas_v2[0].token_name).toEqual(tokenName);
@@ -213,8 +208,8 @@ describe("Indexer", () => {
     it(
       "gets token owners data",
       async () => {
-        const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
-        const tokenOwnersData = await indexerClient.getTokenOwnersData(
+        const accountTokens = await provider.getOwnedTokens(alice.address().hex());
+        const tokenOwnersData = await provider.getTokenOwnersData(
           accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
           0,
         );
@@ -226,8 +221,8 @@ describe("Indexer", () => {
     it(
       "gets token current owner data",
       async () => {
-        const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
-        const tokenOwnersData = await indexerClient.getTokenCurrentOwnerData(
+        const accountTokens = await provider.getOwnedTokens(alice.address().hex());
+        const tokenOwnersData = await provider.getTokenCurrentOwnerData(
           accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
           0,
         );
@@ -237,14 +232,14 @@ describe("Indexer", () => {
     );
 
     it("gets account owned tokens", async () => {
-      const tokens = await indexerClient.getOwnedTokens(alice.address().hex());
+      const tokens = await provider.getOwnedTokens(alice.address().hex());
       expect(tokens.current_token_ownerships_v2.length).toEqual(2);
     });
 
     it("gets account owned tokens by token data id", async () => {
-      const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
+      const accountTokens = await provider.getOwnedTokens(alice.address().hex());
 
-      const tokens = await indexerClient.getOwnedTokensByTokenData(
+      const tokens = await provider.getOwnedTokensByTokenData(
         accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
       );
       expect(tokens.current_token_ownerships_v2).toHaveLength(1);
@@ -252,8 +247,8 @@ describe("Indexer", () => {
     });
 
     it("gets account tokens owned from collection address", async () => {
-      const collectionAddress = await indexerClient.getCollectionAddress(alice.address().hex(), collectionNameV2);
-      const tokensFromCollectionAddress = await indexerClient.getTokenOwnedFromCollectionAddress(
+      const collectionAddress = await provider.getCollectionAddress(alice.address().hex(), collectionNameV2);
+      const tokensFromCollectionAddress = await provider.getTokenOwnedFromCollectionAddress(
         alice.address().hex(),
         collectionAddress,
       );
@@ -265,7 +260,7 @@ describe("Indexer", () => {
     it(
       "gets account current tokens by collection name and creator address",
       async () => {
-        const tokens = await indexerClient.getTokenOwnedFromCollectionNameAndCreatorAddress(
+        const tokens = await provider.getTokenOwnedFromCollectionNameAndCreatorAddress(
           alice.address().hex(),
           collectionNameV2,
           alice.address().hex(),
@@ -279,12 +274,12 @@ describe("Indexer", () => {
     it(
       "returns same result for getTokenOwnedFromCollectionNameAndCreatorAddress and getTokenOwnedFromCollectionAddress",
       async () => {
-        const collectionAddress = await indexerClient.getCollectionAddress(alice.address().hex(), collectionNameV2);
-        const tokensFromCollectionAddress = await indexerClient.getTokenOwnedFromCollectionAddress(
+        const collectionAddress = await provider.getCollectionAddress(alice.address().hex(), collectionNameV2);
+        const tokensFromCollectionAddress = await provider.getTokenOwnedFromCollectionAddress(
           alice.address().hex(),
           collectionAddress,
         );
-        const tokensFromNameAndCreatorAddress = await indexerClient.getTokenOwnedFromCollectionNameAndCreatorAddress(
+        const tokensFromNameAndCreatorAddress = await provider.getTokenOwnedFromCollectionNameAndCreatorAddress(
           alice.address().hex(),
           collectionNameV2,
           alice.address().hex(),
@@ -298,21 +293,21 @@ describe("Indexer", () => {
     );
 
     it("gets the collection data", async () => {
-      const collectionData = await indexerClient.getCollectionData(alice.address().hex(), collectionName);
+      const collectionData = await provider.getCollectionData(alice.address().hex(), collectionName);
       expect(collectionData.current_collections_v2).toHaveLength(1);
       expect(collectionData.current_collections_v2[0].collection_name).toEqual(collectionName);
     });
 
     it("gets the currect collection address", async () => {
-      const collectionData = await indexerClient.getCollectionData(alice.address().hex(), collectionNameV2);
-      const collectionAddress = await indexerClient.getCollectionAddress(alice.address().hex(), collectionNameV2);
+      const collectionData = await provider.getCollectionData(alice.address().hex(), collectionNameV2);
+      const collectionAddress = await provider.getCollectionAddress(alice.address().hex(), collectionNameV2);
       expect(collectionData.current_collections_v2[0].collection_id).toEqual(collectionAddress);
     });
 
     it(
       "queries for all collections that an account has tokens for",
       async () => {
-        const collections = await indexerClient.getCollectionsWithOwnedTokens(alice.address().hex());
+        const collections = await provider.getCollectionsWithOwnedTokens(alice.address().hex());
         expect(collections.current_collection_ownership_v2_view.length).toEqual(2);
       },
       longTestTimeout,
@@ -322,7 +317,7 @@ describe("Indexer", () => {
     it(
       "gets account transactions count",
       async () => {
-        const accountTransactionsCount = await indexerClient.getAccountTransactionsCount(alice.address().hex());
+        const accountTransactionsCount = await provider.getAccountTransactionsCount(alice.address().hex());
         expect(accountTransactionsCount.account_transactions_aggregate.aggregate?.count).toEqual(5);
       },
       longTestTimeout,
@@ -331,7 +326,7 @@ describe("Indexer", () => {
     it(
       "gets account transactions data",
       async () => {
-        const accountTransactionsData = await indexerClient.getAccountTransactionsData(alice.address().hex());
+        const accountTransactionsData = await provider.getAccountTransactionsData(alice.address().hex());
         expect(accountTransactionsData.account_transactions.length).toEqual(5);
         expect(accountTransactionsData.account_transactions[0]).toHaveProperty("transaction_version");
       },
@@ -341,7 +336,7 @@ describe("Indexer", () => {
     it(
       "gets top user transactions",
       async () => {
-        const topUserTransactions = await indexerClient.getTopUserTransactions(5);
+        const topUserTransactions = await provider.getTopUserTransactions(5);
         expect(topUserTransactions.user_transactions.length).toEqual(5);
       },
       longTestTimeout,
@@ -350,7 +345,7 @@ describe("Indexer", () => {
     it(
       "gets user transactions",
       async () => {
-        const userTransactions = await indexerClient.getUserTransactions({ options: { limit: 4 } });
+        const userTransactions = await provider.getUserTransactions({ options: { limit: 4 } });
         expect(userTransactions.user_transactions.length).toEqual(4);
       },
       longTestTimeout,
@@ -359,7 +354,7 @@ describe("Indexer", () => {
     it(
       "gets number of delegators",
       async () => {
-        const numberOfDelegators = await indexerClient.getNumberOfDelegators(alice.address().hex());
+        const numberOfDelegators = await provider.getNumberOfDelegators(alice.address().hex());
         expect(numberOfDelegators.num_active_delegator_per_pool).toHaveLength(0);
       },
       longTestTimeout,
@@ -369,7 +364,7 @@ describe("Indexer", () => {
     it(
       "gets account coin data",
       async () => {
-        const accountCoinData = await indexerClient.getAccountCoinsData(alice.address().hex());
+        const accountCoinData = await provider.getAccountCoinsData(alice.address().hex());
         expect(accountCoinData.current_fungible_asset_balances[0].asset_type).toEqual("0x1::aptos_coin::AptosCoin");
       },
       longTestTimeout,
@@ -378,7 +373,7 @@ describe("Indexer", () => {
     it(
       "gets account coin data count",
       async () => {
-        const accountCoinDataCount = await indexerClient.getAccountCoinsDataCount(alice.address().hex());
+        const accountCoinDataCount = await provider.getAccountCoinsDataCount(alice.address().hex());
         expect(accountCoinDataCount.current_fungible_asset_balances_aggregate.aggregate?.count).toEqual(1);
       },
       longTestTimeout,
@@ -387,14 +382,14 @@ describe("Indexer", () => {
     // TOKEN STANDARD FILTER //
 
     it("gets account owned tokens with a specified token standard", async () => {
-      const tokens = await indexerClient.getOwnedTokens(alice.address().hex(), { tokenStandard: "v2" });
+      const tokens = await provider.getOwnedTokens(alice.address().hex(), { tokenStandard: "v2" });
       expect(tokens.current_token_ownerships_v2).toHaveLength(1);
     });
 
     it(
       "gets account current tokens of a specific collection by the collection address with token standard specified",
       async () => {
-        const tokens = await indexerClient.getTokenOwnedFromCollectionNameAndCreatorAddress(
+        const tokens = await provider.getTokenOwnedFromCollectionNameAndCreatorAddress(
           alice.address().hex(),
           collectionNameV2,
           alice.address().hex(),
@@ -411,7 +406,7 @@ describe("Indexer", () => {
     it(
       "queries for all v2 collections that an account has tokens for",
       async () => {
-        const collections = await indexerClient.getCollectionsWithOwnedTokens(alice.address().hex(), {
+        const collections = await provider.getCollectionsWithOwnedTokens(alice.address().hex(), {
           tokenStandard: "v2",
         });
         expect(collections.current_collection_ownership_v2_view.length).toEqual(1);
@@ -422,7 +417,7 @@ describe("Indexer", () => {
     // ORDER BY //
 
     it("gets account owned tokens sorted desc by token standard", async () => {
-      const tokens = await indexerClient.getOwnedTokens(alice.address().hex(), {
+      const tokens = await provider.getOwnedTokens(alice.address().hex(), {
         orderBy: [{ token_standard: "desc" }],
       });
       expect(tokens.current_token_ownerships_v2).toHaveLength(2);
@@ -430,7 +425,7 @@ describe("Indexer", () => {
     });
 
     it("gets account owned tokens sorted desc by collection name", async () => {
-      const tokens = await indexerClient.getOwnedTokens(alice.address().hex(), {
+      const tokens = await provider.getOwnedTokens(alice.address().hex(), {
         orderBy: [{ current_token_data: { current_collection: { collection_name: "desc" } } }],
       });
       expect(tokens.current_token_ownerships_v2).toHaveLength(2);
@@ -438,11 +433,11 @@ describe("Indexer", () => {
     });
 
     it("gets token activities sorted desc by collection name", async () => {
-      const accountTokens = await indexerClient.getOwnedTokens(alice.address().hex());
+      const accountTokens = await provider.getOwnedTokens(alice.address().hex());
       expect(accountTokens.current_token_ownerships_v2).toHaveLength(2);
       expect(accountTokens.current_token_ownerships_v2[0].token_standard).toEqual("v1");
 
-      const tokens = await indexerClient.getTokenActivities(
+      const tokens = await provider.getTokenActivities(
         accountTokens.current_token_ownerships_v2[0].current_token_data!.token_data_id,
         {
           orderBy: [{ transaction_version: "desc" }],
@@ -455,7 +450,7 @@ describe("Indexer", () => {
     it(
       "gets account transactions data",
       async () => {
-        const accountTransactionsData = await indexerClient.getAccountTransactionsData(alice.address().hex(), {
+        const accountTransactionsData = await provider.getAccountTransactionsData(alice.address().hex(), {
           orderBy: [{ transaction_version: "desc" }],
         });
         expect(accountTransactionsData.account_transactions.length).toEqual(5);

--- a/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
@@ -28,12 +28,6 @@ describe("Provider", () => {
     expect(provider.indexerClient).toBe(undefined);
   });
 
-  it("does not set indexer client when local netowrk is provided", async () => {
-    const provider = new Provider(Network.LOCAL);
-    expect(provider.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.LOCAL]);
-    expect(provider.indexerClient).toBe(undefined);
-  });
-
   it("includes static methods", async () => {
     expect(Provider).toHaveProperty("generateBCSTransaction");
     expect(Provider).toHaveProperty("generateBCSSimulation");

--- a/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
+++ b/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
@@ -2,20 +2,21 @@ export const NetworkToIndexerAPI: Record<string, string> = {
   mainnet: "https://indexer.mainnet.aptoslabs.com/v1/graphql",
   testnet: "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql",
   devnet: "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql",
+  local: "http://127.0.0.1:8090/v1/graphql",
 };
 
 export const NetworkToNodeAPI: Record<string, string> = {
   mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
   testnet: "https://fullnode.testnet.aptoslabs.com/v1",
   devnet: "https://fullnode.devnet.aptoslabs.com/v1",
-  local: "http://localhost:8080/v1",
+  local: "http://127.0.0.1:8080/v1",
 };
 
 export const NodeAPIToNetwork: Record<string, string> = {
   "https://fullnode.mainnet.aptoslabs.com/v1": "mainnet",
   "https://fullnode.testnet.aptoslabs.com/v1": "testnet",
   "https://fullnode.devnet.aptoslabs.com/v1": "devnet",
-  "http://localhost:8080/v1": "local",
+  "http://127.0.0.1:8080/v1": "local",
 };
 
 export enum Network {


### PR DESCRIPTION
### Description
Now that we have a local testnet that can run the indexer API, we should run our indexer tests against it. This makes the tests more reliable because we're no longer relying on a production network which is sometimes down due to upgrades / unreliable internet. We also don't need to deal with auth keys at all now to bypass ratelimiting.

### Test Plan
Demonstrating that it works locally:
```
pnpm test:indexer
  Indexer
    ✓ should throw an error when account address is not valid (23 ms)
    ✓ should not throw an error when account address is missing 0x
    get data
      ✓ gets indexer ledger info (1009 ms)
      ✓ gets account owned objects data (1026 ms)
      ✓ gets token activities (1050 ms)
      ✓ gets token activities count (1036 ms)
      ✓ gets account token count (1013 ms)
      ✓ gets token data (1025 ms)
      ✓ gets token owners data (1044 ms)
      ✓ gets token current owner data (1035 ms)
      ✓ gets account owned tokens (1008 ms)
      ✓ gets account owned tokens by token data id (1035 ms)
      ✓ gets account tokens owned from collection address (1019 ms)
      ✓ gets account current tokens by collection name and creator address (1035 ms)
      ✓ returns same result for getTokenOwnedFromCollectionNameAndCreatorAddress and getTokenOwnedFromCollectionAddress (1055 ms)
      ✓ gets the collection data (1016 ms)
      ✓ gets the currect collection address (1025 ms)
      ✓ queries for all collections that an account has tokens for (1025 ms)
      ✓ gets account transactions count (1022 ms)
      ✓ gets account transactions data (1025 ms)
      ✓ gets top user transactions (1015 ms)
      ✓ gets user transactions (1028 ms)
      ✓ gets number of delegators (1014 ms)
      ✓ gets account coin data (1026 ms)
      ✓ gets account coin data count (1012 ms)
      ✓ gets account owned tokens with a specified token standard (1038 ms)
      ✓ gets account current tokens of a specific collection by the collection address with token standard specified (1031 ms)
      ✓ queries for all v2 collections that an account has tokens for (1037 ms)
      ✓ gets account owned tokens sorted desc by token standard (1013 ms)
      ✓ gets account owned tokens sorted desc by collection name (1042 ms)
      ✓ gets token activities sorted desc by collection name (1033 ms)
      ✓ gets account transactions data (1038 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       33 passed, 33 total
Snapshots:   0 total
Time:        37.988 s
```

Successful run in CI: https://github.com/aptos-labs/aptos-core/actions/runs/6487527720/job/17618043884?pr=10313.

I will have to force land, the old indexer tests job that I delete in this PR still runs because of pull_request_target magic. IT fails here but will gone once this lands.