### PR TITLE
Replacing aggregator v2 identifiers with values before transaction commitment

### DIFF
--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -156,7 +156,7 @@ struct GroupRead<T: Transaction> {
 #[derive(Derivative)]
 #[derivative(Default(bound = "", new = "true"))]
 pub(crate) struct CapturedReads<T: Transaction> {
-    pub(crate) data_reads: HashMap<T::Key, DataRead<T::Value>>,
+    data_reads: HashMap<T::Key, DataRead<T::Value>>,
     group_reads: HashMap<T::Key, GroupRead<T>>,
     // Currently, we record paths for triggering module R/W fallback.
     // TODO: implement a general functionality once the fallback is removed.
@@ -184,6 +184,15 @@ enum UpdateResult {
 }
 
 impl<T: Transaction> CapturedReads<T> {
+    // Return an iterator over the captured reads.
+    pub(crate) fn get_read_values_with_delayed_fields(
+        &self,
+    ) -> impl Iterator<Item = (&T::Key, &DataRead<T::Value>)> {
+        self.data_reads
+            .iter()
+            .filter(|(_, v)| matches!(v, DataRead::Versioned(_, _, Some(_))))
+    }
+
     // Given a hashmap entry for a key, incorporate a new DataRead. This checks
     // consistency and ensures that the most comprehensive read is recorded.
     fn update_entry<K, V: TransactionWrite>(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -439,7 +439,7 @@ where
         txn_idx: TxnIndex,
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         latest_view: &LatestView<T, S, X>,
-    ) {
+    ) -> HashMap<T::Key, T::Value> {
         // For each delayed field in resource write set, replace the identifiers with values.
         let mut write_set_keys = HashSet::new();
         let resource_write_set = last_input_output.resource_write_set(txn_idx);

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -432,14 +432,6 @@ where
                 }
                 break;
             }
-
-            // Remark: When early halting the BlockSTM, we have to make sure the current / new tasks
-            // will be properly handled by the threads. For instance, it is possible that the committing
-            // thread holds an execution task of ExecutionTaskType::Wakeup(DependencyCondvar) for some
-            // other thread pending on the dependency conditional variable from the last iteration. If
-            // the committing thread early halts BlockSTM and resets its scheduler_task to be Done, the
-            // pending thread will be pending on read forever. In other words, we rely on the committing
-            // thread to wake up the pending execution thread, if the committing thread holds the Wakeup task.
         }
     }
 


### PR DESCRIPTION
### Description

Replacing aggregator v2 identifiers with values before transaction commitment. Finishing some of the TODOs and PR comments on the previous PR.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
