### PR TITLE
[TS SDK V2] Port over transaction types

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/transactions/types/chainId.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/chainId.ts
@@ -1,0 +1,21 @@
+import { Serializer, Deserializer } from "../../bcs";
+
+/**
+ * Representation of a ChainId that can serialized and deserialized
+ */
+export class ChainId {
+  public readonly chainId: number;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU8(this.chainId);
+  }
+
+  static deserialize(deserializer: Deserializer): ChainId {
+    const chainId = deserializer.deserializeU8();
+    return new ChainId(chainId);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/identifier.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/identifier.ts
@@ -1,0 +1,23 @@
+import { Serializer, Deserializer } from "../../bcs";
+
+/**
+ * Representation of an Identifier that can serialized and deserialized.
+ * We use Identifier to represent the module "name" in "ModuleId" and
+ * the "function name" in "EntryFunction"
+ */
+export class Identifier {
+  public identifier: string;
+
+  constructor(identifier: string) {
+    this.identifier = identifier;
+  }
+
+  public serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.identifier);
+  }
+
+  static deserialize(deserializer: Deserializer): Identifier {
+    const identifier = deserializer.deserializeStr();
+    return new Identifier(identifier);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/index.ts
@@ -1,0 +1,6 @@
+export * from "./chainId";
+export * from "./rawTransaction";
+export * from "./transactionArguments";
+export * from "./transactionPayload";
+export * from "./moduleId";
+export * from "./identifier";

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/moduleId.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/moduleId.ts
@@ -1,0 +1,46 @@
+import { Serializer, Deserializer } from "../../bcs";
+import { AccountAddress } from "../../core";
+import { Identifier } from "./identifier";
+
+/**
+ * Representation of a ModuleId that can serialized and deserialized
+ * ModuleId means the module address (e.g "0x1") and the module name (e.g "coin")
+ */
+export class ModuleId {
+  public readonly address: AccountAddress;
+  public readonly name: Identifier;
+
+  /**
+   * Full name of a module.
+   * @param address The account address. e.g "0x1"
+   * @param name The module name under the "address". e.g "coin"
+   */
+  constructor(address: AccountAddress, name: Identifier) {
+    this.address = address;
+    this.name = name;
+  }
+
+  /**
+   * Converts a string literal to a ModuleId
+   * @param moduleId String literal in format "account_address::module_name", e.g. "0x1::coin"
+   * @returns ModuleId
+   */
+  static fromStr(moduleId: `${string}::${string}`): ModuleId {
+    const parts = moduleId.split("::");
+    if (parts.length !== 2) {
+      throw new Error("Invalid module id.");
+    }
+    return new ModuleId(AccountAddress.fromString({ input: parts[0] }), new Identifier(parts[1]));
+  }
+
+  serialize(serializer: Serializer): void {
+    this.address.serialize(serializer);
+    this.name.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): ModuleId {
+    const address = AccountAddress.deserialize(deserializer);
+    const name = Identifier.deserialize(deserializer);
+    return new ModuleId(address, name);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/rawTransaction.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/rawTransaction.ts
@@ -1,0 +1,198 @@
+import { Deserializer, Serializer } from "../../bcs";
+import { AccountAddress } from "../../core";
+import { ChainId } from "./chainId";
+import { TransactionArgument } from "./transactionArguments";
+import { TransactionPayload } from "./transactionPayload";
+
+/**
+ * Representation of a Raw Transaction that can serialized and deserialized
+ */
+export class RawTransaction {
+  public readonly sender: AccountAddress;
+
+  public readonly sequence_number: bigint;
+
+  public readonly payload: TransactionPayload;
+
+  public readonly max_gas_amount: bigint;
+
+  public readonly gas_unit_price: bigint;
+
+  public readonly expiration_timestamp_secs: bigint;
+
+  public readonly chain_id: ChainId;
+
+  /**
+   * RawTransactions contain the metadata and payloads that can be submitted to Aptos chain for execution.
+   * RawTransactions must be signed before Aptos chain can execute them.
+   *
+   * @param sender The sender Account Address
+   * @param sequence_number Sequence number of this transaction. This must match the sequence number stored in
+   *   the sender's account at the time the transaction executes.
+   * @param payload Instructions for the Aptos Blockchain, including publishing a module,
+   *   execute a entry function or execute a script payload.
+   * @param max_gas_amount Maximum total gas to spend for this transaction. The account must have more
+   *   than this gas or the transaction will be discarded during validation.
+   * @param gas_unit_price Price to be paid per gas unit.
+   * @param expiration_timestamp_secs The blockchain timestamp at which the blockchain would discard this transaction.
+   * @param chain_id The chain ID of the blockchain that this transaction is intended to be run on.
+   */
+  constructor(
+    sender: AccountAddress,
+    sequence_number: bigint,
+    payload: TransactionPayload,
+    max_gas_amount: bigint,
+    gas_unit_price: bigint,
+    expiration_timestamp_secs: bigint,
+    chain_id: ChainId,
+  ) {
+    this.sender = sender;
+    this.sequence_number = sequence_number;
+    this.payload = payload;
+    this.max_gas_amount = max_gas_amount;
+    this.gas_unit_price = gas_unit_price;
+    this.expiration_timestamp_secs = expiration_timestamp_secs;
+    this.chain_id = chain_id;
+  }
+
+  serialize(serializer: Serializer): void {
+    this.sender.serialize(serializer);
+    serializer.serializeU64(this.sequence_number);
+    this.payload.serialize(serializer);
+    serializer.serializeU64(this.max_gas_amount);
+    serializer.serializeU64(this.gas_unit_price);
+    serializer.serializeU64(this.expiration_timestamp_secs);
+    this.chain_id.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): RawTransaction {
+    const sender = AccountAddress.deserialize(deserializer);
+    const sequence_number = deserializer.deserializeU64();
+    const payload = TransactionPayload.deserialize(deserializer);
+    const max_gas_amount = deserializer.deserializeU64();
+    const gas_unit_price = deserializer.deserializeU64();
+    const expiration_timestamp_secs = deserializer.deserializeU64();
+    const chain_id = ChainId.deserialize(deserializer);
+    return new RawTransaction(
+      sender,
+      sequence_number,
+      payload,
+      max_gas_amount,
+      gas_unit_price,
+      expiration_timestamp_secs,
+      chain_id,
+    );
+  }
+}
+
+/**
+ * Representation of a Raw Transaction With Data that can serialized and deserialized
+ */
+export abstract class RawTransactionWithData {
+  /**
+   * Serialize a Raw Transaction With Data
+   */
+  abstract serialize(serializer: Serializer): void;
+
+  /**
+   * Deserialize a Raw Transaction With Data
+   */
+  static deserialize(deserializer: Deserializer): RawTransactionWithData {
+    const index = deserializer.deserializeUleb128AsU32();
+    /**
+     * index is represented in rust as an enum
+     * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L440}
+     */
+
+    switch (index) {
+      case 0:
+        return MultiAgentRawTransaction.load(deserializer);
+      case 1:
+        return FeePayerRawTransaction.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for RawTransactionWithData: ${index}`);
+    }
+  }
+}
+
+/**
+ * Representation of a Multi Agent Transaction that can serialized and deserialized
+ */
+export class MultiAgentRawTransaction extends RawTransactionWithData {
+  /**
+   * The raw transaction
+   */
+  public readonly raw_txn: RawTransaction;
+
+  /**
+   * The secondary signers on this transaction
+   */
+  public readonly secondary_signer_addresses: Array<AccountAddress>;
+
+  constructor(raw_txn: RawTransaction, secondary_signer_addresses: Array<AccountAddress>) {
+    super();
+    this.raw_txn = raw_txn;
+    this.secondary_signer_addresses = secondary_signer_addresses;
+  }
+
+  serialize(serializer: Serializer): void {
+    // enum variant index
+    serializer.serializeU32AsUleb128(0);
+    this.raw_txn.serialize(serializer);
+    serializer.serializeVector<TransactionArgument>(this.secondary_signer_addresses);
+  }
+
+  static load(deserializer: Deserializer): MultiAgentRawTransaction {
+    const rawTxn = RawTransaction.deserialize(deserializer);
+    const secondarySignerAddresses = deserializer.deserializeVector(AccountAddress);
+
+    return new MultiAgentRawTransaction(rawTxn, secondarySignerAddresses);
+  }
+}
+
+/**
+ * Representation of a Fee Payer Transaction that can serialized and deserialized
+ */
+export class FeePayerRawTransaction extends RawTransactionWithData {
+  /**
+   * The raw transaction
+   */
+  public readonly raw_txn: RawTransaction;
+
+  /**
+   * The secondary signers on this transaction - optional and can be empty
+   */
+  public readonly secondary_signer_addresses: Array<AccountAddress>;
+
+  /**
+   * The fee payer account address
+   */
+  public readonly fee_payer_address: AccountAddress;
+
+  constructor(
+    raw_txn: RawTransaction,
+    secondary_signer_addresses: Array<AccountAddress>,
+    fee_payer_address: AccountAddress,
+  ) {
+    super();
+    this.raw_txn = raw_txn;
+    this.secondary_signer_addresses = secondary_signer_addresses;
+    this.fee_payer_address = fee_payer_address;
+  }
+
+  serialize(serializer: Serializer): void {
+    // enum variant index
+    serializer.serializeU32AsUleb128(1);
+    this.raw_txn.serialize(serializer);
+    serializer.serializeVector<TransactionArgument>(this.secondary_signer_addresses);
+    this.fee_payer_address.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): FeePayerRawTransaction {
+    const rawTxn = RawTransaction.deserialize(deserializer);
+    const secondarySignerAddresses = deserializer.deserializeVector(AccountAddress);
+    const feePayerAddress = AccountAddress.deserialize(deserializer);
+
+    return new FeePayerRawTransaction(rawTxn, secondarySignerAddresses, feePayerAddress);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/transactionArguments.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/transactionArguments.ts
@@ -1,0 +1,216 @@
+import { Serializer, Deserializer, Serializable } from "../../bcs";
+import { AccountAddress } from "../../core";
+
+/**
+ * Representation of a Transaction Argument that can serialized and deserialized
+ */
+export abstract class TransactionArgument extends Serializable {
+  /**
+   * Serialize a Transaction Argument
+   */
+  abstract serialize(serializer: Serializer): void;
+
+  /**
+   * Deserialize a Transaction Argument
+   */
+  static deserialize(deserializer: Deserializer): TransactionArgument {
+    const index = deserializer.deserializeUleb128AsU32();
+    /**
+     * index is represented in rust as an enum
+     * {@link https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-core/types/src/transaction_argument.rs#L11}
+     */
+    switch (index) {
+      case 0:
+        return TransactionArgumentU8.load(deserializer);
+      case 1:
+        return TransactionArgumentU64.load(deserializer);
+      case 2:
+        return TransactionArgumentU128.load(deserializer);
+      case 3:
+        return TransactionArgumentAddress.load(deserializer);
+      case 4:
+        return TransactionArgumentU8Vector.load(deserializer);
+      case 5:
+        return TransactionArgumentBool.load(deserializer);
+      case 6:
+        return TransactionArgumentU16.load(deserializer);
+      case 7:
+        return TransactionArgumentU32.load(deserializer);
+      case 8:
+        return TransactionArgumentU256.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionArgument: ${index}`);
+    }
+  }
+}
+
+export class TransactionArgumentU8 extends TransactionArgument {
+  public readonly value: number;
+
+  constructor(value: number) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serializeU8(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU8 {
+    const value = deserializer.deserializeU8();
+    return new TransactionArgumentU8(value);
+  }
+}
+
+export class TransactionArgumentU16 extends TransactionArgument {
+  public readonly value: number;
+
+  constructor(value: number) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(6);
+    serializer.serializeU16(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU16 {
+    const value = deserializer.deserializeU16();
+    return new TransactionArgumentU16(value);
+  }
+}
+
+export class TransactionArgumentU32 extends TransactionArgument {
+  public readonly value: number;
+
+  constructor(value: number) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(7);
+    serializer.serializeU32(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU32 {
+    const value = deserializer.deserializeU32();
+    return new TransactionArgumentU32(value);
+  }
+}
+
+export class TransactionArgumentU64 extends TransactionArgument {
+  public readonly value: bigint;
+
+  constructor(value: bigint) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
+    serializer.serializeU64(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU64 {
+    const value = deserializer.deserializeU64();
+    return new TransactionArgumentU64(value);
+  }
+}
+
+export class TransactionArgumentU128 extends TransactionArgument {
+  public readonly value: bigint;
+
+  constructor(value: bigint) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(2);
+    serializer.serializeU128(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU128 {
+    const value = deserializer.deserializeU128();
+    return new TransactionArgumentU128(value);
+  }
+}
+
+export class TransactionArgumentU256 extends TransactionArgument {
+  public readonly value: bigint;
+
+  constructor(value: bigint) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(8);
+    serializer.serializeU256(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU256 {
+    const value = deserializer.deserializeU256();
+    return new TransactionArgumentU256(value);
+  }
+}
+
+export class TransactionArgumentAddress extends TransactionArgument {
+  public readonly value: AccountAddress;
+
+  constructor(value: AccountAddress) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(3);
+    this.value.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentAddress {
+    const value = AccountAddress.deserialize(deserializer);
+    return new TransactionArgumentAddress(value);
+  }
+}
+
+export class TransactionArgumentU8Vector extends TransactionArgument {
+  public readonly value: Uint8Array;
+
+  constructor(value: Uint8Array) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(4);
+    serializer.serializeBytes(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU8Vector {
+    const value = deserializer.deserializeBytes();
+    return new TransactionArgumentU8Vector(value);
+  }
+}
+
+export class TransactionArgumentBool extends TransactionArgument {
+  public readonly value: boolean;
+
+  constructor(value: boolean) {
+    super();
+    this.value = value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(5);
+    serializer.serializeBool(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentBool {
+    const value = deserializer.deserializeBool();
+    return new TransactionArgumentBool(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/transactionPayload.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/transactionPayload.ts
@@ -1,0 +1,305 @@
+import { Serializer, Deserializer, Serializable } from "../../bcs";
+import { AccountAddress } from "../../core";
+import { Identifier } from "./identifier";
+import { TransactionArgument } from "./transactionArguments";
+import { ModuleId } from "./moduleId";
+
+/**
+ * Representation of the supported Transaction Payload
+ * that can serialized and deserialized
+ */
+export abstract class TransactionPayload extends Serializable {
+  /**
+   * Serialize a Transaction Payload
+   */
+  abstract serialize(serializer: Serializer): void;
+
+  /**
+   * Deserialize a Transaction Payload
+   */
+  static deserialize(deserializer: Deserializer): TransactionPayload {
+    const index = deserializer.deserializeUleb128AsU32();
+    /**
+     * index is represented in rust as an enum
+     * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L478}
+     */
+    switch (index) {
+      case 0:
+        return TransactionPayloadScript.load(deserializer);
+      // TODO: change to 1 once ModuleBundle has been removed from rust
+      case 2:
+        return TransactionPayloadEntryFunction.load(deserializer);
+      case 3:
+        return TransactionPayloadMultisig.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionPayload: ${index}`);
+    }
+  }
+}
+
+/**
+ * Representation of a Transaction Payload Script that can serialized and deserialized
+ */
+export class TransactionPayloadScript extends TransactionPayload {
+  public readonly script: Script;
+
+  constructor(script: Script) {
+    super();
+    this.script = script;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    this.script.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadScript {
+    const script = Script.deserialize(deserializer);
+    return new TransactionPayloadScript(script);
+  }
+}
+
+/**
+ * Representation of a Transaction Payload Entry Function that can serialized and deserialized
+ */
+export class TransactionPayloadEntryFunction extends TransactionPayload {
+  public readonly entryFunction: EntryFunction;
+
+  constructor(entryFunction: EntryFunction) {
+    super();
+    this.entryFunction = entryFunction;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(2);
+    this.entryFunction.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadEntryFunction {
+    const entryFunction = EntryFunction.deserialize(deserializer);
+    return new TransactionPayloadEntryFunction(entryFunction);
+  }
+}
+
+/**
+ * Representation of a Transaction Payload Multisig that can serialized and deserialized
+ */
+export class TransactionPayloadMultisig extends TransactionPayload {
+  public readonly multiSig: MultiSig;
+
+  constructor(multiSig: MultiSig) {
+    super();
+    this.multiSig = multiSig;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(3);
+    this.multiSig.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadMultisig {
+    const multiSig = MultiSig.deserialize(deserializer);
+    return new TransactionPayloadMultisig(multiSig);
+  }
+}
+
+/**
+ * Representation of a EntryFunction that can serialized and deserialized
+ */
+export class EntryFunction {
+  public readonly module_name: ModuleId;
+
+  public readonly function_name: Identifier;
+
+  public readonly type_args: Array<TypeTag>;
+
+  public readonly args: Array<Uint8Array>;
+
+  /**
+   * Contains the payload to run a function within a module.
+   * @param module_name Fully qualified module name in format "account_address::module_name" e.g. "0x1::coin"
+   * @param function_name The function name. e.g "transfer"
+   * @param type_args Type arguments that move function requires.
+   *
+   * @example
+   * A coin transfer function has one type argument "CoinType".
+   * ```
+   * public entry fun transfer<CoinType>(from: &signer, to: address, amount: u64)
+   * ```
+   * @param args Arugments to the move function.
+   *
+   * @example
+   * A coin transfer function has three arugments "from", "to" and "amount".
+   * ```
+   * public entry fun transfer<CoinType>(from: &signer, to: address, amount: u64)
+   * ```
+   */
+  constructor(module_name: ModuleId, function_name: Identifier, type_args: Array<TypeTag>, args: Array<Uint8Array>) {
+    this.module_name = module_name;
+    this.function_name = function_name;
+    this.type_args = type_args;
+    this.args = args;
+  }
+
+  serialize(serializer: Serializer): void {
+    this.module_name.serialize(serializer);
+    this.function_name.serialize(serializer);
+    serializer.serializeVector<TypeTag>(this.ty_args);
+
+    serializer.serializeU32AsUleb128(this.args.length);
+    this.args.forEach((item: Uint8Array) => {
+      serializer.serializeBytes(item);
+    });
+  }
+
+  static deserialize(deserializer: Deserializer): EntryFunction {
+    const module_name = ModuleId.deserialize(deserializer);
+    const function_name = Identifier.deserialize(deserializer);
+    const ty_args = deserializer.deserializeVector(TypeTag);
+
+    const length = deserializer.deserializeUleb128AsU32();
+    const list: Array<Uint8Array> = [];
+    for (let i = 0; i < length; i += 1) {
+      list.push(deserializer.deserializeBytes());
+    }
+
+    const args = list;
+    return new EntryFunction(module_name, function_name, ty_args, args);
+  }
+}
+
+/**
+ * Representation of a Script that can serialized and deserialized
+ */
+export class Script {
+  /**
+   * The move module bytecode
+   */
+  public readonly bytecode: Uint8Array;
+
+  /**
+   * The type arguments that the bytecode function requires.
+   */
+  public readonly type_args: Array<TypeTag>;
+
+  /**
+   * The arugments that the bytecode function requires.
+   */
+  public readonly args: Array<TransactionArgument>;
+
+  /**
+   * Scripts contain the Move bytecodes payload that can be submitted to Aptos chain for execution.
+   *
+   * @param code The move module bytecode
+   * @param type_args The type arguments that the bytecode function requires.
+   *
+   * @example
+   * A coin transfer function has one type argument "CoinType".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   * @param args The arugments that the bytecode function requires.
+   *
+   * @example
+   * A coin transfer function has three arugments "from", "to" and "amount".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   */
+  constructor(bytecode: Uint8Array, type_args: Array<TypeTag>, args: Array<TransactionArgument>) {
+    this.bytecode = bytecode;
+    this.type_args = type_args;
+    this.args = args;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.bytecode);
+    serializer.serializeVector<TypeTag>(this.type_args);
+    serializer.serializeVector<TransactionArgument>(this.args);
+  }
+
+  static deserialize(deserializer: Deserializer): Script {
+    const bytecode = deserializer.deserializeBytes();
+    const type_args = deserializer.deserializeVector(TypeTag);
+    const args = deserializer.deserializeVector(TransactionArgument);
+    return new Script(bytecode, type_args, args);
+  }
+}
+
+/**
+ * Representation of a MultiSig that can serialized and deserialized
+ */
+export class MultiSig {
+  public readonly multisig_address: AccountAddress;
+
+  public readonly transaction_payload?: MultiSigTransactionPayload;
+
+  /**
+   * Contains the payload to run a multisig account transaction.
+   *
+   * @param multisig_address The multisig account address the transaction will be executed as.
+   *
+   * @param transaction_payload The payload of the multisig transaction. This is optional when executing a multisig
+   *  transaction whose payload is already stored on chain.
+   */
+  constructor(multisig_address: AccountAddress, transaction_payload?: MultiSigTransactionPayload) {
+    this.multisig_address = multisig_address;
+    this.transaction_payload = transaction_payload;
+  }
+
+  serialize(serializer: Serializer): void {
+    this.multisig_address.serialize(serializer);
+    // Options are encoded with an extra u8 field before the value - 0x0 is none and 0x1 is present.
+    // We use serializeBool below to create this prefix value.
+    if (this.transaction_payload === undefined) {
+      serializer.serializeBool(false);
+    } else {
+      serializer.serializeBool(true);
+      this.transaction_payload.serialize(serializer);
+    }
+  }
+
+  static deserialize(deserializer: Deserializer): MultiSig {
+    const multisig_address = AccountAddress.deserialize(deserializer);
+    const payloadPresent = deserializer.deserializeBool();
+    let transaction_payload;
+    if (payloadPresent) {
+      transaction_payload = MultiSigTransactionPayload.deserialize(deserializer);
+    }
+    return new MultiSig(multisig_address, transaction_payload);
+  }
+}
+
+/**
+ * Representation of a MultiSig Transaction Payload that can serialized and deserialized
+ */
+export class MultiSigTransactionPayload {
+  public readonly transaction_payload: EntryFunction;
+
+  /**
+   * Contains the payload to run a multisig account transaction.
+   *
+   * @param transaction_payload The payload of the multisig transaction.
+   * This can only be EntryFunction for now but,
+   * Script might be supported in the future.
+   */
+  constructor(transaction_payload: EntryFunction) {
+    this.transaction_payload = transaction_payload;
+  }
+
+  serialize(serializer: Serializer): void {
+    /**
+     * We can support multiple types of inner transaction payload in the future.
+     * For now it's only EntryFunction but if we support more types,
+     * we need to serialize with the right enum values here
+     */
+    serializer.serializeU32AsUleb128(0);
+    this.transaction_payload.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): MultiSigTransactionPayload {
+    // This is the enum value indicating which type of payload the multisig tx contains.
+    deserializer.deserializeUleb128AsU32();
+    return new MultiSigTransactionPayload(EntryFunction.deserialize(deserializer));
+  }
+}


### PR DESCRIPTION
### Description
This PR ports over the transaction type classes we need to construct a transaction.
No big changes here as all of these classes are pretty much replications of the internal (rust) representations of them.

The only missing part here is the implementation of the `TypeTag` class which @xbtmatt is working on
