### PR TITLE
Improve agg v2 e2e tests

### DIFF
--- a/aptos-move/e2e-move-tests/src/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 pub fn initialize(path: PathBuf) -> (MoveHarness, Account) {
     // Aggregator tests should use parallel execution.
-    let executor = FakeExecutor::from_head_genesis().set_parallel();
+    let executor = FakeExecutor::from_head_genesis();
 
     let mut harness = MoveHarness::new_with_executor(executor);
     let account = harness.new_account_at(AccountAddress::ONE);

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{assert_success, harness::MoveHarness};
-use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
+use aptos_language_e2e_tests::{
+    account::Account,
+    executor::{ExecutorMode, FakeExecutor},
+};
 use aptos_types::{
     account_address::AccountAddress, on_chain_config::FeatureFlag, transaction::SignedTransaction,
 };
@@ -12,25 +15,14 @@ use move_core_types::{
 };
 use std::path::PathBuf;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ExecutorMode {
-    Sequential,
-    // Runs sequential, then parallel, and compares outputs.
-    Both,
-}
-
 pub fn initialize(
     path: PathBuf,
     mode: ExecutorMode,
     aggregator_execution_enabled: bool,
-) -> (MoveHarness, Account) {
+    txns: usize,
+) -> AggV2TestHarness {
     // Aggregator tests should use parallel execution.
-    let executor = FakeExecutor::from_head_genesis();
-    let executor = match mode {
-        ExecutorMode::Sequential => executor.set_not_parallel(),
-        // TODO Poorly named function, to rename.
-        ExecutorMode::Both => executor.set_parallel(),
-    };
+    let executor = FakeExecutor::from_head_genesis().set_executor_mode(mode);
 
     let mut harness = MoveHarness::new_with_executor(executor);
     if aggregator_execution_enabled {
@@ -48,7 +40,24 @@ pub fn initialize(
     }
     let account = harness.new_account_at(AccountAddress::ONE);
     assert_success!(harness.publish_package_cache_building(&account, &path));
-    (harness, account)
+
+    let txn_accounts: Vec<Account> = (0..txns)
+        .map(|_i| harness.new_account_with_key_pair())
+        .collect();
+
+    AggV2TestHarness {
+        harness,
+        account,
+        txn_accounts,
+        txn_index: 0,
+    }
+}
+
+pub struct AggV2TestHarness {
+    pub harness: MoveHarness,
+    pub account: Account,
+    pub txn_accounts: Vec<Account>,
+    pub txn_index: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -89,82 +98,36 @@ impl ElementType {
     }
 }
 
+// For a generic test, so we can test any combination of features, with the same "aggregator equation test case",
+// we define a generic aggregator (or snapshot) location.
+// It is defined by:
+// - the address of the account that resource is stored in
+// - what type the stored element is (u64/u128/string)
+// - what type of resource it is stored in (resource/table/resource group)
+// - the index inside of a vector in resource/resource group,
+//   or (key, index) pair inside table (where key=i / 10, index=i % 10)
 #[derive(Debug)]
-pub struct AggLocation<'a> {
-    account: &'a Account,
+pub struct AggregatorLocation {
+    address: AccountAddress,
     element_type: ElementType,
     use_type: UseType,
     index: u64,
 }
 
-impl<'a> AggLocation<'a> {
+impl AggregatorLocation {
     pub fn new(
-        account: &'a Account,
+        address: AccountAddress,
         element_type: ElementType,
         use_type: UseType,
         index: u64,
-    ) -> AggLocation {
-        AggLocation {
-            account,
+    ) -> AggregatorLocation {
+        AggregatorLocation {
+            address,
             use_type,
             index,
             element_type,
         }
     }
-}
-
-fn create_entry_agg_func_no_arg(
-    harness: &mut MoveHarness,
-    name: &str,
-    agg_loc: &AggLocation,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        agg_loc.account,
-        str::parse(name).unwrap(),
-        vec![agg_loc.element_type.get_type_tag()],
-        vec![
-            bcs::to_bytes(&(agg_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&agg_loc.index).unwrap(),
-        ],
-    )
-}
-
-fn create_entry_agg_func_with_arg(
-    harness: &mut MoveHarness,
-    name: &str,
-    agg_loc: &AggLocation,
-    argument: u128,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        agg_loc.account,
-        str::parse(name).unwrap(),
-        vec![agg_loc.element_type.get_type_tag()],
-        vec![
-            bcs::to_bytes(&(agg_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&agg_loc.index).unwrap(),
-            agg_loc.element_type.value_to_bcs(argument),
-        ],
-    )
-}
-
-fn create_entry_agg_func_with_two_args(
-    harness: &mut MoveHarness,
-    name: &str,
-    agg_loc: &AggLocation,
-    argument_1: u128,
-    argument_2: u128,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        agg_loc.account,
-        str::parse(name).unwrap(),
-        vec![agg_loc.element_type.get_type_tag()],
-        vec![
-            bcs::to_bytes(&(agg_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&agg_loc.index).unwrap(),
-            agg_loc.element_type.value_to_bcs(argument_1),
-            agg_loc.element_type.value_to_bcs(argument_2),
-        ],
-    )
 }
 
 pub fn init(
@@ -189,267 +152,270 @@ pub fn init(
     )
 }
 
-pub fn check(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    expected: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::check", agg_loc, expected)
-}
+impl AggV2TestHarness {
+    fn create_entry_agg_func_with_args(
+        &mut self,
+        name: &str,
+        agg_loc: &AggregatorLocation,
+        arguments: &[u128],
+    ) -> SignedTransaction {
+        self.txn_index += 1;
 
-pub fn check_snapshot(
-    harness: &mut MoveHarness,
-    snap_loc: &AggLocation,
-    expected: u128,
-) -> SignedTransaction {
-    println!(
-        "Check snapshot argument: {:?}",
-        snap_loc.element_type.value_to_bcs(expected)
-    );
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::check_snapshot",
-        snap_loc,
-        expected,
-    )
-}
-
-pub fn new(harness: &mut MoveHarness, agg_loc: &AggLocation, max_value: u128) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::new", agg_loc, max_value)
-}
-
-pub fn add(harness: &mut MoveHarness, agg_loc: &AggLocation, value: u128) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::add", agg_loc, value)
-}
-
-pub fn try_add(harness: &mut MoveHarness, agg_loc: &AggLocation, value: u128) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::try_add", agg_loc, value)
-}
-
-pub fn sub(harness: &mut MoveHarness, agg_loc: &AggLocation, value: u128) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::sub", agg_loc, value)
-}
-
-pub fn try_sub(harness: &mut MoveHarness, agg_loc: &AggLocation, value: u128) -> SignedTransaction {
-    create_entry_agg_func_with_arg(harness, "0x1::aggregator_v2_test::try_sub", agg_loc, value)
-}
-
-pub fn new_add(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    max_value: u128,
-    a: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_two_args(
-        harness,
-        "0x1::aggregator_v2_test::new_add",
-        agg_loc,
-        max_value,
-        a,
-    )
-}
-
-pub fn sub_add(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    a: u128,
-    b: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_two_args(harness, "0x1::aggregator_v2_test::sub_add", agg_loc, a, b)
-}
-
-pub fn add_sub(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    a: u128,
-    b: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_two_args(harness, "0x1::aggregator_v2_test::add_sub", agg_loc, a, b)
-}
-
-pub fn materialize(harness: &mut MoveHarness, agg_loc: &AggLocation) -> SignedTransaction {
-    create_entry_agg_func_no_arg(harness, "0x1::aggregator_v2_test::materialize", agg_loc)
-}
-
-pub fn materialize_and_add(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    value: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::materialize_and_add",
-        agg_loc,
-        value,
-    )
-}
-
-pub fn materialize_and_sub(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    value: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::materialize_and_sub",
-        agg_loc,
-        value,
-    )
-}
-
-pub fn add_and_materialize(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    value: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::add_and_materialize",
-        agg_loc,
-        value,
-    )
-}
-
-pub fn sub_and_materialize(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    value: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::sub_and_materialize",
-        agg_loc,
-        value,
-    )
-}
-
-pub fn add_2(
-    harness: &mut MoveHarness,
-    agg_loc_a: &AggLocation,
-    agg_loc_b: &AggLocation,
-    value_a: u128,
-    value_b: u128,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        agg_loc_a.account,
-        str::parse("0x1::aggregator_v2_test::add_2").unwrap(),
-        vec![
-            agg_loc_a.element_type.get_type_tag(),
-            agg_loc_b.element_type.get_type_tag(),
-        ],
-        vec![
-            bcs::to_bytes(&(agg_loc_a.use_type as u32)).unwrap(),
-            bcs::to_bytes(&agg_loc_a.index).unwrap(),
-            agg_loc_a.element_type.value_to_bcs(value_a),
-            bcs::to_bytes(&agg_loc_b.account.address()).unwrap(),
-            bcs::to_bytes(&(agg_loc_b.use_type as u32)).unwrap(),
-            bcs::to_bytes(&agg_loc_b.index).unwrap(),
-            agg_loc_b.element_type.value_to_bcs(value_b),
-        ],
-    )
-}
-
-pub fn snapshot(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    snap_loc: &AggLocation,
-) -> SignedTransaction {
-    assert_eq!(agg_loc.element_type, snap_loc.element_type);
-    harness.create_entry_function(
-        agg_loc.account,
-        str::parse("0x1::aggregator_v2_test::snapshot").unwrap(),
-        vec![agg_loc.element_type.get_type_tag()],
-        vec![
+        let mut args = vec![
+            bcs::to_bytes(&agg_loc.address).unwrap(),
             bcs::to_bytes(&(agg_loc.use_type as u32)).unwrap(),
             bcs::to_bytes(&agg_loc.index).unwrap(),
-            bcs::to_bytes(&snap_loc.account.address()).unwrap(),
-            bcs::to_bytes(&(snap_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&snap_loc.index).unwrap(),
-        ],
-    )
-}
+        ];
+        for arg in arguments {
+            args.push(agg_loc.element_type.value_to_bcs(*arg))
+        }
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse(name).unwrap(),
+            vec![agg_loc.element_type.get_type_tag()],
+            args,
+        )
+    }
 
