### PR TITLE
[CLI] Health check processors using DB for local testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "tonic 0.10.0",
  "tracing",
  "tracing-subscriber",
+ "version-compare",
  "walkdir",
 ]
 
@@ -14791,6 +14792,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,6 +442,7 @@ backtrace = "0.3.58"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 better_any = "0.1.1"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
+version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
 blake2-rfc = "0.2.18"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -96,6 +96,7 @@ toml = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+version-compare = { workspace = true }
 walkdir = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -144,8 +144,8 @@ impl HealthChecker {
         .await
     }
 
-    /// This is only ever used for display purposes. Ideally the endpoint if this
-    /// HealthChecker is for a service.
+    /// This is only ever used for display purposes. If possible, this should be the
+    /// endpoint of the service that this HealthChecker is checking.
     pub fn address_str(&self) -> &str {
         match self {
             HealthChecker::Http(url, _) => url.as_str(),

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -4,12 +4,15 @@
 use super::indexer_api::confirm_metadata_applied;
 use anyhow::{anyhow, Context, Result};
 use aptos_protos::indexer::v1::GetTransactionsRequest;
-use diesel_async::{pg::AsyncPgConnection, AsyncConnection};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, AsyncConnection, RunQueryDsl};
 use futures::StreamExt;
+use processor::schema::processor_status;
 use reqwest::Url;
 use serde::Serialize;
 use std::time::Duration;
 use tokio::time::Instant;
+use tracing::info;
 
 const MAX_WAIT_S: u64 = 60;
 const WAIT_INTERVAL_MS: u64 = 200;
@@ -28,6 +31,10 @@ pub enum HealthChecker {
     DataServiceGrpc(Url),
     /// Check that a postgres instance is up.
     Postgres(String),
+    /// Check that a processor is successfully processing txns. The first value is the
+    /// postgres connection string. The second is the name of the processor. We check
+    /// the that last_success_version in the processor_status table is present and > 0.
+    Processor(String, String),
     /// Check that the indexer API is up and the metadata has been applied. We only use
     /// this one in the ready server.
     IndexerApiMetadata(Url),
@@ -73,8 +80,41 @@ impl HealthChecker {
             HealthChecker::Postgres(connection_string) => {
                 AsyncPgConnection::establish(connection_string)
                     .await
-                    .context("Failed to connect to postgres")?;
+                    .context("Failed to connect to postgres to check DB liveness")?;
                 Ok(())
+            },
+            HealthChecker::Processor(connection_string, processor_name) => {
+                let mut connection = AsyncPgConnection::establish(connection_string)
+                    .await
+                    .context("Failed to connect to postgres to check processor status")?;
+                let result = processor_status::table
+                    .select((processor_status::last_success_version,))
+                    .filter(processor_status::processor.eq(processor_name))
+                    .first::<(i64,)>(&mut connection)
+                    .await
+                    .optional()
+                    .context("Failed to look up processor status")?;
+                match result {
+                    Some(result) => {
+                        // This is last_success_version.
+                        if result.0 > 0 {
+                            info!(
+                                "Processor {} started processing successfully (currently at version {})",
+                                processor_name, result.0
+                            );
+                            Ok(())
+                        } else {
+                            Err(anyhow!(
+                                "Processor {} found in DB but last_success_version is zero",
+                                processor_name
+                            ))
+                        }
+                    },
+                    None => Err(anyhow!(
+                        "Processor {} has not processed any transactions",
+                        processor_name
+                    )),
+                }
             },
             HealthChecker::IndexerApiMetadata(url) => {
                 confirm_metadata_applied(url.clone()).await?;
@@ -95,8 +135,8 @@ impl HealthChecker {
                 format!(
                     "{} at {} did not start up before {}",
                     prefix,
+                    self.address_str(),
                     waiting_service,
-                    self.address_str()
                 )
             },
             None => format!("{} at {} did not start up", prefix, self.address_str()),
@@ -104,12 +144,15 @@ impl HealthChecker {
         .await
     }
 
+    /// This is only ever used for display purposes. Ideally the endpoint if this
+    /// HealthChecker is for a service.
     pub fn address_str(&self) -> &str {
         match self {
             HealthChecker::Http(url, _) => url.as_str(),
             HealthChecker::NodeApi(url) => url.as_str(),
             HealthChecker::DataServiceGrpc(url) => url.as_str(),
             HealthChecker::Postgres(url) => url.as_str(),
+            HealthChecker::Processor(_, processor_name) => processor_name.as_str(),
             HealthChecker::IndexerApiMetadata(url) => url.as_str(),
         }
     }
@@ -130,6 +173,7 @@ impl std::fmt::Display for HealthChecker {
             HealthChecker::NodeApi(_) => write!(f, "Node API"),
             HealthChecker::DataServiceGrpc(_) => write!(f, "Transaction stream"),
             HealthChecker::Postgres(_) => write!(f, "Postgres"),
+            HealthChecker::Processor(_, processor_name) => write!(f, "{}", processor_name),
             HealthChecker::IndexerApiMetadata(_) => write!(f, "Indexer API with metadata applied"),
         }
     }

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -112,10 +112,11 @@ impl RunLocalTestnet {
         for health_checker in health_checkers {
             let silent = match health_checker {
                 HealthChecker::NodeApi(_) => false,
-                // We don't want to print anything for the processors, it'd be too spammy.
-                HealthChecker::Http(_, name) => name.contains("processor"),
+                HealthChecker::Http(_, _) => false,
                 HealthChecker::DataServiceGrpc(_) => false,
                 HealthChecker::Postgres(_) => false,
+                // We don't want to print anything for the processors, it'd be too spammy.
+                HealthChecker::Processor(_, _) => true,
                 // We don't want to actually wait on this health checker here because
                 // it will never return true since we apply the metadata in a post
                 // healthy step (which comes after we call this function). So we move

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -13,7 +13,7 @@ use processor::{
     IndexerGrpcProcessorConfig,
 };
 use reqwest::Url;
-use server_framework::{run_server_with_config, GenericConfig};
+use server_framework::RunnableConfig;
 use std::collections::HashSet;
 use tokio::sync::OnceCell;
 use tracing::info;
@@ -48,7 +48,7 @@ pub struct ProcessorArgs {
 
 #[derive(Debug)]
 pub struct ProcessorManager {
-    config: GenericConfig<IndexerGrpcProcessorConfig>,
+    config: IndexerGrpcProcessorConfig,
     prerequisite_health_checkers: HashSet<HealthChecker>,
 }
 
@@ -56,7 +56,6 @@ impl ProcessorManager {
     fn new(
         processor_name: &ProcessorName,
         prerequisite_health_checkers: HashSet<HealthChecker>,
-        health_check_port: u16,
         data_service_url: Url,
         postgres_connection_string: String,
     ) -> Result<Self> {
@@ -84,7 +83,7 @@ impl ProcessorManager {
             ProcessorName::TokenV2Processor => ProcessorConfig::TokenV2Processor,
             ProcessorName::UserTransactionProcessor => ProcessorConfig::UserTransactionProcessor,
         };
-        let server_config = IndexerGrpcProcessorConfig {
+        let config = IndexerGrpcProcessorConfig {
             processor_config,
             postgres_connection_string,
             indexer_grpc_data_service_address: data_service_url,
@@ -93,10 +92,6 @@ impl ProcessorManager {
             starting_version: None,
             ending_version: None,
             number_concurrent_processing_tasks: None,
-        };
-        let config = GenericConfig {
-            server_config,
-            health_check_port,
         };
         let manager = Self {
             config,
@@ -116,27 +111,20 @@ impl ProcessorManager {
             bail!("Must specify at least one processor to run");
         }
         let mut managers = Vec::new();
-        // We use this port as the start of the range of ports we use for the health
-        // check servers in each processor because it is not known to be used by any
-        // other service and it is outside of the ephemeral or private port range used
-        // by any OS.
-        let mut health_check_port = 23480;
         for processor_name in &args.processor_args.processors {
             managers.push(Self::new(
                 processor_name,
                 prerequisite_health_checkers.clone(),
-                health_check_port,
                 data_service_url.clone(),
                 postgres_connection_string.clone(),
             )?);
-            health_check_port += 1;
         }
         Ok(managers)
     }
 
-    /// Ccreate the necessary tables in the DB for the processors to work.
+    /// Create the necessary tables in the DB for the processors to work.
     async fn run_migrations(&self) -> Result<()> {
-        let connection_string = &self.config.server_config.postgres_connection_string;
+        let connection_string = &self.config.postgres_connection_string;
         let mut connection = AsyncPgConnection::establish(connection_string)
             .await
             .with_context(|| format!("Failed to connect to postgres at {}", connection_string))?;
@@ -148,21 +136,14 @@ impl ProcessorManager {
 #[async_trait]
 impl ServiceManager for ProcessorManager {
     fn get_name(&self) -> String {
-        format!(
-            "processor_{}",
-            self.config.server_config.processor_config.name()
-        )
+        format!("processor_{}", self.config.processor_config.name())
     }
 
     fn get_health_checkers(&self) -> HashSet<HealthChecker> {
-        hashset![HealthChecker::Http(
-            Url::parse(&format!(
-                "http://127.0.0.1:{}",
-                self.config.health_check_port
-            ))
-            .unwrap(),
-            self.get_name(),
-        )]
+        hashset! {HealthChecker::Processor(
+            self.config.postgres_connection_string.to_string(),
+            self.config.processor_config.name().to_string(),
+        ) }
     }
 
     fn get_prerequisite_health_checkers(&self) -> HashSet<&HealthChecker> {
@@ -193,6 +174,6 @@ impl ServiceManager for ProcessorManager {
             .await;
 
         // Run the processor.
-        run_server_with_config(self.config, tokio::runtime::Handle::current()).await
+        self.config.run().await
     }
 }


### PR DESCRIPTION
### Description
Previously in order to check that the processors were up we would check the health check port of the processor. This has two downsides:
1. This health check port doesn't actually check health at all, it always returns 200. So all this tells us is the health check server came up.
2. This meant we had to open a port for each processor for the health check port, which leads to port exhaustion issues sometimes.

In this PR I change it so when we run the processor, we just run the processor, not the health check port. To check that the processor is up, we instead check the processor status table in the DB.

### Test Plan
```
$ cargo run -p aptos -- node run-local-testnet --assume-yes --force-restart --with-indexer-api

Readiness endpoint: http://0.0.0.0:8070/

Indexer API is starting, please wait...
Transaction stream is starting, please wait...
Node API is starting, please wait...
Faucet is starting, please wait...
Postgres is starting, please wait...

Completed generating configuration:
        Log file: "/Users/dport/.aptos/testnet/validator.log"
        Test dir: "/Users/dport/.aptos/testnet"
        Aptos root key path: "/Users/dport/.aptos/testnet/mint.key"
        Waypoint: 0:380e815958570b4c81b68efd3934c1d1f58c111db3831a77267d7b2af20f6bbf
        ChainId: 4
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9101/metrics
        Aptosnet fullnode network endpoint: /ip4/0.0.0.0/tcp/6181
        Indexer gRPC node stream endpoint: 0.0.0.0:50051

Aptos is running, press ctrl-c to exit

Node API is ready. Endpoint: http://0.0.0.0:8080/
Postgres is ready. Endpoint: postgres://postgres@127.0.0.1:5433/local_testnet
Transaction stream is ready. Endpoint: http://0.0.0.0:50051/
Indexer API is ready. Endpoint: http://127.0.0.1:8090/
Faucet is ready. Endpoint: http://127.0.0.1:8081/

Applying post startup steps...

Setup is complete, you can now use the local testnet!
```

```
$ curl http://0.0.0.0:8070/ | jq .
{
  "ready": [
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "coin_processor"
      ]
    },
    {
      "Http": [
        "http://127.0.0.1:8090/",
        "Indexer API"
      ]
    },
    {
      "DataServiceGrpc": "http://0.0.0.0:50051/"
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "account_transactions_processor"
      ]
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "token_v2_processor"
      ]
    },
    {
      "NodeApi": "http://0.0.0.0:8080/"
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "user_transaction_processor"
      ]
    },
    {
      "Http": [
        "http://127.0.0.1:8081/",
        "Faucet"
      ]
    },
    {
      "Postgres": "postgres://postgres@127.0.0.1:5433/local_testnet"
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "token_processor"
      ]
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "stake_processor"
      ]
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "events_processor"
      ]
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "fungible_asset_processor"
      ]
    },
    {
      "IndexerApiMetadata": "http://127.0.0.1:8090/"
    },
    {
      "Processor": [
        "postgres://postgres@127.0.0.1:5433/local_testnet",
        "default_processor"
      ]
    }
  ],
  "not_ready": []
}
```


