### PR TITLE
[e2e-move-tests] remove aptos crate (cli tool) dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,7 +6183,6 @@ name = "e2e-move-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aptos",
  "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-crypto",

--- a/aptos-move/aptos-vm-benchmarks/src/helper.rs
+++ b/aptos-move/aptos-vm-benchmarks/src/helper.rs
@@ -1,11 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos::move_tool::MemberId;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_framework::BuiltPackage;
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
-use aptos_types::transaction::TransactionPayload;
+use aptos_types::{move_utils::MemberId, transaction::TransactionPayload};
 use move_binary_format::CompiledModule;
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
 use std::{fs::ReadDir, path::PathBuf, string::String, time::Instant};

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-aptos = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }

--- a/aptos-move/e2e-move-tests/src/aptos_governance.rs
+++ b/aptos-move/e2e-move-tests/src/aptos_governance.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::harness::MoveHarness;
-use aptos::move_tool::MemberId;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
-    account_address::AccountAddress, state_store::table::TableHandle,
+    account_address::AccountAddress, move_utils::MemberId, state_store::table::TableHandle,
     transaction::TransactionStatus,
 };
 use serde::{Deserialize, Serialize};

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -3,7 +3,6 @@
 
 use crate::{assert_success, AptosPackageHooks};
 use anyhow::Error;
-use aptos::move_tool::MemberId;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_framework::{natives::code::PackageMetadata, BuildOptions, BuiltPackage};
@@ -20,6 +19,7 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CoinStoreResource, CORE_CODE_ADDRESS},
     contract_event::ContractEvent,
