### PR TITLE
[agg_v2] Adding aggregator_v2.move with sequential (fallback) logic

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -201,10 +201,17 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [aggregator_destroy_base: InternalGas, "aggregator.destroy.base", 10000],
         [aggregator_factory_new_aggregator_base: InternalGas, "aggregator_factory.new_aggregator.base", 10000],
 
+        [aggregator_v2_create_aggregator_base: InternalGas, {12.. => "aggregator_v2.create_aggregator.base"}, 10000],
+        [aggregator_v2_try_add_base: InternalGas, {12.. => "aggregator_v2.try_add.base"}, 6000],
+        [aggregator_v2_try_sub_base: InternalGas, {12.. => "aggregator_v2.try_sub.base"}, 6000],
+        [aggregator_v2_read_base: InternalGas, {12.. => "aggregator_v2.read.base"}, 12000],
+        [aggregator_v2_snapshot_base: InternalGas, {12.. => "aggregator_v2.snapshot.base"}, 6000],
+
         [aggregator_v2_create_snapshot_base: InternalGas, {11.. => "aggregator_v2.create_snapshot.base"}, 6000],
         [aggregator_v2_copy_snapshot_base: InternalGas, {11.. => "aggregator_v2.copy_snapshot.base"}, 6000],
-        [aggregator_v2_read_snapshot_base: InternalGas, {11.. => "aggregator_v2.read_snapshot.base"}, 6000],
+        [aggregator_v2_read_snapshot_base: InternalGas, {11.. => "aggregator_v2.read_snapshot.base"}, 12000],
         [aggregator_v2_string_concat_base: InternalGas, {11.. => "aggregator_v2.string_concat.base"}, 6000],
+        [aggregator_v2_string_concat_per_byte: InternalGasPerByte, { 12.. =>"aggregator_v2.string_concat.per_byte" }, 20],
 
         [object_exists_at_base: InternalGas, { 7.. => "object.exists_at.base" }, 5000],
         // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -6,9 +6,12 @@ use crate::{
         initialize, verify_copy_snapshot, verify_copy_string_snapshot, verify_string_concat,
         verify_string_snapshot_concat,
     },
-    assert_success,
+    assert_abort, assert_success,
     tests::common,
     MoveHarness,
+};
+use aptos_framework::natives::aggregator_natives::aggregator_v2::{
+    EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED, EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
 };
 use aptos_language_e2e_tests::account::Account;
 