-pub fn concat(
-    harness: &mut MoveHarness,
-    input_loc: &AggLocation,
-    output_loc: &AggLocation,
-    prefix: &str,
-    suffix: &str,
-) -> SignedTransaction {
-    assert_eq!(output_loc.element_type, ElementType::String);
-    harness.create_entry_function(
-        input_loc.account,
-        str::parse("0x1::aggregator_v2_test::concat").unwrap(),
-        vec![input_loc.element_type.get_type_tag()],
-        vec![
-            bcs::to_bytes(&(input_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&input_loc.index).unwrap(),
-            bcs::to_bytes(&output_loc.account.address()).unwrap(),
-            bcs::to_bytes(&(output_loc.use_type as u32)).unwrap(),
-            bcs::to_bytes(&output_loc.index).unwrap(),
-            bcs::to_bytes(&prefix.to_string()).unwrap(),
-            bcs::to_bytes(&suffix.to_string()).unwrap(),
-        ],
-    )
-}
+    pub fn check(&mut self, agg_loc: &AggregatorLocation, expected: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::check", agg_loc, &[expected])
+    }
 
-pub fn read_snapshot(harness: &mut MoveHarness, agg_loc: &AggLocation) -> SignedTransaction {
-    create_entry_agg_func_no_arg(harness, "0x1::aggregator_v2_test::read_snapshot", agg_loc)
-}
+    pub fn check_snapshot(
+        &mut self,
+        snap_loc: &AggregatorLocation,
+        expected: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::check_snapshot",
+            snap_loc,
+            &[expected],
+        )
+    }
 
-pub fn add_and_read_snapshot_u128(
-    harness: &mut MoveHarness,
-    agg_loc: &AggLocation,
-    value: u128,
-) -> SignedTransaction {
-    create_entry_agg_func_with_arg(
-        harness,
-        "0x1::aggregator_v2_test::add_and_read_snapshot",
-        agg_loc,
-        value,
-    )
-}
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(&mut self, agg_loc: &AggregatorLocation, max_value: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::new", agg_loc, &[max_value])
+    }
 
-// indempotent verify functions:
+    pub fn add(&mut self, agg_loc: &AggregatorLocation, value: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::add", agg_loc, &[value])
+    }
 
-pub fn verify_copy_snapshot(harness: &mut MoveHarness, account: &Account) -> SignedTransaction {
-    harness.create_entry_function(
-        account,
-        str::parse("0x1::aggregator_v2_test::verify_copy_snapshot").unwrap(),
-        vec![],
-        vec![],
-    )
-}
+    pub fn try_add(&mut self, agg_loc: &AggregatorLocation, value: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::try_add", agg_loc, &[value])
+    }
 
-pub fn verify_copy_string_snapshot(
-    harness: &mut MoveHarness,
-    account: &Account,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        account,
-        str::parse("0x1::aggregator_v2_test::verify_copy_string_snapshot").unwrap(),
-        vec![],
-        vec![],
-    )
-}
+    pub fn sub(&mut self, agg_loc: &AggregatorLocation, value: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::sub", agg_loc, &[value])
+    }
 
-pub fn verify_string_concat(harness: &mut MoveHarness, account: &Account) -> SignedTransaction {
-    harness.create_entry_function(
-        account,
-        str::parse("0x1::aggregator_v2_test::verify_string_concat").unwrap(),
-        vec![],
-        vec![],
-    )
-}
+    pub fn try_sub(&mut self, agg_loc: &AggregatorLocation, value: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::try_sub", agg_loc, &[value])
+    }
 
