### PR TITLE
[netbench] more tests on exp1

### DIFF
--- a/config/src/config/netbench.rs
+++ b/config/src/config/netbench.rs
@@ -13,6 +13,7 @@ pub struct NetbenchConfig {
     pub enable_direct_send_testing: bool, // Whether or not to enable direct send test mode
     pub direct_send_data_size: usize,     // The amount of data to send in each request
     pub direct_send_per_second: u64,      // The interval (microseconds) between requests
+    pub direct_send_ramp_up_ms: Option<u64>, // The interval (milliseconds) for each ramp up phase
 
     pub enable_rpc_testing: bool,
     pub rpc_data_size: usize,
@@ -30,6 +31,7 @@ impl Default for NetbenchConfig {
             enable_direct_send_testing: false,
             direct_send_data_size: 100 * 1024, // 100 KB
             direct_send_per_second: 1_000,
+            direct_send_ramp_up_ms: Some(30_000), // 30 seconds
 
             enable_rpc_testing: false,
             rpc_data_size: 100 * 1024,

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -321,8 +321,15 @@ pub async fn direct_sender(
 
     let mut counter: u64 = rng.gen();
 
+    let start = time_service.now_unix_time().as_micros() as u64;
     loop {
         ticker.next().await;
+        if start + 1_000_000 > time_service.now_unix_time().as_micros() as u64 {
+            ticker.next().await;
+        }
+        if start + 2_000_000 > time_service.now_unix_time().as_micros() as u64 {
+            ticker.next().await;
+        }
 
         counter += 1;
         {

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -299,13 +299,18 @@ pub async fn run_netbench_service(
 const BLAB_MICROS: u64 = 100_000;
 
 /// Determine how many extra ticks to wait for during ramp up
-fn get_num_ramp_up_ticks(ramp_up_ms: u64, counter: u64, start_micros: u64, now_micros: u64) -> u64 {
+fn get_num_ramp_up_ticks(
+    ramp_up_micros: u64,
+    counter: u64,
+    start_micros: u64,
+    now_micros: u64,
+) -> u64 {
     #[allow(clippy::if_same_then_else)]
-    if start_micros + ramp_up_ms > now_micros {
+    if start_micros + ramp_up_micros > now_micros {
         2 // send every 3 ticks
-    } else if start_micros + ramp_up_ms * 2 > now_micros {
+    } else if start_micros + ramp_up_micros * 2 > now_micros {
         1 // send every 2 ticks
-    } else if start_micros + ramp_up_ms * 3 > now_micros && counter % 2 == 0 {
+    } else if start_micros + ramp_up_micros * 3 > now_micros && counter % 2 == 0 {
         1 // send every 1.5 ticks
     } else {
         0 // ramp up complete
@@ -341,7 +346,7 @@ pub async fn direct_sender(
 
         if let Some(ramp_up_ms) = config.direct_send_ramp_up_ms {
             let num_ramp_up_ticks = get_num_ramp_up_ticks(
-                ramp_up_ms,
+                ramp_up_ms * 1000,
                 counter,
                 start,
                 time_service.now_unix_time().as_micros() as u64,

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -324,10 +324,17 @@ pub async fn direct_sender(
     let start = time_service.now_unix_time().as_micros() as u64;
     loop {
         ticker.next().await;
-        if start + 15_000_000 > time_service.now_unix_time().as_micros() as u64 {
-            ticker.next().await;
-        }
         if start + 30_000_000 > time_service.now_unix_time().as_micros() as u64 {
+            // send every 3 ticks
+            ticker.next().await;
+            ticker.next().await;
+        } else if start + 60_000_000 > time_service.now_unix_time().as_micros() as u64 {
+            // send every 2 ticks
+            ticker.next().await;
+        } else if start + 90_000_000 > time_service.now_unix_time().as_micros() as u64
+            && counter % 2 == 0
+        {
+            // send every 1.5 ticks
             ticker.next().await;
         }
 

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -324,10 +324,10 @@ pub async fn direct_sender(
     let start = time_service.now_unix_time().as_micros() as u64;
     loop {
         ticker.next().await;
-        if start + 1_000_000 > time_service.now_unix_time().as_micros() as u64 {
+        if start + 15_000_000 > time_service.now_unix_time().as_micros() as u64 {
             ticker.next().await;
         }
-        if start + 2_000_000 > time_service.now_unix_time().as_micros() as u64 {
+        if start + 30_000_000 > time_service.now_unix_time().as_micros() as u64 {
             ticker.next().await;
         }
 

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -307,7 +307,7 @@ fn get_num_ramp_up_ticks(
 ) -> u64 {
     #[allow(clippy::if_same_then_else)]
     if start_micros + ramp_up_micros > now_micros {
-        2 // send every 3 ticks
+        3 // send every 4 ticks
     } else if start_micros + ramp_up_micros * 2 > now_micros {
         1 // send every 2 ticks
     } else if start_micros + ramp_up_micros * 3 > now_micros && counter % 2 == 0 {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_10_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_12_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 100;
+    netbench_config.direct_send_per_second = 120;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1400,7 +1400,7 @@ fn net_bench_two_region_inner(
     netbench_config_fn: Arc<dyn Fn(&mut NetbenchConfig) + Send + Sync>,
 ) -> ForgeConfig {
     ForgeConfig::default()
-        .add_network_test(wrap_with_two_region_env(Delay::new(180)))
+        .add_network_test(wrap_with_two_region_env(Delay::new(300)))
         .with_initial_validator_count(NonZeroUsize::new(2).unwrap())
         .with_validator_override_node_config_fn(Arc::new(move |config, _| {
             // Use a target that is not too much higher than the achievable throughput, to avoid

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_12_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_32_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 120;
+    netbench_config.direct_send_per_second = 320;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1419,7 +1419,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
     net_bench_two_region_inner(Arc::new(
-        netbench_config_12_megabytes_per_sec_small_messages,
+        netbench_config_32_megabytes_per_sec_small_messages,
     ))
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_12_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_10_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 120;
+    netbench_config.direct_send_per_second = 100;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1419,7 +1419,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
     net_bench_two_region_inner(Arc::new(
-        netbench_config_12_megabytes_per_sec_small_messages,
+        netbench_config_10_megabytes_per_sec_small_messages,
     ))
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_6_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_8_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 60;
+    netbench_config.direct_send_per_second = 80;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1418,7 +1418,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 }
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
-    net_bench_two_region_inner(Arc::new(netbench_config_6_megabytes_per_sec_small_messages))
+    net_bench_two_region_inner(Arc::new(netbench_config_8_megabytes_per_sec_small_messages))
 }
 
 fn three_region_simulation_with_different_node_speed() -> ForgeConfig {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_5_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_6_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 50;
+    netbench_config.direct_send_per_second = 60;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1418,7 +1418,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 }
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
-    net_bench_two_region_inner(Arc::new(netbench_config_5_megabytes_per_sec_small_messages))
+    net_bench_two_region_inner(Arc::new(netbench_config_6_megabytes_per_sec_small_messages))
 }
 
 fn three_region_simulation_with_different_node_speed() -> ForgeConfig {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_32_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_16_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 320;
+    netbench_config.direct_send_per_second = 160;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1419,7 +1419,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
     net_bench_two_region_inner(Arc::new(
-        netbench_config_32_megabytes_per_sec_small_messages,
+        netbench_config_16_megabytes_per_sec_small_messages,
     ))
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1419,7 +1419,7 @@ fn net_bench_two_region_env() -> ForgeConfig {
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
     net_bench_two_region_inner(Arc::new(
-        netbench_config_10_megabytes_per_sec_small_messages,
+        netbench_config_12_megabytes_per_sec_small_messages,
     ))
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1368,12 +1368,12 @@ fn netbench_config_100_megabytes_per_sec(netbench_config: &mut NetbenchConfig) {
     netbench_config.direct_send_per_second = 1000;
 }
 
-fn netbench_config_8_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
+fn netbench_config_12_megabytes_per_sec_small_messages(netbench_config: &mut NetbenchConfig) {
     netbench_config.enabled = true;
     netbench_config.max_network_channel_size = 1000;
     netbench_config.enable_direct_send_testing = true;
     netbench_config.direct_send_data_size = 100000;
-    netbench_config.direct_send_per_second = 80;
+    netbench_config.direct_send_per_second = 120;
 }
 
 /// Currently sending 16 MB/s outbound gets 12 MB/s inbound.
@@ -1418,7 +1418,9 @@ fn net_bench_two_region_env() -> ForgeConfig {
 }
 
 fn net_bench_two_region_env_small_messages() -> ForgeConfig {
-    net_bench_two_region_inner(Arc::new(netbench_config_8_megabytes_per_sec_small_messages))
+    net_bench_two_region_inner(Arc::new(
+        netbench_config_12_megabytes_per_sec_small_messages,
+    ))
 }
 
 fn three_region_simulation_with_different_node_speed() -> ForgeConfig {


### PR DESCRIPTION
- Try slow ramp up for netbench with smaller messages
- Ramp up 15,30s; 6 MB/s
- 8 MB/s
- 12 MB/s
- 10 MB/s
- more ramp up
- 12 MB/s, longer test
- fix
- cleanup
- more cleanup
- 32 MB/s

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
