### PR TITLE
[Network] Parallelize serialization tasks.

### DIFF
--- a/aptos-node/src/network.rs
+++ b/aptos-node/src/network.rs
@@ -346,6 +346,7 @@ fn register_client_and_service_with_network<
 ) -> ApplicationNetworkHandle<T> {
     let (network_sender, network_events) = network_builder.add_client_and_service(
         &application_config,
+        network_config.max_parallel_serialization_tasks,
         network_config.max_parallel_deserialization_tasks,
     );
     ApplicationNetworkHandle {

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -142,6 +142,7 @@ fn create_network(
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_client = NetworkClient::new(
         DIRECT_SEND.into(),

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -100,6 +100,7 @@ pub fn prepare_buffer_manager() -> (
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_client = NetworkClient::new(
         DIRECT_SEND.into(),

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -596,6 +596,7 @@ mod tests {
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
+                None,
             );
             let network_client = NetworkClient::new(
                 DIRECT_SEND.into(),
@@ -702,6 +703,7 @@ mod tests {
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
+                None,
             );
 
             let network_client = NetworkClient::new(

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -128,6 +128,7 @@ fn create_node_for_fuzzing() -> RoundManager {
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_client = NetworkClient::new(
         DIRECT_SEND.into(),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -200,6 +200,7 @@ impl NodeSetup {
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_client = NetworkClient::new(
             DIRECT_SEND.into(),

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -88,6 +88,7 @@ impl SMRNode {
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_client = NetworkClient::new(
             DIRECT_SEND.into(),

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -113,6 +113,7 @@ impl MockSharedMempool {
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_events = NetworkEvents::new(network_notifs_rx, conn_notifs_rx, None);
         let (ac_client, client_events) = mpsc::channel(1_024);

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -575,6 +575,7 @@ fn setup_node_network_interface(
     let network_sender = NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_events = NetworkEvents::new(network_notifs_rx, conn_status_rx, None);
 

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -545,6 +545,7 @@ fn setup_network(
     let network_sender = NetworkSender::new(
         PeerManagerRequestSender::new(reqs_outbound_sender),
         ConnectionRequestSender::new(connection_outbound_sender),
+        None,
     );
     let network_events =
         NetworkEvents::new(reqs_inbound_receiver, connection_inbound_receiver, None);

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -111,7 +111,7 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     let (listener_sender, mut listener_events) = network_builder
-        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None, None);
     network_builder.build(runtime.handle().clone()).start();
     let listener_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],
@@ -144,7 +144,7 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     let (dialer_sender, mut dialer_events) = network_builder
-        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None, None);
     network_builder.build(runtime.handle().clone()).start();
     let dialer_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -920,6 +920,7 @@ fn create_network_sender_and_events(
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(outbound_request_sender),
             ConnectionRequestSender::new(connection_outbound_sender),
+            None,
         );
         let network_events =
             NetworkEvents::new(inbound_request_receiver, connection_inbound_receiver, None);

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -52,6 +52,7 @@ impl TestHarness {
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(peer_mgr_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let hc_network_rx =
             HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);

--- a/network/framework/src/protocols/rpc/error.rs
+++ b/network/framework/src/protocols/rpc/error.rs
@@ -53,6 +53,7 @@ impl From<PeerManagerError> for RpcError {
         }
     }
 }
+
 impl From<oneshot::Canceled> for RpcError {
     fn from(_: oneshot::Canceled) -> Self {
         RpcError::UnexpectedResponseChannelCancel
@@ -62,5 +63,11 @@ impl From<oneshot::Canceled> for RpcError {
 impl From<tokio::time::error::Elapsed> for RpcError {
     fn from(_err: tokio::time::error::Elapsed) -> RpcError {
         RpcError::TimedOut
+    }
+}
+
+impl From<tokio::task::JoinError> for RpcError {
+    fn from(err: tokio::task::JoinError) -> RpcError {
+        RpcError::Error(anyhow!("JoinError: {:?}", err))
     }
 }

--- a/peer-monitoring-service/client/src/tests/mock.rs
+++ b/peer-monitoring-service/client/src/tests/mock.rs
@@ -54,6 +54,7 @@ impl MockMonitoringServer {
             let network_sender = NetworkSender::new(
                 PeerManagerRequestSender::new(peer_manager_request_sender),
                 ConnectionRequestSender::new(connection_request_sender),
+                None,
             );
 
             // Store the channels and network sender

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -76,6 +76,7 @@ impl MockNetwork {
             let network_sender = NetworkSender::new(
                 PeerManagerRequestSender::new(peer_mgr_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
+                None,
             );
 
             // Save the network sender and the request receiver


### PR DESCRIPTION
### Description
This PR updates the networking code to perform message serialization in parallel (this follows from https://github.com/aptos-labs/aptos-core/pull/8762). Specifically:

1. We use `for_each_concurrent` to spawn a fixed number of threads to perform message serialization in parallel (per application). Now, whenever an application (e.g., consensus or mempool) sends a direct send message (to one or multiple peers), the message is sent to this task, to be serialized and then sent to the peer manager.
    
     The benefit of this is: (i) serialization is moved off the application thread, allowing the application thread to return to other work earlier; (ii) serialization is done using a blocking thread (which makes more sense, because it does not yield and may be expensive with large messages); and (iii) serialization can be performed in parallel, because the serialization task works using multiple threads.

2. We also update RPC requests to use blocking threads to perform serialization and deserialization. Note, RPC requests cannot make use of the new serialization task because they are blocking by nature, and applications must already account for this (i.e., perform and handle RPC requests on different threads at the application layer).

Note: it's interesting to point out that the recent PR that added support for [parallel message deserialization](https://github.com/aptos-labs/aptos-core/pull/8762) only did so for: (i) incoming direct send messages; and (ii) incoming RPC requests. Deserialization of RPC responses are handled by case (2) above.

### Test Plan
Existing test infrastructure.