-pub fn verify_string_snapshot_concat(
-    harness: &mut MoveHarness,
-    account: &Account,
-) -> SignedTransaction {
-    harness.create_entry_function(
-        account,
-        str::parse("0x1::aggregator_v2_test::verify_string_snapshot_concat").unwrap(),
-        vec![],
-        vec![],
-    )
+    pub fn new_add(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        max_value: u128,
+        a: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::new_add", agg_loc, &[
+            max_value, a,
+        ])
+    }
+
+    pub fn sub_add(&mut self, agg_loc: &AggregatorLocation, a: u128, b: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::sub_add", agg_loc, &[a, b])
+    }
+
+    pub fn add_sub(&mut self, agg_loc: &AggregatorLocation, a: u128, b: u128) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::add_sub", agg_loc, &[a, b])
+    }
+
+    pub fn materialize(&mut self, agg_loc: &AggregatorLocation) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::materialize", agg_loc, &[])
+    }
+
+    pub fn materialize_and_add(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        value: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::materialize_and_add",
+            agg_loc,
+            &[value],
+        )
+    }
+
+    pub fn materialize_and_sub(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        value: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::materialize_and_sub",
+            agg_loc,
+            &[value],
+        )
+    }
+
+    pub fn add_and_materialize(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        value: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::add_and_materialize",
+            agg_loc,
+            &[value],
+        )
+    }
+
+    pub fn sub_and_materialize(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        value: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::sub_and_materialize",
+            agg_loc,
+            &[value],
+        )
+    }
+
+    pub fn add_2(
+        &mut self,
+        agg_loc_a: &AggregatorLocation,
+        agg_loc_b: &AggregatorLocation,
+        value_a: u128,
+        value_b: u128,
+    ) -> SignedTransaction {
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::add_2").unwrap(),
+            vec![
+                agg_loc_a.element_type.get_type_tag(),
+                agg_loc_b.element_type.get_type_tag(),
+            ],
+            vec![
+                bcs::to_bytes(&agg_loc_a.address).unwrap(),
+                bcs::to_bytes(&(agg_loc_a.use_type as u32)).unwrap(),
+                bcs::to_bytes(&agg_loc_a.index).unwrap(),
+                agg_loc_a.element_type.value_to_bcs(value_a),
+                bcs::to_bytes(&agg_loc_b.address).unwrap(),
+                bcs::to_bytes(&(agg_loc_b.use_type as u32)).unwrap(),
+                bcs::to_bytes(&agg_loc_b.index).unwrap(),
+                agg_loc_b.element_type.value_to_bcs(value_b),
+            ],
+        )
+    }
+
+    pub fn snapshot(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        snap_loc: &AggregatorLocation,
+    ) -> SignedTransaction {
+        assert_eq!(agg_loc.element_type, snap_loc.element_type);
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::snapshot").unwrap(),
+            vec![agg_loc.element_type.get_type_tag()],
+            vec![
+                bcs::to_bytes(&agg_loc.address).unwrap(),
+                bcs::to_bytes(&(agg_loc.use_type as u32)).unwrap(),
+                bcs::to_bytes(&agg_loc.index).unwrap(),
+                bcs::to_bytes(&snap_loc.address).unwrap(),
+                bcs::to_bytes(&(snap_loc.use_type as u32)).unwrap(),
+                bcs::to_bytes(&snap_loc.index).unwrap(),
+            ],
+        )
+    }
+
+    pub fn concat(
+        &mut self,
+        input_loc: &AggregatorLocation,
+        output_loc: &AggregatorLocation,
+        prefix: &str,
+        suffix: &str,
+    ) -> SignedTransaction {
+        assert_eq!(output_loc.element_type, ElementType::String);
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::concat").unwrap(),
+            vec![input_loc.element_type.get_type_tag()],
+            vec![
+                bcs::to_bytes(&input_loc.address).unwrap(),
+                bcs::to_bytes(&(input_loc.use_type as u32)).unwrap(),
+                bcs::to_bytes(&input_loc.index).unwrap(),
+                bcs::to_bytes(&output_loc.address).unwrap(),
+                bcs::to_bytes(&(output_loc.use_type as u32)).unwrap(),
+                bcs::to_bytes(&output_loc.index).unwrap(),
+                bcs::to_bytes(&prefix.to_string()).unwrap(),
+                bcs::to_bytes(&suffix.to_string()).unwrap(),
+            ],
+        )
+    }
+
+    pub fn read_snapshot(&mut self, agg_loc: &AggregatorLocation) -> SignedTransaction {
+        self.create_entry_agg_func_with_args("0x1::aggregator_v2_test::read_snapshot", agg_loc, &[])
+    }
+
+    pub fn add_and_read_snapshot_u128(
+        &mut self,
+        agg_loc: &AggregatorLocation,
+        value: u128,
+    ) -> SignedTransaction {
+        self.create_entry_agg_func_with_args(
+            "0x1::aggregator_v2_test::add_and_read_snapshot",
+            agg_loc,
+            &[value],
+        )
+    }
+
+    // idempotent verify functions:
+
+    pub fn verify_copy_snapshot(&mut self) -> SignedTransaction {
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::verify_copy_snapshot").unwrap(),
+            vec![],
+            vec![],
+        )
+    }
+
+    pub fn verify_copy_string_snapshot(&mut self) -> SignedTransaction {
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::verify_copy_string_snapshot").unwrap(),
+            vec![],
+            vec![],
+        )
+    }
+
+    pub fn verify_string_concat(&mut self) -> SignedTransaction {
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::verify_string_concat").unwrap(),
+            vec![],
+            vec![],
+        )
+    }
+
+    pub fn verify_string_snapshot_concat(&mut self) -> SignedTransaction {
+        self.txn_index += 1;
+        self.harness.create_entry_function(
+            &self.txn_accounts[self.txn_index % self.txn_accounts.len()],
+            str::parse("0x1::aggregator_v2_test::verify_string_snapshot_concat").unwrap(),
+            vec![],
+            vec![],
+        )
+    }
 }

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.data/pack/sources/aggregator_v2_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.data/pack/sources/aggregator_v2_test.move
@@ -2,7 +2,6 @@ module 0x1::aggregator_v2_test {
     use aptos_framework::aggregator_v2::{Self, Aggregator, AggregatorSnapshot};
     use aptos_std::debug;
     use aptos_std::table::{Self, Table};
-    use std::signer;
     use std::vector;
     use std::string::String;
     use std::option::{Self, Option};
@@ -152,8 +151,7 @@ module 0x1::aggregator_v2_test {
         f(value)
     }
 
-    public entry fun new<Element: drop + copy + store>(account: &signer, use_type: u32, i: u64, limit: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun new<Element: drop + copy + store>(_account: &signer, addr: address, use_type: u32, i: u64, limit: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         insert<Aggregator<Element>>(addr, use_type, i, aggregator_v2::create_aggregator(limit));
     }
 
@@ -161,52 +159,45 @@ module 0x1::aggregator_v2_test {
         for_element_ref<Aggregator<Element>, Element>(addr, use_type, i, |aggregator| aggregator_v2::read(aggregator))
     }
 
-    public entry fun try_add<Element: store>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun try_add<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| aggregator_v2::try_add(aggregator, value));
     }
 
-    public entry fun add<Element: store>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun add<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| {
             aggregator_v2::add(aggregator, value);
             true
         });
     }
 
-    public entry fun try_sub<Element: store>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun try_sub<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| aggregator_v2::try_sub(aggregator, value));
     }
 
-    public entry fun sub<Element: store>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun sub<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| {
             aggregator_v2::sub(aggregator, value);
             true
         });
     }
 
-    public entry fun materialize<Element: store + drop>(account: &signer, use_type: u32, i: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun materialize<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         call_read<Element>(addr, use_type, i);
     }
 
     /// Checks that the ith aggregator has expected value. Useful to inject into
     /// transaction block to verify successful and correct execution.
-    public entry fun check<Element: store + drop>(account: &signer, use_type: u32, i: u64, expected: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun check<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64, expected: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         let actual = call_read<Element>(addr, use_type, i);
         assert!(actual == expected, ENOT_EQUAL)
     }
 
