### PR TITLE
get around that RocksDB does not take Windows UNC style paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,6 +3219,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-temppath",
  "byteorder",
+ "dunce",
  "once_cell",
  "proptest",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,6 +482,7 @@ diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs = "5.0.1"
+dunce = "1.0.4"
 ed25519-dalek = { version = "1.0.1", features = ["std", "serde"] }
 ed25519-dalek-bip32 = "0.2.0"
 either = "1.6.1"

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+dunce = { workspace = true }
 once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }


### PR DESCRIPTION
i.e. `//?C:\...` doesn't work

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

`cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes` on Windows 11
