### PR TITLE
[CLI] Update processor dep for local testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,8 +2168,8 @@ dependencies = [
 
 [[package]]
 name = "aptos-indexer-protos"
-version = "1.0.9"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+version = "1.1.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d6f55d4baba32960ea7be60878552e73ffbe8b7e#d6f55d4baba32960ea7be60878552e73ffbe8b7e"
 dependencies = [
  "pbjson",
  "prost 0.11.9",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d6f55d4baba32960ea7be60878552e73ffbe8b7e#d6f55d4baba32960ea7be60878552e73ffbe8b7e"
 dependencies = [
  "chrono",
 ]
@@ -11473,11 +11473,11 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d6f55d4baba32960ea7be60878552e73ffbe8b7e#d6f55d4baba32960ea7be60878552e73ffbe8b7e"
 dependencies = [
  "anyhow",
  "aptos-indexer-protos",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d6f55d4baba32960ea7be60878552e73ffbe8b7e)",
  "async-trait",
  "base64 0.13.0",
  "bcs 0.1.4",
@@ -12893,7 +12893,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=757cf367eceebba546ed96927d46a9b1323e91c5#757cf367eceebba546ed96927d46a9b1323e91c5"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d6f55d4baba32960ea7be60878552e73ffbe8b7e#d6f55d4baba32960ea7be60878552e73ffbe8b7e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Updated
+- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to d6f55d4baba32960ea7be60878552e73ffbe8b7e.
 
 ## [2.2.1] - 2023/10/13
 ### Fixed

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d6f55d4baba32960ea7be60878552e73ffbe8b7e" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "757cf367eceebba546ed96927d46a9b1323e91c5" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d6f55d4baba32960ea7be60878552e73ffbe8b7e" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
### Description
The first of many PRs in the future where all we do is update the dependency on the processor code. These changes let the CLI pick up the latest and greatest processors / core processor framework code.

### Test Plan
```
cargo run -p aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api
```

I confirmed the indexer API starts and all processors work.