### PR TITLE
[Compiler] remove an unnecessary assertion in visibility translation

### DIFF
--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -1245,7 +1245,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     } = pfunction;
     assert!(context.exp_specs.is_empty());
     let attributes = flatten_attributes(context, AttributePosition::Function, pattributes);
-    let visibility = visibility(context, pvisibility);
+    let visibility = visibility(pvisibility);
     let (old_aliases, signature) = function_signature(context, psignature);
     let acquires = acquires
         .into_iter()
@@ -1268,13 +1268,10 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     (name, fdef)
 }
 
-fn visibility(context: &mut Context, pvisibility: P::Visibility) -> E::Visibility {
+fn visibility(pvisibility: P::Visibility) -> E::Visibility {
     match pvisibility {
         P::Visibility::Public(loc) => E::Visibility::Public(loc),
-        P::Visibility::Script(loc) => {
-            assert!(!context.env.has_errors());
-            E::Visibility::Public(loc)
-        },
+        P::Visibility::Script(loc) => E::Visibility::Public(loc),
         P::Visibility::Friend(loc) => E::Visibility::Friend(loc),
         P::Visibility::Internal => E::Visibility::Internal,
     }

--- a/third_party/move/move-compiler/tests/move_check/deprecated/public_script.exp
+++ b/third_party/move/move-compiler/tests/move_check/deprecated/public_script.exp
@@ -1,0 +1,12 @@
+warning[W00001]: DEPRECATED. will be removed
+  ┌─ tests/move_check/deprecated/public_script.move:2:5
+  │
+2 │     public(script) fun main() {
+  │     ^^^^^^^^^^^^^^ 'public(script)' is deprecated in favor of the 'entry' modifier. Replace with 'public entry'
+
+error[E03001]: address with no value
+  ┌─ tests/move_check/deprecated/public_script.move:4:30
+  │
+4 │         let _addr:address = @Test;
+  │                              ^^^^ address 'Test' is not assigned a value. Try assigning it a value when calling the compiler
+

--- a/third_party/move/move-compiler/tests/move_check/deprecated/public_script.move
+++ b/third_party/move/move-compiler/tests/move_check/deprecated/public_script.move
@@ -1,0 +1,6 @@
+module 0x1::Test {
+    public(script) fun main() {
+        // Previously, deprecation plus an error led to a compiler assert.  Make sure that doesn't come back.
+        let _addr:address = @Test;
+    }
+}


### PR DESCRIPTION
### Description

This PR removes an assertion in visibility translation. This assertion will cause the compiler to panic when the target move code contains `public (script)` functions and there are other errors at or above `NonblockingError` level. It is not necessary because the compiler will output these errors after compilation. 