### PR TITLE
[TS-SDK v2] Adding `serializeVector` and `deserializeVector` to SDK v2

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -220,7 +220,6 @@ export class Deserializer {
    * @param cls The BCS-deserializable class to deserialize the buffered bytes into.
    * @example
    * // serialize a vector of addresses
-   * const serializer = new Serializer();
    * const addresses = new Array<AccountAddress>(
    *   AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
    *   AccountAddress.fromHexInputRelaxed({ input: "0x2" }),

--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -212,4 +212,18 @@ export class Deserializer {
     // It is separate from the `deserialize` instance method defined here in Deserializer.
     return cls.deserialize(this);
   }
+
+  /**
+   * Deserializes an array of BCS Deserializable values.
+   *
+   * The serialized bytes must already be loaded into the Deserializer buffer.
+   */
+  deserializeVector<T>(cls: Deserializable<T>): Array<T> {
+    const length = this.deserializeUleb128AsU32();
+    const vector = new Array<T>();
+    for (let i = 0; i < length; i += 1) {
+      vector.push(this.deserialize(cls));
+    }
+    return vector;
+  }
 }

--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -214,9 +214,28 @@ export class Deserializer {
   }
 
   /**
-   * Deserializes an array of BCS Deserializable values.
+   * Deserializes an array of BCS Deserializable values given an existing Deserializer
+   * instance with a loaded byte buffer.
    *
-   * The serialized bytes must already be loaded into the Deserializer buffer.
+   * @param cls The BCS-deserializable class to deserialize the buffered bytes into.
+   * @example
+   * // serialize a vector of addresses
+   * const serializer = new Serializer();
+   * const addresses = new Array<AccountAddress>(
+   *   AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0x2" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0xa" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0xb" }),
+   * );
+   * const serializer = new Serializer();
+   * serializer.serializeVector(addresses);
+   * const serializedBytes = serializer.toUint8Array();
+   *
+   * // deserialize the bytes into an array of addresses
+   * const deserializer = new Deserializer(serializedBytes);
+   * const deserializedAddresses = deserializer.deserializeVector(AccountAddress);
+   * // deserializedAddresses is now an array of AccountAddress instances
+   * @returns an array of deserialized values of type T
    */
   deserializeVector<T>(cls: Deserializable<T>): Array<T> {
     const length = this.deserializeUleb128AsU32();

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -289,7 +289,6 @@ export class Serializer {
    *
    * @param values The array of BCS Serializable values
    * @example
-   * const serializer = new Serializer();
    * const addresses = new Array<AccountAddress>(
    *   AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
    *   AccountAddress.fromHexInputRelaxed({ input: "0x2" }),

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -277,13 +277,33 @@ export class Serializer {
    *
    * @returns the serializer instance
    */
-  serialize<T extends Serializable>(value: T) {
+  serialize<T extends Serializable>(value: T): void {
     // NOTE: The `serialize` method called by `value` is defined in `value`'s
     // Serializable interface, not the one defined in this class.
     value.serialize(this);
   }
 
-  serializeVector<T extends Serializable>(values: Array<T>) {
+  /**
+   * Serializes an array of BCS Serializable values to a serializer instance.
+   * Note that this does not return anything- the bytes are added to the serializer instance's byte buffer.
+   *
+   * @param values The array of BCS Serializable values
+   * @example
+   * const serializer = new Serializer();
+   * const addresses = new Array<AccountAddress>(
+   *   AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0x2" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0xa" }),
+   *   AccountAddress.fromHexInputRelaxed({ input: "0xb" }),
+   * );
+   * const serializer = new Serializer();
+   * serializer.serializeVector(addresses);
+   * const serializedBytes = serializer.toUint8Array();
+   * // serializedBytes is now the BCS-serialized bytes
+   * // The equivalent value in Move would be:
+   * // `bcs::to_bytes(&vector<address> [@0x1, @0x2, @0xa, @0xb])`;
+   */
+  serializeVector<T extends Serializable>(values: Array<T>): void {
     this.serializeU32AsUleb128(values.length);
     values.forEach((item) => {
       item.serialize(this);

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -282,6 +282,13 @@ export class Serializer {
     // Serializable interface, not the one defined in this class.
     value.serialize(this);
   }
+
+  serializeVector<T extends Serializable>(values: Array<T>) {
+    this.serializeU32AsUleb128(values.length);
+    values.forEach((item) => {
+      item.serialize(this);
+    });
+  }
 }
 
 /**

--- a/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Account } from "../../src/api/account";
 import { Serializable, Serializer, Deserializer } from "../../src/bcs";
+import { AccountAddress } from "../../src/core";
 
 describe("BCS Deserializer", () => {
   it("deserializes a non-empty string", () => {
@@ -128,6 +130,22 @@ describe("BCS Deserializer", () => {
       deserializer.deserializeStr();
       deserializer.deserializeStr();
     }).toThrow("Reached to the end of buffer");
+  });
+
+  it("deserializes a vector of Deserializable types correctly", () => {
+    const addresses = new Array<AccountAddress>(
+      AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
+      AccountAddress.fromHexInputRelaxed({ input: "0xa" }),
+      AccountAddress.fromHexInputRelaxed({ input: "0x0123456789abcdef" }),
+    );
+    const serializer = new Serializer();
+    serializer.serializeVector(addresses);
+    const serializedBytes = serializer.toUint8Array();
+    const deserializer = new Deserializer(serializedBytes);
+    const deserializedAddresses = deserializer.deserializeVector(AccountAddress);
+    addresses.forEach((address, i) => {
+      expect(address.equals(deserializedAddresses[i])).toBeTruthy();
+    });
   });
 
   it("deserializes a single deserializable class", () => {

--- a/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Serializable, Serializer } from "../../src/bcs/serializer";
+import { AccountAddress } from "../../src/core";
 
 describe("BCS Serializer", () => {
   let serializer: Serializer;
@@ -222,6 +223,24 @@ describe("BCS Serializer", () => {
     expect(() => {
       const serializer = new Serializer(-1);
     }).toThrow();
+  });
+
+  it("serializes a vector of Serializable types correctly", () => {
+    const addresses = new Array<AccountAddress>(
+      AccountAddress.fromHexInputRelaxed({ input: "0x1" }),
+      AccountAddress.fromHexInputRelaxed({ input: "0xa" }),
+      AccountAddress.fromHexInputRelaxed({ input: "0x0123456789abcdef" }),
+    );
+    const serializer = new Serializer();
+    serializer.serializeVector(addresses);
+    const serializedBytes = serializer.toUint8Array();
+    expect(serializedBytes).toEqual(
+      new Uint8Array([
+        3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+      ]),
+    );
   });
 
   it("serializes multiple Serializable values", () => {


### PR DESCRIPTION
### Description
Fairly self-explanatory- adding the ability to serialize and deserialize `Serializable` and `Deserializable` values respectively, using `Serializer` and `Deserializer`.

Each new function has a corresponding unit test.

### Test Plan
`pnpm jest serializer.test.ts --verbose`
should run both tests
