### PR TITLE
[compiler v2] Resource access control (read-write sets)

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -90,6 +90,7 @@ pub enum FeatureFlag {
     ConcurrentAssets,
     LimitMaxIdentifierLength,
     OperatorBeneficiaryChange,
+    VMBinaryFormatV7,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -185,6 +186,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::AptosStdChainIdNatives => AptosFeatureFlag::APTOS_STD_CHAIN_ID_NATIVES,
             FeatureFlag::VMBinaryFormatV6 => AptosFeatureFlag::VM_BINARY_FORMAT_V6,
+            FeatureFlag::VMBinaryFormatV7 => AptosFeatureFlag::VM_BINARY_FORMAT_V7,
             FeatureFlag::MultiEd25519PkValidateV2Natives => {
                 AptosFeatureFlag::MULTI_ED25519_PK_VALIDATE_V2_NATIVES
             },
@@ -252,6 +254,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::APTOS_STD_CHAIN_ID_NATIVES => FeatureFlag::AptosStdChainIdNatives,
             AptosFeatureFlag::VM_BINARY_FORMAT_V6 => FeatureFlag::VMBinaryFormatV6,
+            AptosFeatureFlag::VM_BINARY_FORMAT_V7 => FeatureFlag::VMBinaryFormatV7,
             AptosFeatureFlag::MULTI_ED25519_PK_VALIDATE_V2_NATIVES => {
                 FeatureFlag::MultiEd25519PkValidateV2Natives
             },

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -9,7 +9,9 @@ use crate::{
     counters::*,
     data_cache::{AsMoveResolver, StorageAdapter},
     errors::expect_only_successful_execution,
-    move_vm_ext::{AptosMoveResolver, RespawnedSession, SessionExt, SessionId},
+    move_vm_ext::{
+        get_max_binary_format_version, AptosMoveResolver, RespawnedSession, SessionExt, SessionId,
+    },
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
     system_module_names::*,
     transaction_metadata::TransactionMetadata,
@@ -855,15 +857,7 @@ impl AptosVM {
 
     /// Deserialize a module bundle.
     fn deserialize_module_bundle(&self, modules: &ModuleBundle) -> VMResult<Vec<CompiledModule>> {
-        let max_version = if self
-            .0
-            .get_features()
-            .is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6)
-        {
-            6
-        } else {
-            5
-        };
+        let max_version = get_max_binary_format_version(self.0.get_features(), None);
         let max_identifier_size = if self
             .0
             .get_features()

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -91,7 +91,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
         features: &Features,
         maybe_resource_group_view: Option<&'e dyn ResourceGroupView>,
     ) -> Self {
-        let max_binary_version = get_max_binary_format_version(features, gas_feature_version);
+        let max_binary_version = get_max_binary_format_version(features, Some(gas_feature_version));
         let max_identifier_size = get_max_identifier_size(features);
         let resource_group_adapter = ResourceGroupAdapter::new(
             maybe_resource_group_view,
@@ -332,7 +332,8 @@ impl<S: StateView> AsMoveResolver<S> for S {
         let config_view = ConfigAdapter(self);
         let (_, gas_feature_version) = gas_config(&config_view);
         let features = Features::fetch_config(&config_view).unwrap_or_default();
-        let max_binary_version = get_max_binary_format_version(&features, gas_feature_version);
+        let max_binary_version =
+            get_max_binary_format_version(&features, Some(gas_feature_version));
         let resource_group_adapter = ResourceGroupAdapter::new(None, self, gas_feature_version);
         let max_identifier_size = get_max_identifier_size(&features);
         StorageAdapter::new(

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -18,6 +18,7 @@ use aptos_types::on_chain_config::{FeatureFlag, Features, TimedFeatureFlag, Time
 use move_binary_format::{
     deserializer::DeserializerConfig,
     errors::VMResult,
+    file_format_common,
     file_format_common::{IDENTIFIER_SIZE_MAX, LEGACY_IDENTIFIER_SIZE_MAX},
 };
 use move_bytecode_verifier::VerifierConfig;
@@ -32,11 +33,21 @@ pub struct MoveVmExt {
     features: Arc<Features>,
 }
 
-pub fn get_max_binary_format_version(features: &Features, gas_feature_version: u64) -> u32 {
-    if features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) && gas_feature_version >= 5 {
-        6
+pub fn get_max_binary_format_version(
+    features: &Features,
+    gas_feature_version_opt: Option<u64>,
+) -> u32 {
+    // For historical reasons, we support still < gas version 5, but if a new caller don't specify
+    // the gas version, we default to 5, which was introduced in late '22.
+    let gas_feature_version = gas_feature_version_opt.unwrap_or(5);
+    if gas_feature_version < 5 {
+        file_format_common::VERSION_5
+    } else if features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V7) {
+        file_format_common::VERSION_7
+    } else if features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) {
+        file_format_common::VERSION_6
     } else {
-        5
+        file_format_common::VERSION_5
     }
 }
 
@@ -66,7 +77,7 @@ impl MoveVmExt {
         //       Therefore it depends on a new version of the gas schedule and cannot be allowed if
         //       the gas schedule hasn't been updated yet.
         let max_binary_format_version =
-            get_max_binary_format_version(&features, gas_feature_version);
+            get_max_binary_format_version(&features, Some(gas_feature_version));
 
         let max_identifier_size = get_max_identifier_size(&features);
 

--- a/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
+++ b/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
@@ -52,6 +52,7 @@ fn access_path_panic() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],

--- a/aptos-move/e2e-testsuite/src/tests/scripts.rs
+++ b/aptos-move/e2e-testsuite/src/tests/scripts.rs
@@ -99,6 +99,7 @@ fn script_none_existing_module_dep() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     };
     script.function_handles.push(fun_handle);
 
@@ -177,6 +178,7 @@ fn script_non_existing_function_dep() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     };
     script.function_handles.push(fun_handle);
 
@@ -257,6 +259,7 @@ fn script_bad_sig_function_dep() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     };
     script.function_handles.push(fun_handle);
 
@@ -465,6 +468,7 @@ fn forbid_script_emitting_events() {
         type_parameters: vec![
             AbilitySet::singleton(Ability::Store) | AbilitySet::singleton(Ability::Drop),
         ],
+        access_specifiers: None,
     });
     script.module_handles.push(ModuleHandle {
         address: AddressIdentifierIndex(0),

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_code_unit.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_code_unit.rs
@@ -32,6 +32,7 @@ fuzz_target!(|code_unit: CodeUnit| {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_mixed.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_mixed.rs
@@ -41,6 +41,7 @@ fuzz_target!(|mix: Mixed| {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);

--- a/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -8,6 +8,7 @@ use move_binary_format::{
         empty_module, AbilitySet, CompiledModule, FunctionHandle, IdentifierIndex, Signature,
         SignatureIndex, SignatureToken,
     },
+    file_format_common::VERSION_MAX,
 };
 use move_core_types::identifier::Identifier;
 use proptest::prelude::*;
@@ -16,9 +17,9 @@ proptest! {
     #[test]
     fn serializer_roundtrip(module in CompiledModule::valid_strategy(20)) {
         let mut serialized = Vec::with_capacity(2048);
-        module.serialize(&mut serialized).expect("serialization should work");
+        module.serialize_for_version(Some(VERSION_MAX), &mut serialized).expect("serialization should work");
 
-        let deserialized_module = CompiledModule::deserialize(&serialized)
+        let deserialized_module = CompiledModule::deserialize_with_max_version(&serialized, VERSION_MAX)
             .expect("deserialization should work");
 
         prop_assert_eq!(module, deserialized_module);
@@ -34,7 +35,7 @@ proptest! {
     #[test]
     fn garbage_inputs(module in any_with::<CompiledModule>(16)) {
         let mut serialized = Vec::with_capacity(65536);
-        module.serialize(&mut serialized).expect("serialization should work");
+        module.serialize_for_version(Some(VERSION_MAX), &mut serialized).expect("serialization should work");
 
         let deserialized_module = CompiledModule::deserialize_no_check_bounds(&serialized)
             .expect("deserialization should work");
@@ -66,14 +67,15 @@ fn simple_generic_module_round_trip() {
         parameters: sig_t1_idx,
         return_: sig_unit_idx,
         type_parameters: vec![AbilitySet::EMPTY],
+        access_specifiers: None,
     });
 
     let mut serialized = Vec::with_capacity(2048);
-    m.serialize(&mut serialized)
+    m.serialize_for_version(Some(VERSION_MAX), &mut serialized)
         .expect("serialization should work");
 
-    let deserialized_m =
-        CompiledModule::deserialize(&serialized).expect("deserialization should work");
+    let deserialized_m = CompiledModule::deserialize_with_max_version(&serialized, VERSION_MAX)
+        .expect("deserialization should work");
 
     assert_eq!(m, deserialized_m);
 }

--- a/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -4,11 +4,12 @@
 
 use move_binary_format::{
     access::ModuleAccess,
+    deserializer::DeserializerConfig,
     file_format::{
         empty_module, AbilitySet, CompiledModule, FunctionHandle, IdentifierIndex, Signature,
         SignatureIndex, SignatureToken,
     },
-    file_format_common::VERSION_MAX,
+    file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_MAX},
 };
 use move_core_types::identifier::Identifier;
 use proptest::prelude::*;
@@ -19,8 +20,11 @@ proptest! {
         let mut serialized = Vec::with_capacity(2048);
         module.serialize_for_version(Some(VERSION_MAX), &mut serialized).expect("serialization should work");
 
-        let deserialized_module = CompiledModule::deserialize_with_max_version(&serialized, VERSION_MAX)
-            .expect("deserialization should work");
+
+        let deserialized_module = CompiledModule::deserialize_with_config(
+                &serialized,
+                &DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX)
+        ).expect("deserialization should work");
 
         prop_assert_eq!(module, deserialized_module);
     }
@@ -74,8 +78,11 @@ fn simple_generic_module_round_trip() {
     m.serialize_for_version(Some(VERSION_MAX), &mut serialized)
         .expect("serialization should work");
 
-    let deserialized_m = CompiledModule::deserialize_with_max_version(&serialized, VERSION_MAX)
-        .expect("deserialization should work");
+    let deserialized_m = CompiledModule::deserialize_with_config(
+        &serialized,
+        &DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX),
+    )
+    .expect("deserialization should work");
 
     assert_eq!(m, deserialized_m);
 }

--- a/third_party/move/move-binary-format/src/binary_views.rs
+++ b/third_party/move/move-binary-format/src/binary_views.rs
@@ -299,6 +299,16 @@ impl<'a> BinaryIndexedView<'a> {
         )
     }
 
+    pub fn safe_module_id_for_handle(&self, module_handle: &ModuleHandle) -> Option<ModuleId> {
+        self.address_identifiers()
+            .get(module_handle.address.0 as usize)
+            .and_then(|a| {
+                self.identifiers()
+                    .get(module_handle.name.0 as usize)
+                    .map(|id| ModuleId::new(*a, id.to_owned()))
+            })
+    }
+
     pub fn self_id(&self) -> Option<ModuleId> {
         match self {
             BinaryIndexedView::Module(m) => Some(m.self_id()),

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -1027,9 +1027,9 @@ fn load_access_specifier(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Acc
             .with_message("invalid access kind".to_owned()));
     };
     let b = load_u8(cursor)?;
-    let negated = if b == SerializedOption::SOME as u8 {
+    let negated = if b == SerializedBool::TRUE as u8 {
         true
-    } else if b == SerializedOption::NONE as u8 {
+    } else if b == SerializedBool::FALSE as u8 {
         false
     } else {
         return Err(PartialVMError::new(StatusCode::MALFORMED)

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -1778,8 +1778,8 @@ impl SerializedType {
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
 pub enum DeprecatedNominalResourceFlag {
-    NOMINAL_RESOURCE = 0x1,
-    NORMAL_STRUCT = 0x2,
+    NOMINAL_RESOURCE    = 0x1,
+    NORMAL_STRUCT       = 0x2,
 }
 
 impl DeprecatedNominalResourceFlag {

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -1919,6 +1919,7 @@ impl SerializedBool {
 }
 
 impl SerializedOption {
+    /// Returns a boolean to indice NONE or SOME (NONE = false)
     fn from_u8(value: u8) -> BinaryLoaderResult<bool> {
         match value {
             0x1 => Ok(false),

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -47,7 +47,7 @@ use move_core_types::{
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
-use std::ops::BitOr;
+use std::{fmt, ops::BitOr};
 use variant_count::VariantCount;
 
 /// Generic index into one of the tables in the binary format.
@@ -297,6 +297,15 @@ pub struct FunctionHandle {
     pub return_: SignatureIndex,
     /// The type formals (identified by their index into the vec) and their constraints
     pub type_parameters: Vec<AbilitySet>,
+    /// An optional list of access specifiers. If this is unspecified, the function is assumed
+    /// to access arbitrary resources. Otherwise, each specifier approximates a set of resources
+    /// which are read/written by the function. An empty list indicates the function is pure and
+    /// does not depend on any global state.
+    #[cfg_attr(
+        any(test, feature = "fuzzing"),
+        proptest(filter = "|x| x.as_ref().map(|v| v.len() <= 64).unwrap_or(true)")
+    )]
+    pub access_specifiers: Option<Vec<AccessSpecifier>>,
 }
 
 /// A field access info (owner type and offset)
@@ -847,6 +856,116 @@ impl Arbitrary for AbilitySet {
             .prop_map(|u| AbilitySet::from_u8(u).expect("proptest mask failed for AbilitySet"))
             .boxed()
     }
+}
+
+/// An `AccessSpecifier` describes an approximation of resources accessed by a function.
+/// Here are some examples on source level:
+/// ```notest
+///   // All resources declared at the address
+///   reads 0xcafe::*;
+///   // All resources in the module
+///   reads 0xcafe::my_module::*;
+///   // The given resource in the module, at arbitray address
+///   reads 0xcafe::my_module::R(*);
+///   // The given resource in the module, at address in dependency of parameter
+///   reads 0xcafe::my_module::R(object::address_of(function_parameter_name))
+///   // Any resource at the given address
+///   reads *(object::address_of(function_parameter_name))
+/// ```
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub struct AccessSpecifier {
+    /// The kind of access: read, write, or both.
+    pub kind: AccessKind,
+    /// Whether the specifier is negated.
+    pub negated: bool,
+    /// The resource specifier.
+    pub resource: ResourceSpecifier,
+    /// The address where the resource is stored. Other fields can have wildcards.
+    pub address: AddressSpecifier,
+}
+
+/// The kind of specified access.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub enum AccessKind {
+    Reads,
+    Writes,
+    Acquires, // reads or writes
+}
+
+impl AccessKind {
+    /// Returns true if this access kind subsumes the other.
+    pub fn subsumes(&self, other: &Self) -> bool {
+        use AccessKind::*;
+        match (self, other) {
+            (Acquires, _) => true,
+            (_, Acquires) => false,
+            _ => self == other,
+        }
+    }
+
+    /// Tries to join two kinds, returns None of no intersection.
+    pub fn try_join(self, other: Self) -> Option<Self> {
+        use AccessKind::*;
+        match (self, other) {
+            (Acquires, k) | (k, Acquires) => Some(k),
+            (k1, k2) if k1 == k2 => Some(k1),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for AccessKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use AccessKind::*;
+        match self {
+            Reads => f.write_str("reads"),
+            Writes => f.write_str("writes"),
+            Acquires => f.write_str("acquires"),
+        }
+    }
+}
+
+/// The specification of a resource in an access specifier.
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub enum ResourceSpecifier {
+    /// Any resource
+    Any,
+    /// A resource declared at the given address.
+    DeclaredAtAddress(AddressIdentifierIndex),
+    /// A resource declared in the given module.
+    DeclaredInModule(ModuleHandleIndex),
+    /// An explicit resource
+    Resource(StructHandleIndex),
+    /// A resource instantiation.
+    ResourceInstantiation(StructHandleIndex, SignatureIndex),
+}
+
+/// The specification of an address in an access specifier.
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub enum AddressSpecifier {
+    /// Resource can be stored at any address.
+    Any,
+    /// A literal address representation.
+    Literal(AddressIdentifierIndex),
+    /// An address derived from a parameter of the current function.
+    Parameter(
+        /// The index of a parameter of the current function. If `modifier` is not given, the
+        /// parameter must have address type. Otherwise `modifier` must be a function which takes
+        /// a value (or reference) of the parameter type and delivers an address.
+        #[cfg_attr(any(test, feature = "fuzzing"), proptest(strategy = "0u8..63"))]
+        LocalIndex,
+        /// If given, a function applied to the parameter. This is a well-known function which
+        /// extracts an address from a value, e.g. `object::address_of`.
+        Option<FunctionInstantiationIndex>,
+    ),
 }
 
 /// A `SignatureToken` is a type declaration for a location.
@@ -2109,6 +2228,7 @@ pub fn basic_test_module() -> CompiledModule {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.identifiers
         .push(Identifier::new("foo".to_string()).unwrap());

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -858,14 +858,14 @@ impl Arbitrary for AbilitySet {
     }
 }
 
-/// An `AccessSpecifier` describes an approximation of resources accessed by a function.
+/// An `AccessSpecifier` describes the resources accessed by a function.
 /// Here are some examples on source level:
 /// ```notest
 ///   // All resources declared at the address
 ///   reads 0xcafe::*;
 ///   // All resources in the module
 ///   reads 0xcafe::my_module::*;
-///   // The given resource in the module, at arbitray address
+///   // The given resource in the module, at arbitrary address
 ///   reads 0xcafe::my_module::R(*);
 ///   // The given resource in the module, at address in dependency of parameter
 ///   reads 0xcafe::my_module::R(object::address_of(function_parameter_name))

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -882,7 +882,7 @@ pub struct AccessSpecifier {
     pub negated: bool,
     /// The resource specifier.
     pub resource: ResourceSpecifier,
-    /// The address where the resource is stored. Other fields can have wildcards.
+    /// The address where the resource is stored.
     pub address: AddressSpecifier,
 }
 
@@ -907,7 +907,7 @@ impl AccessKind {
         }
     }
 
-    /// Tries to join two kinds, returns None of no intersection.
+    /// Tries to join two kinds, returns None if no intersection.
     pub fn try_join(self, other: Self) -> Option<Self> {
         use AccessKind::*;
         match (self, other) {

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -139,6 +139,16 @@ pub enum SerializedOption {
     SOME                    = 0x2,
 }
 
+/// A marker for an boolean in the serialized output.
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum SerializedBool {
+    FALSE                  = 0x1,
+    TRUE                   = 0x2,
+}
+
 /// A marker for access specifier kind.
 #[rustfmt::skip]
 #[allow(non_camel_case_types)]

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -76,6 +76,8 @@ pub const FIELD_OFFSET_MAX: u64 = 255;
 pub const TYPE_PARAMETER_COUNT_MAX: u64 = 255;
 pub const TYPE_PARAMETER_INDEX_MAX: u64 = 65536;
 
+pub const ACCESS_SPECIFIER_COUNT_MAX: u64 = 64;
+
 pub const SIGNATURE_TOKEN_DEPTH_MAX: usize = 256;
 
 /// Constants for table types in the binary.
@@ -125,6 +127,49 @@ pub enum SerializedType {
     U16                     = 0xD,
     U32                     = 0xE,
     U256                    = 0xF,
+}
+
+/// A marker for an option in the serialized output.
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum SerializedOption {
+    NONE                    = 0x1,
+    SOME                    = 0x2,
+}
+
+/// A marker for access specifier kind.
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum SerializedAccessKind {
+    READ                    = 0x1,
+    WRITE                   = 0x2,
+    ACQUIRES                = 0x3,
+}
+
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum SerializedResourceSpecifier {
+    ANY                     = 0x1,
+    AT_ADDRESS              = 0x2,
+    IN_MODULE               = 0x3,
+    RESOURCE                = 0x4,
+    RESOURCE_INSTANTIATION  = 0x5,
+}
+
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum SerializedAddressSpecifier {
+    ANY                     = 0x1,
+    LITERAL                 = 0x2,
+    PARAMETER               = 0x3,
 }
 
 #[rustfmt::skip]
@@ -406,13 +451,23 @@ pub const VERSION_5: u32 = 5;
 ///  + u16, u32, u256 integers and corresponding Ld, Cast bytecodes
 pub const VERSION_6: u32 = 6;
 
-/// Mark which version is the latest version
-pub const VERSION_MAX: u32 = VERSION_6;
+/// Version 7: changes compare to version 6
+/// + access specifiers (read/write set)
+pub const VERSION_7: u32 = 7;
 
-/// A unique version value which is used for experimental code which is not allowed in
+/// Mark which version is the default version
+pub const VERSION_DEFAULT: u32 = VERSION_6;
+
+/// Mark which version is the latest version
+pub const VERSION_MAX: u32 = VERSION_7;
+
+/// A version value which is used for experimental code which is not allowed in
 /// production. The bytecode deserializer accepts modules with this version only when the
 /// cargo feature `testing` is enabled.
-pub const VERSION_EXPERIMENTAL: u32 = u32::MAX;
+///
+/// This is currently set to VERSION_7, the next major version, and should be updated once
+/// this version is ready for production.
+pub const VERSION_NEXT: u32 = VERSION_7;
 
 // Mark which oldest version is supported.
 // TODO(#145): finish v4 compatibility; as of now, only metadata is implemented
@@ -458,11 +513,15 @@ pub(crate) mod versioned_data {
                         .with_message("Bad binary header".to_string()));
                 },
             };
-            if version == 0
-                || (version > u32::min(max_version, VERSION_MAX)
-                    && !(version == VERSION_EXPERIMENTAL && cfg!(feature = "testing")))
-            {
+            if version == 0 || version > u32::min(max_version, VERSION_MAX) {
                 return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION));
+            } else if version == VERSION_NEXT && !cfg!(test) && !cfg!(feature = "fuzzing") {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_VERSION).with_message(format!(
+                        "bytecode version {} only allowed in test code",
+                        VERSION_NEXT
+                    )),
+                );
             }
             Ok((
                 Self {

--- a/third_party/move/move-binary-format/src/proptest_types.rs
+++ b/third_party/move/move-binary-format/src/proptest_types.rs
@@ -89,6 +89,7 @@ pub struct CompiledModuleStrategyGen {
     parameters_count: SizeRange,
     return_count: SizeRange,
     func_type_params: SizeRange,
+    access_specifiers_count: SizeRange,
     acquires_count: SizeRange,
     random_sigs_count: SizeRange,
     tokens_per_random_sig_count: SizeRange,
@@ -105,6 +106,7 @@ impl CompiledModuleStrategyGen {
             parameters_count: (0..4).into(),
             return_count: (0..3).into(),
             func_type_params: (0..3).into(),
+            access_specifiers_count: (0..8).into(),
             acquires_count: (0..2).into(),
             random_sigs_count: (0..5).into(),
             tokens_per_random_sig_count: (0..5).into(),
@@ -183,6 +185,7 @@ impl CompiledModuleStrategyGen {
                 self.parameters_count.clone(),
                 self.return_count.clone(),
                 self.func_type_params.clone(),
+                self.access_specifiers_count.clone(),
             ),
             1..=self.size,
         );

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -34,7 +34,7 @@ impl CompiledScript {
         bytecode_version: Option<u32>,
         binary: &mut Vec<u8>,
     ) -> Result<()> {
-        let version = bytecode_version.unwrap_or(VERSION_MAX);
+        let version = bytecode_version.unwrap_or(VERSION_DEFAULT);
         validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ScriptSerializer::new(version);
@@ -200,6 +200,23 @@ fn serialize_local_index(binary: &mut BinaryData, idx: u8) -> Result<()> {
     write_as_uleb128(binary, idx, LOCAL_INDEX_MAX)
 }
 
+fn serialize_option<T>(
+    binary: &mut BinaryData,
+    option: &Option<T>,
+    value_serializer: impl Fn(&mut BinaryData, &T) -> Result<()>,
+) -> Result<()> {
+    if let Some(val) = option {
+        binary.push(SerializedOption::SOME as u8)?;
+        value_serializer(binary, val)
+    } else {
+        binary.push(SerializedOption::NONE as u8)
+    }
+}
+
+fn serialize_access_specifier_count(binary: &mut BinaryData, len: usize) -> Result<()> {
+    write_as_uleb128(binary, len as u64, ACCESS_SPECIFIER_COUNT_MAX)
+}
+
 fn validate_version(version: u32) -> Result<()> {
     if !(VERSION_MIN..=VERSION_MAX).contains(&version) {
         bail!(
@@ -226,7 +243,7 @@ impl CompiledModule {
         bytecode_version: Option<u32>,
         binary: &mut Vec<u8>,
     ) -> Result<()> {
-        let version = bytecode_version.unwrap_or(VERSION_MAX);
+        let version = bytecode_version.unwrap_or(VERSION_DEFAULT);
         validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ModuleSerializer::new(version);
@@ -468,6 +485,7 @@ fn serialize_type_parameter(
 /// - `FunctionHandle.return_` as a ULEB128 (index into the `SignaturePool`)
 /// - `FunctionHandle.type_parameters` as a `Vec<u8>`
 fn serialize_function_handle(
+    major_version: u32,
     binary: &mut BinaryData,
     function_handle: &FunctionHandle,
 ) -> Result<()> {
@@ -475,7 +493,17 @@ fn serialize_function_handle(
     serialize_identifier_index(binary, &function_handle.name)?;
     serialize_signature_index(binary, &function_handle.parameters)?;
     serialize_signature_index(binary, &function_handle.return_)?;
-    serialize_ability_sets(binary, &function_handle.type_parameters)
+    serialize_ability_sets(binary, &function_handle.type_parameters)?;
+    if major_version >= VERSION_7 {
+        serialize_access_specifiers(binary, &function_handle.access_specifiers)
+    } else if function_handle.access_specifiers.is_some() {
+        Err(anyhow!(
+            "Access specifiers not supported in bytecode version {}",
+            major_version
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn serialize_function_instantiation(
@@ -714,6 +742,80 @@ fn serialize_ability_sets(binary: &mut BinaryData, sets: &[AbilitySet]) -> Resul
         serialize_ability_set(binary, *set)?;
     }
     Ok(())
+}
+
+fn serialize_access_specifiers(
+    binary: &mut BinaryData,
+    accesses: &Option<Vec<AccessSpecifier>>,
+) -> Result<()> {
+    serialize_option(binary, accesses, |binary, specs| {
+        serialize_access_specifier_count(binary, specs.len())?;
+        for acc in specs {
+            serialize_access_specifier(binary, acc)?
+        }
+        Ok(())
+    })
+}
+
+fn serialize_access_specifier(binary: &mut BinaryData, acc: &AccessSpecifier) -> Result<()> {
+    binary.push(match acc.kind {
+        AccessKind::Reads => SerializedAccessKind::READ,
+        AccessKind::Writes => SerializedAccessKind::WRITE,
+        AccessKind::Acquires => SerializedAccessKind::ACQUIRES,
+    } as u8)?;
+    binary.push(
+        if acc.negated {
+            SerializedOption::SOME as u8
+        } else {
+            SerializedOption::NONE as u8
+        },
+    )?;
+    serialize_resource_specifier(binary, &acc.resource)?;
+    serialize_address_specifier(binary, &acc.address)
+}
+
+fn serialize_resource_specifier(
+    binary: &mut BinaryData,
+    resource_spec: &ResourceSpecifier,
+) -> Result<()> {
+    match resource_spec {
+        ResourceSpecifier::Any => binary.push(SerializedResourceSpecifier::ANY as u8),
+        ResourceSpecifier::DeclaredAtAddress(addr) => {
+            binary.push(SerializedResourceSpecifier::AT_ADDRESS as u8)?;
+            serialize_address_identifier_index(binary, addr)
+        },
+        ResourceSpecifier::DeclaredInModule(handle) => {
+            binary.push(SerializedResourceSpecifier::IN_MODULE as u8)?;
+            serialize_module_handle_index(binary, handle)
+        },
+        ResourceSpecifier::Resource(handle) => {
+            binary.push(SerializedResourceSpecifier::RESOURCE as u8)?;
+            serialize_struct_handle_index(binary, handle)
+        },
+        ResourceSpecifier::ResourceInstantiation(handle, sign) => {
+            binary.push(SerializedResourceSpecifier::RESOURCE_INSTANTIATION as u8)?;
+            serialize_struct_handle_index(binary, handle)?;
+            serialize_signature_index(binary, sign)
+        },
+    }
+}
+
+fn serialize_address_specifier(
+    binary: &mut BinaryData,
+    addr_spec: &AddressSpecifier,
+) -> Result<()> {
+    match addr_spec {
+        AddressSpecifier::Any => binary.push(SerializedAddressSpecifier::ANY as u8),
+        AddressSpecifier::Literal(addr) => {
+            binary.push(SerializedAddressSpecifier::LITERAL as u8)?;
+            serialize_address_identifier_index(binary, addr)
+        },
+        AddressSpecifier::Parameter(param, deriver_opt) => {
+            binary.push(SerializedAddressSpecifier::PARAMETER as u8)?;
+            serialize_local_index(binary, *param)?;
+            serialize_option(binary, deriver_opt, serialize_function_inst_index)
+        },
+    }
 }
 
 /// Serializes a `CodeUnit`.
@@ -1133,7 +1235,7 @@ impl CommonSerializer {
             self.table_count += 1;
             self.function_handles.0 = check_index_in_binary(binary.len())?;
             for function_handle in function_handles {
-                serialize_function_handle(binary, function_handle)?;
+                serialize_function_handle(self.major_version, binary, function_handle)?;
             }
             self.function_handles.1 =
                 checked_calculate_table_size(binary, self.function_handles.0)?;

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -765,9 +765,9 @@ fn serialize_access_specifier(binary: &mut BinaryData, acc: &AccessSpecifier) ->
     } as u8)?;
     binary.push(
         if acc.negated {
-            SerializedOption::SOME as u8
+            SerializedBool::TRUE as u8
         } else {
-            SerializedOption::NONE as u8
+            SerializedBool::FALSE as u8
         },
     )?;
     serialize_resource_specifier(binary, &acc.resource)?;

--- a/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -36,6 +36,7 @@ fn mk_module(vis: u8) -> normalized::Module {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
         ],
         function_defs: vec![

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/support/mod.rs
@@ -28,6 +28,7 @@ pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
@@ -34,6 +34,7 @@ fn mk_script_function_module() -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             // fun g_fn<T>()
             FunctionHandle {
@@ -42,6 +43,7 @@ fn mk_script_function_module() -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![AbilitySet::EMPTY],
+                access_specifiers: None,
             },
         ],
         function_defs: vec![
@@ -124,6 +126,7 @@ fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             // 0::M::fn()
             FunctionHandle {
@@ -132,6 +135,7 @@ fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             // 0::M::g_fn<T>()
             FunctionHandle {
@@ -140,6 +144,7 @@ fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![AbilitySet::EMPTY],
+                access_specifiers: None,
             },
         ],
         // 0::M::g_fn<u64>()
@@ -208,6 +213,7 @@ fn mk_invoking_script(use_generic: bool) -> CompiledScript {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             // 0::M::g_fn<T>()
             FunctionHandle {
@@ -216,6 +222,7 @@ fn mk_invoking_script(use_generic: bool) -> CompiledScript {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![AbilitySet::EMPTY],
+                access_specifiers: None,
             },
         ],
         // 0::M::g_fn<u64>()

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -110,6 +110,7 @@ fn make_module() -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             // fun g_fn<T: key>()
             FunctionHandle {
@@ -118,6 +119,7 @@ fn make_module() -> CompiledModule {
                 parameters: SignatureIndex(0),
                 return_: SignatureIndex(0),
                 type_parameters: vec![AbilitySet::EMPTY | Ability::Key],
+                access_specifiers: None,
             },
             // fun test_fn(Sender)
             FunctionHandle {
@@ -126,6 +128,7 @@ fn make_module() -> CompiledModule {
                 parameters: SignatureIndex(1),
                 return_: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
         ],
         function_defs: vec![

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
@@ -38,6 +38,7 @@ fn test_large_types() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(0),
@@ -58,6 +59,7 @@ fn test_large_types() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(1),
@@ -79,6 +81,7 @@ fn test_large_types() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(2),
@@ -99,6 +102,7 @@ fn test_large_types() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(3),
@@ -121,6 +125,7 @@ fn test_large_types() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i + 4),

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -18,6 +18,7 @@ fn test_function_handle_type_instantiation() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: std::iter::repeat(AbilitySet::ALL).take(10).collect(),
+        access_specifiers: None,
     });
 
     assert_eq!(
@@ -40,6 +41,7 @@ fn test_function_handle_type_instantiation() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: std::iter::repeat(AbilitySet::ALL).take(10).collect(),
+        access_specifiers: None,
     });
 
     assert_eq!(
@@ -123,6 +125,7 @@ fn test_function_handle_parameters() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
 
     assert_eq!(
@@ -148,6 +151,7 @@ fn test_function_handle_parameters() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
 
     assert_eq!(
@@ -210,6 +214,7 @@ fn big_vec_unpacks() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],
@@ -652,6 +657,7 @@ fn multi_functions(module: &mut CompiledModule, count: usize) {
             parameters: SignatureIndex((module.signatures.len() - 1) as u16),
             return_: SignatureIndex((module.signatures.len() - 1) as u16),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         module.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex((module.function_handles.len() - 1) as u16),

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
@@ -24,6 +24,7 @@ fn test_locals() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
 
     m.function_defs.push(FunctionDefinition {
@@ -57,6 +58,7 @@ fn test_locals() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(2),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(1),
@@ -79,6 +81,7 @@ fn test_locals() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i + 1),

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
@@ -36,6 +36,7 @@ fn many_backedges() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(2),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(0),
@@ -58,6 +59,7 @@ fn many_backedges() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i),

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
@@ -25,6 +25,7 @@ fn test_bicliques() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(0),
@@ -51,6 +52,7 @@ fn test_bicliques() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(1),
@@ -77,6 +79,7 @@ fn test_bicliques() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(2),
@@ -99,6 +102,7 @@ fn test_bicliques() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i + 2),
@@ -147,6 +151,7 @@ fn test_merge_state_large_graph() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(0),
@@ -172,6 +177,7 @@ fn test_merge_state_large_graph() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(1),
@@ -192,6 +198,7 @@ fn test_merge_state_large_graph() {
         parameters: SignatureIndex(1),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(2),
@@ -213,6 +220,7 @@ fn test_merge_state_large_graph() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i + 3),
@@ -266,6 +274,7 @@ fn test_merge_state() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.function_defs.push(FunctionDefinition {
         function: FunctionHandleIndex(0),
@@ -297,6 +306,7 @@ fn test_merge_state() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i + 1),
@@ -376,6 +386,7 @@ fn test_copyloc_pop() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         });
         m.function_defs.push(FunctionDefinition {
             function: FunctionHandleIndex(i),

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -61,6 +61,7 @@ proptest! {
 fn no_verify_locals_good() {
     let compiled_module_good = CompiledModule {
         version: move_binary_format::file_format_common::VERSION_MAX,
+
         module_handles: vec![ModuleHandle {
             address: AddressIdentifierIndex(0),
             name: IdentifierIndex(0),
@@ -79,6 +80,7 @@ fn no_verify_locals_good() {
                 return_: SignatureIndex(2),
                 parameters: SignatureIndex(0),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
             FunctionHandle {
                 module: ModuleHandleIndex(0),
@@ -86,6 +88,7 @@ fn no_verify_locals_good() {
                 return_: SignatureIndex(2),
                 parameters: SignatureIndex(1),
                 type_parameters: vec![],
+                access_specifiers: None,
             },
         ],
         field_handles: vec![],
@@ -179,6 +182,7 @@ fn big_signature_test() {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -40,6 +40,7 @@ fn test_vec_pack() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(0),
         type_parameters: vec![],
+        access_specifiers: None,
     });
     m.identifiers
         .push(Identifier::new("foo".to_string()).unwrap());

--- a/third_party/move/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
+++ b/third_party/move/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
@@ -30,6 +30,7 @@ fuzz_target!(|code_unit: CodeUnit| {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);

--- a/third_party/move/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
+++ b/third_party/move/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
@@ -39,6 +39,7 @@ fuzz_target!(|mix: Mixed| {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);

--- a/third_party/move/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
+++ b/third_party/move/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
@@ -38,6 +38,7 @@ fn unbalanced_stack_crash() {
         parameters: SignatureIndex(0),
         return_: SignatureIndex(1),
         type_parameters: vec![],
+        access_specifiers: None,
     };
 
     module.function_handles.push(fun_handle);
@@ -131,6 +132,7 @@ fn too_many_locals() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![AbilitySet::ALL],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],
@@ -179,6 +181,7 @@ fn borrow_graph() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],
@@ -275,6 +278,7 @@ fn indirect_code() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.exp
@@ -1,0 +1,49 @@
+
+Diagnostics:
+error: invalid access specifier
+  ┌─ tests/checking/access_specifiers/access_err.move:6:23
+  │
+6 │     fun f1() acquires undef {
+  │                       ^^^^^^
+
+error: undeclared module `undef`
+  ┌─ tests/checking/access_specifiers/access_err.move:9:23
+  │
+9 │     fun f2() acquires 0x42::undef::* {
+  │                       ^^^^^^^^^^^^^^^
+
+error: invalid access specifier: a wildcard cannot be followed by a non-wildcard name component
+   ┌─ tests/checking/access_specifiers/access_err.move:12:23
+   │
+12 │     fun f3() acquires 0x42::*::S {
+   │                       ^^^^^^^^^^^
+
+error: type argument count mismatch (expected 1 but got 0)
+   ┌─ tests/checking/access_specifiers/access_err.move:15:23
+   │
+15 │     fun f4() acquires G {
+   │                       ^^
+
+error: undeclared `m::y`
+   ┌─ tests/checking/access_specifiers/access_err.move:18:35
+   │
+18 │     fun f5(x: address) acquires *(y) {
+   │                                   ^
+
+error: undeclared `m::y`
+   ┌─ tests/checking/access_specifiers/access_err.move:21:51
+   │
+21 │     fun f6(x: address) acquires *(make_up_address(y)) {
+   │                                                   ^
+
+error: expected `address` but found `u64`
+   ┌─ tests/checking/access_specifiers/access_err.move:24:30
+   │
+24 │     fun f7(x: u64) acquires *(make_up_address_wrong(x)) {
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: no function named `undefined` found
+   ┌─ tests/checking/access_specifiers/access_err.move:27:30
+   │
+27 │     fun f8(x: u64) acquires *(undefined(x)) {
+   │                              ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.move
@@ -1,0 +1,37 @@
+module 0x42::m {
+
+    struct S has store {}
+    struct G<T> has store {}
+
+    fun f1() acquires undef {
+    }
+
+    fun f2() acquires 0x42::undef::* {
+    }
+
+    fun f3() acquires 0x42::*::S {
+    }
+
+    fun f4() acquires G {
+    }
+
+    fun f5(x: address) acquires *(y) {
+    }
+
+    fun f6(x: address) acquires *(make_up_address(y)) {
+    }
+
+    fun f7(x: u64) acquires *(make_up_address_wrong(x)) {
+    }
+
+    fun f8(x: u64) acquires *(undefined(x)) {
+    }
+
+    fun make_up_address(foo: u64): address {
+      @0x42
+    }
+
+    fun make_up_address_wrong(foo: u64): u64 {
+        0x42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.exp
@@ -1,0 +1,129 @@
+// ---- Model Dump
+module 0x42::m {
+    struct T {
+        dummy_field: bool,
+    }
+    struct G {
+        dummy_field: bool,
+    }
+    struct R {
+        dummy_field: bool,
+    }
+    struct S {
+        dummy_field: bool,
+    }
+    private fun f1()
+        acquires m::S(*)
+     {
+        Tuple()
+    }
+    private fun f10(x: u64)
+        acquires *(m::make_up_address(x))
+     {
+        Tuple()
+    }
+    private fun f11()
+        !reads *(0x42)
+        !reads *(0x43)
+     {
+        Tuple()
+    }
+    private fun f12()
+     {
+        Tuple()
+    }
+    private fun f2()
+        reads m::S(*)
+     {
+        Tuple()
+    }
+    private fun f3()
+        writes m::S(*)
+     {
+        Tuple()
+    }
+    private fun f4()
+        acquires m::S(*)
+     {
+        Tuple()
+    }
+    private fun f5()
+        acquires 0x42::*(*)
+     {
+        Tuple()
+    }
+    private fun f6()
+        acquires 0x42::m::*(*)
+     {
+        Tuple()
+    }
+    private fun f7()
+        acquires *(*)
+     {
+        Tuple()
+    }
+    private fun f8()
+        acquires *(0x42)
+     {
+        Tuple()
+    }
+    private fun f9(a: address)
+        acquires *(a)
+     {
+        Tuple()
+    }
+    private fun f_multiple()
+        acquires m::R(*)
+        reads m::R(*)
+        writes m::T(*)
+        writes m::S(*)
+        reads m::G<u64>(*)
+     {
+        Tuple()
+    }
+    private fun make_up_address(x: u64): address {
+        0x42
+    }
+    spec fun $f1() {
+        Tuple()
+    }
+    spec fun $f10(x: u64) {
+        Tuple()
+    }
+    spec fun $f11() {
+        Tuple()
+    }
+    spec fun $f12() {
+        Tuple()
+    }
+    spec fun $f2() {
+        Tuple()
+    }
+    spec fun $f3() {
+        Tuple()
+    }
+    spec fun $f4() {
+        Tuple()
+    }
+    spec fun $f5() {
+        Tuple()
+    }
+    spec fun $f6() {
+        Tuple()
+    }
+    spec fun $f7() {
+        Tuple()
+    }
+    spec fun $f8() {
+        Tuple()
+    }
+    spec fun $f9(a: address) {
+        Tuple()
+    }
+    spec fun $f_multiple() {
+        Tuple()
+    }
+    spec fun $make_up_address(x: u64): address {
+        0x42
+    }
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.move
@@ -1,0 +1,50 @@
+module 0x42::m {
+
+    struct S has store {}
+    struct R has store {}
+    struct T has store {}
+    struct G<T> has store {}
+
+    fun f1() acquires S {
+    }
+
+    fun f2() reads S {
+    }
+
+    fun f3() writes S {
+    }
+
+    fun f4() acquires S(*) {
+    }
+
+    fun f_multiple() acquires R reads R writes T, S reads G<u64> {
+    }
+
+    fun f5() acquires 0x42::*::* {
+    }
+
+    fun f6() acquires 0x42::m::* {
+    }
+
+    fun f7() acquires *(*) {
+    }
+
+    fun f8() acquires *(0x42) {
+    }
+
+    fun f9(a: address) acquires *(a) {
+    }
+
+    fun f10(x: u64) acquires *(make_up_address(x)) {
+    }
+
+    fun make_up_address(x: u64): address {
+        @0x42
+    }
+
+    fun f11() !reads *(0x42), *(0x43) {
+    }
+
+    fun f12() pure {
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_one_type_argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_one_type_argument.exp
@@ -3,7 +3,9 @@ module 0x8675309::M {
     struct R {
         dummy_field: bool,
     }
-    private fun t(account: &signer) {
+    private fun t(account: &signer)
+        acquires M::R(*)
+     {
         {
           let _ = exists<M::R>(0x0);
           {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/conditional_global_operations.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/conditional_global_operations.exp
@@ -16,7 +16,11 @@ module 0x42::M {
     struct S {
         dummy_field: bool,
     }
-    private fun ex<T>(s: &signer,a1: address) {
+    private fun ex<T>(s: &signer,a1: address)
+        acquires M::Box<M::R>(*)
+        acquires M::Box<#0>(*)
+        acquires M::Pair<M::S, M::R>(*)
+     {
         MoveTo<M::Box<M::R>>(s, pack M::Box<M::R>(pack M::R(false)));
         BorrowGlobal(Immutable)<M::Box<T>>(a1);
         BorrowGlobal(Mutable)<M::Box<M::Box<T>>>(a1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/conditional_global_operations.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/conditional_global_operations.move
@@ -11,7 +11,7 @@ module M {
     }
 
     // types that can have key/store but the specific instantiation does not
-    fun ex<T>(s: &signer, a1: address) acquires Box, Pair {
+    fun ex<T>(s: &signer, a1: address) acquires Box<R>, Box<T>, Pair<S, R> {
         move_to(s, Box<R> { f: R {} });
         borrow_global<Box<T>>(a1);
         borrow_global_mut<Box<Box<T>>>(a1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins.exp
@@ -3,7 +3,9 @@ module 0x8675309::M {
     struct R {
         dummy_field: bool,
     }
-    private fun t0(a: &signer) {
+    private fun t0(a: &signer)
+        acquires M::R(*)
+     {
         {
           let _ = exists<M::R>(0x0);
           {
@@ -21,7 +23,9 @@ module 0x8675309::M {
           }
         }
     }
-    private fun t1(a: &signer) {
+    private fun t1(a: &signer)
+        acquires M::R(*)
+     {
         {
           let _ = exists<M::R>(0x0);
           {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -106,7 +106,7 @@ fun assign::assign_struct($t0: &mut assign::S) {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.assign {
 struct T {
 	h: u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -214,7 +214,7 @@ fun borrow::mut_param($t0: u64): u64 {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.borrow {
 struct S {
 	f: u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -140,7 +140,7 @@ fun constant::test_constans() {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.constant {
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -272,7 +272,7 @@ fun fields::write_val($t0: fields::S): fields::S {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.fields {
 struct T {
 	h: u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -38,7 +38,7 @@ fun Test::identity<#0>($t0: #0): #0 {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.Test {
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -120,7 +120,7 @@ fun globals::write($t0: address, $t1: u64): u64 {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.globals {
 struct R has store {
 	f: u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -137,7 +137,7 @@ fun if_else::if_else_nested($t0: bool, $t1: u64): u64 {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.if_else {
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -318,7 +318,7 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.loops {
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -380,7 +380,7 @@ fun operators::order($t0: u64, $t1: u64): bool {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.operators {
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -60,7 +60,7 @@ fun pack_unpack::unpack($t0: pack_unpack::S): (u64, u64) {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.pack_unpack {
 struct T {
 	h: u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -35,7 +35,7 @@ fun vector::create(): vector<u64> {
 
 
 ============ disassembled file-format ==================
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.vector {
 
 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -286,7 +286,7 @@ B0:
 
 >>> V2 Compiler {
 == BEGIN Bytecode ==
-// Move bytecode v4294967295
+// Move bytecode v7
 module 42.heap {
 
 
@@ -567,7 +567,7 @@ B5:
 task 1 'run'. lines 67-73:
 
 == BEGIN Bytecode ==
-// Move bytecode v4294967295
+// Move bytecode v7
 script {
 use 0000000000000000000000000000000000000000000000000000000000000042::heap;
 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.exp
@@ -1,7 +1,7 @@
 processed 2 tasks
 
 task 0 'print-bytecode'. lines 1-4:
-// Move bytecode v4294967295
+// Move bytecode v7
 script {
 
 
@@ -12,7 +12,7 @@ B0:
 }
 
 task 1 'print-bytecode'. lines 6-11:
-// Move bytecode v4294967295
+// Move bytecode v7
 module 3.N {
 
 

--- a/third_party/move/move-compiler/src/attr_derivation/mod.rs
+++ b/third_party/move/move-compiler/src/attr_derivation/mod.rs
@@ -129,7 +129,7 @@ pub(crate) fn new_native_fun(
         visibility,
         entry,
         signature,
-        acquires: vec![],
+        access_specifiers: None,
         name,
         inline: false,
         body: sp(loc, FunctionBody_::Native),
@@ -152,7 +152,7 @@ pub(crate) fn new_fun(
         visibility,
         entry,
         signature,
-        acquires: vec![],
+        access_specifiers: None,
         name,
         inline: false,
         body: sp(

--- a/third_party/move/move-compiler/src/command_line/mod.rs
+++ b/third_party/move/move-compiler/src/command_line/mod.rs
@@ -47,3 +47,5 @@ pub const MOVE_COMPILER_WARN_OF_DEPRECATION_USE_FLAG: &str = "Wdeprecation";
 
 pub const WARN_OF_DEPRECATION_USE_IN_APTOS_LIBS: &str = "WARN_OF_DEPRECATION_USE_IN_APTOS_LIBS";
 pub const WARN_OF_DEPRECATION_USE_IN_APTOS_LIBS_FLAG: &str = "Wdeprecation-aptos";
+
+pub const V2_FLAG: &str = "v2";

--- a/third_party/move/move-compiler/src/diagnostics/codes.rs
+++ b/third_party/move/move-compiler/src/diagnostics/codes.rs
@@ -114,6 +114,7 @@ codes!(
         SpecContextRestricted:
             { msg: "syntax item restricted to spec contexts", severity: BlockingError },
         InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
+        InvalidAccessSpecifier: { msg: "invalid access specifier", severity: NonblockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/third_party/move/move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler/src/expansion/ast.rs
@@ -15,6 +15,7 @@ use crate::{
         *,
     },
 };
+use move_binary_format::file_format;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{
@@ -210,9 +211,34 @@ pub struct Function {
     pub entry: Option<Loc>,
     pub signature: FunctionSignature,
     pub acquires: Vec<ModuleAccess>,
+    // Only v2 compiler
+    pub access_specifiers: Option<Vec<AccessSpecifier>>,
     pub body: FunctionBody,
     pub specs: BTreeMap<SpecId, SpecBlock>,
 }
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct AccessSpecifier_ {
+    pub kind: file_format::AccessKind,
+    pub negated: bool,
+    pub module_address: Option<Address>,
+    pub module_name: Option<ModuleName>,
+    pub resource_name: Option<Name>,
+    pub type_args: Option<Vec<Type>>,
+    pub address: AddressSpecifier,
+}
+
+pub type AccessSpecifier = Spanned<AccessSpecifier_>;
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum AddressSpecifier_ {
+    Any,
+    Literal(NumericalAddress),
+    Name(Name),
+    Call(ModuleAccess, Option<Vec<Type>>, Name),
+}
+
+pub type AddressSpecifier = Spanned<AddressSpecifier_>;
 
 //**************************************************************************************************
 // Constants
@@ -1248,6 +1274,7 @@ impl AstDebug for (FunctionName, &Function) {
                 entry,
                 signature,
                 acquires,
+                access_specifiers: _,
                 body,
                 specs: _specs,
             },

--- a/third_party/move/move-compiler/src/naming/translate.rs
+++ b/third_party/move/move-compiler/src/naming/translate.rs
@@ -512,6 +512,7 @@ fn function(
         entry,
         signature,
         acquires,
+        access_specifiers: _,
         body,
         specs: _,
     } = ef;

--- a/third_party/move/move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler/src/parser/ast.rs
@@ -249,10 +249,15 @@ pub type AccessSpecifier = Spanned<AccessSpecifier_>;
 /// An address specifier specifies the address at which a resource is accessed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AddressSpecifier_ {
+    /// Represents that now address was specicied, as in `Resource`
     Empty,
+    /// Represents that the specified address is a wildcard, as in `Resource(*)`.
     Any,
+    /// Represents the precise address.
     Literal(NumericalAddress),
+    /// Represents a parameter name.
     Name(Name),
+    /// Represents a function applied to a parameter name.
     Call(NameAccessChain, Option<Vec<Type>>, Name),
 }
 
@@ -281,10 +286,6 @@ pub enum FunctionBody_ {
 pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
-// (public?) foo<T1(: copyable?), ..., TN(: copyable?)>(x1: t1, ..., xn: tn): t1 * ... * tn {
-//    body
-//  }
-// (public?) native foo<T1(: copyable?), ..., TN(: copyable?)>(x1: t1, ..., xn: tn): t1 * ... * tn;
 pub struct Function {
     pub attributes: Vec<Attributes>,
     pub loc: Loc,

--- a/third_party/move/move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler/src/parser/ast.rs
@@ -292,6 +292,8 @@ pub struct Function {
     pub visibility: Visibility,
     pub entry: Option<Loc>,
     pub signature: FunctionSignature,
+    /// `None` indicates no specifiers given, `Some([])` indicates the `pure` keyword has been
+    /// used.
     pub access_specifiers: Option<Vec<AccessSpecifier>>,
     pub name: FunctionName,
     pub inline: bool,

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -328,12 +328,8 @@ fn parse_leading_name_access_<'a, F: FnOnce() -> &'a str>(
             Ok(sp(loc, LeadingNameAccess_::Name(n)))
         },
         Tok::Star if allow_wildcard => {
-            let loc = current_token_loc(context.tokens);
-            context.tokens.advance()?;
-            Ok(sp(
-                loc,
-                LeadingNameAccess_::Name(Name::new(loc, Symbol::from("*"))),
-            ))
+            let name = advance_wildcard_name(context)?;
+            Ok(sp(name.loc, LeadingNameAccess_::Name(name)))
         },
         Tok::NumValue => {
             let sp!(loc, addr) = parse_address_bytes(context)?;

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -308,13 +308,17 @@ fn parse_address_bytes(
 
 // Parse the beginning of an access, either an address or an identifier:
 //      LeadingNameAccess = <NumericalAddress> | <Identifier>
-fn parse_leading_name_access(context: &mut Context) -> Result<LeadingNameAccess, Box<Diagnostic>> {
-    parse_leading_name_access_(context, || "an address or an identifier")
+fn parse_leading_name_access(
+    context: &mut Context,
+    allow_wildcard: bool,
+) -> Result<LeadingNameAccess, Box<Diagnostic>> {
+    parse_leading_name_access_(context, allow_wildcard, || "an address or an identifier")
 }
 
 // Parse the beginning of an access, either an address or an identifier with a specific description
 fn parse_leading_name_access_<'a, F: FnOnce() -> &'a str>(
     context: &mut Context,
+    allow_wildcard: bool,
     item_description: F,
 ) -> Result<LeadingNameAccess, Box<Diagnostic>> {
     match context.tokens.peek() {
@@ -323,12 +327,26 @@ fn parse_leading_name_access_<'a, F: FnOnce() -> &'a str>(
             let n = parse_identifier(context)?;
             Ok(sp(loc, LeadingNameAccess_::Name(n)))
         },
+        Tok::Star if allow_wildcard => {
+            let loc = current_token_loc(context.tokens);
+            context.tokens.advance()?;
+            Ok(sp(
+                loc,
+                LeadingNameAccess_::Name(Name::new(loc, Symbol::from("*"))),
+            ))
+        },
         Tok::NumValue => {
             let sp!(loc, addr) = parse_address_bytes(context)?;
             Ok(sp(loc, LeadingNameAccess_::AnonymousAddress(addr)))
         },
         _ => Err(unexpected_token_error(context.tokens, item_description())),
     }
+}
+
+fn advance_wildcard_name(context: &mut Context) -> Result<Name, Box<Diagnostic>> {
+    let loc = current_token_loc(context.tokens);
+    context.tokens.advance()?;
+    Ok(Name::new(loc, Symbol::from("*")))
 }
 
 // Parse a variable name:
@@ -353,7 +371,7 @@ fn parse_module_name(context: &mut Context) -> Result<ModuleName, Box<Diagnostic
 //      ModuleIdent = <LeadingNameAccess> "::" <ModuleName>
 fn parse_module_ident(context: &mut Context) -> Result<ModuleIdent, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
-    let address = parse_leading_name_access(context)?;
+    let address = parse_leading_name_access(context, false)?;
 
     consume_token_(
         context.tokens,
@@ -369,12 +387,14 @@ fn parse_module_ident(context: &mut Context) -> Result<ModuleIdent, Box<Diagnost
 
 // Parse a module access (a variable, struct type, or function):
 //      NameAccessChain = <LeadingNameAccess> ( "::" <Identifier> ( "::" <Identifier> )? )?
+// If `allow_wildcard` is true, `*` will be accepted as an identifier.
 fn parse_name_access_chain<'a, F: FnOnce() -> &'a str>(
     context: &mut Context,
+    allow_wildcard: bool,
     item_description: F,
 ) -> Result<NameAccessChain, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
-    let access = parse_name_access_chain_(context, item_description)?;
+    let access = parse_name_access_chain_(context, allow_wildcard, item_description)?;
     let end_loc = context.tokens.previous_end_loc();
     Ok(spanned(
         context.tokens.file_hash(),
@@ -384,13 +404,15 @@ fn parse_name_access_chain<'a, F: FnOnce() -> &'a str>(
     ))
 }
 
-// Parse a module access with a specific description
+// Parse a module access with a specific description. If `allow_wildcard` is true, allows
+// wildcards (`*`) for identifiers.
 fn parse_name_access_chain_<'a, F: FnOnce() -> &'a str>(
     context: &mut Context,
+    allow_wildcard: bool,
     item_description: F,
 ) -> Result<NameAccessChain_, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
-    let ln = parse_leading_name_access_(context, item_description)?;
+    let ln = parse_leading_name_access_(context, allow_wildcard, item_description)?;
     let ln = match ln {
         // A name by itself is a valid access chain
         sp!(_, LeadingNameAccess_::Name(n1)) if context.tokens.peek() != Tok::ColonColon => {
@@ -405,7 +427,7 @@ fn parse_name_access_chain_<'a, F: FnOnce() -> &'a str>(
         start_loc,
         " after an address in a module access chain",
     )?;
-    let n2 = parse_identifier(context)?;
+    let n2 = parse_identifier_or_possibly_wildcard(context, allow_wildcard)?;
     if context.tokens.peek() != Tok::ColonColon {
         return Ok(NameAccessChain_::Two(ln, n2));
     }
@@ -415,8 +437,26 @@ fn parse_name_access_chain_<'a, F: FnOnce() -> &'a str>(
         context.tokens.previous_end_loc(),
     );
     consume_token(context.tokens, Tok::ColonColon)?;
-    let n3 = parse_identifier(context)?;
+    let n3 = parse_identifier_or_possibly_wildcard(context, allow_wildcard)?;
     Ok(NameAccessChain_::Three(sp(ln_n2_loc, (ln, n2)), n3))
+}
+
+fn parse_identifier_or_possibly_wildcard(
+    context: &mut Context,
+    allow_wildcard: bool,
+) -> Result<Name, Box<Diagnostic>> {
+    match context.tokens.peek() {
+        Tok::Identifier => parse_identifier(context),
+        Tok::Star if allow_wildcard => advance_wildcard_name(context),
+        _ => Err(unexpected_token_error(
+            context.tokens,
+            if allow_wildcard {
+                "an identifier or wildcard"
+            } else {
+                "an identifier"
+            },
+        )),
+    }
 }
 
 //**************************************************************************************************
@@ -537,7 +577,7 @@ fn parse_attribute_value(context: &mut Context) -> Result<AttributeValue, Box<Di
         return Ok(sp(v.loc, AttributeValue_::Value(v)));
     }
 
-    let ma = parse_name_access_chain(context, || "attribute name value")?;
+    let ma = parse_name_access_chain(context, false, || "attribute name value")?;
     Ok(sp(ma.loc, AttributeValue_::ModuleAccess(ma)))
 }
 
@@ -656,7 +696,7 @@ fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
     // The item description specified here should include the special case above for
     // variable names, because if the current context cannot be parsed as a struct name
     // it is possible that the user intention was to use a variable name.
-    let ty = parse_name_access_chain(context, || "a variable or struct name")?;
+    let ty = parse_name_access_chain(context, false, || "a variable or struct name")?;
     let ty_args = parse_optional_type_args(context)?;
     let args = parse_comma_list(
         context,
@@ -753,7 +793,7 @@ fn maybe_parse_value(context: &mut Context) -> Result<Option<Value>, Box<Diagnos
     let val = match context.tokens.peek() {
         Tok::AtSign => {
             context.tokens.advance()?;
-            let addr = parse_leading_name_access(context)?;
+            let addr = parse_leading_name_access(context, false)?;
             Value_::Address(addr)
         },
         Tok::True => {
@@ -1155,7 +1195,7 @@ fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnosti
 //          | <NameAccessChain> "!" "(" Comma<Exp> ")"
 //          | <NameAccessChain> <OptionalTypeArgs>
 fn parse_name_exp(context: &mut Context) -> Result<Exp_, Box<Diagnostic>> {
-    let n = parse_name_access_chain(context, || {
+    let n = parse_name_access_chain(context, false, || {
         panic!("parse_name_exp with something other than a ModuleAccess")
     })?;
 
@@ -1713,7 +1753,7 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
             ));
         },
         _ => {
-            let tn = parse_name_access_chain(context, || "a type name")?;
+            let tn = parse_name_access_chain(context, false, || "a type name")?;
             let tys = if context.tokens.peek() == Tok::Less {
                 parse_comma_list(context, Tok::Less, Tok::Greater, parse_type, "a type")?
             } else {
@@ -1942,23 +1982,72 @@ fn parse_function_decl(
         sp(name.loc(), Type_::Unit)
     };
 
-    // ("acquires" (<NameAccessChain> ",")* <NameAccessChain> ","?
-    let mut acquires = vec![];
-    if match_token(context.tokens, Tok::Acquires)? {
-        let follows_acquire = |tok| matches!(tok, Tok::Semicolon | Tok::LBrace);
-        loop {
-            acquires.push(parse_name_access_chain(context, || {
-                "a resource struct name"
-            })?);
-            if follows_acquire(context.tokens.peek()) {
-                break;
-            }
-            consume_token(context.tokens, Tok::Comma)?;
-            if follows_acquire(context.tokens.peek()) {
-                break;
-            }
+    // ( ( "!" )? ("acquires" | "reads" | "writes" ) <AccessSpecifierList> )*
+    let mut access_specifiers = vec![];
+    let mut pure_loc = None;
+    loop {
+        let negated = if context.tokens.peek() == Tok::Exclaim {
+            context.tokens.advance()?;
+            true
+        } else {
+            false
+        };
+        match context.tokens.peek() {
+            Tok::Acquires => {
+                context.tokens.advance()?;
+                access_specifiers.extend(parse_access_specifier_list(
+                    context,
+                    negated,
+                    &AccessSpecifier_::Acquires,
+                )?)
+            },
+            Tok::Identifier if context.tokens.content() == "reads" => {
+                context.tokens.advance()?;
+                access_specifiers.extend(parse_access_specifier_list(
+                    context,
+                    negated,
+                    &AccessSpecifier_::Reads,
+                )?)
+            },
+            Tok::Identifier if context.tokens.content() == "writes" => {
+                context.tokens.advance()?;
+                access_specifiers.extend(parse_access_specifier_list(
+                    context,
+                    negated,
+                    &AccessSpecifier_::Writes,
+                )?)
+            },
+            Tok::Identifier if context.tokens.content() == "pure" => {
+                pure_loc = Some(current_token_loc(context.tokens));
+                if negated {
+                    return Err(Box::new(diag!(
+                        Syntax::InvalidAccessSpecifier,
+                        (pure_loc.unwrap(), "'pure' cannot be negated")
+                    )));
+                }
+                context.tokens.advance()?;
+            },
+            _ => break,
         }
     }
+    let access_specifiers = if let Some(loc) = pure_loc {
+        if !access_specifiers.is_empty() {
+            return Err(Box::new(diag!(
+                Syntax::InvalidAccessSpecifier,
+                (
+                    loc,
+                    "'pure' cannot be mixed with 'acquires'/`reads'/'writes'"
+                )
+            )));
+        }
+        // pure is represented by an empty access list
+        Some(vec![])
+    } else if access_specifiers.is_empty() {
+        // no specifiers is represented as None
+        None
+    } else {
+        Some(access_specifiers)
+    };
 
     let body = match native {
         Some(loc) => {
@@ -1994,7 +2083,7 @@ fn parse_function_decl(
         visibility: visibility.unwrap_or(Visibility::Internal),
         entry,
         signature,
-        acquires,
+        access_specifiers,
         inline,
         name,
         body,
@@ -2008,6 +2097,99 @@ fn parse_parameter(context: &mut Context) -> Result<(Var, Type), Box<Diagnostic>
     consume_token(context.tokens, Tok::Colon)?;
     let t = parse_type(context)?;
     Ok((v, t))
+}
+
+// Parse an access specifier list:
+//      AccessSpecifierList = <AccessSpecifier> ( "," <AccessSpecifier> )* ","?
+fn parse_access_specifier_list(
+    context: &mut Context,
+    negated: bool,
+    ctor: &impl Fn(bool, NameAccessChain, Option<Vec<Type>>, AddressSpecifier) -> AccessSpecifier_,
+) -> Result<Vec<AccessSpecifier>, Box<Diagnostic>> {
+    let mut chain = vec![];
+    loop {
+        chain.push(parse_access_specifier(context, negated, ctor)?);
+        if context.tokens.peek() == Tok::Comma {
+            context.tokens.advance()?;
+            // Trailing comma allowed, check FIRST(<AccessSpecifier>)
+            if matches!(
+                context.tokens.peek(),
+                Tok::Identifier | Tok::Star | Tok::NumValue
+            ) {
+                continue;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    Ok(chain)
+}
+
+// Parse an access specifier:
+//   AccessSpecifier = <NameAccessChainWithWildcard> <AddressSpecifier>
+fn parse_access_specifier(
+    context: &mut Context,
+    negated: bool,
+    ctor: &impl Fn(bool, NameAccessChain, Option<Vec<Type>>, AddressSpecifier) -> AccessSpecifier_,
+) -> Result<AccessSpecifier, Box<Diagnostic>> {
+    let start = context.tokens.start_loc();
+    let name_chain = parse_name_access_chain(context, true, || "an access specifier")?;
+    let type_args = parse_optional_type_args(context)?;
+    let address = parse_address_specifier(context)?;
+    let loc = make_loc(
+        context.tokens.file_hash(),
+        start,
+        address.loc.end() as usize,
+    );
+    Ok(sp(loc, (*ctor)(negated, name_chain, type_args, address)))
+}
+
+// Parse an address specifier:
+//   AddressSpecifier = <empty> | "(" <AddressSpecifierArg> ")"
+//   AddressSpecifierArg = "*" | <Identifier> | <NameAccessChain> "(" <Identifier> ")"
+fn parse_address_specifier(context: &mut Context) -> Result<AddressSpecifier, Box<Diagnostic>> {
+    let start = context.tokens.start_loc();
+    let (spec, end) = if match_token(context.tokens, Tok::LParen)? {
+        let spec = match context.tokens.peek() {
+            Tok::Star => {
+                context.tokens.advance()?;
+                AddressSpecifier_::Any
+            },
+            Tok::NumValue => AddressSpecifier_::Literal(parse_address_bytes(context)?.value),
+            _ => {
+                let chain = parse_name_access_chain(context, false, || "an address specifier")?;
+                let type_args = parse_optional_type_args(context)?;
+                if match_token(context.tokens, Tok::LParen)? {
+                    let name = parse_identifier(context)?;
+                    let call = AddressSpecifier_::Call(chain, type_args, name);
+                    consume_token(context.tokens, Tok::RParen)?;
+                    call
+                } else {
+                    if type_args.is_some() {
+                        return Err(Box::new(diag!(
+                            Syntax::InvalidAccessSpecifier,
+                            (chain.loc, "type arguments not allowed")
+                        )));
+                    }
+                    if let NameAccessChain_::One(name) = chain.value {
+                        AddressSpecifier_::Name(name)
+                    } else {
+                        return Err(Box::new(diag!(
+                            Syntax::InvalidAccessSpecifier,
+                            (chain.loc, "expected a simple name")
+                        )));
+                    }
+                }
+            },
+        };
+        consume_token(context.tokens, Tok::RParen)?;
+        (spec, context.tokens.previous_end_loc())
+    } else {
+        (AddressSpecifier_::Empty, context.tokens.start_loc())
+    };
+    Ok(sp(make_loc(context.tokens.file_hash(), start, end), spec))
 }
 
 //**************************************************************************************************
@@ -2220,7 +2402,7 @@ fn parse_address_block(
         )));
     }
     let start_loc = context.tokens.start_loc();
-    let addr = parse_leading_name_access(context)?;
+    let addr = parse_leading_name_access(context, false)?;
     let end_loc = context.tokens.previous_end_loc();
     let loc = make_loc(context.tokens.file_hash(), start_loc, end_loc);
 
@@ -2259,7 +2441,7 @@ fn parse_friend_decl(
 ) -> Result<FriendDecl, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
     consume_token(context.tokens, Tok::Friend)?;
-    let friend = parse_name_access_chain(context, || "a friend declaration")?;
+    let friend = parse_name_access_chain(context, false, || "a friend declaration")?;
     consume_token(context.tokens, Tok::Semicolon)?;
     let loc = make_loc(
         context.tokens.file_hash(),
@@ -2353,7 +2535,7 @@ fn parse_module(
         consume_token(context.tokens, Tok::Module)?;
         false
     };
-    let sp!(n1_loc, n1_) = parse_leading_name_access(context)?;
+    let sp!(n1_loc, n1_) = parse_leading_name_access(context, false)?;
     let (address, name) = match (n1_, context.tokens.peek()) {
         (addr_ @ LeadingNameAccess_::AnonymousAddress(_), _)
         | (addr_ @ LeadingNameAccess_::Name(_), Tok::ColonColon) => {
@@ -3180,6 +3362,7 @@ fn parse_spec_property(context: &mut Context) -> Result<PragmaProperty, Box<Diag
                 // Parse as a module access for a possibly qualified identifier
                 Some(PragmaValue::Ident(parse_name_access_chain(
                     context,
+                    false,
                     || "an identifier as pragma value",
                 )?))
             },

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -389,6 +389,10 @@ pub struct Flags {
     /// Note that current value of this constant is "Wdeprecation-aptos"
     #[clap(long = cli::WARN_OF_DEPRECATION_USE_IN_APTOS_LIBS_FLAG, default_value=warn_of_deprecation_use_in_aptos_libs_env_var_str())]
     warn_of_deprecation_use_in_aptos_libs: bool,
+
+    /// Support v2 syntax (up to expansion phase)
+    #[clap(long = cli::V2_FLAG)]
+    v2: bool,
 }
 
 impl Flags {
@@ -404,6 +408,7 @@ impl Flags {
             debug: debug_compiler_env_var(),
             warn_of_deprecation_use: move_compiler_warn_of_deprecation_use_env_var(),
             warn_of_deprecation_use_in_aptos_libs: warn_of_deprecation_use_in_aptos_libs_env_var(),
+            v2: false,
         }
     }
 
@@ -419,6 +424,7 @@ impl Flags {
             debug: debug_compiler_env_var(),
             warn_of_deprecation_use: move_compiler_warn_of_deprecation_use_env_var(),
             warn_of_deprecation_use_in_aptos_libs: warn_of_deprecation_use_in_aptos_libs_env_var(),
+            v2: false,
         }
     }
 
@@ -434,6 +440,7 @@ impl Flags {
             debug: debug_compiler_env_var(),
             warn_of_deprecation_use: move_compiler_warn_of_deprecation_use_env_var(),
             warn_of_deprecation_use_in_aptos_libs: warn_of_deprecation_use_in_aptos_libs_env_var(),
+            v2: false,
         }
     }
 
@@ -449,6 +456,7 @@ impl Flags {
             debug: debug_compiler_env_var(),
             warn_of_deprecation_use: move_compiler_warn_of_deprecation_use_env_var(),
             warn_of_deprecation_use_in_aptos_libs: warn_of_deprecation_use_in_aptos_libs_env_var(),
+            v2: false,
         }
     }
 
@@ -464,6 +472,7 @@ impl Flags {
             debug: false,
             warn_of_deprecation_use: move_compiler_warn_of_deprecation_use_env_var(),
             warn_of_deprecation_use_in_aptos_libs: warn_of_deprecation_use_in_aptos_libs_env_var(),
+            v2: true,
         }
     }
 
@@ -551,6 +560,14 @@ impl Flags {
 
     pub fn debug(&self) -> bool {
         self.debug
+    }
+
+    pub fn v2(&self) -> bool {
+        self.v2
+    }
+
+    pub fn set_v2(self, v2: bool) -> Self {
+        Self { v2, ..self }
     }
 }
 

--- a/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
+++ b/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
@@ -198,7 +198,7 @@ fn create_test_poison(mloc: Loc) -> P::ModuleMember {
         loc: mloc,
         visibility: P::Visibility::Internal,
         entry: None,
-        acquires: vec![],
+        access_specifiers: None,
         signature,
         inline: false,
         name: P::FunctionName(sp(mloc, "unit_test_poison".into())),

--- a/third_party/move/move-compiler/tests/move_check/expansion/access_specifier_not_supported.exp
+++ b/third_party/move/move-compiler/tests/move_check/expansion/access_specifier_not_supported.exp
@@ -1,0 +1,24 @@
+error[E01012]: invalid access specifier
+   ┌─ tests/move_check/expansion/access_specifier_not_supported.move:14:23
+   │
+14 │     fun f4() acquires S(*) {
+   │                       ^^^^ compiler version 1 only supports simple 'acquires <resource_name>' clauses
+
+error[E01012]: invalid access specifier
+   ┌─ tests/move_check/expansion/access_specifier_not_supported.move:23:23
+   │
+23 │     fun f7() acquires *(*) {
+   │                       ^^^^ compiler version 1 only supports simple 'acquires <resource_name>' clauses
+
+error[E01012]: invalid access specifier
+   ┌─ tests/move_check/expansion/access_specifier_not_supported.move:26:23
+   │
+26 │     fun f8() acquires *(0x42) {
+   │                       ^^^^^^^ compiler version 1 only supports simple 'acquires <resource_name>' clauses
+
+error[E01012]: invalid access specifier
+   ┌─ tests/move_check/expansion/access_specifier_not_supported.move:29:34
+   │
+29 │     fun f9(_a: address) acquires *(_a) {
+   │                                  ^^^^^ compiler version 1 only supports simple 'acquires <resource_name>' clauses
+

--- a/third_party/move/move-compiler/tests/move_check/expansion/access_specifier_not_supported.move
+++ b/third_party/move/move-compiler/tests/move_check/expansion/access_specifier_not_supported.move
@@ -1,0 +1,31 @@
+module 0x42::m {
+
+    struct S has key {}
+    struct R has key {}
+    struct T has key {}
+    struct G<phantom T> has key {}
+
+    fun f2() reads S {
+    }
+
+    fun f3() writes S {
+    }
+
+    fun f4() acquires S(*) {
+    }
+
+    fun f5() acquires 0x42::*::* {
+    }
+
+    fun f6() acquires 0x42::m::R {
+    }
+
+    fun f7() acquires *(*) {
+    }
+
+    fun f8() acquires *(0x42) {
+    }
+
+    fun f9(_a: address) acquires *(_a) {
+    }
+}

--- a/third_party/move/move-compiler/tests/move_check/parser/acquires_list_generic.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/acquires_list_generic.exp
@@ -1,9 +1,6 @@
-error[E01002]: unexpected token
-  ┌─ tests/move_check/parser/acquires_list_generic.move:6:25
+error[E01012]: invalid access specifier
+  ┌─ tests/move_check/parser/acquires_list_generic.move:6:24
   │
 6 │     fun foo() acquires B<CupC<R>> {
-  │                         ^
-  │                         │
-  │                         Unexpected '<'
-  │                         Expected ','
+  │                        ^^^^^^^^^^^ compiler version 1 only supports simple 'acquires <resource_name>' clauses
 

--- a/third_party/move/move-compiler/tests/move_check/parser/acquires_list_generic.move
+++ b/third_party/move/move-compiler/tests/move_check/parser/acquires_list_generic.move
@@ -1,7 +1,7 @@
-module M {
-    struct CupC<T: drop> {}
+module 0x42::M {
+    struct CupC<phantom T> {}
     struct R {}
-    struct B<T> {}
+    struct B<phantom T> {}
 
     fun foo() acquires B<CupC<R>> {
         abort 0

--- a/third_party/move/move-compiler/tests/move_check/parser/function_acquires_bad_name.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/function_acquires_bad_name.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │                      ^
   │                      │
   │                      Unexpected '{'
-  │                      Expected a resource struct name
+  │                      Expected an access specifier
 

--- a/third_party/move/move-compiler/tests/move_check/parser/function_acquires_missing_comma.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/function_acquires_missing_comma.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │                         ^^
   │                         │
   │                         Unexpected 'X2'
-  │                         Expected ','
+  │                         Expected '{'
 

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -12,7 +12,7 @@ use move_binary_format::{
         StructHandleIndex, StructTypeParameter, TableIndex, TypeParameterIndex, TypeSignature,
         Visibility,
     },
-    file_format_common::VERSION_MAX,
+    file_format_common::VERSION_DEFAULT,
 };
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::value::{MoveTypeLayout, MoveValue};
@@ -376,7 +376,7 @@ pub fn compile_script<'a>(
         source_map,
     ) = context.materialize_pools();
     let script = CompiledScript {
-        version: VERSION_MAX,
+        version: VERSION_DEFAULT,
         module_handles,
         struct_handles,
         function_handles,
@@ -468,7 +468,7 @@ pub fn compile_module<'a>(
         source_map,
     ) = context.materialize_pools();
     let module = CompiledModule {
-        version: VERSION_MAX,
+        version: VERSION_DEFAULT,
         module_handles,
         self_module_handle_idx,
         struct_handles,
@@ -547,7 +547,7 @@ fn compile_explicit_dependency_declarations(
             _source_map,
         ) = context.materialize_pools();
         let compiled_module = CompiledModule {
-            version: VERSION_MAX,
+            version: VERSION_DEFAULT,
             module_handles,
             self_module_handle_idx,
             struct_handles,

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/context.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/context.rs
@@ -666,6 +666,7 @@ impl<'a> Context<'a> {
             parameters: SignatureIndex(params_idx as TableIndex),
             return_: SignatureIndex(return_idx as TableIndex),
             type_parameters,
+            access_specifiers: None,
         };
         // handle duplicate declarations
         // erroring on duplicates needs to be done by the bytecode verifier

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -16,7 +16,10 @@ use crate::{
 };
 use internment::LocalIntern;
 use itertools::Itertools;
-use move_binary_format::file_format::{CodeOffset, Visibility};
+use move_binary_format::{
+    file_format,
+    file_format::{CodeOffset, Visibility},
+};
 use move_core_types::account_address::AccountAddress;
 use num::BigInt;
 use std::{
@@ -382,6 +385,35 @@ pub struct UseDecl {
     pub alias: Option<Symbol>,
     /// A list of member uses, with optional aliasing.
     pub members: Vec<(Loc, Symbol, Option<Symbol>)>,
+}
+
+// =================================================================================================
+/// # Access Specifiers
+
+/// Access specifier
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccessSpecifier {
+    pub loc: Loc,
+    pub kind: file_format::AccessKind,
+    pub negated: bool,
+    pub resource: (Loc, ResourceSpecifier),
+    pub address: (Loc, AddressSpecifier),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ResourceSpecifier {
+    Any,
+    DeclaredAtAddress(Address),
+    DeclaredInModule(ModuleId),
+    Resource(QualifiedInstId<StructId>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AddressSpecifier {
+    Any,
+    Address(Address),
+    Parameter(Symbol),
+    Call(QualifiedInstId<FunId>, Symbol),
 }
 
 // =================================================================================================

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     ast::{
-        Address, Exp, ExpData, ModuleName, Operation, Pattern, QualifiedSymbol, QuantKind, Spec,
-        Value,
+        AccessSpecifier, Address, AddressSpecifier, Exp, ExpData, ModuleName, Operation, Pattern,
+        QualifiedSymbol, QuantKind, ResourceSpecifier, Spec, Value,
     },
     builder::{
         model_builder::{AnyFunEntry, ConstEntry, EntryVisibility, LocalVarEntry},
@@ -24,10 +24,7 @@ use crate::{
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
 use move_compiler::{
-    expansion::{
-        ast as EA,
-        ast::{ModuleAccess_, SpecBlock, SpecId},
-    },
+    expansion::ast as EA,
     hlir::ast as HA,
     naming::ast as NA,
     parser::ast as PA,
@@ -75,7 +72,7 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     /// Set containing all the functions called during translation.
     pub called_spec_funs: BTreeSet<(ModuleId, SpecFunId)>,
     /// A mapping from SpecId to SpecBlock (expansion ast)
-    pub spec_block_map: BTreeMap<SpecId, SpecBlock>,
+    pub spec_block_map: BTreeMap<EA::SpecId, EA::SpecBlock>,
 }
 
 /// Mode of translation
@@ -136,7 +133,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         et
     }
 
-    pub fn set_spec_block_map(&mut self, map: BTreeMap<SpecId, SpecBlock>) {
+    pub fn set_spec_block_map(&mut self, map: BTreeMap<EA::SpecId, EA::SpecBlock>) {
         self.spec_block_map = map
     }
 
@@ -849,6 +846,171 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     }
 }
 
+/// # Access Specifier Translation
+
+impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
+    pub(crate) fn translate_access_specifiers(
+        &mut self,
+        specifiers: &Option<Vec<EA::AccessSpecifier>>,
+    ) -> Option<Vec<AccessSpecifier>> {
+        specifiers.as_ref().map(|v| {
+            v.iter()
+                .map(|s| self.translate_access_specifier(s))
+                .collect()
+        })
+    }
+
+    fn translate_access_specifier(&mut self, specifier: &EA::AccessSpecifier) -> AccessSpecifier {
+        fn is_wildcard(name: &Name) -> bool {
+            name.value.as_str() == "*"
+        }
+        let loc = self.to_loc(&specifier.loc);
+        let EA::AccessSpecifier_ {
+            kind,
+            negated,
+            module_address,
+            module_name,
+            resource_name,
+            type_args,
+            address,
+        } = &specifier.value;
+        let resource = match (module_address, module_name, resource_name) {
+            (None, None, None) => ResourceSpecifier::Any,
+            (Some(address), None, None) => {
+                ResourceSpecifier::DeclaredAtAddress(self.translate_address(&loc, address))
+            },
+            (Some(address), Some(module), None) if is_wildcard(&module.0) => {
+                ResourceSpecifier::DeclaredAtAddress(self.translate_address(&loc, address))
+            },
+            (Some(address), Some(module), Some(resource))
+                if is_wildcard(&module.0) && is_wildcard(resource) =>
+            {
+                ResourceSpecifier::DeclaredAtAddress(self.translate_address(&loc, address))
+            },
+            (Some(address), Some(module), Some(resource)) if !is_wildcard(&module.0) => {
+                let module_name = ModuleName::new(
+                    self.translate_address(&loc, address),
+                    self.symbol_pool().make(module.0.value.as_str()),
+                );
+                let module_id = if self.parent.module_name == module_name {
+                    self.parent.module_id
+                } else if let Some(module_env) = self.parent.parent.env.find_module(&module_name) {
+                    module_env.get_id()
+                } else {
+                    self.error(&loc, &format!("undeclared module `{}`", module));
+                    self.parent.module_id
+                };
+                if is_wildcard(resource) {
+                    ResourceSpecifier::DeclaredInModule(module_id)
+                } else {
+                    // Construct an expansion type so we can feed it through the standard translation
+                    // process.
+                    let mident = sp(specifier.loc, EA::ModuleIdent_ {
+                        address: *address,
+                        module: *module,
+                    });
+                    let maccess = sp(
+                        specifier.loc,
+                        EA::ModuleAccess_::ModuleAccess(mident, *resource),
+                    );
+                    let ety = sp(
+                        specifier.loc,
+                        EA::Type_::Apply(maccess, type_args.as_ref().cloned().unwrap_or_default()),
+                    );
+                    let ty = self.translate_type(&ety);
+                    if let Type::Struct(mid, sid, inst) = ty {
+                        ResourceSpecifier::Resource(mid.qualified_inst(sid, inst))
+                    } else {
+                        // errors reported
+                        debug_assert!(self.parent.parent.env.has_errors());
+                        ResourceSpecifier::Any
+                    }
+                }
+            },
+            (Some(_), Some(module), Some(resource))
+                if is_wildcard(&module.0) && !is_wildcard(resource) =>
+            {
+                self.error(&loc, "invalid access specifier: a wildcard cannot be followed by a non-wildcard name component");
+                ResourceSpecifier::Any
+            },
+            _ => {
+                self.error(&loc, "invalid access specifier");
+                ResourceSpecifier::Any
+            },
+        };
+        let address = self.translate_address_specifier(address);
+        AccessSpecifier {
+            loc: loc.clone(),
+            kind: *kind,
+            negated: *negated,
+            resource: (loc, resource),
+            address,
+        }
+    }
+
+    fn translate_address_specifier(
+        &mut self,
+        specifier: &EA::AddressSpecifier,
+    ) -> (Loc, AddressSpecifier) {
+        let loc = self.to_loc(&specifier.loc);
+        match &specifier.value {
+            EA::AddressSpecifier_::Any => (loc, AddressSpecifier::Any),
+            EA::AddressSpecifier_::Literal(addr) => (
+                loc,
+                AddressSpecifier::Address(Address::Numerical(addr.into_inner())),
+            ),
+            EA::AddressSpecifier_::Name(name) => {
+                // Construct an expansion name exp for regular type check
+                let maccess = sp(name.loc, EA::ModuleAccess_::Name(*name));
+                self.translate_name(
+                    &self.to_loc(&name.loc),
+                    &maccess,
+                    None,
+                    &Type::new_prim(PrimitiveType::Address),
+                );
+                (
+                    loc,
+                    AddressSpecifier::Parameter(self.symbol_pool().make(name.value.as_str())),
+                )
+            },
+            EA::AddressSpecifier_::Call(maccess, type_args, name) => {
+                // Construct an expansion function call for regular type check
+                let name_exp = sp(
+                    name.loc,
+                    EA::Exp_::Name(sp(name.loc, EA::ModuleAccess_::Name(*name)), None),
+                );
+                if let ExpData::Call(id, Operation::MoveFunction(mid, fid), _) = self
+                    .translate_fun_call(
+                        &Type::new_prim(PrimitiveType::Address),
+                        &loc,
+                        maccess,
+                        type_args.as_ref().map(|v| v.as_slice()),
+                        &[&name_exp],
+                    )
+                {
+                    let inst = self.parent.parent.env.get_node_instantiation(id);
+                    (
+                        loc,
+                        AddressSpecifier::Call(
+                            mid.qualified_inst(fid, inst),
+                            self.symbol_pool().make(name.value.as_str()),
+                        ),
+                    )
+                } else {
+                    // Error reported
+                    debug_assert!(self.parent.parent.env.has_errors());
+                    (loc, AddressSpecifier::Any)
+                }
+            },
+        }
+    }
+
+    fn translate_address(&mut self, loc: &Loc, addr: &EA::Address) -> Address {
+        let x = self.parent.parent.resolve_address(loc, addr);
+        Address::Numerical(x.into_inner())
+    }
+}
+
 /// # Expression Translation
 
 impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
@@ -1202,7 +1364,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
 
     /// Translates a specification block embedded in an expression, and returns the
     /// model representation of it.
-    fn translate_spec_block(&mut self, loc: &Loc, block: &SpecBlock) -> Spec {
+    fn translate_spec_block(&mut self, loc: &Loc, block: &EA::SpecBlock) -> Spec {
         let fun_name = if let Some(name) = &self.fun_name {
             name.clone()
         } else {
@@ -3002,7 +3164,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         if type_args.is_some() {
             self.error(loc, "macro invocation cannot have type arguments");
             self.new_error_exp()
-        } else if let ModuleAccess_::Name(name) = &maccess.value {
+        } else if let EA::ModuleAccess_::Name(name) = &maccess.value {
             let name_sym = self.symbol_pool().make(name.value.as_str());
             if self.mode == ExpTranslationMode::TryImplAsSpec
                 && name_sym == self.parent.parent.assert_symbol()

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -875,7 +875,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             address,
         } = &specifier.value;
         let resource = match (module_address, module_name, resource_name) {
-            (None, None, None) => ResourceSpecifier::Any,
+            (None, None, None) => {
+                // This stems from a  specifier of the form `acquires *(0x1)`
+                ResourceSpecifier::Any
+            },
             (Some(address), None, None) => {
                 ResourceSpecifier::DeclaredAtAddress(self.translate_address(&loc, address))
             },

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -79,7 +79,7 @@ pub(crate) struct ModuleBuilder<'env, 'translator> {
     /// Translated function definitions, if we are compiling Move code
     pub fun_defs: BTreeMap<Symbol, Exp>,
     /// Translated access specifiers, if we are compiling Move code
-    pub access_specifiers: BTreeMap<Symbol, Vec<AccessSpecifier>>,
+    pub fun_access_specifiers: BTreeMap<Symbol, Vec<AccessSpecifier>>,
     /// Translated struct specifications.
     pub struct_specs: BTreeMap<Symbol, Spec>,
     /// Translated module spec
@@ -154,7 +154,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             spec_vars: vec![],
             fun_specs: BTreeMap::new(),
             fun_defs: BTreeMap::new(),
-            access_specifiers: BTreeMap::new(),
+            fun_access_specifiers: BTreeMap::new(),
             struct_specs: BTreeMap::new(),
             module_spec: Spec::default(),
             spec_block_infos: Default::default(),
@@ -1270,7 +1270,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     .is_none());
                 if let Some(specifiers) = access_specifiers {
                     assert!(self
-                        .access_specifiers
+                        .fun_access_specifiers
                         .insert(full_name.symbol, specifiers)
                         .is_none());
                 }
@@ -3600,7 +3600,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             // New function
             let spec = self.fun_specs.remove(&name.symbol).unwrap_or_default();
             let def = self.fun_defs.remove(&name.symbol);
-            let access_specifiers = self.access_specifiers.remove(&name.symbol);
+            let access_specifiers = self.fun_access_specifiers.remove(&name.symbol);
             let data = FunctionData {
                 name: name.symbol,
                 loc: entry.loc.clone(),

--- a/third_party/move/move-model/src/lib.rs
+++ b/third_party/move/move-model/src/lib.rs
@@ -511,6 +511,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
         parameters: script.parameters,
         return_: return_sig_idx,
         type_parameters: script.type_parameters,
+        access_specifiers: None, // TODO: access specifiers for script functions
     });
 
     // Create a function definition for the main function.
@@ -717,6 +718,7 @@ fn retrospective_lambda_lifting(
             },
             entry: None,
             acquires: vec![], // TODO: might need inference here
+            access_specifiers: None,
             body: new_body,
             specs: BTreeMap::new(),
         };

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3667,6 +3667,11 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Returns the access specifiers of this function.
+    /// If this is `None`, all accesses are allowed. If the list is empty,
+    /// no accesses are allowed. Otherwise the list is divided into _inclusions_ and _exclusions_,
+    /// the later being negated specifiers. Access is allowed if (a) any of the inclusion
+    /// specifiers allows it (union of inclusion specifiers) (b) none of the exclusions
+    /// specifiers disallows it (intersection of exclusion specifiers).
     pub fn get_access_specifiers(&self) -> Option<&[AccessSpecifier]> {
         self.data.access_specifiers.as_deref()
     }

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -17,8 +17,9 @@
 
 use crate::{
     ast::{
-        Address, Attribute, ConditionKind, Exp, ExpData, GlobalInvariant, ModuleName, PropertyBag,
-        PropertyValue, Spec, SpecBlockInfo, SpecFunDecl, SpecVarDecl, UseDecl, Value,
+        AccessSpecifier, Address, AddressSpecifier, Attribute, ConditionKind, Exp, ExpData,
+        GlobalInvariant, ModuleName, PropertyBag, PropertyValue, ResourceSpecifier, Spec,
+        SpecBlockInfo, SpecFunDecl, SpecVarDecl, UseDecl, Value,
     },
     code_writer::CodeWriter,
     emit, emitln,
@@ -46,8 +47,9 @@ use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
     file_format::{
-        Bytecode, CodeOffset, Constant as VMConstant, ConstantPoolIndex, FunctionDefinitionIndex,
-        FunctionHandleIndex, SignatureIndex, SignatureToken, StructDefinitionIndex,
+        AccessKind, Bytecode, CodeOffset, Constant as VMConstant, ConstantPoolIndex,
+        FunctionDefinitionIndex, FunctionHandleIndex, SignatureIndex, SignatureToken,
+        StructDefinitionIndex,
     },
     normalized::Type as MType,
     views::{FunctionDefinitionView, FunctionHandleView, StructHandleView},
@@ -1914,6 +1916,54 @@ impl GlobalEnv {
             }
             for fun in module.get_functions() {
                 emit!(writer, "{}", fun.get_header_string());
+                if let Some(specs) = fun.get_access_specifiers() {
+                    emitln!(writer);
+                    writer.indent();
+                    for spec in specs {
+                        if spec.negated {
+                            emit!(writer, "!")
+                        }
+                        match &spec.kind {
+                            AccessKind::Reads => emit!(writer, "reads "),
+                            AccessKind::Writes => emit!(writer, "writes "),
+                            AccessKind::Acquires => emit!(writer, "acquires "),
+                        }
+                        match &spec.resource.1 {
+                            ResourceSpecifier::Any => emit!(writer, "*"),
+                            ResourceSpecifier::DeclaredAtAddress(addr) => {
+                                emit!(
+                                    writer,
+                                    "0x{}::*",
+                                    addr.expect_numerical().short_str_lossless()
+                                )
+                            },
+                            ResourceSpecifier::DeclaredInModule(mid) => {
+                                emit!(writer, "{}::*", self.get_module(*mid).get_full_name_str())
+                            },
+                            ResourceSpecifier::Resource(sid) => {
+                                emit!(writer, "{}", sid.to_type().display(tctx))
+                            },
+                        }
+                        emit!(writer, "(");
+                        match &spec.address.1 {
+                            AddressSpecifier::Any => emit!(writer, "*"),
+                            AddressSpecifier::Address(addr) => {
+                                emit!(writer, "0x{}", addr.expect_numerical().short_str_lossless())
+                            },
+                            AddressSpecifier::Parameter(sym) => {
+                                emit!(writer, "{}", sym.display(self.symbol_pool()))
+                            },
+                            AddressSpecifier::Call(fun, sym) => emit!(
+                                writer,
+                                "{}({})",
+                                self.get_function(fun.to_qualified_id()).get_full_name_str(),
+                                sym.display(self.symbol_pool())
+                            ),
+                        }
+                        emitln!(writer, ")")
+                    }
+                    writer.unindent()
+                }
                 if let Some(exp) = fun.get_def() {
                     emitln!(writer, " {");
                     writer.indent();
@@ -3176,6 +3226,9 @@ pub struct FunctionData {
     /// Result type of the function, uses `Type::Tuple` for multiple values.
     pub(crate) result_type: Type,
 
+    /// Access specifiers.
+    pub(crate) access_specifiers: Option<Vec<AccessSpecifier>>,
+
     /// Specification associated with this function.
     pub(crate) spec: RefCell<Spec>,
 
@@ -3611,6 +3664,11 @@ impl<'env> FunctionEnv<'env> {
         } else {
             1
         }
+    }
+
+    /// Returns the access specifiers of this function.
+    pub fn get_access_specifiers(&self) -> Option<&[AccessSpecifier]> {
+        self.data.access_specifiers.as_deref()
     }
 
     /// Get the name to be used for a local by index, if a compiled module and source map

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -938,15 +938,12 @@ impl Substitution {
             match &c {
                 Constraint::SomeNumber(options) => match ty {
                     Type::Primitive(prim) if options.contains(prim) => Ok(()),
-                    _ => {
-                        println!("mismatch {:?} {:?} {:?}", ty, order, c);
-                        Err(TypeUnificationError::ConstraintUnsatisfied(
-                            loc.clone(),
-                            ty.clone(),
-                            order,
-                            c,
-                        ))
-                    },
+                    _ => Err(TypeUnificationError::ConstraintUnsatisfied(
+                        loc.clone(),
+                        ty.clone(),
+                        order,
+                        c,
+                    )),
                 },
                 Constraint::SomeReference(inner_type) => match ty {
                     Type::Reference(_, target_type) => {

--- a/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -58,6 +58,7 @@ fn instantiation_err() {
             parameters: SignatureIndex(0),
             return_: SignatureIndex(0),
             type_parameters: vec![AbilitySet::PRIMITIVES],
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],

--- a/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -107,6 +107,7 @@ fn make_script_with_non_linking_structs(parameters: Signature) -> Vec<u8> {
             parameters: SignatureIndex(1),
             return_: SignatureIndex(0),
             type_parameters: vec![],
+            access_specifiers: None,
         }],
 
         function_instantiations: vec![],
@@ -180,6 +181,7 @@ fn make_module_with_function(
             parameters: parameters_idx,
             return_: return_idx,
             type_parameters,
+            access_specifiers: None,
         }],
         field_handles: vec![],
         friend_decls: vec![],

--- a/third_party/move/testing-infra/test-generation/tests/control_flow_instructions.rs
+++ b/third_party/move/testing-infra/test-generation/tests/control_flow_instructions.rs
@@ -31,6 +31,7 @@ fn generate_module_with_function() -> CompiledModule {
         parameters: SignatureIndex::new(1),
         return_: SignatureIndex::new(2),
         type_parameters: vec![],
+        access_specifiers: None,
     }];
     module
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -47,6 +47,7 @@ pub enum FeatureFlag {
     CONCURRENT_ASSETS = 37,
     LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
+    VM_BINARY_FORMAT_V7 = 40,
 }
 
 /// Representation of features on chain as a bitset.
@@ -59,6 +60,7 @@ pub struct Features {
 impl Default for Features {
     fn default() -> Self {
         Features {
+            // TODO: for gods sake, make this based on the enum above
             features: vec![0b00100000, 0b00100000, 0b10001100, 0b01100000, 0b00000000],
         }
     }


### PR DESCRIPTION
### Description

This is an e2e implementation of resource access control for Move, with most parts in place:

- Replaces the acquires syntax in a downwards-compatible way
- The extended syntax is only available in compiler v2
- One can now specify `acquires`, `reads`, and `writes`
- One can specify the address of a resource in dependency of parameters
- Multiple levels of wildcards are allowed, e.g. `acquires *(object::address_of(param))` specifies that all resources at the given address are read or written.
- Implements parsing->expansion->move model->file format generator
- Extends `file_format::FunctionHandle` to carry the new information, introducing bytecode version v7. v7 became the new experimental version only available in test code for now.
- TODO: dynamic runtime checking of resource access. Static analysis is also on the horizon, but not needed for an MVP of this feature.
- TODO: bytecode verification of access specifiers

An AIP for this new feature will be filed soon.

As an example, here is some extract from the tests:

```move
module 0x42::m {

    struct S has store {}
    struct R has store {}
    struct T has store {}
    struct G<T> has store {}

    fun f1() acquires S {
    }

    fun f2() reads S {
    }

    fun f3() writes S {
    }

    fun f4() acquires S(*) {
    }

    fun f_multiple() acquires R reads R writes T, S reads G<u64> {
    }

    fun f5() acquires 0x42::*::* {
    }

    fun f6() acquires 0x42::m::R {
    }

    fun f7() acquires *(*) {
    }

    fun f8() acquires *(0x42) {
    }

    fun f9(a: address) acquires *(a) {
    }

    fun f10(x: u64) acquires *(make_up_address(x)) {
    }

    fun make_up_address(x: u64): address {
        @0x42
    }
}
```


### Test Plan

Unit tests for v2 and v1 compiler.
