### PR TITLE
fix WarmVmCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,8 @@ dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-types",
+ "bcs 0.1.4",
+ "bytes",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
@@ -3762,6 +3764,8 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tiny-keccak",
 ]
@@ -7955,9 +7959,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "io-lifetimes"
@@ -11994,7 +11998,7 @@ checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
- "io-lifetimes 0.7.3",
+ "io-lifetimes 0.7.5",
  "libc",
  "linux-raw-sys 0.0.46",
  "windows-sys 0.36.1",

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -12,7 +12,7 @@ use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
     chain_id::ChainId,
-    on_chain_config::{Features, OnChainConfig, TimedFeatures},
+    on_chain_config::{Features, OnChainConfig, TimedFeaturesBuilder},
     transaction::{
         SignedTransaction, Transaction, TransactionInfo, TransactionOutput, TransactionPayload,
         Version,
@@ -235,7 +235,7 @@ impl AptosDebugger {
             LATEST_GAS_FEATURE_VERSION,
             ChainId::test().id(),
             features,
-            TimedFeatures::enable_all(),
+            TimedFeaturesBuilder::enable_all().build(),
             &state_view_storage,
         )
         .unwrap();

--- a/aptos-move/aptos-native-interface/Cargo.toml
+++ b/aptos-move/aptos-native-interface/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = { workspace = true }
 aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
+bcs = { workspace = true }
+bytes = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }

--- a/aptos-move/aptos-native-interface/src/builder.rs
+++ b/aptos-move/aptos-native-interface/src/builder.rs
@@ -6,8 +6,9 @@ use crate::{
     errors::{SafeNativeError, SafeNativeResult},
 };
 use aptos_gas_algebra::DynamicExpression;
-use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters};
+use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, ToOnChainGasSchedule};
 use aptos_types::on_chain_config::{Features, TimedFeatures};
+use bytes::Bytes;
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
@@ -169,5 +170,31 @@ impl SafeNativeBuilder {
         natives
             .into_iter()
             .map(|(func_name, func)| (func_name.into(), self.make_native(func)))
+    }
+
+    pub fn id_bytes(&self) -> Bytes {
+        let Self {
+            data,
+            enable_incremental_gas_charging,
+            gas_hook: _gas_hook,
+        } = self;
+        let SharedData {
+            gas_feature_version,
+            native_gas_params,
+            misc_gas_params,
+            timed_features,
+            features,
+        } = data.as_ref();
+
+        bcs::to_bytes(&(
+            enable_incremental_gas_charging,
+            gas_feature_version,
+            native_gas_params.to_on_chain_gas_schedule(*gas_feature_version),
+            misc_gas_params.to_on_chain_gas_schedule(*gas_feature_version),
+            timed_features,
+            features,
+        ))
+        .expect("bcs::to_bytes() failed.")
+        .into()
     }
 }

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -6,7 +6,7 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_move_stdlib::natives::all_natives;
 use aptos_native_interface::SafeNativeBuilder;
 use aptos_table_natives::NativeTableContext;
