### PR TITLE
[Docs] Add link to processor image on DockerHub

### DIFF
--- a/developer-docs-site/docs/indexer/api/self-hosted.md
+++ b/developer-docs-site/docs/indexer/api/self-hosted.md
@@ -88,3 +88,5 @@ docker run -it --network host --mount type=bind,source=/tmp/config.yaml,target=/
 ```
 
 This command binds the container to the host network and mounts the config file from the host into the container. This specific invocation assumes that your config file in the host is at `/tmp/config.yaml`.
+
+See the image on DockerHub here: https://hub.docker.com/r/aptoslabs/indexer-processor-rust/tags.


### PR DESCRIPTION
### Description
To make it nice and easy for people to see the image and what tags are available.

### Test Plan
Docs.
