### PR TITLE
[Adapter][Executor] New resource group integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-infallible",
  "aptos-types",
+ "aptos-vm-types",
  "bcs 0.1.4",
  "bytes",
  "claims",

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -91,6 +91,7 @@ pub enum FeatureFlag {
     LimitMaxIdentifierLength,
     OperatorBeneficiaryChange,
     VMBinaryFormatV7,
+    ResourceGroupsChargeAsSizeSum,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -236,6 +237,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::ConcurrentAssets => AptosFeatureFlag::CONCURRENT_ASSETS,
             FeatureFlag::LimitMaxIdentifierLength => AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
             FeatureFlag::OperatorBeneficiaryChange => AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
+            FeatureFlag::ResourceGroupsChargeAsSizeSum => {
+                AptosFeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM
+            },
         }
     }
 }
@@ -304,6 +308,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::CONCURRENT_ASSETS => FeatureFlag::ConcurrentAssets,
             AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH => FeatureFlag::LimitMaxIdentifierLength,
             AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE => FeatureFlag::OperatorBeneficiaryChange,
+            AptosFeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM => {
+                FeatureFlag::ResourceGroupsChargeAsSizeSum
+            },
         }
     }
 }

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -333,7 +333,7 @@ impl VMChangeSet {
         &self.module_write_set
     }
 
