### PR TITLE
[aptos-vm] enable automatic creation of sponsored accounts

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -84,6 +84,7 @@ pub enum FeatureFlag {
     SaferResourceGroups,
     SaferMetadata,
     Secp256k1ECDSAAuthenticator,
+    SponsoredAutomaticAccountCreation,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -220,6 +221,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::Secp256k1ECDSAAuthenticator => {
                 AptosFeatureFlag::SECP256K1_ECDSA_AUTHENTICATOR
             },
+            FeatureFlag::SponsoredAutomaticAccountCreation => {
+                AptosFeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
+            },
         }
     }
 }
@@ -278,6 +282,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::SAFER_METADATA => FeatureFlag::SaferMetadata,
             AptosFeatureFlag::SECP256K1_ECDSA_AUTHENTICATOR => {
                 FeatureFlag::Secp256k1ECDSAAuthenticator
+            },
+            AptosFeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION => {
+                FeatureFlag::SponsoredAutomaticAccountCreation
             },
         }
     }

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -378,6 +378,7 @@ impl AptosVMImpl {
             .iter()
             .map(|auth_key| MoveValue::vector_u8(auth_key.to_vec()))
             .collect();
+
         let (prologue_function_name, args) = if let (Some(fee_payer), Some(fee_payer_auth_key)) = (
             txn_data.fee_payer(),
             txn_data.fee_payer_authentication_key.as_ref(),
@@ -429,7 +430,6 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &APTOS_TRANSACTION_VALIDATION.module_id(),
                 prologue_function_name,
-                // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
                 serialize_values(&args),
                 &mut gas_meter,
@@ -458,7 +458,6 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &APTOS_TRANSACTION_VALIDATION.module_id(),
                 &APTOS_TRANSACTION_VALIDATION.module_prologue_name,
-                // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -8,6 +8,16 @@ use aptos_types::account_config;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::ModuleId};
 use once_cell::sync::Lazy;
 
+pub static ACCOUNT_MODULE: Lazy<ModuleId> = Lazy::new(|| {
+    ModuleId::new(
+        account_config::CORE_CODE_ADDRESS,
+        ident_str!("account").to_owned(),
+    )
+});
+
+pub const CREATE_ACCOUNT_IF_DOES_NOT_EXIST: &IdentStr =
+    ident_str!("create_account_if_does_not_exist");
+
 // Data to resolve basic account and transaction flow functions and structs
 /// The ModuleId for the aptos block module
 pub static BLOCK_MODULE: Lazy<ModuleId> = Lazy::new(|| {

--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -1,216 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
-use aptos_language_e2e_tests::{account::TransactionBuilder, transaction_status_eq};
-use aptos_types::{
-    account_address::AccountAddress,
-    move_utils::MemberId,
-    on_chain_config::FeatureFlag,
-    transaction::{EntryFunction, Script, TransactionArgument, TransactionStatus},
+use crate::{assert_success, MoveHarness};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_language_e2e_tests::{
+    account::{Account, TransactionBuilder},
+    transaction_status_eq,
 };
-use move_core_types::vm_status::StatusCode;
-
-fn read_coin(h: &MoveHarness, account: &AccountAddress) -> u64 {
-    h.read_aptos_balance(account)
-}
-
-#[test]
-fn test_two_to_two_transfer_fee_payer() {
-    let mut h = MoveHarness::new_with_features(vec![FeatureFlag::GAS_PAYER_ENABLED], vec![]);
-
-    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
-    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
-    let carol = h.new_account_at(AccountAddress::from_hex_literal("0xca501").unwrap());
-    let david = h.new_account_at(AccountAddress::from_hex_literal("0xda51d").unwrap());
-    let payer = h.new_account_at(AccountAddress::from_hex_literal("0xea51d").unwrap());
-
-    let amount_alice = 100;
-    let amount_bob = 200;
-    let amount_carol = 50;
-    let amount_david = amount_alice + amount_bob - amount_carol;
-
-    let build_options = aptos_framework::BuildOptions {
-        with_srcs: false,
-        with_abis: false,
-        with_source_maps: false,
-        with_error_map: false,
-        ..aptos_framework::BuildOptions::default()
-    };
-
-    let package = aptos_framework::BuiltPackage::build(
-        common::test_dir_path("../../../move-examples/scripts/two_by_two_transfer"),
-        build_options,
-    )
-    .expect("building package must succeed");
-
-    let alice_start = read_coin(&h, alice.address());
-    let bob_start = read_coin(&h, bob.address());
-    let carol_start = read_coin(&h, carol.address());
-    let david_start = read_coin(&h, david.address());
-    let payer_start = read_coin(&h, payer.address());
-
-    let code = package.extract_script_code()[0].clone();
-    let script = Script::new(code, vec![], vec![
-        TransactionArgument::U64(amount_alice),
-        TransactionArgument::U64(amount_bob),
-        TransactionArgument::Address(*carol.address()),
-        TransactionArgument::Address(*david.address()),
-        TransactionArgument::U64(amount_carol),
-    ]);
-
-    let transaction = TransactionBuilder::new(alice.clone())
-        .secondary_signers(vec![bob.clone()])
-        .fee_payer(payer.clone())
-        .script(script)
-        .sequence_number(h.sequence_number(alice.address()))
-        .max_gas_amount(1_000_000)
-        .gas_unit_price(1)
-        .sign_fee_payer();
-
-    let output = h.executor.execute_transaction(transaction);
-    assert_success!(output.status().to_owned());
-    h.executor.apply_write_set(output.write_set());
-
-    let alice_end = read_coin(&h, alice.address());
-    let bob_end = read_coin(&h, bob.address());
-    let carol_end = read_coin(&h, carol.address());
-    let david_end = read_coin(&h, david.address());
-    let payer_end = read_coin(&h, payer.address());
-
-    // Make sure sender alice doesn't pay gas
-    assert_eq!(alice_start - amount_alice, alice_end);
-    assert_eq!(bob_start - amount_bob, bob_end);
-    assert_eq!(carol_start + amount_carol, carol_end);
-    assert_eq!(david_start + amount_david, david_end);
-    // Make sure payer pays
-    assert_eq!(payer_start - output.gas_used(), payer_end);
-}
-
-#[test]
-fn test_two_to_two_transfer_fee_payer_is_sender() {
-    let mut h = MoveHarness::new_with_features(vec![FeatureFlag::GAS_PAYER_ENABLED], vec![]);
-
-    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
-    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
-    let carol = h.new_account_at(AccountAddress::from_hex_literal("0xca501").unwrap());
-    let david = h.new_account_at(AccountAddress::from_hex_literal("0xda51d").unwrap());
-    let payer = h.new_account_at(AccountAddress::from_hex_literal("0xea51d").unwrap());
-
-    let amount_alice = 100;
-    let amount_bob = 200;
-    let amount_carol = 50;
-    let amount_david = amount_alice + amount_bob - amount_carol;
-
-    let build_options = aptos_framework::BuildOptions {
-        with_srcs: false,
-        with_abis: false,
-        with_source_maps: false,
-        with_error_map: false,
-        ..aptos_framework::BuildOptions::default()
-    };
-
-    let package = aptos_framework::BuiltPackage::build(
-        common::test_dir_path("../../../move-examples/scripts/two_by_two_transfer"),
-        build_options,
-    )
-    .expect("building package must succeed");
-
-    let alice_start = read_coin(&h, alice.address());
-    let bob_start = read_coin(&h, bob.address());
-    let carol_start = read_coin(&h, carol.address());
-    let david_start = read_coin(&h, david.address());
-    let payer_start = read_coin(&h, payer.address());
-
-    let code = package.extract_script_code()[0].clone();
-    let script = Script::new(code, vec![], vec![
-        TransactionArgument::U64(amount_alice),
-        TransactionArgument::U64(amount_bob),
-        TransactionArgument::Address(*carol.address()),
-        TransactionArgument::Address(*david.address()),
-        TransactionArgument::U64(amount_carol),
-    ]);
-
-    let transaction = TransactionBuilder::new(alice.clone())
-        .secondary_signers(vec![bob.clone()])
-        .fee_payer(alice.clone())
-        .script(script)
-        .sequence_number(h.sequence_number(alice.address()))
-        .max_gas_amount(1_000_000)
-        .gas_unit_price(1)
-        .sign_fee_payer();
-
-    let output = h.executor.execute_transaction(transaction);
-    assert_success!(output.status().to_owned());
-    h.executor.apply_write_set(output.write_set());
-
-    let alice_end = read_coin(&h, alice.address());
-    let bob_end = read_coin(&h, bob.address());
-    let carol_end = read_coin(&h, carol.address());
-    let david_end = read_coin(&h, david.address());
-    let payer_end = read_coin(&h, payer.address());
-
-    // Make sure alice pays gas
-    assert_eq!(alice_start - amount_alice - output.gas_used(), alice_end);
-    assert_eq!(bob_start - amount_bob, bob_end);
-    assert_eq!(carol_start + amount_carol, carol_end);
-    assert_eq!(david_start + amount_david, david_end);
-    // Make sure payer doesn't pays
-    assert_eq!(payer_start, payer_end);
-}
-
-#[test]
-fn test_two_to_two_transfer_fee_payer_without_feature() {
-    let mut h = MoveHarness::new_with_features(vec![], vec![FeatureFlag::GAS_PAYER_ENABLED]);
-
-    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
-    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
-    let carol = h.new_account_at(AccountAddress::from_hex_literal("0xca501").unwrap());
-    let david = h.new_account_at(AccountAddress::from_hex_literal("0xda51d").unwrap());
-    let payer = h.new_account_at(AccountAddress::from_hex_literal("0xea51d").unwrap());
-
-    let amount_alice = 100;
-    let amount_bob = 200;
-    let amount_carol = 50;
-
-    let build_options = aptos_framework::BuildOptions {
-        with_srcs: false,
-        with_abis: false,
-        with_source_maps: false,
-        with_error_map: false,
-        ..aptos_framework::BuildOptions::default()
-    };
-
-    let package = aptos_framework::BuiltPackage::build(
-        common::test_dir_path("../../../move-examples/scripts/two_by_two_transfer"),
-        build_options,
-    )
-    .expect("building package must succeed");
-
-    let code = package.extract_script_code()[0].clone();
-    let script = Script::new(code, vec![], vec![
-        TransactionArgument::U64(amount_alice),
-        TransactionArgument::U64(amount_bob),
-        TransactionArgument::Address(*carol.address()),
-        TransactionArgument::Address(*david.address()),
-        TransactionArgument::U64(amount_carol),
-    ]);
-
-    let transaction = TransactionBuilder::new(alice.clone())
-        .secondary_signers(vec![bob])
-        .fee_payer(payer)
-        .script(script)
-        .sequence_number(h.sequence_number(alice.address()))
-        .max_gas_amount(1_000_000)
-        .gas_unit_price(1)
-        .sign_fee_payer();
-
-    let output = h.executor.execute_transaction(transaction);
-    assert!(transaction_status_eq(
-        output.status(),
-        &TransactionStatus::Discard(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION)
-    ));
-}
+use aptos_types::{
+    account_address::AccountAddress, account_config::CoinStoreResource,
+    on_chain_config::FeatureFlag, transaction::TransactionStatus,
+};
+use move_core_types::{move_resource::MoveStructType, vm_status::StatusCode};
 
 #[test]
 fn test_normal_tx_with_signer_with_fee_payer() {
@@ -219,78 +20,87 @@ fn test_normal_tx_with_signer_with_fee_payer() {
     let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start = read_coin(&h, alice.address());
-    let bob_start = read_coin(&h, bob.address());
+    let alice_start = h.read_aptos_balance(alice.address());
+    let bob_start = h.read_aptos_balance(bob.address());
 
-    // Load the code
-    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(
-        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
-    );
-
-    let fun: MemberId = str::parse("0xcafe::test::hi").unwrap();
-    let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![bcs::to_bytes(
-        &"Hi",
-    )
-    .unwrap()]);
+    let payload = aptos_stdlib::aptos_account_set_allow_direct_coin_transfers(true);
     let transaction = TransactionBuilder::new(alice.clone())
         .fee_payer(bob.clone())
-        .entry_function(entry)
+        .payload(payload)
         .sequence_number(h.sequence_number(alice.address()))
         .max_gas_amount(1_000_000)
         .gas_unit_price(1)
         .sign_fee_payer();
 
-    let output = h.executor.execute_transaction(transaction);
-    // The last signer became the gas payer and thus, the execution errors with a mismatch
-    // between required signers as parameters and signers passed in.
-    assert_success!(output.status().to_owned());
-    h.executor.apply_write_set(output.write_set());
+    let output = h.run_raw(transaction);
+    assert_success!(*output.status());
 
-    let alice_after = read_coin(&h, alice.address());
-    let bob_after = read_coin(&h, bob.address());
+    let alice_after = h.read_aptos_balance(alice.address());
+    let bob_after = h.read_aptos_balance(bob.address());
 
     assert_eq!(alice_start, alice_after);
     assert!(bob_start > bob_after);
 }
 
 #[test]
-fn test_normal_tx_without_signer_with_fee_payer() {
+fn test_account_not_exist_with_fee_payer_create_account() {
     let mut h = MoveHarness::new_with_features(vec![FeatureFlag::GAS_PAYER_ENABLED], vec![]);
 
-    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
+    let alice = Account::new();
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start = read_coin(&h, alice.address());
-    let bob_start = read_coin(&h, bob.address());
+    let alice_start =
+        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    assert!(alice_start.is_none());
+    let bob_start = h.read_aptos_balance(bob.address());
 
-    // Load the code
-    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(
-        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
-    );
-
-    let fun: MemberId = str::parse("0xcafe::test::nothing").unwrap();
-    let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![]);
+    let payload = aptos_stdlib::aptos_account_set_allow_direct_coin_transfers(true);
     let transaction = TransactionBuilder::new(alice.clone())
         .fee_payer(bob.clone())
-        .entry_function(entry)
-        .sequence_number(h.sequence_number(alice.address()))
+        .payload(payload)
+        .sequence_number(0)
         .max_gas_amount(1_000_000)
         .gas_unit_price(1)
         .sign_fee_payer();
 
-    let output = h.executor.execute_transaction(transaction);
-    // The last signer became the gas payer and thus, the execution errors with a mismatch
-    // between required signers as parameters and signers passed in.
-    assert_success!(output.status().to_owned());
-    h.executor.apply_write_set(output.write_set());
+    let output = h.run_raw(transaction);
+    assert_success!(*output.status());
 
-    let alice_after = read_coin(&h, alice.address());
-    let bob_after = read_coin(&h, bob.address());
+    let alice_after =
+        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    assert!(alice_after.is_none());
+    let bob_after = h.read_aptos_balance(bob.address());
 
-    assert_eq!(alice_start, alice_after);
     assert!(bob_start > bob_after);
+}
+
+#[test]
+fn test_account_not_exist_with_fee_payer_without_create_account() {
+    let mut h = MoveHarness::new_with_features(vec![FeatureFlag::GAS_PAYER_ENABLED], vec![
+        FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
+    ]);
+
+    let alice = Account::new();
+    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
+
+    let alice_start =
+        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    assert!(alice_start.is_none());
+
+    let payload = aptos_stdlib::aptos_account_set_allow_direct_coin_transfers(true);
+    let transaction = TransactionBuilder::new(alice.clone())
+        .fee_payer(bob.clone())
+        .payload(payload)
+        .sequence_number(0)
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign_fee_payer();
+
+    let output = h.run_raw(transaction);
+    assert!(transaction_status_eq(
+        output.status(),
+        &TransactionStatus::Discard(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST)
+    ));
 }
 
 #[test]
@@ -300,23 +110,16 @@ fn test_normal_tx_with_fee_payer_insufficient_funds() {
     let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
     let bob = h.new_account_with_balance_and_sequence_number(1, 0);
 
-    // Load the code
-    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(
-        h.publish_package_cache_building(&acc, &common::test_dir_path("string_args.data/pack"))
-    );
-
-    let fun: MemberId = str::parse("0xcafe::test::nothing").unwrap();
-    let entry = EntryFunction::new(fun.module_id, fun.member_id, vec![], vec![]);
+    let payload = aptos_stdlib::aptos_account_set_allow_direct_coin_transfers(true);
     let transaction = TransactionBuilder::new(alice.clone())
-        .fee_payer(bob)
-        .entry_function(entry)
+        .fee_payer(bob.clone())
+        .payload(payload)
         .sequence_number(h.sequence_number(alice.address()))
         .max_gas_amount(1_000_000)
         .gas_unit_price(1)
         .sign_fee_payer();
 
-    let output = h.executor.execute_transaction(transaction);
+    let output = h.run_raw(transaction);
     assert!(transaction_status_eq(
         output.status(),
         &TransactionStatus::Discard(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE)

--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -19,6 +19,7 @@
 -  [Struct `SignerCapabilityOfferProofChallengeV2`](#0x1_account_SignerCapabilityOfferProofChallengeV2)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_account_initialize)
+-  [Function `create_account_if_does_not_exist`](#0x1_account_create_account_if_does_not_exist)
 -  [Function `create_account`](#0x1_account_create_account)
 -  [Function `create_account_unchecked`](#0x1_account_create_account_unchecked)
 -  [Function `exists_at`](#0x1_account_exists_at)
@@ -53,6 +54,7 @@
 -  [Function `verify_signed_message`](#0x1_account_verify_signed_message)
 -  [Specification](#@Specification_1)
     -  [Function `initialize`](#@Specification_1_initialize)
+    -  [Function `create_account_if_does_not_exist`](#@Specification_1_create_account_if_does_not_exist)
     -  [Function `create_account`](#@Specification_1_create_account)
     -  [Function `create_account_unchecked`](#@Specification_1_create_account_unchecked)
     -  [Function `exists_at`](#@Specification_1_exists_at)
@@ -840,6 +842,32 @@ Only called during genesis to initialize system resources for this module.
     <b>move_to</b>(aptos_framework, <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
         address_map: <a href="../../aptos-stdlib/doc/table.md#0x1_table_new">table::new</a>(),
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_account_create_account_if_does_not_exist"></a>
+
+## Function `create_account_if_does_not_exist`
+
+
+
+<pre><code><b>fun</b> <a href="account.md#0x1_account_create_account_if_does_not_exist">create_account_if_does_not_exist</a>(account_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="account.md#0x1_account_create_account_if_does_not_exist">create_account_if_does_not_exist</a>(account_address: <b>address</b>) {
+    <b>if</b> (!<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_address)) {
+        <a href="account.md#0x1_account_create_account">create_account</a>(account_address);
+    }
 }
 </code></pre>
 
@@ -2085,6 +2113,30 @@ OriginatingAddress does not exist under <code>@aptos_framework</code> before the
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(aptos_addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(aptos_addr);
 <b>ensures</b> <b>exists</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(aptos_addr);
+</code></pre>
+
+
+
+<a name="@Specification_1_create_account_if_does_not_exist"></a>
+
+### Function `create_account_if_does_not_exist`
+
+
+<pre><code><b>fun</b> <a href="account.md#0x1_account_create_account_if_does_not_exist">create_account_if_does_not_exist</a>(account_address: <b>address</b>)
+</code></pre>
+
+
+Ensure that the account exists at the end of the call.
+
+
+<pre><code><b>let</b> authentication_key = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(account_address);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_address) && (
+    account_address == @vm_reserved
+    || account_address == @aptos_framework
+    || account_address == @aptos_token
+    || !(len(authentication_key) == 32)
+);
+<b>ensures</b> <b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_address);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -173,6 +173,12 @@ module aptos_framework::account {
         });
     }
 
+    fun create_account_if_does_not_exist(account_address: address) {
+        if (!exists<Account>(account_address)) {
+            create_account(account_address);
+        }
+    }
+
     /// Publishes a new `Account` resource under `new_address`. A signer representing `new_address`
     /// is returned. This way, the caller of this function can publish additional resources under
     /// `new_address`.

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -15,6 +15,20 @@ spec aptos_framework::account {
         //ensures global<OriginatingAddress>(aptos_addr).address_map == table::new();
     }
 
+    /// Ensure that the account exists at the end of the call.
+    spec create_account_if_does_not_exist(account_address: address) {
+        let authentication_key = bcs::to_bytes(account_address);
+
+        aborts_if !exists<Account>(account_address) && (
+            account_address == @vm_reserved
+            || account_address == @aptos_framework
+            || account_address == @aptos_token
+            || !(len(authentication_key) == 32)
+        );
+        ensures exists<Account>(account_address);
+    }
+
+
     /// Check if the bytes of the new address is 32.
     /// The Account does not exist under the new address before creating the account.
     /// Limit the new account address is not @vm_reserved / @aptos_framework / @aptos_toke.

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
@@ -24,6 +24,7 @@ spec aptos_framework::transaction_validation {
     /// Create a schema to reuse some code.
     /// Give some constraints that may abort according to the conditions.
     spec schema PrologueCommonAbortsIf {
+        use std::bcs;
         use aptos_framework::timestamp::{CurrentTimeMicroseconds};
         use aptos_framework::chain_id::{ChainId};
         use aptos_framework::account::{Account};
@@ -43,14 +44,29 @@ spec aptos_framework::transaction_validation {
         aborts_if !exists<ChainId>(@aptos_framework);
         aborts_if !(chain_id::get() == chain_id);
         let transaction_sender = signer::address_of(sender);
-        aborts_if !account::exists_at(transaction_sender);
-        aborts_if !(txn_sequence_number >= global<Account>(transaction_sender).sequence_number);
-        aborts_if !(txn_authentication_key == global<Account>(transaction_sender).authentication_key);
+
+        aborts_if (
+            !features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+            || account::exists_at(transaction_sender)
+            || transaction_sender == gas_payer
+            || txn_sequence_number > 0
+        ) && (
+            !(txn_sequence_number >= global<Account>(transaction_sender).sequence_number)
+            || !(txn_authentication_key == global<Account>(transaction_sender).authentication_key)
+            || !account::exists_at(transaction_sender)
+            || !(txn_sequence_number == global<Account>(transaction_sender).sequence_number)
+        );
+
+        aborts_if features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+            && transaction_sender != gas_payer
+            && txn_sequence_number == 0
+            && !account::exists_at(transaction_sender)
+            && txn_authentication_key != bcs::to_bytes(transaction_sender);
+
         aborts_if !(txn_sequence_number < (1u64 << 63));
 
         let max_transaction_fee = txn_gas_price * txn_max_gas_units;
         aborts_if max_transaction_fee > MAX_U64;
-        aborts_if !(txn_sequence_number == global<Account>(transaction_sender).sequence_number);
         aborts_if !exists<CoinStore<AptosCoin>>(gas_payer);
         // property 1: The sender of a transaction should have sufficient coin balance to pay the transaction fee.
         aborts_if !(global<CoinStore<AptosCoin>>(gas_payer).coin.value >= max_transaction_fee);

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -72,6 +72,8 @@ return true.
 -  [Function `module_event_enabled`](#0x1_features_module_event_enabled)
 -  [Function `get_aggregator_snapshots_feature`](#0x1_features_get_aggregator_snapshots_feature)
 -  [Function `aggregator_snapshots_enabled`](#0x1_features_aggregator_snapshots_enabled)
+-  [Function `get_sponsored_automatic_account_creation`](#0x1_features_get_sponsored_automatic_account_creation)
+-  [Function `sponsored_automatic_account_creation_enabled`](#0x1_features_sponsored_automatic_account_creation_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -393,6 +395,17 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_SIGNER_NATIVE_FORMAT_FIX">SIGNER_NATIVE_FORMAT_FIX</a>: u64 = 25;
+</code></pre>
+
+
+
+<a name="0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION"></a>
+
+Whether the automatic creation of accounts is enabled for sponsored transactions.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>: u64 = 34;
 </code></pre>
 
 
@@ -1371,6 +1384,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_snapshots_enabled">aggregator_snapshots_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_AGGREGATOR_SNAPSHOTS">AGGREGATOR_SNAPSHOTS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_sponsored_automatic_account_creation"></a>
+
+## Function `get_sponsored_automatic_account_creation`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_sponsored_automatic_account_creation">get_sponsored_automatic_account_creation</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_sponsored_automatic_account_creation">get_sponsored_automatic_account_creation</a>(): u64 { <a href="features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_sponsored_automatic_account_creation_enabled"></a>
+
+## Function `sponsored_automatic_account_creation_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sponsored_automatic_account_creation_enabled">sponsored_automatic_account_creation_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sponsored_automatic_account_creation_enabled">sponsored_automatic_account_creation_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -251,6 +251,15 @@ module std::features {
         is_enabled(AGGREGATOR_SNAPSHOTS)
     }
 
+    /// Whether the automatic creation of accounts is enabled for sponsored transactions.
+    /// Lifetime: transient
+    const SPONSORED_AUTOMATIC_ACCOUNT_CREATION: u64 = 34;
+
+    public fun get_sponsored_automatic_account_creation(): u64 { SPONSORED_AUTOMATIC_ACCOUNT_CREATION }
+
+    public fun sponsored_automatic_account_creation_enabled(): bool acquires Features {
+        is_enabled(SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+    }
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -431,6 +431,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SAFER_RESOURCE_GROUPS,
         FeatureFlag::SAFER_METADATA,
         FeatureFlag::SECP256K1_ECDSA_AUTHENTICATOR,
+        FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
     ]
 }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -41,6 +41,7 @@ pub enum FeatureFlag {
     SAFER_RESOURCE_GROUPS = 31,
     SAFER_METADATA = 32,
     SECP256K1_ECDSA_AUTHENTICATOR = 33,
+    SPONSORED_AUTOMATIC_ACCOUNT_CREATION = 34,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
This is the implementation of AIP-52:
https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-52.md

This AIP proposes to allow sponsored transactions, one in which the gas payer is not the primary signer of the transaction, to create accounts for the primary signer if it does not exist. Currently when submitting a sponsored transaction an account must first exist. This is an unnecessary friction for using gas fee payer accounts for new accounts. As it means that the gas fee payer solution must first submit an independent transaction to the blockchain.

I also cleaned up the tests for fee payer since there were a lot, and they were excessively complex.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
