### PR TITLE
[framework] Turn on test-only checking and fix errors

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -946,7 +946,7 @@ module aptos_framework::account {
     }
 
     #[test_only]
-    public entry fun create_account_from_ed25519_public_key(pk_bytes: vector<u8>): signer {
+    public fun create_account_from_ed25519_public_key(pk_bytes: vector<u8>): signer {
         let pk = ed25519::new_unvalidated_public_key_from_bytes(pk_bytes);
         let curr_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&pk);
         let alice_address = from_bcs::to_address(curr_auth_key);

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -624,7 +624,7 @@ module aptos_framework::aptos_governance {
     }
 
     #[test_only]
-    public entry fun resolve_proposal_for_test(proposal_id: u64, signer_address: address, multi_step: bool, finish_multi_step_execution: bool): signer acquires ApprovedExecutionHashes, GovernanceResponsbility {
+    public fun resolve_proposal_for_test(proposal_id: u64, signer_address: address, multi_step: bool, finish_multi_step_execution: bool): signer acquires ApprovedExecutionHashes, GovernanceResponsbility {
         if (multi_step) {
             let execution_hash = vector::empty<u8>();
             vector::push_back(&mut execution_hash, 1);

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1012,7 +1012,7 @@ module aptos_framework::vesting {
     const VALIDATOR_STATUS_INACTIVE: u64 = 4;
 
     #[test_only]
-    public entry fun setup(aptos_framework: &signer, accounts: &vector<address>) {
+    public fun setup(aptos_framework: &signer, accounts: &vector<address>) {
         use aptos_framework::aptos_account::create_account;
 
         stake::initialize_for_test_custom(aptos_framework, MIN_STAKE, GRANT_AMOUNT * 10, 3600, true, 10, 10000, 1000000);

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -1798,7 +1798,7 @@ module aptos_token::token {
     }
 
     #[test_only]
-    public entry fun create_collection_and_token(
+    public fun create_collection_and_token(
         creator: &signer,
         amount: u64,
         collection_max: u64,

--- a/aptos-move/framework/aptos-token/sources/token_transfers.move
+++ b/aptos-move/framework/aptos-token/sources/token_transfers.move
@@ -229,7 +229,7 @@ module aptos_token::token_transfers {
     }
 
     #[test_only]
-    public entry fun create_token(creator: &signer, amount: u64): TokenId {
+    public fun create_token(creator: &signer, amount: u64): TokenId {
         use std::string::{Self, String};
 
         let collection_name = string::utf8(b"Hello, World");

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -23,6 +23,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
                 known_attributes: extended_checks::get_all_attribute_names().clone(),
                 ..Default::default()
             },
+            full_model_generation: true, // Run extended checks also on test code
             ..Default::default()
         },
         // TODO(Gas): double check if this is correct


### PR DESCRIPTION
This turns on running extended checks also on test-only code in the framework unit tests. A few errors discovered this way are fixed.

Changes to function declarations in this PR do not effect compatibility because only test-only functions are effected which are stripped before deployment.

Related to #10335, but more needs to be done to make this behavior the default. This cannot happen before the next framework release.