### PR TITLE
[Quorum Store] 33% increase in backlog_txn_limit_count

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -26,7 +26,7 @@ impl Default for QuorumStoreBackPressureConfig {
     fn default() -> QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
-            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 3,
+            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 4,
             // QS will create batches at the max rate until this number is reached
             backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,


### PR DESCRIPTION
### Description

The previous `backlog_txn_limit_count` was too conservative. Especially when running through PFNs, which cause duplicate txns and these are included in the backlog count. We should optimize for this case, since most txns should go through PFNs in prod.

Higher values of `backlog_txn_limit_count` actually show some VFNs lagging behind in non-PFN tests (due to VNs going full throttle). We will need to think more on what to do in this case.

### Test Plan

Ran ad-hoc test with PFNs, see an increase in TPS (latest run 7K).