### PR TITLE
[ts-sdk] Fix nested type tag in object parsing

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Fix nested type tag parsing in `Object` types
 
 ## 1.20.0 (2023-09-22)
 

--- a/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
@@ -351,8 +351,9 @@ export class TypeTagParser {
       // If it is nested, we have to consume another nested generic
       if (this.tokens[0][1] === "<") {
         this.consumeWholeGeneric();
+      } else {
+        this.tokens.shift();
       }
-      this.tokens.shift();
     }
     this.consume(">");
   }

--- a/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
@@ -115,7 +115,7 @@ describe("TypeTagParser", () => {
       expect(result instanceof TypeTagAddress).toBeTruthy();
 
       const typeTag2 = "0x1::object::Object<0x1::coin::Fun<A, B<C>>>";
-      const parser2 = new TypeTagParser(typeTag);
+      const parser2 = new TypeTagParser(typeTag2);
       const result2 = parser2.parseTypeTag();
       expect(result2 instanceof TypeTagAddress).toBeTruthy();
     });


### PR DESCRIPTION
### Description
Turns out this test was being skipped, and this properly fixes the bug, which was caught while cleaning up the V2 SDK

### Test Plan
CI and `pnpm test`