-    public entry fun new_add<Element: drop + copy + store>(account: &signer, use_type: u32, i: u64, limit: Element, a: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        new(account, use_type, i, limit);
-        add(account, use_type, i, a);
+    public entry fun new_add<Element: drop + copy + store>(account: &signer, addr: address, use_type: u32, i: u64, limit: Element, a: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
+        new(account, addr, use_type, i, limit);
+        add(account, addr, use_type, i, a);
     }
 
-    public entry fun sub_add<Element: store>(account: &signer, use_type: u32, i: u64, a: Element, b: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun sub_add<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, a: Element, b: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| {
             aggregator_v2::sub(aggregator, a);
             aggregator_v2::add(aggregator, b);
@@ -214,8 +205,7 @@ module 0x1::aggregator_v2_test {
         });
     }
 
-    public entry fun add_sub<Element: store>(account: &signer, use_type: u32, i: u64, a: Element, b: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun add_sub<Element: store>(_account: &signer, addr: address, use_type: u32, i: u64, a: Element, b: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, bool>(addr, use_type, i, |aggregator| {
             aggregator_v2::add(aggregator, b);
             aggregator_v2::sub(aggregator, a);
@@ -223,10 +213,9 @@ module 0x1::aggregator_v2_test {
         });
     }
 
-    public entry fun materialize_and_add<Element: store + drop>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun materialize_and_add<Element: store + drop>(account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         call_read<Element>(addr, use_type, i);
-        add<Element>(account, use_type, i, value);
+        add<Element>(account, addr, use_type, i, value);
 
         // issue with type inference of lambda?
         // for_element_mut<Aggregator<u128>, bool>(account, use_type, i, |aggregator| {
@@ -235,10 +224,9 @@ module 0x1::aggregator_v2_test {
         // });
     }
 
-    public entry fun materialize_and_sub<Element: store + drop>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun materialize_and_sub<Element: store + drop>(account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         call_read<Element>(addr, use_type, i);
-        sub<Element>(account, use_type, i, value);
+        sub<Element>(account, addr, use_type, i, value);
 
         // issue with type inference of lambda?
         // for_element_mut<Aggregator<u128>, bool>(account, use_type, i, |aggregator| {
@@ -247,59 +235,49 @@ module 0x1::aggregator_v2_test {
         // });
     }
 
-    public entry fun add_and_materialize<Element: store + drop>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun add_and_materialize<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, Element>(addr, use_type, i, |aggregator| {
             aggregator_v2::add(aggregator, value);
             aggregator_v2::read(aggregator)
         });
     }
 
-    public entry fun sub_and_materialize<Element: store + drop>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun sub_and_materialize<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, Element>(addr, use_type, i, |aggregator| {
             aggregator_v2::sub(aggregator, value);
             aggregator_v2::read(aggregator)
         });
     }
 
-    public entry fun add_2<A: store, B: store>(account_a: &signer, use_type_a: u32, i_a: u64, a: A, addr_b: address, use_type_b: u32, i_b: u64, b: B) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        add<A>(account_a, use_type_a, i_a, a);
-        for_element_mut<Aggregator<B>, bool>(addr_b, use_type_b, i_b, |aggregator| {
-            aggregator_v2::add(aggregator, b);
-            true
-        });
+    public entry fun add_2<A: store, B: store>(account: &signer, addr_a: address, use_type_a: u32, i_a: u64, a: A, addr_b: address, use_type_b: u32, i_b: u64, b: B) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
+        add<A>(account, addr_a, use_type_a, i_a, a);
+        add<B>(account, addr_b, use_type_b, i_b, b);
     }
 
-    public entry fun snapshot<Element: store>(account_i: &signer, use_type_i: u32, i: u64, addr_j: address, use_type_j: u32, j: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr_i = signer::address_of(account_i);
+    public entry fun snapshot<Element: store>(_account: &signer, addr_i: address, use_type_i: u32, i: u64, addr_j: address, use_type_j: u32, j: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         let snapshot = for_element_ref<Aggregator<Element>, AggregatorSnapshot<Element>>(addr_i, use_type_i, i, |aggregator| {
             aggregator_v2::snapshot<Element>(aggregator)
         });
         insert<AggregatorSnapshot<Element>>(addr_j, use_type_j, j, snapshot);
     }
 
-    public entry fun concat<Element: store>(account_i: &signer, use_type_i: u32, i: u64, addr_j: address, use_type_j: u32, j: u64, prefix: String, suffix: String) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr_i = signer::address_of(account_i);
+    public entry fun concat<Element: store>(_account: &signer, addr_i: address, use_type_i: u32, i: u64, addr_j: address, use_type_j: u32, j: u64, prefix: String, suffix: String) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         let snapshot = for_element_ref<AggregatorSnapshot<Element>, AggregatorSnapshot<String>>(addr_i, use_type_i, i, |snapshot| {
             aggregator_v2::string_concat<Element>(prefix, snapshot, suffix)
         });
         insert<AggregatorSnapshot<String>>(addr_j, use_type_j, j, snapshot);
     }
 
-    public entry fun read_snapshot<Element: store + drop>(account: &signer, use_type: u32, i: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun read_snapshot<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_ref<AggregatorSnapshot<Element>, Element>(addr, use_type, i, |snapshot| aggregator_v2::read_snapshot(snapshot));
     }
 
-    public entry fun check_snapshot<Element: store + drop>(account: &signer, use_type: u32, i: u64, expected: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun check_snapshot<Element: store + drop>(_account: &signer, addr: address, use_type: u32, i: u64, expected: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         let actual = for_element_ref<AggregatorSnapshot<Element>, Element>(addr, use_type, i, |snapshot| aggregator_v2::read_snapshot(snapshot));
         assert!(actual == expected, ENOT_EQUAL)
     }
 
-    public entry fun add_and_read_snapshot<Element: copy + store + drop>(account: &signer, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
-        let addr = signer::address_of(account);
+    public entry fun add_and_read_snapshot<Element: copy + store + drop>(_account: &signer, addr: address, use_type: u32, i: u64, value: Element) acquires AggregatorInResource, AggregatorInTable, AggregatorInResourceGroup {
         for_element_mut<Aggregator<Element>, Element>(addr, use_type, i, |aggregator| {
             aggregator_v2::add(aggregator, value);
             aggregator_v2::sub(aggregator, value);

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    aggregator_v2::{
-        add, add_2, add_and_materialize, add_and_read_snapshot_u128, add_sub, check,
-        check_snapshot, concat, init, initialize, materialize, materialize_and_add,
-        materialize_and_sub, new, new_add, read_snapshot, snapshot, sub, sub_add,
-        sub_and_materialize, verify_copy_snapshot, verify_copy_string_snapshot,
-        verify_string_concat, verify_string_snapshot_concat, AggLocation, ElementType,
-        ExecutorMode, UseType,
-    },
+    aggregator_v2::{init, initialize, AggV2TestHarness, AggregatorLocation, ElementType, UseType},
     assert_abort, assert_success,
     tests::common,
     MoveHarness,
@@ -17,20 +10,25 @@ use crate::{
 use aptos_framework::natives::aggregator_natives::aggregator_v2::{
     EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED, EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE,
 };
-use aptos_language_e2e_tests::account::Account;
+use aptos_language_e2e_tests::executor::ExecutorMode;
 use aptos_types::transaction::SignedTransaction;
 use proptest::prelude::*;
 
-const DEFAULT_EXECUTOR_MODE: ExecutorMode = ExecutorMode::Sequential;
+const EAGGREGATOR_OVERFLOW: u64 = 0x02_0001;
+const EAGGREGATOR_UNDERFLOW: u64 = 0x02_0002;
+
+const DEFAULT_EXECUTOR_MODE: ExecutorMode = ExecutorMode::SequentialOnly;
 
 fn setup(
     executor_mode: ExecutorMode,
     aggregator_execution_enabled: bool,
-) -> (MoveHarness, Account) {
+    txns: usize,
+) -> AggV2TestHarness {
     initialize(
         common::test_dir_path("aggregator_v2.data/pack"),
         executor_mode,
         aggregator_execution_enabled,
+        txns,
     )
 }
 
@@ -42,96 +40,105 @@ mod test_cases {
     #[test_case(true)]
     #[test_case(false)]
     fn test_copy_snapshot(execution_enabled: bool) {
-        let (mut h, acc) = setup(DEFAULT_EXECUTOR_MODE, execution_enabled);
-        let txn = verify_copy_snapshot(&mut h, &acc);
-        assert_abort!(h.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
+        let mut h = setup(DEFAULT_EXECUTOR_MODE, execution_enabled, 1);
+        let txn = h.verify_copy_snapshot();
+        assert_abort!(h.harness.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
     }
 
     #[test_case(true)]
     #[test_case(false)]
     fn test_copy_string_snapshot(execution_enabled: bool) {
-        let (mut h, acc) = setup(DEFAULT_EXECUTOR_MODE, execution_enabled);
-        let txn = verify_copy_string_snapshot(&mut h, &acc);
-        assert_abort!(h.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
+        let mut h = setup(DEFAULT_EXECUTOR_MODE, execution_enabled, 1);
+        let txn = h.verify_copy_string_snapshot();
+        assert_abort!(h.harness.run(txn), EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED);
     }
 
     #[test_case(true)]
     #[test_case(false)]
     fn test_snapshot_concat(execution_enabled: bool) {
-        let (mut h, acc) = setup(DEFAULT_EXECUTOR_MODE, execution_enabled);
-        let txn = verify_string_concat(&mut h, &acc);
-        assert_success!(h.run(txn));
+        let mut h = setup(DEFAULT_EXECUTOR_MODE, execution_enabled, 1);
+        let txn = h.verify_string_concat();
+        assert_success!(h.harness.run(txn));
     }
 
     #[test_case(true)]
     #[test_case(false)]
     fn test_string_snapshot_concat(execution_enabled: bool) {
-        let (mut h, acc) = setup(DEFAULT_EXECUTOR_MODE, execution_enabled);
-        let txn = verify_string_snapshot_concat(&mut h, &acc);
-        assert_abort!(h.run(txn), EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE);
+        let mut h = setup(DEFAULT_EXECUTOR_MODE, execution_enabled, 1);
+        let txn = h.verify_string_snapshot_concat();
+        assert_abort!(h.harness.run(txn), EUNSUPPORTED_AGGREGATOR_SNAPSHOT_TYPE);
     }
 
     // This tests uses multuple blocks, so requires exchange to be done to work.
     // #[test_case(true)]
     #[test_case(false)]
     fn test_aggregators_e2e(execution_enabled: bool) {
+        println!("Testing test_aggregators_e2e {:?}", execution_enabled);
         let element_type = ElementType::U64;
         let use_type = UseType::UseTableType;
 
-        let (mut h, acc) = setup(DEFAULT_EXECUTOR_MODE, execution_enabled);
+        let mut h = setup(DEFAULT_EXECUTOR_MODE, execution_enabled, 100);
 
-        let init_txn = init(&mut h, &acc, use_type, element_type, true);
-        h.run(init_txn);
+        let init_txn = init(&mut h.harness, &h.account, use_type, element_type, true);
+        h.harness.run(init_txn);
 
-        let loc = |i| AggLocation::new(&acc, element_type, use_type, i);
+        let addr = *h.account.address();
+        let loc = |i| AggregatorLocation::new(addr, element_type, use_type, i);
 
-        let block_size = 300;
+        let block_size = 30;
 
         // Create many aggregators with deterministic limit.
-        let txns: Vec<SignedTransaction> = (0..block_size)
-            .map(|i| new(&mut h, &loc(i), (i as u128) * 100000))
+        let txns = (0..block_size)
+            .map(|i| (0, h.new(&loc(i), (i as u128) * 100000)))
             .collect();
-        h.run_block(txns);
+        run_block_in_parts(&mut h.harness, BlockSplit::Whole, txns);
 
         // All transactions in block must fail, so values of aggregators are still 0.
-        let failed_txns: Vec<SignedTransaction> = (0..block_size)
+        let failed_txns = (0..block_size)
             .map(|i| match i % 2 {
-                0 => materialize_and_add(&mut h, &loc(i), (i as u128) * 100000 + 1),
-                _ => materialize_and_sub(&mut h, &loc(i), (i as u128) * 100000 + 1),
+                0 => (
+                    EAGGREGATOR_OVERFLOW,
+                    h.materialize_and_add(&loc(i), (i as u128) * 100000 + 1),
+                ),
+                _ => (
+                    EAGGREGATOR_UNDERFLOW,
+                    h.materialize_and_sub(&loc(i), (i as u128) * 100000 + 1),
+                ),
             })
             .collect();
-        h.run_block(failed_txns);
+        run_block_in_parts(&mut h.harness, BlockSplit::Whole, failed_txns);
 
         // Now test all operations. To do that, make sure aggregator have values large enough.
-        let txns: Vec<SignedTransaction> = (0..block_size)
-            .map(|i| add(&mut h, &loc(i), (i as u128) * 1000))
+        let txns = (0..block_size)
+            .map(|i| (0, h.add(&loc(i), (i as u128) * 1000)))
             .collect();
-        h.run_block(txns);
+
+        run_block_in_parts(&mut h.harness, BlockSplit::Whole, txns);
 
         // TODO: proptests with random transaction generator might be useful here.
-        let txns: Vec<SignedTransaction> = (0..block_size)
+        let txns = (0..block_size)
             .map(|i| match i % 4 {
-                0 => sub_add(&mut h, &loc(i), (i as u128) * 1000, (i as u128) * 3000),
-                1 => materialize_and_add(&mut h, &loc(i), (i as u128) * 1000),
-                2 => sub_and_materialize(&mut h, &loc(i), (i as u128) * 1000),
-                _ => add(&mut h, &loc(i), i as u128),
+                0 => (
+                    0,
+                    h.sub_add(&loc(i), (i as u128) * 1000, (i as u128) * 3000),
+                ),
+                1 => (0, h.materialize_and_add(&loc(i), (i as u128) * 1000)),
+                2 => (0, h.sub_and_materialize(&loc(i), (i as u128) * 1000)),
+                _ => (0, h.add(&loc(i), i as u128)),
             })
             .collect();
-        h.run_block(txns);
+        run_block_in_parts(&mut h.harness, BlockSplit::Whole, txns);
 
         // Finally, check values.
-        let txns: Vec<SignedTransaction> = (0..block_size)
+        let txns = (0..block_size)
             .map(|i| match i % 4 {
-                0 => check(&mut h, &loc(i), (i as u128) * 3000),
-                1 => check(&mut h, &loc(i), (i as u128) * 2000),
-                2 => check(&mut h, &loc(i), 0),
-                _ => check(&mut h, &loc(i), (i as u128) * 1000 + (i as u128)),
+                0 => (0, h.check(&loc(i), (i as u128) * 3000)),
+                1 => (0, h.check(&loc(i), (i as u128) * 2000)),
+                2 => (0, h.check(&loc(i), 0)),
+                _ => (0, h.check(&loc(i), (i as u128) * 1000 + (i as u128))),
             })
             .collect();
-        let outputs = h.run_block(txns);
-        for status in outputs {
-            assert_success!(status);
-        }
+        run_block_in_parts(&mut h.harness, BlockSplit::Whole, txns);
     }
 }
 
@@ -157,6 +164,11 @@ pub fn run_block_in_parts(
             return;
         }
         let (errors, txns): (Vec<_>, Vec<_>) = txn_block.into_iter().unzip();
+        println!(
+            "=== E2E move test: Running block from {} with {} tnx ===",
+            offset,
+            txns.len()
+        );
         let outputs = harness.run_block(txns);
         for (idx, (error, status)) in errors.into_iter().zip(outputs.into_iter()).enumerate() {
             if error > 0 {
@@ -237,32 +249,38 @@ pub struct TestEnvConfig {
     pub block_split: BlockSplit,
 }
 
-#[allow(unused_variables)]
+#[allow(clippy::arc_with_non_send_sync)] // I think this is noise, don't see an issue, and tests run fine
 fn arb_test_env(num_txns: usize) -> BoxedStrategy<TestEnvConfig> {
     prop_oneof![
-        // For execution enabled, use only whole blocks and txn-per-block for block splits, as it block split shouldn't matter there.
+        // For execution disabled, use only whole blocks and txn-per-block for block splits, as it block split shouldn't matter there.
         Just(TestEnvConfig {
-            executor_mode: ExecutorMode::Both,
+            executor_mode: ExecutorMode::BothComparison,
             aggregator_execution_enabled: false,
             block_split: BlockSplit::Whole
         }),
         Just(TestEnvConfig {
-            executor_mode: ExecutorMode::Both,
+            executor_mode: ExecutorMode::BothComparison,
             aggregator_execution_enabled: false,
             block_split: BlockSplit::TxnPerBlock
         }),
-        // For now only test whole blocks with execution enabled.
-        // Just(TestEnvConfig {
-        //     executor_mode: DEFAULT_EXECUTOR_MODE,
-        //     aggregator_execution_enabled: true,
-        //     block_split: BlockSplit::Whole
-        // }),
+        // Sequential execution doesn't have exchanges, so we cannot use BothComparison, nor block split
+        // TODO join once sequential exchange lands.
         Just(TestEnvConfig {
-            executor_mode: ExecutorMode::Both,
+            executor_mode: ExecutorMode::SequentialOnly,
             aggregator_execution_enabled: true,
             block_split: BlockSplit::Whole
         }),
-        // arb_block_split(num_txns).prop_map(|block_split| TestEnvConfig{ use_parallel: true, aggregator_execution_enabled: true, block_split }),
+        arb_block_split(num_txns).prop_map(|block_split| TestEnvConfig {
+            executor_mode: ExecutorMode::ParallelOnly,
+            aggregator_execution_enabled: true,
+            block_split
+        }),
+        // Currently, only this fails, so you can comment out all other tests, and run this one for debugging:
+        // Just(TestEnvConfig {
+        //     executor_mode: ExecutorMode::ParallelOnly,
+        //     aggregator_execution_enabled: true,
+        //     block_split: BlockSplit::TxnPerBlock
+        // }),
     ]
     .boxed()
 }
@@ -283,7 +301,8 @@ fn arb_use_type() -> BoxedStrategy<UseType> {
     prop_oneof![
         Just(UseType::UseResourceType),
         Just(UseType::UseTableType),
-        Just(UseType::UseResourceGroupType),
+        // TODO add back once ResourceGroups are supported
+        // Just(UseType::UseResourceGroupType),
     ]
     .boxed()
 }
@@ -292,37 +311,37 @@ proptest! {
     #![proptest_config(ProptestConfig {
         // Cases are expensive, few cases is enough.
         // We will test a few more comprehensive tests more times, and the rest even fewer.
-        cases: 10,
-        result_cache: prop::test_runner::basic_result_cache,
+        cases: 200,
+        // result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 
     #[test]
     fn test_aggregator_lifetime(test_env in arb_test_env(14), element_type in arb_agg_type(), use_type in arb_use_type()) {
         println!("Testing test_aggregator_lifetime {:?}", test_env);
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 14);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, new(&mut h, &agg_loc, 1500)),
-            (0, add(&mut h, &agg_loc, 400)),
-            (0, materialize(&mut h, &agg_loc)),
-            (0, add(&mut h, &agg_loc, 500)),
-            (0, check(&mut h, &agg_loc, 900)),
-            (0, materialize_and_add(&mut h, &agg_loc, 600)),
-            (0, materialize_and_sub(&mut h, &agg_loc, 600)),
-            (0, check(&mut h, &agg_loc, 900)),
-            (0, sub_add(&mut h, &agg_loc, 200, 300)),
-            (0, check(&mut h, &agg_loc, 1000)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, h.new(&agg_loc, 1500)),
+            (0, h.add(&agg_loc, 400)), // 400
+            (0, h.materialize(&agg_loc)),
+            (0, h.add(&agg_loc, 500)), // 900
+            (0, h.check(&agg_loc, 900)),
+            (0, h.materialize_and_add(&agg_loc, 600)), // 1500
+            (0, h.materialize_and_sub(&agg_loc, 600)), // 900
+            (0, h.check(&agg_loc, 900)),
+            (0, h.sub_add(&agg_loc, 200, 300)), // 1000
+            (0, h.check(&agg_loc, 1000)),
             // These 2 transactions fail, and should have no side-effects.
-            (0x02_0001, add_and_materialize(&mut h, &agg_loc, 501)),
-            (0x02_0002, sub_and_materialize(&mut h, &agg_loc, 1001)),
-            (0, check(&mut h, &agg_loc, 1000)),
+            (0x02_0001, h.add_and_materialize(&agg_loc, 501)),
+            (0x02_0002, h.sub_and_materialize(&agg_loc, 1001)),
+            (0, h.check(&agg_loc, 1000)),
         ];
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -336,53 +355,53 @@ proptest! {
         is_2_collocated in any::<bool>(),
         is_3_collocated in any::<bool>(),
     ) {
-        println!("Testing test_aggregator_lifetime {:?}", test_env);
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
-        let acc_2 = h.new_account_with_key_pair();
-        let acc_3 = h.new_account_with_key_pair();
+        println!("Testing test_multiple_aggregators_and_collocation {:?}", test_env);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 24);
+        let acc_2 = h.harness.new_account_with_key_pair();
+        let acc_3 = h.harness.new_account_with_key_pair();
 
         let mut idx_1 = 0;
-        let agg_1_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_1_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
         let agg_2_loc = {
-            let (cur_acc, idx_2) = if is_2_collocated { idx_1 += 1; (&acc, idx_1) } else { (&acc_2, 0)};
-            AggLocation::new(cur_acc, element_type, use_type, idx_2)
+            let (cur_acc, idx_2) = if is_2_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_2.address(), 0)};
+            AggregatorLocation::new(*cur_acc, element_type, use_type, idx_2)
         };
         let agg_3_loc = {
-            let (cur_acc, idx_3) = if is_3_collocated { idx_1 += 1; (&acc, idx_1) } else { (&acc_3, 0)};
-            AggLocation::new(cur_acc, element_type, use_type, idx_3)
+            let (cur_acc, idx_3) = if is_3_collocated { idx_1 += 1; (h.account.address(), idx_1) } else { (acc_3.address(), 0)};
+            AggregatorLocation::new(*cur_acc, element_type, use_type, idx_3)
         };
         println!("agg_1_loc: {:?}", agg_1_loc);
         println!("agg_2_loc: {:?}", agg_2_loc);
         println!("agg_3_loc: {:?}", agg_3_loc);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, init(&mut h, &acc_2, use_type, element_type, true)),
-            (0, init(&mut h, &acc_3, use_type, element_type, true)),
-            (0, new_add(&mut h, &agg_1_loc, 10, 5)),
-            (0, new_add(&mut h, &agg_2_loc, 10, 5)),
-            (0, new_add(&mut h, &agg_3_loc, 10, 5)),  // 5, 5, 5
-            (0, add_2(&mut h, &agg_1_loc, &agg_2_loc, 1, 1)), // 6, 6, 5
-            (0, add_2(&mut h, &agg_1_loc, &agg_3_loc, 1, 1)), // 7, 6, 6
-            (0x02_0001, add(&mut h, &agg_1_loc, 5)), // X
-            (0, add_sub(&mut h, &agg_1_loc, 3, 3)), // 7, 6, 6
-            (0x02_0001, add_2(&mut h, &agg_1_loc, &agg_2_loc, 3, 5)), // X
-            (0, add_2(&mut h, &agg_1_loc, &agg_2_loc, 3, 1)), // 10, 7, 6
-            (0x02_0001, add_sub(&mut h, &agg_1_loc, 3, 3)), // X
-            (0, sub(&mut h, &agg_1_loc, 3)), // 7, 7, 6
-            (0, add_2(&mut h, &agg_2_loc, &agg_3_loc, 2, 2)), // 7, 9, 8
-            (0, check(&mut h, &agg_2_loc, 9)),
-            (0x02_0001, add_2(&mut h, &agg_1_loc, &agg_2_loc, 1, 2)), // X
-            (0, add_2(&mut h, &agg_2_loc, &agg_3_loc, 1, 2)), // 7, 10, 10
-            (0x02_0001, add(&mut h, &agg_2_loc, 1)), // X
-            (0x02_0001, add_and_materialize(&mut h, &agg_3_loc, 1)), // X
-            (0x02_0001, add_2(&mut h, &agg_1_loc, &agg_2_loc, 1, 1)), // X
-            (0, check(&mut h, &agg_1_loc, 7)),
-            (0, check(&mut h, &agg_2_loc, 10)),
-            (0, check(&mut h, &agg_3_loc, 10)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, init(&mut h.harness, &acc_2, use_type, element_type, true)),
+            (0, init(&mut h.harness, &acc_3, use_type, element_type, true)),
+            (0, h.new_add(&agg_1_loc, 10, 5)),
+            (0, h.new_add(&agg_2_loc, 10, 5)),
+            (0, h.new_add(&agg_3_loc, 10, 5)),  // 5, 5, 5
+            (0, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // 6, 6, 5
+            (0, h.add_2(&agg_1_loc, &agg_3_loc, 1, 1)), // 7, 6, 6
+            (0x02_0001, h.add(&agg_1_loc, 5)), // X
+            (0, h.add_sub(&agg_1_loc, 3, 3)), // 7, 6, 6
+            (0x02_0001, h.add_2(&agg_1_loc, &agg_2_loc, 3, 5)), // X
+            (0, h.add_2(&agg_1_loc, &agg_2_loc, 3, 1)), // 10, 7, 6
+            (0x02_0001, h.add_sub(&agg_1_loc, 3, 3)), // X
+            (0, h.sub(&agg_1_loc, 3)), // 7, 7, 6
+            (0, h.add_2(&agg_2_loc, &agg_3_loc, 2, 2)), // 7, 9, 8
+            (0, h.check(&agg_2_loc, 9)),
+            (0x02_0001, h.add_2(&agg_1_loc, &agg_2_loc, 1, 2)), // X
+            (0, h.add_2(&agg_2_loc, &agg_3_loc, 1, 2)), // 7, 10, 10
+            (0x02_0001, h.add(&agg_2_loc, 1)), // X
+            (0x02_0001, h.add_and_materialize(&agg_3_loc, 1)), // X
+            (0x02_0001, h.add_2(&agg_1_loc, &agg_2_loc, 1, 1)), // X
+            (0, h.check(&agg_1_loc, 7)),
+            (0, h.check(&agg_2_loc, 10)),
+            (0, h.check(&agg_3_loc, 10)),
         ];
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -392,8 +411,8 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig {
         // Cases are expensive, few cases is enough for these
-        cases: 5,
-        result_cache: prop::test_runner::basic_result_cache,
+        cases: 200,
+        // result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 
@@ -403,19 +422,19 @@ proptest! {
         let element_type = ElementType::U64;
         let use_type = UseType::UseResourceType;
 
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 4);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, new(&mut h, &agg_loc, 600)),
-            (0, add(&mut h, &agg_loc, 400)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, h.new(&agg_loc, 600)),
+            (0, h.add(&agg_loc, 400)),
             // Value dropped below zero - abort with EAGGREGATOR_UNDERFLOW.
-            (0x02_0002, sub(&mut h, &agg_loc, 500))
+            (0x02_0002, h.sub(&agg_loc, 500))
         ];
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -427,19 +446,19 @@ proptest! {
         let element_type = ElementType::U64;
         let use_type = UseType::UseResourceType;
 
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 3);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, new(&mut h, &agg_loc, 600)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, h.new(&agg_loc, 600)),
             // Underflow on materialized value leads to abort with EAGGREGATOR_UNDERFLOW.
-            (0x02_0002, materialize_and_sub(&mut h, &agg_loc, 400)),
+            (0x02_0002, h.materialize_and_sub(&agg_loc, 400)),
         ];
 
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -451,19 +470,19 @@ proptest! {
         let element_type = ElementType::U64;
         let use_type = UseType::UseResourceType;
 
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 3);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, new_add(&mut h, &agg_loc, 600, 400)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, h.new_add(&agg_loc, 600, 400)),
             // Limit exceeded - abort with EAGGREGATOR_OVERFLOW.
-            (0x02_0001, add(&mut h, &agg_loc, 201))
+            (0x02_0001, h.add(&agg_loc, 201))
         ];
 
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -475,19 +494,19 @@ proptest! {
         let element_type = ElementType::U64;
         let use_type = UseType::UseResourceType;
 
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h= setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 3);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, new(&mut h, &agg_loc, 399)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, h.new(&agg_loc, 399)),
             // Overflow on materialized value leads to abort with EAGGREGATOR_OVERFLOW.
-            (0x02_0001, materialize_and_add(&mut h, &agg_loc, 400)),
+            (0x02_0001, h.materialize_and_add(&agg_loc, 400)),
         ];
 
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );
@@ -499,27 +518,27 @@ proptest! {
         let element_type = ElementType::U64;
         let use_type = UseType::UseResourceType;
 
-        let (mut h, acc) = setup(test_env.executor_mode, test_env.aggregator_execution_enabled);
+        let mut h = setup(test_env.executor_mode, test_env.aggregator_execution_enabled, 9);
 
-        let agg_loc = AggLocation::new(&acc, element_type, use_type, 0);
-        let snap_loc = AggLocation::new(&acc, element_type, use_type, 0);
-        let derived_snap_loc = AggLocation::new(&acc, ElementType::String, use_type, 0);
+        let agg_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+        let snap_loc = AggregatorLocation::new(*h.account.address(), element_type, use_type, 0);
+        let derived_snap_loc = AggregatorLocation::new(*h.account.address(), ElementType::String, use_type, 0);
 
         let txns = vec![
-            (0, init(&mut h, &acc, use_type, element_type, true)),
-            (0, init(&mut h, &acc, use_type, element_type, false)),
-            (0, init(&mut h, &acc, use_type, ElementType::String, false)),
-            (0, new_add(&mut h, &agg_loc, 400, 100)),
-            (0, snapshot(&mut h, &agg_loc, &snap_loc)),
-            (0, check_snapshot(&mut h, &snap_loc, 100)),
-            (0, read_snapshot(&mut h, &agg_loc)),
-            (0, add_and_read_snapshot_u128(&mut h, &agg_loc, 100)),
-            (0, concat(&mut h, &snap_loc, &derived_snap_loc, "12", "13")),
-            (0, check_snapshot(&mut h, &derived_snap_loc, 1210013)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, true)),
+            (0, init(&mut h.harness, &h.account, use_type, element_type, false)),
+            (0, init(&mut h.harness, &h.account, use_type, ElementType::String, false)),
+            (0, h.new_add(&agg_loc, 400, 100)),
+            (0, h.snapshot(&agg_loc, &snap_loc)),
+            (0, h.check_snapshot(&snap_loc, 100)),
+            (0, h.read_snapshot(&agg_loc)),
+            (0, h.add_and_read_snapshot_u128(&agg_loc, 100)),
+            (0, h.concat(&snap_loc, &derived_snap_loc, "12", "13")),
+            (0, h.check_snapshot(&derived_snap_loc, 1210013)),
         ];
 
         run_block_in_parts(
-            &mut h,
+            &mut h.harness,
             test_env.block_split,
             txns,
         );

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -96,6 +96,14 @@ const POSTFIX: &str = "_should_error";
 /// Maps block number N to the index of the input and output transactions
 pub type TraceSeqMapping = (usize, Vec<usize>, Vec<usize>);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutorMode {
+    SequentialOnly,
+    ParallelOnly,
+    // Runs sequential, then parallel, and compares outputs.
+    BothComparison,
+}
+
 /// Provides an environment to run a VM instance.
 ///
 /// This struct is a mock in-memory implementation of the Aptos executor.
@@ -108,9 +116,10 @@ pub struct FakeExecutor {
     trace_dir: Option<PathBuf>,
     rng: KeyGen,
     /// If set, determines whether or not to execute a comparison test with the parallel
-    /// block executor. If not set, environment variable E2E_PARALLEL_EXEC must be set
-    /// s.t. the comparison test is executed.
-    no_parallel_exec: Option<bool>,
+    /// block executor.
+    /// If not set, environment variable E2E_PARALLEL_EXEC must be set
+    /// s.t. the comparison test is executed (BothComparison).
+    executor_mode: Option<ExecutorMode>,
     features: Features,
     chain_id: u8,
 }
@@ -137,7 +146,7 @@ impl FakeExecutor {
             executed_output: None,
             trace_dir: None,
             rng: KeyGen::from_seed(RNG_SEED),
-            no_parallel_exec: None,
+            executor_mode: None,
             features: Features::default(),
             chain_id: chain_id.id(),
         };
@@ -147,18 +156,21 @@ impl FakeExecutor {
         executor
     }
 
+    pub fn set_executor_mode(mut self, mode: ExecutorMode) -> Self {
+        self.executor_mode = Some(mode);
+        self
+    }
+
     /// Configure this executor to not use parallel execution. By default, parallel execution is
     /// enabled if E2E_PARALLEL_EXEC is set. This overrides the default.
-    pub fn set_not_parallel(mut self) -> Self {
-        self.no_parallel_exec = Some(true);
-        self
+    pub fn set_not_parallel(self) -> Self {
+        self.set_executor_mode(ExecutorMode::SequentialOnly)
     }
 
     /// Configure this executor to use parallel execution. By default, parallel execution is
     /// enabled if E2E_PARALLEL_EXEC is set. This overrides the default.
-    pub fn set_parallel(mut self) -> Self {
-        self.no_parallel_exec = Some(false);
-        self
+    pub fn set_parallel(self) -> Self {
+        self.set_executor_mode(ExecutorMode::BothComparison)
     }
 
     /// Creates an executor from the genesis file GENESIS_FILE_LOCATION
@@ -211,7 +223,7 @@ impl FakeExecutor {
             executed_output: None,
             trace_dir: None,
             rng: KeyGen::from_seed(RNG_SEED),
-            no_parallel_exec: None,
+            executor_mode: None,
             features: Features::default(),
             chain_id: ChainId::test().id(),
         }
@@ -481,20 +493,37 @@ impl FakeExecutor {
 
         let sig_verified_block = into_signature_verified_block(txn_block);
 
-        let output = AptosVM::execute_block(&sig_verified_block, &self.data_store, None);
+        let mode = self.executor_mode.unwrap_or_else(|| {
+            if env::var(ENV_ENABLE_PARALLEL).is_ok() {
+                ExecutorMode::BothComparison
+            } else {
+                ExecutorMode::SequentialOnly
+            }
+        });
 
-        let no_parallel = if let Some(no_parallel) = self.no_parallel_exec {
-            no_parallel
+        let sequential_output = if mode != ExecutorMode::ParallelOnly {
+            Some(AptosVM::execute_block(
+                &sig_verified_block,
+                &self.data_store,
+                None,
+            ))
         } else {
-            env::var(ENV_ENABLE_PARALLEL).is_err()
+            None
         };
 
-        if !no_parallel {
-            let parallel_output = self.execute_transaction_block_parallel(&sig_verified_block);
+        let parallel_output = if mode != ExecutorMode::SequentialOnly {
+            Some(self.execute_transaction_block_parallel(&sig_verified_block))
+        } else {
+            None
+        };
+
+        if mode == ExecutorMode::BothComparison {
+            let sequential_output = sequential_output.as_ref().unwrap();
+            let parallel_output = parallel_output.as_ref().unwrap();
 
             // make more granular comparison, to be able to understand test failures better
-            if output.is_ok() && parallel_output.is_ok() {
-                let seq_txn_output = output.as_ref().unwrap();
+            if sequential_output.is_ok() && parallel_output.is_ok() {
+                let seq_txn_output = sequential_output.as_ref().unwrap();
                 let par_txn_output = parallel_output.as_ref().unwrap();
                 assert_eq!(seq_txn_output.len(), par_txn_output.len());
                 for (idx, (seq_output, par_output)) in
@@ -507,9 +536,11 @@ impl FakeExecutor {
                     );
                 }
             } else {
-                assert_eq!(output, parallel_output);
+                assert_eq!(sequential_output, parallel_output);
             }
         }
+
+        let output = sequential_output.or(parallel_output).unwrap();
 
         if let Some(logger) = &self.executed_output {
             logger.log(format!("{:#?}\n", output).as_str());


### PR DESCRIPTION
Previously we were only doing transactions from single account, so if they were executed speculatively, they would fail on SEQUENCE_NUMBER_TOO_NEW. modifying to use different account for each transaction, so all can happen in parallel.

adding all modes that currently work

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
