### PR TITLE
[Storage] Don't use Rayon for Async Proof fetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "rayon",
  "serde",
  "thiserror",
+ "threadpool",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -619,6 +619,7 @@ termcolor = "1.1.2"
 test-case = "3.1.0"
 textwrap = "0.15.0"
 thiserror = "1.0.37"
+threadpool = "1.8.1"
 time = { version = "0.3.24", features = ["serde"] }
 tiny-bip39 = "0.8.2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -34,7 +34,7 @@ parking_lot = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-threadpool = "1.8.1"
+threadpool = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -34,6 +34,7 @@ parking_lot = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+threadpool = "1.8.1"
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }

--- a/storage/storage-interface/src/async_proof_fetcher.rs
+++ b/storage/storage-interface/src/async_proof_fetcher.rs
@@ -15,6 +15,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
+    string::ToString,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -23,8 +24,12 @@ use std::{
 };
 use threadpool::ThreadPool;
 
-static IO_POOL: Lazy<ThreadPool> =
-    Lazy::new(|| ThreadPool::new(AptosVM::get_num_proof_reading_threads()));
+static IO_POOL: Lazy<ThreadPool> = Lazy::new(|| {
+    ThreadPool::with_name(
+        "proof_reader".to_string(),
+        AptosVM::get_num_proof_reading_threads(),
+    )
+});
 
 struct Proof {
     state_key_hash: HashValue,


### PR DESCRIPTION
### Description

Looking at the flamegraph from recent executor benchmark, we see that around 5-7% of the CPU is being spent in Rayon's task stealing. The issue is that we spawn too many task (one task per key - ~100k task for a block of size 25k) and these tasks are very small, spawning too many small tasks on rayon thread pool has a huge overhead that more the thread pool is spending most of the CPU cycles in rayon's task stealing. Changing this from Rayon to threadpool (which doesn't have any task stealing) gets rid of the rayon overhead and gives us around 3-4% TPS boost. 

### Test Plan

Ran the executor benchmark and observed 3-4% TPS improvements. 
