### PR TITLE
[docker] Set image hash to multiplatform ones

### DIFF
--- a/docker/builder/debian-base.Dockerfile
+++ b/docker/builder/debian-base.Dockerfile
@@ -2,8 +2,10 @@
 
 FROM debian AS debian-base
 
+ARG TARGETARCH
+
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # Add Tini to make sure the binaries receive proper SIGTERM signals when Docker is shut down
-ADD --chmod=755 https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+ADD --chmod=755 https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH /tini
 ENTRYPOINT ["/tini", "--"]

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -69,7 +69,8 @@ group "forge-images" {
 target "debian-base" {
   dockerfile = "docker/builder/debian-base.Dockerfile"
   contexts = {
-    debian = "docker-image://debian:bullseye@sha256:9d23db14fbdc095689c423af56b9525538de139a1bbe950b4f0467698fb874d2"
+    # Run `docker buildx imagetools inspect debian:bullseye` to find the latest multi-platform hash
+    debian = "docker-image://debian:bullseye@sha256:54d33aaad0bc936a9a40d856764c7bc35c0afaa9cab51f88bb95f6cd8004438d"
   }
 }
 
@@ -78,7 +79,8 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    rust = "docker-image://rust:1.72.1-bullseye@sha256:6562d50b62366d5b9db92b34c6684fab5bf3b9f627e59a863c9c0675760feed4"
+    # Run `docker buildx imagetools inspect rust:1.72.1-bullseye` to find the latest multi-platform hash
+    rust = "docker-image://rust:1.72.1-bullseye@sha256:9e3b35bd7a1f8f534acc033f02170f68e1dfc18ecdb9cfd3c1e2e148bdd6e039"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -13,9 +13,12 @@ IMAGES = {
     "rust": "rust:1.72.1-bullseye",
 }
 
+
 def update() -> int:
     script_dir = os.path.dirname(os.path.realpath(__file__))
-    dockerfile_path = os.path.join(script_dir, "..", "docker", "builder", "docker-bake-rust-all.hcl")
+    dockerfile_path = os.path.join(
+        script_dir, "..", "docker", "builder", "docker-bake-rust-all.hcl"
+    )
 
     update_exists = False
 
@@ -23,20 +26,22 @@ def update() -> int:
         manifest = None
         digest = None
         current_digest = None
-        regex = f"{base_image} = \"docker-image://{image_name}.*\""
+        regex = f'{base_image} = "docker-image://{image_name}.*"'
 
         print(f"Update {image_name}")
-        manifest_inspect = subprocess.check_output(["docker", "manifest", "inspect", image_name])
-        manifest = json.loads(manifest_inspect)
-
-        if manifest == None:
-            print(f"Unable to find manifest for {image_name}")
-            continue
-
-        for m in manifest["manifests"]:
-            if m["platform"]["architecture"] == ARCH and m["platform"]["os"] == OS:
-                digest = m["digest"]
-                break
+        # Note space before {{ in --format is important.
+        digest = subprocess.check_output(
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "inspect",
+                image_name,
+                "--format",
+                " {{.Manifest.Digest}}",
+            ]
+        )
+        digest = digest.strip().decode("utf-8")
 
         if digest == None:
             print(f"Unable to find digest for {image_name}")
@@ -48,9 +53,9 @@ def update() -> int:
 
         for line in dockerfile_content.splitlines():
             if re.search(regex, line):
-                current_digest = line.split("@")[1].split("\"")[0]
+                current_digest = line.split("@")[1].split('"')[0]
                 break
-            
+
         if current_digest == None:
             print(f"Unable to find current_digest for {image_name}")
             continue
@@ -60,7 +65,11 @@ def update() -> int:
             continue
 
         print(f"Found update for {image_name}: {current_digest} -> {digest}")
-        dockerfile_content = re.sub(regex, f"{base_image} = \"docker-image://{image_name}@{digest}\"", dockerfile_content)
+        dockerfile_content = re.sub(
+            regex,
+            f'{base_image} = "docker-image://{image_name}@{digest}"',
+            dockerfile_content,
+        )
 
         with open(dockerfile_path, "w") as f:
             f.write(dockerfile_content)
@@ -68,6 +77,7 @@ def update() -> int:
         update_exists = True
 
     return update_exists
+
 
 def write_github_output(key, value) -> None:
     print(f"GITHUB_OUTPUT: {key}={value}")


### PR DESCRIPTION
### Description

Currently, our docker builders can only build linux/amd64 images because we hardcode base-image SHA hashes to linux/amd64 ones. But, what we really should be using are the multi-platform image hashes from the `docker buildx imagetools inspect` tool. This PR updates those hashes.

This will allow us to build images for both macos/arm and linux/amd.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Wait for CI
