### PR TITLE
Replace aggregator identifiers with values in sequential execution

### DIFF
--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -146,6 +146,8 @@ impl VMOutput {
         TransactionOutput::new(write_set, events, gas_used, status)
     }
 
+    /// Updates the VMChangeSet based on the input aggregator v1 deltas, patched resource write set,
+    /// patched events, and generates TransactionOutput
     pub fn into_transaction_output_with_materialized_write_set(
         mut self,
         materialized_aggregator_v1_deltas: Vec<(StateKey, WriteOp)>,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -150,23 +150,6 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .to_vec()
     }
 
-    /// Can be called (at most) once after transaction is committed to internally
-    /// include the delta outputs with the transaction outputs.
-    fn incorporate_delta_writes(&self, delta_writes: Vec<(StateKey, WriteOp)>) {
-        assert!(
-            self.committed_output
-                .set(
-                    self.vm_output
-                        .lock()
-                        .take()
-                        .expect("Output must be set to combine with deltas")
-                        .into_transaction_output_with_materialized_deltas(delta_writes),
-                )
-                .is_ok(),
-            "Could not combine VMOutput with deltas"
-        );
-    }
-
     fn incorporate_materialized_txn_output(
         &self,
         aggregator_v1_writes: Vec<(<Self::Txn as BlockExecutableTransaction>::Key, WriteOp)>,

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -877,7 +877,7 @@ where
         }
     }
 
