### PR TITLE
[Data Streaming Service] Support early termination in lagging subscription streams.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "aptos-network",
  "aptos-short-hex-str",
  "aptos-storage-service-types",
+ "aptos-time-service",
  "aptos-types",
  "async-trait",
  "claims",

--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -171,6 +171,7 @@ fn setup_data_streaming_service(
         state_sync_config.data_streaming_service,
         aptos_data_client,
         streaming_service_listener,
+        TimeService::real(),
     );
 
     // Start the data streaming service

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -229,9 +229,12 @@ pub struct DataStreamingServiceConfig {
     /// memory. Once the number grows beyond this value, garbage collection occurs.
     pub max_notification_id_mappings: u64,
 
-    /// Maxinum number of consecutive subscriptions that can be made before
+    /// Maximum number of consecutive subscriptions that can be made before
     /// the subscription stream is terminated and a new stream must be created.
     pub max_num_consecutive_subscriptions: u64,
+
+    /// Maximum lag (in seconds) we'll tolerate when sending subscription requests
+    pub max_subscription_stream_lag_secs: u64,
 
     /// The interval (milliseconds) at which to check the progress of each stream.
     pub progress_check_interval_ms: u64,
@@ -248,6 +251,7 @@ impl Default for DataStreamingServiceConfig {
             max_request_retry: 5,
             max_notification_id_mappings: 300,
             max_num_consecutive_subscriptions: 40, // At ~4 blocks per second, this should last 10 seconds
+            max_subscription_stream_lag_secs: 15,  // 15 seconds
             progress_check_interval_ms: 50,
         }
     }

--- a/state-sync/aptos-data-client/src/error.rs
+++ b/state-sync/aptos-data-client/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     InvalidRequest(String),
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
+    #[error("The subscription stream is lagging behind the data advertisements: {0}")]
+    SubscriptionStreamIsLagging(String),
     #[error("Timed out waiting for a response: {0}")]
     TimeoutWaitingForResponse(String),
     #[error("Unexpected error encountered: {0}")]
@@ -31,6 +33,7 @@ impl Error {
             Self::DataIsTooLarge(_) => "data_is_too_large",
             Self::InvalidRequest(_) => "invalid_request",
             Self::InvalidResponse(_) => "invalid_response",
+            Self::SubscriptionStreamIsLagging(_) => "subscription_stream_is_lagging",
             Self::TimeoutWaitingForResponse(_) => "timeout_waiting_for_response",
             Self::UnexpectedErrorEncountered(_) => "unexpected_error_encountered",
         }

--- a/state-sync/data-streaming-service/Cargo.toml
+++ b/state-sync/data-streaming-service/Cargo.toml
@@ -23,6 +23,7 @@ aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
 aptos-short-hex-str = { workspace = true }
+aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 enum_dispatch = { workspace = true }
@@ -35,6 +36,7 @@ tokio-stream = { workspace = true }
 
 [dev-dependencies]
 aptos-storage-service-types = { workspace = true }
+aptos-time-service = { workspace = true, features = ["testing"] }
 aptos-types = { workspace = true, features = ["fuzzing"] }
 claims = { workspace = true }
 rand = { workspace = true }

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -73,6 +73,29 @@ impl DataClientRequest {
             },
         }
     }
+
+    /// Returns true iff the request is an optimistic fetch request
+    pub fn is_optimistic_fetch_request(&self) -> bool {
+        matches!(self, DataClientRequest::NewTransactionsWithProof(_))
+            || matches!(self, DataClientRequest::NewTransactionOutputsWithProof(_))
+            || matches!(
+                self,
+                DataClientRequest::NewTransactionsOrOutputsWithProof(_)
+            )
+    }
+
+    /// Returns true iff the request is a subscription request
+    pub fn is_subscription_request(&self) -> bool {
+        matches!(self, DataClientRequest::SubscribeTransactionsWithProof(_))
+            || matches!(
+                self,
+                DataClientRequest::SubscribeTransactionOutputsWithProof(_)
+            )
+            || matches!(
+                self,
+                DataClientRequest::SubscribeTransactionsOrOutputsWithProof(_)
+            )
+    }
 }
 
 /// A request for fetching states values.

--- a/state-sync/data-streaming-service/src/metrics.rs
+++ b/state-sync/data-streaming-service/src/metrics.rs
@@ -171,6 +171,15 @@ pub static RECEIVED_RESPONSE_ERROR: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter that keeps track of the subscription stream lag (versions)
+pub static SUBSCRIPTION_STREAM_LAG: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_data_streaming_service_subscription_stream_lag",
+        "Counters related to the subscription stream lag",
+    )
+    .unwrap()
+});
+
 /// Time it takes to process a data request
 pub static DATA_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     let histogram_opts = histogram_opts!(
@@ -217,6 +226,11 @@ pub fn set_active_data_streams(value: usize) {
 /// Sets the number of pending data responses
 pub fn set_pending_data_responses(value: usize) {
     PENDING_DATA_RESPONSES.set(value as i64);
+}
+
+/// Sets the subscription stream lag
+pub fn set_subscription_stream_lag(value: u64) {
+    SUBSCRIPTION_STREAM_LAG.set(value as i64);
 }
 
 /// Starts the timer for the provided histogram and label values.

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -693,8 +693,7 @@ impl ContinuousTransactionStreamEngine {
 
             // Note: if the stream hits the total max subscription stream index,
             // then no new requests should be created. The stream will eventually
-            // be marked for termination once a response is received for
-            // the last subscription request.
+            // be terminated once a response is received for the last request.
             if subscription_stream_index
                 > active_subscription_stream.get_max_subscription_stream_index()
             {

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -37,6 +37,7 @@ use aptos_data_client::{
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
 use aptos_storage_service_types::responses::CompleteDataRange;
+use aptos_time_service::TimeService;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::SparseMerkleRangeProof,
@@ -1189,6 +1190,7 @@ fn create_data_stream(
         aptos_data_client,
         notification_generator,
         &advertised_data,
+        TimeService::mock(),
     )
     .unwrap()
 }

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -20,6 +20,7 @@ use crate::{
     },
 };
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
+use aptos_time_service::TimeService;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     transaction::{TransactionListWithProof, TransactionOutputListWithProof},
@@ -1667,6 +1668,7 @@ pub fn create_streaming_client_and_server(
         data_streaming_service_config,
         aptos_data_client,
         streaming_service_listener,
+        TimeService::mock(),
     );
 
     (streaming_client, streaming_service)


### PR DESCRIPTION
### Description
This PR updates the data streaming service in state sync to support early termination of lagging subscription streams. This is useful for subscription streams that cause peers to lag behind the rest of the chain (e.g., if the network channel used by the stream is slow or faulty, or if the peer serving the subscription stream is actively malicious). In these cases, the data streaming service will monitor the lag of a subscription stream and terminate the stream prematurely, iff: (i) the stream is lagging for too long; and (ii) the lag has increased since the last check (indicating that the lag is getting worse and the stream is falling behind).

Note: to avoid being overly aggressive, we don't terminate subscriptions streams that lag temporarily, exhibit a "bounded" lag (that doesn't get worse), or lag and then catch up.

The PR offers several commits:
1. Add early termination support for lagging subscription streams.
2. Add unit tests for the new functionality.
3. Add metrics for stream lag.

### Test Plan
New and existing test infrastructure.