### PR TITLE
[forge] Fix fullnode override in forge

### DIFF
--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -275,7 +275,7 @@ impl ForgeConfig {
                 helm_values["validator"]["config"] = override_config.get_yaml().unwrap();
             }
             if let Some(override_config) = &fullnode_override_node_config {
-                helm_values["validator"]["config"] = override_config.get_yaml().unwrap();
+                helm_values["fullnode"]["config"] = override_config.get_yaml().unwrap();
             }
             if multi_region_config {
                 helm_values["multicluster"]["enabled"] = true.into();


### PR DESCRIPTION
### Description

Fixing a mistake made in a previous PR, that made fullnode configs not apply (and overwrite validator configs)

### Test Plan

Ran a fullnode test and manually check the config that is logged.
