### PR TITLE
[small] Add 3 aggregator related feature flags

### DIFF
--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -120,7 +120,7 @@ impl<'a, 'b, 'c, 'd> SafeNativeContext<'a, 'b, 'c, 'd> {
     }
 
     /// Returns true if the aggregator snapshots feature is enabled.
-    pub fn aggregator_snapshots_enabled(&self) -> bool {
-        self.get_feature_flags().is_aggregator_snapshots_enabled()
+    pub fn aggregator_v2_api_enabled(&self) -> bool {
+        self.get_feature_flags().is_aggregator_v2_api_enabled()
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -79,13 +79,15 @@ pub enum FeatureFlag {
     ModuleEvent,
     EmitFeeStatement,
     StorageDeletionRefund,
-    AggregatorSnapshots,
+    AggregatorV2Api,
     SignatureCheckerV2ScriptFix,
     SaferResourceGroups,
     SaferMetadata,
     Secp256k1ECDSAAuthenticator,
     SponsoredAutomaticAccountCreation,
     FeePayerAccountOptional,
+    AggregatorV2DelayedFields,
+    ConcurrentAssets,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -213,7 +215,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::ModuleEvent => AptosFeatureFlag::MODULE_EVENT,
             FeatureFlag::EmitFeeStatement => AptosFeatureFlag::EMIT_FEE_STATEMENT,
             FeatureFlag::StorageDeletionRefund => AptosFeatureFlag::STORAGE_DELETION_REFUND,
-            FeatureFlag::AggregatorSnapshots => AptosFeatureFlag::AGGREGATOR_SNAPSHOTS,
+            FeatureFlag::AggregatorV2Api => AptosFeatureFlag::AGGREGATOR_V2_API,
             FeatureFlag::SignatureCheckerV2ScriptFix => {
                 AptosFeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX
             },
@@ -226,6 +228,10 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
             },
             FeatureFlag::FeePayerAccountOptional => AptosFeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
+            FeatureFlag::AggregatorV2DelayedFields => {
+                AptosFeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS
+            },
+            FeatureFlag::ConcurrentAssets => AptosFeatureFlag::CONCURRENT_ASSETS,
         }
     }
 }
@@ -276,7 +282,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::MODULE_EVENT => FeatureFlag::ModuleEvent,
             AptosFeatureFlag::EMIT_FEE_STATEMENT => FeatureFlag::EmitFeeStatement,
             AptosFeatureFlag::STORAGE_DELETION_REFUND => FeatureFlag::StorageDeletionRefund,
-            AptosFeatureFlag::AGGREGATOR_SNAPSHOTS => FeatureFlag::AggregatorSnapshots,
+            AptosFeatureFlag::AGGREGATOR_V2_API => FeatureFlag::AggregatorV2Api,
             AptosFeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX => {
                 FeatureFlag::SignatureCheckerV2ScriptFix
             },
@@ -289,6 +295,10 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::SponsoredAutomaticAccountCreation
             },
             AptosFeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL => FeatureFlag::FeePayerAccountOptional,
