### PR TITLE
global index in blockstm

### DIFF
--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -32,6 +32,7 @@ use aptos_vm::{
 };
 use proptest::{collection::vec, prelude::Strategy, strategy::ValueTree, test_runner::TestRunner};
 use std::{net::SocketAddr, sync::Arc, time::Instant};
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 
 pub struct TransactionBenchState<S> {
     num_transactions: usize,
@@ -205,12 +206,15 @@ where
     ) -> (Vec<TransactionOutput>, usize) {
         let block_size = transactions.len();
         let timer = Instant::now();
+        let preprocessed_txns = BlockAptosVM::verify_transactions(transactions);
+        let txn_provider = Arc::new(DefaultTxnProvider::new(preprocessed_txns));
         let output = BlockAptosVM::execute_block::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+            _
         >(
             Arc::clone(&RAYON_EXEC_POOL),
-            transactions,
+            txn_provider,
             self.state_view.as_ref(),
             1,
             maybe_block_gas_limit,
@@ -254,12 +258,15 @@ where
     ) -> (Vec<TransactionOutput>, usize) {
         let block_size = transactions.len();
         let timer = Instant::now();
+        let preprocessed_txns = BlockAptosVM::verify_transactions(transactions);
+        let txn_provider = Arc::new(DefaultTxnProvider::new(preprocessed_txns));
         let output = BlockAptosVM::execute_block::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+            _
         >(
             Arc::clone(&RAYON_EXEC_POOL),
-            transactions,
+            txn_provider,
             self.state_view.as_ref(),
             concurrency_level_per_shard,
             maybe_block_gas_limit,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -183,7 +183,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 pub struct BlockAptosVM();
 
 impl BlockAptosVM {
-    pub(crate) fn verify_transactions(transactions: Vec<Transaction>) -> Vec<PreprocessedTransaction> {
+    pub fn verify_transactions(transactions: Vec<Transaction>) -> Vec<PreprocessedTransaction> {
         transactions
             .into_par_iter()
             .with_min_len(25)

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -39,7 +39,7 @@ use move_core_types::{language_storage::StructTag, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::{prelude::*, ThreadPool};
 use std::{collections::HashMap, sync::Arc};
-use aptos_block_executor::txn_provider::{TxnProviderTrait1, TxnProviderTrait2};
+use aptos_block_executor::txn_provider::{TxnIndexProvider, BlockSTMPlugin};
 
 impl BlockExecutorTransaction for PreprocessedTransaction {
     type Event = ContractEvent;
@@ -194,7 +194,7 @@ impl BlockAptosVM {
     pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook<Output = AptosTransactionOutput>,
-        TP: TxnProviderTrait1 + TxnProviderTrait2<PreprocessedTransaction, AptosTransactionOutput, VMStatus> + Send + Sync + 'static
+        TP: TxnIndexProvider + BlockSTMPlugin<PreprocessedTransaction, AptosTransactionOutput, VMStatus> + Send + Sync + 'static
     >(
         executor_thread_pool: Arc<ThreadPool>,
         txn_provider: Arc<TP>,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -39,6 +39,7 @@ use move_core_types::{language_storage::StructTag, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::{prelude::*, ThreadPool};
 use std::{collections::HashMap, sync::Arc};
+use aptos_block_executor::txn_provider::{TxnProviderTrait1, TxnProviderTrait2};
 
 impl BlockExecutorTransaction for PreprocessedTransaction {
     type Event = ContractEvent;
@@ -182,7 +183,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 pub struct BlockAptosVM();
 
 impl BlockAptosVM {
-    fn verify_transactions(transactions: Vec<Transaction>) -> Vec<PreprocessedTransaction> {
+    pub(crate) fn verify_transactions(transactions: Vec<Transaction>) -> Vec<PreprocessedTransaction> {
         transactions
             .into_par_iter()
             .with_min_len(25)
@@ -193,9 +194,10 @@ impl BlockAptosVM {
     pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook<Output = AptosTransactionOutput>,
+        TP: TxnProviderTrait1 + TxnProviderTrait2<PreprocessedTransaction, AptosTransactionOutput, VMStatus> + Send + Sync + 'static
     >(
         executor_thread_pool: Arc<ThreadPool>,
-        transactions: Vec<Transaction>,
+        txn_provider: Arc<TP>,
         state_view: &S,
         concurrency_level: usize,
         maybe_block_gas_limit: Option<u64>,
@@ -206,13 +208,8 @@ impl BlockAptosVM {
         // This is time consuming so don't wait and do the checking
         // sequentially while executing the transactions.
         // TODO: state sync runs this code but doesn't need to verify signatures
-        let signature_verification_timer =
-            BLOCK_EXECUTOR_SIGNATURE_VERIFICATION_SECONDS.start_timer();
-        let signature_verified_block =
-            executor_thread_pool.install(|| Self::verify_transactions(transactions));
-        drop(signature_verification_timer);
 
-        let num_txns = signature_verified_block.len();
+        let num_txns = txn_provider.num_txns();
         if state_view.id() != StateViewId::Miscellaneous {
             // Speculation is disabled in Miscellaneous context, which is used by testing and
             // can even lead to concurrent execute_block invocations, leading to errors on flush.
@@ -226,6 +223,7 @@ impl BlockAptosVM {
             S,
             L,
             ExecutableTestType,
+            TP,
         >::new(
             concurrency_level,
             executor_thread_pool,
@@ -233,7 +231,7 @@ impl BlockAptosVM {
             transaction_commit_listener,
         );
 
-        let ret = executor.execute_block(state_view, signature_verified_block, state_view);
+        let ret = executor.execute_block(state_view, txn_provider.clone(), state_view);
         match ret {
             Ok(outputs) => {
                 let output_vec: Vec<TransactionOutput> = outputs

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -129,7 +129,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     .into_iter()
                     .map(|txn| txn.into_txn().into_txn())
                     .collect();
-                let pre_processed_txns = RAYON_EXEC_POOL.install(||{BlockAptosVM::verify_transactions(txns)});
+                let pre_processed_txns = executor_thread_pool.install(||{BlockAptosVM::verify_transactions(txns)});
 
                 let txn_provider = Arc::new(DefaultTxnProvider::new(pre_processed_txns));
                 let ret = BlockAptosVM::execute_block(

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -146,6 +146,7 @@ mod scheduler;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;
+pub mod txn_provider;
 #[cfg(test)]
 mod unit_tests;
 pub mod view;

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -16,6 +16,8 @@ use std::{
         Arc, Condvar,
     },
 };
+use std::collections::HashMap;
+use crate::txn_provider::TxnProviderTrait1;
 
 const TXN_IDX_MASK: u64 = (1 << 32) - 1;
 
@@ -198,15 +200,14 @@ impl ValidationStatus {
     }
 }
 
-pub struct Scheduler {
-    /// Number of txns to execute, immutable.
-    num_txns: TxnIndex,
+pub struct Scheduler<P: ?Sized> {
+    txn_provider: Arc<P>,
 
     /// An index i maps to indices of other transactions that depend on transaction i, i.e. they
     /// should be re-executed once transaction i's next incarnation finishes.
-    txn_dependency: Vec<CachePadded<Mutex<Vec<TxnIndex>>>>,
+    txn_dependency: HashMap<TxnIndex, CachePadded<Mutex<Vec<TxnIndex>>>>,
     /// An index i maps to the most up-to-date status of transaction i.
-    txn_status: Vec<CachePadded<(RwLock<ExecutionStatus>, RwLock<ValidationStatus>)>>,
+    txn_status: HashMap<TxnIndex, CachePadded<(RwLock<ExecutionStatus>, RwLock<ValidationStatus>)>>,
 
     /// Next transaction to commit, and sweeping lower bound on the wave of a validation that must
     /// be successful in order to commit the next transaction.
@@ -241,33 +242,36 @@ pub struct Scheduler {
 }
 
 /// Public Interfaces for the Scheduler
-impl Scheduler {
-    pub fn new(num_txns: TxnIndex) -> Self {
+impl<TP: TxnProviderTrait1> Scheduler<TP> {
+    pub fn new(txn_provider: Arc<TP>) -> Self {
         // Empty block should early return and not create a scheduler.
-        assert!(num_txns > 0, "No scheduler needed for 0 transactions");
+        assert!(txn_provider.num_txns() > 0, "No scheduler needed for 0 transactions");
 
         Self {
-            num_txns,
-            txn_dependency: (0..num_txns)
-                .map(|_| CachePadded::new(Mutex::new(Vec::new())))
+            txn_provider: txn_provider.clone(),
+            txn_dependency: txn_provider.txns_and_deps().into_iter()
+                .map(|idx| (idx, CachePadded::new(Mutex::new(Vec::new()))))
                 .collect(),
-            txn_status: (0..num_txns)
-                .map(|_| {
-                    CachePadded::new((
-                        RwLock::new(ExecutionStatus::Ready(0, ExecutionTaskType::Execution)),
-                        RwLock::new(ValidationStatus::new()),
-                    ))
+            txn_status: txn_provider.txns().into_iter()
+                .map(|idx| {
+                    (
+                        idx,
+                        CachePadded::new((
+                            RwLock::new(ExecutionStatus::Ready(0, ExecutionTaskType::Execution)),
+                            RwLock::new(ValidationStatus::new()),
+                        ))
+                    )
                 })
                 .collect(),
-            commit_state: CachePadded::new(Mutex::new((0, 0))),
-            execution_idx: AtomicU32::new(0),
-            validation_idx: AtomicU64::new(0),
+            commit_state: CachePadded::new(Mutex::new((txn_provider.first_txn(), 0))),
+            execution_idx: AtomicU32::new(txn_provider.first_txn()),
+            validation_idx: AtomicU64::new(txn_provider.first_txn() as u64),// wave is 0!
             done_marker: CachePadded::new(AtomicBool::new(false)),
         }
     }
 
-    pub fn num_txns(&self) -> TxnIndex {
-        self.num_txns
+    pub fn next_txn(&self, idx: TxnIndex) -> TxnIndex {
+        self.txn_provider.next_txn(idx)
     }
 
     /// If successful, returns Some(TxnIndex), the index of committed transaction.
@@ -277,13 +281,10 @@ impl Scheduler {
         let mut commit_state_mutex = self.commit_state.lock();
         let commit_state = commit_state_mutex.deref_mut();
         let (commit_idx, commit_wave) = (&mut commit_state.0, &mut commit_state.1);
-
-        if let Some(validation_status) = self.txn_status[*commit_idx as usize].1.try_read() {
+        let pair = self.txn_status.get(commit_idx).unwrap();
+        if let Some(validation_status) = pair.1.try_read() {
             // Acquired the validation status read lock.
-            if let Some(status) = self.txn_status[*commit_idx as usize]
-                .0
-                .try_upgradable_read()
-            {
+            if let Some(status) = pair.0.try_upgradable_read() {
                 // Acquired the execution status read lock, which can be upgrade to write lock if necessary.
                 if let ExecutionStatus::Executed(incarnation) = *status {
                     // Status is executed and we are holding the lock.
@@ -295,17 +296,17 @@ impl Scheduler {
                     *commit_wave = max(*commit_wave, validation_status.max_triggered_wave);
                     if let Some(validated_wave) = validation_status.maybe_max_validated_wave {
                         if validated_wave >= max(*commit_wave, validation_status.required_wave) {
+                            let old_commit_idx = *commit_idx;
                             let mut status_write = RwLockUpgradableReadGuard::upgrade(status);
                             // Upgrade the execution status read lock to write lock.
                             // Can commit.
                             *status_write = ExecutionStatus::Committed(incarnation);
-
-                            *commit_idx += 1;
-                            if *commit_idx == self.num_txns {
+                            *commit_idx = self.next_txn(*commit_idx);
+                            if *commit_idx == self.txn_provider.end_txn_idx() {
                                 // All txns have been committed, the parallel execution can finish.
                                 self.done_marker.store(true, Ordering::SeqCst);
                             }
-                            return Some(*commit_idx - 1);
+                            return Some(old_commit_idx);
                         }
                     }
                 }
@@ -331,7 +332,7 @@ impl Scheduler {
         // Note: we could upgradable read, then upgrade and write. Similar for other places.
         // However, it is likely an overkill (and overhead to actually upgrade),
         // while unlikely there would be much contention on a specific index lock.
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
 
         if *status == ExecutionStatus::Executed(incarnation) {
             *status = ExecutionStatus::Aborting(incarnation);
@@ -354,10 +355,10 @@ impl Scheduler {
                 Self::unpack_validation_idx(self.validation_idx.load(Ordering::Acquire));
             let idx_to_execute = self.execution_idx.load(Ordering::Acquire);
 
-            let prefer_validate = idx_to_validate < min(idx_to_execute, self.num_txns)
+            let prefer_validate = idx_to_validate < min(idx_to_execute, self.txn_provider.end_txn_idx())
                 && !self.never_executed(idx_to_validate);
 
-            if !prefer_validate && idx_to_execute >= self.num_txns {
+            if !prefer_validate && idx_to_execute >= self.txn_provider.end_txn_idx() {
                 return if self.done() {
                     // Check again to avoid commit delay due to a race.
                     SchedulerTask::Done
@@ -405,7 +406,7 @@ impl Scheduler {
         // Create a condition variable associated with the dependency.
         let dep_condvar = Arc::new((Mutex::new(DependencyStatus::Unresolved), Condvar::new()));
 
-        let mut stored_deps = self.txn_dependency[dep_txn_idx as usize].lock();
+        let mut stored_deps = self.txn_dependency.get(&dep_txn_idx).unwrap().lock();
 
         // Note: is_executed & suspend calls acquire (a different, status) mutex, while holding
         // (dependency) mutex. This is the only place in scheduler where a thread may hold > 1
@@ -442,7 +443,7 @@ impl Scheduler {
     }
 
     pub fn finish_validation(&self, txn_idx: TxnIndex, wave: Wave) {
-        let mut validation_status = self.txn_status[txn_idx as usize].1.write();
+        let mut validation_status = self.txn_status.get(&txn_idx).unwrap().1.write();
         validation_status.maybe_max_validated_wave = Some(
             validation_status
                 .maybe_max_validated_wave
@@ -467,11 +468,11 @@ impl Scheduler {
         // difference and like this correctness argument is much easier to see, in fact also
         // the reason why we grab write lock directly, and never release it during the whole function.
         // So even validation status readers have to wait if they somehow end up at the same index.
-        let mut validation_status = self.txn_status[txn_idx as usize].1.write();
+        let mut validation_status = self.txn_status.get(&txn_idx).unwrap().1.write();
         self.set_executed_status(txn_idx, incarnation);
 
         let txn_deps: Vec<TxnIndex> = {
-            let mut stored_deps = self.txn_dependency[txn_idx as usize].lock();
+            let mut stored_deps = self.txn_dependency.get(&txn_idx).unwrap().lock();
             // Holding the lock, take dependency vector.
             std::mem::take(&mut stored_deps)
         };
@@ -504,7 +505,7 @@ impl Scheduler {
                 // The transaction execution required revalidating all higher txns (not
                 // only itself), currently happens when incarnation writes to a new path
                 // (w.r.t. the write-set of its previous completed incarnation).
-                if let Some(wave) = self.decrease_validation_idx(txn_idx + 1) {
+                if let Some(wave) = self.decrease_validation_idx(self.txn_provider.next_txn(txn_idx)) {
                     cur_wave = wave;
                 };
             }
@@ -514,6 +515,41 @@ impl Scheduler {
         }
 
         SchedulerTask::NoTask
+    }
+
+    /// Resume any transaction blocked by a given txn `blocker` by notifying their condvars.
+    /// Clear the blocking status (`self.txn_dependency`).
+    /// Return the minimum txn index that is resumed, if any.
+    ///
+    /// Only used in sharded execution mode.
+    pub fn fast_resume_dependents(&self, blocker: TxnIndex) {
+        let dependents: Vec<TxnIndex> = {
+            let mut stored_deps = self.txn_dependency.get(&blocker).unwrap().lock();
+            // Holding the lock, take dependency vector.
+            std::mem::take(&mut stored_deps)
+        };
+
+        // Mark dependencies as resolved and find the minimum index among them.
+        for dependent in dependents {
+            // Mark the status of dependencies as 'Ready' since dependency on
+            // transaction txn_idx is now resolved.
+            // self.resume(dep);
+            let mut status = self.txn_status.get(&dependent).unwrap().0.write();
+            match &*status {
+                ExecutionStatus::ExecutionHalted => {
+                    //Nothing to do?
+                },
+                ExecutionStatus::Suspended(incarnation, dep_condvar) => {
+                    let (dep_status_lock, cvar) = &*dep_condvar.clone();
+                    *dep_status_lock.lock() = DependencyStatus::Resolved;
+                    cvar.notify_one();
+                    *status = ExecutionStatus::Executing(*incarnation);// sharding todo: is this really needed?
+                },
+                _ => {
+                    unreachable!()
+                }
+            }
+        }
     }
 
     /// Finalize a validation task of version (txn_idx, incarnation). In some cases,
@@ -529,13 +565,13 @@ impl Scheduler {
             // Also, as a convention, we always acquire validation status lock before execution
             // status lock, as we have to have a consistent order and this order is easier to
             // provide correctness between finish_execution & try_commit.
-            let _validation_status = self.txn_status[txn_idx as usize].1.write();
+            let _validation_status = self.txn_status.get(&txn_idx).unwrap().1.write();
 
             self.set_aborted_status(txn_idx, incarnation);
 
             // Schedule higher txns for validation, skipping txn_idx itself (needs to be
             // re-executed first).
-            self.decrease_validation_idx(txn_idx + 1);
+            self.decrease_validation_idx(self.next_txn(txn_idx));
 
             // can release the lock early.
         }
@@ -572,7 +608,7 @@ impl Scheduler {
         // resolving the conditional variables, to help other theads that may be pending
         // on the read dependency. See the comment of the function resolve_condvar().
         if !self.done_marker.swap(true, Ordering::SeqCst) {
-            for txn_idx in 0..self.num_txns {
+            for txn_idx in self.txn_provider.txns() {
                 self.resolve_condvar(txn_idx);
             }
         }
@@ -583,7 +619,7 @@ impl Scheduler {
     /// Therefore the commit thread needs to wake up all such pending threads, by sending notification to the condition
     /// variable and setting the lock variables properly.
     pub fn resolve_condvar(&self, txn_idx: TxnIndex) {
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
         {
             // Only transactions with status Suspended or Ready may have the condition variable of pending threads.
             match &*status {
@@ -605,7 +641,7 @@ impl Scheduler {
 }
 
 /// Private functions of the Scheduler
-impl Scheduler {
+impl<TP: TxnProviderTrait1> Scheduler<TP> {
     fn unpack_validation_idx(validation_idx: u64) -> (TxnIndex, Wave) {
         (
             (validation_idx & TXN_IDX_MASK) as TxnIndex,
@@ -616,8 +652,8 @@ impl Scheduler {
     /// Decreases the validation index, adjusting the wave and validation status as needed.
     fn decrease_validation_idx(&self, target_idx: TxnIndex) -> Option<Wave> {
         // We only call with txn_idx + 1, so it can equal num_txns, but not be strictly larger.
-        debug_assert!(target_idx <= self.num_txns);
-        if target_idx >= self.num_txns {
+        debug_assert!(target_idx <= self.txn_provider.end_txn_idx());
+        if target_idx == self.txn_provider.end_txn_idx() {
             return None;
         }
 
@@ -626,7 +662,7 @@ impl Scheduler {
                 .fetch_update(Ordering::Acquire, Ordering::SeqCst, |val_idx| {
                     let (txn_idx, wave) = Self::unpack_validation_idx(val_idx);
                     if txn_idx > target_idx {
-                        let mut validation_status = self.txn_status[target_idx as usize].1.write();
+                        let mut validation_status = self.txn_status.get(&target_idx).unwrap().1.write();
                         // Update the minimum wave all the suffix txn needs to pass.
                         // We set it to max for safety (to avoid overwriting with lower values
                         // by a slower thread), but currently this isn't strictly required
@@ -656,14 +692,14 @@ impl Scheduler {
     /// An unsuccessful incarnation returns None. Since incarnation numbers never decrease
     /// for each transaction, incarnate function may not succeed more than once per version.
     fn try_incarnate(&self, txn_idx: TxnIndex) -> Option<(Incarnation, ExecutionTaskType)> {
-        if txn_idx >= self.num_txns {
+        if txn_idx == self.txn_provider.end_txn_idx() {
             return None;
         }
 
         // Note: we could upgradable read, then upgrade and write. Similar for other places.
         // However, it is likely an overkill (and overhead to actually upgrade),
         // while unlikely there would be much contention on a specific index lock.
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
         if let ExecutionStatus::Ready(incarnation, execution_task_type) = &*status {
             let ret: (u32, ExecutionTaskType) = (*incarnation, (*execution_task_type).clone());
             *status = ExecutionStatus::Executing(*incarnation);
@@ -683,28 +719,35 @@ impl Scheduler {
     /// and a committed (in between) txn does not need to be scheduled for validation -
     /// so can return None.
     fn is_executed(&self, txn_idx: TxnIndex, include_committed: bool) -> Option<Incarnation> {
-        debug_assert!(txn_idx < self.num_txns);
-
-        let status = self.txn_status[txn_idx as usize].0.read();
-        match *status {
-            ExecutionStatus::Executed(incarnation) => Some(incarnation),
-            ExecutionStatus::Committed(incarnation) => {
-                if include_committed {
-                    // Committed txns are also considered executed for dependency resolution purposes.
-                    Some(incarnation)
-                } else {
-                    // Committed txns do not need to be scheduled for validation in try_validate_next_version.
-                    None
-                }
-            },
-            _ => None,
+        if self.txn_provider.is_local(txn_idx) {
+            let status_wrapper = self.txn_status.get(&txn_idx).unwrap();
+            let status = status_wrapper.0.read();
+            match *status {
+                ExecutionStatus::Executed(incarnation) => Some(incarnation),
+                ExecutionStatus::Committed(incarnation) => {
+                    if include_committed {
+                        // Committed txns are also considered executed for dependency resolution purposes.
+                        Some(incarnation)
+                    } else {
+                        // Committed txns do not need to be scheduled for validation in try_validate_next_version.
+                        None
+                    }
+                },
+                _ => None,
+            }
+        } else {
+            if self.txn_provider.txn_output_has_arrived(txn_idx) {
+                Some(0)
+            } else {
+                None
+            }
         }
     }
 
     /// Returns true iff no incarnation (even the 0-th one) has set the executed status, i.e.
     /// iff the execution status is READY_TO_EXECUTE/EXECUTING/SUSPENDED for incarnation 0.
     fn never_executed(&self, txn_idx: TxnIndex) -> bool {
-        let status = self.txn_status[txn_idx as usize].0.read();
+        let status = self.txn_status.get(&txn_idx).unwrap().0.read();
         matches!(
             *status,
             ExecutionStatus::Ready(0, _)
@@ -731,7 +774,7 @@ impl Scheduler {
         // but if we used fetch-and-increment, two threads can arrive in a cloned state and
         // both increment, effectively skipping over the 'never_executed' transaction index.
         let validation_idx = (idx_to_validate as u64) | ((wave as u64) << 32);
-        let new_validation_idx = ((idx_to_validate + 1) as u64) | ((wave as u64) << 32);
+        let new_validation_idx = ((self.next_txn(idx_to_validate)) as u64) | ((wave as u64) << 32);
         if self
             .validation_idx
             .compare_exchange(
@@ -761,9 +804,9 @@ impl Scheduler {
     /// return the version to the caller for the corresponding ExecutionTask.
     /// - Otherwise, return None.
     fn try_execute_next_version(&self) -> Option<(TxnIndex, Incarnation, ExecutionTaskType)> {
-        let idx_to_execute = self.execution_idx.fetch_add(1, Ordering::SeqCst);
+        let idx_to_execute = self.execution_idx.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v|Some(self.txn_provider.next_txn(v))).unwrap();
 
-        if idx_to_execute >= self.num_txns {
+        if idx_to_execute == self.txn_provider.end_txn_idx() {
             return None;
         }
 
@@ -780,7 +823,7 @@ impl Scheduler {
     /// Return true when the txn is successfully suspended.
     /// Return false when the execution is halted.
     fn suspend(&self, txn_idx: TxnIndex, dep_condvar: DependencyCondvar) -> bool {
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
         match *status {
             ExecutionStatus::Executing(incarnation) => {
                 *status = ExecutionStatus::Suspended(incarnation, dep_condvar);
@@ -795,7 +838,7 @@ impl Scheduler {
     /// incremented incarnation number.
     /// The caller must ensure that the transaction is in the Suspended state.
     fn resume(&self, txn_idx: TxnIndex) {
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
 
         if matches!(*status, ExecutionStatus::ExecutionHalted) {
             return;
@@ -813,7 +856,7 @@ impl Scheduler {
 
     /// Set status of the transaction to Executed(incarnation).
     fn set_executed_status(&self, txn_idx: TxnIndex, incarnation: Incarnation) {
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
         // The execution is already halted.
         if matches!(*status, ExecutionStatus::ExecutionHalted) {
             return;
@@ -827,7 +870,7 @@ impl Scheduler {
     /// After a successful abort, mark the transaction as ready for re-execution with
     /// an incremented incarnation number.
     fn set_aborted_status(&self, txn_idx: TxnIndex, incarnation: Incarnation) {
-        let mut status = self.txn_status[txn_idx as usize].0.write();
+        let mut status = self.txn_status.get(&txn_idx).unwrap().0.write();
         // The execution is already halted.
         if matches!(*status, ExecutionStatus::ExecutionHalted) {
             return;

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -17,7 +17,7 @@ use std::{
     },
 };
 use std::collections::HashMap;
-use crate::txn_provider::TxnProviderTrait1;
+use crate::txn_provider::TxnIndexProvider;
 
 const TXN_IDX_MASK: u64 = (1 << 32) - 1;
 
@@ -242,7 +242,7 @@ pub struct Scheduler<P: ?Sized> {
 }
 
 /// Public Interfaces for the Scheduler
-impl<TP: TxnProviderTrait1> Scheduler<TP> {
+impl<TP: TxnIndexProvider> Scheduler<TP> {
     pub fn new(txn_provider: Arc<TP>) -> Self {
         // Empty block should early return and not create a scheduler.
         assert!(txn_provider.num_txns() > 0, "No scheduler needed for 0 transactions");
@@ -641,7 +641,7 @@ impl<TP: TxnProviderTrait1> Scheduler<TP> {
 }
 
 /// Private functions of the Scheduler
-impl<TP: TxnProviderTrait1> Scheduler<TP> {
+impl<TP: TxnIndexProvider> Scheduler<TP> {
     fn unpack_validation_idx(validation_idx: u64) -> (TxnIndex, Wave) {
         (
             (validation_idx & TXN_IDX_MASK) as TxnIndex,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -21,7 +21,7 @@ use std::{
         Arc,
     },
 };
-use crate::txn_provider::TxnProviderTrait1;
+use crate::txn_provider::TxnIndexProvider;
 
 type TxnInput<T> = CapturedReads<T>;
 
@@ -59,7 +59,7 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: 
 impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     TxnLastInputOutput<T, O, E>
 {
-    pub fn new<P: TxnProviderTrait1>(txn_provider: Arc<P>) -> Self {
+    pub fn new<P: TxnIndexProvider>(txn_provider: Arc<P>) -> Self {
         Self {
             inputs: txn_provider.txns().into_iter()
                 .map(|idx| (idx, CachePadded::new(ArcSwapOption::empty())))

--- a/aptos-move/block-executor/src/txn_provider/default.rs
+++ b/aptos-move/block-executor/src/txn_provider/default.rs
@@ -11,7 +11,7 @@ use move_core_types::account_address::AccountAddress;
 use crate::scheduler::Scheduler;
 use crate::task::{Transaction, TransactionOutput};
 use crate::txn_last_input_output::TxnOutput;
-use crate::txn_provider::{TxnProviderTrait1, TxnProviderTrait2};
+use crate::txn_provider::{TxnIndexProvider, BlockSTMPlugin};
 
 /// Some logic of vanilla BlockSTM.
 pub struct DefaultTxnProvider<T> {
@@ -28,7 +28,7 @@ impl<T> DefaultTxnProvider<T> {
     }
 }
 
-impl<T> TxnProviderTrait1 for DefaultTxnProvider<T> {
+impl<T> TxnIndexProvider for DefaultTxnProvider<T> {
     fn end_txn_idx(&self) -> TxnIndex {
         self.txns.len() as TxnIndex
     }
@@ -53,7 +53,7 @@ impl<T> TxnProviderTrait1 for DefaultTxnProvider<T> {
         self.txns()
     }
 
-    fn local_rank(&self, idx: TxnIndex) -> usize {
+    fn local_index(&self, idx: TxnIndex) -> usize {
         idx as usize
     }
 
@@ -74,7 +74,7 @@ impl<T> TxnProviderTrait1 for DefaultTxnProvider<T> {
     }
 }
 
-impl<T, TO, TE> TxnProviderTrait2<T, TO, TE> for DefaultTxnProvider<T>
+impl<T, TO, TE> BlockSTMPlugin<T, TO, TE> for DefaultTxnProvider<T>
     where
         T: Transaction,
         TO: TransactionOutput<Txn = T>,
@@ -100,7 +100,7 @@ impl<T, TO, TE> TxnProviderTrait2<T, TO, TE> for DefaultTxnProvider<T>
         // Nothing to do.
     }
 
-    fn commit_strategy(&self) -> u8 {
-        0
+    fn use_dedicated_committing_thread(&self) -> bool {
+        false
     }
 }

--- a/aptos-move/block-executor/src/txn_provider/default.rs
+++ b/aptos-move/block-executor/src/txn_provider/default.rs
@@ -1,0 +1,106 @@
+// Copyright © Aptos Foundation
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::slice::Iter;
+use std::sync::Arc;
+use aptos_mvhashmap::MVHashMap;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::executable::Executable;
+use move_core_types::account_address::AccountAddress;
+use crate::scheduler::Scheduler;
+use crate::task::{Transaction, TransactionOutput};
+use crate::txn_last_input_output::TxnOutput;
+use crate::txn_provider::{TxnProviderTrait1, TxnProviderTrait2};
+
+/// Some logic of vanilla BlockSTM.
+pub struct DefaultTxnProvider<T> {
+    block_id: [u8; 32],
+    txns: Vec<T>,
+}
+
+impl<T> DefaultTxnProvider<T> {
+    pub fn new(txns: Vec<T>) -> Self {
+        Self {
+            block_id: AccountAddress::random().into_bytes(),
+            txns
+        }
+    }
+}
+
+impl<T> TxnProviderTrait1 for DefaultTxnProvider<T> {
+    fn end_txn_idx(&self) -> TxnIndex {
+        self.txns.len() as TxnIndex
+    }
+
+    fn num_txns(&self) -> usize {
+        self.txns.len()
+    }
+
+    fn first_txn(&self) -> TxnIndex {
+        if self.num_txns() == 0 { self.end_txn_idx() } else { 0 }
+    }
+
+    fn next_txn(&self, idx: TxnIndex) -> TxnIndex {
+        if idx == self.end_txn_idx() { idx } else { idx + 1 }
+    }
+
+    fn txns(&self) -> Vec<TxnIndex> {
+        (0..self.num_txns() as TxnIndex).collect()
+    }
+
+    fn txns_and_deps(&self) -> Vec<TxnIndex> {
+        self.txns()
+    }
+
+    fn local_rank(&self, idx: TxnIndex) -> usize {
+        idx as usize
+    }
+
+    fn is_local(&self, _idx: TxnIndex) -> bool {
+        true
+    }
+
+    fn txn_output_has_arrived(&self, _txn_idx: TxnIndex) -> bool {
+        unreachable!()
+    }
+
+    fn block_idx(&self) -> &[u8] {
+        self.block_id.as_slice()
+    }
+
+    fn shard_idx(&self) -> usize {
+        0
+    }
+}
+
+impl<T, TO, TE> TxnProviderTrait2<T, TO, TE> for DefaultTxnProvider<T>
+    where
+        T: Transaction,
+        TO: TransactionOutput<Txn = T>,
+        TE: Debug + Send + Clone,
+{
+    fn remote_dependencies(&self) -> Vec<(TxnIndex, T::Key)> {
+        vec![]
+    }
+
+    fn run_sharding_msg_loop<TAG, X: Executable + 'static>(&self, _mv_cache: &MVHashMap<T::Key, TAG, T::Value, X>, _scheduler: &Scheduler<Self>) {
+        // Nothing to do.
+    }
+
+    fn shutdown_receiver(&self) {
+        // Nothing to do.
+    }
+
+    fn txn(&self, idx: TxnIndex) -> &T {
+        &self.txns[idx as usize]
+    }
+
+    fn on_local_commit(&self, _txn_idx: TxnIndex, _txn_output: Arc<TxnOutput<TO, TE>>) {
+        // Nothing to do.
+    }
+
+    fn commit_strategy(&self) -> u8 {
+        0
+    }
+}

--- a/aptos-move/block-executor/src/txn_provider/mod.rs
+++ b/aptos-move/block-executor/src/txn_provider/mod.rs
@@ -1,0 +1,63 @@
+// Copyright © Aptos Foundation
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt::Debug;
+use std::slice::Iter;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, mpsc, Mutex};
+use std::sync::mpsc::{Receiver, Sender};
+use dashmap::DashSet;
+use rayon::Scope;
+use aptos_logger::info;
+use aptos_mvhashmap::MVHashMap;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::block_executor::partitioner::ShardId;
+use aptos_types::executable::Executable;
+use aptos_types::state_store::state_key::StateKey;
+use aptos_types::write_set::WriteOp;
+use crate::errors::Error;
+use crate::scheduler::Scheduler;
+use crate::task::{ExecutionStatus, ExecutorTask, Transaction, TransactionOutput};
+use crate::txn_last_input_output::{TxnLastInputOutput, TxnOutput};
+
+#[derive(Clone, Debug)]
+pub struct RemoteCommit<TO: TransactionOutput, TE: Debug> {
+    pub global_txn_idx: TxnIndex,
+    pub txn_output: Arc<TxnOutput<TO, TE>>,
+}
+
+pub enum ShardingMsg<TO: TransactionOutput, TE: Debug> {
+    RemoteCommit(RemoteCommit<TO, TE>),
+    Shutdown,
+}
+
+pub trait TxnProviderTrait1 {
+    fn end_txn_idx(&self) -> TxnIndex;
+    fn num_txns(&self) -> usize;
+    fn first_txn(&self) -> TxnIndex;
+    fn next_txn(&self, idx: TxnIndex) -> TxnIndex;
+    fn txns(&self) -> Vec<TxnIndex>;
+    fn txns_and_deps(&self) -> Vec<TxnIndex>;
+    fn local_rank(&self, idx: TxnIndex) -> usize;
+    fn is_local(&self, idx: TxnIndex) -> bool;
+    fn txn_output_has_arrived(&self, txn_idx: TxnIndex) -> bool;
+    fn block_idx(&self) -> &[u8]; //debug only
+    fn shard_idx(&self) -> usize;
+}
+
+pub trait TxnProviderTrait2<T: Transaction, TO, TE>
+    where
+        T: Transaction,
+        TO: TransactionOutput<Txn = T>,
+        TE: Debug + Send + Clone,
+{
+    fn remote_dependencies(&self) -> Vec<(TxnIndex, T::Key)>;
+    fn run_sharding_msg_loop<TAG, X: Executable + 'static>(&self, mv_cache: &MVHashMap<T::Key, TAG, T::Value, X>, scheduler: &Scheduler<Self>);
+    fn shutdown_receiver(&self);
+    fn txn(&self, idx: TxnIndex) -> &T;
+    fn on_local_commit(&self, txn_idx: TxnIndex, txn_output: Arc<TxnOutput<TO, TE>>);
+    fn commit_strategy(&self) -> u8;
+}
+
+pub mod default;
+pub mod sharded;

--- a/aptos-move/block-executor/src/txn_provider/mod.rs
+++ b/aptos-move/block-executor/src/txn_provider/mod.rs
@@ -31,32 +31,66 @@ pub enum ShardingMsg<TO: TransactionOutput, TE: Debug> {
     Shutdown,
 }
 
-pub trait TxnProviderTrait1 {
+/// The transaction index operations that are implemented differently between unsharded execution and sharded execution.
+pub trait TxnIndexProvider {
+    /// Get the special `TxnIndex` used in BlockSTM that indicates the end of the local txn list.
     fn end_txn_idx(&self) -> TxnIndex;
+
+    /// Get number of local txns.
     fn num_txns(&self) -> usize;
+
+    /// Get the 1st local txn.
     fn first_txn(&self) -> TxnIndex;
+
+    /// Given the global index of a local txn, return the global index of the one right after in the local txn list.
     fn next_txn(&self, idx: TxnIndex) -> TxnIndex;
+
+    /// Get the global indices of all local txns.
     fn txns(&self) -> Vec<TxnIndex>;
+
+    /// Get the global indices of all local txns + their remote dependencies.
     fn txns_and_deps(&self) -> Vec<TxnIndex>;
-    fn local_rank(&self, idx: TxnIndex) -> usize;
+
+    /// Given the global index of a local txn, return its index in the local sub-sequence.
+    fn local_index(&self, idx: TxnIndex) -> usize;
+
+    /// Given a global txn index, return whether the txn is assigned to the current shard.
     fn is_local(&self, idx: TxnIndex) -> bool;
+
+    /// Given the global index of a remote txn, return whether its output has arrived.
     fn txn_output_has_arrived(&self, txn_idx: TxnIndex) -> bool;
+
+    /// Get the block ID.
     fn block_idx(&self) -> &[u8]; //debug only
+
+    /// Get the index of the current shard.
     fn shard_idx(&self) -> usize;
 }
 
-pub trait TxnProviderTrait2<T: Transaction, TO, TE>
+/// Some other places where unsharded execution and sharded execution work differently.
+pub trait BlockSTMPlugin<T: Transaction, TO, TE>
     where
         T: Transaction,
         TO: TransactionOutput<Txn = T>,
         TE: Debug + Send + Clone,
 {
+    /// Get all the remote dependency set of all local txns.
     fn remote_dependencies(&self) -> Vec<(TxnIndex, T::Key)>;
-    fn run_sharding_msg_loop<TAG, X: Executable + 'static>(&self, mv_cache: &MVHashMap<T::Key, TAG, T::Value, X>, scheduler: &Scheduler<Self>);
-    fn shutdown_receiver(&self);
+
+    /// Get a reference of the txn object by its global index.
     fn txn(&self, idx: TxnIndex) -> &T;
+
+    /// Run a loop to receive remote txn output and unblock local txns.
+    fn run_sharding_msg_loop<TAG, X: Executable + 'static>(&self, mv_cache: &MVHashMap<T::Key, TAG, T::Value, X>, scheduler: &Scheduler<Self>);
+
+    /// Stop the loop above.
+    fn shutdown_receiver(&self);
+
+    /// Some extra processing once a local txn is committed.
     fn on_local_commit(&self, txn_idx: TxnIndex, txn_output: Arc<TxnOutput<TO, TE>>);
-    fn commit_strategy(&self) -> u8;
+
+    /// Return whether a dedicated committing thread should be used in BlockSTM.
+    fn use_dedicated_committing_thread(&self) -> bool;
 }
 
 pub mod default;

--- a/aptos-move/block-executor/src/txn_provider/sharded.rs
+++ b/aptos-move/block-executor/src/txn_provider/sharded.rs
@@ -1,0 +1,1 @@
+// Copyright © Aptos Foundation


### PR DESCRIPTION
### Description

BlockSTM scheduler can now work with non-contiguous `TxnIndex`s, which is required by sharded execution v3. 

Recall that:
- In sharded execution v3, each shard gets a sub-sequence of the entire block. E.g., if the entire block is `[T0, T1, T2, T3, T4]`, the partitioning may be `shard 0: [T1, T3], shard 1: [T0, T2, T4]`. Remote dependencies are calculated during partitioning, and marked as ESTIMATE in MVHashMap at the beginning of BlockSTM.
- Unsharded execution is a special case of v3 with only 1 shard.
- In sharded execution v2, each sub-block is a sub-array of the entire block. E.g., if the entire block is `[T0, T1, T2, T3, T4]`, the partitioning may be `round 0 shard 0: [T0], round 0 shard 1: [T1, T2], round 1 shard 0: [T3, T4], round 1 shard 1: []`. Each sub-block is handled by an unsharded execution with a special base view that's aware of remote dependencies and blocks reads if the remote dependency is not yet ready.
