### PR TITLE
Fix build for tools image by upgrading libtinfo6 version

### DIFF
--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget \
     curl \
     perl-base=5.32.1-4+deb11u1 \
-    libtinfo6=6.2+20201114-2+deb11u1 \
+    libtinfo6=6.2+20201114-2+deb11u2 \
     git \
     libssl1.1 \
     ca-certificates \


### PR DESCRIPTION
### Description
Fixes this issue:
```
176.7 The following packages have unmet dependencies:
177.0  libncursesw6 : Depends: libtinfo6 (= 6.2+20201114-2+deb11u2) but 6.2+20201114-2+deb11u1 is to be installed
177.1 E: Unable to correct problems, you have held broken packages.
```

### Test Plan
```
./docker/builder/docker-bake-rust-all.sh tools
```