### PR TITLE
[TS SDK v2] Adding support for entry function classes => script transaction arguments

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/bcs/serializable/move-structs.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializable/move-structs.ts
@@ -5,7 +5,7 @@ import { Serializable, Serializer } from "../serializer";
 import { Deserializable, Deserializer } from "../deserializer";
 import { Bool, U128, U16, U256, U32, U64, U8 } from "./move-primitives";
 import { AnyNumber, HexInput } from "../../types";
-import { AccountAddress } from "../../core";
+import { AccountAddress, Hex } from "../../core";
 
 /**
  * This class is the Aptos Typescript SDK representation of a Move `vector<T>`,
@@ -66,8 +66,21 @@ export class MoveVector<T extends Serializable> extends Serializable {
    * @params values: an array of `numbers` to convert to U8s
    * @returns a `MoveVector<U8>`
    */
-  static U8(values: Array<number>): MoveVector<U8> {
-    return new MoveVector<U8>(values.map((v) => new U8(v)));
+  static U8(values: Array<number> | HexInput): MoveVector<U8> {
+    let numbers: Array<number>;
+
+    if (Array.isArray(values) && typeof values[0] === "number") {
+      numbers = values;
+    } else if (typeof values === "string") {
+      const hex = Hex.fromHexInput({ hexInput: values });
+      numbers = Array.from(hex.toUint8Array());
+    } else if (values instanceof Uint8Array) {
+      numbers = Array.from(values);
+    } else {
+      throw new Error("Invalid input type");
+    }
+
+    return new MoveVector<U8>(numbers.map((v) => new U8(v)));
   }
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/transactions/types/scriptTransactionArguments.ts
+++ b/ecosystem/typescript/sdk_v2/src/transactions/types/scriptTransactionArguments.ts
@@ -2,7 +2,7 @@ import { Serializer, Deserializer, Serializable } from "../../bcs";
 import { AccountAddress } from "../../core";
 import { AnyNumber, HexInput, ScriptTransactionArgumentVariants, Uint16, Uint32, Uint8 } from "../../types";
 import { U8, U16, U32, U64, U128, U256, Bool } from "../../bcs/serializable/move-primitives";
-import { MoveVector } from "../../bcs/serializable/move-structs";
+import { MoveObject, MoveString, MoveVector } from "../../bcs/serializable/move-structs";
 /**
  * Representation of a Script Transaction Argument that can be serialized and deserialized
  */
@@ -74,8 +74,14 @@ export abstract class ScriptTransactionArgument extends Serializable {
       if (allArgsU8) {
         return new ScriptTransactionArgumentU8Vector(arg.values.map((v) => v.value));
       }
-      throw new Error("Unsupported vector type");
+      throw new Error("Unsupported vector type. Script payloads only support vector<u8>");
     }
+    // TODO: investigate if script payloads support MoveObjects, MoveStrings, and MoveOptions
+    //       We may support them in the form of vector<u8>, which would actually make things simpler
+    //       overall. We would just convert them to their BCS serialized representations first and
+    //       then pass those in as ScriptTransactionArgumentVectorU8s
+    // if (arg instanceof MoveObject || arg instanceof MoveString) { 
+    // }
     throw new Error("Unsupported argument type");
   }
 }

--- a/ecosystem/typescript/sdk_v2/tests/unit/bcs-helper.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/bcs-helper.test.ts
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+import { hexToBytes } from "@noble/hashes/utils";
 import { Deserializable, Deserializer } from "../../src/bcs/deserializer";
 import { FixedBytes } from "../../src/bcs/serializable/fixed-bytes";
 import { Bool, U128, U16, U256, U32, U64, U8 } from "../../src/bcs/serializable/move-primitives";
