### PR TITLE
[gha/docker] remove deprecated indexer build

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -279,7 +279,6 @@ jobs:
       - permission-check
       - determine-docker-build-metadata
       - rust-images
-      - rust-images-indexer
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test
@@ -309,7 +308,6 @@ jobs:
       - permission-check
       - determine-docker-build-metadata
       - rust-images
-      - rust-images-indexer
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test
@@ -338,7 +336,6 @@ jobs:
       - permission-check
       - determine-docker-build-metadata
       - rust-images
-      - rust-images-indexer
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test
@@ -361,7 +358,6 @@ jobs:
       - permission-check
       - determine-docker-build-metadata
       - rust-images
-      - rust-images-indexer
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -134,22 +134,6 @@ jobs:
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
 
-  rust-images-indexer:
-    needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
-    secrets: inherit
-    with:
-      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      TARGET_CACHE_ID: ${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      PROFILE: release
-      FEATURES: indexer
-      BUILD_ADDL_TESTING_IMAGES: true
-      TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
@@ -263,7 +247,6 @@ jobs:
       - permission-check
       - determine-docker-build-metadata
       - rust-images
-      - rust-images-indexer
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test

--- a/docker/builder/docker-bake-rust-all.sh
+++ b/docker/builder/docker-bake-rust-all.sh
@@ -6,8 +6,9 @@
 # You need to execute this from the repository root as working directory
 # E.g. docker/docker-bake-rust-all.sh
 # If you want to build a specific target only, run:
-#  docker/docker-bake-rust-all.sh <target>
-# E.g. docker/docker-bake-rust-all.sh indexer
+#   docker/docker-bake-rust-all.sh <target>
+# See targets in docker/builder/docker-bake-rust-all.hcl
+#   e.g. docker/docker-bake-rust-all.sh forge-images
 
 set -ex
 

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -29,7 +29,6 @@
 
 const Features = {
   Default: "default",
-  Indexer: "indexer",
 };
 
 const IMAGES_TO_RELEASE_ONLY_INTERNAL = ["validator-testing"];
@@ -40,7 +39,6 @@ const IMAGES_TO_RELEASE = {
     ],
     release: [
       Features.Default,
-      Features.Indexer,
     ],
   },
   "validator-testing": {
@@ -49,7 +47,6 @@ const IMAGES_TO_RELEASE = {
     ],
     release: [
       Features.Default,
-      Features.Indexer,
     ],
   },
   faucet: {


### PR DESCRIPTION
### Description

Revert the revert, and also remove the dependencies that made it fail

# Test plan

lint and also dispatch shows it runs ok https://github.com/aptos-labs/aptos-core/actions/runs/6412278550


<!-- Please provide us with clear details for verifying that your changes work. -->
