### PR TITLE
Pass layout to initiate the exchange

### DIFF
--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -210,25 +210,14 @@ impl<'e, E: ExecutorView> ResourceGroupResolver for StorageAdapter<'e, E> {
 impl<'e, E: ExecutorView> AptosMoveResolver for StorageAdapter<'e, E> {}
 
 impl<'e, E: ExecutorView> ResourceResolver for StorageAdapter<'e, E> {
-    // TODO - merge into one function with optional layout
-
     fn get_resource_bytes_with_metadata_and_layout(
         &self,
         address: &AccountAddress,
         struct_tag: &StructTag,
         metadata: &[Metadata],
-        layout: &MoveTypeLayout,
+        maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize)> {
-        Ok(self.get_any_resource_with_layout(address, struct_tag, metadata, Some(layout))?)
-    }
-
-    fn get_resource_bytes_with_metadata(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-        metadata: &[Metadata],
-    ) -> anyhow::Result<(Option<Bytes>, usize)> {
-        Ok(self.get_any_resource_with_layout(address, struct_tag, metadata, None)?)
+        Ok(self.get_any_resource_with_layout(address, struct_tag, metadata, maybe_layout)?)
     }
 }
 
@@ -264,21 +253,12 @@ impl<'e, E: ExecutorView> TableResolver for StorageAdapter<'e, E> {
         &self,
         handle: &TableHandle,
         key: &[u8],
-        layout: &MoveTypeLayout,
+        layout: Option<&MoveTypeLayout>,
     ) -> Result<Option<Bytes>, Error> {
         self.executor_view.get_resource_bytes(
             &StateKey::table_item((*handle).into(), key.to_vec()),
-            Some(layout),
+            layout,
         )
-    }
-
-    fn resolve_table_entry_bytes(
-        &self,
-        handle: &TableHandle,
-        key: &[u8],
-    ) -> Result<Option<Bytes>, Error> {
-        self.executor_view
-            .get_resource_bytes(&StateKey::table_item((*handle).into(), key.to_vec()), None)
     }
 }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -72,6 +72,10 @@ impl MoveVmExt {
             type_byte_cost = 1;
         }
 
+        // If aggregator execution is enabled, we need to tag aggregator_v2 types,
+        // so they can be exchanged with identifiers during VM execution.
+        let aggregator_v2_type_tagging = features.is_aggregator_v2_delayed_fields_enabled();
+
         let mut builder = SafeNativeBuilder::new(
             gas_feature_version,
             native_gas_params.clone(),
@@ -97,6 +101,7 @@ impl MoveVmExt {
                     type_max_cost,
                     type_base_cost,
                     type_byte_cost,
+                    aggregator_v2_type_tagging,
                 },
                 resolver,
             )?,

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -87,15 +87,7 @@ impl TableResolver for AptosBlankStorage {
         &self,
         _handle: &TableHandle,
         _key: &[u8],
-        _layout: &MoveTypeLayout,
-    ) -> Result<Option<Bytes>, Error> {
-        Ok(None)
-    }
-
-    fn resolve_table_entry_bytes(
-        &self,
-        _handle: &TableHandle,
-        _key: &[u8],
+        _layout: Option<&MoveTypeLayout>,
     ) -> Result<Option<Bytes>, Error> {
         Ok(None)
     }

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -26,6 +26,7 @@ use aptos_types::{
 };
 #[cfg(feature = "testing")]
 use bytes::Bytes;
