### PR TITLE
[indexer grpc] Fix the cache worker grpc client message size.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
@@ -28,7 +28,9 @@ pub async fn create_grpc_client(address: Url) -> GrpcClientType {
                     address = address.to_string(),
                     "[Indexer Cache] Connected to indexer gRPC server."
                 );
-                Ok(client)
+                Ok(client
+                    .max_decoding_message_size(usize::MAX)
+                    .max_encoding_message_size(usize::MAX))
             },
             Err(e) => {
                 tracing::error!(


### PR DESCRIPTION
### Description

* Tonic implicitly limits the decoding size to 4Mbtes. Relax it to unlimited. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