-use aptos_types::on_chain_config::{Features, TimedFeatures};
+use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use move_binary_format::CompiledModule;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::Identifier};
 use move_ir_compiler::Compiler;
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),
         MiscGasParameters::zeros(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     );
 

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -29,7 +29,7 @@ use aptos_types::{
     fee_statement::FeeStatement,
     on_chain_config::{
         ApprovedExecutionHashes, ConfigStorage, ConfigurationResource, FeatureFlag, Features,
-        GasSchedule, GasScheduleV2, OnChainConfig, TimedFeatures, Version,
+        GasSchedule, GasScheduleV2, OnChainConfig, TimedFeatures, TimedFeaturesBuilder, Version,
     },
     transaction::{AbortInfo, ExecutionStatus, Multisig, TransactionStatus},
     vm_status::{StatusCode, VMStatus},
@@ -146,10 +146,11 @@ impl AptosVMImpl {
             .map(|config| config.last_reconfiguration_time())
             .unwrap_or(0);
 
-        let mut timed_features = TimedFeatures::new(chain_id, timestamp);
+        let mut timed_features_builder = TimedFeaturesBuilder::new(chain_id, timestamp);
         if let Some(profile) = crate::AptosVM::get_timed_feature_override() {
-            timed_features = timed_features.with_override_profile(profile)
+            timed_features_builder = timed_features_builder.with_override_profile(profile)
         }
+        let timed_features = timed_features_builder.build();
 
         let move_vm = MoveVmExt::new(
             native_gas_params,

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -1,10 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    move_vm_ext::{warm_vm_cache::WarmVmCache, AptosMoveResolver, SessionExt, SessionId},
-    natives::aptos_natives_with_builder,
-};
+use crate::move_vm_ext::{warm_vm_cache::WarmVmCache, AptosMoveResolver, SessionExt, SessionId};
 use aptos_framework::natives::{
     aggregator_natives::NativeAggregatorContext,
     code::NativeCodeContext,
@@ -89,7 +86,7 @@ impl MoveVmExt {
 
         Ok(Self {
             inner: WarmVmCache::get_warm_vm(
-                aptos_natives_with_builder(&mut builder),
+                builder,
                 VMConfig {
                     verifier: verifier_config,
                     max_binary_format_version,

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -17,7 +17,7 @@ use aptos_native_interface::SafeNativeBuilder;
 use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
-    on_chain_config::{Features, TimedFeatures},
+    on_chain_config::{Features, TimedFeatures, TimedFeaturesBuilder},
 };
 #[cfg(feature = "testing")]
 use aptos_types::{
@@ -109,7 +109,7 @@ pub fn assert_no_test_natives(err_msg: &str) {
             LATEST_GAS_FEATURE_VERSION,
             NativeGasParameters::zeros(),
             MiscGasParameters::zeros(),
-            TimedFeatures::enable_all(),
+            TimedFeaturesBuilder::enable_all().build(),
             Features::default()
         )
         .into_iter()

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -37,7 +37,7 @@ use aptos_types::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     on_chain_config::{
-        Features, OnChainConfig, TimedFeatureOverride, TimedFeatures, ValidatorSet, Version,
+        Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder, ValidatorSet, Version,
     },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -714,8 +714,9 @@ impl FakeExecutor {
         iterations: u64,
     ) -> u128 {
         // FIXME: should probably read the timestamp from storage.
-        let timed_features =
-            TimedFeatures::enable_all().with_override_profile(TimedFeatureOverride::Testing);
+        let timed_features = TimedFeaturesBuilder::enable_all()
+            .with_override_profile(TimedFeatureOverride::Testing)
+            .build();
 
         let resolver = self.data_store.as_move_resolver();
 
@@ -787,8 +788,9 @@ impl FakeExecutor {
 
         let (write_set, _events) = {
             // FIXME: should probably read the timestamp from storage.
-            let timed_features =
-                TimedFeatures::enable_all().with_override_profile(TimedFeatureOverride::Testing);
+            let timed_features = TimedFeaturesBuilder::enable_all()
+                .with_override_profile(TimedFeatureOverride::Testing)
+                .build();
 
             let resolver = self.data_store.as_move_resolver();
 
@@ -864,8 +866,9 @@ impl FakeExecutor {
     ) {
         let (write_set, events) = {
             // FIXME: should probably read the timestamp from storage.
-            let timed_features =
-                TimedFeatures::enable_all().with_override_profile(TimedFeatureOverride::Testing);
+            let timed_features = TimedFeaturesBuilder::enable_all()
+                .with_override_profile(TimedFeatureOverride::Testing)
+                .build();
 
             let resolver = self.data_store.as_move_resolver();
 
@@ -939,7 +942,7 @@ impl FakeExecutor {
             self.chain_id,
             self.features.clone(),
             // FIXME: should probably read the timestamp from storage.
-            TimedFeatures::enable_all(),
+            TimedFeaturesBuilder::enable_all().build(),
             &resolver,
         )
         .unwrap();

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -4,7 +4,7 @@
 
 use aptos_framework::{extended_checks, path_in_crate};
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
-use aptos_types::on_chain_config::{Features, TimedFeatures};
+use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
 use move_package::CompilerConfig;
@@ -46,7 +46,7 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),
         MiscGasParameters::zeros(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     )
 }

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -5,7 +5,7 @@ use aptos_framework::extended_checks;
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
-    on_chain_config::{Features, TimedFeatures},
+    on_chain_config::{Features, TimedFeaturesBuilder},
 };
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
@@ -60,7 +60,7 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),
         MiscGasParameters::zeros(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     )
 }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -23,7 +23,7 @@ use aptos_types::{
     contract_event::{ContractEvent, ContractEventV1},
     on_chain_config::{
         FeatureFlag, Features, GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig,
-        TimedFeatures, APTOS_MAX_KNOWN_VERSION,
+        TimedFeaturesBuilder, APTOS_MAX_KNOWN_VERSION,
     },
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
 };
@@ -110,7 +110,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         LATEST_GAS_FEATURE_VERSION,
         ChainId::test().id(),
         Features::default(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         &data_cache,
     )
     .unwrap();
@@ -219,7 +219,7 @@ pub fn encode_genesis_change_set(
         LATEST_GAS_FEATURE_VERSION,
         ChainId::test().id(),
         Features::default(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         &data_cache,
     )
     .unwrap();
@@ -906,7 +906,7 @@ pub fn test_genesis_module_publishing() {
         LATEST_GAS_FEATURE_VERSION,
         ChainId::test().id(),
         Features::default(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         &data_cache,
     )
     .unwrap();

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -9,7 +9,7 @@ use aptos_state_view::StateView;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{self, aptos_test_root_address},
-    on_chain_config::{Features, TimedFeatures},
+    on_chain_config::{Features, TimedFeaturesBuilder},
     transaction::{ChangeSet, Script, Version},
 };
 use aptos_vm::{
@@ -116,7 +116,7 @@ where
         LATEST_GAS_FEATURE_VERSION,
         chain_id,
         Features::default(),
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         &resolver,
     )
     .unwrap();

--- a/crates/aptos/src/move_tool/aptos_debug_natives.rs
+++ b/crates/aptos/src/move_tool/aptos_debug_natives.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
-use aptos_types::on_chain_config::{Features, TimedFeatures};
+use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 
@@ -19,7 +19,7 @@ pub fn aptos_debug_natives(
         LATEST_GAS_FEATURE_VERSION,
         native_gas_parameters,
         misc_gas_params,
-        TimedFeatures::enable_all(),
+        TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     )
 }

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
@@ -30,7 +30,7 @@ use aptos_storage_interface::StateSnapshotReceiver;
 use aptos_types::{
     access_path::Path,
     ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::{Features, TimedFeatureOverride, TimedFeatures},
+    on_chain_config::{Features, TimedFeatureOverride, TimedFeaturesBuilder},
     proof::TransactionInfoWithProof,
     state_store::{
         state_key::{StateKey, StateKeyInner},
@@ -236,7 +236,9 @@ impl StateSnapshotRestoreController {
         let config = verifier_config(
             &Features::default(),
             // FIXME: feed chain id & timestamp from the state.
-            &TimedFeatures::enable_all().with_override_profile(TimedFeatureOverride::Replay),
+            &TimedFeaturesBuilder::enable_all()
+                .with_override_profile(TimedFeatureOverride::Replay)
+                .build(),
         );
         for (key, value) in blob {
             if let StateKeyInner::AccessPath(p) = key.inner() {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -37,6 +37,8 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tiny-keccak = { workspace = true }
 

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -45,7 +45,7 @@ pub use self::{
         TransactionShufflerType,
     },
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
-    timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures},
+    timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures, TimedFeaturesBuilder},
     timestamp::CurrentTimeMicroseconds,
     transaction_fee::TransactionFeeBurnCap,
     validator_set::{ConsensusScheme, ValidatorSet},


### PR DESCRIPTION
to fix #10147 
Natives are stateful so must be covered by the WarmVmId.

1. add TimedFeaturesBuilder and convert TimedFeatures to an array of booleans.
2. add SafeNativeBulder::id_bytes() to fix the bug
3. rebuild vm (and hence all the natives) only when the builder id_bytes() change.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

replay-verify
https://github.com/aptos-labs/aptos-core/actions/runs/6357753314

also ran single machine benchmark, didn't see it getting too much slower (loading PackageRegistry from storage still dominates the time consumption)
<img width="178" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/1943319/c466a25c-fe33-4125-aa45-0ffce981a940">