+            AptosFeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS => {
+                FeatureFlag::AggregatorV2DelayedFields
+            },
+            AptosFeatureFlag::CONCURRENT_ASSETS => FeatureFlag::ConcurrentAssets,
         }
     }
 }

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -13,7 +13,7 @@ pub fn initialize(path: PathBuf) -> (MoveHarness, Account) {
     let executor = FakeExecutor::from_head_genesis().set_parallel();
 
     let mut harness = MoveHarness::new_with_executor(executor);
-    harness.enable_features(vec![FeatureFlag::AGGREGATOR_SNAPSHOTS], vec![]);
+    harness.enable_features(vec![FeatureFlag::AGGREGATOR_V2_API], vec![]);
     let account = harness.new_account_at(AccountAddress::ONE);
     assert_success!(harness.publish_package_cache_building(&account, &path));
     (harness, account)

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -70,10 +70,12 @@ return true.
 -  [Function `signer_native_format_fix_enabled`](#0x1_features_signer_native_format_fix_enabled)
 -  [Function `get_module_event_feature`](#0x1_features_get_module_event_feature)
 -  [Function `module_event_enabled`](#0x1_features_module_event_enabled)
--  [Function `get_aggregator_snapshots_feature`](#0x1_features_get_aggregator_snapshots_feature)
--  [Function `aggregator_snapshots_enabled`](#0x1_features_aggregator_snapshots_enabled)
+-  [Function `get_aggregator_v2_api_feature`](#0x1_features_get_aggregator_v2_api_feature)
+-  [Function `aggregator_v2_api_enabled`](#0x1_features_aggregator_v2_api_enabled)
 -  [Function `get_sponsored_automatic_account_creation`](#0x1_features_get_sponsored_automatic_account_creation)
 -  [Function `sponsored_automatic_account_creation_enabled`](#0x1_features_sponsored_automatic_account_creation_enabled)
+-  [Function `get_concurrent_assets_feature`](#0x1_features_get_concurrent_assets_feature)
+-  [Function `concurrent_assets_enabled`](#0x1_features_concurrent_assets_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -128,13 +130,26 @@ The enabled features, represented by a bitset stored on chain.
 ## Constants
 
 
-<a name="0x1_features_AGGREGATOR_SNAPSHOTS"></a>
+<a name="0x1_features_AGGREGATOR_V2_API"></a>
 
-Whether the aggregator snapshots feature is enabled.
+Whether the Aggregator V2 API feature is enabled.
+Once enabled, the functions from aggregator_v2.move will be available for use.
 Lifetime: transient
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_AGGREGATOR_SNAPSHOTS">AGGREGATOR_SNAPSHOTS</a>: u64 = 30;
+<pre><code><b>const</b> <a href="features.md#0x1_features_AGGREGATOR_V2_API">AGGREGATOR_V2_API</a>: u64 = 30;
+</code></pre>
+
+
+
+<a name="0x1_features_AGGREGATOR_V2_DELAYED_FIELDS"></a>
+
+Whether the Aggregator V2 delayed fields feature is enabled.
+Once enabled, Aggregator V2 functions become parallel.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_AGGREGATOR_V2_DELAYED_FIELDS">AGGREGATOR_V2_DELAYED_FIELDS</a>: u64 = 36;
 </code></pre>
 
 
@@ -232,6 +247,18 @@ Lifetime: transient
 
 
 
+<a name="0x1_features_CONCURRENT_ASSETS"></a>
+
+Whether enable TokenV2 collection creation and Fungible Asset creation
+to create higher throughput concurrent variants.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_CONCURRENT_ASSETS">CONCURRENT_ASSETS</a>: u64 = 37;
+</code></pre>
+
+
+
 <a name="0x1_features_CRYPTOGRAPHY_ALGEBRA_NATIVES"></a>
 
 Whether generic algebra basic operation support in <code>crypto_algebra.<b>move</b></code> are enabled.
@@ -283,6 +310,15 @@ The provided signer has not a framework address.
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_EFRAMEWORK_SIGNER_NEEDED">EFRAMEWORK_SIGNER_NEEDED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_features_FEE_PAYER_ACCOUNT_OPTIONAL"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_FEE_PAYER_ACCOUNT_OPTIONAL">FEE_PAYER_ACCOUNT_OPTIONAL</a>: u64 = 35;
 </code></pre>
 
 
@@ -361,6 +397,33 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS">RESOURCE_GROUPS</a>: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_features_SAFER_METADATA"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SAFER_METADATA">SAFER_METADATA</a>: u64 = 32;
+</code></pre>
+
+
+
+<a name="0x1_features_SAFER_RESOURCE_GROUPS"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SAFER_RESOURCE_GROUPS">SAFER_RESOURCE_GROUPS</a>: u64 = 31;
+</code></pre>
+
+
+
+<a name="0x1_features_SECP256K1_ECDSA_AUTHENTICATOR"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SECP256K1_ECDSA_AUTHENTICATOR">SECP256K1_ECDSA_AUTHENTICATOR</a>: u64 = 33;
 </code></pre>
 
 
@@ -1345,13 +1408,13 @@ Lifetime: transient
 
 </details>
 
-<a name="0x1_features_get_aggregator_snapshots_feature"></a>
+<a name="0x1_features_get_aggregator_v2_api_feature"></a>
 
-## Function `get_aggregator_snapshots_feature`
+## Function `get_aggregator_v2_api_feature`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aggregator_snapshots_feature">get_aggregator_snapshots_feature</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aggregator_v2_api_feature">get_aggregator_v2_api_feature</a>(): u64
 </code></pre>
 
 
@@ -1360,20 +1423,20 @@ Lifetime: transient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aggregator_snapshots_feature">get_aggregator_snapshots_feature</a>(): u64 { <a href="features.md#0x1_features_AGGREGATOR_SNAPSHOTS">AGGREGATOR_SNAPSHOTS</a> }
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aggregator_v2_api_feature">get_aggregator_v2_api_feature</a>(): u64 { <a href="features.md#0x1_features_AGGREGATOR_V2_API">AGGREGATOR_V2_API</a> }
 </code></pre>
 
 
 
 </details>
 
-<a name="0x1_features_aggregator_snapshots_enabled"></a>
+<a name="0x1_features_aggregator_v2_api_enabled"></a>
 
-## Function `aggregator_snapshots_enabled`
+## Function `aggregator_v2_api_enabled`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_snapshots_enabled">aggregator_snapshots_enabled</a>(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_v2_api_enabled">aggregator_v2_api_enabled</a>(): bool
 </code></pre>
 
 
@@ -1382,8 +1445,8 @@ Lifetime: transient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_snapshots_enabled">aggregator_snapshots_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_AGGREGATOR_SNAPSHOTS">AGGREGATOR_SNAPSHOTS</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_v2_api_enabled">aggregator_v2_api_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_AGGREGATOR_V2_API">AGGREGATOR_V2_API</a>)
 }
 </code></pre>
 
@@ -1430,6 +1493,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sponsored_automatic_account_creation_enabled">sponsored_automatic_account_creation_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_concurrent_assets_feature"></a>
+
+## Function `get_concurrent_assets_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_concurrent_assets_feature">get_concurrent_assets_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_concurrent_assets_feature">get_concurrent_assets_feature</a>(): u64 { <a href="features.md#0x1_features_CONCURRENT_ASSETS">CONCURRENT_ASSETS</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_concurrent_assets_enabled"></a>
+
+## Function `concurrent_assets_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_concurrent_assets_enabled">concurrent_assets_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_concurrent_assets_enabled">concurrent_assets_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_CONCURRENT_ASSETS">CONCURRENT_ASSETS</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -241,15 +241,22 @@ module std::features {
     /// Lifetime: transient
     const SIGNATURE_CHECKER_V2_SCRIPT_FIX: u64 = 29;
 
-    /// Whether the aggregator snapshots feature is enabled.
+    /// Whether the Aggregator V2 API feature is enabled.
+    /// Once enabled, the functions from aggregator_v2.move will be available for use.
     /// Lifetime: transient
-    const AGGREGATOR_SNAPSHOTS: u64 = 30;
+    const AGGREGATOR_V2_API: u64 = 30;
 
-    public fun get_aggregator_snapshots_feature(): u64 { AGGREGATOR_SNAPSHOTS }
+    public fun get_aggregator_v2_api_feature(): u64 { AGGREGATOR_V2_API }
 
-    public fun aggregator_snapshots_enabled(): bool acquires Features {
-        is_enabled(AGGREGATOR_SNAPSHOTS)
+    public fun aggregator_v2_api_enabled(): bool acquires Features {
+        is_enabled(AGGREGATOR_V2_API)
     }
+
+    const SAFER_RESOURCE_GROUPS: u64 = 31;
+
+    const SAFER_METADATA: u64 = 32;
+
+    const SECP256K1_ECDSA_AUTHENTICATOR: u64 = 33;
 
     /// Whether the automatic creation of accounts is enabled for sponsored transactions.
     /// Lifetime: transient
@@ -260,6 +267,25 @@ module std::features {
     public fun sponsored_automatic_account_creation_enabled(): bool acquires Features {
         is_enabled(SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
     }
+
+    const FEE_PAYER_ACCOUNT_OPTIONAL: u64 = 35;
+
+    /// Whether the Aggregator V2 delayed fields feature is enabled.
+    /// Once enabled, Aggregator V2 functions become parallel.
+    /// Lifetime: transient
+    const AGGREGATOR_V2_DELAYED_FIELDS: u64 = 36;
+
+    /// Whether enable TokenV2 collection creation and Fungible Asset creation
+    /// to create higher throughput concurrent variants.
+    /// Lifetime: transient
+    const CONCURRENT_ASSETS: u64 = 37;
+
+    public fun get_concurrent_assets_feature(): u64 { CONCURRENT_ASSETS }
+
+    public fun concurrent_assets_enabled(): bool acquires Features {
+        is_enabled(CONCURRENT_ASSETS)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -48,7 +48,7 @@ fn native_create_snapshot(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    if !context.aggregator_snapshots_enabled() {
+    if !context.aggregator_v2_api_enabled() {
         return Err(SafeNativeError::Abort {
             abort_code: EAGGREGATOR_SNAPSHOTS_NOT_ENABLED,
         });

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -427,7 +427,6 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::EMIT_FEE_STATEMENT,
         FeatureFlag::STORAGE_DELETION_REFUND,
         FeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX,
-        FeatureFlag::AGGREGATOR_SNAPSHOTS,
         FeatureFlag::SAFER_RESOURCE_GROUPS,
         FeatureFlag::SAFER_METADATA,
         FeatureFlag::SECP256K1_ECDSA_AUTHENTICATOR,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -37,12 +37,14 @@ pub enum FeatureFlag {
     EMIT_FEE_STATEMENT = 27,
     STORAGE_DELETION_REFUND = 28,
     SIGNATURE_CHECKER_V2_SCRIPT_FIX = 29,
-    AGGREGATOR_SNAPSHOTS = 30,
+    AGGREGATOR_V2_API = 30,
     SAFER_RESOURCE_GROUPS = 31,
     SAFER_METADATA = 32,
     SECP256K1_ECDSA_AUTHENTICATOR = 33,
     SPONSORED_AUTOMATIC_ACCOUNT_CREATION = 34,
     FEE_PAYER_ACCOUNT_OPTIONAL = 35,
+    AGGREGATOR_V2_DELAYED_FIELDS = 36,
+    CONCURRENT_ASSETS = 37,
 }
 
 /// Representation of features on chain as a bitset.
@@ -96,8 +98,16 @@ impl Features {
             && self.is_enabled(FeatureFlag::STORAGE_DELETION_REFUND)
     }
 
-    pub fn is_aggregator_snapshots_enabled(&self) -> bool {
-        self.is_enabled(FeatureFlag::AGGREGATOR_SNAPSHOTS)
+    /// Whether the Aggregator V2 API feature is enabled.
+    /// Once enabled, the functions from aggregator_v2.move will be available for use.
+    pub fn is_aggregator_v2_api_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::AGGREGATOR_V2_API)
+    }
+
+    /// Whether the Aggregator V2 delayed fields feature is enabled.
+    /// Once enabled, Aggregator V2 functions become parallel.
+    pub fn is_aggregator_v2_delayed_fields_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS)
     }
 }
 


### PR DESCRIPTION
taking the indices before the rest of PRs land - as multiple PRs depend on these, and there are often conflicts with other flags going in.

repurpose SNAPSHOTS API flag to cover aggregator v2 api as well (as it will not be released separately)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