+use move_core_types::value::MoveTypeLayout;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 #[cfg(feature = "testing")]
 use {
@@ -82,6 +83,15 @@ impl TDelayedFieldView for AptosBlankStorage {
 
 #[cfg(feature = "testing")]
 impl TableResolver for AptosBlankStorage {
+    fn resolve_table_entry_bytes_with_layout(
+        &self,
+        _handle: &TableHandle,
+        _key: &[u8],
+        _layout: &MoveTypeLayout,
+    ) -> Result<Option<Bytes>, Error> {
+        Ok(None)
+    }
+
     fn resolve_table_entry_bytes(
         &self,
         _handle: &TableHandle,

--- a/aptos-move/aptos-vm/src/tests/mock_view.rs
+++ b/aptos-move/aptos-vm/src/tests/mock_view.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     account_address::AccountAddress,
     language_storage::StructTag,
     metadata::Metadata,
-    resolver::{resource_size, ResourceResolver},
+    resolver::ResourceResolver,
     value::{IdentifierMappingKind, MoveTypeLayout},
     vm_status::StatusCode,
 };
@@ -142,7 +142,7 @@ impl ResourceResolver for MockStateView {
         address: &AccountAddress,
         typ: &StructTag,
         _metadata: &[Metadata],
-        layout: &MoveTypeLayout,
+        maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize)> {
         let ap = AccessPath::resource_access_path(*address, typ.clone())
             .expect("Access path for resource have to be valid");
@@ -154,32 +154,17 @@ impl ResourceResolver for MockStateView {
                 // If a resource is not cached, we must exchange lifted values.
                 match self.db.get_bytes(&state_key) {
                     Some(blob) => {
-                        let patched_blob = patch_blob_from_db!(blob, layout, self)?;
-                        let resource_size = patched_blob.len();
-                        (Some(patched_blob.into()), resource_size)
+                        if let Some(layout) = maybe_layout {
+                            let patched_blob = patch_blob_from_db!(blob, layout, self)?;
+                            let resource_size = patched_blob.len();
+                            (Some(patched_blob.into()), resource_size)
+                        } else {
+                            let resource_size = blob.len();
+                            (Some(blob), resource_size)
+                        }
                     },
                     None => (None, 0),
                 }
-            },
-        })
-    }
-
-    fn get_resource_bytes_with_metadata(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-        _metadata: &[Metadata],
-    ) -> anyhow::Result<(Option<Bytes>, usize)> {
-        let ap = AccessPath::resource_access_path(*address, typ.clone())
-            .expect("Access path for resource have to be valid");
-        let state_key = StateKey::access_path(ap);
-
-        Ok(match self.in_memory_cache.get(&state_key) {
-            Some(blob) => (Some(blob.clone()), blob.len()),
-            None => {
-                let maybe_blob = self.db.get_bytes(&state_key);
-                let resource_size = resource_size(&maybe_blob);
-                (maybe_blob, resource_size)
             },
         })
     }
@@ -190,7 +175,7 @@ impl TableResolver for MockStateView {
         &self,
         handle: &TableHandle,
         key: &[u8],
-        layout: &MoveTypeLayout,
+        maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<Option<Bytes>> {
         let state_key = StateKey::table_item((*handle).into(), key.to_vec());
         Ok(match self.in_memory_cache.get(&state_key) {
@@ -200,23 +185,16 @@ impl TableResolver for MockStateView {
                 // Since we have a layout passed, we can need to do the value exchange
                 // here by serialization round-trip.
                 match self.db.get_bytes(&state_key) {
-                    Some(blob) => Some(patch_blob_from_db!(blob, layout, self)?.into()),
+                    Some(blob) => Some(
+                        if let Some(layout) = maybe_layout {
+                            patch_blob_from_db!(blob, layout, self)?.into()
+                        } else {
+                            blob
+                        },
+                    ),
                     None => None,
                 }
             },
         })
-    }
-
-    fn resolve_table_entry_bytes(
-        &self,
-        handle: &TableHandle,
-        key: &[u8],
-    ) -> anyhow::Result<Option<Bytes>> {
-        let state_key = StateKey::table_item((*handle).into(), key.to_vec());
-        Ok(self
-            .in_memory_cache
-            .get(&state_key)
-            .cloned()
-            .or_else(|| self.db.get_bytes(&state_key)))
     }
 }

--- a/aptos-move/aptos-vm/src/tests/mock_view.rs
+++ b/aptos-move/aptos-vm/src/tests/mock_view.rs
@@ -137,7 +137,7 @@ macro_rules! patch_blob_from_db {
 }
 
 impl ResourceResolver for MockStateView {
-    fn get_resource_value_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         address: &AccountAddress,
         typ: &StructTag,
@@ -186,7 +186,7 @@ impl ResourceResolver for MockStateView {
 }
 
 impl TableResolver for MockStateView {
-    fn resolve_table_entry_value(
+    fn resolve_table_entry_bytes_with_layout(
         &self,
         handle: &TableHandle,
         key: &[u8],

--- a/aptos-move/aptos-vm/src/tests/test_resolver_with_identifier_mapping.rs
+++ b/aptos-move/aptos-vm/src/tests/test_resolver_with_identifier_mapping.rs
@@ -83,7 +83,12 @@ fn test_resource_in_storage() {
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let (blob, _) = view
-        .get_resource_value_with_metadata(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[], &TEST_LAYOUT)
+        .get_resource_bytes_with_metadata_and_layout(
+            &TEST_ADDRESS,
+            &TEST_RESOURCE_TAG,
+            &[],
+            &TEST_LAYOUT,
+        )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
@@ -111,7 +116,7 @@ fn test_table_item_in_storage() {
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let blob = view
-        .resolve_table_entry_value(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
+        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
@@ -145,7 +150,12 @@ fn test_resource_in_memory_cache() {
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let (blob, _) = view
-        .get_resource_value_with_metadata(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[], &TEST_LAYOUT)
+        .get_resource_bytes_with_metadata_and_layout(
+            &TEST_ADDRESS,
+            &TEST_RESOURCE_TAG,
+            &[],
+            &TEST_LAYOUT,
+        )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
@@ -176,7 +186,7 @@ fn test_table_item_in_memory_cache() {
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let blob = view
-        .resolve_table_entry_value(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
+        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");

--- a/aptos-move/aptos-vm/src/tests/test_resolver_with_identifier_mapping.rs
+++ b/aptos-move/aptos-vm/src/tests/test_resolver_with_identifier_mapping.rs
@@ -76,7 +76,7 @@ fn test_resource_in_storage() {
     );
 
     let (blob, _) = view
-        .get_resource_bytes_with_metadata(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[])
+        .get_resource_bytes_with_metadata_and_layout(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[], None)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 200, 300, 400, "foo", "bar");
@@ -87,7 +87,7 @@ fn test_resource_in_storage() {
             &TEST_ADDRESS,
             &TEST_RESOURCE_TAG,
             &[],
-            &TEST_LAYOUT,
+            Some(&TEST_LAYOUT),
         )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
@@ -109,14 +109,18 @@ fn test_table_item_in_storage() {
     );
 
     let blob = view
-        .resolve_table_entry_bytes(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY)
+        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, None)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 200, 300, 400, "foo", "bar");
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let blob = view
-        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
+        .resolve_table_entry_bytes_with_layout(
+            &TEST_TABLE_HANDLE,
+            &TEST_TABLE_KEY,
+            Some(&TEST_LAYOUT),
+        )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
@@ -143,7 +147,7 @@ fn test_resource_in_memory_cache() {
     view.assert_mapping_equal_at(2, bytes_to_string(to_utf8_bytes("bar")));
 
     let (blob, _) = view
-        .get_resource_bytes_with_metadata(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[])
+        .get_resource_bytes_with_metadata_and_layout(&TEST_ADDRESS, &TEST_RESOURCE_TAG, &[], None)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
@@ -154,7 +158,7 @@ fn test_resource_in_memory_cache() {
             &TEST_ADDRESS,
             &TEST_RESOURCE_TAG,
             &[],
-            &TEST_LAYOUT,
+            Some(&TEST_LAYOUT),
         )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
@@ -179,14 +183,18 @@ fn test_table_item_in_memory_cache() {
     view.assert_mapping_equal_at(2, bytes_to_string(to_utf8_bytes("bar")));
 
     let blob = view
-        .resolve_table_entry_bytes(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY)
+        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, None)
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");
     assert!(actual_value.equals(&expected_value).unwrap());
 
     let blob = view
-        .resolve_table_entry_bytes_with_layout(&TEST_TABLE_HANDLE, &TEST_TABLE_KEY, &TEST_LAYOUT)
+        .resolve_table_entry_bytes_with_layout(
+            &TEST_TABLE_HANDLE,
+            &TEST_TABLE_KEY,
+            Some(&TEST_LAYOUT),
+        )
         .unwrap();
     let actual_value = Value::simple_deserialize(&blob.unwrap(), &TEST_LAYOUT).unwrap();
     let expected_value = test_struct!(100, 0, 300, 1, "foo", "2");

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -433,7 +433,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                         // There are aggregators / aggregator snapshots in the
                         // resource, so we have to replace the actual values with
                         // identifiers.
-                        // TODO(aggregator): gate by the flag.
                         (Some(state_value), Some(layout)) => {
                             let res = self.replace_values_with_identifiers(state_value, layout);
                             match res {

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -220,7 +220,7 @@ impl Table {
                 let resolved_data = if self.value_layout_info.has_aggregator_lifting {
                     // There is an aggregator lifting: need to pass layout to ensure
                     // it gets recorded.
-                    context.resolver.resolve_table_entry_value(
+                    context.resolver.resolve_table_entry_bytes_with_layout(
                         &self.handle,
                         entry.key(),
                         &self.value_layout_info.layout,

--- a/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
@@ -25,6 +25,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
     resolver::{resource_size, ModuleResolver, ResourceResolver},
+    value::MoveTypeLayout,
 };
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 use move_vm_test_utils::gas_schedule::GasStatus;
@@ -396,11 +397,12 @@ impl<'a> ModuleResolver for HarnessProxy<'a> {
 }
 
 impl<'a> ResourceResolver for HarnessProxy<'a> {
-    fn get_resource_bytes_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         address: &AccountAddress,
         typ: &StructTag,
         _metadata: &[Metadata],
+        _maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize)> {
         let res = self
             .harness

--- a/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
@@ -25,7 +25,6 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
     resolver::{resource_size, ModuleResolver, ResourceResolver},
-    value::MoveTypeLayout,
 };
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 use move_vm_test_utils::gas_schedule::GasStatus;
@@ -397,16 +396,6 @@ impl<'a> ModuleResolver for HarnessProxy<'a> {
 }
 
 impl<'a> ResourceResolver for HarnessProxy<'a> {
-    fn get_resource_value_with_metadata(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-        metadata: &[Metadata],
-        _layout: &MoveTypeLayout,
-    ) -> anyhow::Result<(Option<Bytes>, usize)> {
-        self.get_resource_bytes_with_metadata(address, typ, metadata)
-    }
-
     fn get_resource_bytes_with_metadata(
         &self,
         address: &AccountAddress,

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -89,14 +89,14 @@ pub struct TableChange {
 /// A table resolver which needs to be provided by the environment. This allows to lookup
 /// data in remote storage, as well as retrieve cost of table operations.
 pub trait TableResolver {
-    fn resolve_table_entry_value(
+    // TODO merge these two functions into one, with optional layout
+
+    fn resolve_table_entry_bytes_with_layout(
         &self,
         handle: &TableHandle,
         key: &[u8],
-        #[allow(unused_variables)] layout: &MoveTypeLayout,
-    ) -> Result<Option<Bytes>, anyhow::Error> {
-        self.resolve_table_entry_bytes(handle, key)
-    }
+        layout: &MoveTypeLayout,
+    ) -> Result<Option<Bytes>, anyhow::Error>;
 
     fn resolve_table_entry_bytes(
         &self,

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -89,19 +89,11 @@ pub struct TableChange {
 /// A table resolver which needs to be provided by the environment. This allows to lookup
 /// data in remote storage, as well as retrieve cost of table operations.
 pub trait TableResolver {
-    // TODO merge these two functions into one, with optional layout
-
     fn resolve_table_entry_bytes_with_layout(
         &self,
         handle: &TableHandle,
         key: &[u8],
-        layout: &MoveTypeLayout,
-    ) -> Result<Option<Bytes>, anyhow::Error>;
-
-    fn resolve_table_entry_bytes(
-        &self,
-        handle: &TableHandle,
-        key: &[u8],
+        maybe_layout: Option<&MoveTypeLayout>,
     ) -> Result<Option<Bytes>, anyhow::Error>;
 }
 
@@ -246,7 +238,7 @@ impl Table {
             Entry::Vacant(entry) => {
                 let (gv, loaded) = match context
                     .resolver
-                    .resolve_table_entry_bytes(&self.handle, entry.key())
+                    .resolve_table_entry_bytes_with_layout(&self.handle, entry.key(), None)
                     .map_err(|err| {
                         partial_extension_error(format!("remote table resolver failure: {}", err))
                     })? {

--- a/third_party/move/move-core/types/src/resolver.rs
+++ b/third_party/move/move-core/types/src/resolver.rs
@@ -44,7 +44,7 @@ pub fn resource_size(resource: &Option<Bytes>) -> usize {
 pub trait ResourceResolver {
     // TODO: this can return Value, so that we can push deserialization to
     // implementations of `ResourceResolver`.
-    fn get_resource_value_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         address: &AccountAddress,
         typ: &StructTag,

--- a/third_party/move/move-core/types/src/resolver.rs
+++ b/third_party/move/move-core/types/src/resolver.rs
@@ -49,18 +49,7 @@ pub trait ResourceResolver {
         address: &AccountAddress,
         typ: &StructTag,
         metadata: &[Metadata],
-        // Default implementation does not use layout. This way there is no
-        // need to implement this method.
-        #[allow(unused_variables)] layout: &MoveTypeLayout,
-    ) -> anyhow::Result<(Option<Bytes>, usize), Error> {
-        self.get_resource_bytes_with_metadata(address, typ, metadata)
-    }
-
-    fn get_resource_bytes_with_metadata(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-        metadata: &[Metadata],
+        layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize), Error>;
 }
 
@@ -82,7 +71,7 @@ pub trait MoveResolver: ModuleResolver + ResourceResolver {
         typ: &StructTag,
         metadata: &[Metadata],
     ) -> Result<(Option<Bytes>, usize), Error> {
-        self.get_resource_bytes_with_metadata(address, typ, metadata)
+        self.get_resource_bytes_with_metadata_and_layout(address, typ, metadata, None)
     }
 }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
     resolver::{ModuleResolver, ResourceResolver},
-    value::{serialize_values, MoveValue},
+    value::{serialize_values, MoveTypeLayout, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_runtime::move_vm::MoveVM;
@@ -522,11 +522,12 @@ impl ModuleResolver for BogusStorage {
 }
 
 impl ResourceResolver for BogusStorage {
-    fn get_resource_bytes_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
         _metadata: &[Metadata],
+        _maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize)> {
         Ok(Err(
             PartialVMError::new(self.bad_status_code).finish(Location::Undefined)

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -23,6 +23,7 @@ pub struct VMConfig {
     pub type_max_cost: u64,
     pub type_base_cost: u64,
     pub type_byte_cost: u64,
+    pub aggregator_v2_type_tagging: bool,
 }
 
 impl Default for VMConfig {
@@ -37,6 +38,7 @@ impl Default for VMConfig {
             type_max_cost: 0,
             type_base_cost: 0,
             type_byte_cost: 0,
+            aggregator_v2_type_tagging: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -191,8 +191,9 @@ impl<'r> TransactionDataCache<'r> {
             // Remote, in turn ensures that all aggregator values are lifted if the resolved
             // resource comes from storage.
             let resolved_result = if has_aggregator_lifting {
-                self.remote
-                    .get_resource_value_with_metadata(&addr, &ty_tag, metadata, &ty_layout)
+                self.remote.get_resource_bytes_with_metadata_and_layout(
+                    &addr, &ty_tag, metadata, &ty_layout,
+                )
             } else {
                 self.remote
                     .get_resource_bytes_with_metadata(&addr, &ty_tag, metadata)

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -190,14 +190,16 @@ impl<'r> TransactionDataCache<'r> {
             // If we need to process aggregator lifting, we pass type layout to remote.
             // Remote, in turn ensures that all aggregator values are lifted if the resolved
             // resource comes from storage.
-            let resolved_result = if has_aggregator_lifting {
-                self.remote.get_resource_bytes_with_metadata_and_layout(
-                    &addr, &ty_tag, metadata, &ty_layout,
-                )
-            } else {
-                self.remote
-                    .get_resource_bytes_with_metadata(&addr, &ty_tag, metadata)
-            };
+            let resolved_result = self.remote.get_resource_bytes_with_metadata_and_layout(
+                &addr,
+                &ty_tag,
+                metadata,
+                if has_aggregator_lifting {
+                    Some(&ty_layout)
+                } else {
+                    None
+                },
+            );
 
             let (data, bytes_loaded) = resolved_result.map_err(|err| {
                 let msg = format!("Unexpected storage error: {:?}", err);

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1943,11 +1943,14 @@ impl Loader {
     // It seems that this is only because there is no support for native
     // types.
     // Let's think how we can do this nicer.
-
     fn get_identifier_mapping_kind(
         &self,
         struct_name: &StructIdentifier,
     ) -> Option<IdentifierMappingKind> {
+        if !self.vm_config.aggregator_v2_type_tagging {
+            return None;
+        }
+
         let ident_str_to_kind = |ident_str: &IdentStr| -> Option<IdentifierMappingKind> {
             if ident_str.eq(ident_str!("Aggregator")) {
                 Some(IdentifierMappingKind::Aggregator)

--- a/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -22,7 +22,7 @@ use move_core_types::{
     metadata::Metadata,
     resolver::{ModuleResolver, ResourceResolver},
     u256::U256,
-    value::{serialize_values, MoveValue},
+    value::{serialize_values, MoveTypeLayout, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_types::gas::UnmeteredGasMeter;
@@ -261,11 +261,12 @@ impl ModuleResolver for RemoteStore {
 }
 
 impl ResourceResolver for RemoteStore {
-    fn get_resource_bytes_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         _address: &AccountAddress,
         _tag: &StructTag,
         _metadata: &[Metadata],
+        _maybe_layout: Option<&MoveTypeLayout>,
     ) -> anyhow::Result<(Option<Bytes>, usize)> {
         Ok((None, 0))
     }

--- a/third_party/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/third_party/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -19,6 +19,7 @@ use move_core_types::{
     metadata::Metadata,
     parser,
     resolver::{resource_size, ModuleResolver, ResourceResolver},
+    value::MoveTypeLayout,
 };
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
@@ -345,11 +346,12 @@ impl ModuleResolver for OnDiskStateView {
 }
 
 impl ResourceResolver for OnDiskStateView {
-    fn get_resource_bytes_with_metadata(
+    fn get_resource_bytes_with_metadata_and_layout(
         &self,
         address: &AccountAddress,
         struct_tag: &StructTag,
         _metadata: &[Metadata],
+        _maybe_layout: Option<&MoveTypeLayout>,
     ) -> Result<(Option<Bytes>, usize)> {
         let buf = self.get_resource_bytes(*address, struct_tag.clone())?;
         let buf_size = resource_size(&buf);


### PR DESCRIPTION
- why are methods with layout named with "value" and methods without named with "bytes"? that is very confusing
- where should the gating - i.e. only do exchange if AGGREGATOR_EXECUTION flag is set - be?

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
