### PR TITLE
[fee-payer] make fee payer address optionally set during signing

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -255,19 +255,18 @@ async fn test_multi_agent_signed_transaction() {
 async fn test_fee_payer_signed_transaction() {
     let mut context = new_test_context(current_function_name!());
     let account = context.gen_account();
-    let secondary = context.gen_account();
+    let fee_payer = context.gen_account();
     let factory = context.transaction_factory();
     let mut root_account = context.root_account().await;
 
-    // Create secondary signer account
     context
-        .commit_block(&[context.create_user_account_by(&mut root_account, &secondary)])
+        .commit_block(&[context.create_user_account_by(&mut root_account, &fee_payer)])
         .await;
 
     // Create a new account with a multi-agent signer
     let txn = root_account.sign_fee_payer_with_transaction_builder(
         vec![],
-        &secondary,
+        &fee_payer,
         factory.create_user_account(account.public_key()),
     );
 
@@ -286,7 +285,7 @@ async fn test_fee_payer_signed_transaction() {
             fee_payer_signer,
         } => (sender, secondary_signers, fee_payer_signer),
         _ => panic!(
-            "expecting TransactionAuthenticator::MultiAgent, but got: {:?}",
+            "expecting TransactionAuthenticator::FeePayer, but got: {:?}",
             txn.authenticator()
         ),
     };
@@ -303,7 +302,7 @@ async fn test_fee_payer_signed_transaction() {
             ],
             "secondary_signers": [
             ],
-            "fee_payer_address": secondary.address().to_hex_literal(),
+            "fee_payer_address": fee_payer.address().to_hex_literal(),
             "fee_payer_signer": {
                 "type": "ed25519_signature",
                 "public_key": format!("0x{}",hex::encode(fee_payer_signer.public_key_bytes())),
@@ -313,6 +312,60 @@ async fn test_fee_payer_signed_transaction() {
     );
 
     // ensure fee payer txns can be submitted into mempool by JSON format
+    context
+        .expect_status_code(202)
+        .post("/transactions", resp)
+        .await;
+
+    // Now test for the new format where the fee payer is unset... this also tests account creation
+    let another_account = context.gen_account();
+    let yet_another_account = context.gen_account();
+    let another_raw_txn = another_account
+        .sign_fee_payer_with_transaction_builder(
+            vec![],
+            &fee_payer,
+            factory.create_user_account(yet_another_account.public_key()),
+        )
+        .into_raw_transaction();
+    let another_txn = another_raw_txn
+        .clone()
+        .sign_fee_payer(
+            another_account.private_key(),
+            vec![],
+            vec![],
+            AccountAddress::ZERO,
+            fee_payer.private_key(),
+        )
+        .unwrap();
+
+    let another_txn = match another_txn.authenticator() {
+        TransactionAuthenticator::FeePayer {
+            sender,
+            secondary_signer_addresses,
+            secondary_signers,
+            fee_payer_address: _,
+            fee_payer_signer,
+        } => {
+            let auth = TransactionAuthenticator::fee_payer(
+                sender,
+                secondary_signer_addresses,
+                secondary_signers,
+                fee_payer.address(),
+                fee_payer_signer,
+            );
+            SignedTransaction::new_signed_transaction(another_raw_txn, auth)
+        },
+        _ => panic!(
+            "expecting TransactionAuthenticator::FeePayer, but got: {:?}",
+            txn.authenticator()
+        ),
+    };
+
+    let body = bcs::to_bytes(&another_txn).unwrap();
+    let resp = context
+        .expect_status_code(202)
+        .post_bcs_txn("/transactions", body)
+        .await;
     context
         .expect_status_code(202)
         .post("/transactions", resp)

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -85,6 +85,7 @@ pub enum FeatureFlag {
     SaferMetadata,
     Secp256k1ECDSAAuthenticator,
     SponsoredAutomaticAccountCreation,
+    FeePayerAccountOptional,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -224,6 +225,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::SponsoredAutomaticAccountCreation => {
                 AptosFeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
             },
+            FeatureFlag::FeePayerAccountOptional => AptosFeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
         }
     }
 }
@@ -286,6 +288,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION => {
                 FeatureFlag::SponsoredAutomaticAccountCreation
             },
+            AptosFeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL => FeatureFlag::FeePayerAccountOptional,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/adapter_common.rs
+++ b/aptos-move/aptos-vm/src/adapter_common.rs
@@ -28,7 +28,7 @@ pub trait VMAdapter {
 
     /// Checks the signature of the given signed transaction and returns
     /// `Ok(SignatureCheckedTransaction)` if the signature is valid.
-    fn check_signature(txn: SignedTransaction) -> Result<SignatureCheckedTransaction>;
+    fn check_signature(&self, txn: SignedTransaction) -> Result<SignatureCheckedTransaction>;
 
     /// Check if the transaction format is supported.
     fn check_transaction_format(&self, txn: &SignedTransaction) -> Result<(), VMStatus>;

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1654,7 +1654,7 @@ impl VMValidator for AptosVM {
             }
         }
 
