### PR TITLE
[Bug] Fix issue 10468

### DIFF
--- a/third_party/move/move-compiler/src/diagnostics/mod.rs
+++ b/third_party/move/move-compiler/src/diagnostics/mod.rs
@@ -23,7 +23,7 @@ use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
-    ops::Range, intrinsics::unreachable,
+    ops::Range,
 };
 
 //**************************************************************************************************

--- a/third_party/move/move-compiler/src/diagnostics/mod.rs
+++ b/third_party/move/move-compiler/src/diagnostics/mod.rs
@@ -61,6 +61,15 @@ pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
     std::process::exit(1)
 }
 
+// report diagnostics, but do not exit if diags are all warnings
+pub fn report_diagnostics_maynot_exit(files: &FilesSourceText, diags: Diagnostics) {
+    let should_exit = diags
+        .diagnostics
+        .iter()
+        .any(|diag| diag.info.severity() > Severity::Warning);
+    report_diagnostics_impl(files, diags, should_exit);
+}
+
 pub fn report_warnings(files: &FilesSourceText, warnings: Diagnostics) {
     if warnings.is_empty() {
         return;

--- a/third_party/move/move-compiler/src/diagnostics/mod.rs
+++ b/third_party/move/move-compiler/src/diagnostics/mod.rs
@@ -58,7 +58,6 @@ pub struct Diagnostics {
 pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
     let should_exit = true;
     report_diagnostics_impl(files, diags, should_exit);
-    std::process::exit(1)
 }
 
 // report diagnostics, but do not exit if diags are all warnings

--- a/third_party/move/move-compiler/src/diagnostics/mod.rs
+++ b/third_party/move/move-compiler/src/diagnostics/mod.rs
@@ -23,7 +23,7 @@ use move_symbol_pool::Symbol;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
-    ops::Range,
+    ops::Range, intrinsics::unreachable,
 };
 
 //**************************************************************************************************
@@ -58,6 +58,7 @@ pub struct Diagnostics {
 pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
     let should_exit = true;
     report_diagnostics_impl(files, diags, should_exit);
+    unreachable!()
 }
 
 // report diagnostics, but do not exit if diags are all warnings

--- a/third_party/move/move-compiler/src/diagnostics/mod.rs
+++ b/third_party/move/move-compiler/src/diagnostics/mod.rs
@@ -62,7 +62,7 @@ pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
 }
 
 // report diagnostics, but do not exit if diags are all warnings
-pub fn report_diagnostics_maynot_exit(files: &FilesSourceText, diags: Diagnostics) {
+pub fn report_diagnostics_exit_on_error(files: &FilesSourceText, diags: Diagnostics) {
     let should_exit = diags
         .diagnostics
         .iter()

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -224,7 +224,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
                     Severity::Warning
                 },
             ) {
-                diagnostics::report_diagnostics_maynot_exit(&files, diags);
+                diagnostics::report_diagnostics_exit_on_error(&files, diags);
             }
 
             let compilation_result = compiler.at_cfgir(cfgir).build();

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -224,7 +224,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
                     Severity::Warning
                 },
             ) {
-                diagnostics::report_diagnostics(&files, diags);
+                diagnostics::report_diagnostics_maynot_exit(&files, diags);
             }
 
             let compilation_result = compiler.at_cfgir(cfgir).build();


### PR DESCRIPTION
### Description
Move unit tests continue to run in the presence of compiler warnings, but the warnings are shown.
### Test Plan
Existing tests &
```
MOVE_COMPILER_WARN_OF_DEPRECATION_USE=1 WARN_OF_DEPRECATION_USE_IN_APTOS_LIBS=1 cargo test -p aptos-framework --test move_unit_test -- --skip prover
```
