### PR TITLE
[CLI] Use JoinSet rather than a vec of JoinHandles

### DIFF
--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -4,9 +4,7 @@
 use super::health_checker::HealthChecker;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::FutureExt;
 use std::{collections::HashSet, fmt::Debug};
-use tokio::task::JoinHandle;
 use tracing::warn;
 
 #[async_trait]
@@ -40,32 +38,28 @@ pub trait ServiceManager: Debug + Send + Sync + 'static {
     fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker>;
 
     /// This is the function we use from the outside to start the service. It makes
-    /// sure all the prerequisite services have started and then spawns a tokio task to
-    /// run the service. The user should never need to override this implementation.
-    fn run(self: Box<Self>) -> JoinHandle<()> {
+    /// sure all the prerequisite services have started and then calls the inner
+    /// function to run the service. The user should never need to override this
+    /// implementation.
+    async fn run(self: Box<Self>) -> Result<()> {
         // We make a new function here so that each task waits for its prereqs within
         // its own run function. This way we can start each service in any order.
         let name = self.get_name();
         let name_clone = name.to_string();
-        let future = async move {
-            for health_checker in self.get_prerequisite_health_checkers() {
-                health_checker
-                    .wait(Some(&self.get_name()))
-                    .await
-                    .context("Prerequisite service did not start up successfully")?;
-            }
-            self.run_service()
+        for health_checker in self.get_prerequisite_health_checkers() {
+            health_checker
+                .wait(Some(&self.get_name()))
                 .await
-                .context("Service ended with an error")?;
-            warn!(
-                "Service {} ended unexpectedly without any error",
-                name_clone
-            );
-            Ok(())
-        };
-        tokio::spawn(future.map(move |result: Result<()>| {
-            warn!("{} stopped unexpectedly {:#?}", name, result);
-        }))
+                .context("Prerequisite service did not start up successfully")?;
+        }
+        self.run_service()
+            .await
+            .context("Service ended with an error")?;
+        warn!(
+            "Service {} ended unexpectedly without any error",
+            name_clone
+        );
+        Ok(())
     }
 
     /// The ServiceManager may return PostHealthySteps. The tool will run these after


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/10333
- Next in stack: N/A

### Description
Tokio already has a way to spawn a bunch of tasks and manager them together, the JoinSet. This PR makes us use that instead of a vec of JoinHandles. I also make us use task IDs, which simplify figuring out which task ended.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api
```

I tested that ctrl-C and friends work as expected.