### PR TITLE
[CLI] Correctly persist postgres data between restarts

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Fixed postgres data persistence between restarts when using `aptos node run-local-testnet --with-indexer-api`.
 
 ## [2.2.0] - 2023/10/11
 ### Added

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -8,7 +8,7 @@ use super::{
     RunLocalTestnet,
 };
 use crate::node::local_testnet::utils::{
-    get_docker, setup_docker_logging, KillContainerShutdownStep,
+    get_docker, setup_docker_logging, StopContainerShutdownStep,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -205,14 +205,14 @@ impl ServiceManager for IndexerApiManager {
 
         let id = docker.create_container(options, config).await?.id;
 
-        info!("Created container with this ID: {}", id);
+        info!("Created container for indexer API with this ID: {}", id);
 
         docker
             .start_container(&id, None::<StartContainerOptions<&str>>)
             .await
             .context("Failed to start indexer API container")?;
 
-        info!("Started container {}", id);
+        info!("Started indexer API container {}", id);
 
         // Wait for the container to stop (which it shouldn't).
         let wait = docker
@@ -262,9 +262,9 @@ impl ServiceManager for IndexerApiManager {
     fn get_shutdown_steps(&self) -> Vec<Box<dyn ShutdownStep>> {
         // Unfortunately the Hasura container does not shut down when the CLI does and
         // there doesn't seem to be a good way to make it do so. To work around this,
-        // we register a step that will delete the container on shutdown.
+        // we register a step that will stop the container on shutdown.
         // Read more here: https://stackoverflow.com/q/77171786/3846032.
-        vec![Box::new(KillContainerShutdownStep::new(
+        vec![Box::new(StopContainerShutdownStep::new(
             INDEXER_API_CONTAINER_NAME,
         ))]
     }

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -116,7 +116,11 @@ impl ProcessorManager {
             bail!("Must specify at least one processor to run");
         }
         let mut managers = Vec::new();
-        let mut health_check_port = 43234;
+        // We use this port as the start of the range of ports we use for the health
+        // check servers in each processor because it is not known to be used by any
+        // other service and it is outside of the ephemeral or private port range used
+        // by any OS.
+        let mut health_check_port = 23480;
         for processor_name in &args.processor_args.processors {
             managers.push(Self::new(
                 processor_name,


### PR DESCRIPTION
### Description
The previous code was not correctly persisting postgres data between restarts without `--force-restart` when using `--with-indexer-api`. We fix this by storing the data through a bindmount in the host system, so the container lifetime doesn't matter. This simplifies `--force-restart` too, the DB state gets wiped the same as all the other state. This way we can treat the postgres container as no more special than the Hasura container, which we kill mercilessly since it is has no persistent state.

### Test Plan

Run a fresh local testnet:
```
cargo run -p aptos -- node run-local-testnet --with-indexer-api --force-restart --assume-yes
```

Wait for it to start up happily. Run the local testnet again without wiping anything:
```
cargo run -p aptos -- node run-local-testnet --with-indexer-api
```

Wait for it to start up happily. Stop it. Repeat a few times and see that it always starts up happily and picks up where it left off re processing.