### PR TITLE
[State Sync] Migrate to the new storage synchronizer pipeline.

### DIFF
--- a/state-sync/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/driver_factory.rs
@@ -144,7 +144,7 @@ impl DriverFactory {
 
         // Create the storage synchronizer
         let event_subscription_service = Arc::new(Mutex::new(event_subscription_service));
-        let (storage_synchronizer, _, _) = StorageSynchronizer::new(
+        let (storage_synchronizer, _, _, _) = StorageSynchronizer::new(
             node_config.state_sync.state_sync_driver,
             chunk_executor,
             commit_notification_sender.clone(),

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -14,6 +14,7 @@ pub const DRIVER_CONSENSUS_SYNC_NOTIFICATION: &str = "driver_consensus_sync_noti
 pub const STORAGE_SYNCHRONIZER_PENDING_DATA: &str = "storage_synchronizer_pending_data";
 pub const STORAGE_SYNCHRONIZER_APPLY_CHUNK: &str = "apply_chunk";
 pub const STORAGE_SYNCHRONIZER_EXECUTE_CHUNK: &str = "execute_chunk";
+pub const STORAGE_SYNCHRONIZER_UPDATE_LEDGER: &str = "update_ledger";
 pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
 
 /// An enum representing the component currently executing

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -152,7 +152,6 @@ mock! {
         fn enqueue_chunk_by_execution<'a>(
             &self,
             txn_list_with_proof: TransactionListWithProof,
-            // Target LI that has been verified independently: the proofs are relative to this version.
             verified_target_li: &LedgerInfoWithSignatures,
             epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
         ) -> Result<()>;
@@ -160,7 +159,6 @@ mock! {
         fn enqueue_chunk_by_transaction_outputs<'a>(
             &self,
             txn_output_list_with_proof: TransactionOutputListWithProof,
-            // Target LI that has been verified independently: the proofs are relative to this version.
             verified_target_li: &LedgerInfoWithSignatures,
             epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
         ) -> Result<()>;


### PR DESCRIPTION
### Description
This PR updates the storage synchronizer in state sync to migrate from a 2-step synchronization pipeline (i.e., `apply/execute -> commit`), to the 3-step pipeline (i.e., `apply/execute -> ledger_update -> commit`).

### Test Plan
New and existing tests.