### PR TITLE
rename StacklessControlFlowGraph::is_dummmy() to is_dummy()

### DIFF
--- a/third_party/move/evm/move-to-yul/src/functions.rs
+++ b/third_party/move/evm/move-to-yul/src/functions.rs
@@ -114,7 +114,7 @@ impl<'a> FunctionGenerator<'a> {
             // Emit state machine to represent control flow.
             // TODO: Eliminate the need for this, see also
             //    https://medium.com/leaningtech/solving-the-structured-control-flow-problem-once-and-for-all-5123117b1ee2
-            if cfg.successors(entry_bb).iter().all(|b| cfg.is_dummmy(*b)) {
+            if cfg.successors(entry_bb).iter().all(|b| cfg.is_dummy(*b)) {
                 // In this trivial case, we have only one block and can omit the state machine
                 if let BlockContent::Basic { lower, upper } = cfg.content(entry_bb) {
                     for offs in *lower..*upper + 1 {
@@ -174,7 +174,7 @@ impl<'a> FunctionGenerator<'a> {
     /// Get the actual entry block, skipping trailing dummy blocks.
     fn get_actual_entry_block(cfg: &StacklessControlFlowGraph) -> BlockId {
         let mut entry_bb = cfg.entry_block();
-        while cfg.is_dummmy(entry_bb) {
+        while cfg.is_dummy(entry_bb) {
             assert_eq!(cfg.successors(entry_bb).len(), 1);
             entry_bb = *cfg.successors(entry_bb).iter().last().unwrap();
         }

--- a/third_party/move/move-model/bytecode/src/dataflow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/dataflow_analysis.rs
@@ -36,7 +36,7 @@ pub trait TransferFunctions {
         instrs: &[Bytecode],
         cfg: &StacklessControlFlowGraph,
     ) -> Self::State {
-        if cfg.is_dummmy(block_id) {
+        if cfg.is_dummy(block_id) {
             return state;
         }
         let instr_inds = cfg.instr_indexes(block_id).unwrap();
@@ -126,7 +126,7 @@ pub trait DataflowAnalysis: TransferFunctions {
         let mut result = BTreeMap::new();
         for (block_id, block_state) in state_map {
             let mut state = block_state.pre;
-            if !cfg.is_dummmy(block_id) {
+            if !cfg.is_dummy(block_id) {
                 let instr_inds = cfg.instr_indexes(block_id).unwrap();
                 if Self::BACKWARD {
                     for offset in instr_inds.rev() {

--- a/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
@@ -238,7 +238,7 @@ impl StacklessControlFlowGraph {
         self.blocks.len() as u16
     }
 
-    pub fn is_dummmy(&self, block_id: BlockId) -> bool {
+    pub fn is_dummy(&self, block_id: BlockId) -> bool {
         matches!(self.blocks[&block_id].content, BlockContent::Dummy)
     }
 


### PR DESCRIPTION
### Description

rename StacklessControlFlowGraph::is_dummmy() to is_dummy()

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

This is just a fix for typo in a function name.