@@ -549,5 +550,44 @@ describe("Tests for the Serializable class", () => {
     const deserializer = new Deserializer(fixedBytes.bcsToBytes());
     const deserializedFixedBytes = FixedBytes.deserialize(deserializer, AccountAddress.LENGTH);
     expect(deserializedFixedBytes.value).toEqual(address.data);
+  });
+
+  describe("MoveVector.U8 factory method tests", () => {
+    it("creates a MoveVector.U8 correctly", () => {
+      const vec = MoveVector.U8([1, 2, 3]);
+      const vecFromString = MoveVector.U8("0x010203");
+      const vecFromUint8Array = MoveVector.U8(new Uint8Array([1, 2, 3]));
+      expect(vec.bcsToBytes()).toEqual(vecFromString.bcsToBytes());
+      expect(vec.bcsToBytes()).toEqual(vecFromUint8Array.bcsToBytes());
+    });
+
+    it("serializes and deserializes a MoveVector.U8 from various input types correctly", () => {
+      const vec = MoveVector.U8([1, 2, 3]);
+      const vecFromString = MoveVector.U8("0x010203");
+      const vecFromUint8Array = MoveVector.U8(new Uint8Array([1, 2, 3]));
+      const deserializedVec = MoveVector.deserialize(new Deserializer(vec.bcsToBytes()), U8);
+      const deserializedVecFromString = MoveVector.deserialize(new Deserializer(vecFromString.bcsToBytes()), U8);
+      const deserializedVecFromUint8Array = MoveVector.deserialize(
+        new Deserializer(vecFromUint8Array.bcsToBytes()),
+        U8,
+      );
+      expect(deserializedVec.values.map((v) => v.value)).toEqual(vec.values.map((v) => v.value));
+      expect(deserializedVecFromString.values.map((v) => v.value)).toEqual(vec.values.map((v) => v.value));
+      expect(deserializedVecFromUint8Array.values.map((v) => v.value)).toEqual(vec.values.map((v) => v.value));
+    });
+
+    it("throws an error when trying to create a MoveVector.U8 from an invalid hex string", () => {
+      expect(() => MoveVector.U8("0x0102030")).toThrow();
+      expect(() => MoveVector.U8("0xgg")).toThrow();
+      // TODO: Add input validation to HexInput for truncating non-hex values like below
+      // expect(() => MoveVector.U8("asdf")).toThrow();
+      expect(() => MoveVector.U8("gg")).toThrow();
+    });
+
+    it("throws an error when trying to create a MoveVector.U8 from an invalid input type", () => {
+      expect(() => MoveVector.U8({} as any)).toThrow();
+      expect(() => MoveVector.U8(["01", "02", "03"] as any)).toThrow();
+      expect(() => MoveVector.U8([BigInt(1)] as any)).toThrow();
+    });
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/script_transaction_args.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/script_transaction_args.test.ts
@@ -1,0 +1,124 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Serializer, Deserializer } from "../../src/bcs";
+import { AccountAddress } from "../../src/core";
+import {
+  ScriptTransactionArgument,
+  ScriptTransactionArgumentAddress,
+  ScriptTransactionArgumentBool,
+  ScriptTransactionArgumentU128,
+  ScriptTransactionArgumentU16,
+  ScriptTransactionArgumentU256,
+  ScriptTransactionArgumentU32,
+  ScriptTransactionArgumentU64,
+  ScriptTransactionArgumentU8,
+  ScriptTransactionArgumentU8Vector,
+} from "../../src/transactions/types";
+import { Bool, U128, U16, U256, U32, U64, U8 } from "../../src/bcs/serializable/move-primitives";
+import { MoveVector } from "../../src/bcs/serializable/move-structs";
+
+describe("Tests for the script transaction argument class", () => {
+  let serializer: Serializer;
+  let scriptU8Bytes: Uint8Array;
+  let scriptU16Bytes: Uint8Array;
+  let scriptU32Bytes: Uint8Array;
+  let scriptU64Bytes: Uint8Array;
+  let scriptU128Bytes: Uint8Array;
+  let scriptU256Bytes: Uint8Array;
+  let scriptBoolBytes: Uint8Array;
+  let scriptAddressBytes: Uint8Array;
+  let scriptVectorU8Bytes: Uint8Array;
+
+  beforeEach(() => {
+    serializer = new Serializer();
+    scriptU8Bytes = new Uint8Array([0, 1]);
+    scriptU16Bytes = new Uint8Array([6, 2, 0]);
+    scriptU32Bytes = new Uint8Array([7, 3, 0, 0, 0]);
+    scriptU64Bytes = new Uint8Array([1, 4, 0, 0, 0, 0, 0, 0, 0]);
+    scriptU128Bytes = new Uint8Array([2, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    scriptU256Bytes = new Uint8Array([
+      8, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    scriptBoolBytes = new Uint8Array([5, 0]);
+    scriptAddressBytes = new Uint8Array([3, ...AccountAddress.FOUR.data]);
+    scriptVectorU8Bytes = new Uint8Array([4, 5, 1, 2, 3, 4, 5]);
+  });
+
+  it("should serialize all types of ScriptTransactionArguments correctly", () => {
+    const validateBytes = (input: ScriptTransactionArgument, expectedOutput: Uint8Array) => {
+      const serializer = new Serializer();
+      input.serialize(serializer);
+      const serializedBytes = serializer.toUint8Array();
+      expect(serializedBytes).toEqual(expectedOutput);
+    };
+    validateBytes(new ScriptTransactionArgumentU8(1), scriptU8Bytes);
+    validateBytes(new ScriptTransactionArgumentU16(2), scriptU16Bytes);
+    validateBytes(new ScriptTransactionArgumentU32(3), scriptU32Bytes);
+    validateBytes(new ScriptTransactionArgumentU64(4), scriptU64Bytes);
+    validateBytes(new ScriptTransactionArgumentU128(5), scriptU128Bytes);
+    validateBytes(new ScriptTransactionArgumentU256(6), scriptU256Bytes);
+    validateBytes(new ScriptTransactionArgumentBool(false), scriptBoolBytes);
+    validateBytes(new ScriptTransactionArgumentAddress(AccountAddress.FOUR), scriptAddressBytes);
+    validateBytes(new ScriptTransactionArgumentU8Vector([1, 2, 3, 4, 5]), scriptVectorU8Bytes);
+  });
+
+  it("should deserialize all types of ScriptTransactionArguments correctly", () => {
+    const deserializeToScriptArg = (input: ScriptTransactionArgument) => {
+      const deserializer = new Deserializer(input.bcsToBytes());
+      return ScriptTransactionArgument.deserialize(deserializer);
+    };
+
+    const scriptArgU8 = deserializeToScriptArg(new ScriptTransactionArgumentU8(1)) as ScriptTransactionArgumentU8;
+    const scriptArgU16 = deserializeToScriptArg(new ScriptTransactionArgumentU16(2)) as ScriptTransactionArgumentU16;
+    const scriptArgU32 = deserializeToScriptArg(new ScriptTransactionArgumentU32(3)) as ScriptTransactionArgumentU32;
+    const scriptArgU64 = deserializeToScriptArg(new ScriptTransactionArgumentU64(4)) as ScriptTransactionArgumentU64;
+    const scriptArgU128 = deserializeToScriptArg(new ScriptTransactionArgumentU128(5)) as ScriptTransactionArgumentU128;
+    const scriptArgU256 = deserializeToScriptArg(new ScriptTransactionArgumentU256(6)) as ScriptTransactionArgumentU256;
+    const scriptArgBool = deserializeToScriptArg(
+      new ScriptTransactionArgumentBool(false),
+    ) as ScriptTransactionArgumentBool;
+    const scriptArgAddress = deserializeToScriptArg(
+      new ScriptTransactionArgumentAddress(AccountAddress.FOUR),
+    ) as ScriptTransactionArgumentAddress;
+    const scriptArgU8Vector = deserializeToScriptArg(
+      new ScriptTransactionArgumentU8Vector([1, 2, 3, 4, 5]),
+    ) as ScriptTransactionArgumentU8Vector;
+
+    expect(scriptArgU8.value.value).toEqual(1);
+    expect(scriptArgU16.value.value).toEqual(2);
+    expect(scriptArgU32.value.value).toEqual(3);
+    expect(scriptArgU64.value.value).toEqual(4n);
+    expect(scriptArgU128.value.value).toEqual(5n);
+    expect(scriptArgU256.value.value).toEqual(6n);
+    expect(scriptArgBool.value.value).toEqual(false);
+    expect(scriptArgAddress.value.data).toEqual(AccountAddress.FOUR.data);
+    expect(scriptArgU8Vector.value.values.map((v) => v.value)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("should convert all Move primitives to script transaction arguments correctly", () => {
+    const deserializeToScriptArg = (
+      input: U8 | U16 | U32 | U64 | U128 | U256 | Bool | MoveVector<U8> | AccountAddress,
+    ) => {
+      const scriptArg = ScriptTransactionArgument.fromMovePrimitive(input);
+      serializer = new Serializer();
+      scriptArg.serialize(serializer);
+      const deserializer = new Deserializer(serializer.toUint8Array());
+      return ScriptTransactionArgument.deserialize(deserializer);
+    };
+
+    expect(deserializeToScriptArg(new U8(1)) instanceof ScriptTransactionArgumentU8).toBe(true);
+    expect(deserializeToScriptArg(new U16(2)) instanceof ScriptTransactionArgumentU16).toBe(true);
+    expect(deserializeToScriptArg(new U32(3)) instanceof ScriptTransactionArgumentU32).toBe(true);
+    expect(deserializeToScriptArg(new U64(4)) instanceof ScriptTransactionArgumentU64).toBe(true);
+    expect(deserializeToScriptArg(new U128(5)) instanceof ScriptTransactionArgumentU128).toBe(true);
+    expect(deserializeToScriptArg(new U256(6)) instanceof ScriptTransactionArgumentU256).toBe(true);
+    expect(deserializeToScriptArg(new Bool(false)) instanceof ScriptTransactionArgumentBool).toBe(true);
+    expect(
+      deserializeToScriptArg(new AccountAddress(AccountAddress.FOUR)) instanceof ScriptTransactionArgumentAddress,
+    ).toBe(true);
+    expect(deserializeToScriptArg(MoveVector.U8([1, 2, 3, 4, 5])) instanceof ScriptTransactionArgumentU8Vector).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
### Description

1. Added support for converting Move primitives to a `ScriptTransactionArgument` so we can maintain the types across various transaction builder patterns.

   - I've also changed the `ScriptTransactionArgument` classes to have their inner values represented as these Move classes. This provides input validation and consolidates construction of these serializable types into a single source
   - This may make more sense as a `toScriptTransactionArgument` function in the Move classes themselves..?

2. Also added support to create a `MoveVector<U8>` from `HexInput`

3. Added unit tests for all the above

NOTE: Some of this may need to be changed later depending on how we use these in the tx builder pattern. We may need to use `FixedBytes` instead of `MoveVector<U8>`, will need to test it later.

The goal is to get the conversion function in now and add/change it later if it doesn't make sense in the e2e flow.

Note the TODO:
```typescript
    // TODO: investigate if script payloads support MoveObjects, MoveStrings, and MoveOptions
    //       We may support them in the form of vector<u8>, which would actually make things simpler
    //       overall. We would just convert them to their BCS serialized representations first and
    //       then pass those in as ScriptTransactionArgumentVectorU8s
    // if (arg instanceof MoveObject || arg instanceof MoveString) { 
```

### Test Plan
```shell
pnpm jest script_transaction_args.test.ts bcs-helper.test.ts serializer.test.ts --verbose
```