@@ -20,14 +23,14 @@ fn setup() -> (MoveHarness, Account) {
 fn test_copy_snapshot() {
     let (mut h, acc) = setup();
     let txn = verify_copy_snapshot(&mut h, &acc);
-    assert_success!(h.run(txn));
+    assert_abort!(h.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
 }
 
 #[test]
 fn test_copy_string_snapshot() {
     let (mut h, acc) = setup();
     let txn = verify_copy_string_snapshot(&mut h, &acc);
-    assert_success!(h.run(txn));
+    assert_abort!(h.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
 }
 
 #[test]
@@ -41,5 +44,5 @@ fn test_string_concat() {
 fn test_string_snapshot_concat() {
     let (mut h, acc) = setup();
     let txn = verify_string_snapshot_concat(&mut h, &acc);
-    assert_success!(h.run(txn));
+    assert_abort!(h.run(txn), EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE);
 }

--- a/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
@@ -34,6 +34,7 @@ operation that also reduced parallelism, and should be avoided as much as possib
 -  [Function `test_aggregator_valid_type`](#0x1_aggregator_v2_test_aggregator_valid_type)
 -  [Specification](#@Specification_1)
     -  [Function `create_aggregator`](#@Specification_1_create_aggregator)
+    -  [Function `create_unbounded_aggregator`](#@Specification_1_create_unbounded_aggregator)
     -  [Function `try_add`](#@Specification_1_try_add)
     -  [Function `try_sub`](#@Specification_1_try_sub)
     -  [Function `read`](#@Specification_1_read)
@@ -56,7 +57,7 @@ operation that also reduced parallelism, and should be avoided as much as possib
 Represents an integer which supports parallel additions and subtractions
 across multiple transactions. See the module description for more details.
 
-Currently supported types for Element are u64 and u128.
+Currently supported types for IntElement are u64 and u128.
 
 
 <pre><code><b>struct</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt; <b>has</b> drop, store
@@ -164,7 +165,7 @@ and any calls will raise this error.
 
 <a name="0x1_aggregator_v2_ECONCAT_STRING_LENGTH_TOO_LARGE"></a>
 
-Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together)
+Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together).
 
 
 <pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_ECONCAT_STRING_LENGTH_TOO_LARGE">ECONCAT_STRING_LENGTH_TOO_LARGE</a>: u64 = 8;
@@ -223,7 +224,7 @@ Returns <code>max_value</code> exceeding which aggregator overflows.
 
 Creates new aggregator, with given 'max_value'.
 
-Currently supported types for Element are u64 and u128.
+Currently supported types for IntElement are u64 and u128.
 EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
 
 
@@ -250,7 +251,7 @@ EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
 Creates new aggregator, without any 'max_value' on top of the implicit bound restriction
 due to the width of the type (i.e. MAX_U64 for u64, MAX_U128 for u128).
 
-Currently supported types for Element are u64 and u128.
+Currently supported types for IntElement are u64 and u128.
 EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
 
 
@@ -521,7 +522,7 @@ If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_test_aggregator_valid_type">test_aggregator_valid_type</a>()
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_test_aggregator_valid_type">test_aggregator_valid_type</a>()
 </code></pre>
 
 
@@ -530,7 +531,7 @@ If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_test_aggregator_valid_type">test_aggregator_valid_type</a>() {
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_test_aggregator_valid_type">test_aggregator_valid_type</a>() {
     <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;u64&gt;();
     <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;u128&gt;();
     <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;u64&gt;(5);
@@ -553,6 +554,22 @@ If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(max_value: IntElement): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_create_unbounded_aggregator"></a>
+
+### Function `create_unbounded_aggregator`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
@@ -3,28 +3,96 @@
 
 # Module `0x1::aggregator_v2`
 
-This module provides an interface for aggregators (version 2).
-Only skeleton - for AggregagtorSnapshot - is provided at this time,
-to allow transition of usages.
+This module provides an interface for aggregators (version 2). Aggregators are
+similar to unsigned integers and support addition and subtraction (aborting on
+underflow or on overflowing a custom upper limit). The difference from integers
+is that aggregators allow to perform both additions and subtractions in parallel
+across multiple transactions, enabling parallel execution. For example, if the
+first transaction is doing <code><a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(X, 1)</code> for aggregator <code>X</code>, and the second is
+doing <code><a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(X,3)</code>, they can be executed in parallel avoiding a read-modify-write
+dependency.
+However, reading the aggregator value (i.e. calling <code><a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>(X)</code>) is an expensive
+operation and should be avoided as much as possible because it reduces the
+parallelism.
 
 
+-  [Struct `Aggregator`](#0x1_aggregator_v2_Aggregator)
 -  [Struct `AggregatorSnapshot`](#0x1_aggregator_v2_AggregatorSnapshot)
 -  [Constants](#@Constants_0)
+-  [Function `max_value`](#0x1_aggregator_v2_max_value)
+-  [Function `create_aggregator`](#0x1_aggregator_v2_create_aggregator)
+-  [Function `create_unbounded_aggregator`](#0x1_aggregator_v2_create_unbounded_aggregator)
+-  [Function `try_add`](#0x1_aggregator_v2_try_add)
+-  [Function `add`](#0x1_aggregator_v2_add)
+-  [Function `try_sub`](#0x1_aggregator_v2_try_sub)
+-  [Function `sub`](#0x1_aggregator_v2_sub)
+-  [Function `read`](#0x1_aggregator_v2_read)
+-  [Function `snapshot`](#0x1_aggregator_v2_snapshot)
 -  [Function `create_snapshot`](#0x1_aggregator_v2_create_snapshot)
 -  [Function `copy_snapshot`](#0x1_aggregator_v2_copy_snapshot)
 -  [Function `read_snapshot`](#0x1_aggregator_v2_read_snapshot)
 -  [Function `string_concat`](#0x1_aggregator_v2_string_concat)
+-  [Specification](#@Specification_1)
+    -  [Function `create_aggregator`](#@Specification_1_create_aggregator)
+    -  [Function `try_add`](#@Specification_1_try_add)
+    -  [Function `try_sub`](#@Specification_1_try_sub)
+    -  [Function `read`](#@Specification_1_read)
+    -  [Function `snapshot`](#@Specification_1_snapshot)
+    -  [Function `create_snapshot`](#@Specification_1_create_snapshot)
+    -  [Function `copy_snapshot`](#@Specification_1_copy_snapshot)
+    -  [Function `string_concat`](#@Specification_1_string_concat)
 
 
-<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
 </code></pre>
 
 
+
+<a name="0x1_aggregator_v2_Aggregator"></a>
+
+## Struct `Aggregator`
+
+Represents an integer which supports parallel additions and subtractions
+across multiple transactions. See the module description for more details.
+
+Currently supported types for Element are u64 and u128.
+
+
+<pre><code><b>struct</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: IntElement</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>max_value: IntElement</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
 
 <a name="0x1_aggregator_v2_AggregatorSnapshot"></a>
 
 ## Struct `AggregatorSnapshot`
 
+Represents a constant value, that was derived from an aggregator at given instant in time.
+Unlike read() and storing the value directly, this enables parallel execution of transactions,
+while storing snapshot of aggregator state elsewhere.
 
 
 <pre><code><b>struct</b> <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;Element&gt; <b>has</b> drop, store
@@ -53,12 +121,53 @@ to allow transition of usages.
 ## Constants
 
 
+<a name="0x1_aggregator_v2_EAGGREGATOR_OVERFLOW"></a>
+
+The value of aggregator overflows. Raised by uncoditional add() call
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_OVERFLOW">EAGGREGATOR_OVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW"></a>
+
+The value of aggregator underflows (goes below zero). Raised by uncoditional sub() call
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW">EAGGREGATOR_UNDERFLOW</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED"></a>
+
+The native aggregator function, that is in the move file, is not yet supported.
+and any calls will raise this error.
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED">EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED</a>: u64 = 9;
+</code></pre>
+
+
+
 <a name="0x1_aggregator_v2_EAGGREGATOR_SNAPSHOTS_NOT_ENABLED"></a>
 
 The aggregator snapshots feature flag is not enabled.
 
 
 <pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_SNAPSHOTS_NOT_ENABLED">EAGGREGATOR_SNAPSHOTS_NOT_ENABLED</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_ECONCAT_STRING_LENGTH_TOO_LARGE"></a>
+
+Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together)
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_ECONCAT_STRING_LENGTH_TOO_LARGE">ECONCAT_STRING_LENGTH_TOO_LARGE</a>: u64 = 8;
 </code></pre>
 
 
@@ -73,10 +182,244 @@ The generic type supplied to the aggregator snapshot is not supported.
 
 
 
+<a name="0x1_aggregator_v2_EUNSUPPORTED_AGGREGATOR_TYPE"></a>
+
+The generic type supplied to the aggregator is not supported.
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EUNSUPPORTED_AGGREGATOR_TYPE">EUNSUPPORTED_AGGREGATOR_TYPE</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_max_value"></a>
+
+## Function `max_value`
+
+Returns <code>max_value</code> exceeding which aggregator overflows.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_max_value">max_value</a>&lt;IntElement: <b>copy</b>, drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;): IntElement
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_max_value">max_value</a>&lt;IntElement: <b>copy</b> + drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;): IntElement {
+    <a href="aggregator.md#0x1_aggregator">aggregator</a>.max_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_create_aggregator"></a>
+
+## Function `create_aggregator`
+
+Creates new aggregator, with given 'max_value'.
+
+Currently supported types for Element are u64 and u128.
+EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(max_value: IntElement): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;IntElement: <b>copy</b> + drop&gt;(max_value: IntElement): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_create_unbounded_aggregator"></a>
+
+## Function `create_unbounded_aggregator`
+
+Creates new aggregator, without any 'max_value' on top of the implicit bound restriction
+due to the width of the type (i.e. MAX_U64 for u64, MAX_U128 for u128).
+
+Currently supported types for Element are u64 and u128.
+EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement: <b>copy</b> + drop&gt;(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_try_add"></a>
+
+## Function `try_add`
+
+Adds <code>value</code> to aggregator.
+If addition would exceed the max_value, <code><b>false</b></code> is returned, and aggregator value is left unchanged.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_add"></a>
+
+## Function `add`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement) {
+    <b>assert</b>!(<a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_OVERFLOW">EAGGREGATOR_OVERFLOW</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_try_sub"></a>
+
+## Function `try_sub`
+
+Subtracts <code>value</code> from aggregator.
+If subtraction would result in a negative value, <code><b>false</b></code> is returned, and aggregator value is left unchanged.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_sub"></a>
+
+## Function `sub`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement) {
+    <b>assert</b>!(<a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW">EAGGREGATOR_UNDERFLOW</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_read"></a>
+
+## Function `read`
+
+Returns a value stored in this aggregator.
+Note: This operation prevents parallelism of the transaction that calls it.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;): IntElement
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;): IntElement;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_snapshot"></a>
+
+## Function `snapshot`
+
+Returns a wrapper of a current value of an aggregator
+Unlike read(), this enables parallel execution of transactions.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot">snapshot</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot">snapshot</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;IntElement&gt;;
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_aggregator_v2_create_snapshot"></a>
 
 ## Function `create_snapshot`
 
+Creates a snapshot of a given value.
+Useful for when object is sometimes created via snapshot() or string_concat(), and sometimes directly.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>&lt;Element: <b>copy</b>, drop&gt;(value: Element): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;
@@ -99,6 +442,7 @@ The generic type supplied to the aggregator snapshot is not supported.
 
 ## Function `copy_snapshot`
 
+NOT YET IMPLEMENTED, always raises EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_copy_snapshot">copy_snapshot</a>&lt;Element: <b>copy</b>, drop&gt;(snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;
@@ -121,6 +465,8 @@ The generic type supplied to the aggregator snapshot is not supported.
 
 ## Function `read_snapshot`
 
+Returns a value stored in this snapshot.
+Note: This operation prevents parallelism of the transaction that calls it.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_read_snapshot">read_snapshot</a>&lt;Element&gt;(snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;): Element
@@ -143,9 +489,13 @@ The generic type supplied to the aggregator snapshot is not supported.
 
 ## Function `string_concat`
 
+Concatenates <code>before</code>, <code>snapshot</code> and <code>after</code> into a single string.
+snapshot passed needs to have integer type - currently supported types are u64 and u128.
+Raises EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE if called with another type.
+If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_TOO_LARGE is raised.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_string_concat">string_concat</a>&lt;Element&gt;(before: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;, after: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_string_concat">string_concat</a>&lt;IntElement&gt;(before: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;IntElement&gt;, after: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;
 </code></pre>
 
 
@@ -154,12 +504,143 @@ The generic type supplied to the aggregator snapshot is not supported.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_string_concat">string_concat</a>&lt;Element&gt;(before: String, snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;Element&gt;, after: String): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;String&gt;;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_string_concat">string_concat</a>&lt;IntElement&gt;(before: String, snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;IntElement&gt;, after: String): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;String&gt;;
 </code></pre>
 
 
 
 </details>
+
+<a name="@Specification_1"></a>
+
+## Specification
+
+
+<a name="@Specification_1_create_aggregator"></a>
+
+### Function `create_aggregator`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(max_value: IntElement): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_try_add"></a>
+
+### Function `try_add`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_try_sub"></a>
+
+### Function `try_sub`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_read"></a>
+
+### Function `read`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;): IntElement
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_snapshot"></a>
+
+### Function `snapshot`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot">snapshot</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_create_snapshot"></a>
+
+### Function `create_snapshot`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>&lt;Element: <b>copy</b>, drop&gt;(value: Element): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_copy_snapshot"></a>
+
+### Function `copy_snapshot`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_copy_snapshot">copy_snapshot</a>&lt;Element: <b>copy</b>, drop&gt;(snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;Element&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_string_concat"></a>
+
+### Function `string_concat`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_string_concat">string_concat</a>&lt;IntElement&gt;(before: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, snapshot: &<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;IntElement&gt;, after: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
 
 
 [move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
@@ -1,8 +1,23 @@
-/// This module provides an interface for aggregators (version 2).
-/// Only skeleton - for AggregagtorSnapshot - is provided at this time,
-/// to allow transition of usages.
+/// This module provides an interface for aggregators (version 2). Aggregators are
+/// similar to unsigned integers and support addition and subtraction (aborting on
+/// underflow or on overflowing a custom upper limit). The difference from integers
+/// is that aggregators allow to perform both additions and subtractions in parallel
+/// across multiple transactions, enabling parallel execution. For example, if the
+/// first transaction is doing `try_add(X, 1)` for aggregator `X`, and the second is
+/// doing `try_sub(X,3)`, they can be executed in parallel avoiding a read-modify-write
+/// dependency.
+/// However, reading the aggregator value (i.e. calling `read(X)`) is an expensive
+/// operation and should be avoided as much as possible because it reduces the
+/// parallelism.
 module aptos_framework::aggregator_v2 {
+    use std::error;
     use std::string::String;
+
+    /// The value of aggregator overflows. Raised by uncoditional add() call
+    const EAGGREGATOR_OVERFLOW: u64 = 1;
+
+    /// The value of aggregator underflows (goes below zero). Raised by uncoditional sub() call
+    const EAGGREGATOR_UNDERFLOW: u64 = 2;
 
     /// The generic type supplied to the aggregator snapshot is not supported.
     const EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE: u64 = 5;
@@ -10,88 +25,174 @@ module aptos_framework::aggregator_v2 {
     /// The aggregator snapshots feature flag is not enabled.
     const EAGGREGATOR_SNAPSHOTS_NOT_ENABLED: u64 = 6;
 
+    /// The generic type supplied to the aggregator is not supported.
+    const EUNSUPPORTED_AGGREGATOR_TYPE: u64 = 7;
+
+    /// Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together)
+    const ECONCAT_STRING_LENGTH_TOO_LARGE: u64 = 8;
+
+    /// The native aggregator function, that is in the move file, is not yet supported.
+    /// and any calls will raise this error.
+    const EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED: u64 = 9;
+
+    /// Represents an integer which supports parallel additions and subtractions
+    /// across multiple transactions. See the module description for more details.
+    ///
+    /// Currently supported types for Element are u64 and u128.
+    struct Aggregator<IntElement> has store {
+        value: IntElement,
+        max_value: IntElement,
+    }
+
+    /// Represents a constant value, that was derived from an aggregator at given instant in time.
+    /// Unlike read() and storing the value directly, this enables parallel execution of transactions,
+    /// while storing snapshot of aggregator state elsewhere.
     struct AggregatorSnapshot<Element> has store, drop {
         value: Element,
     }
 
+    /// Returns `max_value` exceeding which aggregator overflows.
+    public fun max_value<IntElement: copy + drop>(aggregator: &Aggregator<IntElement>): IntElement {
+        aggregator.max_value
+    }
+
+    /// Creates new aggregator, with given 'max_value'.
+    ///
+    /// Currently supported types for Element are u64 and u128.
+    /// EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
+    public native fun create_aggregator<IntElement: copy + drop>(max_value: IntElement): Aggregator<IntElement>;
+
+    /// Creates new aggregator, without any 'max_value' on top of the implicit bound restriction
+    /// due to the width of the type (i.e. MAX_U64 for u64, MAX_U128 for u128).
+    ///
+    /// Currently supported types for Element are u64 and u128.
+    /// EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
+    public native fun create_unbounded_aggregator<IntElement: copy + drop>(): Aggregator<IntElement>;
+
+    /// Adds `value` to aggregator.
+    /// If addition would exceed the max_value, `false` is returned, and aggregator value is left unchanged.
+    public native fun try_add<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement): bool;
+
+    // Adds `value` to aggregator, uncoditionally.
+    // If addition would exceed the max_value, EAGGREGATOR_OVERFLOW exception will be thrown
+    public fun add<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement) {
+        assert!(try_add(aggregator, value), error::out_of_range(EAGGREGATOR_OVERFLOW));
+    }
+
+    /// Subtracts `value` from aggregator.
+    /// If subtraction would result in a negative value, `false` is returned, and aggregator value is left unchanged.
+    public native fun try_sub<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement): bool;
+
+    // Adds `value` to aggregator, uncoditionally.
+    // If subtraction would result in a negative value, EAGGREGATOR_UNDERFLOW exception will be thrown
+    public fun sub<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement) {
+        assert!(try_sub(aggregator, value), error::out_of_range(EAGGREGATOR_UNDERFLOW));
+    }
+
+    /// Returns a value stored in this aggregator.
+    /// Note: This operation prevents parallelism of the transaction that calls it.
+    public native fun read<IntElement>(aggregator: &Aggregator<IntElement>): IntElement;
+
+    /// Returns a wrapper of a current value of an aggregator
+    /// Unlike read(), this enables parallel execution of transactions.
+    public native fun snapshot<IntElement>(aggregator: &Aggregator<IntElement>): AggregatorSnapshot<IntElement>;
+
+    /// Creates a snapshot of a given value.
+    /// Useful for when object is sometimes created via snapshot() or string_concat(), and sometimes directly.
     public native fun create_snapshot<Element: copy + drop>(value: Element): AggregatorSnapshot<Element>;
 
+    /// NOT YET IMPLEMENTED, always raises EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED.
     public native fun copy_snapshot<Element: copy + drop>(snapshot: &AggregatorSnapshot<Element>): AggregatorSnapshot<Element>;
 
+    /// Returns a value stored in this snapshot.
+    /// Note: This operation prevents parallelism of the transaction that calls it.
     public native fun read_snapshot<Element>(snapshot: &AggregatorSnapshot<Element>): Element;
 
-    public native fun string_concat<Element>(before: String, snapshot: &AggregatorSnapshot<Element>, after: String): AggregatorSnapshot<String>;
+    /// Concatenates `before`, `snapshot` and `after` into a single string.
+    /// snapshot passed needs to have integer type - currently supported types are u64 and u128.
+    /// Raises EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE if called with another type.
+    /// If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_TOO_LARGE is raised.
+    public native fun string_concat<IntElement>(before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String): AggregatorSnapshot<String>;
+
+    #[test(_fx = @std)]
+    public fun test_correct_read(_fx: &signer) {
+        // use std::features;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
+
+        let snapshot = create_snapshot(42);
+        // copy not yet supported
+        // let snapshot2 = copy_snapshot(&snapshot);
+        assert!(read_snapshot(&snapshot) == 42, 0);
+        // assert!(read_snapshot(&snapshot2) == 42, 0);
+    }
+
+    #[test(_fx = @std)]
+    public fun test_correct_read_string(_fx: &signer) {
+        // use std::features;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
+
+        let snapshot = create_snapshot(std::string::utf8(b"42"));
+        // copy not yet supported
+        // let snapshot2 = copy_snapshot(&snapshot);
+        assert!(read_snapshot(&snapshot) == std::string::utf8(b"42"), 0);
+        // assert!(read_snapshot(&snapshot2) == std::string::utf8(b"42"), 0);
+    }
+
+    #[test(_fx = @std)]
+    public fun test_string_concat1(_fx: &signer) {
+        // use std::features;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
+
+        let snapshot = create_snapshot(42);
+        let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
+        assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
+    }
+
+    #[test(_fx = @std)]
+    #[expected_failure(abort_code = 0x030005, location = Self)]
+    public fun test_string_concat2(_fx: &signer) {
+        // use std::features;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
+
+        let snapshot = create_snapshot<String>(std::string::utf8(b"42"));
+        let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
+        read_snapshot(&snapshot2);
+        // String concatenation not supported
+        // assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
+    }
 
     // #[test(fx = @std)]
-    // public fun test_correct_read(fx: &signer) {
-    //     use std::features;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
-
-    //     let snapshot = create_snapshot(42);
-    //     let snapshot2 = copy_snapshot(&snapshot);
-    //     assert!(read_snapshot(&snapshot) == 42, 0);
-    //     assert!(read_snapshot(&snapshot2) == 42, 0);
-    // }
-
-    // #[test(fx = @std)]
-    // public fun test_correct_read_string(fx: &signer) {
-    //     use std::features;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
-
-    //     let snapshot = create_snapshot(std::string::utf8(b"42"));
-    //     let snapshot2 = copy_snapshot(&snapshot);
-    //     assert!(read_snapshot(&snapshot) == std::string::utf8(b"42"), 0);
-    //     assert!(read_snapshot(&snapshot2) == std::string::utf8(b"42"), 0);
-    // }
-
-    // #[test(fx = @std)]
-    // public fun test_string_concat1(fx: &signer) {
-    //     use std::features;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
-
-    //     let snapshot = create_snapshot(42);
-    //     let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
-    //     assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
-    // }
-
-    // #[test(fx = @std)]
-    // public fun test_string_concat2(fx: &signer) {
-    //     use std::features;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
-
-    //     let snapshot = create_snapshot<String>(std::string::utf8(b"42"));
-    //     let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
-    //     assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
-    // }
-
-    // #[test]
     // #[expected_failure(abort_code = 0x030006, location = Self)]
-    // public fun test_snapshot_feature_not_enabled() {
+    // public fun test_snapshot_feature_not_enabled(fx: &signer) {
+    //     use std::features;
+    //     let feature = features::get_aggregator_v2_api_feature();
+    //     features::change_feature_flags(fx, vector[], vector[feature]);
+
     //     create_snapshot(42);
     // }
 
-    // #[test(fx = @std)]
-    // #[expected_failure(abort_code = 0x030005, location = Self)]
-    // public fun test_snpashot_invalid_type1(fx: &signer) {
-    //     use std::features;
-    //     use std::option;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
+    #[test(_fx = @std)]
+    #[expected_failure(abort_code = 0x030005, location = Self)]
+    public fun test_snpashot_invalid_type1(_fx: &signer) {
+        // use std::features;
+        use std::option;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
 
-    //     create_snapshot(option::some(42));
-    // }
+        create_snapshot(option::some(42));
+    }
 
-    // #[test(fx = @std)]
-    // #[expected_failure(abort_code = 0x030005, location = Self)]
-    // public fun test_snpashot_invalid_type2(fx: &signer) {
-    //     use std::features;
-    //     let feature = features::get_aggregator_snapshots_feature();
-    //     features::change_feature_flags(fx, vector[feature], vector[]);
+    #[test(_fx = @std)]
+    #[expected_failure(abort_code = 0x030005, location = Self)]
+    public fun test_snpashot_invalid_type2(_fx: &signer) {
+        // use std::features;
+        // let feature = features::get_aggregator_v2_api_feature();
+        // features::change_feature_flags(fx, vector[feature], vector[]);
 
-    //     create_snapshot(vector[42]);
-    // }
+        create_snapshot(vector[42]);
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
@@ -6,9 +6,8 @@
 /// first transaction is doing `try_add(X, 1)` for aggregator `X`, and the second is
 /// doing `try_sub(X,3)`, they can be executed in parallel avoiding a read-modify-write
 /// dependency.
-/// However, reading the aggregator value (i.e. calling `read(X)`) is an expensive
-/// operation and should be avoided as much as possible because it reduces the
-/// parallelism.
+/// However, reading the aggregator value (i.e. calling `read(X)`) is a resource-intensive
+/// operation that also reduced parallelism, and should be avoided as much as possible.
 module aptos_framework::aggregator_v2 {
     use std::error;
     use std::string::String;
@@ -22,8 +21,8 @@ module aptos_framework::aggregator_v2 {
     /// The generic type supplied to the aggregator snapshot is not supported.
     const EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE: u64 = 5;
 
-    /// The aggregator snapshots feature flag is not enabled.
-    const EAGGREGATOR_SNAPSHOTS_NOT_ENABLED: u64 = 6;
+    /// The aggregator api v2 feature flag is not enabled.
+    const EAGGREGATOR_API_V2_NOT_ENABLED: u64 = 6;
 
     /// The generic type supplied to the aggregator is not supported.
     const EUNSUPPORTED_AGGREGATOR_TYPE: u64 = 7;
@@ -39,7 +38,7 @@ module aptos_framework::aggregator_v2 {
     /// across multiple transactions. See the module description for more details.
     ///
     /// Currently supported types for Element are u64 and u128.
-    struct Aggregator<IntElement> has store {
+    struct Aggregator<IntElement> has store, drop {
         value: IntElement,
         max_value: IntElement,
     }
@@ -90,11 +89,13 @@ module aptos_framework::aggregator_v2 {
     }
 
     /// Returns a value stored in this aggregator.
-    /// Note: This operation prevents parallelism of the transaction that calls it.
+    /// Note: This operation is resource-intensive, and reduces parallelism.
+    /// (Especially if called in a transaction that also modifies the aggregator,
+    /// or has other read/write conflicts)
     public native fun read<IntElement>(aggregator: &Aggregator<IntElement>): IntElement;
 
     /// Returns a wrapper of a current value of an aggregator
-    /// Unlike read(), this enables parallel execution of transactions.
+    /// Unlike read(), it is fast and avoids sequential dependencies.
     public native fun snapshot<IntElement>(aggregator: &Aggregator<IntElement>): AggregatorSnapshot<IntElement>;
 
     /// Creates a snapshot of a given value.
@@ -105,7 +106,9 @@ module aptos_framework::aggregator_v2 {
     public native fun copy_snapshot<Element: copy + drop>(snapshot: &AggregatorSnapshot<Element>): AggregatorSnapshot<Element>;
 
     /// Returns a value stored in this snapshot.
-    /// Note: This operation prevents parallelism of the transaction that calls it.
+    /// Note: This operation is resource-intensive, and reduces parallelism.
+    /// (Especially if called in a transaction that also modifies the aggregator,
+    /// or has other read/write conflicts)
     public native fun read_snapshot<Element>(snapshot: &AggregatorSnapshot<Element>): Element;
 
     /// Concatenates `before`, `snapshot` and `after` into a single string.
@@ -114,85 +117,98 @@ module aptos_framework::aggregator_v2 {
     /// If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_TOO_LARGE is raised.
     public native fun string_concat<IntElement>(before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String): AggregatorSnapshot<String>;
 
-    #[test(_fx = @std)]
-    public fun test_correct_read(_fx: &signer) {
-        // use std::features;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
+    #[test]
+    public fun test_aggregator() {
+        let agg = create_aggregator(10);
+        assert!(try_add(&mut agg, 5), 1);
+        assert!(try_add(&mut agg, 5), 2);
+        assert!(read(&agg) == 10, 3);
+        assert!(!try_add(&mut agg, 5), 4);
+        assert!(read(&agg) == 10, 5);
+        assert!(try_sub(&mut agg, 5), 6);
+        assert!(read(&agg) == 5, 7);
 
-        let snapshot = create_snapshot(42);
-        // copy not yet supported
-        // let snapshot2 = copy_snapshot(&snapshot);
-        assert!(read_snapshot(&snapshot) == 42, 0);
-        // assert!(read_snapshot(&snapshot2) == 42, 0);
+        let snap = snapshot(&agg);
+        assert!(try_add(&mut agg, 2), 8);
+        assert!(read(&agg) == 7, 9);
+        assert!(read_snapshot(&snap) == 5, 10);
     }
 
-    #[test(_fx = @std)]
-    public fun test_correct_read_string(_fx: &signer) {
-        // use std::features;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
+    #[test]
+    public fun test_correct_read() {
+        let snapshot = create_snapshot(42);
+        assert!(read_snapshot(&snapshot) == 42, 0);
 
         let snapshot = create_snapshot(std::string::utf8(b"42"));
-        // copy not yet supported
-        // let snapshot2 = copy_snapshot(&snapshot);
         assert!(read_snapshot(&snapshot) == std::string::utf8(b"42"), 0);
-        // assert!(read_snapshot(&snapshot2) == std::string::utf8(b"42"), 0);
     }
 
-    #[test(_fx = @std)]
-    public fun test_string_concat1(_fx: &signer) {
-        // use std::features;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
+    #[test]
+    #[expected_failure(abort_code = 0x030009, location = Self)]
+    public fun test_copy_not_yet_supported() {
+        let snapshot = create_snapshot(42);
+        copy_snapshot(&snapshot);
+    }
 
+    #[test]
+    public fun test_string_concat1() {
         let snapshot = create_snapshot(42);
         let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
         assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
     }
 
-    #[test(_fx = @std)]
+    #[test]
     #[expected_failure(abort_code = 0x030005, location = Self)]
-    public fun test_string_concat2(_fx: &signer) {
-        // use std::features;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
-
+    public fun test_string_concat_from_string_not_supported() {
         let snapshot = create_snapshot<String>(std::string::utf8(b"42"));
-        let snapshot2 = string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
-        read_snapshot(&snapshot2);
-        // String concatenation not supported
-        // assert!(read_snapshot(&snapshot2) == std::string::utf8(b"before42after"), 0);
+        string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
     }
 
     // #[test(fx = @std)]
     // #[expected_failure(abort_code = 0x030006, location = Self)]
     // public fun test_snapshot_feature_not_enabled(fx: &signer) {
     //     use std::features;
+    //     use aptos_framework::reconfiguration;
     //     let feature = features::get_aggregator_v2_api_feature();
     //     features::change_feature_flags(fx, vector[], vector[feature]);
-
+    //     reconfiguration::reconfigure_for_test();
     //     create_snapshot(42);
     // }
 
-    #[test(_fx = @std)]
-    #[expected_failure(abort_code = 0x030005, location = Self)]
-    public fun test_snpashot_invalid_type1(_fx: &signer) {
-        // use std::features;
-        use std::option;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
+    // #[test(fx = @std)]
+    // #[expected_failure(abort_code = 0x030006, location = Self)]
+    // public fun test_aggregator_feature_not_enabled(fx: &signer) {
+    //     use std::features;
+    //     use aptos_framework::reconfiguration;
+    //     let feature = features::get_aggregator_v2_api_feature();
+    //     features::change_feature_flags(fx, vector[], vector[feature]);
+    //     reconfiguration::reconfigure_for_test();
+    //     create_aggregator(42);
+    // }
 
+    #[test]
+    #[expected_failure(abort_code = 0x030007, location = Self)]
+    public fun test_aggregator_invalid_type1() {
+        create_unbounded_aggregator<u8>();
+    }
+
+    public fun test_aggregator_valid_type() {
+        create_unbounded_aggregator<u64>();
+        create_unbounded_aggregator<u128>();
+        create_aggregator<u64>(5);
+        create_aggregator<u128>(5);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0x030005, location = Self)]
+    public fun test_snpashot_invalid_type1() {
+        use std::option;
         create_snapshot(option::some(42));
     }
 
-    #[test(_fx = @std)]
+    #[test]
     #[expected_failure(abort_code = 0x030005, location = Self)]
-    public fun test_snpashot_invalid_type2(_fx: &signer) {
-        // use std::features;
-        // let feature = features::get_aggregator_v2_api_feature();
-        // features::change_feature_flags(fx, vector[feature], vector[]);
-
+    public fun test_snpashot_invalid_type2() {
         create_snapshot(vector[42]);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
@@ -1,0 +1,41 @@
+spec aptos_framework::aggregator_v2 {
+    spec create_aggregator {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec try_add {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec try_sub {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec read {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec snapshot {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec create_snapshot {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec copy_snapshot {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec string_concat {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
@@ -4,6 +4,11 @@ spec aptos_framework::aggregator_v2 {
         pragma opaque;
     }
 
+    spec create_unbounded_aggregator {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
     spec try_add {
         // TODO: temporary mockup.
         pragma opaque;

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -3,17 +3,22 @@
 
 use crate::natives::{
     aggregator_natives::helpers_v2::{
-        aggregator_snapshot_value_as_bytes, aggregator_snapshot_value_as_u128,
-        aggregator_snapshot_value_as_u64, string_to_bytes,
+        aggregator_snapshot_field_value, get_aggregator_fields_u128, get_aggregator_fields_u64,
+        set_aggregator_value_field, string_to_bytes, to_utf8_bytes, u128_to_u64,
     },
     AccountAddress,
 };
+use aptos_gas_algebra::NumBytes;
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
     SafeNativeResult,
 };
-use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
+use move_binary_format::errors::PartialVMError;
+use move_core_types::{
+    value::{MoveStructLayout, MoveTypeLayout},
+    vm_status::StatusCode,
+};
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
@@ -25,8 +30,20 @@ use std::{collections::VecDeque, ops::Deref};
 /// The generic type supplied to aggregator snapshots is not supported.
 pub const EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE: u64 = 0x03_0005;
 
-/// The aggregator snapshots feature is not enabled.
-pub const EAGGREGATOR_SNAPSHOTS_NOT_ENABLED: u64 = 0x03_0006;
+/// The aggregator api feature is not enabled.
+pub const EAGGREGATOR_API_NOT_ENABLED: u64 = 0x03_0006;
+
+/// The generic type supplied to the aggregators is not supported.
+pub const EUNSUPPORTED_AGGREGATOR_TYPE: u64 = 0x03_0007;
+
+/// Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together)
+pub const ECONCAT_STRING_LENGTH_TOO_LARGE: u64 = 0x03_0008;
+
+/// The native aggregator function, that is in the move file, is not yet supported.
+/// and any calls will raise this error.
+pub const EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED: u64 = 0x03_0009;
+
+pub const CONCAT_PREFIX_AND_SUFFIX_MAX_LENGTH: usize = 256;
 
 /// Checks if the type argument `type_arg` is a string type.
 fn is_string_type(context: &SafeNativeContext, type_arg: &Type) -> SafeNativeResult<bool> {
@@ -37,6 +54,364 @@ fn is_string_type(context: &SafeNativeContext, type_arg: &Type) -> SafeNativeRes
             && type_.address == AccountAddress::ONE);
     }
     Ok(false)
+}
+
+/// Given the native function argument and a type, returns a tuple of its
+/// fields: (`aggregator id`, `limit`).
+pub fn get_aggregator_fields_by_type(
+    ty_arg: &Type,
+    agg: &StructRef,
+) -> SafeNativeResult<(u128, u128)> {
+    match ty_arg {
+        Type::U128 => {
+            // Get aggregator information and a value to add.
+            let (id, limit) = get_aggregator_fields_u128(agg)?;
+            Ok((id, limit))
+        },
+        Type::U64 => {
+            // Get aggregator information and a value to add.
+            let (id, limit) = get_aggregator_fields_u64(agg)?;
+            Ok((id as u128, limit as u128))
+        },
+        _ => Err(SafeNativeError::Abort {
+            abort_code: EUNSUPPORTED_AGGREGATOR_TYPE,
+        }),
+    }
+}
+
+/// Given the list of native function arguments and a type, pop the next argument if it is of given type.
+pub fn pop_value_by_type(ty_arg: &Type, args: &mut VecDeque<Value>) -> SafeNativeResult<u128> {
+    match ty_arg {
+        Type::U128 => Ok(safely_pop_arg!(args, u128)),
+        Type::U64 => Ok(safely_pop_arg!(args, u64) as u128),
+        _ => Err(SafeNativeError::Abort {
+            abort_code: EUNSUPPORTED_AGGREGATOR_TYPE,
+        }),
+    }
+}
+
+pub fn create_value_by_type(ty_arg: &Type, value: u128) -> SafeNativeResult<Value> {
+    match ty_arg {
+        Type::U128 => Ok(Value::u128(value)),
+        Type::U64 => Ok(Value::u64(u128_to_u64(value)?)),
+        _ => Err(SafeNativeError::Abort {
+            abort_code: EUNSUPPORTED_AGGREGATOR_TYPE,
+        }),
+    }
+}
+
+// To avoid checking is_string_type multiple times, check type_arg only once, and convert into this enum
+enum SnapshotType {
+    U128,
+    U64,
+    String,
+}
+
+impl SnapshotType {
+    fn from_ty_arg(context: &SafeNativeContext, ty_arg: &Type) -> SafeNativeResult<Self> {
+        match ty_arg {
+            Type::U128 => Ok(Self::U128),
+            Type::U64 => Ok(Self::U64),
+            _ => {
+                // Check if the type is a string
+                if is_string_type(context, ty_arg)? {
+                    Ok(Self::String)
+                } else {
+                    // If not a string, return an error
+                    Err(SafeNativeError::Abort {
+                        abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
+                    })
+                }
+            },
+        }
+    }
+
+    pub fn pop_snapshot_field_by_type(
+        &self,
+        args: &mut VecDeque<Value>,
+    ) -> SafeNativeResult<SnapshotValue> {
+        self.parse_snapshot_value_by_type(aggregator_snapshot_field_value(&safely_pop_arg!(
+            args, StructRef
+        ))?)
+    }
+
+    pub fn pop_snapshot_value_by_type(
+        &self,
+        args: &mut VecDeque<Value>,
+    ) -> SafeNativeResult<SnapshotValue> {
+        match self {
+            SnapshotType::U128 => Ok(SnapshotValue::Integer(safely_pop_arg!(args, u128))),
+            SnapshotType::U64 => Ok(SnapshotValue::Integer(safely_pop_arg!(args, u64) as u128)),
+            SnapshotType::String => {
+                let input = string_to_bytes(safely_pop_arg!(args, Struct))?;
+                Ok(SnapshotValue::String(input))
+            },
+        }
+    }
+
+    pub fn parse_snapshot_value_by_type(&self, value: Value) -> SafeNativeResult<SnapshotValue> {
+        // Simpler to wrap to be able to reuse safely_pop_arg functions
+        self.pop_snapshot_value_by_type(&mut VecDeque::from([value]))
+    }
+
+    pub fn create_snapshot_value_by_type(&self, value: SnapshotValue) -> SafeNativeResult<Value> {
+        match (self, value) {
+            (SnapshotType::U128, SnapshotValue::Integer(v)) => Ok(Value::u128(v)),
+            (SnapshotType::U64, SnapshotValue::Integer(v)) => Ok(Value::u64(u128_to_u64(v)?)),
+            (SnapshotType::String, value) => {
+                Ok(Value::struct_(Struct::pack(vec![Value::vector_u8(
+                    match value {
+                        SnapshotValue::String(v) => v,
+                        SnapshotValue::Integer(v) => to_utf8_bytes(v),
+                    },
+                )])))
+            },
+            // ty_arg cannot be Integer, if value is String
+            _ => Err(SafeNativeError::Abort {
+                abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
+            }),
+        }
+    }
+}
+
+// ================= START TEMPORARY CODE =================
+// TODO: aggregator_v2 branch will introduce these in different places in code
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotValue {
+    Integer(u128),
+    String(Vec<u8>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SnapshotToStringFormula {
+    Concat { prefix: Vec<u8>, suffix: Vec<u8> },
+}
+
+impl SnapshotToStringFormula {
+    pub fn apply_to(&self, base: u128) -> Vec<u8> {
+        match self {
+            SnapshotToStringFormula::Concat { prefix, suffix } => {
+                let middle_string = base.to_string();
+                let middle = middle_string.as_bytes();
+                let mut result = Vec::with_capacity(prefix.len() + middle.len() + suffix.len());
+                result.extend(prefix);
+                result.extend(middle);
+                result.extend(suffix);
+                result
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BoundedMathError {
+    Overflow,
+    Underflow,
+}
+
+// Unsigned operations operate on [0, max_value] range.
+// Signed operations operate on [-max_value, max_value] range.
+pub struct BoundedMath {
+    max_value: u128,
+}
+
+impl BoundedMath {
+    pub fn new(max_value: u128) -> Self {
+        Self { max_value }
+    }
+
+    pub fn get_max_value(&self) -> u128 {
+        self.max_value
+    }
+
+    pub fn unsigned_add(&self, base: u128, value: u128) -> Result<u128, BoundedMathError> {
+        if self.max_value < base || value > (self.max_value - base) {
+            Err(BoundedMathError::Overflow)
+        } else {
+            Ok(base + value)
+        }
+    }
+
+    pub fn unsigned_subtract(&self, base: u128, value: u128) -> Result<u128, BoundedMathError> {
+        if value > base {
+            Err(BoundedMathError::Underflow)
+        } else {
+            Ok(base - value)
+        }
+    }
+}
+
+// ================= END TEMPORARY CODE =================
+
+/***************************************************************************************************
+ * native fun create_aggregator<Element>(max_value: Element): Aggregator<Element>;
+ **************************************************************************************************/
+
+fn native_create_aggregator(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    if !context.aggregator_v2_api_enabled() {
+        return Err(SafeNativeError::Abort {
+            abort_code: EAGGREGATOR_API_NOT_ENABLED,
+        });
+    }
+
+    debug_assert_eq!(args.len(), 1);
+
+    context.charge(AGGREGATOR_V2_CREATE_AGGREGATOR_BASE)?;
+    let max_value = pop_value_by_type(&ty_args[0], &mut args)?;
+
+    let value_field_value = 0;
+
+    Ok(smallvec![Value::struct_(Struct::pack(vec![
+        create_value_by_type(&ty_args[0], value_field_value)?,
+        create_value_by_type(&ty_args[0], max_value)?,
+    ]))])
+}
+
+/***************************************************************************************************
+ * native fun create_unbounded_aggregator<IntElement: copy + drop>(): Aggregator<IntElement>;
+ **************************************************************************************************/
+
+fn native_create_unbounded_aggregator(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    if !context.aggregator_v2_api_enabled() {
+        return Err(SafeNativeError::Abort {
+            abort_code: EAGGREGATOR_API_NOT_ENABLED,
+        });
+    }
+
+    debug_assert_eq!(args.len(), 0);
+
+    context.charge(AGGREGATOR_V2_CREATE_AGGREGATOR_BASE)?;
+    let max_value = {
+        match &ty_args[0] {
+            Type::U128 => u128::MAX,
+            Type::U64 => u64::MAX as u128,
+            _ => {
+                return Err(SafeNativeError::Abort {
+                    abort_code: EUNSUPPORTED_AGGREGATOR_TYPE,
+                })
+            },
+        }
+    };
+
+    let value_field_value = 0;
+
+    Ok(smallvec![Value::struct_(Struct::pack(vec![
+        create_value_by_type(&ty_args[0], value_field_value)?,
+        create_value_by_type(&ty_args[0], max_value)?,
+    ]))])
+}
+
+/***************************************************************************************************
+ * native fun try_add<Element>(aggregator: &mut Aggregator<Element>, value: Element): bool;
+ **************************************************************************************************/
+fn native_try_add(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 2);
+    context.charge(AGGREGATOR_V2_TRY_ADD_BASE)?;
+
+    let input = pop_value_by_type(&ty_args[0], &mut args)?;
+    let agg_struct = safely_pop_arg!(args, StructRef);
+    let (agg_value, agg_max_value) = get_aggregator_fields_by_type(&ty_args[0], &agg_struct)?;
+
+    let result_value = {
+        let math = BoundedMath::new(agg_max_value);
+        match math.unsigned_add(agg_value, input) {
+            Ok(sum) => {
+                set_aggregator_value_field(&agg_struct, create_value_by_type(&ty_args[0], sum)?)?;
+                true
+            },
+            Err(_) => false,
+        }
+    };
+
+    Ok(smallvec![Value::bool(result_value)])
+}
+
+/***************************************************************************************************
+ * native fun try_sub<Element>(aggregator: &mut Aggregator<Element>, value: Element): bool;
+ **************************************************************************************************/
+fn native_try_sub(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 2);
+    context.charge(AGGREGATOR_V2_TRY_SUB_BASE)?;
+
+    let input = pop_value_by_type(&ty_args[0], &mut args)?;
+    let agg_struct = safely_pop_arg!(args, StructRef);
+    let (agg_value, agg_max_value) = get_aggregator_fields_by_type(&ty_args[0], &agg_struct)?;
+
+    let result_value = {
+        let math = BoundedMath::new(agg_max_value);
+        match math.unsigned_subtract(agg_value, input) {
+            Ok(sum) => {
+                set_aggregator_value_field(&agg_struct, create_value_by_type(&ty_args[0], sum)?)?;
+                true
+            },
+            Err(_) => false,
+        }
+    };
+    Ok(smallvec![Value::bool(result_value)])
+}
+
+/***************************************************************************************************
+ * native fun read<Element>(aggregator: &Aggregator<Element>): Element;
+ **************************************************************************************************/
+
+fn native_read(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 1);
+    context.charge(AGGREGATOR_V2_READ_BASE)?;
+
+    let (agg_value, agg_max_value) =
+        get_aggregator_fields_by_type(&ty_args[0], &safely_pop_arg!(args, StructRef))?;
+
+    let result_value = agg_value;
+
+    if result_value > agg_max_value {
+        return Err(SafeNativeError::InvariantViolation(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        )));
+    };
+    Ok(smallvec![create_value_by_type(&ty_args[0], result_value)?])
+}
+
+/***************************************************************************************************
+ * native fun snapshot(aggregator: &Aggregator): AggregatorSnapshot<u128>;
+ **************************************************************************************************/
+
+fn native_snapshot(
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert_eq!(args.len(), 1);
+    context.charge(AGGREGATOR_V2_SNAPSHOT_BASE)?;
+
+    let (agg_value, _agg_max_value) =
+        get_aggregator_fields_by_type(&ty_args[0], &safely_pop_arg!(args, StructRef))?;
+
+    let result_value = agg_value;
+
+    Ok(smallvec![Value::struct_(Struct::pack(vec![
+        create_value_by_type(&ty_args[0], result_value)?
+    ]))])
 }
 
 /***************************************************************************************************
@@ -50,7 +425,7 @@ fn native_create_snapshot(
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     if !context.aggregator_v2_api_enabled() {
         return Err(SafeNativeError::Abort {
-            abort_code: EAGGREGATOR_SNAPSHOTS_NOT_ENABLED,
+            abort_code: EAGGREGATOR_API_NOT_ENABLED,
         });
     }
 
@@ -58,33 +433,14 @@ fn native_create_snapshot(
     debug_assert_eq!(args.len(), 1);
     context.charge(AGGREGATOR_V2_CREATE_SNAPSHOT_BASE)?;
 
-    match ty_args[0] {
-        Type::U128 => {
-            let input = safely_pop_arg!(args, u128);
-            Ok(smallvec![Value::struct_(Struct::pack(vec![Value::u128(
-                input
-            )]))])
-        },
-        Type::U64 => {
-            let input = safely_pop_arg!(args, u64);
-            Ok(smallvec![Value::struct_(Struct::pack(vec![Value::u64(
-                input
-            )]))])
-        },
-        _ => {
-            // Check if the type is a string
-            if is_string_type(context, &ty_args[0])? {
-                let input = string_to_bytes(safely_pop_arg!(args, Struct))?;
-                let move_string_value = Value::struct_(Struct::pack(vec![Value::vector_u8(input)]));
-                let move_snapshot_value = Value::struct_(Struct::pack(vec![move_string_value]));
-                return Ok(smallvec![move_snapshot_value]);
-            }
-            // If not a string, return an error
-            Err(SafeNativeError::Abort {
-                abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
-            })
-        },
-    }
+    let snapshot_type = SnapshotType::from_ty_arg(context, &ty_args[0])?;
+    let input = snapshot_type.pop_snapshot_value_by_type(&mut args)?;
+
+    let result_value = input;
+
+    Ok(smallvec![Value::struct_(Struct::pack(vec![
+        snapshot_type.create_snapshot_value_by_type(result_value)?
+    ]))])
 }
 
 /***************************************************************************************************
@@ -92,41 +448,26 @@ fn native_create_snapshot(
  **************************************************************************************************/
 
 fn native_copy_snapshot(
-    context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
+    _context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert_eq!(ty_args.len(), 1);
-    debug_assert_eq!(args.len(), 1);
-    context.charge(AGGREGATOR_V2_COPY_SNAPSHOT_BASE)?;
+    Err(SafeNativeError::Abort {
+        abort_code: EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
+    })
 
-    match ty_args[0] {
-        Type::U128 => {
-            let value = aggregator_snapshot_value_as_u128(&safely_pop_arg!(args, StructRef))?;
-            Ok(smallvec![Value::struct_(Struct::pack(vec![Value::u128(
-                value
-            )]))])
-        },
-        Type::U64 => {
-            let value = aggregator_snapshot_value_as_u64(&safely_pop_arg!(args, StructRef))?;
-            Ok(smallvec![Value::struct_(Struct::pack(vec![Value::u64(
-                value
-            )]))])
-        },
-        _ => {
-            // Check if the type is a string
-            if is_string_type(context, &ty_args[0])? {
-                let value = aggregator_snapshot_value_as_bytes(&safely_pop_arg!(args, StructRef))?;
-                let move_string_value = Value::struct_(Struct::pack(vec![Value::vector_u8(value)]));
-                let move_snapshot_value = Value::struct_(Struct::pack(vec![move_string_value]));
-                return Ok(smallvec![move_snapshot_value]);
-            }
-            // If not a string, return an error
-            Err(SafeNativeError::Abort {
-                abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
-            })
-        },
-    }
+    // debug_assert_eq!(ty_args.len(), 1);
+    // debug_assert_eq!(args.len(), 1);
+    // context.charge(AGGREGATOR_V2_COPY_SNAPSHOT_BASE)?;
+
+    // let snapshot_type = SnapshotType::from_ty_arg(context, &ty_args[0])?;
+    // let snapshot_value = snapshot_type.pop_snapshot_field_by_type(&mut args)?;
+
+    // let result_value = snapshot_value;
+
+    // Ok(smallvec![Value::struct_(Struct::pack(vec![
+    //     snapshot_type.create_snapshot_value_by_type(result_value)?
+    // ]))])
 }
 
 /***************************************************************************************************
@@ -142,28 +483,14 @@ fn native_read_snapshot(
     debug_assert_eq!(args.len(), 1);
     context.charge(AGGREGATOR_V2_READ_SNAPSHOT_BASE)?;
 
-    match ty_args[0] {
-        Type::U128 => {
-            let value = aggregator_snapshot_value_as_u128(&safely_pop_arg!(args, StructRef))?;
-            Ok(smallvec![Value::u128(value)])
-        },
-        Type::U64 => {
-            let value = aggregator_snapshot_value_as_u64(&safely_pop_arg!(args, StructRef))?;
-            Ok(smallvec![Value::u64(value)])
-        },
-        _ => {
-            // Check if the type is a string
-            if is_string_type(context, &ty_args[0])? {
-                let value = aggregator_snapshot_value_as_bytes(&safely_pop_arg!(args, StructRef))?;
-                let move_string_value = Value::struct_(Struct::pack(vec![Value::vector_u8(value)]));
-                return Ok(smallvec![move_string_value]);
-            }
-            // If not a string, return an error
-            Err(SafeNativeError::Abort {
-                abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
-            })
-        },
-    }
+    let snapshot_type = SnapshotType::from_ty_arg(context, &ty_args[0])?;
+    let snapshot_value = snapshot_type.pop_snapshot_field_by_type(&mut args)?;
+
+    let result_value = snapshot_value;
+
+    Ok(smallvec![
+        snapshot_type.create_snapshot_value_by_type(result_value)?
+    ])
 }
 
 /***************************************************************************************************
@@ -179,37 +506,44 @@ fn native_string_concat(
     debug_assert_eq!(args.len(), 3);
     context.charge(AGGREGATOR_V2_STRING_CONCAT_BASE)?;
 
-    let after = string_to_bytes(safely_pop_arg!(args, Struct))?;
+    let snapshot_input_type = SnapshotType::from_ty_arg(context, &ty_args[0])?;
 
-    let snapshot_value = match ty_args[0] {
-        Type::U128 => {
-            let value = aggregator_snapshot_value_as_u128(&safely_pop_arg!(args, StructRef))?;
-            Ok(value.to_string().into_bytes())
+    // Concat works only with integer snapshot types
+    // This is to avoid unnecessary recursive snapshot dependencies
+    if !matches!(snapshot_input_type, SnapshotType::U128 | SnapshotType::U64) {
+        return Err(SafeNativeError::Abort {
+            abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
+        });
+    }
+
+    // popping arguments from the end
+    let suffix = string_to_bytes(safely_pop_arg!(args, Struct))?;
+    let snapshot_value = match snapshot_input_type.pop_snapshot_field_by_type(&mut args)? {
+        SnapshotValue::Integer(v) => v,
+        SnapshotValue::String(_) => {
+            return Err(SafeNativeError::Abort {
+                abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
+            })
         },
-        Type::U64 => {
-            let value = aggregator_snapshot_value_as_u64(&safely_pop_arg!(args, StructRef))?;
-            Ok(value.to_string().into_bytes())
-        },
-        _ => {
-            // Check if the type is a string
-            if is_string_type(context, &ty_args[0])? {
-                Ok(aggregator_snapshot_value_as_bytes(&safely_pop_arg!(
-                    args, StructRef
-                ))?)
-            } else {
-                Err(SafeNativeError::Abort {
-                    abort_code: EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
-                })
-            }
-        },
-    }?;
-    let before = string_to_bytes(safely_pop_arg!(args, Struct))?;
-    let mut result = before.clone();
-    result.extend(&snapshot_value);
-    result.extend(&after);
-    let move_string_value = Value::struct_(Struct::pack(vec![Value::vector_u8(result)]));
-    let move_snapshot_value = Value::struct_(Struct::pack(vec![move_string_value]));
-    Ok(smallvec![move_snapshot_value])
+    };
+
+    let prefix = string_to_bytes(safely_pop_arg!(args, Struct))?;
+
+    if prefix.len() + suffix.len() > CONCAT_PREFIX_AND_SUFFIX_MAX_LENGTH {
+        return Err(SafeNativeError::Abort {
+            abort_code: ECONCAT_STRING_LENGTH_TOO_LARGE,
+        });
+    }
+
+    context.charge(STRING_UTILS_PER_BYTE * NumBytes::new((prefix.len() + suffix.len()) as u64))?;
+
+    let result_value = SnapshotValue::String(
+        SnapshotToStringFormula::Concat { prefix, suffix }.apply_to(snapshot_value),
+    );
+
+    Ok(smallvec![Value::struct_(Struct::pack(vec![
+        SnapshotType::String.create_snapshot_value_by_type(result_value)?
+    ]))])
 }
 
 /***************************************************************************************************
@@ -220,7 +554,19 @@ pub fn make_all(
     builder: &SafeNativeBuilder,
 ) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
     let natives = [
-        ("create_snapshot", native_create_snapshot as RawSafeNative),
+        (
+            "create_aggregator",
+            native_create_aggregator as RawSafeNative,
+        ),
+        (
+            "create_unbounded_aggregator",
+            native_create_unbounded_aggregator,
+        ),
+        ("try_add", native_try_add),
+        ("read", native_read),
+        ("try_sub", native_try_sub),
+        ("snapshot", native_snapshot),
+        ("create_snapshot", native_create_snapshot),
         ("copy_snapshot", native_copy_snapshot),
         ("read_snapshot", native_read_snapshot),
         ("string_concat", native_string_concat),

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -244,6 +244,16 @@ impl BoundedMath {
 
 // ================= END TEMPORARY CODE =================
 
+macro_rules! abort_if_not_enabled {
+    ($context:expr) => {
+        if !$context.aggregator_v2_api_enabled() {
+            return Err(SafeNativeError::Abort {
+                abort_code: EAGGREGATOR_API_NOT_ENABLED,
+            });
+        }
+    };
+}
+
 /***************************************************************************************************
  * native fun create_aggregator<Element>(max_value: Element): Aggregator<Element>;
  **************************************************************************************************/
@@ -253,11 +263,7 @@ fn native_create_aggregator(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    if !context.aggregator_v2_api_enabled() {
-        return Err(SafeNativeError::Abort {
-            abort_code: EAGGREGATOR_API_NOT_ENABLED,
-        });
-    }
+    abort_if_not_enabled!(context);
 
     debug_assert_eq!(args.len(), 1);
 
@@ -281,11 +287,7 @@ fn native_create_unbounded_aggregator(
     ty_args: Vec<Type>,
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    if !context.aggregator_v2_api_enabled() {
-        return Err(SafeNativeError::Abort {
-            abort_code: EAGGREGATOR_API_NOT_ENABLED,
-        });
-    }
+    abort_if_not_enabled!(context);
 
     debug_assert_eq!(args.len(), 0);
 
@@ -318,6 +320,8 @@ fn native_try_add(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(args.len(), 2);
     context.charge(AGGREGATOR_V2_TRY_ADD_BASE)?;
 
@@ -347,6 +351,8 @@ fn native_try_sub(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(args.len(), 2);
     context.charge(AGGREGATOR_V2_TRY_SUB_BASE)?;
 
@@ -376,6 +382,8 @@ fn native_read(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(args.len(), 1);
     context.charge(AGGREGATOR_V2_READ_BASE)?;
 
@@ -401,6 +409,8 @@ fn native_snapshot(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(args.len(), 1);
     context.charge(AGGREGATOR_V2_SNAPSHOT_BASE)?;
 
@@ -423,11 +433,7 @@ fn native_create_snapshot(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    if !context.aggregator_v2_api_enabled() {
-        return Err(SafeNativeError::Abort {
-            abort_code: EAGGREGATOR_API_NOT_ENABLED,
-        });
-    }
+    abort_if_not_enabled!(context);
 
     debug_assert_eq!(ty_args.len(), 1);
     debug_assert_eq!(args.len(), 1);
@@ -448,10 +454,11 @@ fn native_create_snapshot(
  **************************************************************************************************/
 
 fn native_copy_snapshot(
-    _context: &mut SafeNativeContext,
+    context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
     Err(SafeNativeError::Abort {
         abort_code: EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
     })
@@ -479,6 +486,8 @@ fn native_read_snapshot(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(ty_args.len(), 1);
     debug_assert_eq!(args.len(), 1);
     context.charge(AGGREGATOR_V2_READ_SNAPSHOT_BASE)?;
@@ -502,6 +511,8 @@ fn native_string_concat(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    abort_if_not_enabled!(context);
+
     debug_assert_eq!(ty_args.len(), 1);
     debug_assert_eq!(args.len(), 3);
     context.charge(AGGREGATOR_V2_STRING_CONCAT_BASE)?;

--- a/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
@@ -1,45 +1,80 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::natives::aggregator_natives::helpers::get_aggregator_field;
-use aptos_aggregator::aggregator_extension::extension_error;
+
 use move_binary_format::errors::PartialVMResult;
-use move_vm_types::values::{Struct, StructRef, Value};
+use move_vm_types::{
+    natives::function::{PartialVMError, StatusCode},
+    values::{Reference, Struct, StructRef, Value},
+};
 
+/// Indices of `value` and `limit` fields in the `Aggregator` Move
+/// struct.
 const VALUE_FIELD_INDEX: usize = 0;
+const LIMIT_FIELD_INDEX: usize = 1;
 
-/// Returns ID of aggregator snapshot based on a reference to `AggregatorSnapshot` Move struct.
-pub(crate) fn aggregator_snapshot_value_as_u128(
-    aggregator_snapshot: &StructRef,
-) -> PartialVMResult<u128> {
-    let value = get_aggregator_field(aggregator_snapshot, VALUE_FIELD_INDEX)?.value_as::<u128>()?;
-    Ok(value)
+/// Given a reference to `Aggregator` Move struct, returns a tuple of its
+/// fields: (`value`, `limit`).
+pub fn get_aggregator_fields_u128(aggregator: &StructRef) -> PartialVMResult<(u128, u128)> {
+    let value = get_aggregator_field(aggregator, VALUE_FIELD_INDEX)?.value_as::<u128>()?;
+    let limit = get_aggregator_field(aggregator, LIMIT_FIELD_INDEX)?.value_as::<u128>()?;
+    Ok((value, limit))
+}
+
+pub fn set_aggregator_value_field(aggregator: &StructRef, value: Value) -> PartialVMResult<()> {
+    set_aggregator_field(aggregator, VALUE_FIELD_INDEX, value)
+}
+
+/// Given a reference to `Aggregator` Move struct, returns a tuple of its
+/// fields: (`value`, `limit`).
+pub fn get_aggregator_fields_u64(aggregator: &StructRef) -> PartialVMResult<(u64, u64)> {
+    let value = get_aggregator_field(aggregator, VALUE_FIELD_INDEX)?.value_as::<u64>()?;
+    let limit = get_aggregator_field(aggregator, LIMIT_FIELD_INDEX)?.value_as::<u64>()?;
+    Ok((value, limit))
 }
 
 /// Returns ID of aggregator snapshot based on a reference to `AggregatorSnapshot` Move struct.
-pub(crate) fn aggregator_snapshot_value_as_u64(
+pub(crate) fn aggregator_snapshot_field_value(
     aggregator_snapshot: &StructRef,
-) -> PartialVMResult<u64> {
-    let value = get_aggregator_field(aggregator_snapshot, VALUE_FIELD_INDEX)?.value_as::<u64>()?;
-    Ok(value)
+) -> PartialVMResult<Value> {
+    get_aggregator_field(aggregator_snapshot, VALUE_FIELD_INDEX)
 }
 
-pub(crate) fn aggregator_snapshot_value_as_bytes(
-    aggregator_snapshot: &StructRef,
-) -> PartialVMResult<Vec<u8>> {
-    get_aggregator_field(aggregator_snapshot, VALUE_FIELD_INDEX)?
-        .value_as::<Struct>()?
-        .unpack()?
-        .collect::<Vec<Value>>()
-        .pop()
-        .map_or(
-            Err(extension_error("unable to pop string field in snapshot")),
-            |v| v.value_as::<Vec<u8>>(),
-        )
+// ================= START TEMPORARY CODE =================
+// TODO: aggregator_v2 branch will introduce these in different places in code
+
+/// Given a reference to `Aggregator` Move struct returns a field value at `index`.
+pub(crate) fn get_aggregator_field(aggregator: &StructRef, index: usize) -> PartialVMResult<Value> {
+    let field_ref = aggregator.borrow_field(index)?.value_as::<Reference>()?;
+    field_ref.read_ref()
 }
 
-pub(crate) fn string_to_bytes(string_value: Struct) -> PartialVMResult<Vec<u8>> {
-    string_value.unpack()?.collect::<Vec<Value>>().pop().map_or(
-        Err(extension_error("unable to extract string value")),
+/// Given a reference to `Aggregator` Move struct, updates a field value at `index`.
+pub(crate) fn set_aggregator_field(
+    aggregator: &StructRef,
+    index: usize,
+    value: Value,
+) -> PartialVMResult<()> {
+    let field_ref = aggregator.borrow_field(index)?.value_as::<Reference>()?;
+    field_ref.write_ref(value)
+}
+
+pub fn string_to_bytes(value: Struct) -> PartialVMResult<Vec<u8>> {
+    value.unpack()?.collect::<Vec<Value>>().pop().map_or(
+        Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
+            .with_message("Unable to extract bytes from String".to_string())),
         |v| v.value_as::<Vec<u8>>(),
     )
 }
+
+pub fn to_utf8_bytes(value: impl ToString) -> Vec<u8> {
+    value.to_string().into_bytes()
+}
+
+pub fn u128_to_u64(value: u128) -> PartialVMResult<u64> {
+    u64::try_from(value).map_err(|_| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+            .with_message("Cannot cast u128 into u64".to_string())
+    })
+}
+
+// ================= END TEMPORARY CODE =================

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -427,6 +427,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::EMIT_FEE_STATEMENT,
         FeatureFlag::STORAGE_DELETION_REFUND,
         FeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX,
+        FeatureFlag::AGGREGATOR_V2_API,
         FeatureFlag::SAFER_RESOURCE_GROUPS,
         FeatureFlag::SAFER_METADATA,
         FeatureFlag::SINGLE_SENDER_AUTHENTICATOR,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -57,7 +57,7 @@ pub struct Features {
 impl Default for Features {
     fn default() -> Self {
         Features {
-            features: vec![0b00100000, 0b00100000, 0b00001100, 0b00100000],
+            features: vec![0b00100000, 0b00100000, 0b00001100, 0b01100000],
         }
     }
 }


### PR DESCRIPTION
Self-contained logic that can be landed on main, and so ecosystem PRs can land independently of the rest of the aggregator changes

once aggregator backend execution logic lands, this will be a fallback logic used until separate aggregator execution flag is turned on.

Copied from aggregators_v2 branch

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
