### PR TITLE
[Python SDK] Use AccountAddress.from_str_relaxed when parsing addresses from the node API

### DIFF
--- a/ecosystem/python/sdk/aptos_sdk/account.py
+++ b/ecosystem/python/sdk/aptos_sdk/account.py
@@ -49,7 +49,7 @@ class Account:
         with open(path) as file:
             data = json.load(file)
         return Account(
-            AccountAddress.from_str(data["account_address"]),
+            AccountAddress.from_str_relaxed(data["account_address"]),
             ed25519.PrivateKey.from_str(data["private_key"]),
         )
 

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -27,7 +27,7 @@ class Object:
     def parse(resource: dict[str, Any]) -> Object:
         return Object(
             resource["allow_ungated_transfer"],
-            AccountAddress.from_str(resource["owner"]),
+            AccountAddress.from_str_relaxed(resource["owner"]),
         )
 
     def __str__(self) -> str:
@@ -54,7 +54,7 @@ class Collection:
     @staticmethod
     def parse(resource: dict[str, Any]) -> Collection:
         return Collection(
-            AccountAddress.from_str(resource["creator"]),
+            AccountAddress.from_str_relaxed(resource["creator"]),
             resource["description"],
             resource["name"],
             resource["uri"],
@@ -81,7 +81,7 @@ class Royalty:
         return Royalty(
             resource["numerator"],
             resource["denominator"],
-            AccountAddress.from_str(resource["payee_address"]),
+            AccountAddress.from_str_relaxed(resource["payee_address"]),
         )
 
 
@@ -114,7 +114,7 @@ class Token:
     @staticmethod
     def parse(resource: dict[str, Any]):
         return Token(
-            AccountAddress.from_str(resource["collection"]["inner"]),
+            AccountAddress.from_str_relaxed(resource["collection"]["inner"]),
             int(resource["index"]),
             resource["description"],
             resource["name"],
@@ -626,5 +626,5 @@ class AptosTokenClient:
         for event in output["events"]:
             if event["type"] != "0x4::collection::MintEvent":
                 continue
-            mints.append(AccountAddress.from_str(event["data"]["token"]))
+            mints.append(AccountAddress.from_str_relaxed(event["data"]["token"]))
         return mints

--- a/ecosystem/python/sdk/examples/rotate_key.py
+++ b/ecosystem/python/sdk/examples/rotate_key.py
@@ -40,7 +40,7 @@ async def rotate_auth_key_ed_25519_payload(
             from_account.address()
         ),
         originator=from_account.address(),
-        current_auth_key=AccountAddress.from_str(from_account.auth_key()),
+        current_auth_key=AccountAddress.from_str_relaxed(from_account.auth_key()),
         new_public_key=to_account.public_key().key.encode(),
     )
 


### PR DESCRIPTION
### Description
@xbtmatt pointed out that the token client fails to parse the account addresses in resources sometimes: https://aptos-org.slack.com/archives/C05UCAA0YKW/p1696372884560539. The reason is the node API returns addresses in a non-AIP-40-compliant manner, namely that it shortens addresses unconditionally (the standard states it should only do this for special addresses). As such, any time we parse an account address from the node API we should use `from_str_relaxed`.

I checked all other uses of AccountAddress.from_str in the SDK to make sure they're valid too.

### Test Plan
I ran the examples like 20 times and they always passed:
```
export APTOS_NODE_URL='http://127.0.0.1:8080/v1'
export APTOS_FAUCET_URL='http://127.0.0.1:8081'
make examples
```