-    // Called by `try_into_transaction_output_with_materialized_writes` only.
+    // Called by `into_transaction_output_with_materialized_writes` only.
     pub(crate) fn extend_aggregator_v1_write_set(
         &mut self,
         additional_aggregator_writes: impl Iterator<Item = (StateKey, WriteOp)>,
@@ -342,12 +342,17 @@ impl VMChangeSet {
             .extend(additional_aggregator_writes)
     }
 
+    // Called by `into_transaction_output_with_materialized_writes` only.
     pub(crate) fn extend_resource_write_set(
         &mut self,
         patched_resource_writes: impl Iterator<Item = (StateKey, WriteOp)>,
+        finalized_group_writes: impl Iterator<Item = (StateKey, WriteOp)>,
     ) {
-        self.resource_write_set
-            .extend(patched_resource_writes.map(|(k, v)| (k, (v, None))))
+        self.resource_write_set.extend(
+            patched_resource_writes
+                .chain(finalized_group_writes)
+                .map(|(k, v)| (k, (v, None))),
+        );
     }
 
     /// The events are set to the input events.

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -65,7 +65,7 @@ pub trait TResourceGroupView {
 
     /// Some resolvers might not be capable of the optimization, and should return false.
     /// Others might return based on the config or the run paramaters.
-    fn is_resource_group_split_in_change_set_enabled(&self) -> bool {
+    fn is_resource_group_split_in_change_set_capable(&self) -> bool {
         false
     }
 

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -63,6 +63,12 @@ pub trait TResourceGroupView {
     type ResourceTag;
     type Layout;
 
+    /// Some resolvers might not be capable of the optimization, and should return false.
+    /// Others might return based on the config or the run paramaters.
+    fn is_resource_group_split_in_change_set_enabled(&self) -> bool {
+        false
+    }
+
     /// The size of the resource group, based on the sizes of the latest entries at observed
     /// tags. During parallel execution, this is an estimated value that will get validated,
     /// but as long as it is assumed correct, the transaction can deterministically derive

--- a/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
@@ -92,8 +92,10 @@ impl<'r> ResourceGroupAdapter<'r> {
             //     In this case, disabled will lead to a different gas behavior,
             //     but gas is not relevant for those contexts.
             resource_group_charge_as_size_sum_enabled
-                && maybe_resource_group_view
-                    .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
+            // TODO[agg_v2][fix] : Gate based on view.is_resource_group_split_in_change_set_capable(),
+            // when that gets connected.
+            // && maybe_resource_group_view
+            //     .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
         );
 
         Self {

--- a/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
@@ -91,11 +91,10 @@ impl<'r> ResourceGroupAdapter<'r> {
             //     (outside of BlockExecutor) i.e. unit tests, view functions, etc.
             //     In this case, disabled will lead to a different gas behavior,
             //     but gas is not relevant for those contexts.
-            resource_group_charge_as_size_sum_enabled
-            // TODO[agg_v2][fix] : Gate based on view.is_resource_group_split_in_change_set_capable(),
-            // when that gets connected.
-            // && maybe_resource_group_view
-            //     .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
+            resource_group_charge_as_size_sum_enabled, // TODO[agg_v2][fix] : Gate based on view.is_resource_group_split_in_change_set_capable(),
+                                                       // when that gets connected.
+                                                       // && maybe_resource_group_view
+                                                       //     .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
         );
 
         Self {

--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -45,13 +45,18 @@ fn test_ok_output_equality_no_deltas() {
     // Different ways to materialize deltas:
     //   1. `try_materialize` preserves the type and returns a result.
     //   2. `try_into_transaction_output` changes the type and returns a result.
-    //   3. `into_transaction_output_with_materialized_deltas` changes the type and
-    //       simply merges materialized deltas.
+    //   3. `into_transaction_output_with_materialized_write_set` changes the type and
+    //       simply merges writes for materialized deltas & combined groups.
     let materialized_vm_output = assert_ok!(vm_output.clone().try_materialize(&state_view));
     let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
     let txn_output_2 = vm_output
         .clone()
-        .into_transaction_output_with_materialized_deltas(vec![]);
+        .into_transaction_output_with_materialized_write_set(
+            vec![],
+            BTreeMap::new(),
+            vec![],
+            vec![],
+        );
 
     // Because there are no deltas, we should not see any difference in write sets and
     // also all calls must succeed.
@@ -79,7 +84,12 @@ fn test_ok_output_equality_with_deltas() {
     let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
     let txn_output_2 = vm_output
         .clone()
-        .into_transaction_output_with_materialized_deltas(vec![mock_modify("3", 400)]);
+        .into_transaction_output_with_materialized_write_set(
+            vec![mock_modify("3", 400)],
+            BTreeMap::new(),
+            vec![],
+            vec![],
+        );
 
     let expected_aggregator_write_set =
         BTreeMap::from([mock_modify("2", 2), mock_modify("3", 400)]);

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -60,6 +60,8 @@ impl AptosTransactionOutput {
     fn take_output(mut self) -> TransactionOutput {
         match self.committed_output.take() {
             Some(output) => output,
+            // TODO: revisit whether we should always get it via committed, or o.w. create a
+            // dedicated API without creating empty data structures.
             None => self
                 .vm_output
                 .lock()
@@ -92,7 +94,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get writes")
+            .expect("Output must be set to get resource group writes")
             .change_set()
             .resource_group_write_set()
             .iter()
@@ -116,7 +118,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get writes")
+            .expect("Output must be set to get metadata ops")
             .change_set()
             .resource_group_write_set()
             .iter()
@@ -129,7 +131,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get writes")
+            .expect("Output must be set to get resource writes")
             .change_set()
             .resource_write_set()
             .clone()
@@ -140,7 +142,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get writes")
+            .expect("Output must be set to get module writes")
             .change_set()
             .module_write_set()
             .clone()
@@ -151,7 +153,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get writes")
+            .expect("Output must be set to get aggregator V1 writes")
             .change_set()
             .aggregator_v1_write_set()
             .clone()
@@ -162,7 +164,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get deltas")
+            .expect("Output must be set to get deltas")
             .change_set()
             .aggregator_v1_delta_set()
             .clone()
@@ -173,7 +175,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get aggregator change set")
+            .expect("Output must be set to get aggregator change set")
             .change_set()
             .delayed_field_change_set()
             .clone()
@@ -184,7 +186,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         self.vm_output
             .lock()
             .as_ref()
-            .expect("Output to be set to get events")
+            .expect("Output must be set to get events")
             .change_set()
             .events()
             .to_vec()

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -31,14 +31,16 @@ use aptos_types::{
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::output::VMOutput;
-use move_core_types::{value::MoveTypeLayout, vm_status::VMStatus};
+use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
 use std::{collections::BTreeMap, sync::Arc};
 
-// Wrapper to avoid orphan rule
+/// Output type wrapper used by block executor. VM output is stored first, then
+/// transformed into TransactionOutput type that is returned.
 #[derive(Debug)]
 pub struct AptosTransactionOutput {
+    // Note: should these mutexes be changed to ExplicitSyncSwapper?
     vm_output: Mutex<Option<VMOutput>>,
     committed_output: OnceCell<TransactionOutput>,
 }
@@ -63,7 +65,12 @@ impl AptosTransactionOutput {
                 .lock()
                 .take()
                 .expect("Output must be set")
-                .into_transaction_output_with_materialized_deltas(vec![]),
+                .into_transaction_output_with_materialized_write_set(
+                    vec![],
+                    BTreeMap::new(),
+                    vec![],
+                    vec![],
+                ),
         }
     }
 }
@@ -71,15 +78,53 @@ impl AptosTransactionOutput {
 impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     type Txn = SignatureVerifiedTransaction;
 
-    /// Execution output for transactions that comes after SkipRest signal.
+    /// Execution output for transactions that comes after SkipRest signal or when there was a
+    /// problem creating the output (e.g. group serialization issue).
     fn skip_output() -> Self {
         Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
     }
 
     // TODO: get rid of the cloning data-structures in the following APIs.
 
-    /// Should never be called after incorporate_delta_writes, as it
+    /// Should never be called after incorporate_additional_writes, as it
     /// will consume vm_output to prepare an output with deltas.
+    fn resource_group_write_set(&self) -> Vec<(StateKey, WriteOp, BTreeMap<StructTag, WriteOp>)> {
+        self.vm_output
+            .lock()
+            .as_ref()
+            .expect("Output to be set to get writes")
+            .change_set()
+            .resource_group_write_set()
+            .iter()
+            .map(|(group_key, group_write)| {
+                (
+                    group_key.clone(),
+                    group_write.metadata_op().clone(),
+                    // TODO: propagate layouts.
+                    group_write
+                        .inner_ops()
+                        .iter()
+                        .map(|(tag, (op, _maybe_layout))| (tag.clone(), op.clone()))
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// More efficient implementation to avoid unnecessarily cloning inner_ops.
+    fn resource_group_metadata_ops(&self) -> Vec<(StateKey, WriteOp)> {
+        self.vm_output
+            .lock()
+            .as_ref()
+            .expect("Output to be set to get writes")
+            .change_set()
+            .resource_group_write_set()
+            .iter()
+            .map(|(group_key, group_write)| (group_key.clone(), group_write.metadata_op().clone()))
+            .collect()
+    }
+
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn resource_write_set(&self) -> BTreeMap<StateKey, (WriteOp, Option<Arc<MoveTypeLayout>>)> {
         self.vm_output
             .lock()
@@ -90,8 +135,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    /// Should never be called after incorporate_delta_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn module_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
@@ -102,8 +146,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    /// Should never be called after incorporate_delta_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn aggregator_v1_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
@@ -114,8 +157,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    /// Should never be called after incorporate_delta_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn aggregator_v1_delta_set(&self) -> BTreeMap<StateKey, DeltaOp> {
         self.vm_output
             .lock()
@@ -126,8 +168,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    /// Should never be called after incorporate_delta_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {
         self.vm_output
             .lock()
@@ -138,8 +179,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    /// Should never be called after incorporate_delta_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
         self.vm_output
             .lock()
@@ -158,6 +198,10 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             <Self::Txn as BlockExecutableTransaction>::Value,
         >,
         patched_events: Vec<<Self::Txn as BlockExecutableTransaction>::Event>,
+        combined_groups: Vec<(
+            <Self::Txn as BlockExecutableTransaction>::Key,
+            <Self::Txn as BlockExecutableTransaction>::Value,
+        )>,
     ) {
         assert!(
             self.committed_output
@@ -169,7 +213,8 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
                         .into_transaction_output_with_materialized_write_set(
                             aggregator_v1_writes,
                             patched_resource_write_set,
-                            patched_events
+                            patched_events,
+                            combined_groups,
                         ),
                 )
                 .is_ok(),

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -97,6 +97,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
             maybe_resource_group_view,
             executor_view,
             gas_feature_version,
+            features.is_resource_group_charge_as_size_sum_enabled(),
         );
 
         Self::new(
@@ -334,7 +335,12 @@ impl<S: StateView> AsMoveResolver<S> for S {
         let features = Features::fetch_config(&config_view).unwrap_or_default();
         let max_binary_version =
             get_max_binary_format_version(&features, Some(gas_feature_version));
-        let resource_group_adapter = ResourceGroupAdapter::new(None, self, gas_feature_version);
+        let resource_group_adapter = ResourceGroupAdapter::new(
+            None,
+            self,
+            gas_feature_version,
+            features.is_resource_group_charge_as_size_sum_enabled(),
+        );
         let max_identifier_size = get_max_identifier_size(&features);
         StorageAdapter::new(
             self,
@@ -405,12 +411,19 @@ pub(crate) mod tests {
         state_view: &S,
         group_size_kind: GroupSizeKind,
     ) -> StorageAdapter<S> {
-        let gas_feature_version = match group_size_kind {
-            GroupSizeKind::AsSum => 12,
-            GroupSizeKind::AsBlob => 10,
-            GroupSizeKind::None => 1,
+        let (gas_feature_version, resource_group_charge_as_size_sum_enabled) = match group_size_kind
+        {
+            GroupSizeKind::AsSum => (12, true),
+            GroupSizeKind::AsBlob => (10, false),
+            GroupSizeKind::None => (1, false),
         };
-        let group_adapter = ResourceGroupAdapter::new(None, state_view, gas_feature_version);
+
+        let group_adapter = ResourceGroupAdapter::new(
+            None,
+            state_view,
+            gas_feature_version,
+            resource_group_charge_as_size_sum_enabled,
+        );
         StorageAdapter::new(state_view, 0, 0, group_adapter)
     }
 }

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -17,13 +17,15 @@ pub enum IntentionalFallbackToSequential {
     // on writes. WriteSetPayload::Direct cannot be processed to do so, as we get outputs directly.
     // We communicate to the executor to retry with capability disabled.
     DirectWriteSetTransaction,
+    /// We defensively check certain resource group related invariant violations.
+    ResourceGroupError,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error<E> {
     FallbackToSequential(PanicOr<IntentionalFallbackToSequential>),
     /// Execution of a thread yields a non-recoverable error, such error will be propagated back to
-    /// the caller.
+    /// the caller (leading to the block execution getting aborted). TODO: revisit name (UserError).
     UserError(E),
 }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -14,7 +14,7 @@ use crate::{
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
-    txn_last_input_output::TxnLastInputOutput,
+    txn_last_input_output::{KeyKind, TxnLastInputOutput},
     view::{LatestView, ParallelState, SequentialState, ViewState},
 };
 use aptos_aggregator::{
@@ -122,7 +122,33 @@ where
         // For tracking whether the recent execution wrote outside of the previous write/delta set.
         let mut updates_outside = false;
         let mut apply_updates = |output: &E::Output| -> ::std::result::Result<(), PanicError> {
-            // First, apply writes.
+            for (group_key, group_metadata_op, group_ops) in
+                output.resource_group_write_set().into_iter()
+            {
+                if prev_modified_keys.remove(&group_key).is_none() {
+                    // Previously no write to the group at all.
+                    updates_outside = true;
+                }
+
+                versioned_cache.data().write(
+                    group_key.clone(),
+                    idx_to_execute,
+                    incarnation,
+                    // Group metadata op needs no layout (individual resources in groups do).
+                    (group_metadata_op, None),
+                );
+                if versioned_cache.group_data().write(
+                    group_key,
+                    idx_to_execute,
+                    incarnation,
+                    group_ops.into_iter(),
+                ) {
+                    // Should return true if writes outside.
+                    updates_outside = true;
+                }
+            }
+
+            // Then, process resource & aggregator_v1 & module writes.
             for (k, v) in output.resource_write_set().into_iter().chain(
                 output
                     .aggregator_v1_write_set()
@@ -235,12 +261,16 @@ where
         };
 
         // Remove entries from previous write/delta set that were not overwritten.
-        for (k, is_module) in prev_modified_keys {
-            if is_module {
-                versioned_cache.modules().remove(&k, idx_to_execute);
-            } else {
-                versioned_cache.data().remove(&k, idx_to_execute);
-            }
+        for (k, kind) in prev_modified_keys {
+            use KeyKind::*;
+            match kind {
+                Resource => versioned_cache.data().remove(&k, idx_to_execute),
+                Module => versioned_cache.modules().remove(&k, idx_to_execute),
+                Group => {
+                    versioned_cache.data().remove(&k, idx_to_execute);
+                    versioned_cache.group_data().remove(&k, idx_to_execute);
+                },
+            };
         }
 
         for id in prev_modified_delayed_fields {
@@ -297,12 +327,16 @@ where
 
         // Not valid and successfully aborted, mark the latest write/delta sets as estimates.
         if let Some(keys) = last_input_output.modified_keys(txn_idx) {
-            for (k, is_module_path) in keys {
-                if is_module_path {
-                    versioned_cache.modules().mark_estimate(&k, txn_idx);
-                } else {
-                    versioned_cache.data().mark_estimate(&k, txn_idx);
-                }
+            for (k, kind) in keys {
+                use KeyKind::*;
+                match kind {
+                    Resource => versioned_cache.data().mark_estimate(&k, txn_idx),
+                    Module => versioned_cache.modules().mark_estimate(&k, txn_idx),
+                    Group => {
+                        versioned_cache.data().mark_estimate(&k, txn_idx);
+                        versioned_cache.group_data().mark_estimate(&k, txn_idx);
+                    },
+                };
             }
         }
 
@@ -370,6 +404,14 @@ where
         Ok(execution_still_valid)
     }
 
+    /// This method may be executed by different threads / workers, but is guaranteed to be executed
+    /// non-concurrently by the scheduling in parallel executor. This allows to perform light logic
+    /// related to committing a transaction in a simple way and without excessive synchronization
+    /// overhead. On the other hand, materialization that happens after commit (& after this method)
+    /// is concurrent and deals with logic such as patching delayed fields / resource groups
+    /// in outputs, which is heavier (due to serialization / deserialization, copies, etc). Moreover,
+    /// since prepare_and_queue_commit_ready_txns takes care of synchronization in the flag-combining
+    /// way, the materialization can be almost embarassingly parallelizable.
     fn prepare_and_queue_commit_ready_txns(
         &self,
         maybe_block_gas_limit: Option<u64>,
@@ -388,7 +430,7 @@ where
         block: &[T],
     ) -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
         let mut shared_commit_state_guard = shared_commit_state.acquire();
-        let (accumulated_fee_statement, txn_fee_statements, maybe_error) =
+        let (accumulated_fee_statement, txn_fee_statements, shared_maybe_error) =
             shared_commit_state_guard.dereference_mut();
 
         let update_counters_and_log_info =
@@ -481,6 +523,45 @@ where
                 }
             }
 
+            let group_metadata_ops = last_input_output.group_metadata_ops(txn_idx);
+            let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
+            let mut maybe_err = None;
+            for (group_key, metadata_op) in group_metadata_ops.into_iter() {
+                // finalize_group copies Arc of values and the Tags (TODO: optimize as needed).
+                match versioned_cache
+                    .group_data()
+                    .finalize_group(&group_key, txn_idx)
+                {
+                    Ok(finalized_group) => {
+                        // finalize_group already applies the deletions.
+                        if finalized_group.is_empty() != metadata_op.is_deletion() {
+                            error!(
+                                "Group is empty = {} but op is deletion = {} in parallel execution",
+                                finalized_group.is_empty(),
+                                metadata_op.is_deletion()
+                            );
+                            maybe_err = Some(Error::FallbackToSequential(PanicOr::Or(
+                                IntentionalFallbackToSequential::ResourceGroupError,
+                            )));
+                        }
+                        finalized_groups.push((group_key, metadata_op, finalized_group));
+                    },
+                    Err(e) => {
+                        error!("Error committing resource group {:?}", e);
+                        maybe_err = Some(Error::FallbackToSequential(PanicOr::Or(
+                            IntentionalFallbackToSequential::ResourceGroupError,
+                        )));
+                    },
+                };
+
+                if maybe_err.is_some() {
+                    break;
+                }
+            }
+            last_input_output.record_finalized_group(txn_idx, finalized_groups);
+
+            maybe_err = maybe_err.or_else(|| last_input_output.maybe_execution_error(txn_idx));
+
             // We `halt` the execution in the following 4 cases:
             // 1) We detect module read/write intersection
             // 2) A transaction triggered an Abort
@@ -488,12 +569,12 @@ where
             // 4) We skip_rest after a transaction
 
             // We cover cases 1 and 2 here
-            if let Some(err) = last_input_output.execution_error(txn_idx) {
+            if let Some(err) = maybe_err {
+                *shared_maybe_error = Some(err);
                 if scheduler.halt() {
-                    *maybe_error = Some(err);
                     info!(
                         "Block execution was aborted due to {:?}",
-                        maybe_error.as_ref().unwrap()
+                        shared_maybe_error.as_ref().unwrap()
                     );
                     update_counters_and_log_info(
                         txn_idx,
@@ -628,7 +709,7 @@ where
         delayed_field_keys: Option<impl Iterator<Item = T::Identifier>>,
         write_set_keys: HashSet<T::Key>,
         read_set: RefCell<HashSet<T::Key>>,
-        unsync_map: &UnsyncMap<T::Key, T::Value, X, T::Identifier>,
+        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         latest_view: &LatestView<T, S, X>,
     ) -> HashMap<T::Key, T::Value> {
         let mut patched_resource_write_set = HashMap::new();
@@ -728,6 +809,33 @@ where
         aggregator_v1_delta_writes
     }
 
+    fn serialize_groups(
+        finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
+    ) -> ::std::result::Result<Vec<(T::Key, T::Value)>, PanicOr<IntentionalFallbackToSequential>>
+    {
+        finalized_groups
+            .into_iter()
+            .map(|(group_key, mut metadata_op, finalized_group)| {
+                let btree: BTreeMap<T::Tag, Bytes> = finalized_group
+                    .into_iter()
+                    .map(|(resource_tag, arc_v)| {
+                        let bytes = arc_v
+                            .extract_raw_bytes()
+                            .expect("Deletions should already be applied");
+                        (resource_tag, bytes)
+                    })
+                    .collect();
+
+                bcs::to_bytes(&btree)
+                    .map_err(|_| PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError))
+                    .map(|group_bytes| {
+                        metadata_op.set_bytes(group_bytes.into());
+                        (group_key, metadata_op)
+                    })
+            })
+            .collect()
+    }
+
     fn materialize_txn_commit(
         &self,
         txn_idx: TxnIndex,
@@ -737,11 +845,12 @@ where
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         base_view: &S,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
-    ) {
+    ) -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
         let parallel_state = ParallelState::<T, X>::new(versioned_cache, scheduler, shared_counter);
         let latest_view = LatestView::new(base_view, ViewState::Sync(parallel_state), txn_idx);
         let resource_write_set = last_input_output.resource_write_set(txn_idx);
         let delayed_field_keys = last_input_output.delayed_field_keys(txn_idx);
+        let finalized_groups = last_input_output.take_finalized_group(txn_idx);
 
         let (mut patched_resource_write_set, write_set_keys) =
             Self::map_id_to_values_in_write_set(resource_write_set, &latest_view);
@@ -762,11 +871,15 @@ where
             base_view,
         );
 
+        // TODO[agg_v2]: patch group writes in finalized groups
+        let serialized_groups = Self::serialize_groups(finalized_groups)?;
+
         last_input_output.record_materialized_txn_output(
             txn_idx,
             aggregator_v1_delta_writes,
             patched_resource_write_set,
             patched_events,
+            serialized_groups,
         );
         if let Some(txn_commit_listener) = &self.transaction_commit_hook {
             let txn_output = last_input_output.txn_output(txn_idx).unwrap();
@@ -807,6 +920,7 @@ where
                 panic!("Cannot be materializing with {}", msg);
             },
         };
+        Ok(())
     }
 
     fn worker_loop(
@@ -834,19 +948,21 @@ where
         let _timer = WORK_WITH_TASK_SECONDS.start_timer();
         let mut scheduler_task = SchedulerTask::NoTask;
 
-        let drain_commit_queue = || {
-            while let Ok(txn_idx) = scheduler.pop_from_commit_queue() {
-                self.materialize_txn_commit(
-                    txn_idx,
-                    versioned_cache,
-                    scheduler,
-                    shared_counter,
-                    last_input_output,
-                    base_view,
-                    final_results,
-                );
-            }
-        };
+        let drain_commit_queue =
+            || -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
+                while let Ok(txn_idx) = scheduler.pop_from_commit_queue() {
+                    self.materialize_txn_commit(
+                        txn_idx,
+                        versioned_cache,
+                        scheduler,
+                        shared_counter,
+                        last_input_output,
+                        base_view,
+                        final_results,
+                    )?;
+                }
+                Ok(())
+            };
 
         loop {
             // Priorotize committing validated transactions
@@ -866,7 +982,7 @@ where
                 scheduler.queueing_commits_mark_done();
             }
 
-            drain_commit_queue();
+            drain_commit_queue()?;
 
             scheduler_task = match scheduler_task {
                 SchedulerTask::ValidationTask(txn_idx, incarnation, wave) => {
@@ -910,7 +1026,7 @@ where
                 },
                 SchedulerTask::NoTask => scheduler.next_task(),
                 SchedulerTask::Done => {
-                    drain_commit_queue();
+                    drain_commit_queue()?;
                     break Ok(());
                 },
             }
@@ -1000,11 +1116,22 @@ where
     }
 
     fn apply_output_sequential(
-        unsync_map: &UnsyncMap<T::Key, T::Value, X, T::Identifier>,
+        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         output: &E::Output,
-    ) {
+    ) -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
         for (key, (write_op, layout)) in output.resource_write_set().into_iter() {
             unsync_map.write(key, write_op, layout);
+        }
+
+        // TODO[agg_v2](fix): provide layouts
+        for (group_key, _, group_ops) in output.resource_group_write_set().into_iter() {
+            for (value_tag, group_op) in group_ops.into_iter() {
+                unsync_map
+                    .insert_group_op(&group_key, value_tag, group_op)
+                    .map_err(|_| {
+                        PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError)
+                    })?;
+            }
         }
 
         for (key, write_op) in output
@@ -1061,6 +1188,8 @@ where
         for (id, value) in updates.into_iter() {
             unsync_map.write_delayed_field(id, value);
         }
+
+        Ok(())
     }
 
     // TODO[agg_v2][fix] Propagate code_invariant_error, to use second fallback.
@@ -1109,7 +1238,27 @@ where
                     counters::update_sequential_txn_gas_counters(&fee_statement);
 
                     // Apply the writes.
-                    Self::apply_output_sequential(&unsync_map, &output);
+                    // TODO: return code invariant error if dynamic change set optimizations disabled.
+                    Self::apply_output_sequential(&unsync_map, &output)
+                        .map_err(Error::FallbackToSequential)?;
+
+                    let group_metadata_ops = output.resource_group_metadata_ops();
+                    let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
+                    for (group_key, group_metadata_op) in group_metadata_ops.into_iter() {
+                        let finalized_group = unsync_map.finalize_group(&group_key);
+                        if finalized_group.is_empty() != group_metadata_op.is_deletion() {
+                            error!(
+                                "Group is empty = {} but op is deletion = {} in sequential execution",
+                                finalized_group.is_empty(),
+                                group_metadata_op.is_deletion()
+                            );
+                            // TODO: code invariant error if dynamic change set optimizations disabled.
+                            return Err(Error::FallbackToSequential(PanicOr::Or(
+                                IntentionalFallbackToSequential::ResourceGroupError,
+                            )));
+                        }
+                        finalized_groups.push((group_key, group_metadata_op, finalized_group));
+                    }
 
                     if dynamic_change_set_optimizations_enabled {
                         // Replace delayed field id with values in resource write set and read set.
@@ -1136,14 +1285,31 @@ where
                             &latest_view,
                         );
 
+                        // TODO[agg_v2]: patch group writes in finalized groups
+                        let serialized_groups = Self::serialize_groups(finalized_groups)
+                            .map_err(Error::FallbackToSequential)?;
+
+                        // TODO[agg_v2] patch resources in groups and provide explicitly
                         output.incorporate_materialized_txn_output(
                             // No aggregator v1 delta writes are needed for sequential execution.
                             vec![],
                             patched_resource_write_set,
                             patched_events,
+                            serialized_groups,
                         );
                     } else {
                         assert!(output.delayed_field_change_set().is_empty());
+
+                        // TODO[agg_v2]: fallback to no resource group capability instead of unwrap.
+                        let serialized_groups = Self::serialize_groups(finalized_groups)
+                            .map_err(Error::FallbackToSequential)?;
+
+                        output.incorporate_materialized_txn_output(
+                            vec![],
+                            BTreeMap::new(),
+                            vec![],
+                            serialized_groups,
+                        );
                     }
 
                     if let Some(commit_hook) = &self.transaction_commit_hook {
@@ -1251,11 +1417,10 @@ where
                 let can_use_dynamic_change_set_optimizations = match e {
                     PanicOr::Or(IntentionalFallbackToSequential::ModulePathReadWrite) => {
                         debug!("[Execution]: Module read & written, sequential fallback");
-                        true
-                    },
-                    PanicOr::Or(IntentionalFallbackToSequential::DirectWriteSetTransaction) => {
                         false
                     },
+                    PanicOr::Or(IntentionalFallbackToSequential::DirectWriteSetTransaction)
+                    | PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError) => false,
                     PanicOr::CodeInvariantError(msg) => {
                         error!(
                             "[Execution]: CodeInvariantError({:?}), sequential fallback",
@@ -1284,10 +1449,15 @@ where
         if let Err(Error::FallbackToSequential(e)) = &ret {
             match e {
                 PanicOr::Or(IntentionalFallbackToSequential::ModulePathReadWrite) => {
-                    panic!("ModulePathReadWrite shouldn't happen in sequential execution")
+                    unreachable!("ModulePathReadWrite shouldn't happen in sequential execution")
+                },
+                PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError) => {
+                    error!("[Execution]: Sequential fallback due to ResourceGroupError");
                 },
                 PanicOr::Or(IntentionalFallbackToSequential::DirectWriteSetTransaction) => {
-                    info!("[Execution]: DirectWriteSetTransaction found, during ModulePathReadWrite sequential fallback");
+                    info!(
+                        "[Execution]: DirectWriteSetTransaction found, during sequential fallback"
+                    );
                 },
                 PanicOr::CodeInvariantError(msg) => {
                     error!("[Execution]: CodeInvariantError({:?}) in sequential with dynamic_change_set_optimizations_enabled, sequential fallback", msg);

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1417,7 +1417,7 @@ where
                 let can_use_dynamic_change_set_optimizations = match e {
                     PanicOr::Or(IntentionalFallbackToSequential::ModulePathReadWrite) => {
                         debug!("[Execution]: Module read & written, sequential fallback");
-                        false
+                        true
                     },
                     PanicOr::Or(IntentionalFallbackToSequential::DirectWriteSetTransaction)
                     | PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError) => false,

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1307,7 +1307,7 @@ where
                         output.incorporate_materialized_txn_output(
                             vec![],
                             BTreeMap::new(),
-                            vec![],
+                            output.get_events().into_iter().map(|(e, _)| e).collect(),
                             serialized_groups,
                         );
                     }
@@ -1479,6 +1479,8 @@ where
         // If after trying available fallbacks, we still are askign to do a fallback,
         // something unrecoverable went wrong.
         if let Err(Error::FallbackToSequential(e)) = &ret {
+            // TODO[agg_v2][fix] make sure this can never happen - we have sequential raising
+            // this error often when something that should never happen goes wrong
             panic!("Sequential execution failed with {:?}", e);
         }
 

--- a/aptos-move/block-executor/src/explicit_sync_wrapper.rs
+++ b/aptos-move/block-executor/src/explicit_sync_wrapper.rs
@@ -16,6 +16,7 @@ use std::{
 /// where we can prove that there will be no concurrent access to the
 /// underlying object (or its elements).  Use with caution - only when
 /// the safety can be proven.
+#[derive(Debug)]
 pub struct ExplicitSyncWrapper<T> {
     value: UnsafeCell<T>,
 }

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -13,18 +13,22 @@
 /// of each transaction of the tested block executor execution.
 use crate::{
     errors::{Error as BlockExecutorError, Result as BlockExecutorResult},
-    proptest_types::types::{MockOutput, MockTransaction, STORAGE_AGGREGATOR_VALUE},
+    proptest_types::types::{
+        MockOutput, MockTransaction, ValueType, RESERVED_TAG, STORAGE_AGGREGATOR_VALUE,
+    },
 };
 use aptos_aggregator::delta_change_set::serialize;
 use aptos_types::{contract_event::ReadWriteEvent, write_set::TransactionWrite};
-use claims::{assert_matches, assert_none, assert_some_eq};
+use aptos_vm_types::resource_group_adapter::group_size_as_sum;
+use bytes::Bytes;
+use claims::{assert_matches, assert_none, assert_some, assert_some_eq};
 use itertools::izip;
 use std::{collections::HashMap, fmt::Debug, hash::Hash, result::Result, sync::atomic::Ordering};
 
 // TODO: extend to derived values, and code.
 #[derive(Clone)]
-enum BaselineValue<V> {
-    GenericWrite(V),
+enum BaselineValue {
+    GenericWrite(ValueType),
     Aggregator(u128),
     Empty,
 }
@@ -36,7 +40,7 @@ enum BaselineValue<V> {
 //    Underflow,
 // }
 
-impl<V: Debug + Clone + PartialEq + Eq + TransactionWrite> BaselineValue<V> {
+impl BaselineValue {
     // Compare to the read results during block execution.
     pub(crate) fn assert_read_result(&self, bytes_read: &Option<Vec<u8>>) {
         match (self, bytes_read) {
@@ -78,27 +82,27 @@ enum BaselineStatus {
 ///
 /// For both read_values and resolved_deltas the keys are not included because they are
 /// in the same order as the reads and deltas in the Transaction::Write.
-pub(crate) struct BaselineOutput<K, V> {
+pub(crate) struct BaselineOutput<K> {
     status: BaselineStatus,
-    read_values: Vec<Result<Vec<BaselineValue<V>>, ()>>,
+    read_values: Vec<Result<Vec<BaselineValue>, ()>>,
     resolved_deltas: Vec<Result<HashMap<K, u128>, ()>>,
+    group_reads: Vec<Result<Vec<(K, u32)>, ()>>,
 }
 
-impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + TransactionWrite>
-    BaselineOutput<K, V>
-{
+impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
     /// Must be invoked after parallel execution to have incarnation information set and
     /// work with dynamic read/writes.
     pub(crate) fn generate<E: Debug + Clone + ReadWriteEvent>(
-        txns: &[MockTransaction<K, V, E>],
+        txns: &[MockTransaction<K, E>],
         maybe_block_gas_limit: Option<u64>,
     ) -> Self {
-        let mut current_world = HashMap::<K, BaselineValue<V>>::new();
+        let mut current_world = HashMap::<K, BaselineValue>::new();
         let mut accumulated_gas = 0;
 
         let mut status = BaselineStatus::Success;
         let mut read_values = vec![];
         let mut resolved_deltas = vec![];
+        let mut group_reads = vec![];
         for txn in txns.iter() {
             match txn {
                 MockTransaction::Abort => {
@@ -180,6 +184,10 @@ impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + Transacti
                                     .insert(k.clone(), BaselineValue::GenericWrite(v.clone()));
                             }
 
+                            group_reads.push(Ok(incarnation_behaviors[last_incarnation]
+                                .group_reads
+                                .clone()));
+
                             // Apply gas.
                             accumulated_gas += incarnation_behaviors[last_incarnation].gas;
                             if let Some(block_gas_limit) = maybe_block_gas_limit {
@@ -193,6 +201,7 @@ impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + Transacti
                             // Transaction does not take effect and we record delta application failure.
                             read_values.push(Err(()));
                             resolved_deltas.push(Err(()));
+                            group_reads.push(Err(()));
                         },
                     }
                 },
@@ -203,6 +212,7 @@ impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + Transacti
             status,
             read_values,
             resolved_deltas,
+            group_reads,
         }
     }
 
@@ -210,8 +220,11 @@ impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + Transacti
     // itself to be easily traceable in case of an error.
     pub(crate) fn assert_output<E: Debug>(
         &self,
-        results: &BlockExecutorResult<Vec<MockOutput<K, V, E>>, usize>,
+        results: &BlockExecutorResult<Vec<MockOutput<K, E>>, usize>,
     ) {
+        let base_map: HashMap<u32, Bytes> = HashMap::from([(RESERVED_TAG, vec![0].into())]);
+        let mut group_world = HashMap::new();
+
         match results {
             Ok(results) => {
                 let committed = self.read_values.len();
@@ -221,17 +234,94 @@ impl<K: Debug + Hash + Clone + Eq, V: Debug + Clone + PartialEq + Eq + Transacti
                 izip!(
                     results.iter().take(committed),
                     self.read_values.iter(),
-                    self.resolved_deltas.iter()
+                    self.resolved_deltas.iter(),
+                    self.group_reads.iter(),
                 )
-                .for_each(|(output, reads, resolved_deltas)| {
-                    reads
+                .for_each(|(output, reads, resolved_deltas, group_reads)| {
+                    // Compute group read results.
+                    let group_read_results: Vec<Option<Bytes>> = group_reads
                         .as_ref()
-                        .expect("Aggregator failures not yet tested")
+                        .unwrap()
                         .iter()
-                        .zip(output.read_results.iter())
-                        .for_each(|(baseline_read, result_read)| {
-                            baseline_read.assert_read_result(result_read)
-                        });
+                        .map(|(group_key, resource_tag)| {
+                            let group_map =
+                                group_world.entry(group_key).or_insert(base_map.clone());
+
+                            group_map.get(resource_tag).cloned()
+                        })
+                        .collect();
+                    // Test group read results.
+                    let read_len = reads.as_ref().unwrap().len();
+                    assert_eq!(
+                        group_read_results.len(),
+                        output.read_results.len() - read_len
+                    );
+                    izip!(
+                        output.read_results.iter().skip(read_len),
+                        group_read_results.into_iter()
+                    )
+                    .for_each(|(result_group_read, baseline_group_read)| {
+                        assert!(
+                            result_group_read.clone().map(Into::<Bytes>::into)
+                                == baseline_group_read
+                        );
+                    });
+
+                    for (group_key, size) in output.read_group_sizes.iter() {
+                        let group_map = group_world.entry(group_key).or_insert(base_map.clone());
+
+                        assert_eq!(*size, group_size_as_sum(group_map.iter()).unwrap());
+                    }
+
+                    // Test normal reads.
+                    izip!(
+                        reads
+                            .as_ref()
+                            .expect("Aggregator failures not yet tested")
+                            .iter(),
+                        output.read_results.iter().take(read_len)
+                    )
+                    .for_each(|(baseline_read, result_read)| {
+                        baseline_read.assert_read_result(result_read)
+                    });
+
+                    // Update group world.
+                    for (group_key, _, updates) in output.group_writes.iter() {
+                        for (tag, v) in updates {
+                            let group_map =
+                                group_world.entry(group_key).or_insert(base_map.clone());
+                            if v.is_deletion() {
+                                assert_some!(group_map.remove(tag));
+                            } else {
+                                let existed = group_map
+                                    .insert(*tag, v.extract_raw_bytes().unwrap())
+                                    .is_some();
+                                assert_eq!(existed, v.is_modification());
+                            }
+                        }
+                    }
+
+                    // Test recorded finalized group writes: it should contain the whole group, and
+                    // as such, correspond to the contents of the group_world.
+                    // TODO: figure out what can still be tested here, e.g. RESERVED_TAG
+                    // let groups_tested =
+                    //     (output.group_writes.len() + group_reads.as_ref().unwrap().len()) > 0;
+                    // for (group_key, _, finalized_updates) in output.recorded_groups.get().unwrap() {
+                    //     let baseline_group_map =
+                    //         group_world.entry(group_key).or_insert(base_map.clone());
+                    //     assert_eq!(finalized_updates.len(), baseline_group_map.len());
+                    //     if groups_tested {
+                    //         // RESERVED_TAG should always be contained.
+                    //         assert_ge!(finalized_updates.len(), 1);
+
+                    //         for (tag, v) in finalized_updates.iter() {
+                    //             assert_eq!(
+                    //                 v.bytes().unwrap(),
+                    //                 baseline_group_map.get(tag).unwrap(),
+                    //             );
+                    //         }
+                    //     }
+                    // }
 
                     let baseline_deltas = resolved_deltas
                         .as_ref()

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -8,7 +8,7 @@ use crate::{
         baseline::BaselineOutput,
         types::{
             EmptyDataView, KeyType, MockOutput, MockTask, MockTransaction, TransactionGen,
-            TransactionGenParams, ValueType,
+            TransactionGenParams,
         },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
@@ -36,8 +36,8 @@ pub(crate) struct BencherState<
     K: Hash + Clone + Debug + Eq + PartialOrd + Ord,
     E: Send + Sync + Debug + Clone + ReadWriteEvent,
 > {
-    transactions: Vec<MockTransaction<KeyType<K>, ValueType, E>>,
-    baseline_output: BaselineOutput<KeyType<K>, ValueType>,
+    transactions: Vec<MockTransaction<KeyType<K>, E>>,
+    baseline_output: BaselineOutput<KeyType<K>>,
 }
 
 impl<K, V, E> Bencher<K, V, E>
@@ -114,7 +114,7 @@ where
     }
 
     pub(crate) fn run(self) {
-        let data_view = EmptyDataView::<KeyType<K>, ValueType> {
+        let data_view = EmptyDataView::<KeyType<K>> {
             phantom: PhantomData,
         };
 
@@ -126,10 +126,10 @@ where
         );
 
         let output = BlockExecutor::<
-            MockTransaction<KeyType<K>, ValueType, E>,
-            MockTask<KeyType<K>, ValueType, E>,
-            EmptyDataView<KeyType<K>, ValueType>,
-            NoOpTransactionCommitHook<MockOutput<KeyType<K>, ValueType, E>, usize>,
+            MockTransaction<KeyType<K>, E>,
+            MockTask<KeyType<K>, E>,
+            EmptyDataView<KeyType<K>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
         >::new(num_cpus::get(), executor_thread_pool, None, None)
         .execute_transactions_parallel((), &self.transactions, &data_view);

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -9,7 +9,8 @@ use crate::{
         baseline::BaselineOutput,
         types::{
             DeltaDataView, EmptyDataView, KeyType, MockEvent, MockOutput, MockTask,
-            MockTransaction, TransactionGen, TransactionGenParams, ValueType, MAX_GAS_PER_TXN,
+            MockTransaction, NonEmptyGroupDataView, TransactionGen, TransactionGenParams,
+            MAX_GAS_PER_TXN,
         },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
@@ -27,6 +28,7 @@ use proptest::{
 };
 use rand::Rng;
 use std::{cmp::max, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use test_case::test_case;
 
 fn run_transactions<K, V, E>(
     key_universe: &[K],
@@ -55,7 +57,7 @@ fn run_transactions<K, V, E>(
         *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::SkipRest;
     }
 
-    let data_view = EmptyDataView::<KeyType<K>, ValueType> {
+    let data_view = EmptyDataView::<KeyType<K>> {
         phantom: PhantomData,
     };
 
@@ -68,10 +70,10 @@ fn run_transactions<K, V, E>(
 
     for _ in 0..num_repeat {
         let output = BlockExecutor::<
-            MockTransaction<KeyType<K>, ValueType, E>,
-            MockTask<KeyType<K>, ValueType, E>,
-            EmptyDataView<KeyType<K>, ValueType>,
-            NoOpTransactionCommitHook<MockOutput<KeyType<K>, ValueType, E>, usize>,
+            MockTransaction<KeyType<K>, E>,
+            MockTask<KeyType<K>, E>,
+            EmptyDataView<KeyType<K>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -195,7 +197,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
 
-    let data_view = DeltaDataView::<KeyType<[u8; 32]>, ValueType> {
+    let data_view = DeltaDataView::<KeyType<[u8; 32]>> {
         phantom: PhantomData,
     };
 
@@ -208,10 +210,10 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
 
     for _ in 0..20 {
         let output = BlockExecutor::<
-            MockTransaction<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            MockTask<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            DeltaDataView<KeyType<[u8; 32]>, ValueType>,
-            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType, MockEvent>, usize>,
+            MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+            MockTask<KeyType<[u8; 32]>, MockEvent>,
+            DeltaDataView<KeyType<[u8; 32]>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -240,7 +242,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
     .expect("creating a new value should succeed")
     .current();
 
-    let data_view = DeltaDataView::<KeyType<[u8; 32]>, ValueType> {
+    let data_view = DeltaDataView::<KeyType<[u8; 32]>> {
         phantom: PhantomData,
     };
 
@@ -259,10 +261,10 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
 
     for _ in 0..20 {
         let output = BlockExecutor::<
-            MockTransaction<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            MockTask<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            DeltaDataView<KeyType<[u8; 32]>, ValueType>,
-            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType, MockEvent>, usize>,
+            MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+            MockTask<KeyType<[u8; 32]>, MockEvent>,
+            DeltaDataView<KeyType<[u8; 32]>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -402,7 +404,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         },
     };
 
-    let data_view = DeltaDataView::<KeyType<[u8; 32]>, ValueType> {
+    let data_view = DeltaDataView::<KeyType<[u8; 32]>> {
         phantom: PhantomData,
     };
 
@@ -415,10 +417,10 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     // Confirm still no intersection
     let output = BlockExecutor::<
-        MockTransaction<KeyType<[u8; 32]>, ValueType, MockEvent>,
-        MockTask<KeyType<[u8; 32]>, ValueType, MockEvent>,
-        DeltaDataView<KeyType<[u8; 32]>, ValueType>,
-        NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType, MockEvent>, usize>,
+        MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+        MockTask<KeyType<[u8; 32]>, MockEvent>,
+        DeltaDataView<KeyType<[u8; 32]>>,
+        NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
         ExecutableTestType,
     >::new(
         num_cpus::get(),
@@ -458,10 +460,10 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     for _ in 0..200 {
         let output = BlockExecutor::<
-            MockTransaction<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            MockTask<KeyType<[u8; 32]>, ValueType, MockEvent>,
-            DeltaDataView<KeyType<[u8; 32]>, ValueType>,
-            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType, MockEvent>, usize>,
+            MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+            MockTask<KeyType<[u8; 32]>, MockEvent>,
+            DeltaDataView<KeyType<[u8; 32]>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -477,6 +479,95 @@ fn publishing_fixed_params_with_block_gas_limit(
                 IntentionalFallbackToSequential::ModulePathReadWrite
             ))
         );
+    }
+}
+
+#[test_case(1000, 100, 30, 15, 0)]
+#[test_case(1000, 50, 20, 10, 0)]
+#[test_case(1000, 15, 5, 5, 0)]
+#[test_case(1000, 20, 10, 5, 1)]
+#[test_case(1000, 20, 10, 5, 2)]
+#[test_case(1000, 20, 10, 5, 3)]
+#[test_case(1000, 20, 10, 5, 4)]
+fn non_empty_group(
+    num_txns: usize,
+    key_universe_len: usize,
+    num_repeat_parallel: usize,
+    num_repeat_sequential: usize,
+    group_size_testing: usize,
+) {
+    let mut runner = TestRunner::default();
+
+    let key_universe = vec(any::<[u8; 32]>(), key_universe_len)
+        .new_tree(&mut runner)
+        .expect("creating a new value should succeed")
+        .current();
+
+    let transaction_gen = vec(
+        any_with::<TransactionGen<[u8; 32]>>(TransactionGenParams::new_dynamic()),
+        num_txns,
+    )
+    .new_tree(&mut runner)
+    .expect("creating a new value should succeed")
+    .current();
+
+    // Determines the probability that any given incarnation of an executed txn will query
+    // the size of a given group (3 groups).
+    let group_size_pcts = match group_size_testing {
+        0 => [None, None, None],
+        1 => [Some(30), None, None],
+        2 => [Some(80), None, None],
+        3 => [Some(30), Some(80), None],
+        4 => [Some(30), Some(50), Some(70)],
+        _ => unreachable!("Unexpected test configuration"),
+    };
+
+    let transactions: Vec<_> = transaction_gen
+        .into_iter()
+        .map(|txn_gen| {
+            txn_gen.materialize_groups::<[u8; 32], MockEvent>(&key_universe, group_size_pcts)
+        })
+        .collect();
+
+    let data_view = NonEmptyGroupDataView::<KeyType<[u8; 32]>> {
+        group_keys: key_universe[(key_universe_len - 3)..key_universe_len]
+            .iter()
+            .map(|k| KeyType(*k, false))
+            .collect(),
+    };
+
+    let executor_thread_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_cpus::get())
+            .build()
+            .unwrap(),
+    );
+
+    for _ in 0..num_repeat_parallel {
+        let output = BlockExecutor::<
+            MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+            MockTask<KeyType<[u8; 32]>, MockEvent>,
+            NonEmptyGroupDataView<KeyType<[u8; 32]>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
+            ExecutableTestType,
+        >::new(num_cpus::get(), executor_thread_pool.clone(), None, None)
+        .execute_transactions_parallel((), &transactions, &data_view);
+
+        BaselineOutput::generate(&transactions, None).assert_output(&output);
+    }
+
+    for _ in 0..num_repeat_sequential {
+        let output = BlockExecutor::<
+            MockTransaction<KeyType<[u8; 32]>, MockEvent>,
+            MockTask<KeyType<[u8; 32]>, MockEvent>,
+            NonEmptyGroupDataView<KeyType<[u8; 32]>>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
+            ExecutableTestType,
+        >::new(num_cpus::get(), executor_thread_pool.clone(), None, None)
+        .execute_transactions_sequential((), &transactions, &data_view, true);
+        // TODO: test dynamic disabled as well.
+
+        BaselineOutput::generate(&transactions, None).assert_output(&output);
     }
 }
 

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -2,7 +2,10 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::task::{ExecutionStatus, ExecutorTask, TransactionOutput};
+use crate::{
+    explicit_sync_wrapper::ExplicitSyncWrapper,
+    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
+};
 use aptos_aggregator::{
     delayed_change::DelayedChange,
     delta_change_set::{delta_add, delta_sub, serialize, DeltaOp},
@@ -17,22 +20,23 @@ use aptos_types::{
     event::EventKey,
     executable::ModulePath,
     fee_statement::FeeStatement,
+    on_chain_config::CurrentTimeMicroseconds,
     state_store::{
         state_storage_usage::StateStorageUsage,
-        state_value::{StateValue, StateValueMetadataKind},
+        state_value::{StateValue, StateValueMetadata, StateValueMetadataKind},
     },
     transaction::BlockExecutableTransaction as Transaction,
-    write_set::{TransactionWrite, WriteOp},
+    write_set::{TransactionWrite, WriteOp, WriteOpKind},
 };
-use aptos_vm_types::resolver::TExecutorView;
+use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use bytes::Bytes;
-use claims::assert_ok;
+use claims::{assert_ge, assert_le, assert_ok};
 use move_core_types::{language_storage::TypeTag, value::MoveTypeLayout};
 use once_cell::sync::OnceCell;
 use proptest::{arbitrary::Arbitrary, collection::vec, prelude::*, proptest, sample::Index};
 use proptest_derive::Arbitrary;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
+    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap, HashSet},
     convert::TryInto,
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -47,19 +51,21 @@ use std::{
 // TODO: extend to delta failures.
 pub(crate) const STORAGE_AGGREGATOR_VALUE: u128 = 100001;
 pub(crate) const MAX_GAS_PER_TXN: u64 = 4;
+// For some resource group tests we ensure that the groups are never empty because they contain
+// a value at RESERVED_TAG (starting from mock storage resolution) that is never deleted.
+pub(crate) const RESERVED_TAG: u32 = 0;
 
-pub(crate) struct DeltaDataView<K, V> {
-    pub(crate) phantom: PhantomData<(K, V)>,
+pub(crate) struct DeltaDataView<K> {
+    pub(crate) phantom: PhantomData<K>,
 }
 
-impl<K, V> TStateView for DeltaDataView<K, V>
+impl<K> TStateView for DeltaDataView<K>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
-    V: Debug + Send + Sync + Debug + Clone + TransactionWrite + 'static,
 {
     type Key = K;
 
-    /// Gets the state value for a given state key.
+    // Contains mock storage value with STORAGE_AGGREGATOR_VALUE.
     fn get_state_value(&self, _: &K) -> anyhow::Result<Option<StateValue>> {
         Ok(Some(StateValue::new_legacy(
             serialize(&STORAGE_AGGREGATOR_VALUE).into(),
@@ -71,18 +77,48 @@ where
     }
 
     fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {
-        unreachable!();
+        unreachable!("Not used in tests");
     }
 }
 
-pub(crate) struct EmptyDataView<K, V> {
-    pub(crate) phantom: PhantomData<(K, V)>,
+pub(crate) struct NonEmptyGroupDataView<K> {
+    pub(crate) group_keys: HashSet<K>,
 }
 
-impl<K, V> TStateView for EmptyDataView<K, V>
+impl<K> TStateView for NonEmptyGroupDataView<K>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
-    V: Debug + Send + Sync + Debug + Clone + TransactionWrite + 'static,
+{
+    type Key = K;
+
+    // Contains mock storage value with a non-empty group (w. value at RESERVED_TAG).
+    fn get_state_value(&self, key: &K) -> anyhow::Result<Option<StateValue>> {
+        if self.group_keys.contains(key) {
+            let group: BTreeMap<u32, Bytes> = BTreeMap::from([(RESERVED_TAG, vec![0].into())]);
+
+            let bytes = bcs::to_bytes(&group).unwrap();
+            Ok(Some(StateValue::new_legacy(bytes.into())))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn id(&self) -> StateViewId {
+        StateViewId::Miscellaneous
+    }
+
+    fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {
+        unreachable!("Not used in tests");
+    }
+}
+
+pub(crate) struct EmptyDataView<K> {
+    pub(crate) phantom: PhantomData<K>,
+}
+
+impl<K> TStateView for EmptyDataView<K>
+where
+    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
 {
     type Key = K;
 
@@ -96,7 +132,7 @@ where
     }
 
     fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {
-        unreachable!();
+        unreachable!("Not used in tests");
     }
 }
 
@@ -134,11 +170,22 @@ impl<K: Hash + Clone + Debug + Eq + PartialOrd + Ord> ModulePath for KeyType<K> 
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct ValueType {
     /// Wrapping the types used for testing to add TransactionWrite trait implementation (below).
     bytes: Option<Bytes>,
     metadata: StateValueMetadataKind,
+    write_op_kind: ExplicitSyncWrapper<WriteOpKind>,
+}
+
+impl Clone for ValueType {
+    fn clone(&self) -> Self {
+        ValueType::new(
+            self.bytes.clone(),
+            self.metadata.clone(),
+            self.write_op_kind(),
+        )
+    }
 }
 
 impl Arbitrary for ValueType {
@@ -150,16 +197,29 @@ impl Arbitrary for ValueType {
             .prop_map(|mut v| {
                 let use_value = v[0] < 128;
                 v.resize(16, 0);
-                ValueType::new(v, use_value)
+                ValueType::from_value(v, use_value)
             })
             .boxed()
     }
 }
 
 impl ValueType {
-    /// If use_value is not set, the resulting Value will correspond to a deletion, i.e.
-    /// not contain a value (o.w. deletion).
-    pub(crate) fn new<V: Into<Vec<u8>> + Debug + Clone + Eq + Send + Sync + Arbitrary>(
+    pub(crate) fn new(
+        bytes: Option<Bytes>,
+        metadata: StateValueMetadataKind,
+        kind: WriteOpKind,
+    ) -> Self {
+        Self {
+            bytes,
+            metadata,
+            write_op_kind: ExplicitSyncWrapper::new(kind),
+        }
+    }
+
+    /// If use_value is true, we use WriteOpKind::Creation by default, o.w. Deletion.
+    /// For resource groups, mock executor updates the WriteOp kind to avoid the consistency
+    /// check with existence (not checked for normal resources, storage asserts).
+    pub(crate) fn from_value<V: Into<Vec<u8>> + Debug + Clone + Eq + Send + Sync + Arbitrary>(
         value: V,
         use_value: bool,
     ) -> Self {
@@ -170,13 +230,28 @@ impl ValueType {
                 v.into()
             }),
             metadata: None,
+            write_op_kind: ExplicitSyncWrapper::new(
+                if !use_value {
+                    WriteOpKind::Deletion
+                } else {
+                    WriteOpKind::Creation
+                },
+            ),
         }
     }
 
+    /// If len = 0, treated as Deletion for testing.
     pub(crate) fn with_len_and_metadata(len: usize, metadata: StateValueMetadataKind) -> Self {
         Self {
             bytes: (len > 0).then_some(vec![100_u8; len].into()),
             metadata,
+            write_op_kind: ExplicitSyncWrapper::new(
+                if len == 0 {
+                    WriteOpKind::Deletion
+                } else {
+                    WriteOpKind::Creation
+                },
+            ),
         }
     }
 }
@@ -193,10 +268,23 @@ impl TransactionWrite for ValueType {
                 None => (None, None),
             };
 
+        let empty = maybe_bytes.is_none();
+
         Self {
             bytes: maybe_bytes,
             metadata: maybe_metadata,
+            write_op_kind: ExplicitSyncWrapper::new(
+                if empty {
+                    WriteOpKind::Deletion
+                } else {
+                    WriteOpKind::Creation
+                },
+            ),
         }
+    }
+
+    fn write_op_kind(&self) -> WriteOpKind {
+        self.write_op_kind.dereference().clone()
     }
 
     fn as_state_value(&self) -> Option<StateValue> {
@@ -242,6 +330,12 @@ pub(crate) struct TransactionGen<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + 
     /// Generate gas for different incarnations of the transactions.
     #[proptest(strategy = "vec(any::<Index>(), params.incarnation_alternatives)")]
     gas: Vec<Index>,
+    /// Generate indices to derive random behavior for querying resource group sizes.
+    /// For now hardcoding 3 resource groups.
+    #[proptest(
+        strategy = "vec((any::<Index>(), any::<Index>(), any::<Index>()), params.incarnation_alternatives)"
+    )]
+    group_size_indicators: Vec<(Index, Index, Index)>,
 }
 
 /// Describes behavior of a particular incarnation of a mock transaction, as keys to be read,
@@ -254,17 +348,45 @@ pub(crate) struct TransactionGen<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + 
 /// Then we can generate the baseline by sequentially executing the behavior prescribed for
 /// those latest incarnations.
 #[derive(Clone, Debug)]
-pub(crate) struct MockIncarnation<K, V, E> {
+pub(crate) struct MockIncarnation<K, E> {
     /// A vector of keys to be read during mock incarnation execution.
     pub(crate) reads: Vec<K>,
     /// A vector of keys and corresponding values to be written during mock incarnation execution.
-    pub(crate) writes: Vec<(K, V)>,
+    pub(crate) writes: Vec<(K, ValueType)>,
+    pub(crate) group_reads: Vec<(K, u32)>,
+    pub(crate) group_writes: Vec<(K, HashMap<u32, ValueType>)>,
+    /// Keys to query group size for
+    pub(crate) group_sizes: Vec<K>,
     /// A vector of keys and corresponding deltas to be produced during mock incarnation execution.
     pub(crate) deltas: Vec<(K, DeltaOp)>,
-    // A vector of events.
+    /// A vector of events.
     pub(crate) events: Vec<E>,
     /// total execution gas to be charged for mock incarnation execution.
     pub(crate) gas: u64,
+}
+
+impl<K, E> MockIncarnation<K, E> {
+    /// Group writes are derived from normal transaction behavior, transforming one MockIncarnation
+    /// into another one with group_reads / group_writes / group_sizes set. Hence, the constructor
+    /// here always sets it to an empty vector.
+    pub(crate) fn new(
+        reads: Vec<K>,
+        writes: Vec<(K, ValueType)>,
+        deltas: Vec<(K, DeltaOp)>,
+        events: Vec<E>,
+        gas: u64,
+    ) -> Self {
+        Self {
+            reads,
+            writes,
+            group_reads: vec![],
+            group_writes: vec![],
+            group_sizes: vec![],
+            deltas,
+            events,
+            gas,
+        }
+    }
 }
 
 /// A mock transaction that could be used to test the correctness and throughput of the system.
@@ -273,7 +395,7 @@ pub(crate) struct MockIncarnation<K, V, E> {
 /// counter value. Each execution of the transaction increments the incarnation counter, and its
 /// value determines the index for choosing the read & write sets of the particular execution.
 #[derive(Clone, Debug)]
-pub(crate) enum MockTransaction<K, V, E> {
+pub(crate) enum MockTransaction<K, E> {
     Write {
         /// Incarnation counter, increased during each mock (re-)execution. Allows tracking the final
         /// incarnation for each mock transaction, whose behavior should be reproduced for baseline.
@@ -281,7 +403,7 @@ pub(crate) enum MockTransaction<K, V, E> {
         incarnation_counter: Arc<AtomicUsize>,
         /// A vector of mock behaviors prescribed for each incarnation of the transaction, chosen
         /// round robin depending on the incarnation counter value).
-        incarnation_behaviors: Vec<MockIncarnation<K, V, E>>,
+        incarnation_behaviors: Vec<MockIncarnation<K, E>>,
     },
     /// Skip the execution of trailing transactions.
     SkipRest,
@@ -289,33 +411,43 @@ pub(crate) enum MockTransaction<K, V, E> {
     Abort,
 }
 
-impl<K, V, E> MockTransaction<K, V, E> {
-    pub(crate) fn from_behavior(behavior: MockIncarnation<K, V, E>) -> Self {
+impl<K, E> MockTransaction<K, E> {
+    pub(crate) fn from_behavior(behavior: MockIncarnation<K, E>) -> Self {
         Self::Write {
             incarnation_counter: Arc::new(AtomicUsize::new(0)),
             incarnation_behaviors: vec![behavior],
         }
     }
 
-    pub(crate) fn from_behaviors(behaviors: Vec<MockIncarnation<K, V, E>>) -> Self {
+    pub(crate) fn from_behaviors(behaviors: Vec<MockIncarnation<K, E>>) -> Self {
         Self::Write {
             incarnation_counter: Arc::new(AtomicUsize::new(0)),
             incarnation_behaviors: behaviors,
+        }
+    }
+
+    pub(crate) fn into_behaviors(self) -> Vec<MockIncarnation<K, E>> {
+        match self {
+            Self::Write {
+                incarnation_behaviors,
+                ..
+            } => incarnation_behaviors,
+            Self::SkipRest => unreachable!("SkipRest does not contain incarnation behaviors"),
+            Self::Abort => unreachable!("Abort does not contain incarnation behaviors"),
         }
     }
 }
 
 impl<
         K: Debug + Hash + Ord + Clone + Send + Sync + ModulePath + 'static,
-        V: Clone + Send + Sync + TransactionWrite + 'static,
         E: Debug + Clone + Send + Sync + ReadWriteEvent + 'static,
-    > Transaction for MockTransaction<K, V, E>
+    > Transaction for MockTransaction<K, E>
 {
     type Event = E;
     type Identifier = DelayedFieldID;
     type Key = K;
     type Tag = u32;
-    type Value = V;
+    type Value = ValueType;
 }
 
 // TODO: try and test different strategies.
@@ -369,7 +501,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
                         None => {
                             // One out of 23 writes will be a deletion
                             let is_deletion = allow_deletes
-                                && ValueType::new(value.clone(), true)
+                                && ValueType::from_value(value.clone(), true)
                                     .as_u128()
                                     .unwrap()
                                     .unwrap()
@@ -377,7 +509,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
                                     == 0;
                             incarnation_writes.push((
                                 KeyType(key, module_write_fn(i)),
-                                ValueType::new(value.clone(), !is_deletion),
+                                ValueType::from_value(value.clone(), !is_deletion),
                             ));
                         },
                     }
@@ -414,6 +546,21 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
             .collect()
     }
 
+    fn group_size_indicator_from_gen(
+        group_size_query_gen: Vec<(Index, Index, Index)>,
+    ) -> Vec<(u8, u8, u8)> {
+        group_size_query_gen
+            .into_iter()
+            .map(|(idx1, idx2, idx3)| {
+                (
+                    idx1.index(100) as u8,
+                    idx2.index(100) as u8,
+                    idx3.index(100) as u8,
+                )
+            })
+            .collect()
+    }
+
     fn new_mock_write_txn<K: Clone + Hash + Debug + Eq + Ord, E: Debug + Clone + ReadWriteEvent>(
         self,
         universe: &[K],
@@ -421,7 +568,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         module_write_fn: &dyn Fn(usize) -> bool,
         delta_fn: &dyn Fn(usize, &V) -> Option<DeltaOp>,
         allow_deletes: bool,
-    ) -> MockTransaction<KeyType<K>, ValueType, E> {
+    ) -> MockTransaction<KeyType<K>, E> {
         let reads = Self::reads_from_gen(universe, self.reads, &module_read_fn);
         let gas = Self::gas_from_gen(self.gas);
 
@@ -435,12 +582,14 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         .into_iter()
         .zip(reads)
         .zip(gas)
-        .map(|(((writes, deltas), reads), gas)| MockIncarnation {
-            reads,
-            writes,
-            deltas,
-            events: vec![],
-            gas,
+        .map(|(((writes, deltas), reads), gas)| {
+            MockIncarnation::new(
+                reads,
+                writes,
+                deltas,
+                vec![], // events
+                gas,
+            )
         })
         .collect();
 
@@ -455,7 +604,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         universe: &[K],
         // Are writes and reads module access (same access path).
         module_access: (bool, bool),
-    ) -> MockTransaction<KeyType<K>, ValueType, E> {
+    ) -> MockTransaction<KeyType<K>, E> {
         let is_module_read = |_| -> bool { module_access.1 };
         let is_module_write = |_| -> bool { module_access.0 };
         let is_delta = |_, _: &V| -> Option<DeltaOp> { None };
@@ -471,6 +620,115 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         )
     }
 
+    // Generates a mock txn without group reads/writes and converts it to have group
+    // operations. Last 3 keys of the universe are used as group keys.
+    pub(crate) fn materialize_groups<
+        K: Clone + Hash + Debug + Eq + Ord,
+        E: Send + Sync + Debug + Clone + ReadWriteEvent,
+    >(
+        self,
+        universe: &[K],
+        group_size_query_pcts: [Option<u8>; 3],
+    ) -> MockTransaction<KeyType<K>, E> {
+        let universe_len = universe.len();
+        assert_ge!(universe_len, 3, "Universe must have size >= 3");
+
+        let is_module_read = |_| -> bool { false };
+        let is_module_write = |_| -> bool { false };
+        let is_delta = |_, _: &V| -> Option<DeltaOp> { None };
+
+        let group_size_query_indicators =
+            Self::group_size_indicator_from_gen(self.group_size_indicators.clone());
+        let mut behaviors = self
+            .new_mock_write_txn(
+                &universe[0..universe.len() - 3],
+                &is_module_read,
+                &is_module_write,
+                &is_delta,
+                false,
+            )
+            .into_behaviors();
+
+        let key_to_group = |key: &KeyType<K>| -> Option<(usize, u32)> {
+            let mut hasher = DefaultHasher::new();
+            key.hash(&mut hasher);
+            let bytes = hasher.finish().to_be_bytes();
+            // Choose from a smaller universe so different ops have intersection on a key.
+            let tag = (bytes[0] % 16) as u32;
+
+            let group_key_idx = bytes[1] % 4;
+
+            (group_key_idx < 3).then_some((group_key_idx as usize, tag))
+        };
+
+        for (behavior_idx, behavior) in behaviors.iter_mut().enumerate() {
+            let mut reads = vec![];
+            let mut group_reads = vec![];
+            for read_key in behavior.reads.clone() {
+                assert!(read_key != KeyType(universe[universe_len - 1].clone(), false));
+                assert!(read_key != KeyType(universe[universe_len - 2].clone(), false));
+                assert!(read_key != KeyType(universe[universe_len - 3].clone(), false));
+                match key_to_group(&read_key) {
+                    Some((idx, tag)) => group_reads.push((
+                        KeyType(universe[universe_len - 1 - idx].clone(), false),
+                        tag,
+                    )),
+                    None => reads.push(read_key),
+                }
+            }
+
+            let mut writes = vec![];
+            let mut group_writes = vec![];
+            let mut inner_ops = vec![HashMap::new(); 3];
+            for (write_key, value) in behavior.writes.clone() {
+                match key_to_group(&write_key) {
+                    Some((key_idx, tag)) => {
+                        if tag != RESERVED_TAG || !value.is_deletion() {
+                            inner_ops[key_idx].insert(tag, value);
+                        }
+                    },
+                    None => writes.push((write_key, value)),
+                }
+            }
+            for (idx, inner_ops) in inner_ops.into_iter().enumerate() {
+                if !inner_ops.is_empty() {
+                    group_writes.push((
+                        KeyType(universe[universe_len - 1 - idx].clone(), false),
+                        inner_ops,
+                    ));
+                }
+            }
+
+            // Group test does not handle deltas (different view, no default storage value).
+            assert!(behavior.deltas.is_empty());
+            behavior.reads = reads;
+            behavior.writes = writes;
+            behavior.group_reads = group_reads;
+            behavior.group_writes = group_writes;
+
+            behavior.group_sizes = group_size_query_pcts
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, size_query_pct)| match size_query_pct {
+                    Some(size_query_pct) => {
+                        assert_le!(*size_query_pct, 100, "Must be percetange point (0..100]");
+                        let indicator = match idx {
+                            0 => group_size_query_indicators[behavior_idx].0,
+                            1 => group_size_query_indicators[behavior_idx].1,
+                            2 => group_size_query_indicators[behavior_idx].2,
+                            _ => unreachable!("Test uses 3 groups"),
+                        };
+                        (indicator < *size_query_pct)
+                            .then(|| KeyType(universe[universe_len - 1 - idx].clone(), false))
+                    },
+                    None => None,
+                })
+                .collect();
+        }
+
+        MockTransaction::from_behaviors(behaviors)
+    }
+
     pub(crate) fn materialize_with_deltas<
         K: Clone + Hash + Debug + Eq + Ord,
         E: Send + Sync + Debug + Clone + ReadWriteEvent,
@@ -479,12 +737,15 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         universe: &[K],
         delta_threshold: usize,
         allow_deletes: bool,
-    ) -> MockTransaction<KeyType<K>, ValueType, E> {
+    ) -> MockTransaction<KeyType<K>, E> {
         let is_module_read = |_| -> bool { false };
         let is_module_write = |_| -> bool { false };
         let is_delta = |i, v: &V| -> Option<DeltaOp> {
             if i >= delta_threshold {
-                let val = ValueType::new(v.clone(), true).as_u128().unwrap().unwrap();
+                let val = ValueType::from_value(v.clone(), true)
+                    .as_u128()
+                    .unwrap()
+                    .unwrap();
                 if val % 10 == 0 {
                     None
                 } else if val % 10 < 5 {
@@ -518,7 +779,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         // writes. This way there will be module accesses but no intersection.
         read_threshold: usize,
         write_threshold: usize,
-    ) -> MockTransaction<KeyType<K>, ValueType, E> {
+    ) -> MockTransaction<KeyType<K>, E> {
         assert!(read_threshold < universe.len());
         assert!(write_threshold > read_threshold);
         assert!(write_threshold < universe.len());
@@ -542,24 +803,23 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
 ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Default)]
-pub(crate) struct MockTask<K, V, E>(PhantomData<(K, V, E)>);
+pub(crate) struct MockTask<K, E>(PhantomData<(K, E)>);
 
-impl<K, V, E> MockTask<K, V, E> {
+impl<K, E> MockTask<K, E> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<K, V, E> ExecutorTask for MockTask<K, V, E>
+impl<K, E> ExecutorTask for MockTask<K, E>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
-    V: Send + Sync + Debug + Clone + TransactionWrite + 'static,
     E: Send + Sync + Debug + Clone + ReadWriteEvent + 'static,
 {
     type Argument = ();
     type Error = usize;
-    type Output = MockOutput<K, V, E>;
-    type Txn = MockTransaction<K, V, E>;
+    type Output = MockOutput<K, E>;
+    type Txn = MockTransaction<K, E>;
 
     fn init(_argument: Self::Argument) -> Self {
         Self::new()
@@ -567,7 +827,8 @@ where
 
     fn execute_transaction(
         &self,
-        view: &impl TExecutorView<K, u32, MoveTypeLayout, DelayedFieldID>,
+        view: &(impl TExecutorView<K, u32, MoveTypeLayout, DelayedFieldID>
+              + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         txn: &Self::Txn,
         txn_idx: TxnIndex,
         _materialize_deltas: bool,
@@ -601,11 +862,91 @@ where
                         },
                     }
                 }
+                // Read from groups.
+                // TODO: also read group sizes (if there are any group reads).
+                for (group_key, resource_tag) in behavior.group_reads.iter() {
+                    match view.get_resource_from_group(group_key, resource_tag, None) {
+                        Ok(v) => read_results.push(v.map(Into::into)),
+                        Err(_) => read_results.push(None),
+                    }
+                }
+
+                let read_group_sizes = behavior
+                    .group_sizes
+                    .iter()
+                    .map(|group_key| {
+                        (
+                            group_key.clone(),
+                            view.resource_group_size(group_key).expect(
+                                "Group must exist and size computation should must succeed",
+                            ),
+                        )
+                    })
+                    .collect();
+
+                let mut group_writes = vec![];
+                for (key, inner_ops) in behavior.group_writes.iter() {
+                    let mut new_inner_ops = HashMap::new();
+                    for (tag, inner_op) in inner_ops.iter() {
+                        let exists = view
+                            .get_resource_from_group(key, tag, None)
+                            .unwrap()
+                            .is_some();
+
+                        // inner op is either deletion or creation.
+                        assert!(!inner_op.is_modification());
+                        if exists == inner_op.is_deletion() {
+                            // insert the provided inner op.
+                            new_inner_ops.insert(*tag, inner_op.clone());
+                        }
+
+                        assert!(
+                            *tag != RESERVED_TAG || exists,
+                            "RESERVED_TAG must always be present in groups in tests"
+                        );
+
+                        if exists && inner_op.is_creation() {
+                            // Adjust the type, otherwise executor will assert.
+                            if inner_op.bytes().unwrap()[0] % 4 < 3 || *tag == RESERVED_TAG {
+                                new_inner_ops.insert(
+                                    *tag,
+                                    ValueType::new(
+                                        inner_op.bytes.clone(),
+                                        inner_op.metadata.clone(),
+                                        WriteOpKind::Modification,
+                                    ),
+                                );
+                            } else {
+                                new_inner_ops.insert(
+                                    *tag,
+                                    ValueType::new(None, None, WriteOpKind::Deletion),
+                                );
+                            }
+                        }
+                    }
+
+                    if !inner_ops.is_empty() {
+                        // Not testing metadata_op here, always modification.
+                        group_writes.push((
+                            key.clone(),
+                            ValueType::new(
+                                Some(Bytes::new()),
+                                raw_metadata(5),
+                                WriteOpKind::Modification,
+                            ),
+                            new_inner_ops,
+                        ));
+                    }
+                }
+
+                // generate group_writes.
                 ExecutionStatus::Success(MockOutput {
                     writes: behavior.writes.clone(),
+                    group_writes,
                     deltas: behavior.deltas.clone(),
                     events: behavior.events.to_vec(),
                     read_results,
+                    read_group_sizes,
                     materialized_delta_writes: OnceCell::new(),
                     total_gas: behavior.gas,
                 })
@@ -616,29 +957,36 @@ where
     }
 }
 
-#[derive(Debug)]
+pub(crate) fn raw_metadata(v: u64) -> StateValueMetadataKind {
+    Some(StateValueMetadata::new(v, &CurrentTimeMicroseconds {
+        microseconds: v,
+    }))
+}
 
-pub(crate) struct MockOutput<K, V, E> {
-    pub(crate) writes: Vec<(K, V)>,
+#[derive(Debug)]
+pub(crate) struct MockOutput<K, E> {
+    pub(crate) writes: Vec<(K, ValueType)>,
+    // Key, metadata_op, inner_ops
+    pub(crate) group_writes: Vec<(K, ValueType, HashMap<u32, ValueType>)>,
     pub(crate) deltas: Vec<(K, DeltaOp)>,
     pub(crate) events: Vec<E>,
     pub(crate) read_results: Vec<Option<Vec<u8>>>,
+    pub(crate) read_group_sizes: Vec<(K, u64)>,
     pub(crate) materialized_delta_writes: OnceCell<Vec<(K, WriteOp)>>,
     pub(crate) total_gas: u64,
 }
 
-impl<K, V, E> TransactionOutput for MockOutput<K, V, E>
+impl<K, E> TransactionOutput for MockOutput<K, E>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
-    V: Send + Sync + Debug + Clone + TransactionWrite + 'static,
     E: Send + Sync + Debug + Clone + ReadWriteEvent + 'static,
 {
-    type Txn = MockTransaction<K, V, E>;
+    type Txn = MockTransaction<K, E>;
 
     // TODO[agg_v2](tests): Assigning MoveTypeLayout as None for all the writes for now.
     // That means, the resources do not have any DelayedFields embededded in them.
     // Change it to test resources with DelayedFields as well.
-    fn resource_write_set(&self) -> BTreeMap<K, (V, Option<Arc<MoveTypeLayout>>)> {
+    fn resource_write_set(&self) -> BTreeMap<K, (ValueType, Option<Arc<MoveTypeLayout>>)> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_none())
@@ -647,7 +995,7 @@ where
             .collect()
     }
 
-    fn module_write_set(&self) -> BTreeMap<K, V> {
+    fn module_write_set(&self) -> BTreeMap<K, ValueType> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_some())
@@ -657,7 +1005,7 @@ where
 
     // Aggregator v1 writes are included in resource_write_set for tests (writes are produced
     // for all keys including ones for v1_aggregators without distinguishing).
-    fn aggregator_v1_write_set(&self) -> BTreeMap<K, V> {
+    fn aggregator_v1_write_set(&self) -> BTreeMap<K, ValueType> {
         BTreeMap::new()
     }
 
@@ -681,12 +1029,24 @@ where
         self.events.iter().map(|e| (e.clone(), None)).collect()
     }
 
+    fn resource_group_write_set(&self) -> Vec<(K, ValueType, BTreeMap<u32, ValueType>)> {
+        self.group_writes
+            .iter()
+            .cloned()
+            .map(|(group_key, metadata_v, inner_ops)| {
+                (group_key, metadata_v, inner_ops.into_iter().collect())
+            })
+            .collect()
+    }
+
     fn skip_output() -> Self {
         Self {
             writes: vec![],
+            group_writes: vec![],
             deltas: vec![],
             events: vec![],
             read_results: vec![],
+            read_group_sizes: vec![],
             materialized_delta_writes: OnceCell::new(),
             total_gas: 0,
         }
@@ -700,6 +1060,10 @@ where
             <Self::Txn as Transaction>::Value,
         >,
         _patched_events: Vec<<Self::Txn as Transaction>::Event>,
+        _combined_groups: Vec<(
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Value,
+        )>,
     ) {
         assert_ok!(self.materialized_delta_writes.set(aggregator_v1_writes));
         // TODO[agg_v2](tests): Set the patched resource write set and events. But that requires the function

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -116,12 +116,32 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// Get the events of a transaction from its output.
     fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
 
+    fn resource_group_write_set(
+        &self,
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        <Self::Txn as Transaction>::Value,
+        BTreeMap<<Self::Txn as Transaction>::Tag, <Self::Txn as Transaction>::Value>,
+    )>;
+
+    fn resource_group_metadata_ops(
+        &self,
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        <Self::Txn as Transaction>::Value,
+    )> {
+        self.resource_group_write_set()
+            .into_iter()
+            .map(|(key, op, _)| (key, op))
+            .collect()
+    }
+
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;
 
-    /// In parallel execution, will be called once per transaction when the output is
-    /// ready to be committed. In sequential execution, won't be called (deltas are
-    /// materialized and incorporated during execution).
+    /// Will be called once per transaction when the output is ready to be committed.
+    /// Ensures that any writes corresponding to materialized deltas and group updates
+    /// (recorded in output separately) are incorporated into the transaction output.
     fn incorporate_materialized_txn_output(
         &self,
         aggregator_v1_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,
@@ -130,6 +150,10 @@ pub trait TransactionOutput: Send + Sync + Debug {
             <Self::Txn as Transaction>::Value,
         >,
         patched_events: Vec<<Self::Txn as Transaction>::Event>,
+        combined_groups: Vec<(
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Value,
+        )>,
     );
 
     /// Return the fee statement of the transaction.

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -4,6 +4,7 @@
 use crate::{
     captured_reads::CapturedReads,
     errors::{Error, IntentionalFallbackToSequential},
+    explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
 };
 use aptos_aggregator::types::PanicOr;
@@ -35,6 +36,12 @@ pub(crate) struct TxnOutput<O: TransactionOutput, E: Debug> {
     output_status: ExecutionStatus<O, Error<E>>,
 }
 
+pub(crate) enum KeyKind {
+    Resource,
+    Module,
+    Group,
+}
+
 impl<O: TransactionOutput, E: Debug> TxnOutput<O, E> {
     pub fn from_output_status(output_status: ExecutionStatus<O, Error<E>>) -> Self {
         Self { output_status }
@@ -47,6 +54,11 @@ impl<O: TransactionOutput, E: Debug> TxnOutput<O, E> {
 
 pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug> {
     inputs: Vec<CachePadded<ArcSwapOption<TxnInput<T>>>>, // txn_idx -> input.
+    // Set once when the group outputs are committed sequentially, to be processed later by
+    // concurrent materialization / output preparation.
+    finalized_groups: Vec<
+        CachePadded<ExplicitSyncWrapper<Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>>>,
+    >,
 
     outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<O, E>>>>, // txn_idx -> output.
 
@@ -69,6 +81,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 .collect(),
             outputs: (0..num_txns)
                 .map(|_| CachePadded::new(ArcSwapOption::empty()))
+                .collect(),
+            finalized_groups: (0..num_txns)
+                .map(|_| CachePadded::new(ExplicitSyncWrapper::<Vec<_>>::new(vec![])))
                 .collect(),
             module_writes: DashSet::new(),
             module_reads: DashSet::new(),
@@ -172,7 +187,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         )
     }
 
-    pub(crate) fn execution_error(&self, txn_idx: TxnIndex) -> Option<Error<E>> {
+    pub(crate) fn maybe_execution_error(&self, txn_idx: TxnIndex) -> Option<Error<E>> {
         if self.module_read_write_intersection.load(Ordering::Acquire) {
             return Some(Error::FallbackToSequential(PanicOr::Or(
                 IntentionalFallbackToSequential::ModulePathReadWrite,
@@ -208,7 +223,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     pub(crate) fn modified_keys(
         &self,
         txn_idx: TxnIndex,
-    ) -> Option<impl Iterator<Item = (T::Key, bool)>> {
+    ) -> Option<impl Iterator<Item = (T::Key, KeyKind)>> {
         self.outputs[txn_idx as usize]
             .load_full()
             .and_then(|txn_output| match &txn_output.output_status {
@@ -217,8 +232,17 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                         .into_keys()
                         .chain(t.aggregator_v1_write_set().into_keys())
                         .chain(t.aggregator_v1_delta_set().into_keys())
-                        .map(|k| (k, false))
-                        .chain(t.module_write_set().into_keys().map(|k| (k, true))),
+                        .map(|k| (k, KeyKind::Resource))
+                        .chain(
+                            t.module_write_set()
+                                .into_keys()
+                                .map(|k| (k, KeyKind::Module)),
+                        )
+                        .chain(
+                            t.resource_group_metadata_ops()
+                                .into_iter()
+                                .map(|(k, _)| (k, KeyKind::Group)),
+                        ),
                 ),
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::DirectWriteSetTransactionNotCapableError
@@ -277,6 +301,21 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         )
     }
 
+    pub(crate) fn group_metadata_ops(&self, txn_idx: TxnIndex) -> Vec<(T::Key, T::Value)> {
+        self.outputs[txn_idx as usize].load().as_ref().map_or(
+            vec![],
+            |txn_output| match &txn_output.output_status {
+                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
+                    t.resource_group_metadata_ops()
+                },
+                ExecutionStatus::Abort(_)
+                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
+                | ExecutionStatus::SpeculativeExecutionAbortError(_)
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
+            },
+        )
+    }
+
     pub(crate) fn events(
         &self,
         txn_idx: TxnIndex,
@@ -298,14 +337,31 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         )
     }
 
+    pub(crate) fn record_finalized_group(
+        &self,
+        txn_idx: TxnIndex,
+        finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
+    ) {
+        *self.finalized_groups[txn_idx as usize].acquire() = finalized_groups;
+    }
+
+    pub(crate) fn take_finalized_group(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)> {
+        std::mem::take(&mut self.finalized_groups[txn_idx as usize].acquire())
+    }
+
     // Called when a transaction is committed to record WriteOps for materialized aggregator values
-    // corresponding to the (deltas) in the recorded final output of the transaction.
+    // corresponding to the (deltas) in the recorded final output of the transaction, as well as
+    // finalized group updates.
     pub(crate) fn record_materialized_txn_output(
         &self,
         txn_idx: TxnIndex,
         delta_writes: Vec<(T::Key, WriteOp)>,
         patched_resource_write_set: BTreeMap<T::Key, T::Value>,
         patched_events: Vec<T::Event>,
+        combined_groups: Vec<(T::Key, T::Value)>,
     ) {
         match &self.outputs[txn_idx as usize]
             .load_full()
@@ -317,6 +373,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     delta_writes,
                     patched_resource_write_set,
                     patched_events,
+                    combined_groups,
                 );
             },
             ExecutionStatus::Abort(_)

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -25,7 +25,6 @@ use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     contract_event::ReadWriteEvent,
     executable::{ExecutableTestType, ModulePath},
-    write_set::TransactionWrite,
 };
 use claims::assert_matches;
 use rand::{prelude::*, random};
@@ -34,13 +33,12 @@ use std::{
 };
 
 // TODO: add unit test for block gas limit!
-fn run_and_assert<K, V, E>(transactions: Vec<MockTransaction<K, V, E>>)
+fn run_and_assert<K, E>(transactions: Vec<MockTransaction<K, E>>)
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
-    V: Send + Sync + Debug + Clone + Eq + TransactionWrite + 'static,
     E: Send + Sync + Debug + Clone + ReadWriteEvent + 'static,
 {
-    let data_view = DeltaDataView::<K, V> {
+    let data_view = DeltaDataView::<K> {
         phantom: PhantomData,
     };
 
@@ -52,10 +50,10 @@ where
     );
 
     let output = BlockExecutor::<
-        MockTransaction<K, V, E>,
-        MockTask<K, V, E>,
-        DeltaDataView<K, V>,
-        NoOpTransactionCommitHook<MockOutput<K, V, E>, usize>,
+        MockTransaction<K, E>,
+        MockTask<K, E>,
+        DeltaDataView<K>,
+        NoOpTransactionCommitHook<MockOutput<K, E>, usize>,
         ExecutableTestType,
     >::new(num_cpus::get(), executor_thread_pool, None, None)
     .execute_transactions_parallel((), &transactions, &data_view);
@@ -65,7 +63,7 @@ where
 }
 
 fn random_value(delete_value: bool) -> ValueType {
-    ValueType::new(
+    ValueType::from_value(
         (0..32).map(|_| (random::<u8>())).collect::<Vec<u8>>(),
         !delete_value,
     )
@@ -75,7 +73,7 @@ fn random_value(delete_value: bool) -> ValueType {
 fn empty_block() {
     // This test checks that we do not trigger asserts due to an empty block, e.g. in the
     // scheduler. Instead, parallel execution should gracefully early return empty output.
-    run_and_assert::<KeyType<[u8; 32]>, ValueType, MockEvent>(vec![]);
+    run_and_assert::<KeyType<[u8; 32]>, MockEvent>(vec![]);
 }
 
 #[test]
@@ -83,54 +81,50 @@ fn delta_counters() {
     let key = KeyType(random::<[u8; 32]>(), false);
     let mut transactions = vec![MockTransaction::from_behavior(MockIncarnation::<
         KeyType<[u8; 32]>,
-        ValueType,
         MockEvent,
-    > {
-        reads: vec![],
-        writes: vec![(key, random_value(false))],
-        events: vec![],
-        deltas: vec![],
-        gas: 1,
-    })];
+    >::new(
+        vec![],
+        vec![(key, random_value(false))], // writes
+        vec![],
+        vec![],
+        1, // gas
+    ))];
 
     for _ in 0..50 {
         transactions.push(MockTransaction::from_behavior(MockIncarnation::<
             KeyType<[u8; 32]>,
-            ValueType,
             MockEvent,
-        > {
-            reads: vec![key],
-            writes: vec![],
-            events: vec![],
-            deltas: vec![(key, delta_add(5, u128::MAX))],
-            gas: 1,
-        }));
+        >::new(
+            vec![key], // reads
+            vec![],
+            vec![(key, delta_add(5, u128::MAX))], // deltas
+            vec![],
+            1, // gas
+        )));
     }
 
     transactions.push(MockTransaction::from_behavior(MockIncarnation::<
         KeyType<[u8; 32]>,
-        ValueType,
         MockEvent,
-    > {
-        reads: vec![],
-        writes: vec![(key, random_value(false))],
-        events: vec![],
-        deltas: vec![],
-        gas: 1,
-    }));
+    >::new(
+        vec![],
+        vec![(key, random_value(false))], // writes
+        vec![],
+        vec![],
+        1, // gas
+    )));
 
     for _ in 0..50 {
         transactions.push(MockTransaction::from_behavior(MockIncarnation::<
             KeyType<[u8; 32]>,
-            ValueType,
             MockEvent,
-        > {
-            reads: vec![key],
-            writes: vec![],
-            events: vec![],
-            deltas: vec![(key, delta_sub(2, u128::MAX))],
-            gas: 1,
-        }));
+        >::new(
+            vec![key], // reads
+            vec![],
+            vec![(key, delta_sub(2, u128::MAX))], // deltas
+            vec![],
+            1, // gas
+        )));
     }
 
     run_and_assert(transactions)
@@ -147,35 +141,32 @@ fn delta_chains() {
 
     for i in 0..500 {
         transactions.push(
-            MockTransaction::<KeyType<[u8; 32]>, ValueType, MockEvent>::from_behavior(
-                MockIncarnation {
-                    reads: keys.clone(),
-                    writes: vec![],
-                    events: vec![],
-                    deltas: keys
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(j, k)| match (i + j) % 2 == 0 {
-                            true => Some((
-                                *k,
-                                // Deterministic pattern for adds/subtracts.
-                                DeltaOp::new(
-                                    if (i % 2 == 0) == (j < 5) {
-                                        SignedU128::Positive(10)
-                                    } else {
-                                        SignedU128::Negative(1)
-                                    },
-                                    // below params irrelevant for this test.
-                                    u128::MAX,
-                                    DeltaHistory::new(),
-                                ),
-                            )),
-                            false => None,
-                        })
-                        .collect(),
-                    gas: 1,
-                },
-            ),
+            MockTransaction::<KeyType<[u8; 32]>, MockEvent>::from_behavior(MockIncarnation::new(
+                keys.clone(), // reads
+                vec![],
+                keys.iter()
+                    .enumerate()
+                    .filter_map(|(j, k)| match (i + j) % 2 == 0 {
+                        true => Some((
+                            *k,
+                            // Deterministic pattern for adds/subtracts.
+                            DeltaOp::new(
+                                if (i % 2 == 0) == (j < 5) {
+                                    SignedU128::Positive(10)
+                                } else {
+                                    SignedU128::Negative(1)
+                                },
+                                // below params irrelevant for this test.
+                                u128::MAX,
+                                DeltaHistory::new(),
+                            ),
+                        )),
+                        false => None,
+                    })
+                    .collect(), // deltas
+                vec![],
+                1, // gas
+            )),
         );
     }
 
@@ -195,15 +186,14 @@ fn cycle_transactions() {
         for _ in 0..WRITES_PER_KEY {
             transactions.push(MockTransaction::from_behavior(MockIncarnation::<
                 KeyType<[u8; 32]>,
-                ValueType,
                 MockEvent,
-            > {
-                reads: vec![KeyType(key, false)],
-                writes: vec![(KeyType(key, false), random_value(false))],
-                events: vec![],
-                deltas: vec![],
-                gas: 1,
-            }));
+            >::new(
+                vec![KeyType(key, false)],                        // reads
+                vec![(KeyType(key, false), random_value(false))], // writes
+                vec![],
+                vec![],
+                1, // gas
+            )));
         }
     }
     run_and_assert(transactions)
@@ -222,28 +212,26 @@ fn one_reads_all_barrier() {
         for key in &keys {
             transactions.push(MockTransaction::from_behavior(MockIncarnation::<
                 KeyType<[u8; 32]>,
-                ValueType,
                 MockEvent,
-            > {
-                reads: vec![*key],
-                writes: vec![(*key, random_value(false))],
-                events: vec![],
-                deltas: vec![],
-                gas: 1,
-            }));
+            >::new(
+                vec![*key],                        // reads
+                vec![(*key, random_value(false))], // writes
+                vec![],
+                vec![],
+                1, // gas
+            )));
         }
         // One transaction reading the write results of every prior transactions in the block.
         transactions.push(MockTransaction::from_behavior(MockIncarnation::<
             KeyType<[u8; 32]>,
-            ValueType,
             MockEvent,
-        > {
-            reads: keys.clone(),
-            writes: vec![],
-            events: vec![],
-            deltas: vec![],
-            gas: 1,
-        }));
+        >::new(
+            keys.clone(), //reads
+            vec![],
+            vec![],
+            vec![],
+            1, //gas
+        )));
     }
     run_and_assert(transactions)
 }
@@ -256,29 +244,27 @@ fn one_writes_all_barrier() {
         .collect();
     for _ in 0..NUM_BLOCKS {
         for key in &keys {
-            transactions.push(MockTransaction::from_behavior(MockIncarnation {
-                reads: vec![*key],
-                writes: vec![(*key, random_value(false))],
-                events: vec![],
-                deltas: vec![],
-                gas: 1,
-            }));
+            transactions.push(MockTransaction::from_behavior(MockIncarnation::new(
+                vec![*key],                        //reads
+                vec![(*key, random_value(false))], //writes
+                vec![],
+                vec![],
+                1, //gas
+            )));
         }
         // One transaction writing to the write results of every prior transactions in the block.
         transactions.push(MockTransaction::from_behavior(MockIncarnation::<
             KeyType<[u8; 32]>,
-            ValueType,
             MockEvent,
-        > {
-            reads: keys.clone(),
-            writes: keys
-                .iter()
+        >::new(
+            keys.clone(), // reads
+            keys.iter()
                 .map(|key| (*key, random_value(false)))
-                .collect::<Vec<_>>(),
-            events: vec![],
-            deltas: vec![],
-            gas: 1,
-        }));
+                .collect::<Vec<_>>(), //writes
+            vec![],
+            vec![],
+            1, // gas
+        )));
     }
     run_and_assert(transactions)
 }
@@ -294,15 +280,14 @@ fn early_aborts() {
         for key in &keys {
             transactions.push(MockTransaction::from_behavior(MockIncarnation::<
                 KeyType<[u8; 32]>,
-                ValueType,
                 MockEvent,
-            > {
-                reads: vec![*key],
-                writes: vec![(*key, random_value(false))],
-                events: vec![],
-                deltas: vec![],
-                gas: 1,
-            }));
+            >::new(
+                vec![*key],                        // reads
+                vec![(*key, random_value(false))], // writes
+                vec![],
+                vec![],
+                1, // gas
+            )));
         }
         // One transaction that triggers an abort
         transactions.push(MockTransaction::Abort)
@@ -321,15 +306,14 @@ fn early_skips() {
         for key in &keys {
             transactions.push(MockTransaction::from_behavior(MockIncarnation::<
                 KeyType<[u8; 32]>,
-                ValueType,
                 MockEvent,
-            > {
-                reads: vec![*key],
-                writes: vec![(*key, random_value(false))],
-                events: vec![],
-                deltas: vec![],
-                gas: 1,
-            }));
+            >::new(
+                vec![*key],                        // reads
+                vec![(*key, random_value(false))], //writes
+                vec![],
+                vec![],
+                1, // gas
+            )));
         }
         // One transaction that triggers an abort
         transactions.push(MockTransaction::SkipRest)

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -6,6 +6,7 @@ use crate::{
     counters,
     scheduler::{DependencyResult, DependencyStatus, Scheduler, TWaitForDependency},
 };
+use anyhow::bail;
 use aptos_aggregator::{
     bounded_math::{ok_overflow, BoundedMath, SignedU128},
     delta_change_set::serialize,
@@ -19,7 +20,8 @@ use aptos_aggregator::{
 use aptos_logger::error;
 use aptos_mvhashmap::{
     types::{
-        MVDataError, MVDataOutput, MVDelayedFieldsError, MVModulesError, MVModulesOutput, TxnIndex,
+        GroupReadResult, MVDataError, MVDataOutput, MVDelayedFieldsError, MVGroupError,
+        MVModulesError, MVModulesOutput, StorageVersion, TxnIndex,
     },
     unsync_map::UnsyncMap,
     versioned_delayed_fields::TVersionedDelayedFieldView,
@@ -38,6 +40,7 @@ use aptos_types::{
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use aptos_vm_types::resolver::{StateStorageView, TModuleView, TResourceGroupView, TResourceView};
 use bytes::Bytes;
+use claims::assert_ok;
 use move_core_types::{
     value::{IdentifierMappingKind, MoveTypeLayout},
     vm_status::{StatusCode, VMStatus},
@@ -51,7 +54,7 @@ use move_vm_types::{
 };
 use std::{
     cell::RefCell,
-    collections::HashSet,
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -404,6 +407,119 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
         self.versioned_map.modules().fetch_module(key, txn_idx)
     }
 
+    fn read_from_group(
+        &self,
+        group_key: &T::Key,
+        resource_tag: &T::Tag,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<GroupReadResult> {
+        use MVGroupError::*;
+
+        if let Some(DataRead::Versioned(_, v, layout)) =
+            self.captured_reads
+                .borrow()
+                .get_by_kind(group_key, Some(resource_tag), ReadKind::Value)
+        {
+            return Ok(GroupReadResult::Value(v.extract_raw_bytes(), layout));
+        }
+
+        loop {
+            match self
+                .versioned_map
+                .group_data()
+                .read_from_group(group_key, resource_tag, txn_idx)
+            {
+                Ok((version, v, layout)) => {
+                    let data_read = DataRead::Versioned(version, v.clone(), layout.clone());
+
+                    assert_ok!(
+                        self.captured_reads.borrow_mut().capture_read(
+                            group_key.clone(),
+                            Some(resource_tag.clone()),
+                            data_read
+                        ),
+                        "Resource read in group recorded once: may not be inconsistent"
+                    );
+
+                    return Ok(GroupReadResult::Value(v.extract_raw_bytes(), layout));
+                },
+                Err(Uninitialized) => {
+                    return Ok(GroupReadResult::Uninitialized);
+                },
+                Err(TagNotFound) => {
+                    let data_read = DataRead::Versioned(
+                        Err(StorageVersion),
+                        Arc::<T::Value>::new(TransactionWrite::from_state_value(None)),
+                        None,
+                    );
+                    assert_ok!(
+                        self.captured_reads.borrow_mut().capture_read(
+                            group_key.clone(),
+                            Some(resource_tag.clone()),
+                            data_read
+                        ),
+                        "Resource read in group recorded once: may not be inconsistent"
+                    );
+
+                    return Ok(GroupReadResult::Value(None, None));
+                },
+                Err(Dependency(dep_idx)) => {
+                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
+                        bail!("Interrupted as block execution was halted");
+                    }
+                },
+                Err(TagSerializationError) => {
+                    unreachable!("Reading a resource does not require tag serialization");
+                },
+            }
+        }
+    }
+
+    fn read_group_size(
+        &self,
+        group_key: &T::Key,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<GroupReadResult> {
+        use MVGroupError::*;
+
+        if let Some(group_size) = self.captured_reads.borrow().group_size(group_key) {
+            return Ok(GroupReadResult::Size(group_size));
+        }
+
+        loop {
+            match self
+                .versioned_map
+                .group_data()
+                .get_group_size(group_key, txn_idx)
+            {
+                Ok(group_size) => {
+                    assert_ok!(
+                        self.captured_reads
+                            .borrow_mut()
+                            .capture_group_size(group_key.clone(), group_size),
+                        "Group size may not be inconsistent: must be recorded once"
+                    );
+
+                    return Ok(GroupReadResult::Size(group_size));
+                },
+                Err(Uninitialized) => {
+                    return Ok(GroupReadResult::Uninitialized);
+                },
+                Err(TagNotFound) => {
+                    unreachable!("Reading group size does not require a specific tag look-up");
+                },
+                Err(Dependency(dep_idx)) => {
+                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
+                        bail!("Interrupted as block execution was halted");
+                    }
+                },
+                Err(TagSerializationError) => {
+                    bail!("Resource tag bcs serialization error");
+                },
+            }
+        }
+    }
+
     /// Captures a read from the VM execution, but not unresolved deltas, as in this case it is the
     /// callers responsibility to set the aggregator's base value and call fetch_data again.
     fn read_data_by_kind(
@@ -490,7 +606,7 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
 }
 
 pub(crate) struct SequentialState<'a, T: Transaction, X: Executable> {
-    pub(crate) unsync_map: &'a UnsyncMap<T::Key, T::Value, X, T::Identifier>,
+    pub(crate) unsync_map: &'a UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
     pub(crate) read_set: RefCell<HashSet<T::Key>>,
     pub(crate) counter: &'a RefCell<u32>,
     pub(crate) dynamic_change_set_optimizations_enabled: bool,
@@ -765,6 +881,31 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             },
         }
     }
+
+    fn initialize_mvhashmap_base_group_contents(&self, group_key: &T::Key) -> anyhow::Result<()> {
+        let base_group: BTreeMap<T::Tag, Bytes> = match self.get_base_value(group_key)? {
+            Some(state_value) => bcs::from_bytes(state_value.bytes())
+                .map_err(|_| anyhow::Error::msg("Resource group deserialization error"))?,
+            None => BTreeMap::new(),
+        };
+        let base_group_sentinel_ops = base_group.into_iter().map(|(t, bytes)| {
+            (
+                t,
+                TransactionWrite::from_state_value(Some(StateValue::new_legacy(bytes))),
+            )
+        });
+
+        match &self.latest_view {
+            ViewState::Sync(state) => state
+                .versioned_map
+                .group_data()
+                .set_base_values(group_key.clone(), base_group_sentinel_ops),
+            ViewState::Unsync(state) => state
+                .unsync_map
+                .set_group_base_values(group_key.clone(), base_group_sentinel_ops),
+        };
+        Ok(())
+    }
 }
 
 impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceView
@@ -822,17 +963,54 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceGr
     type Layout = MoveTypeLayout;
     type ResourceTag = T::Tag;
 
-    fn resource_group_size(&self, _group_key: &Self::GroupKey) -> anyhow::Result<u64> {
-        unimplemented!("TResourceGroupView not yet implemented");
+    fn resource_group_size(&self, group_key: &Self::GroupKey) -> anyhow::Result<u64> {
+        let mut group_read = match &self.latest_view {
+            ViewState::Sync(state) => state.read_group_size(group_key, self.txn_idx)?,
+            ViewState::Unsync(state) => state.unsync_map.get_group_size(group_key)?,
+        };
+
+        if matches!(group_read, GroupReadResult::Uninitialized) {
+            self.initialize_mvhashmap_base_group_contents(group_key)?;
+
+            group_read = match &self.latest_view {
+                ViewState::Sync(state) => state.read_group_size(group_key, self.txn_idx)?,
+                ViewState::Unsync(state) => state.unsync_map.get_group_size(group_key)?,
+            }
+        };
+
+        Ok(group_read.into_size())
     }
 
     fn get_resource_from_group(
         &self,
-        _group_key: &Self::GroupKey,
-        _resource_tag: &Self::ResourceTag,
+        group_key: &Self::GroupKey,
+        resource_tag: &Self::ResourceTag,
         _maybe_layout: Option<&Self::Layout>,
     ) -> anyhow::Result<Option<Bytes>> {
-        unimplemented!("TResourceGroupView not yet implemented");
+        // TODO[agg_v2]: support layouts.
+        let mut group_read = match &self.latest_view {
+            ViewState::Sync(state) => {
+                state.read_from_group(group_key, resource_tag, self.txn_idx)?
+            },
+            ViewState::Unsync(state) => state
+                .unsync_map
+                .get_value_from_group(group_key, resource_tag),
+        };
+
+        if matches!(group_read, GroupReadResult::Uninitialized) {
+            self.initialize_mvhashmap_base_group_contents(group_key)?;
+
+            group_read = match &self.latest_view {
+                ViewState::Sync(state) => {
+                    state.read_from_group(group_key, resource_tag, self.txn_idx)?
+                },
+                ViewState::Unsync(state) => state
+                    .unsync_map
+                    .get_value_from_group(group_key, resource_tag),
+            };
+        };
+
+        Ok(group_read.into_value().0)
     }
 
     fn resource_size_in_group(
@@ -840,7 +1018,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceGr
         _group_key: &Self::GroupKey,
         _resource_tag: &Self::ResourceTag,
     ) -> anyhow::Result<u64> {
-        unimplemented!("TResourceGroupView not yet implemented");
+        unimplemented!("Currently resolved by ResourceGroupAdapter");
     }
 
     fn resource_exists_in_group(
@@ -848,7 +1026,13 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceGr
         _group_key: &Self::GroupKey,
         _resource_tag: &Self::ResourceTag,
     ) -> anyhow::Result<bool> {
-        unimplemented!("TResourceGroupView not yet implemented");
+        unimplemented!("Currently resolved by ResourceGroupAdapter");
+    }
+
+    fn release_group_cache(
+        &self,
+    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
+        unimplemented!("Currently resolved by ResourceGroupAdapter");
     }
 }
 

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -6,7 +6,10 @@ use aptos_language_e2e_tests::{
     common_transactions::peer_to_peer_txn, data_store::GENESIS_CHANGE_SET_HEAD,
     executor::FakeExecutor,
 };
-use aptos_types::transaction::{Transaction, TransactionStatus, WriteSetPayload};
+use aptos_types::{
+    transaction::{Transaction, TransactionStatus, WriteSetPayload},
+    write_set::TransactionWrite,
+};
 
 #[test]
 fn no_deletion_in_genesis() {

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -18,6 +18,7 @@ aptos-aggregator = { workspace = true, features = ["testing"] }
 aptos-crypto = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-types = { workspace = true }
+aptos-vm-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 claims = { workspace = true }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -7,6 +7,7 @@ use aptos_aggregator::{
 };
 use aptos_crypto::hash::HashValue;
 use aptos_types::executable::ExecutableDescriptor;
+use bytes::Bytes;
 use move_core_types::value::MoveTypeLayout;
 use std::sync::{atomic::AtomicU32, Arc};
 
@@ -60,6 +61,29 @@ pub enum MVModulesError {
     NotFound,
     /// A dependency on other transaction has been found during the read.
     Dependency(TxnIndex),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum GroupReadResult {
+    Value(Option<Bytes>, Option<Arc<MoveTypeLayout>>),
+    Size(u64),
+    Uninitialized,
+}
+
+impl GroupReadResult {
+    pub fn into_value(self) -> (Option<Bytes>, Option<Arc<MoveTypeLayout>>) {
+        match self {
+            GroupReadResult::Value(maybe_bytes, maybe_layout) => (maybe_bytes, maybe_layout),
+            _ => unreachable!("Expected bytes"),
+        }
+    }
+
+    pub fn into_size(self) -> u64 {
+        match self {
+            GroupReadResult::Size(size) => size,
+            _ => unreachable!("Expected size"),
+        }
+    }
 }
 
 /// Returned as Ok(..) when read successfully from the multi-version data-structure.
@@ -150,8 +174,10 @@ pub(crate) mod test {
     use super::*;
     use aptos_aggregator::delta_change_set::serialize;
     use aptos_types::{
-        access_path::AccessPath, executable::ModulePath, state_store::state_value::StateValue,
-        write_set::TransactionWrite,
+        access_path::AccessPath,
+        executable::ModulePath,
+        state_store::state_value::StateValue,
+        write_set::{TransactionWrite, WriteOpKind},
     };
     use bytes::Bytes;
     use claims::{assert_err, assert_ok_eq};
@@ -189,34 +215,59 @@ pub(crate) mod test {
     }
 
     #[derive(Debug, PartialEq, Eq)]
+    // Kind is set to Creation by default as that makes sense for providing
+    // group base values (used in some tests), and most tests do not care about
+    // the kind. Otherwise, there are specific constructors that initialize kind
+    // for the tests that care (testing group commit logic in parallel).
     pub(crate) struct TestValue {
         bytes: Bytes,
+        kind: WriteOpKind,
     }
 
     impl TestValue {
         pub(crate) fn deletion() -> Self {
             Self {
-                bytes: vec![].into(),
+                bytes: Bytes::new(),
+                kind: WriteOpKind::Deletion,
             }
         }
 
-        pub fn new(mut seed: Vec<u32>) -> Self {
+        pub(crate) fn with_kind(value: usize, is_creation: bool) -> Self {
+            let mut s = Self::from_u128(value as u128);
+            s.kind = if is_creation {
+                WriteOpKind::Creation
+            } else {
+                WriteOpKind::Modification
+            };
+            s
+        }
+
+        pub(crate) fn new(mut seed: Vec<u32>) -> Self {
             seed.resize(4, 0);
             Self {
                 bytes: seed.into_iter().flat_map(|v| v.to_be_bytes()).collect(),
+                kind: WriteOpKind::Creation,
             }
         }
 
         pub(crate) fn from_u128(value: u128) -> Self {
             Self {
                 bytes: serialize(&value).into(),
+                kind: WriteOpKind::Creation,
             }
         }
 
-        pub(crate) fn with_len(len: usize) -> Self {
-            assert!(len > 0, "0 is deletion");
+        pub(crate) fn creation_with_len(len: usize) -> Self {
             Self {
                 bytes: vec![100_u8; len].into(),
+                kind: WriteOpKind::Creation,
+            }
+        }
+
+        pub(crate) fn modification_with_len(len: usize) -> Self {
+            Self {
+                bytes: vec![100_u8; len].into(),
+                kind: WriteOpKind::Modification,
             }
         }
     }
@@ -224,6 +275,10 @@ pub(crate) mod test {
     impl TransactionWrite for TestValue {
         fn bytes(&self) -> Option<&Bytes> {
             (!self.bytes.is_empty()).then_some(&self.bytes)
+        }
+
+        fn write_op_kind(&self) -> WriteOpKind {
+            self.kind.clone()
         }
 
         fn from_state_value(_maybe_state_value: Option<StateValue>) -> Self {

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -74,7 +74,7 @@ impl GroupReadResult {
     pub fn into_value(self) -> (Option<Bytes>, Option<Arc<MoveTypeLayout>>) {
         match self {
             GroupReadResult::Value(maybe_bytes, maybe_layout) => (maybe_bytes, maybe_layout),
-            _ => unreachable!("Expected bytes"),
+            _ => unreachable!("Expected a value"),
         }
     }
 
@@ -214,11 +214,11 @@ pub(crate) mod test {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq)]
     // Kind is set to Creation by default as that makes sense for providing
     // group base values (used in some tests), and most tests do not care about
     // the kind. Otherwise, there are specific constructors that initialize kind
     // for the tests that care (testing group commit logic in parallel).
+    #[derive(Debug, PartialEq, Eq)]
     pub(crate) struct TestValue {
         bytes: Bytes,
         kind: WriteOpKind,

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -32,7 +32,8 @@ fn match_unresolved(
 
 #[test]
 fn unsync_map_data_basic() {
-    let map: UnsyncMap<KeyType<Vec<u8>>, TestValue, ExecutableTestType, ()> = UnsyncMap::new();
+    let map: UnsyncMap<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()> =
+        UnsyncMap::new();
 
     let ap = KeyType(b"/foo/b".to_vec());
 
@@ -223,10 +224,10 @@ fn aggregator_base_mismatch() {
     let vd: VersionedData<KeyType<Vec<u8>>, TestValue> = VersionedData::new();
     let ap = KeyType(b"/foo/b".to_vec());
 
-    vd.set_base_value(ap.clone(), TestValue::with_len(1), None);
+    vd.set_base_value(ap.clone(), TestValue::creation_with_len(1), None);
     // This call must panic, because it provides a mismatching base value:
     // However, only base value length is compared in assert.
-    vd.set_base_value(ap, TestValue::with_len(2), None);
+    vd.set_base_value(ap, TestValue::creation_with_len(2), None);
 }
 
 #[test]

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -8,8 +8,9 @@ use super::{
 };
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, DeltaOp};
 use aptos_types::{
-    executable::ExecutableTestType, state_store::state_value::StateValue,
-    write_set::TransactionWrite,
+    executable::ExecutableTestType,
+    state_store::state_value::StateValue,
+    write_set::{TransactionWrite, WriteOpKind},
 };
 use bytes::Bytes;
 use claims::assert_none;
@@ -64,9 +65,13 @@ impl<V: Into<Vec<u8>> + Clone> Value<V> {
     }
 }
 
-impl<V: Into<Vec<u8>> + Clone> TransactionWrite for Value<V> {
+impl<V: Into<Vec<u8>> + Clone + Debug> TransactionWrite for Value<V> {
     fn bytes(&self) -> Option<&Bytes> {
         self.maybe_bytes.as_ref()
+    }
+
+    fn write_op_kind(&self) -> WriteOpKind {
+        unimplemented!("Irrelevant for the test")
     }
 
     fn from_state_value(_maybe_state_value: Option<StateValue>) -> Self {

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -1,25 +1,38 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{types::MVModulesOutput, utils::module_hash};
+use crate::{
+    types::{GroupReadResult, MVModulesOutput},
+    utils::module_hash,
+};
+use anyhow::bail;
 use aptos_aggregator::types::DelayedFieldValue;
 use aptos_crypto::hash::HashValue;
 use aptos_types::{
     executable::{Executable, ExecutableDescriptor, ModulePath},
-    write_set::TransactionWrite,
+    write_set::{TransactionWrite, WriteOpKind},
 };
+use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use move_core_types::value::MoveTypeLayout;
-use std::{cell::RefCell, collections::HashMap, hash::Hash, sync::Arc};
+use serde::Serialize;
+use std::{cell::RefCell, collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 
 /// UnsyncMap is designed to mimic the functionality of MVHashMap for sequential execution.
 /// In this case only the latest recorded version is relevant, simplifying the implementation.
 /// The functionality also includes Executable caching based on the hash of ExecutableDescriptor
 /// (i.e. module hash for modules published during the latest block - not at storage version).
-pub struct UnsyncMap<K: ModulePath, V: TransactionWrite, X: Executable, I: Copy> {
+pub struct UnsyncMap<
+    K: ModulePath,
+    T: Hash + Clone + Debug + Eq + Serialize,
+    V: TransactionWrite,
+    X: Executable,
+    I: Copy,
+> {
     // Only use Arc to provide unified interfaces with the MVHashMap / concurrent setting. This
     // simplifies the trait-based integration for executable caching. TODO: better representation.
     // Optional hash can store the hash of the module to avoid re-computations.
     map: RefCell<HashMap<K, (Arc<V>, Option<HashValue>, Option<Arc<MoveTypeLayout>>)>>,
+    group_cache: RefCell<HashMap<K, HashMap<T, Arc<V>>>>,
     executable_cache: RefCell<HashMap<HashValue, Arc<X>>>,
     executable_bytes: RefCell<usize>,
     delayed_field_map: RefCell<HashMap<I, DelayedFieldValue>>,
@@ -27,14 +40,16 @@ pub struct UnsyncMap<K: ModulePath, V: TransactionWrite, X: Executable, I: Copy>
 
 impl<
         K: ModulePath + Hash + Clone + Eq,
+        T: Hash + Clone + Debug + Eq + Serialize,
         V: TransactionWrite,
         X: Executable,
         I: Hash + Clone + Copy + Eq,
-    > Default for UnsyncMap<K, V, X, I>
+    > Default for UnsyncMap<K, T, V, X, I>
 {
     fn default() -> Self {
         Self {
             map: RefCell::new(HashMap::new()),
+            group_cache: RefCell::new(HashMap::new()),
             executable_cache: RefCell::new(HashMap::new()),
             executable_bytes: RefCell::new(0),
             delayed_field_map: RefCell::new(HashMap::new()),
@@ -44,18 +59,102 @@ impl<
 
 impl<
         K: ModulePath + Hash + Clone + Eq,
+        T: Hash + Clone + Debug + Eq + Serialize,
         V: TransactionWrite,
         X: Executable,
         I: Hash + Clone + Copy + Eq,
-    > UnsyncMap<K, V, X, I>
+    > UnsyncMap<K, T, V, X, I>
 {
     pub fn new() -> Self {
-        Self {
-            map: RefCell::new(HashMap::new()),
-            executable_cache: RefCell::new(HashMap::new()),
-            executable_bytes: RefCell::new(0),
-            delayed_field_map: RefCell::new(HashMap::new()),
+        Self::default()
+    }
+
+    pub fn set_group_base_values(
+        &self,
+        group_key: K,
+        base_values: impl IntoIterator<Item = (T, V)>,
+    ) {
+        assert!(
+            self.group_cache
+                .borrow_mut()
+                .insert(
+                    group_key,
+                    base_values
+                        .into_iter()
+                        .map(|(t, v)| (t, Arc::new(v)))
+                        .collect()
+                )
+                .is_none(),
+            "UnsyncMap group cache must be empty to provide base values"
+        );
+    }
+
+    pub fn get_group_size(&self, group_key: &K) -> anyhow::Result<GroupReadResult> {
+        Ok(match self.group_cache.borrow().get(group_key) {
+            Some(group_map) => GroupReadResult::Size(group_size_as_sum(
+                group_map
+                    .iter()
+                    .flat_map(|(t, v)| v.bytes().map(|bytes| (t, bytes))),
+            )?),
+            None => GroupReadResult::Uninitialized,
+        })
+    }
+
+    pub fn get_value_from_group(&self, group_key: &K, value_tag: &T) -> GroupReadResult {
+        self.group_cache.borrow().get(group_key).map_or(
+            GroupReadResult::Uninitialized,
+            |group_map| {
+                GroupReadResult::Value(
+                    group_map.get(value_tag).and_then(|v| v.extract_raw_bytes()),
+                    // TODO[agg_v2]: support layouts.
+                    None,
+                )
+            },
+        )
+    }
+
+    /// Contains the latest group ops for the given group key.
+    pub fn finalize_group(&self, group_key: &K) -> Vec<(T, Arc<V>)> {
+        self.group_cache
+            .borrow()
+            .get(group_key)
+            .expect("Resource group must be cached")
+            .clone()
+            .into_iter()
+            .collect()
+    }
+
+    pub fn insert_group_op(&self, group_key: &K, value_tag: T, v: V) -> anyhow::Result<()> {
+        use std::collections::hash_map::Entry::*;
+        use WriteOpKind::*;
+
+        match (
+            self.group_cache
+                .borrow_mut()
+                .get_mut(group_key)
+                .expect("Resource group must be cached")
+                .entry(value_tag.clone()),
+            v.write_op_kind(),
+        ) {
+            (Occupied(entry), Deletion) => {
+                entry.remove();
+            },
+            (Occupied(mut entry), Modification) => {
+                entry.insert(Arc::new(v));
+            },
+            (Vacant(entry), Creation) => {
+                entry.insert(Arc::new(v));
+            },
+            (_, _) => {
+                bail!(
+                    "WriteOp kind {:?} not consistent with previous value at tag {:?}",
+                    v.write_op_kind(),
+                    value_tag
+                );
+            },
         }
+
+        Ok(())
     }
 
     pub fn fetch_data(&self, key: &K) -> Option<(Arc<V>, Option<Arc<MoveTypeLayout>>)> {
@@ -114,5 +213,251 @@ impl<
 
     pub fn write_delayed_field(&self, id: I, value: DelayedFieldValue) {
         self.delayed_field_map.borrow_mut().insert(id, value);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::types::test::{KeyType, TestValue};
+    use aptos_types::executable::ExecutableTestType;
+    use claims::{assert_err, assert_none, assert_ok, assert_ok_eq, assert_some_eq};
+
+    fn finalize_group_as_hashmap(
+        map: &UnsyncMap<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>,
+        key: &KeyType<Vec<u8>>,
+    ) -> HashMap<usize, Arc<TestValue>> {
+        map.finalize_group(key).into_iter().collect()
+    }
+
+    #[test]
+    fn group_commit_idx() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        map.set_group_base_values(
+            ap.clone(),
+            // base tag 1, 2, 3
+            (1..4).map(|i| (i, TestValue::with_kind(i, true))),
+        );
+        assert_ok!(map.insert_group_op(&ap, 2, TestValue::with_kind(202, false)));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(203, false)));
+        let committed = finalize_group_as_hashmap(&map, &ap);
+
+        // // The value at tag 1 is from base, while 2 and 3 are from txn 3.
+        // // (Arc compares with value equality)
+        assert_eq!(committed.len(), 3);
+        assert_some_eq!(committed.get(&1), &Arc::new(TestValue::with_kind(1, true)));
+        assert_some_eq!(
+            committed.get(&2),
+            &Arc::new(TestValue::with_kind(202, false))
+        );
+        assert_some_eq!(
+            committed.get(&3),
+            &Arc::new(TestValue::with_kind(203, false))
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(303, false)));
+        assert_ok!(map.insert_group_op(&ap, 4, TestValue::with_kind(304, true)));
+        let committed = finalize_group_as_hashmap(&map, &ap);
+        assert_eq!(committed.len(), 4);
+        assert_some_eq!(committed.get(&1), &Arc::new(TestValue::with_kind(1, true)));
+        assert_some_eq!(
+            committed.get(&2),
+            &Arc::new(TestValue::with_kind(202, false))
+        );
+        assert_some_eq!(
+            committed.get(&3),
+            &Arc::new(TestValue::with_kind(303, false))
+        );
+        assert_some_eq!(
+            committed.get(&4),
+            &Arc::new(TestValue::with_kind(304, true))
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::with_kind(100, true)));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion()));
+        assert_err!(map.insert_group_op(&ap, 1, TestValue::deletion()));
+        let committed = finalize_group_as_hashmap(&map, &ap);
+        assert_eq!(committed.len(), 4);
+        assert_some_eq!(
+            committed.get(&0),
+            &Arc::new(TestValue::with_kind(100, true))
+        );
+        assert_none!(committed.get(&1));
+        assert_some_eq!(
+            committed.get(&2),
+            &Arc::new(TestValue::with_kind(202, false))
+        );
+        assert_some_eq!(
+            committed.get(&3),
+            &Arc::new(TestValue::with_kind(303, false))
+        );
+        assert_some_eq!(
+            committed.get(&4),
+            &Arc::new(TestValue::with_kind(304, true))
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::with_kind(400, true)));
+        assert_ok!(map.insert_group_op(&ap, 2, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 4, TestValue::deletion()));
+        let committed = finalize_group_as_hashmap(&map, &ap);
+        assert_eq!(committed.len(), 1);
+        assert_some_eq!(
+            committed.get(&1),
+            &Arc::new(TestValue::with_kind(400, true))
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn set_base_twice() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        map.set_group_base_values(
+            ap.clone(),
+            (1..4).map(|i| (i, TestValue::with_kind(i, true))),
+        );
+        map.set_group_base_values(
+            ap.clone(),
+            (1..4).map(|i| (i, TestValue::with_kind(i, true))),
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn group_op_without_base() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::with_kind(10, true)));
+    }
+
+    #[should_panic]
+    #[test]
+    fn group_no_path_exists() {
+        let ap = KeyType(b"/foo/b".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        map.finalize_group(&ap);
+    }
+
+    #[test]
+    fn group_size() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        assert_ok_eq!(map.get_group_size(&ap), GroupReadResult::Uninitialized);
+
+        map.set_group_base_values(
+            ap.clone(),
+            // base tag 1, 2, 3, 4
+            (1..5).map(|i| (i, TestValue::creation_with_len(1))),
+        );
+
+        let tag: usize = 5;
+        let tag_len = bcs::serialized_size(&tag).unwrap();
+        let one_entry_len = TestValue::creation_with_len(1).bytes().unwrap().len();
+        let two_entry_len = TestValue::creation_with_len(2).bytes().unwrap().len();
+        let three_entry_len = TestValue::creation_with_len(3).bytes().unwrap().len();
+        let four_entry_len = TestValue::creation_with_len(4).bytes().unwrap().len();
+
+        let exp_size = 4 * one_entry_len + 4 * tag_len;
+        assert_ok_eq!(
+            map.get_group_size(&ap),
+            GroupReadResult::Size(exp_size as u64)
+        );
+
+        assert_err!(map.insert_group_op(&ap, 0, TestValue::modification_with_len(2)));
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::creation_with_len(2)));
+        assert_err!(map.insert_group_op(&ap, 1, TestValue::creation_with_len(2)));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::modification_with_len(2)));
+        let exp_size = 2 * two_entry_len + 3 * one_entry_len + 5 * tag_len;
+        assert_ok_eq!(
+            map.get_group_size(&ap),
+            GroupReadResult::Size(exp_size as u64)
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 4, TestValue::modification_with_len(3)));
+        assert_ok!(map.insert_group_op(&ap, 5, TestValue::creation_with_len(3)));
+        let exp_size = exp_size + 2 * three_entry_len + tag_len - one_entry_len;
+        assert_ok_eq!(
+            map.get_group_size(&ap),
+            GroupReadResult::Size(exp_size as u64)
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 0, TestValue::modification_with_len(4)));
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::modification_with_len(4)));
+        let exp_size = 2 * four_entry_len + 2 * three_entry_len + 2 * one_entry_len + 6 * tag_len;
+        assert_ok_eq!(
+            map.get_group_size(&ap),
+            GroupReadResult::Size(exp_size as u64)
+        );
+    }
+
+    #[test]
+    fn group_value() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
+
+        assert_eq!(
+            map.get_value_from_group(&ap, &1),
+            GroupReadResult::Uninitialized
+        );
+
+        map.set_group_base_values(
+            ap.clone(),
+            // base tag 1, 2, 3, 4
+            (1..5).map(|i| (i, TestValue::creation_with_len(i))),
+        );
+
+        for i in 1..5 {
+            assert_eq!(
+                map.get_value_from_group(&ap, &i),
+                GroupReadResult::Value(TestValue::creation_with_len(i).bytes().cloned(), None)
+            )
+        }
+        assert_eq!(
+            map.get_value_from_group(&ap, &0),
+            GroupReadResult::Value(None, None)
+        );
+        assert_eq!(
+            map.get_value_from_group(&ap, &6),
+            GroupReadResult::Value(None, None)
+        );
+
+        assert_ok!(map.insert_group_op(&ap, 1, TestValue::deletion()));
+        assert_ok!(map.insert_group_op(&ap, 3, TestValue::modification_with_len(8)));
+        assert_ok!(map.insert_group_op(&ap, 6, TestValue::creation_with_len(9)));
+
+        assert_eq!(
+            map.get_value_from_group(&ap, &1),
+            GroupReadResult::Value(None, None)
+        );
+        assert_eq!(
+            map.get_value_from_group(&ap, &3),
+            GroupReadResult::Value(TestValue::creation_with_len(8).bytes().cloned(), None)
+        );
+        assert_eq!(
+            map.get_value_from_group(&ap, &6),
+            GroupReadResult::Value(TestValue::creation_with_len(9).bytes().cloned(), None)
+        );
+
+        // others unaffected.
+        assert_eq!(
+            map.get_value_from_group(&ap, &0),
+            GroupReadResult::Value(None, None)
+        );
+        assert_eq!(
+            map.get_value_from_group(&ap, &2),
+            GroupReadResult::Value(TestValue::creation_with_len(2).bytes().cloned(), None)
+        );
+        assert_eq!(
+            map.get_value_from_group(&ap, &4),
+            GroupReadResult::Value(TestValue::creation_with_len(4).bytes().cloned(), None)
+        );
     }
 }

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -296,7 +296,7 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
         };
     }
 
-    /// Versioned write of data at ag given key (and version).
+    /// Versioned write of data at a given key (and version).
     pub fn write(
         &self,
         key: K,

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -262,7 +262,7 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
 
     pub fn set_base_value(&self, key: K, data: V, maybe_layout: Option<Arc<MoveTypeLayout>>) {
         let mut v = self.values.entry(key).or_default();
-        let bytes_len = data.bytes_len();
+        let bytes_len = data.bytes().map(|b| b.len());
         // For base value, incarnation is irrelevant, and is always set to 0.
 
         use btree_map::Entry::*;
@@ -287,25 +287,16 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
                         // Assert the length of bytes for efficiency (instead of full equality)
                         layout.is_some() == maybe_layout.is_some()
                             && *i == 0
-                            && (layout.is_some() || v.bytes_len() == bytes_len)
+                            && (layout.is_some() || v.bytes().map(|b| b.len()) == bytes_len)
                     } else {
                         true
                     }
                 );
             },
         };
-
-        // let prev_entry = v.versioned_map.insert(
-        //     ShiftedTxnIndex::zero(),
-        //     CachePadded::new(Entry::new_write_from(0, data, maybe_layout)),
-        // );
-
-        // assert!(prev_entry.map_or(true, |entry| -> bool {
-
-        // }));
     }
 
-    /// Versioned write of data at a given key (and version).
+    /// Versioned write of data at ag given key (and version).
     pub fn write(
         &self,
         key: K,

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::types::{Flag, Incarnation, MVGroupError, ShiftedTxnIndex, TxnIndex, Version};
-use aptos_types::write_set::TransactionWrite;
-use claims::assert_some;
+use anyhow::bail;
+use aptos_types::write_set::{TransactionWrite, WriteOpKind};
+use claims::{assert_none, assert_some};
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
 use move_core_types::value::MoveTypeLayout;
 use serde::Serialize;
 use std::{
-    collections::{btree_map::BTreeMap, HashMap},
+    collections::{btree_map::BTreeMap, HashMap, HashSet},
     fmt::Debug,
     hash::Hash,
     sync::Arc,
@@ -88,7 +89,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                 // base value may have already been provided by another transaction
                 // executed simultaneously and asking for the same resource group.
                 // Value from storage must be identical, but then delayed field
-                // identifier exchange could've modiefied it.
+                // identifier exchange could've modified it.
                 //
                 // If maybe_layout is None, they are required to be identical
                 // If maybe_layout is Some, there might have been an exchange
@@ -97,11 +98,13 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                     let prev_v = previous
                         .get(&tag)
                         .expect("Reading twice from storage must be consistent");
-                    assert!(v.bytes_len() == prev_v.bytes_len());
+                    assert!(v.bytes().map(|b| b.len()) == prev_v.bytes().map(|b| b.len()));
                 }
             },
             // For base value, incarnation is irrelevant, and is always set to 0.
-            None => self.write(shifted_idx, 0, values),
+            None => {
+                self.write(shifted_idx, 0, values);
+            },
         }
     }
 
@@ -111,10 +114,21 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
         incarnation: Incarnation,
         // TODO[agg_v2](fix) add layout to values
         values: impl IntoIterator<Item = (T, V)>,
-    ) {
+    ) -> bool {
+        let zero_idx = ShiftedTxnIndex::zero();
+        let at_base_version = shifted_idx == zero_idx;
+
+        // Remove any prior entries.
+        let prev_tags: HashSet<T> = self.remove(shifted_idx.clone()).into_iter().collect();
+        let mut writes_outside = false;
+
         let arc_map = values
             .into_iter()
             .map(|(tag, v)| {
+                if !prev_tags.contains(&tag) {
+                    writes_outside = true;
+                }
+
                 let arc_v = Arc::new(v);
 
                 // Update versioned_map.
@@ -129,14 +143,19 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
             })
             .collect();
 
-        let zero = ShiftedTxnIndex::zero();
-        let base_idx = shifted_idx == zero;
+        assert_none!(
+            self.idx_to_update
+                .insert(shifted_idx, CachePadded::new(arc_map)),
+            "prev_map previously removed and processed."
+        );
 
-        self.idx_to_update
-            .insert(shifted_idx, CachePadded::new(arc_map));
-        if base_idx {
-            self.commit_idx(zero);
+        if at_base_version {
+            // base version is from storage and final - immediately treat as committed.
+            self.commit_idx(zero_idx)
+                .expect("Marking storage version as committed must succeed");
         }
+
+        writes_outside
     }
 
     fn mark_estimate(&mut self, txn_idx: TxnIndex) {
@@ -159,41 +178,62 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
         }
     }
 
-    fn delete(&mut self, txn_idx: TxnIndex) {
-        let shifted_idx = ShiftedTxnIndex::new(txn_idx);
-        // Delete idx updates first, then entries.
-        let idx_updates = self
+    fn remove(&mut self, shifted_idx: ShiftedTxnIndex) -> Vec<T> {
+        // Remove idx updates first, then entries.
+        let idx_update_tags: Vec<T> = self
             .idx_to_update
             .remove(&shifted_idx)
-            .expect("Group updates must exist at the index to mark estimate");
+            .map_or(vec![], |map| map.into_inner().into_keys().collect());
 
-        // Similar to mark_estimate, need to delete an individual entry for each tag.
-        for (tag, _) in idx_updates.iter() {
+        // Similar to mark_estimate, need to remove an individual entry for each tag.
+        for tag in idx_update_tags.iter() {
             assert_some!(
                 self.versioned_map
                     .get_mut(tag)
                     .expect("Versioned entry must exist for tag")
                     .remove(&shifted_idx),
-                "Entry for tag / idx must exist to be deleted"
+                "Entry for tag / idx must exist to be removed"
             );
         }
+
+        idx_update_tags
     }
 
-    // Records and returns pointers for the latest committed value for each tag in the group.
-    fn commit_idx(&mut self, shifted_idx: ShiftedTxnIndex) -> HashMap<T, Arc<V>> {
+    // Records the latest committed op for each tag in the group (removed tags ar excluded).
+    fn commit_idx(&mut self, shifted_idx: ShiftedTxnIndex) -> anyhow::Result<()> {
+        use std::collections::hash_map::Entry::*;
+        use WriteOpKind::*;
+
         let idx_updates = self
             .idx_to_update
             .get(&shifted_idx)
             .expect("Group updates must exist at the index to commit");
         for (tag, v) in idx_updates.iter() {
-            if v.is_deletion() {
-                self.committed_group.remove(tag);
-            } else {
-                self.committed_group.insert(tag.clone(), v.clone());
+            match (self.committed_group.entry(tag.clone()), v.write_op_kind()) {
+                (Occupied(entry), Deletion) => {
+                    entry.remove();
+                },
+                (Occupied(mut entry), Modification) => {
+                    entry.insert(v.clone());
+                },
+                (Vacant(entry), Creation) => {
+                    entry.insert(v.clone());
+                },
+                (_, _) => {
+                    bail!(
+                        "WriteOp kind {:?} not consistent with previous value at tag {:?}",
+                        v.write_op_kind(),
+                        tag
+                    );
+                },
             }
         }
 
-        self.committed_group.clone()
+        Ok(())
+    }
+
+    fn get_committed_group(&self) -> Vec<(T, Arc<V>)> {
+        self.committed_group.clone().into_iter().collect()
     }
 
     fn get_latest_tagged_value(
@@ -254,11 +294,16 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                                 idx.idx().expect("May not depend on storage version"),
                             ))
                         } else {
-                            let delta = entry.value.bytes_len() as u64
-                                + bcs::serialized_size(tag)
-                                    .map_err(|_| MVGroupError::TagSerializationError)?
-                                    as u64;
-                            Ok(len + delta)
+                            match entry.value.bytes() {
+                                Some(bytes) => {
+                                    let delta = bytes.len() as u64
+                                        + bcs::serialized_size(tag)
+                                            .map_err(|_| MVGroupError::TagSerializationError)?
+                                            as u64;
+                                    Ok(len + delta)
+                                },
+                                None => Ok(len),
+                            }
                         }
                     },
                     None => Ok(len),
@@ -293,12 +338,12 @@ impl<
         txn_idx: TxnIndex,
         incarnation: Incarnation,
         values: impl IntoIterator<Item = (T, V)>,
-    ) {
+    ) -> bool {
         self.group_values.entry(key).or_default().write(
             ShiftedTxnIndex::new(txn_idx),
             incarnation,
             values,
-        );
+        )
     }
 
     /// Mark all entry from transaction 'txn_idx' at access path 'key' as an estimated write
@@ -310,13 +355,12 @@ impl<
             .mark_estimate(txn_idx);
     }
 
-    /// Delete all entries from transaction 'txn_idx' at access path 'key'. Will panic
-    /// if the corresponding entry does not exist.
-    pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
+    /// Remove all entries from transaction 'txn_idx' at access path 'key'.
+    pub fn remove(&self, key: &K, txn_idx: TxnIndex) {
         self.group_values
             .get_mut(key)
             .expect("Path must exist")
-            .delete(txn_idx);
+            .remove(ShiftedTxnIndex::new(txn_idx));
     }
 
     /// Read the latest value corresponding to a tag at a given group (identified by key).
@@ -355,10 +399,15 @@ impl<
     /// The method must be called when all transactions <= txn_idx are actually committed, and
     /// the values pointed by weak are guaranteed to be fixed and available during the lifetime
     /// of the data-structure itself.
-    pub fn commit_group(&self, key: &K, txn_idx: TxnIndex) -> HashMap<T, Arc<V>> {
+    ///
+    /// The method checks that each committed write op kind is consistent with the existence of
+    /// a previous value of the resource (must be creation iff no previous value, deletion or
+    /// modification otherwise). When consistent, the output is Ok(..).
+    pub fn finalize_group(&self, key: &K, txn_idx: TxnIndex) -> anyhow::Result<Vec<(T, Arc<V>)>> {
         let mut v = self.group_values.get_mut(key).expect("Path must exist");
 
-        v.commit_idx(ShiftedTxnIndex::new(txn_idx))
+        v.commit_idx(ShiftedTxnIndex::new(txn_idx))?;
+        Ok(v.get_committed_group())
     }
 }
 
@@ -369,7 +418,7 @@ mod test {
         test::{KeyType, TestValue},
         StorageVersion,
     };
-    use claims::{assert_matches, assert_none, assert_ok_eq, assert_some_eq};
+    use claims::{assert_err, assert_matches, assert_none, assert_ok_eq, assert_some_eq};
     use test_case::test_case;
 
     #[should_panic]
@@ -385,10 +434,10 @@ mod test {
                 map.mark_estimate(&ap, 1);
             },
             1 => {
-                map.delete(&ap, 2);
+                map.remove(&ap, 2);
             },
             2 => {
-                map.commit_group(&ap, 0);
+                let _ = map.finalize_group(&ap, 0);
             },
             _ => unreachable!("Wrong test index"),
         }
@@ -411,11 +460,11 @@ mod test {
             3,
             1,
             // tags 0, 1, 2.
-            (0..2).map(|i| (i, TestValue::with_len(1))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(1))),
         );
 
         // Size should be uninitialized even if the output of lower txn is stored
-        // (as long as the base isn't provided).
+        // (as long as the base isn't set).
         assert_matches!(
             map.get_group_size(&ap_1, 3),
             Err(MVGroupError::Uninitialized)
@@ -433,7 +482,7 @@ mod test {
         assert_eq!(
             map.read_from_group(&ap_1, &1, 4).unwrap(),
             // Arc compares by value, no return size, incarnation.
-            (Ok((3, 1)), Arc::new(TestValue::with_len(1)), None)
+            (Ok((3, 1)), Arc::new(TestValue::creation_with_len(1)), None)
         );
         // ap_0 should still be uninitialized.
         assert_matches!(
@@ -446,7 +495,7 @@ mod test {
             4,
             0,
             // tags 1, 2.
-            (1..3).map(|i| (i, TestValue::with_len(4))),
+            (1..3).map(|i| (i, TestValue::creation_with_len(4))),
         );
         assert_matches!(
             map.read_from_group(&ap_2, &2, 4),
@@ -455,7 +504,7 @@ mod test {
         map.set_base_values(
             ap_2.clone(),
             // base tags 0, 1.
-            (0..2).map(|i| (i, TestValue::with_len(2))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(2))),
         );
 
         // Tag not found vs not initialized,
@@ -470,11 +519,15 @@ mod test {
         // vs finding a versioned entry from txn 4, vs from storage.
         assert_eq!(
             map.read_from_group(&ap_2, &2, 5).unwrap(),
-            (Ok((4, 0)), Arc::new(TestValue::with_len(4)), None)
+            (Ok((4, 0)), Arc::new(TestValue::creation_with_len(4)), None)
         );
         assert_eq!(
             map.read_from_group(&ap_2, &0, 5).unwrap(),
-            (Err(StorageVersion), Arc::new(TestValue::with_len(2)), None)
+            (
+                Err(StorageVersion),
+                Arc::new(TestValue::creation_with_len(2)),
+                None
+            )
         );
     }
 
@@ -516,7 +569,7 @@ mod test {
             (Ok((5, 3)), Arc::new(TestValue::new(vec![5, 3])), None)
         );
 
-        map.delete(&ap, 10);
+        map.remove(&ap, 10);
         assert_eq!(
             map.read_from_group(&ap, &0, 12).unwrap(),
             (Ok((5, 3)), Arc::new(TestValue::new(vec![5, 3])), None)
@@ -538,22 +591,22 @@ mod test {
             5,
             3,
             // tags 0, 1
-            (0..2).map(|i| (i, TestValue::with_len(2))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(2))),
         );
         assert_matches!(map.get_group_size(&ap, 12), Err(Uninitialized));
 
         map.set_base_values(
             ap.clone(),
             // base tag 1, 2, 3, 4
-            (1..5).map(|i| (i, TestValue::with_len(1))),
+            (1..5).map(|i| (i, TestValue::creation_with_len(1))),
         );
 
         let tag: usize = 5;
         let tag_len = bcs::serialized_size(&tag).unwrap();
-        let one_entry_len = TestValue::with_len(1).bytes_len();
-        let two_entry_len = TestValue::with_len(2).bytes_len();
-        let three_entry_len = TestValue::with_len(3).bytes_len();
-        let four_entry_len = TestValue::with_len(4).bytes_len();
+        let one_entry_len = TestValue::creation_with_len(1).bytes().unwrap().len();
+        let two_entry_len = TestValue::creation_with_len(2).bytes().unwrap().len();
+        let three_entry_len = TestValue::creation_with_len(3).bytes().unwrap().len();
+        let four_entry_len = TestValue::creation_with_len(4).bytes().unwrap().len();
         let exp_size = 2 * two_entry_len + 3 * one_entry_len + 5 * tag_len;
         assert_ok_eq!(map.get_group_size(&ap, 12), exp_size as u64);
 
@@ -562,7 +615,7 @@ mod test {
             10,
             1,
             // tags 4, 5
-            (4..6).map(|i| (i, TestValue::with_len(3))),
+            (4..6).map(|i| (i, TestValue::creation_with_len(3))),
         );
         let exp_size_12 = exp_size + 2 * three_entry_len + tag_len - one_entry_len;
         assert_ok_eq!(map.get_group_size(&ap, 12), exp_size_12 as u64);
@@ -577,14 +630,22 @@ mod test {
             ap.clone(),
             6,
             1,
-            (0..2).map(|i| (i, TestValue::with_len(4))),
+            (0..2).map(|i| (i, TestValue::creation_with_len(4))),
         );
         let exp_size_7 = 2 * four_entry_len + 3 * one_entry_len + 5 * tag_len;
         assert_ok_eq!(map.get_group_size(&ap, 7), exp_size_7 as u64);
         assert_matches!(map.get_group_size(&ap, 6), Err(Dependency(5)));
 
-        map.delete(&ap, 5);
+        map.remove(&ap, 5);
         assert_ok_eq!(map.get_group_size(&ap, 6), exp_size_4 as u64);
+    }
+
+    fn finalize_group_as_hashmap(
+        map: &VersionedGroupData<KeyType<Vec<u8>>, usize, TestValue>,
+        key: &KeyType<Vec<u8>>,
+        idx: TxnIndex,
+    ) -> HashMap<usize, Arc<TestValue>> {
+        map.finalize_group(key, idx).unwrap().into_iter().collect()
     }
 
     #[test]
@@ -595,7 +656,7 @@ mod test {
         map.set_base_values(
             ap.clone(),
             // base tag 1, 2, 3
-            (1..4).map(|i| (i, TestValue::from_u128(i as u128))),
+            (1..4).map(|i| (i, TestValue::with_kind(i, true))),
         );
         map.write(
             ap.clone(),
@@ -603,7 +664,7 @@ mod test {
             3,
             // insert at 0, remove at 1.
             vec![
-                (0, TestValue::from_u128(100_u128)),
+                (0, TestValue::with_kind(100, true)),
                 (1, TestValue::deletion()),
             ],
         );
@@ -612,77 +673,147 @@ mod test {
             3,
             0,
             // tags 2, 3
-            (2..4).map(|i| (i, TestValue::from_u128(200 + i as u128))),
+            (2..4).map(|i| (i, TestValue::with_kind(200 + i, false))),
         );
-        let committed_3 = map.commit_group(&ap, 3);
+        let committed_3 = finalize_group_as_hashmap(&map, &ap, 3);
         // The value at tag 1 is from base, while 2 and 3 are from txn 3.
         // (Arc compares with value equality)
         assert_eq!(committed_3.len(), 3);
-        assert_some_eq!(committed_3.get(&1), &Arc::new(TestValue::from_u128(1)));
+        assert_some_eq!(
+            committed_3.get(&1),
+            &Arc::new(TestValue::with_kind(1, true))
+        );
         assert_some_eq!(
             committed_3.get(&2),
-            &Arc::new(TestValue::from_u128(200 + 2))
+            &Arc::new(TestValue::with_kind(202, false))
         );
         assert_some_eq!(
             committed_3.get(&3),
-            &Arc::new(TestValue::from_u128(200 + 3))
+            &Arc::new(TestValue::with_kind(203, false))
         );
 
-        map.write(
-            ap.clone(),
-            5,
-            3,
-            // tags 3, 4
-            (3..5).map(|i| (i, TestValue::from_u128(300 + i as u128))),
-        );
-        let committed_5 = map.commit_group(&ap, 5);
+        map.write(ap.clone(), 5, 3, vec![
+            (3, TestValue::with_kind(303, false)),
+            (4, TestValue::with_kind(304, true)),
+        ]);
+        let committed_5 = finalize_group_as_hashmap(&map, &ap, 5);
         assert_eq!(committed_5.len(), 4);
-        assert_some_eq!(committed_5.get(&1), &Arc::new(TestValue::from_u128(1)));
+        assert_some_eq!(
+            committed_5.get(&1),
+            &Arc::new(TestValue::with_kind(1, true))
+        );
         assert_some_eq!(
             committed_5.get(&2),
-            &Arc::new(TestValue::from_u128(200 + 2))
+            &Arc::new(TestValue::with_kind(202, false))
         );
         assert_some_eq!(
             committed_5.get(&3),
-            &Arc::new(TestValue::from_u128(300 + 3))
+            &Arc::new(TestValue::with_kind(303, false))
         );
         assert_some_eq!(
             committed_5.get(&4),
-            &Arc::new(TestValue::from_u128(300 + 4))
+            &Arc::new(TestValue::with_kind(304, true))
         );
 
-        let committed_7 = map.commit_group(&ap, 7);
+        let committed_7 = finalize_group_as_hashmap(&map, &ap, 7);
         assert_eq!(committed_7.len(), 4);
-        assert_some_eq!(committed_7.get(&0), &Arc::new(TestValue::from_u128(100)));
+        assert_some_eq!(
+            committed_7.get(&0),
+            &Arc::new(TestValue::with_kind(100, true))
+        );
         assert_none!(committed_7.get(&1));
         assert_some_eq!(
             committed_7.get(&2),
-            &Arc::new(TestValue::from_u128(200 + 2))
+            &Arc::new(TestValue::with_kind(202, false))
         );
         assert_some_eq!(
             committed_7.get(&3),
-            &Arc::new(TestValue::from_u128(300 + 3))
+            &Arc::new(TestValue::with_kind(303, false))
         );
         assert_some_eq!(
             committed_7.get(&4),
-            &Arc::new(TestValue::from_u128(300 + 4))
+            &Arc::new(TestValue::with_kind(304, true))
         );
 
         map.write(
             ap.clone(),
             8,
             0,
-            // re-insert at 1, delete everything else
+            // re-insert at 1, remove everything else
             vec![
                 (0, TestValue::deletion()),
-                (1, TestValue::from_u128(400_u128)),
+                (1, TestValue::with_kind(400, true)),
                 (2, TestValue::deletion()),
                 (3, TestValue::deletion()),
                 (4, TestValue::deletion()),
             ],
         );
-        let committed_8 = map.commit_group(&ap, 8);
+        let committed_8 = finalize_group_as_hashmap(&map, &ap, 8);
         assert_eq!(committed_8.len(), 1);
-        assert_some_eq!(committed_8.get(&1), &Arc::new(TestValue::from_u128(400)));
+        assert_some_eq!(
+            committed_8.get(&1),
+            &Arc::new(TestValue::with_kind(400, true))
+        );
+    }
+
+    #[test]
+    fn group_commit_op_kind_checks() {
+        let ap = KeyType(b"/foo/f".to_vec());
+        let map = VersionedGroupData::<KeyType<Vec<u8>>, usize, TestValue>::new();
+
+        map.set_base_values(
+            ap.clone(),
+            // base tag 1, 2, 3
+            (1..4).map(|i| (i, TestValue::with_kind(i, true))),
+        );
+        map.write(
+            ap.clone(),
+            3,
+            2,
+            // remove at 0, must fail commit.
+            vec![(0, TestValue::deletion())],
+        );
+        assert_err!(map.finalize_group(&ap, 3));
+
+        map.write(
+            ap.clone(),
+            3,
+            2,
+            // modify at 0, must fail commit.
+            vec![(0, TestValue::with_kind(100, false))],
+        );
+        assert_err!(map.finalize_group(&ap, 3));
+
+        map.write(
+            ap.clone(),
+            3,
+            2,
+            // create at 1, must fail commit
+            vec![(1, TestValue::with_kind(101, true))],
+        );
+        assert_err!(map.finalize_group(&ap, 3));
+
+        // sanity check the commit succeeds with proper kind.
+        map.write(
+            ap.clone(),
+            3,
+            2,
+            // modify at 0, must fail commit.
+            vec![
+                (0, TestValue::with_kind(100, true)),
+                (1, TestValue::with_kind(101, false)),
+            ],
+        );
+        let committed = finalize_group_as_hashmap(&map, &ap, 3);
+        assert_some_eq!(
+            committed.get(&0),
+            &Arc::new(TestValue::with_kind(100, true))
+        );
+        assert_some_eq!(
+            committed.get(&1),
+            &Arc::new(TestValue::with_kind(101, false))
+        );
+        assert_some_eq!(committed.get(&2), &Arc::new(TestValue::with_kind(2, true)));
+        assert_some_eq!(committed.get(&3), &Arc::new(TestValue::with_kind(3, true)));
     }
 }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -26,6 +26,7 @@ use aptos_types::{
         TimedFeaturesBuilder, APTOS_MAX_KNOWN_VERSION,
     },
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
+    write_set::TransactionWrite,
 };
 use aptos_vm::{
     data_cache::AsMoveResolver,

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -746,7 +746,7 @@ pub enum StatusCode {
     RESERVED_INVARIANT_VIOLATION_ERROR_5 = 2027,
 
     // Errors that can arise from binary decoding (deserialization)
-    // Deserializtion Errors: 3000-3999
+    // Deserialization Errors: 3000-3999
     UNKNOWN_BINARY_ERROR = 3000,
     MALFORMED = 3001,
     BAD_MAGIC = 3002,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -48,6 +48,7 @@ pub enum FeatureFlag {
     LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
     VM_BINARY_FORMAT_V7 = 40,
+    RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM = 40,
 }
 
 /// Representation of features on chain as a bitset.
@@ -112,6 +113,10 @@ impl Features {
     /// Once enabled, Aggregator V2 functions become parallel.
     pub fn is_aggregator_v2_delayed_fields_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS)
+    }
+
+    pub fn is_resource_group_charge_as_size_sum_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM)
     }
 }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -48,7 +48,7 @@ pub enum FeatureFlag {
     LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
     VM_BINARY_FORMAT_V7 = 40,
-    RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM = 40,
+    RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM = 41,
 }
 
 /// Representation of features on chain as a bitset.

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -16,6 +16,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map, BTreeMap},
+    fmt::Debug,
     ops::{Deref, DerefMut},
 };
 
@@ -32,6 +33,13 @@ pub static TOTAL_SUPPLY_STATE_KEY: Lazy<StateKey> = Lazy::new(|| {
         ],
     )
 });
+
+#[derive(Eq, Clone, Debug, PartialEq)]
+pub enum WriteOpKind {
+    Creation,
+    Modification,
+    Deletion,
+}
 
 #[derive(Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum WriteOp {
@@ -52,37 +60,6 @@ pub enum WriteOp {
 }
 
 impl WriteOp {
-    #[inline]
-    pub fn is_deletion(&self) -> bool {
-        match self {
-            WriteOp::Deletion | WriteOp::DeletionWithMetadata { .. } => true,
-            WriteOp::Modification(_)
-            | WriteOp::ModificationWithMetadata { .. }
-            | WriteOp::Creation(_)
-            | WriteOp::CreationWithMetadata { .. } => false,
-        }
-    }
-
-    pub fn is_creation(&self) -> bool {
-        match self {
-            WriteOp::Creation(_) | WriteOp::CreationWithMetadata { .. } => true,
-            WriteOp::Modification(_)
-            | WriteOp::ModificationWithMetadata { .. }
-            | WriteOp::Deletion
-            | WriteOp::DeletionWithMetadata { .. } => false,
-        }
-    }
-
-    pub fn is_modification(&self) -> bool {
-        match self {
-            WriteOp::Modification(_) | WriteOp::ModificationWithMetadata { .. } => true,
-            WriteOp::Creation(_)
-            | WriteOp::CreationWithMetadata { .. }
-            | WriteOp::Deletion
-            | WriteOp::DeletionWithMetadata { .. } => false,
-        }
-    }
-
     /// Merges two write ops on the same state item.
     ///
     /// returns `false` if the result indicates no op has happened -- that's when the first op
@@ -167,7 +144,7 @@ impl WriteOp {
     }
 }
 
-pub trait TransactionWrite {
+pub trait TransactionWrite: Debug {
     fn bytes(&self) -> Option<&Bytes>;
 
     // Returns state value that would be observed by a read following the 'self' write.
@@ -193,10 +170,6 @@ pub trait TransactionWrite {
         self.bytes().cloned()
     }
 
-    fn bytes_len(&self) -> usize {
-        self.bytes().map(|bytes| bytes.len()).unwrap_or(0)
-    }
-
     fn as_u128(&self) -> anyhow::Result<Option<u128>> {
         match self.bytes() {
             Some(bytes) => Ok(Some(bcs::from_bytes(bytes)?)),
@@ -204,8 +177,18 @@ pub trait TransactionWrite {
         }
     }
 
+    fn write_op_kind(&self) -> WriteOpKind;
+
     fn is_deletion(&self) -> bool {
-        self.bytes().is_none()
+        self.write_op_kind() == WriteOpKind::Deletion
+    }
+
+    fn is_creation(&self) -> bool {
+        self.write_op_kind() == WriteOpKind::Creation
+    }
+
+    fn is_modification(&self) -> bool {
+        self.write_op_kind() == WriteOpKind::Modification
     }
 
     fn set_bytes(&mut self, bytes: Bytes);
@@ -237,6 +220,16 @@ impl TransactionWrite for WriteOp {
                 data: bytes,
                 metadata,
             },
+        }
+    }
+
+    fn write_op_kind(&self) -> WriteOpKind {
+        match self {
+            WriteOp::Creation(_) | WriteOp::CreationWithMetadata { .. } => WriteOpKind::Creation,
+            WriteOp::Modification(_) | WriteOp::ModificationWithMetadata { .. } => {
+                WriteOpKind::Modification
+            },
+            WriteOp::Deletion | WriteOp::DeletionWithMetadata { .. } => WriteOpKind::Deletion,
         }
     }
 


### PR DESCRIPTION
Final PR to connect all pieces to make resource groups work properly (and efficiently) in block executor. 
(for context: https://github.com/aptos-labs/aptos-core/pull/9927)

gated by an explicit feature.

Parallel executor proptests now cover resource operations (read/write/size) within groups (mixed with normal), for always non-empty groups.

Future steps:
- group metadata tests on group creation/deletion (own mock executor, maybe also in group prop-tests that metadata does not change) - blocked for enabling the feature
- make sure e2e tests pass (e.g. for resource groups, parallel mode), potentially add more e2e tests: different block boundaries, etc, and enable the explicit flag in a separate PR (that will be smaller, and tests + flag)
- make sure r/w conflicts within the resource groups are gotten rid of and perf improves as expected.