-        let txn = match Self::check_signature(transaction) {
+        let txn = match self.check_signature(transaction) {
             Ok(t) => t,
             _ => {
                 return VMValidatorResult::error(StatusCode::INVALID_SIGNATURE);
@@ -1700,7 +1700,19 @@ impl VMAdapter for AptosVM {
         self.0.new_session(resolver, session_id)
     }
 
-    fn check_signature(txn: SignedTransaction) -> Result<SignatureCheckedTransaction> {
+    fn check_signature(&self, txn: SignedTransaction) -> Result<SignatureCheckedTransaction> {
+        if let aptos_types::transaction::authenticator::TransactionAuthenticator::FeePayer {
+            ..
+        } = &txn.authenticator_ref()
+        {
+            if self
+                .0
+                .get_features()
+                .is_enabled(FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL)
+            {
+                return txn.check_fee_payer_signature();
+            }
+        }
         txn.check_signature()
     }
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -432,6 +432,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SAFER_METADATA,
         FeatureFlag::SECP256K1_ECDSA_AUTHENTICATOR,
         FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
+        FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
     ]
 }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -42,6 +42,7 @@ pub enum FeatureFlag {
     SAFER_METADATA = 32,
     SECP256K1_ECDSA_AUTHENTICATOR = 33,
     SPONSORED_AUTOMATIC_ACCOUNT_CREATION = 34,
+    FEE_PAYER_ACCOUNT_OPTIONAL = 35,
 }
 
 /// Representation of features on chain as a bitset.

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -157,8 +157,6 @@ impl TransactionAuthenticator {
                 fee_payer_address,
                 fee_payer_signer,
             } => {
-                // We need to include the fee payer and other signer addresses in the payload data
-                // to sign.
                 let message = RawTransactionWithData::new_fee_payer(
                     raw_txn.clone(),
                     secondary_signer_addresses.clone(),
@@ -194,6 +192,73 @@ impl TransactionAuthenticator {
                 public_key,
                 signature,
             } => signature.verify(raw_txn, public_key),
+        }
+    }
+
+    /// Return Ok if all AccountAuthenticator's public keys match their signatures, Err otherwise
+    /// Special check for fee payer transaction having optional fee payer address in the
+    /// transaction. This will be removed after 1.8 has been fully released.
+    pub fn verify_with_optional_fee_payer(&self, raw_txn: &RawTransaction) -> Result<()> {
+        match self {
+            Self::FeePayer {
+                sender,
+                secondary_signer_addresses,
+                secondary_signers,
+                fee_payer_address,
+                fee_payer_signer,
+            } => {
+                // Some checks duplicated here to so we don't need to repeat checks.
+                let num_sigs: usize = self.sender().number_of_signatures()
+                    + self
+                        .secondary_signers()
+                        .iter()
+                        .map(|auth| auth.number_of_signatures())
+                        .sum::<usize>();
+                if num_sigs > MAX_NUM_OF_SIGS {
+                    return Err(Error::new(AuthenticationError::MaxSignaturesExceeded));
+                }
+
+                // In the fee payer model, the fee payer address can be optionally signed. We
+                // realized when we designed the fee payer model, that we made it too restrictive
+                // by requiring the signature over the fee payer address. So now we need to live in
+                // a world where we support a multitude of different solutions. The modern approach
+                // assumes that some may sign over the address and others will sign over the zero
+                // address, so we verify both and only fail if the signature fails for either of
+                // them. The legacy approach is to assume the address of the fee payer is signed
+                // over.
+                let mut to_verify = vec![sender, fee_payer_signer];
+                let _ = secondary_signers
+                    .iter()
+                    .map(|signer| to_verify.push(signer))
+                    .collect::<Vec<_>>();
+
+                let no_fee_payer_address_message = RawTransactionWithData::new_fee_payer(
+                    raw_txn.clone(),
+                    secondary_signer_addresses.clone(),
+                    AccountAddress::ZERO,
+                );
+
+                let remaining = to_verify
+                    .iter()
+                    .filter(|verifier| verifier.verify(&no_fee_payer_address_message).is_err())
+                    .collect::<Vec<_>>();
+                if remaining.is_empty() {
+                    return Ok(());
+                }
+
+                let fee_payer_address_message = RawTransactionWithData::new_fee_payer(
+                    raw_txn.clone(),
+                    secondary_signer_addresses.clone(),
+                    *fee_payer_address,
+                );
+
+                for verifier in remaining {
+                    verifier.verify(&fee_payer_address_message)?;
+                }
+
+                Ok(())
+            },
+            _ => self.verify(raw_txn),
         }
     }
 
@@ -675,11 +740,214 @@ impl fmt::Display for AuthenticationKey {
 
 #[cfg(test)]
 mod tests {
-    use crate::transaction::authenticator::AuthenticationKey;
-    use std::str::FromStr;
+    use super::*;
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 
     #[test]
     fn test_from_str_should_not_panic_by_given_empty_string() {
         assert!(AuthenticationKey::from_str("").is_err());
+    }
+
+    #[test]
+    fn verify_fee_payer_with_optional_fee_payer_address() {
+        // This massive test basically verifies that various combinations of signatures work
+        // with the appropriate verifiers:
+        // verify -- only works with properly set fee payer address
+        // verify_with_optional_fee_payer -- works with either fee payer address or zero
+        // both of them reject anything else
+        let sender = Ed25519PrivateKey::generate_for_testing();
+        let sender_pub = sender.public_key();
+        let sender_auth = AuthenticationKey::ed25519(&sender_pub);
+        let sender_addr = sender_auth.account_address();
+
+        let fee_payer = Ed25519PrivateKey::generate_for_testing();
+        let fee_payer_pub = fee_payer.public_key();
+        let fee_payer_auth = AuthenticationKey::ed25519(&fee_payer_pub);
+        let fee_payer_addr = fee_payer_auth.account_address();
+
+        let second_sender_0 = Ed25519PrivateKey::generate_for_testing();
+        let second_sender_0_pub = second_sender_0.public_key();
+        let second_sender_0_auth = AuthenticationKey::ed25519(&second_sender_0_pub);
+        let second_sender_0_addr = second_sender_0_auth.account_address();
+
+        let second_sender_1 = Ed25519PrivateKey::generate_for_testing();
+        let second_sender_1_pub = second_sender_1.public_key();
+        let second_sender_1_auth = AuthenticationKey::ed25519(&second_sender_1_pub);
+        let second_sender_1_addr = second_sender_1_auth.account_address();
+
+        let raw_txn = crate::test_helpers::transaction_test_helpers::get_test_signed_transaction(
+            sender_addr,
+            0,
+            &sender,
+            sender_pub,
+            None,
+            0,
+            0,
+            None,
+        )
+        .into_raw_transaction();
+
+        let original_fee_payer = raw_txn
+            .clone()
+            .sign_fee_payer(
+                &sender,
+                vec![second_sender_0_addr, second_sender_1_addr],
+                vec![&second_sender_0, &second_sender_0],
+                fee_payer_addr,
+                &fee_payer,
+            )
+            .unwrap()
+            .into_inner();
+        original_fee_payer.clone().check_signature().unwrap();
+        original_fee_payer
+            .clone()
+            .check_fee_payer_signature()
+            .unwrap();
+
+        let (sender_actual, second_signers_actual, fee_payer_signer_actual) =
+            match original_fee_payer.authenticator_ref() {
+                TransactionAuthenticator::FeePayer {
+                    sender,
+                    secondary_signer_addresses: _,
+                    secondary_signers,
+                    fee_payer_address: _,
+                    fee_payer_signer,
+                } => (sender, secondary_signers, fee_payer_signer),
+                _ => panic!("Impossible path."),
+            };
+
+        let new_fee_payer = raw_txn
+            .clone()
+            .sign_fee_payer(
+                &sender,
+                vec![second_sender_0_addr, second_sender_1_addr],
+                vec![&second_sender_0, &second_sender_0],
+                AccountAddress::ZERO,
+                &fee_payer,
+            )
+            .unwrap()
+            .into_inner();
+        new_fee_payer.clone().check_signature().unwrap();
+        new_fee_payer.clone().check_fee_payer_signature().unwrap();
+
+        let (sender_zero, second_signers_zero, fee_payer_signer_zero) =
+            match new_fee_payer.authenticator_ref() {
+                TransactionAuthenticator::FeePayer {
+                    sender,
+                    secondary_signer_addresses: _,
+                    secondary_signers,
+                    fee_payer_address: _,
+                    fee_payer_signer,
+                } => (sender, secondary_signers, fee_payer_signer),
+                _ => panic!("Impossible path."),
+            };
+
+        let bad_fee_payer = raw_txn
+            .clone()
+            .sign_fee_payer(
+                &sender,
+                vec![second_sender_0_addr, second_sender_1_addr],
+                vec![&second_sender_0, &second_sender_0],
+                AccountAddress::ONE,
+                &fee_payer,
+            )
+            .unwrap()
+            .into_inner();
+
+        let (sender_bad, second_signers_bad, fee_payer_signer_bad) =
+            match bad_fee_payer.authenticator_ref() {
+                TransactionAuthenticator::FeePayer {
+                    sender,
+                    secondary_signer_addresses: _,
+                    secondary_signers,
+                    fee_payer_address: _,
+                    fee_payer_signer,
+                } => (sender, secondary_signers, fee_payer_signer),
+                _ => panic!("Impossible path."),
+            };
+
+        let fee_payer_unset_at_signing = TransactionAuthenticator::fee_payer(
+            sender_zero.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_zero.clone(),
+            fee_payer_addr,
+            fee_payer_signer_zero.clone(),
+        );
+        fee_payer_unset_at_signing
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap();
+        fee_payer_unset_at_signing
+            .clone()
+            .verify(&raw_txn)
+            .unwrap_err();
+
+        let fee_payer_partial_at_signing_0 = TransactionAuthenticator::fee_payer(
+            sender_actual.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_zero.clone(),
+            fee_payer_addr,
+            fee_payer_signer_zero.clone(),
+        );
+        fee_payer_partial_at_signing_0
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap();
+        fee_payer_partial_at_signing_0
+            .clone()
+            .verify(&raw_txn)
+            .unwrap_err();
+
+        let fee_payer_partial_at_signing_1 = TransactionAuthenticator::fee_payer(
+            sender_zero.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_actual.clone(),
+            fee_payer_addr,
+            fee_payer_signer_actual.clone(),
+        );
+        fee_payer_partial_at_signing_1
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap();
+        fee_payer_partial_at_signing_1.verify(&raw_txn).unwrap_err();
+
+        let fee_payer_bad_0 = TransactionAuthenticator::fee_payer(
+            sender_bad.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_actual.clone(),
+            fee_payer_addr,
+            fee_payer_signer_actual.clone(),
+        );
+        fee_payer_bad_0
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap_err();
+        fee_payer_bad_0.clone().verify(&raw_txn).unwrap_err();
+
+        let fee_payer_bad_1 = TransactionAuthenticator::fee_payer(
+            sender_zero.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_bad.clone(),
+            fee_payer_addr,
+            fee_payer_signer_actual.clone(),
+        );
+        fee_payer_bad_1
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap_err();
+        fee_payer_bad_1.clone().verify(&raw_txn).unwrap_err();
+
+        let fee_payer_bad_2 = TransactionAuthenticator::fee_payer(
+            sender_zero.clone(),
+            vec![second_sender_0_addr, second_sender_1_addr],
+            second_signers_actual.clone(),
+            fee_payer_addr,
+            fee_payer_signer_bad.clone(),
+        );
+        fee_payer_bad_2
+            .clone()
+            .verify_with_optional_fee_payer(&raw_txn)
+            .unwrap_err();
+        fee_payer_bad_2.clone().verify(&raw_txn).unwrap_err();
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -594,6 +594,17 @@ impl Debug for SignedTransaction {
 }
 
 impl SignedTransaction {
+    pub fn new_signed_transaction(
+        raw_txn: RawTransaction,
+        authenticator: TransactionAuthenticator,
+    ) -> SignedTransaction {
+        SignedTransaction {
+            raw_txn,
+            authenticator,
+            size: OnceCell::new(),
+        }
+    }
+
     pub fn new(
         raw_txn: RawTransaction,
         public_key: Ed25519PublicKey,
@@ -738,6 +749,14 @@ impl SignedTransaction {
     /// the signature is valid.
     pub fn check_signature(self) -> Result<SignatureCheckedTransaction> {
         self.authenticator.verify(&self.raw_txn)?;
+        Ok(SignatureCheckedTransaction(self))
+    }
+
+    /// Special check for fee payer transaction having optional fee payer address in the
+    /// transaction. This will be removed after 1.8 has been fully released.
+    pub fn check_fee_payer_signature(self) -> Result<SignatureCheckedTransaction> {
+        self.authenticator
+            .verify_with_optional_fee_payer(&self.raw_txn)?;
         Ok(SignatureCheckedTransaction(self))
     }
 


### PR DESCRIPTION
sometimes the client would like to send a transaction to a fee paying network without knowing who will actually pay for it... this PR makes the fee payer address optional by allowing signatures on Address::ZERO

AIP forthcoming will update...

I've built this on the updated sponsored transction PR, will rebase and land as appropriate assuming sufficient approvals land.