+    move_utils::MemberId,
     on_chain_config::{FeatureFlag, GasScheduleV2, OnChainConfig},
     state_store::{
         state_key::StateKey,

--- a/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
+++ b/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
@@ -4,6 +4,7 @@
 use crate::{assert_success, MoveHarness};
 use aptos_types::{
     account_address::AccountAddress,
+    move_utils::MemberId,
     transaction::{ExecutionStatus, ModuleBundle, TransactionPayload},
 };
 use move_binary_format::{
@@ -105,7 +106,7 @@ fn access_path_panic() {
 
     let res = h.run_entry_function(
         &acc,
-        aptos::move_tool::MemberId {
+        MemberId {
             module_id: cm.self_id(),
             member_id: Identifier::new("f").unwrap(),
         },

--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{assert_success, tests::common, MoveHarness};
-use aptos::move_tool::MemberId;
 use aptos_language_e2e_tests::{account::TransactionBuilder, transaction_status_eq};
 use aptos_types::{
     account_address::AccountAddress,
+    move_utils::MemberId,
     on_chain_config::FeatureFlag,
     transaction::{EntryFunction, Script, TransactionArgument, TransactionStatus},
 };

--- a/aptos-move/e2e-move-tests/src/tests/rotate_auth_key.rs
+++ b/aptos-move/e2e-move-tests/src/tests/rotate_auth_key.rs
@@ -6,7 +6,6 @@ use crate::{
     tests::offer_rotation_capability::{offer_rotation_capability_v2, revoke_rotation_capability},
     MoveHarness,
 };
-use aptos::common::types::RotationProofChallenge;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -16,7 +15,7 @@ use aptos_crypto::{
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{AccountResource, CORE_CODE_ADDRESS},
+    account_config::{AccountResource, RotationProofChallenge, CORE_CODE_ADDRESS},
     state_store::{state_key::StateKey, table::TableHandle},
     transaction::{authenticator::AuthenticationKey, TransactionStatus},
 };

--- a/aptos-move/e2e-move-tests/src/tests/token_objects.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_objects.rs
@@ -84,7 +84,7 @@ fn test_basic_token() {
     let object_0: ObjectCore = h
         .read_resource_from_resource_group(&token_addr, obj_group_tag.clone(), obj_tag.clone())
         .unwrap();
-    let mut token_0: Token = h
+    let token_0: Token = h
         .read_resource_from_resource_group(
             &token_addr,
             obj_group_tag.clone(),
@@ -121,6 +121,5 @@ fn test_basic_token() {
     // Determine that the only difference is the mutated description
     assert_eq!(token_1.description, "Oh no!");
     token_1.description = "The best hero ever!".to_string();
-    *token_0.mutation_events.count_mut() = token_1.mutation_events.count();
-    assert_eq!(token_0, token_1);
+    assert_eq!(token_0.mutation_events.key(), token_1.mutation_events.key());
 }

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -6,8 +6,8 @@ use crate::common::{
         account_address_from_auth_key, account_address_from_public_key,
         AuthenticationKeyInputOptions, CliCommand, CliConfig, CliError, CliTypedResult,
         ConfigSearchMode, EncodingOptions, EncodingType, ExtractPublicKey, ParsePrivateKey,
-        ProfileConfig, ProfileOptions, PublicKeyInputOptions, RestOptions, RotationProofChallenge,
-        TransactionOptions, TransactionSummary,
+        ProfileConfig, ProfileOptions, PublicKeyInputOptions, RestOptions, TransactionOptions,
+        TransactionSummary,
     },
     utils::{prompt_yes, prompt_yes_with_override, read_line},
 };
@@ -22,7 +22,8 @@ use aptos_rest_client::{
     Client,
 };
 use aptos_types::{
-    account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
+    account_address::AccountAddress,
+    account_config::{RotationProofChallenge, CORE_CODE_ADDRESS},
     transaction::authenticator::AuthenticationKey,
 };
 use async_trait::async_trait;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1942,25 +1942,6 @@ pub struct PoolAddressArgs {
     pub(crate) pool_address: AccountAddress,
 }
 
-// This struct includes TypeInfo (account_address, module_name, and struct_name)
-// and RotationProofChallenge-specific information (sequence_number, originator, current_auth_key, and new_public_key)
-// Since the struct RotationProofChallenge is defined in "0x1::account::RotationProofChallenge",
-// we will be passing in "0x1" to `account_address`, "account" to `module_name`, and "RotationProofChallenge" to `struct_name`
-// Originator refers to the user's address
-#[derive(Serialize, Deserialize)]
-pub struct RotationProofChallenge {
-    // Should be `CORE_CODE_ADDRESS`
-    pub account_address: AccountAddress,
-    // Should be `account`
-    pub module_name: String,
-    // Should be `RotationProofChallenge`
-    pub struct_name: String,
-    pub sequence_number: u64,
-    pub originator: AccountAddress,
-    pub current_auth_key: AccountAddress,
-    pub new_public_key: Vec<u8>,
-}
-
 /// Common options for interactions with a multisig account.
 #[derive(Clone, Debug, Parser, Serialize)]
 pub struct MultisigAccount {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1701,6 +1701,7 @@ fn txn_arg_parser<T: serde::de::DeserializeOwned>(
 }
 
 /// Identifier of a module member (function or struct).
+/// Duplicated from aptos_types, as we also need to load_account_arg from the CLI.
 #[derive(Debug, Clone)]
 pub struct MemberId {
     pub module_id: ModuleId,

--- a/testsuite/smoke-test/src/aptos_cli/move.rs
+++ b/testsuite/smoke-test/src/aptos_cli/move.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::smoke_test_environment::SwarmBuilder;
-use aptos::{move_tool::MemberId, test::CliTestFramework};
+use aptos::test::CliTestFramework;
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_logger::info;
+use aptos_types::move_utils::MemberId;
 use move_core_types::account_address::AccountAddress;
 use move_package::source_package::manifest_parser::parse_move_manifest_from_file;
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr};

--- a/types/src/account_config/resources/challenge.rs
+++ b/types/src/account_config/resources/challenge.rs
@@ -1,0 +1,24 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+
+// This struct includes TypeInfo (account_address, module_name, and struct_name)
+// and RotationProofChallenge-specific information (sequence_number, originator, current_auth_key, and new_public_key)
+// Since the struct RotationProofChallenge is defined in "0x1::account::RotationProofChallenge",
+// we will be passing in "0x1" to `account_address`, "account" to `module_name`, and "RotationProofChallenge" to `struct_name`
+// Originator refers to the user's address
+#[derive(Serialize, Deserialize)]
+pub struct RotationProofChallenge {
+    // Should be `CORE_CODE_ADDRESS`
+    pub account_address: AccountAddress,
+    // Should be `account`
+    pub module_name: String,
+    // Should be `RotationProofChallenge`
+    pub struct_name: String,
+    pub sequence_number: u64,
+    pub originator: AccountAddress,
+    pub current_auth_key: AccountAddress,
+    pub new_public_key: Vec<u8>,
+}

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod chain_id;
+pub mod challenge;
 pub mod coin_info;
 pub mod coin_store;
 pub mod core_account;
 pub mod object;
 
 pub use chain_id::*;
+pub use challenge::*;
 pub use coin_info::*;
 pub use coin_store::*;
 pub use core_account::*;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -21,6 +21,7 @@ pub mod governance;
 pub mod ledger_info;
 pub mod mempool_status;
 pub mod move_resource;
+pub mod move_utils;
 pub mod network_address;
 pub mod nibble;
 pub mod on_chain_config;

--- a/types/src/move_utils/mod.rs
+++ b/types/src/move_utils/mod.rs
@@ -1,0 +1,40 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account_address::AccountAddress;
+use anyhow::{bail, Context};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use std::str::FromStr;
+
+/// Identifier of a module member (function or struct).
+#[derive(Debug, Clone)]
+pub struct MemberId {
+    pub module_id: ModuleId,
+    pub member_id: Identifier,
+}
+
+fn parse_member_id(function_id: &str) -> anyhow::Result<MemberId> {
+    let ids: Vec<&str> = function_id.split_terminator("::").collect();
+    if ids.len() != 3 {
+        bail!(
+            "FunctionId is not well formed.  Must be of the form <address>::<module>::<function>"
+                .to_string()
+        );
+    }
+    let address = AccountAddress::from_str(ids.first().unwrap())?;
+    let module = Identifier::from_str(ids.get(1).unwrap()).context("Module Name")?;
+    let member_id = Identifier::from_str(ids.get(2).unwrap()).context("Member Name")?;
+    let module_id = ModuleId::new(address, module);
+    Ok(MemberId {
+        module_id,
+        member_id,
+    })
+}
+
+impl FromStr for MemberId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_member_id(s)
+    }
+}


### PR DESCRIPTION
e2e-move-tests were depending on aptos crate, just to use two utility structs. With that it basically required everything to be built. 

moving these to aptos-types (let me know if you have a better preference), reduces number of dependencies from ~1400 to ~1000, and significantly reducing build time. 
Also when modifying some code, and re-running, much less things need to be build, and the very-time-consuming "aptos" crate is not built any more

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
