### PR TITLE
[telemetry-svc][bugfix] Fix PeerId check for custom event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
  "base64 0.13.0",
  "bcs 0.1.4",
  "chrono",
+ "claims",
  "clap 4.3.21",
  "debug-ignore",
  "flate2",

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -34,7 +34,7 @@ hex = { workspace = true }
 jsonwebtoken = { workspace = true }
 once_cell = { workspace = true }
 prometheus = { workspace = true }
-rand ={ workspace = true }
+rand = { workspace = true }
 rand_core = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
@@ -51,4 +51,5 @@ uuid = { workspace = true }
 warp = { workspace = true }
 
 [dev-dependencies]
+claims = { workspace = true }
 httpmock = { workspace = true }

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -14,9 +14,10 @@ use crate::{
     },
 };
 use anyhow::anyhow;
+use aptos_types::PeerId;
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use serde_json::json;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 use tokio::time::Instant;
 use warp::{filters::BoxedFilter, hyper::StatusCode, reject, reply, Filter, Rejection, Reply};
 
@@ -37,17 +38,18 @@ pub fn custom_event_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
         .boxed()
 }
 
-pub(crate) async fn handle_custom_event(
-    context: Context,
-    claims: Claims,
-    body: TelemetryDump,
-) -> anyhow::Result<impl Reply, Rejection> {
-    if !body
-        .user_id
-        .eq_ignore_ascii_case(&claims.peer_id.to_string())
-    {
+fn validate_custom_event_body(
+    claims: &Claims,
+    body: &TelemetryDump,
+) -> anyhow::Result<(), Rejection> {
+    let body_peer_id = PeerId::from_str(&body.user_id).map_err(|_| {
+        reject::custom(ServiceError::bad_request(
+            CustomEventIngestError::InvalidEvent(body.user_id.clone(), claims.peer_id).into(),
+        ))
+    })?;
+    if body_peer_id != claims.peer_id {
         return Err(reject::custom(ServiceError::bad_request(
-            CustomEventIngestError::InvalidEvent(body.user_id, claims.peer_id).into(),
+            CustomEventIngestError::InvalidEvent(body.user_id.clone(), claims.peer_id).into(),
         )));
     }
 
@@ -56,6 +58,16 @@ pub(crate) async fn handle_custom_event(
             CustomEventIngestError::EmptyPayload.into(),
         )));
     }
+
+    Ok(())
+}
+
+pub(crate) async fn handle_custom_event(
+    context: Context,
+    claims: Claims,
+    body: TelemetryDump,
+) -> anyhow::Result<impl Reply, Rejection> {
+    validate_custom_event_body(&claims, &body)?;
 
     let mut insert_request = TableDataInsertAllRequest::new();
 
@@ -128,4 +140,83 @@ pub(crate) async fn handle_custom_event(
     debug!("row inserted succeefully: {:?}", &row);
 
     Ok(reply::with_status(reply::reply(), StatusCode::CREATED))
+}
+
+#[cfg(test)]
+mod test {
+    use super::validate_custom_event_body;
+    use crate::types::{
+        auth::Claims,
+        common::NodeType,
+        telemetry::{TelemetryDump, TelemetryEvent},
+    };
+    use aptos_types::{chain_id::ChainId, PeerId};
+    use claims::assert_ok;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_validate_custom_event_body() {
+        let claims = Claims {
+            chain_id: ChainId::test(),
+            peer_id: PeerId::from_hex_literal("0x1234").unwrap(),
+            node_type: NodeType::Validator,
+            epoch: 1,
+            exp: 100,
+            iat: 200,
+            run_uuid: Uuid::new_v4(),
+        };
+
+        let body = TelemetryDump {
+            client_id: String::new(),
+            user_id: String::from("0x1"),
+            timestamp_micros: String::new(),
+            events: Vec::new(),
+        };
+        assert_eq!(format!("{:?}", validate_custom_event_body(&claims, &body)), "Err(Rejection(ServiceError { http_code: 400, error_code: CustomEventIngestError(InvalidEvent(\"0x1\", 0000000000000000000000000000000000000000000000000000000000001234)) }))");
+
+        let body = TelemetryDump {
+            client_id: String::new(),
+            user_id: String::from("0x1234"),
+            timestamp_micros: String::new(),
+            events: vec![TelemetryEvent {
+                name: "test".into(),
+                params: BTreeMap::new(),
+            }],
+        };
+        assert_ok!(validate_custom_event_body(&claims, &body));
+
+        let body = TelemetryDump {
+            client_id: String::new(),
+            user_id: String::from("1234"),
+            timestamp_micros: String::new(),
+            events: vec![TelemetryEvent {
+                name: "test".into(),
+                params: BTreeMap::new(),
+            }],
+        };
+        assert_ok!(validate_custom_event_body(&claims, &body));
+
+        let body = TelemetryDump {
+            client_id: String::new(),
+            user_id: String::from("0x00001234"),
+            timestamp_micros: String::new(),
+            events: vec![TelemetryEvent {
+                name: "test".into(),
+                params: BTreeMap::new(),
+            }],
+        };
+        assert_ok!(validate_custom_event_body(&claims, &body));
+
+        let body = TelemetryDump {
+            client_id: String::new(),
+            user_id: String::from("00001234"),
+            timestamp_micros: String::new(),
+            events: vec![TelemetryEvent {
+                name: "test".into(),
+                params: BTreeMap::new(),
+            }],
+        };
+        assert_ok!(validate_custom_event_body(&claims, &body));
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes PeerId check during custom event Ingestion. #8727 changed how PeerId is represented as string by default making it a backwards-incompatible change. Therefore, instead of comparing strings, this PR parses the peer ID string into a PeerId struct and compares it instead.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added new unit tests to catch this incompatibility.
