### PR TITLE
[compiler v1] Better compiler error messages (#9222)

### DIFF
--- a/third_party/move/move-compiler/src/typing/core.rs
+++ b/third_party/move/move-compiler/src/typing/core.rs
@@ -1574,7 +1574,7 @@ fn join_tvar(
     }
 }
 
-fn forward_tvar(subst: &Subst, id: TVar) -> TVar {
+pub fn forward_tvar(subst: &Subst, id: TVar) -> TVar {
     let mut cur = id;
     loop {
         match subst.get(cur) {

--- a/third_party/move/move-compiler/src/typing/core.rs
+++ b/third_party/move/move-compiler/src/typing/core.rs
@@ -295,7 +295,7 @@ impl<'env> Context<'env> {
             .expect("ICE should have failed in naming")
     }
 
-    fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
+    pub fn struct_definition(&self, m: &ModuleIdent, n: &StructName) -> &StructDefinition {
         let minfo = self.module_info(m);
         minfo
             .structs

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -362,8 +362,10 @@ fn lvalue(context: &mut Context, b: &mut T::LValue) {
             type_(context, ty);
             core::check_non_fun(context, ty.as_ref())
         },
-        L::BorrowUnpack(_, _, _, bts, fields) | L::Unpack(_, _, bts, fields) => {
-            types(context, bts);
+        L::BorrowUnpack(_, mod_id, struct_name, bts, fields) | L::Unpack(mod_id, struct_name, bts, fields) => {
+            for (i, b) in bts.iter_mut().enumerate() {
+                type_struct_ty_param(context, b, i, &TypeName_::ModuleType(*mod_id, *struct_name))
+            }
             for (_, _, (_, (bt, innerb))) in fields.iter_mut() {
                 type_(context, bt);
                 lvalue(context, innerb)

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -85,7 +85,8 @@ fn type_fun_ty_param(
     type_msg_(context, ty, &format!("Cannot infer the type parameter `{param_name}` for generic function `{m}::{n}`. Try providing a type parameter."));
 }
 
-pub fn type_msg_(context: &mut Context, ty: &mut Type, msg_uninferred: &str) {
+// Try to expand the type of ty, warning with msg_uninferred if type cannot be inferred.
+fn type_msg_(context: &mut Context, ty: &mut Type, msg_uninferred: &str) {
     use Type_::*;
     match &mut ty.value {
         Anything | UnresolvedError | Param(_) | Unit => (),

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -58,7 +58,7 @@ fn types(context: &mut Context, ss: &mut Vec<Type>) {
 }
 
 // type_ for expanding the `i`-th type param of struct `ty_name`
-fn type_struct_ty_param(context: &mut Context, ty: &mut Type, i: usize, ty_name: &TypeName_) {s
+fn type_struct_ty_param(context: &mut Context, ty: &mut Type, i: usize, ty_name: &TypeName_) {
     if let TypeName_::ModuleType(mod_id, struct_name) = ty_name {
         let param_name = &context
             .struct_definition(mod_id, struct_name)

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -110,7 +110,8 @@ fn type_with_context_msg(context: &mut Context, ty: &mut Type, msg_uninferred: &
             let replacement = unfold_type_or_last_var(&context.subst, ty_tvar);
             let replacement = match replacement {
                 Err(sp!(loc, last_tvar)) => {
-                    // avoid duplicate error messages
+                    // this is to avoid duplicate error messages for uninferred type variables
+                    // in the first time they are resolved to Err(_), and to Anything for all following queries
                     context.subst.insert(last_tvar, sp(ty.loc, Type_::Anything));
                     context
                         .env
@@ -141,6 +142,7 @@ fn type_with_context_msg(context: &mut Context, ty: &mut Type, msg_uninferred: &
     }
 }
 
+// Try to expand the type of ty, warning with msg_uninferred if type cannot be inferred.
 pub fn type_(context: &mut Context, ty: &mut Type) {
     type_with_context_msg(
         context,

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -380,13 +380,14 @@ fn module_call(context: &mut Context, call: &mut T::ModuleCall) {
 
 fn builtin_function(context: &mut Context, b: &mut T::BuiltinFunction) {
     use T::BuiltinFunction_ as B;
+    let f_name = b.value.display_name();
     match &mut b.value {
         B::MoveTo(bt)
         | B::MoveFrom(bt)
         | B::BorrowGlobal(_, bt)
         | B::Exists(bt)
         | B::Freeze(bt) => {
-            type_(context, bt);
+            type_msg_(context, bt, &format!("Cannot infer a type parameter for built-in function '{f_name}'"));
         },
         B::Assert(_) => (),
     }

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -67,7 +67,7 @@ fn type_struct_ty_param(context: &mut Context, ty: &mut Type, i: usize, ty_name:
                 .param
                 .user_specified_name
                 .value;
-            let msg = format!("Cannot infer the type parameter {param_name} for generic struct {ty_name}. Try providing a type parameter.");
+            let msg = format!("Cannot infer the type parameter `{param_name}` for generic struct `{ty_name}`. Try providing a type parameter.");
             type_msg_(context, ty, &msg);
         },
         _ => type_(context, ty),
@@ -82,7 +82,7 @@ fn type_fun_ty_param(
     n: &FunctionName,
 ) {
     let param_name = context.function_info(m, n).signature.type_parameters[i].user_specified_name;
-    type_msg_(context, ty, &format!("Cannot infer the type parameter {param_name} for generic function {m}::{n}. Try providing a type parameter."));
+    type_msg_(context, ty, &format!("Cannot infer the type parameter `{param_name}` for generic function `{m}::{n}`. Try providing a type parameter."));
 }
 
 pub fn type_msg_(context: &mut Context, ty: &mut Type, msg_uninferred: &str) {
@@ -238,7 +238,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
             };
             let new_exp = if v > max {
                 let msg = format!(
-                    "Expected a literal of type '{}', but the value is too large.",
+                    "Expected a literal of type `{}`, but the value is too large.",
                     bt
                 );
                 let fix_bt = if v > u128_max {
@@ -255,7 +255,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
                 };
 
                 let fix = format!(
-                    "Annotating the literal might help inference: '{value}{type}'",
+                    "Annotating the literal might help inference: `{value}{type}`",
                     value=v,
                     type=fix_bt,
                 );
@@ -417,7 +417,7 @@ fn builtin_function(context: &mut Context, b: &mut T::BuiltinFunction) {
             type_msg_(
                 context,
                 bt,
-                &format!("Cannot infer a type parameter for built-in function '{f_name}'"),
+                &format!("Cannot infer a type parameter for built-in function `{f_name}`"),
             );
         },
         B::Assert(_) => (),

--- a/third_party/move/move-compiler/src/typing/expand.rs
+++ b/third_party/move/move-compiler/src/typing/expand.rs
@@ -62,7 +62,7 @@ fn type_struct_ty_param(context: &mut Context, ty: &mut Type, i: usize, ty_name:
     match ty_name {
         TypeName_::ModuleType(mod_id, struct_name) => {
             let param_name = &context.struct_definition(mod_id, struct_name).type_parameters[i].param.user_specified_name.value;
-            let msg = format!("Cannot infer a type parameter {param_name} for generic struct {ty_name}. Try providing a type parameter.");
+            let msg = format!("Cannot infer the type parameter {param_name} for generic struct {ty_name}. Try providing a type parameter.");
             type_msg_(context, ty, &msg);
         },
         _ => type_(context, ty),

--- a/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
@@ -126,7 +126,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:9
    │
 28 │         G2{} == G2{};
-   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::G2`. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9

--- a/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
@@ -128,12 +128,6 @@ error[E04010]: cannot infer type
 28 │         G2{} == G2{};
    │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/eq_invalid.move:28:17
-   │
-28 │         G2{} == G2{};
-   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9
    │

--- a/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
@@ -126,13 +126,13 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:9
    │
 28 │         G2{} == G2{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:17
    │
 28 │         G2{} == G2{};
-   │                 ^^^^ Could not infer this type. Try adding an annotation
+   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9

--- a/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/eq_invalid.exp
@@ -126,7 +126,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/eq_invalid.move:28:9
    │
 28 │         G2{} == G2{};
-   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/eq_invalid.move:29:9

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
@@ -22,5 +22,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_nested.move:6:19
   │
 6 │         (0, (S{}, R{}))
-  │                   ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::R. Try providing a type parameter.
+  │                   ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::R. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
@@ -22,5 +22,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_nested.move:6:19
   │
 6 │         (0, (S{}, R{}))
-  │                   ^^^ Could not infer this type. Try adding an annotation
+  │                   ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::R. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_nested.exp
@@ -22,5 +22,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_nested.move:6:19
   │
 6 │         (0, (S{}, R{}))
-  │                   ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::R. Try providing a type parameter.
+  │                   ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::R`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
@@ -32,5 +32,11 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
   │
 9 │         (0, S{ }, Box { f: abort 0 });
-  │                   ^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+  │                   ^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::Box. Try providing a type parameter.
+
+error[E04010]: cannot infer type
+  ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
+  │
+9 │         (0, S{ }, Box { f: abort 0 });
+  │                   ^^^^^^^^^^^^^^^^^^ Could not infer the type of field f
 

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
@@ -34,9 +34,3 @@ error[E04010]: cannot infer type
 9 │         (0, S{ }, Box { f: abort 0 });
   │                   ^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::Box. Try providing a type parameter.
 
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
-  │
-9 │         (0, S{ }, Box { f: abort 0 });
-  │                   ^^^^^^^^^^^^^^^^^^ Could not infer the type of field f
-

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
@@ -32,5 +32,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
   │
 9 │         (0, S{ }, Box { f: abort 0 });
-  │                   ^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::Box. Try providing a type parameter.
+  │                   ^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::Box. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/exp_list_resource_drop.exp
@@ -32,5 +32,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
   │
 9 │         (0, S{ }, Box { f: abort 0 });
-  │                   ^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::Box. Try providing a type parameter.
+  │                   ^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::Box`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
@@ -14,5 +14,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/ignore_inferred_resource.move:4:9
   │
 4 │         S{};
-  │         ^^^ Could not infer this type. Try adding an annotation
+  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
@@ -14,5 +14,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/ignore_inferred_resource.move:4:9
   │
 4 │         S{};
-  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::S`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/ignore_inferred_resource.exp
@@ -14,5 +14,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/ignore_inferred_resource.move:4:9
   │
 4 │         S{};
-  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
@@ -32,13 +32,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:30:9
    │
 30 │         destroy(account, move_from(a));
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/invalid_type_acquire.move:30:26
-   │
-30 │         destroy(account, move_from(a));
-   │                          ^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter T for generic function 0x2::M::destroy. Try providing a type parameter.
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:31:26
@@ -173,7 +167,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:48:9
    │
 48 │         exists(a);
-   │         ^^^^^^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^^^^^^ Cannot infer a type parameter for built-in function 'exists'
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:49:9
@@ -218,13 +212,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:54:9
    │
 54 │         move_to(account, any());
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/invalid_type_acquire.move:54:26
-   │
-54 │         move_to(account, any());
-   │                          ^^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter for built-in function 'move_to'
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:55:9

--- a/third_party/move/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/invalid_type_acquire.exp
@@ -32,7 +32,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:30:9
    │
 30 │         destroy(account, move_from(a));
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter T for generic function 0x2::M::destroy. Try providing a type parameter.
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer the type parameter `T` for generic function `0x2::M::destroy`. Try providing a type parameter.
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:31:26
@@ -167,7 +167,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:48:9
    │
 48 │         exists(a);
-   │         ^^^^^^^^^ Cannot infer a type parameter for built-in function 'exists'
+   │         ^^^^^^^^^ Cannot infer a type parameter for built-in function `exists`
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:49:9
@@ -212,7 +212,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:54:9
    │
 54 │         move_to(account, any());
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter for built-in function 'move_to'
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ Cannot infer a type parameter for built-in function `move_to`
 
 error[E04009]: expected specific type
    ┌─ tests/move_check/typing/invalid_type_acquire.move:55:9

--- a/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
@@ -106,7 +106,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:26:9
    │
 26 │         G0{} != G0{};
-   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::G0`. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
@@ -124,7 +124,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
    │
 27 │         G1{} != G1{};
-   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::G1`. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:17
@@ -154,7 +154,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
    │
 28 │         G2{} != G2{};
-   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::G2`. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:17

--- a/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
@@ -106,13 +106,13 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:26:9
    │
 26 │         G0{} != G0{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
 
 error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:26:17
    │
 26 │         G0{} != G0{};
-   │                 ^^^^ Could not infer this type. Try adding an annotation
+   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
@@ -130,7 +130,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
    │
 27 │         G1{} != G1{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:17
@@ -148,7 +148,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:27:17
    │
 27 │         G1{} != G1{};
-   │                 ^^^^ Could not infer this type. Try adding an annotation
+   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
@@ -166,7 +166,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
    │
 28 │         G2{} != G2{};
-   │         ^^^^ Could not infer this type. Try adding an annotation
+   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:17
@@ -184,7 +184,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:28:17
    │
 28 │         G2{} != G2{};
-   │                 ^^^^ Could not infer this type. Try adding an annotation
+   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/neq_invalid.move:32:9

--- a/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
@@ -106,7 +106,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:26:9
    │
 26 │         G0{} != G0{};
-   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
@@ -124,7 +124,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
    │
 27 │         G1{} != G1{};
-   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:17
@@ -154,7 +154,7 @@ error[E04010]: cannot infer type
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
    │
 28 │         G2{} != G2{};
-   │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
+   │         ^^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:17

--- a/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/neq_invalid.exp
@@ -108,12 +108,6 @@ error[E04010]: cannot infer type
 26 │         G0{} != G0{};
    │         ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
 
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/neq_invalid.move:26:17
-   │
-26 │         G0{} != G0{};
-   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G0. Try providing a type parameter.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:27:9
    │
@@ -144,12 +138,6 @@ error[E05001]: ability constraint not satisfied
    │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                 The type '0x8675309::M::G1<_>' does not have the ability 'drop'
 
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/neq_invalid.move:27:17
-   │
-27 │         G1{} != G1{};
-   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G1. Try providing a type parameter.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/neq_invalid.move:28:9
    │
@@ -179,12 +167,6 @@ error[E05001]: ability constraint not satisfied
    │                 │
    │                 '!=' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                 The type '0x8675309::M::G2<_>' does not have the ability 'drop'
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_check/typing/neq_invalid.move:28:17
-   │
-28 │         G2{} != G2{};
-   │                 ^^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::G2. Try providing a type parameter.
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/typing/neq_invalid.move:32:9

--- a/third_party/move/move-compiler/tests/move_check/typing/number_literal_too_large.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/number_literal_too_large.exp
@@ -5,80 +5,80 @@ error[E04021]: invalid number after type inference
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │
   │         Invalid numerical literal
-  │         Annotating the literal might help inference: '340282366920938463463374607431768211455u128'
-  │         Expected a literal of type 'u64', but the value is too large.
+  │         Annotating the literal might help inference: `340282366920938463463374607431768211455u128`
+  │         Expected a literal of type `u64`, but the value is too large.
 
 error[E04021]: invalid number after type inference
   ┌─ tests/move_check/typing/number_literal_too_large.move:5:10
   │
 5 │         (340282366920938463463374607431768211454: u64);
-  │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  --- Expected a literal of type 'u64', but the value is too large.
+  │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  --- Expected a literal of type `u64`, but the value is too large.
   │          │                                         
   │          Invalid numerical literal
-  │          Annotating the literal might help inference: '340282366920938463463374607431768211454u128'
+  │          Annotating the literal might help inference: `340282366920938463463374607431768211454u128`
 
 error[E04021]: invalid number after type inference
   ┌─ tests/move_check/typing/number_literal_too_large.move:6:10
   │
 6 │         (340282366920938463463374607431768211454: u8);
-  │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type 'u8', but the value is too large.
+  │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type `u8`, but the value is too large.
   │          │                                         
   │          Invalid numerical literal
-  │          Annotating the literal might help inference: '340282366920938463463374607431768211454u128'
+  │          Annotating the literal might help inference: `340282366920938463463374607431768211454u128`
 
 error[E04021]: invalid number after type inference
   ┌─ tests/move_check/typing/number_literal_too_large.move:8:10
   │
 8 │         (18446744073709551616: u64);
-  │          ^^^^^^^^^^^^^^^^^^^^  --- Expected a literal of type 'u64', but the value is too large.
+  │          ^^^^^^^^^^^^^^^^^^^^  --- Expected a literal of type `u64`, but the value is too large.
   │          │                      
   │          Invalid numerical literal
-  │          Annotating the literal might help inference: '18446744073709551616u128'
+  │          Annotating the literal might help inference: `18446744073709551616u128`
 
 error[E04021]: invalid number after type inference
   ┌─ tests/move_check/typing/number_literal_too_large.move:9:10
   │
 9 │         (18446744073709551616: u8);
-  │          ^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type 'u8', but the value is too large.
+  │          ^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type `u8`, but the value is too large.
   │          │                      
   │          Invalid numerical literal
-  │          Annotating the literal might help inference: '18446744073709551616u128'
+  │          Annotating the literal might help inference: `18446744073709551616u128`
 
 error[E04021]: invalid number after type inference
    ┌─ tests/move_check/typing/number_literal_too_large.move:11:10
    │
 11 │         (18446744073709551615: u8);
-   │          ^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type 'u8', but the value is too large.
+   │          ^^^^^^^^^^^^^^^^^^^^  -- Expected a literal of type `u8`, but the value is too large.
    │          │                      
    │          Invalid numerical literal
-   │          Annotating the literal might help inference: '18446744073709551615u64'
+   │          Annotating the literal might help inference: `18446744073709551615u64`
 
 error[E04021]: invalid number after type inference
    ┌─ tests/move_check/typing/number_literal_too_large.move:13:10
    │
 13 │         (256: u8);
-   │          ^^^  -- Expected a literal of type 'u8', but the value is too large.
+   │          ^^^  -- Expected a literal of type `u8`, but the value is too large.
    │          │     
    │          Invalid numerical literal
-   │          Annotating the literal might help inference: '256u16'
+   │          Annotating the literal might help inference: `256u16`
 
 error[E04021]: invalid number after type inference
    ┌─ tests/move_check/typing/number_literal_too_large.move:19:10
    │
 19 │         (3402534025: u16);
-   │          ^^^^^^^^^^  --- Expected a literal of type 'u16', but the value is too large.
+   │          ^^^^^^^^^^  --- Expected a literal of type `u16`, but the value is too large.
    │          │            
    │          Invalid numerical literal
-   │          Annotating the literal might help inference: '3402534025u32'
+   │          Annotating the literal might help inference: `3402534025u32`
 
 error[E04021]: invalid number after type inference
    ┌─ tests/move_check/typing/number_literal_too_large.move:22:10
    │
 22 │         (3402534025534025: u32);
-   │          ^^^^^^^^^^^^^^^^  --- Expected a literal of type 'u32', but the value is too large.
+   │          ^^^^^^^^^^^^^^^^  --- Expected a literal of type `u32`, but the value is too large.
    │          │                  
    │          Invalid numerical literal
-   │          Annotating the literal might help inference: '3402534025534025u64'
+   │          Annotating the literal might help inference: `3402534025534025u64`
 
 error[E04021]: invalid number after type inference
    ┌─ tests/move_check/typing/number_literal_too_large.move:24:9
@@ -87,6 +87,6 @@ error[E04021]: invalid number after type inference
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │         │
    │         Invalid numerical literal
-   │         Annotating the literal might help inference: '340282366920938463463374607431768211455607431768211455u256'
-   │         Expected a literal of type 'u64', but the value is too large.
+   │         Annotating the literal might help inference: `340282366920938463463374607431768211455607431768211455u256`
+   │         Expected a literal of type `u64`, but the value is too large.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/recursive_local.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/recursive_local.exp
@@ -20,9 +20,3 @@ error[E04005]: expected a single type
   │         │    
   │         Invalid type for local
 
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/recursive_local.move:5:14
-  │
-5 │         x = (x, 0);
-  │              ^ Could not infer this type. Try adding an annotation
-

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_call.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_call.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_call.move:3:9
   │
 3 │         foo()
-  │         ^^^^^ Could not infer this type. Try adding an annotation
+  │         ^^^^^ Cannot infer the type parameter T for generic function 0x8675309::M::foo. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_call.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_call.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_call.move:3:9
   │
 3 │         foo()
-  │         ^^^^^ Cannot infer the type parameter T for generic function 0x8675309::M::foo. Try providing a type parameter.
+  │         ^^^^^ Cannot infer the type parameter `T` for generic function `0x8675309::M::foo`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_pack.move:5:9
   │
 5 │         S{};
-  │         ^^^ Could not infer this type. Try adding an annotation
+  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_pack.move:5:9
   │
 5 │         S{};
-  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::S`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_pack.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_pack.move:5:9
   │
 5 │         S{};
-  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:9
   │
 5 │         S{} = S{};
-  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
@@ -2,17 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:9
   │
 5 │         S{} = S{};
-  │         ^^^ Could not infer this type. Try adding an annotation
-
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:9
-  │
-5 │         S{} = S{};
   │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
-
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:15
-  │
-5 │         S{} = S{};
-  │               ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:9
   │
 5 │         S{} = S{};
-  │         ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │         ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::S`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_assign.exp
@@ -5,8 +5,14 @@ error[E04010]: cannot infer type
   │         ^^^ Could not infer this type. Try adding an annotation
 
 error[E04010]: cannot infer type
+  ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:9
+  │
+5 │         S{} = S{};
+  │         ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+
+error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_assign.move:5:15
   │
 5 │         S{} = S{};
-  │               ^^^ Could not infer this type. Try adding an annotation
+  │               ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
@@ -2,17 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:13
   │
 5 │         let S{} = S{};
-  │             ^^^ Could not infer this type. Try adding an annotation
-
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:13
-  │
-5 │         let S{} = S{};
   │             ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
-
-error[E04010]: cannot infer type
-  ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:19
-  │
-5 │         let S{} = S{};
-  │                   ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
@@ -5,8 +5,14 @@ error[E04010]: cannot infer type
   │             ^^^ Could not infer this type. Try adding an annotation
 
 error[E04010]: cannot infer type
+  ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:13
+  │
+5 │         let S{} = S{};
+  │             ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+
+error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:19
   │
 5 │         let S{} = S{};
-  │                   ^^^ Could not infer this type. Try adding an annotation
+  │                   ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:13
   │
 5 │         let S{} = S{};
-  │             ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │             ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::S`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_bind.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_bind.move:5:13
   │
 5 │         let S{} = S{};
-  │             ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │             ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_decl.move:5:13
   │
 5 │         let S{};
-  │             ^^^ Could not infer this type. Try adding an annotation
+  │             ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_decl.move:5:13
   │
 5 │         let S{};
-  │             ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │             ^^^ Cannot infer the type parameter `T` for generic struct `0x8675309::M::S`. Try providing a type parameter.
 

--- a/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/uninferred_type_unpack_decl.exp
@@ -2,5 +2,5 @@ error[E04010]: cannot infer type
   ┌─ tests/move_check/typing/uninferred_type_unpack_decl.move:5:13
   │
 5 │         let S{};
-  │             ^^^ Cannot infer a type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
+  │             ^^^ Cannot infer the type parameter T for generic struct 0x8675309::M::S. Try providing a type parameter.
 


### PR DESCRIPTION
### Description
This improves the compiler error messages when type inference fails by

- removing duplicated error messages for the same uninferred type variable ([uninferred_type_unpack_assign.exp](https://github.com/aptos-labs/aptos-core/compare/main...fEst1ck:aptos-core:better-compiler-err-msg#diff-f1676ba2459a1234f8bb7314ec79fee1ad79868ceace16149c2f5557c1204e3e)).
- telling why we cannot infer; e.g., which generic needs to be provided.
### Test Plan
Existing tests of compiler v1.
