### PR TITLE
[move_vm] Fix loader dependency check

### DIFF
--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -5,7 +5,8 @@
 use crate::compiler::compile_modules_in_file;
 use move_binary_format::{
     file_format::{
-        empty_module, AddressIdentifierIndex, IdentifierIndex, ModuleHandle, TableIndex,
+        empty_module, AbilitySet, AddressIdentifierIndex, IdentifierIndex, ModuleHandle,
+        ModuleHandleIndex, StructHandle, StructTypeParameter, TableIndex,
     },
     CompiledModule,
 };
@@ -194,6 +195,37 @@ fn load_concurrent_many() {
     adapter.publish_modules(modules);
     // makes 150 threads
     adapter.call_functions_async(30);
+}
+
+#[test]
+fn load_phantom_module() {
+    let data_store = InMemoryStorage::new();
+    let mut adapter = Adapter::new(data_store);
+    let modules = get_modules();
+    adapter.publish_modules(modules);
+
+    let mut module = empty_module();
+    module.address_identifiers[0] = WORKING_ACCOUNT;
+    module.identifiers[0] = Identifier::new("I").unwrap();
+    module.identifiers.push(Identifier::new("H").unwrap());
+    module.module_handles.push(ModuleHandle {
+        address: AddressIdentifierIndex(0),
+        name: IdentifierIndex((module.identifiers.len() - 1) as TableIndex),
+    });
+    module.identifiers.push(Identifier::new("S").unwrap());
+    module.struct_handles.push(StructHandle {
+        module: ModuleHandleIndex((module.module_handles.len() - 1) as TableIndex),
+        name: IdentifierIndex((module.identifiers.len() - 1) as TableIndex),
+        abilities: AbilitySet::EMPTY,
+        type_parameters: vec![StructTypeParameter {
+            constraints: AbilitySet::EMPTY,
+            is_phantom: false,
+        }],
+    });
+
+    let module_id = module.self_id();
+    adapter.publish_modules(vec![module]);
+    adapter.vm.load_module(&module_id, &adapter.store).unwrap();
 }
 
 #[test]

--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests_modules.move
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests_modules.move
@@ -170,4 +170,9 @@ address 0x2 {
             another_b
         }
     }
+    module H {
+        struct S<phantom T> {
+            f1: u64,
+        }
+    }
 }

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -273,19 +273,9 @@ impl Module {
                 let module_id = module.module_id_for_handle(module_handle);
 
                 if module_handle != module.self_handle() {
-                    let struct_ = cache.resolve_struct_by_name(struct_name, &module_id)?;
-                    if !struct_handle.abilities.is_subset(struct_.abilities)
-                        || !struct_handle
-                            .type_parameters
-                            .iter()
-                            .map(|ty| ty.is_phantom)
-                            .eq(struct_.phantom_ty_args_mask.iter().cloned())
-                    {
-                        return Err(PartialVMError::new(
-                            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        )
-                        .with_message("Ability definition of module mismatch".to_string()));
-                    }
+                    cache
+                        .resolve_struct_by_name(struct_name, &module_id)?
+                        .check_compatibility(struct_handle)?;
                 }
                 struct_names.push(Arc::new(StructIdentifier {
                     module: module_id,

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -127,8 +127,14 @@ impl StructType {
 
     // Check if the local struct handle is compatible with the defined struct type.
     pub fn check_compatibility(&self, struct_handle: &StructHandle) -> PartialVMResult<()> {
-        if !self.abilities.is_subset(struct_handle.abilities)
-            || self.phantom_ty_args_mask.len() != struct_handle.type_parameters.len()
+        if !self.abilities.is_subset(struct_handle.abilities) {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Ability definition of module mismatch".to_string()),
+            );
+        }
+
+        if self.phantom_ty_args_mask.len() != struct_handle.type_parameters.len()
             || !self
                 .phantom_ty_args_mask
                 .iter()
@@ -138,8 +144,9 @@ impl StructType {
                 })
         {
             return Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Ability definition of module mismatch".to_string()),
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    "Phantom type parameter definition of module mismatch".to_string(),
+                ),
             );
         }
 
@@ -389,11 +396,11 @@ impl Type {
                 "Unexpected TyParam type after translating from TypeTag to Type".to_string(),
             )),
 
-            Type::Vector(ty) => AbilitySet::polymorphic_abilities(
-                AbilitySet::VECTOR,
-                vec![false],
-                vec![ty.abilities()?],
-            ),
+            Type::Vector(ty) => {
+                AbilitySet::polymorphic_abilities(AbilitySet::VECTOR, vec![false], vec![
+                    ty.abilities()?
+                ])
+            },
             Type::Struct { ability, .. } => Ok(*ability),
             Type::StructInstantiation {
                 ty_args,


### PR DESCRIPTION
### Description

The runtime dependency check is a bit stricter than what bytecode verifier permits. Relax the constraint so that runtime check aligns with the static behavior.

### Test Plan

Added a test case. The test would fail without the fix.