### PR TITLE
[State Sync] Enable subscription syncing by default.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -240,14 +240,14 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
-            enable_subscription_streaming: false,
+            enable_subscription_streaming: true,
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,
             max_data_stream_channel_sizes: 300,
             max_request_retry: 5,
             max_notification_id_mappings: 300,
-            max_num_consecutive_subscriptions: 50,
+            max_num_consecutive_subscriptions: 40, // At ~4 blocks per second, this should last 10 seconds
             progress_check_interval_ms: 50,
         }
     }


### PR DESCRIPTION
### Description
This PR enables subscription syncing by default (in the state sync configs).

### Test Plan
Existing test infrastructure.