-    fn apply_delayed_field_writes_sequential(
+    fn apply_output_sequential(
         unsync_map: &UnsyncMap<T::Key, T::Value, X, T::Identifier>,
         output: &E::Output,
     ) {
@@ -986,7 +986,7 @@ where
                     counters::update_sequential_txn_gas_counters(&fee_statement);
 
                     // Apply the writes.
-                    Self::apply_delayed_field_writes_sequential(&unsync_map, &output);
+                    Self::apply_output_sequential(&unsync_map, &output);
 
                     // Replace delayed field id with values in resource write set and read set.
                     let delayed_field_keys = Some(output.delayed_field_change_set().into_keys());

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1011,10 +1011,10 @@ where
                         &latest_view,
                     );
 
-                    // No delta writes are needed for sequential execution.
                     output.incorporate_materialized_txn_output(
+                        // No aggregator v1 delta writes are needed for sequential execution.
                         vec![],
-                        HashMap::new(),
+                        patched_resource_write_set,
                         patched_events,
                     );
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -532,17 +532,15 @@ where
     fn map_id_to_values_in_read_set_sequential(
         delayed_field_keys: Option<impl Iterator<Item = T::Identifier>>,
         write_set_keys: HashSet<T::Key>,
-        read_set: RefCell<HashMap<T::Key, HashSet<T::Identifier>>>,
+        read_set: RefCell<HashSet<T::Key>>,
         unsync_map: &UnsyncMap<T::Key, T::Value, X, T::Identifier>,
         latest_view: &LatestView<T, S, X>,
     ) -> HashMap<T::Key, T::Value> {
         let mut patched_resource_write_set = HashMap::new();
         if let Some(delayed_field_keys) = delayed_field_keys {
             let delayed_field_keys = delayed_field_keys.collect::<HashSet<_>>();
-            for (key, delayed_field_keys_in_resource) in read_set.borrow().iter() {
-                if write_set_keys.contains(key)
-                    || delayed_field_keys.is_disjoint(delayed_field_keys_in_resource)
-                {
+            for key in read_set.borrow().iter() {
+                if write_set_keys.contains(key) {
                     continue;
                 }
                 // layout is Some(_) if it contains an delayed field
@@ -965,7 +963,7 @@ where
                 ViewState::Unsync(SequentialState {
                     unsync_map: &unsync_map,
                     counter: &counter,
-                    delayed_field_keys_in_resources: RefCell::new(HashMap::new()),
+                    read_set: RefCell::new(HashSet::new()),
                 }),
                 idx as TxnIndex,
             );

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -692,10 +692,6 @@ where
         }
     }
 
-    fn incorporate_delta_writes(&self, delta_writes: Vec<(K, WriteOp)>) {
-        assert_ok!(self.materialized_delta_writes.set(delta_writes));
-    }
-
     fn incorporate_materialized_txn_output(
         &self,
         aggregator_v1_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -140,14 +140,6 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// In parallel execution, will be called once per transaction when the output is
     /// ready to be committed. In sequential execution, won't be called (deltas are
     /// materialized and incorporated during execution).
-    fn incorporate_delta_writes(
-        &self,
-        delta_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,
-    );
-
-    /// In parallel execution, will be called once per transaction when the output is
-    /// ready to be committed. In sequential execution, won't be called (deltas are
-    /// materialized and incorporated during execution).
     fn incorporate_materialized_txn_output(
         &self,
         aggregator_v1_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -507,8 +507,12 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                                             let res = self.replace_values_with_identifiers(state_value, layout);
                                             let patched_state_value = match res {
                                                 Ok((patched_state_value, delayed_field_keys)) => {
-                                                    state.delayed_field_keys_in_resources.borrow_mut().insert(state_key.clone(), delayed_field_keys);
-                                                    state.unsync_map.write(state_key.clone(), TransactionWrite::from_state_value(Some(patched_state_value.clone())), maybe_layout.map(|layout| Arc::new(layout.clone())));
+                                                    state.delayed_field_keys_in_resources
+                                                        .borrow_mut()
+                                                        .insert(state_key.clone(), delayed_field_keys);
+                                                    state.unsync_map.write(state_key.clone(),
+                                                        TransactionWrite::from_state_value(Some(patched_state_value.clone())),
+                                                        maybe_layout.map(|layout| Arc::new(layout.clone())));
                                                     Some(patched_state_value)
                                                 }
                                                 Err(err) => {

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -506,7 +506,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                                             let patched_state_value = match res {
                                                 Ok((patched_state_value, delayed_field_keys)) => {
                                                     state.delayed_field_keys_in_resources.borrow_mut().insert(state_key.clone(), delayed_field_keys);
-                                                    // state.unsync_map.write(*state_key, patched_state_value, maybe_layout.clone().map(Arc::new));
+                                                    state.unsync_map.write(*state_key, patched_state_value, maybe_layout.map(|layout| Arc::new(layout.clone())));
                                                     Some(patched_state_value)
                                                 }
                                                 Err(err) => {

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -506,7 +506,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                                             let patched_state_value = match res {
                                                 Ok((patched_state_value, delayed_field_keys)) => {
                                                     state.delayed_field_keys_in_resources.borrow_mut().insert(state_key.clone(), delayed_field_keys);
-                                                    state.unsync_map.write(*state_key, patched_state_value, maybe_layout.map(|layout| Arc::new(layout.clone())));
+                                                    state.unsync_map.write(state_key.clone(), TransactionWrite::from_state_value(Some(patched_state_value.clone())), maybe_layout.map(|layout| Arc::new(layout.clone())));
                                                     Some(patched_state_value)
                                                 }
                                                 Err(err) => {

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -330,18 +330,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
         &self,
     ) -> RefCell<HashMap<T::Key, HashSet<T::Identifier>>> {
         match &self.latest_view {
-            ViewState::Sync(_) => unreachable!("Take reads called in parallel setting"),
+            ViewState::Sync(_) => unreachable!(
+                "Read set for sequential execution while running in parallel execution mode"
+            ),
             ViewState::Unsync(state) => state.delayed_field_keys_in_resources.clone(),
-        }
-    }
-
-    pub(crate) fn fetch_from_unsync_map(
-        &self,
-        key: T::Key,
-    ) -> Option<(Arc<T::Value>, Option<Arc<MoveTypeLayout>>)> {
-        match &self.latest_view {
-            ViewState::Sync(_) => None,
-            ViewState::Unsync(state) => state.unsync_map.fetch_data(&key),
         }
     }
 

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -39,11 +39,12 @@ fn unsync_map_data_basic() {
     // Reads that should go the DB return None
     assert_none!(map.fetch_data(&ap));
     // Ensure write registers the new value.
-    map.write(ap.clone(), value_for(10, 1));
-    assert_some_eq!(map.fetch_data(&ap), Arc::new(value_for(10, 1)));
+    //TODO: Hardocoding layout to None. Test when layout is Some(.) as well.
+    map.write(ap.clone(), value_for(10, 1), None);
+    assert_some_eq!(map.fetch_data(&ap), (Arc::new(value_for(10, 1)), None));
     // Ensure the next write overwrites the value.
-    map.write(ap.clone(), value_for(14, 1));
-    assert_some_eq!(map.fetch_data(&ap), Arc::new(value_for(14, 1)));
+    map.write(ap.clone(), value_for(14, 1), None);
+    assert_some_eq!(map.fetch_data(&ap), (Arc::new(value_for(14, 1)), None));
 }
 
 #[test]


### PR DESCRIPTION
### Description

In sequential execution, replace aggregator identifiers with values in resource write set, read set and events before committing the transaction.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
