### PR TITLE
 [vm] Resource access control: runtime engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,8 +4170,6 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "regex",
- "ring 0.16.20",
- "rsa 0.9.6",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -8529,7 +8527,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring 0.16.20",
- "rsa 0.6.1",
+ "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -11333,8 +11331,6 @@ dependencies = [
  "bytes",
  "fail 0.4.0",
  "hex",
- "lazy_static",
- "lru 0.7.8",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-compiler",
@@ -11378,13 +11374,12 @@ name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
  "bcs 0.1.4",
- "claims",
  "derivative",
+ "itertools 0.10.5",
  "move-binary-format",
  "move-core-types",
  "once_cell",
  "proptest",
- "rand 0.8.5",
  "serde",
  "smallbitvec",
  "smallvec",
@@ -12437,17 +12432,6 @@ dependencies = [
  "der 0.5.1",
  "pkcs8 0.8.0",
  "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.8",
- "pkcs8 0.10.2",
- "spki 0.7.3",
 ]
 
 [[package]]
@@ -13869,30 +13853,10 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "pkcs1 0.3.3",
+ "pkcs1",
  "pkcs8 0.8.0",
  "rand_core 0.6.4",
  "smallvec",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
  "subtle",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,8 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "regex",
+ "ring 0.16.20",
+ "rsa 0.9.6",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -8527,7 +8529,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring 0.16.20",
- "rsa",
+ "rsa 0.6.1",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -11331,6 +11333,8 @@ dependencies = [
  "bytes",
  "fail 0.4.0",
  "hex",
+ "lazy_static",
+ "lru 0.7.8",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-compiler",
@@ -11374,12 +11378,14 @@ name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
  "bcs 0.1.4",
+ "claims",
  "derivative",
  "itertools 0.10.5",
  "move-binary-format",
  "move-core-types",
  "once_cell",
  "proptest",
+ "rand 0.8.5",
  "serde",
  "smallbitvec",
  "smallvec",
@@ -12432,6 +12438,17 @@ dependencies = [
  "der 0.5.1",
  "pkcs8 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.8",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -13853,10 +13870,30 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "pkcs1",
+ "pkcs1 0.3.3",
  "pkcs8 0.8.0",
  "rand_core 0.6.4",
  "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]

--- a/third_party/move/documentation/coding_guidelines.md
+++ b/third_party/move/documentation/coding_guidelines.md
@@ -39,7 +39,7 @@ We require every PR to have approval by at least two reviewers. This is enforced
 - Don't forget to list any issues this PR fixes (if you mention 'closes #nnn' in the PR description the issue will be automatically closed).
 - If you have any significant TODOs in your code, please open an issue for them. Use `TODO(#nnn)` to link the TODO to the issue.
 - Respond to each comment of the reviewers. If you think you resolved a request for a change, just use 'done' as a response. If you disagree with the reviewer, explain why -- it is OK to pushback, but should be justified.
-- Once you are done with addressing comments, indicate this to the reviewers by adding a top-level comment to the PR. You can use 'PTLA' ('please take another look') as an acronym for this purpose.
+- Once you are done with addressing comments, indicate this to the reviewers by adding a top-level comment to the PR. You can use 'PTAL' ('please take another look') as an acronym for this purpose.
 - If possible, avoid force push so the reviewer can see how you changed code in comparison. There are exceptions to this, for example if you need to rebase.
 
 ### Guidelines for Reviewers of PRs

--- a/third_party/move/move-binary-format/Cargo.toml
+++ b/third_party/move/move-binary-format/Cargo.toml
@@ -31,3 +31,4 @@ serde_json = "1.0.64"
 [features]
 default = []
 fuzzing = ["proptest", "proptest-derive", "arbitrary", "move-core-types/fuzzing"]
+testing = []

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -540,9 +540,7 @@ pub(crate) mod versioned_data {
                 return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION)
                     .with_message(format!("bytecode version {} unsupported", version)));
             } else if version == VERSION_NEXT
-                && !cfg!(test)
-                && !cfg!(feature = "testing")
-                && !cfg!(feature = "fuzzing")
+                && !cfg!(any(test, feature = "testing", feature = "fuzzing"))
             {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_VERSION).with_message(format!(

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -139,7 +139,7 @@ pub enum SerializedOption {
     SOME                    = 0x2,
 }
 
-/// A marker for an boolean in the serialized output.
+/// A marker for a boolean in the serialized output.
 #[rustfmt::skip]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
@@ -537,8 +537,13 @@ pub(crate) mod versioned_data {
                 },
             };
             if version == 0 || version > u32::min(max_version, VERSION_MAX) {
-                return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION));
-            } else if version == VERSION_NEXT && !cfg!(test) && !cfg!(feature = "fuzzing") {
+                return Err(PartialVMError::new(StatusCode::UNKNOWN_VERSION)
+                    .with_message(format!("bytecode version {} unsupported", version)));
+            } else if version == VERSION_NEXT
+                && !cfg!(test)
+                && !cfg!(feature = "testing")
+                && !cfg!(feature = "fuzzing")
+            {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_VERSION).with_message(format!(
                         "bytecode version {} only allowed in test code",

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
@@ -1,0 +1,29 @@
+processed 6 tasks
+
+task 2 'run'. lines 30-30:
+return values: true
+
+task 3 'run'. lines 32-32:
+return values: true
+
+task 4 'run'. lines 34-34:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x2)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 5 'run'. lines 36-36:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x2)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
@@ -24,6 +24,6 @@ Error: Function execution failed with VMError: {
     sub_status: None,
     location: 0x42::test,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(1), 1)],
+    offsets: [(FunctionDefinitionIndex(1), 3)],
     exec_state: Some(ExecutionState { stack_trace: [] }),
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.move
@@ -16,11 +16,11 @@ module 0x42::test {
         borrow_global<R>(signer::address_of(s)).value
     }
 
-    fun fail1(a: address): bool reads R(a) {
+    fun fail1(_a: address): bool reads R(_a) {
         borrow_global<R>(@0x2).value
     }
 
-    fun fail2(s: &signer): bool reads R(signer::address_of(s)) {
+    fun fail2(_s: &signer): bool reads R(signer::address_of(_s)) {
         borrow_global<R>(@0x2).value
     }
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.move
@@ -1,0 +1,36 @@
+//# publish
+module 0x42::test {
+    use 0x1::signer;
+
+    struct R has key, drop { value: bool }
+
+    fun init(s: &signer) {
+        move_to(s, R{value: true});
+    }
+
+    fun ok1(a: address): bool reads R(a) {
+        borrow_global<R>(a).value
+    }
+
+    fun ok2(s: &signer): bool reads R(signer::address_of(s)) {
+        borrow_global<R>(signer::address_of(s)).value
+    }
+
+    fun fail1(a: address): bool reads R(a) {
+        borrow_global<R>(@0x2).value
+    }
+
+    fun fail2(s: &signer): bool reads R(signer::address_of(s)) {
+        borrow_global<R>(@0x2).value
+    }
+}
+
+//# run --verbose --signers 0x1 -- 0x42::test::init
+
+//# run --verbose --args @0x1 -- 0x42::test::ok1
+
+//# run --verbose --signers 0x1 -- 0x42::test::ok2
+
+//# run --verbose --args @0x1 -- 0x42::test::fail1
+
+//# run --verbose --signers 0x1 -- 0x42::test::fail2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/generic.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/generic.exp
@@ -1,0 +1,18 @@
+processed 5 tasks
+
+task 2 'run'. lines 25-25:
+return values: true
+
+task 3 'run'. lines 27-27:
+return values: true
+
+task 4 'run'. lines 29-29:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R<bool>(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/generic.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/generic.move
@@ -1,0 +1,29 @@
+//# publish
+module 0x42::test {
+
+    struct R<T> has key, drop { value: T }
+
+    fun init(s: &signer) {
+        move_to(s, R<bool>{value: true});
+    }
+
+    fun ok1(): bool reads R {
+        borrow_global<R<bool>>(@0x1).value
+    }
+
+    fun ok2(): bool reads R<bool> {
+        borrow_global<R<bool>>(@0x1).value
+    }
+
+    fun fail1(): bool reads R<u64> {
+        borrow_global<R<bool>>(@0x1).value
+    }
+}
+
+//# run --verbose --signers 0x1 -- 0x42::test::init
+
+//# run --verbose -- 0x42::test::ok1
+
+//# run --verbose -- 0x42::test::ok2
+
+//# run --verbose -- 0x42::test::fail1

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/negation.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/negation.exp
@@ -1,0 +1,29 @@
+processed 6 tasks
+
+task 2 'run'. lines 28-28:
+return values: true
+
+task 3 'run'. lines 30-30:
+return values: true
+
+task 4 'run'. lines 32-32:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 5 'run'. lines 34-34:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/negation.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/negation.move
@@ -1,0 +1,34 @@
+//# publish
+module 0x42::test {
+    struct R has key, drop { value: bool }
+
+    fun init(s: &signer) {
+        move_to(s, R{value: true});
+    }
+
+    fun ok1(): bool reads 0x42::*::*, !reads 0x43::*::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun ok2(): bool acquires *, !reads 0x43::*::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun fail1(): bool !reads 0x42::*::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun fail2(): bool !reads *(0x1) {
+        borrow_global<R>(@0x1).value
+    }
+}
+
+//# run --verbose --signers 0x1 -- 0x42::test::init
+
+//# run --verbose -- 0x42::test::ok1
+
+//# run --verbose -- 0x42::test::ok2
+
+//# run --verbose -- 0x42::test::fail1
+
+//# run --verbose -- 0x42::test::fail2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/resource.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/resource.exp
@@ -1,0 +1,71 @@
+processed 12 tasks
+
+task 2 'run'. lines 63-63:
+return values: true
+
+task 3 'run'. lines 65-65:
+return values: true
+
+task 4 'run'. lines 67-67:
+return values: true
+
+task 5 'run'. lines 69-69:
+return values: true
+
+task 6 'run'. lines 71-71:
+return values: true
+
+task 7 'run'. lines 73-73:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 8 'run'. lines 75-75:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 9 'run'. lines 77-77:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `writes 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 10 'run'. lines 79-79:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `writes 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 11 'run'. lines 81-81:
+Error: Function execution failed with VMError: {
+    message: not allowed to call `0x0000000000000000000000000000000000000000000000000000000000000042::test::fail_no_subsumes`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/resource.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/resource.move
@@ -1,0 +1,81 @@
+//# publish
+module 0x42::test {
+    struct R has key, drop { value: bool }
+    struct Other has key, drop {}
+
+    fun init(s: &signer) {
+        move_to(s, R{value: true});
+    }
+
+    fun ok1(): bool reads R {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun ok2(): bool reads R {
+        exists<R>(@0x1)
+    }
+
+    fun ok3(s: &signer): bool writes R {
+        move_to(s, R{value: true});
+        true
+    }
+
+    fun ok4(): bool writes R {
+        borrow_global_mut<R>(@0x1).value = false;
+        true
+    }
+
+    fun ok5(): bool acquires R {
+        borrow_global_mut<R>(@0x1).value = false;
+        true
+    }
+
+
+    fun fail1(): bool reads Other {
+        !borrow_global<R>(@0x1).value
+    }
+
+    fun fail2(): bool reads Other {
+        !exists<R>(@0x1)
+    }
+
+    fun fail3(): bool reads R writes Other {
+        let r = move_from<R>(@0x1);
+        !r.value
+    }
+
+    fun fail4(): bool reads R writes Other {
+        borrow_global_mut<R>(@0x1).value = false;
+        false
+    }
+
+    fun fail5(): bool reads Other {
+        fail_no_subsumes()
+    }
+
+    fun fail_no_subsumes(): bool reads R {
+        borrow_global<R>(@0x1).value
+    }
+}
+
+//# run --verbose --signers 0x1 -- 0x42::test::init
+
+//# run --verbose -- 0x42::test::ok1
+
+//# run --verbose -- 0x42::test::ok2
+
+//# run --verbose --signers 0x2 -- 0x42::test::ok3
+
+//# run --verbose -- 0x42::test::ok4
+
+//# run --verbose -- 0x42::test::ok5
+
+//# run --verbose -- 0x42::test::fail1
+
+//# run --verbose -- 0x42::test::fail2
+
+//# run --verbose -- 0x42::test::fail3
+
+//# run --verbose -- 0x42::test::fail4
+
+//# run --verbose -- 0x42::test::fail5

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/wildcard.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/wildcard.exp
@@ -1,0 +1,35 @@
+processed 8 tasks
+
+task 2 'run'. lines 36-36:
+return values: true
+
+task 3 'run'. lines 38-38:
+return values: true
+
+task 4 'run'. lines 40-40:
+return values: true
+
+task 5 'run'. lines 42-42:
+return values: true
+
+task 6 'run'. lines 44-44:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+
+task 7 'run'. lines 46-46:
+Error: Function execution failed with VMError: {
+    message: not allowed to perform `reads 0x42::test::R(@0x1)`,
+    major_status: ACCESS_DENIED,
+    sub_status: None,
+    location: 0x42::test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/wildcard.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/wildcard.move
@@ -1,0 +1,46 @@
+//# publish
+module 0x42::test {
+    struct R has key, drop { value: bool }
+
+    fun init(s: &signer) {
+        move_to(s, R{value: true});
+    }
+
+    fun ok1(): bool reads 0x42::*::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun ok2(): bool reads 0x42::test::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun ok3(): bool reads 0x42::test::*(*) {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun ok4(): bool reads *(0x1) {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun fail1(): bool reads 0x43::*::* {
+        borrow_global<R>(@0x1).value
+    }
+
+    fun fail2(): bool reads *(0x2) {
+        borrow_global<R>(@0x1).value
+    }
+}
+
+//# run --verbose --signers 0x1 -- 0x42::test::init
+
+//# run --verbose -- 0x42::test::ok1
+
+//# run --verbose -- 0x42::test::ok2
+
+//# run --verbose -- 0x42::test::ok3
+
+//# run --verbose -- 0x42::test::ok4
+
+//# run --verbose -- 0x42::test::fail1
+
+//# run --verbose -- 0x42::test::fail2

--- a/third_party/move/move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler/src/parser/ast.rs
@@ -249,7 +249,7 @@ pub type AccessSpecifier = Spanned<AccessSpecifier_>;
 /// An address specifier specifies the address at which a resource is accessed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AddressSpecifier_ {
-    /// Represents that now address was specicied, as in `Resource`
+    /// Represents that no address was specified, as in `Resource`
     Empty,
     /// Represents that the specified address is a wildcard, as in `Resource(*)`.
     Any,

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -208,14 +208,14 @@ impl ResourceKey {
 }
 
 /// Represents the initial key into global storage where we first index by the address, and then
-/// the struct tag
+/// the struct tag. The struct fields are public to support pattern matching.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct ModuleId {
-    address: AccountAddress,
-    name: Identifier,
+    pub address: AccountAddress,
+    pub name: Identifier,
 }
 
 impl From<ModuleId> for (AccountAddress, Identifier) {

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -740,11 +740,14 @@ pub enum StatusCode {
     // be re-executed.
     // Should never be committed on chain
     SPECULATIVE_EXECUTION_ABORT_ERROR = 2024,
+    ACCESS_CONTROL_INVARIANT_VIOLATION = 2025,
 
     // Reserved error code for future use
-    RESERVED_INVARIANT_VIOLATION_ERROR_3 = 2025,
-    RESERVED_INVARIANT_VIOLATION_ERROR_4 = 2026,
-    RESERVED_INVARIANT_VIOLATION_ERROR_5 = 2027,
+    RESERVED_INVARIANT_VIOLATION_ERROR_1 = 2026,
+    RESERVED_INVARIANT_VIOLATION_ERROR_2 = 2027,
+    RESERVED_INVARIANT_VIOLATION_ERROR_3 = 2028,
+    RESERVED_INVARIANT_VIOLATION_ERROR_4 = 2029,
+    RESERVED_INVARIANT_VIOLATION_ERROR_5 = 2030,
 
     // Errors that can arise from binary decoding (deserialization)
     // Deserialization Errors: 3000-3999
@@ -804,11 +807,13 @@ pub enum StatusCode {
     IO_LIMIT_REACHED = 4031,
     STORAGE_LIMIT_REACHED = 4032,
     TYPE_TAG_LIMIT_EXCEEDED = 4033,
+    ACCESS_DENIED = 4034,
+    ACCESS_STACK_LIMIT_EXCEEDED = 4035,
     // Reserved error code for future use
-    RESERVED_RUNTIME_ERROR_2 = 4034,
-    RESERVED_RUNTIME_ERROR_3 = 4035,
-    RESERVED_RUNTIME_ERROR_4 = 4036,
-    RESERVED_RUNTIME_ERROR_5 = 4037,
+    RESERVED_RUNTIME_ERROR_1 = 4036,
+    RESERVED_RUNTIME_ERROR_2 = 4037,
+    RESERVED_RUNTIME_ERROR_3 = 4038,
+    RESERVED_RUNTIME_ERROR_4 = 4039,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -807,9 +807,12 @@ pub enum StatusCode {
     IO_LIMIT_REACHED = 4031,
     STORAGE_LIMIT_REACHED = 4032,
     TYPE_TAG_LIMIT_EXCEEDED = 4033,
+    // A resource was accessed in a way which is not permitted by the active access control
+    // specifier.
     ACCESS_DENIED = 4034,
+    // The stack of access control specifier has overflowed.
     ACCESS_STACK_LIMIT_EXCEEDED = 4035,
-    // Reserved error code for future use
+    // Reserved error code for future use. Always keep this buffer of well-defined new codes.
     RESERVED_RUNTIME_ERROR_1 = 4036,
     RESERVED_RUNTIME_ERROR_2 = 4037,
     RESERVED_RUNTIME_ERROR_3 = 4038,

--- a/third_party/move/move-vm/runtime/src/access_control.rs
+++ b/third_party/move/move-vm/runtime/src/access_control.rs
@@ -1,0 +1,96 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Represents the state machine managing resource access control in VM execution.
+
+use crate::{interpreter::ACCESS_STACK_SIZE_LIMIT, loader::Function};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::vm_status::StatusCode;
+use move_vm_types::loaded_data::runtime_access_specifier::{
+    AccessInstance, AccessSpecifier, AccessSpecifierEnv,
+};
+
+/// The state of access control. Maintains a stack of active access specifiers.
+///
+/// The top-most element is the active access control policy, the values below are restore points
+/// to return to when the current context is exited.
+///
+/// At any time, in the current semantics, the top-most element of the stack represents the join
+/// of all elements beneath + some restrictions. Notice that technically it is possible to change
+/// this, for example, when privileged code is called.
+#[derive(Clone, Debug)]
+pub struct AccessControlState {
+    specifier_stack: Vec<AccessSpecifier>,
+}
+
+impl Default for AccessControlState {
+    fn default() -> Self {
+        Self {
+            specifier_stack: vec![AccessSpecifier::Any],
+        }
+    }
+}
+
+impl AccessControlState {
+    /// Enters a function, applying its access specifier to the state.
+    pub(crate) fn enter_function(
+        &mut self,
+        env: &impl AccessSpecifierEnv,
+        fun: &Function,
+    ) -> PartialVMResult<()> {
+        if matches!(fun.access_specifier, AccessSpecifier::Any) {
+            // Shortcut case that no access is specified
+            return Ok(());
+        }
+        // Specialize the functions access specifier
+        let mut fun_specifier = fun.access_specifier.clone();
+        fun_specifier.specialize(env)?;
+        // Join with top of stack
+        let current = self.check_stack_and_peek()?;
+        let new_specifier = current.join(&fun_specifier);
+        if let Some(false) = new_specifier.subsumes(&fun_specifier) {
+            // We don't allow to call this function, even if in some code paths access would be ok.
+            // This ensures that static analysis results are compatible.
+            return Err(PartialVMError::new(StatusCode::ACCESS_DENIED)
+                .with_message(format!("not allowed to call `{}`", fun.pretty_string())));
+        }
+        if self.specifier_stack.len() >= ACCESS_STACK_SIZE_LIMIT {
+            Err(
+                PartialVMError::new(StatusCode::ACCESS_STACK_LIMIT_EXCEEDED).with_message(format!(
+                    "access specifier stack overflow (limit = {})",
+                    ACCESS_STACK_SIZE_LIMIT
+                )),
+            )
+        } else {
+            self.specifier_stack.push(new_specifier);
+            Ok(())
+        }
+    }
+
+    /// Exit function, restoring access state before entering.
+    pub(crate) fn exit_function(&mut self, fun: &Function) -> PartialVMResult<()> {
+        if !matches!(fun.access_specifier, AccessSpecifier::Any) {
+            self.check_stack_and_peek()?;
+            self.specifier_stack.pop();
+        }
+        Ok(())
+    }
+
+    fn check_stack_and_peek(&self) -> PartialVMResult<&AccessSpecifier> {
+        self.specifier_stack.last().ok_or_else(|| {
+            PartialVMError::new(StatusCode::ACCESS_CONTROL_INVARIANT_VIOLATION)
+                .with_message("unbalanced access specifier stack".to_owned())
+        })
+    }
+
+    /// Check whether the given access is allowed in the current state.
+    pub(crate) fn check_access(&self, access: AccessInstance) -> PartialVMResult<()> {
+        if let Some(active) = self.specifier_stack.last() {
+            if !active.enables(&access) {
+                return Err(PartialVMError::new(StatusCode::ACCESS_DENIED)
+                    .with_message(format!("not allowed to perform `{}`", access)));
+            }
+        }
+        Ok(())
+    }
+}

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -15,7 +15,7 @@ use move_binary_format::{
     errors::*,
     file_format::{
         Ability, AbilitySet, AccessKind, Bytecode, FieldInstantiationIndex, FunctionHandleIndex,
-        FunctionInstantiationIndex, SignatureIndex, StructDefInstantiationIndex,
+        FunctionInstantiationIndex, LocalIndex, SignatureIndex, StructDefInstantiationIndex,
     },
 };
 use move_core_types::{

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -26,3 +26,5 @@ pub mod config;
 // Only include debugging functionality in debug builds
 #[cfg(any(debug_assertions, feature = "debugging"))]
 mod debug;
+
+mod access_control;

--- a/third_party/move/move-vm/runtime/src/loader/access_specifier_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/access_specifier_loader.rs
@@ -1,0 +1,130 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::{
+    binary_views::BinaryIndexedView,
+    errors::{PartialVMError, PartialVMResult},
+    file_format as FF,
+    file_format::TableIndex,
+};
+use move_core_types::vm_status::StatusCode;
+use move_vm_types::loaded_data::{
+    runtime_access_specifier::{
+        AccessSpecifier, AccessSpecifierClause, AddressSpecifier, AddressSpecifierFunction,
+        ResourceSpecifier,
+    },
+    runtime_types::{StructIdentifier, Type},
+};
+use std::sync::Arc;
+
+/// Loads an access specifier from the file format into the runtime representation.
+pub fn load_access_specifier(
+    module: BinaryIndexedView,
+    signature_table: &[Vec<Type>],
+    struct_name_table: &[Arc<StructIdentifier>],
+    specifier: &Option<Vec<FF::AccessSpecifier>>,
+) -> PartialVMResult<AccessSpecifier> {
+    if let Some(specs) = specifier {
+        let mut incls = vec![];
+        let mut excls = vec![];
+        for spec in specs {
+            let resource = load_resource_specifier(
+                module,
+                signature_table,
+                struct_name_table,
+                &spec.resource,
+            )?;
+            let address = load_address_specifier(module, &spec.address)?;
+            let clause = AccessSpecifierClause {
+                kind: spec.kind,
+                resource,
+                address,
+            };
+            if spec.negated {
+                excls.push(clause)
+            } else {
+                incls.push(clause)
+            }
+        }
+        Ok(AccessSpecifier::Constraint(incls, excls))
+    } else {
+        Ok(AccessSpecifier::Any)
+    }
+}
+
+fn load_resource_specifier(
+    module: BinaryIndexedView,
+    signature_table: &[Vec<Type>],
+    struct_name_table: &[Arc<StructIdentifier>],
+    spec: &FF::ResourceSpecifier,
+) -> PartialVMResult<ResourceSpecifier> {
+    use FF::ResourceSpecifier::*;
+    match spec {
+        Any => Ok(ResourceSpecifier::Any),
+        DeclaredAtAddress(addr_idx) => Ok(ResourceSpecifier::DeclaredAtAddress(*access_table(
+            module.address_identifiers(),
+            addr_idx.0,
+        )?)),
+        DeclaredInModule(mod_idx) => Ok(ResourceSpecifier::DeclaredInModule(
+            module
+                .safe_module_id_for_handle(access_table(module.module_handles(), mod_idx.0)?)
+                .ok_or_else(index_out_of_range)?,
+        )),
+        Resource(str_idx) => Ok(ResourceSpecifier::Resource(
+            access_table(struct_name_table, str_idx.0)?.as_ref().clone(),
+        )),
+        ResourceInstantiation(str_idx, ty_idx) => Ok(ResourceSpecifier::ResourceInstantiation(
+            access_table(struct_name_table, str_idx.0)?.as_ref().clone(),
+            access_table(signature_table, ty_idx.0)?.clone(),
+        )),
+    }
+}
+
+fn load_address_specifier(
+    module: BinaryIndexedView,
+    spec: &FF::AddressSpecifier,
+) -> PartialVMResult<AddressSpecifier> {
+    use FF::AddressSpecifier::*;
+    match spec {
+        Any => Ok(AddressSpecifier::Any),
+        Literal(idx) => Ok(AddressSpecifier::Literal(*access_table(
+            module.address_identifiers(),
+            idx.0,
+        )?)),
+        Parameter(param, fun) => {
+            let fun = if let Some(idx) = fun {
+                let fun_inst = access_table(module.function_instantiations(), idx.0)?;
+                let fun_handle = access_table(module.function_handles(), fun_inst.handle.0)?;
+                let mod_handle = access_table(module.module_handles(), fun_handle.module.0)?;
+                let mod_id = module
+                    .safe_module_id_for_handle(mod_handle)
+                    .ok_or_else(index_out_of_range)?;
+                let mod_name = mod_id.short_str_lossless();
+                let fun_name = access_table(module.identifiers(), fun_handle.name.0)?;
+                AddressSpecifierFunction::parse(&mod_name, fun_name.as_str()).ok_or_else(|| {
+                    PartialVMError::new(StatusCode::ACCESS_CONTROL_INVARIANT_VIOLATION)
+                        .with_message(format!(
+                            "function `{}::{}` not supported for address specifier",
+                            mod_name, fun_name
+                        ))
+                })?
+            } else {
+                AddressSpecifierFunction::Identity
+            };
+            Ok(AddressSpecifier::Eval(fun, *param))
+        },
+    }
+}
+
+fn access_table<T>(table: &[T], idx: TableIndex) -> PartialVMResult<&T> {
+    if (idx as usize) < table.len() {
+        Ok(&table[idx as usize])
+    } else {
+        Err(index_out_of_range())
+    }
+}
+
+fn index_out_of_range() -> PartialVMError {
+    PartialVMError::new(StatusCode::ACCESS_CONTROL_INVARIANT_VIOLATION)
+        .with_message("table index out of range".to_owned())
+}

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -72,7 +72,7 @@ impl Function {
         index: FunctionDefinitionIndex,
         module: &CompiledModule,
         signature_table: &[Vec<Type>],
-        struct_name_table: &[Arc<StructIdentifier>],
+        struct_names: &[StructIdentifier],
     ) -> PartialVMResult<Self> {
         let def = module.function_def_at(index);
         let handle = module.function_handle_at(def.function);
@@ -113,7 +113,7 @@ impl Function {
         let access_specifier = load_access_specifier(
             BinaryIndexedView::Module(module),
             signature_table,
-            struct_name_table,
+            struct_names,
             &handle.access_specifiers,
         )?;
 

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -4,16 +4,22 @@
 
 use super::ModuleStorageAdapter;
 use crate::{
-    loader::{Loader, Module, Resolver, ScriptHash},
+    loader::{
+        access_specifier_loader::load_access_specifier, Loader, Module, Resolver, ScriptHash,
+    },
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
 };
 use move_binary_format::{
     access::ModuleAccess,
+    binary_views::BinaryIndexedView,
     errors::{PartialVMError, PartialVMResult},
     file_format::{AbilitySet, Bytecode, CompiledModule, FunctionDefinitionIndex, Visibility},
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
-use move_vm_types::loaded_data::runtime_types::Type;
+use move_vm_types::loaded_data::{
+    runtime_access_specifier::AccessSpecifier,
+    runtime_types::{StructIdentifier, Type},
+};
 use std::{fmt::Debug, sync::Arc};
 
 // A simple wrapper for the "owner" of the function (Module or Script)
@@ -41,6 +47,7 @@ pub(crate) struct Function {
     pub(crate) return_types: Vec<Type>,
     pub(crate) local_types: Vec<Type>,
     pub(crate) parameter_types: Vec<Type>,
+    pub(crate) access_specifier: AccessSpecifier,
 }
 
 // This struct must be treated as an identifier for a function and not somehow relying on
@@ -65,7 +72,8 @@ impl Function {
         index: FunctionDefinitionIndex,
         module: &CompiledModule,
         signature_table: &[Vec<Type>],
-    ) -> Self {
+        struct_name_table: &[Arc<StructIdentifier>],
+    ) -> PartialVMResult<Self> {
         let def = module.function_def_at(index);
         let handle = module.function_handle_at(def.function);
         let name = module.identifier_at(handle.name).to_owned();
@@ -102,9 +110,16 @@ impl Function {
             vec![]
         };
 
+        let access_specifier = load_access_specifier(
+            BinaryIndexedView::Module(module),
+            signature_table,
+            struct_name_table,
+            &handle.access_specifiers,
+        )?;
+
         let parameter_types = signature_table[handle.parameters.0 as usize].clone();
 
-        Self {
+        Ok(Self {
             file_format_version: module.version(),
             index,
             code,
@@ -117,7 +132,8 @@ impl Function {
             local_types,
             return_types,
             parameter_types,
-        }
+            access_specifier,
+        })
     }
 
     #[allow(unused)]

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -50,7 +50,6 @@ mod type_loader;
 
 pub(crate) use function::{Function, FunctionHandle, FunctionInstantiation, LoadedFunction, Scope};
 pub(crate) use modules::{Module, ModuleCache, ModuleStorage, ModuleStorageAdapter};
-use move_vm_types::loaded_data::runtime_access_specifier::AccessSpecifier;
 pub(crate) use script::{Script, ScriptCache};
 use type_loader::intern_type;
 

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -42,6 +42,7 @@ use std::{
     sync::Arc,
 };
 
+mod access_specifier_loader;
 mod function;
 mod modules;
 mod script;
@@ -49,6 +50,7 @@ mod type_loader;
 
 pub(crate) use function::{Function, FunctionHandle, FunctionInstantiation, LoadedFunction, Scope};
 pub(crate) use modules::{Module, ModuleCache, ModuleStorage, ModuleStorageAdapter};
+use move_vm_types::loaded_data::runtime_access_specifier::AccessSpecifier;
 pub(crate) use script::{Script, ScriptCache};
 use type_loader::intern_type;
 

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -272,6 +272,7 @@ impl Module {
 
         let mut create = || {
             let mut struct_idxs = vec![];
+            let mut struct_names = vec![];
             // validate the correctness of struct handle references.
             for struct_handle in module.struct_handles() {
                 let struct_name = module.identifier_at(struct_handle.name);
@@ -283,10 +284,12 @@ impl Module {
                         .get_struct_type_by_identifier(struct_name, &module_id)?
                         .check_compatibility(struct_handle)?;
                 }
-                struct_idxs.push(name_cache.insert_or_get(StructIdentifier {
+                let name = StructIdentifier {
                     module: module_id,
                     name: struct_name.to_owned(),
-                }));
+                };
+                struct_idxs.push(name_cache.insert_or_get(name.clone()));
+                struct_names.push(name)
             }
 
             // Build signature table
@@ -327,8 +330,13 @@ impl Module {
 
             for (idx, func) in module.function_defs().iter().enumerate() {
                 let findex = FunctionDefinitionIndex(idx as TableIndex);
-                let function =
-                    Function::new(natives, findex, &module, &signature_table, &struct_names)?;
+                let function = Function::new(
+                    natives,
+                    findex,
+                    &module,
+                    signature_table.as_slice(),
+                    &struct_names,
+                )?;
 
                 function_map.insert(function.name.to_owned(), idx);
                 function_defs.push(Arc::new(function));

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -327,7 +327,8 @@ impl Module {
 
             for (idx, func) in module.function_defs().iter().enumerate() {
                 let findex = FunctionDefinitionIndex(idx as TableIndex);
-                let function = Function::new(natives, findex, &module, signature_table.as_slice());
+                let function =
+                    Function::new(natives, findex, &module, &signature_table, &struct_names)?;
 
                 function_map.insert(function.name.to_owned(), idx);
                 function_defs.push(Arc::new(function));

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -12,7 +12,10 @@ use move_binary_format::{
     file_format::{Bytecode, CompiledScript, FunctionDefinitionIndex, Signature, SignatureIndex},
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
-use move_vm_types::loaded_data::runtime_types::{StructIdentifier, Type};
+use move_vm_types::loaded_data::{
+    runtime_access_specifier::AccessSpecifier,
+    runtime_types::{StructIdentifier, Type},
+};
 use std::{collections::BTreeMap, sync::Arc};
 
 // A Script is very similar to a `CompiledScript` but data is "transformed" to a representation
@@ -145,6 +148,7 @@ impl Script {
             return_types: return_tys.clone(),
             local_types: local_tys,
             parameter_types: parameter_tys.clone(),
+            access_specifier: AccessSpecifier::Any,
         });
 
         let mut single_signature_token_map = BTreeMap::new();

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 derivative = "2.2.0"
+itertools = "0.10.0"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", features = ["derive", "rc"] }
@@ -24,6 +25,7 @@ move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
 
 [dev-dependencies]
+move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
 claims = "0.7"
 proptest = "1.0.0"
 rand = "0.8.5"

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -25,8 +25,8 @@ move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
 
 [dev-dependencies]
-move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
 claims = "0.7"
+move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
 proptest = "1.0.0"
 rand = "0.8.5"
 

--- a/third_party/move/move-vm/types/proptest-regressions/loaded_data/runtime_access_specifiers_prop_tests.txt
+++ b/third_party/move/move-vm/types/proptest-regressions/loaded_data/runtime_access_specifiers_prop_tests.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 909d52933dc057f54814b28bd6ed88504cee077ece2e6d70252adeeab2ba9f58 # shrinks to access = AccessInstance { kind: Reads, resource: StructIdentifier { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000001, name: Identifier("ac") }, name: Identifier("ac") }, instance: [], address: 0000000000000000000000000000000000000000000000000000000000000001 }, s1 = Any, s2 = Any
+cc dba42d5ed4d6a925756fb4ea8f829bed5a209f2be288885b453b352eec92ce5f # shrinks to access = AccessInstance { kind: Reads, resource: StructIdentifier { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000001, name: Identifier("ac") }, name: Identifier("ac") }, instance: [], address: 0000000000000000000000000000000000000000000000000000000000000001 }, s1 = Any, s2 = Any
+cc b95bd44e13064041a78409ce4f11d729f189756de014c143b909e7eec2b8c81f # shrinks to access = AccessInstance { kind: Reads, resource: StructIdentifier { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("ac") }, name: Identifier("ac") }, instance: [], address: 0000000000000000000000000000000000000000000000000000000000000002 }, s1 = Constraint([AccessSpecifierClause { kind: Acquires, resource: Any, address: Literal(0000000000000000000000000000000000000000000000000000000000000001) }], []), s2 = Constraint([AccessSpecifierClause { kind: Acquires, resource: Any, address: Any }], [])

--- a/third_party/move/move-vm/types/src/loaded_data/mod.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/mod.rs
@@ -5,4 +5,7 @@
 //!
 //! This module contains the loaded definition of code data used in runtime.
 
+pub mod runtime_access_specifier;
+#[cfg(test)]
+mod runtime_access_specifiers_prop_tests;
 pub mod runtime_types;

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
@@ -1,0 +1,535 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime representation of access control specifiers.
+//!
+//! Specifiers are represented as a list of inclusion and exclusion clauses. Each
+//! of those clauses corresponds to an `acquires A`, `reads A`, or `writes A`
+//! declaration in the language. Exclusions stem from negation, e.g. `!reads A`.
+//!
+//! Specifiers support access check via `AccessSpecifier::enables`. Moreover,
+//! access specifiers can be joined via `AccessSpecifier::join`. The join of two access
+//! specifiers behaves like intersection: for `a1 join a2`, access is allowed if it
+//! is both allowed by `a1` and `a2`. Joining happens when a function is entered which
+//! has access specifiers: then the current active access specifier is joined with the
+//! function's specifier. The join operator is complete (no approximation). A further
+//! operator `AccessSpecifier::subsumes` allows to test whether one specifier
+//! allows all the access of the other. This used to abort execution if a function
+//! is entered which declares accesses not allowed by the context. However, the
+//!`subsumes` function is incomplete. This is semantically sound since
+//! if subsume is undecided, abortion only happens later at the time of actual access
+//! instead of when the function is entered.
+//!
+//! The `join` operation attempts to simplify the resulting access specifier, making
+//! access checks faster and keeping memory use low. This is only implemented for
+//! inclusions, which are fully simplified. Exclusions are accumulated.
+//! There is potential for optimization by simplifying exclusions but since those are effectively
+//! negations, such a simplification is not trivial and may require recursive specifiers, which
+//! we like to avoid.
+
+use crate::{
+    loaded_data::runtime_types::{StructIdentifier, Type},
+    values::{Reference, SignerRef, Value},
+};
+use itertools::Itertools;
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult},
+    file_format::{AccessKind, LocalIndex},
+};
+use move_core_types::{
+    account_address::AccountAddress, language_storage::ModuleId, vm_status::StatusCode,
+};
+use std::{fmt, fmt::Debug};
+
+/// Represents an access specifier.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub enum AccessSpecifier {
+    /// Universal access granted
+    Any,
+    /// A constraint in normalized form: `Constraint(inclusions, exclusions)`.
+    /// The inclusions are a _disjunction_ and the exclusions a _conjunction_ of
+    /// access clauses. An access is valid if it is enabled by any of the
+    /// inclusions, and not enabled for each of the exclusions.
+    Constraint(Vec<AccessSpecifierClause>, Vec<AccessSpecifierClause>),
+}
+
+/// Represents an access specifier clause
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub struct AccessSpecifierClause {
+    pub kind: AccessKind,
+    pub resource: ResourceSpecifier,
+    pub address: AddressSpecifier,
+}
+
+/// Represents a resource specifier.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub enum ResourceSpecifier {
+    Any,
+    DeclaredAtAddress(AccountAddress),
+    DeclaredInModule(ModuleId),
+    Resource(StructIdentifier),
+    ResourceInstantiation(StructIdentifier, Vec<Type>),
+}
+
+/// Represents an address specifier.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub enum AddressSpecifier {
+    Any,
+    Literal(AccountAddress),
+    /// The `Eval` specifier represents a value dependent on a parameter of the
+    /// current function. Once address specifiers are instantiated in a given
+    /// caller context it is replaced by a literal.
+    Eval(AddressSpecifierFunction, LocalIndex),
+}
+
+/// Represents a well-known function used in an address specifier.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
+pub enum AddressSpecifierFunction {
+    Identity,
+    SignerAddress,
+    ObjectAddress,
+}
+
+/// A trait representing an environment for evaluating dynamic values in access specifiers.
+pub trait AccessSpecifierEnv {
+    fn eval_address_specifier_function(
+        &self,
+        fun: AddressSpecifierFunction,
+        local: LocalIndex,
+    ) -> PartialVMResult<AccountAddress>;
+}
+
+/// A struct to represent an access.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
+pub struct AccessInstance {
+    pub kind: AccessKind,
+    pub resource: StructIdentifier,
+    pub instance: Vec<Type>,
+    pub address: AccountAddress,
+}
+
+impl AccessSpecifier {
+    /// Returns true if this access specifier is known to have no accesses. Note that this
+    /// may be under-approximated in the presence of exclusions. That is, if
+    /// `!s.is_empty()`, it is still possible that all concrete accesses fail.
+    pub fn is_empty(&self) -> bool {
+        if let AccessSpecifier::Constraint(incl, _) = self {
+            incl.is_empty()
+        } else {
+            false
+        }
+    }
+
+    /// Specializes the access specifier for the given environment. This evaluates
+    /// `AddressSpecifier::Eval` terms.
+    pub fn specialize(&mut self, env: &impl AccessSpecifierEnv) -> PartialVMResult<()> {
+        match self {
+            AccessSpecifier::Any => Ok(()),
+            AccessSpecifier::Constraint(incls, excls) => {
+                for clause in incls {
+                    clause.specialize(env)?;
+                }
+                for clause in excls {
+                    clause.specialize(env)?;
+                }
+                Ok(())
+            },
+        }
+    }
+
+    /// Returns true if the concrete access instance is enabled.
+    pub fn enables(&self, access: &AccessInstance) -> bool {
+        use AccessSpecifier::*;
+        match self {
+            Any => true,
+            Constraint(incls, excls) => {
+                incls.iter().any(|c| c.enables(access)) && excls.iter().all(|c| !c.enables(access))
+            },
+        }
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        use AccessSpecifier::*;
+        match (self, other) {
+            (Any, s) | (s, Any) => s.clone(),
+            (Constraint(incls, excls), Constraint(other_incls, other_excls)) => {
+                // Inclusions are disjunctions. The join of two disjunctions is
+                //   (a + b) * (c + d) = a*(c + d) + b*(c + d) = a*c + a*d + b*c + b*d
+                // For the exclusions, we can simply concatenate them.
+                // TODO: this is quadratic and  need to be metered
+                let mut new_incls = vec![];
+                for incl in incls {
+                    for other_incl in other_incls {
+                        // try_join returns None if the result is empty.
+                        if let Some(new_incl) = incl.join(other_incl) {
+                            new_incls.push(new_incl);
+                        }
+                    }
+                }
+                if new_incls.is_empty() {
+                    // Drop exclusions since they are redundant
+                    Constraint(new_incls, vec![])
+                } else {
+                    Constraint(
+                        new_incls,
+                        excls
+                            .iter()
+                            .cloned()
+                            .chain(other_excls.iter().cloned())
+                            .collect(),
+                    )
+                }
+            },
+        }
+    }
+
+    /// Check whether self allows all the accesses than other. Returns None if this is not
+    /// decidable.
+    pub fn subsumes(&self, other: &Self) -> Option<bool> {
+        use AccessSpecifier::*;
+        match (self, other) {
+            (Any, _) => Some(true),
+            (_, Any) => Some(false),
+            (Constraint(_, excls), _) if !excls.is_empty() => {
+                // If there are exclusions, we don't know the effective subset, so bail out
+                None
+            },
+            (Constraint(incls, _), Constraint(other_incls, _)) => {
+                // We can ignore the exclusions from other. As long as the inclusions are subsumed
+                // subset can be decided.
+                // TODO: this is quadratic and  need to be metered
+                'outer: for other in other_incls {
+                    if incls.is_empty() {
+                        // Known to be not inclusive
+                        return Some(false);
+                    }
+                    for incl in incls {
+                        if incl.subsumes(other) {
+                            // Can discharge this one.
+                            continue 'outer;
+                        }
+                    }
+                    // We don't know (but can likely improve this)
+                    return None;
+                }
+                Some(true)
+            },
+        }
+    }
+}
+
+impl AccessSpecifierClause {
+    /// Checks whether this clause allows the access.
+    fn enables(&self, access: &AccessInstance) -> bool {
+        let AccessInstance {
+            kind,
+            resource,
+            instance,
+            address,
+        } = access;
+        if self.kind != AccessKind::Acquires && &self.kind != kind {
+            return false;
+        }
+        self.resource.enables(resource, instance) && self.address.enables(address)
+    }
+
+    /// Specializes this clause.
+    fn specialize(&mut self, env: &impl AccessSpecifierEnv) -> PartialVMResult<()> {
+        // Only addresses can be specialized right now.
+        self.address.specialize(env)
+    }
+
+    /// Join two clauses. Returns None if there is no intersection in access.
+    fn join(&self, other: &Self) -> Option<Self> {
+        let Self {
+            kind,
+            resource,
+            address,
+        } = self;
+        let Self {
+            kind: other_kind,
+            resource: other_resource,
+            address: other_address,
+        } = other;
+
+        kind.try_join(*other_kind).and_then(|kind| {
+            resource.join(other_resource).and_then(|resource| {
+                address.join(other_address).map(|address| Self {
+                    kind,
+                    resource,
+                    address,
+                })
+            })
+        })
+    }
+
+    fn subsumes(&self, other: &Self) -> bool {
+        self.kind.subsumes(&other.kind)
+            && self.resource.subsumes(&other.resource)
+            && self.address.subsumes(&other.address)
+    }
+}
+
+/// A few macros to make complex match arms better readable. Those data types are struct with
+/// named fields, and formatters tend to layout those very verbose.
+macro_rules! module_addr {
+    ($addr:pat) => {
+        ModuleId { address: $addr, .. }
+    };
+}
+
+macro_rules! struct_identifier_module {
+    ($m:pat) => {
+        StructIdentifier { module: $m, .. }
+    };
+}
+
+macro_rules! struct_identifier_addr {
+    ($addr:pat) => {
+        struct_identifier_module!(module_addr!($addr))
+    };
+}
+
+macro_rules! some_if {
+    ($val:expr, $check:expr) => {{
+        if $check {
+            Some($val)
+        } else {
+            None
+        }
+    }};
+}
+
+impl ResourceSpecifier {
+    /// Checks whether the struct/type pair is enabled by this specifier.
+    fn enables(&self, struct_id: &StructIdentifier, type_inst: &[Type]) -> bool {
+        use ResourceSpecifier::*;
+        match self {
+            Any => true,
+            DeclaredAtAddress(addr) => struct_id.module.address() == addr,
+            DeclaredInModule(module_id) => &struct_id.module == module_id,
+            Resource(enabled_struct_id) => enabled_struct_id == struct_id,
+            ResourceInstantiation(enabled_struct_id, enabled_type_inst) => {
+                enabled_struct_id == struct_id && enabled_type_inst == type_inst
+            },
+        }
+    }
+
+    /// Joins two resource specifiers. Returns none of there is no intersection.
+    fn join(&self, other: &Self) -> Option<Self> {
+        use ResourceSpecifier::*;
+        match &self {
+            Any => Some(other.clone()),
+            DeclaredAtAddress(addr) => match &other {
+                Any => Some(self.clone()),
+                DeclaredAtAddress(other_addr)
+                | DeclaredInModule(module_addr!(other_addr))
+                | Resource(struct_identifier_addr!(other_addr))
+                | ResourceInstantiation(struct_identifier_addr!(other_addr), _) => {
+                    some_if!(other.clone(), addr == other_addr)
+                },
+            },
+            DeclaredInModule(module_id) => match &other {
+                Any => Some(self.clone()),
+                DeclaredAtAddress(addr) => some_if!(self.clone(), addr == module_id.address()),
+                DeclaredInModule(other_module_id)
+                | Resource(struct_identifier_module!(other_module_id))
+                | ResourceInstantiation(struct_identifier_module!(other_module_id), _) => {
+                    some_if!(other.clone(), module_id == other_module_id)
+                },
+            },
+            Resource(struct_id) => match &other {
+                Any => Some(self.clone()),
+                DeclaredAtAddress(addr) => {
+                    some_if!(self.clone(), addr == struct_id.module.address())
+                },
+                DeclaredInModule(module_id) => {
+                    some_if!(self.clone(), module_id == &struct_id.module)
+                },
+                Resource(other_struct_id) | ResourceInstantiation(other_struct_id, _) => {
+                    some_if!(other.clone(), struct_id == other_struct_id)
+                },
+            },
+            ResourceInstantiation(struct_id, inst) => match other {
+                Any => Some(self.clone()),
+                DeclaredAtAddress(addr) => {
+                    some_if!(self.clone(), struct_id.module.address() == addr)
+                },
+                DeclaredInModule(module_id) => {
+                    some_if!(self.clone(), &struct_id.module == module_id)
+                },
+                Resource(other_struct_id) => some_if!(self.clone(), struct_id == other_struct_id),
+                ResourceInstantiation(other_struct_id, other_inst) => {
+                    some_if!(
+                        self.clone(),
+                        struct_id == other_struct_id && inst == other_inst
+                    )
+                },
+            },
+        }
+    }
+
+    fn subsumes(&self, other: &Self) -> bool {
+        use ResourceSpecifier::*;
+        match &self {
+            Any => true,
+            DeclaredAtAddress(addr) => match &other {
+                Any => false,
+                DeclaredAtAddress(other_addr)
+                | DeclaredInModule(module_addr!(other_addr))
+                | Resource(struct_identifier_addr!(other_addr))
+                | ResourceInstantiation(struct_identifier_addr!(other_addr), _) => {
+                    addr == other_addr
+                },
+            },
+            DeclaredInModule(module_id) => match &other {
+                Any | DeclaredAtAddress(_) => false,
+                DeclaredInModule(other_module_id)
+                | Resource(struct_identifier_module!(other_module_id))
+                | ResourceInstantiation(struct_identifier_module!(other_module_id), _) => {
+                    module_id == other_module_id
+                },
+            },
+            Resource(struct_id) => match &other {
+                Any | DeclaredAtAddress(_) | DeclaredInModule(_) => false,
+                Resource(other_struct_id) | ResourceInstantiation(other_struct_id, _) => {
+                    struct_id == other_struct_id
+                },
+            },
+            ResourceInstantiation(struct_id, inst) => match other {
+                Any | DeclaredAtAddress(_) | DeclaredInModule(_) | Resource(_) => false,
+                ResourceInstantiation(other_struct_id, other_inst) => {
+                    struct_id == other_struct_id && inst == other_inst
+                },
+            },
+        }
+    }
+}
+
+impl AddressSpecifier {
+    /// Checks whether the given address is enabled by this specifier.
+    fn enables(&self, addr: &AccountAddress) -> bool {
+        use AddressSpecifier::*;
+        match self {
+            Any => true,
+            Literal(a) => a == addr,
+            Eval(_, _) => false,
+        }
+    }
+
+    /// Specializes this specifier, resolving `Eval` variants.
+    fn specialize(&mut self, env: &impl AccessSpecifierEnv) -> PartialVMResult<()> {
+        if let AddressSpecifier::Eval(fun, arg) = self {
+            *self = AddressSpecifier::Literal(env.eval_address_specifier_function(*fun, *arg)?)
+        }
+        Ok(())
+    }
+
+    /// Joins two address specifiers. Returns None if there is no intersection.
+    fn join(&self, other: &Self) -> Option<Self> {
+        use AddressSpecifier::*;
+        match (self, other) {
+            (Any, s) | (s, Any) => Some(s.clone()),
+            (Literal(a1), Literal(a2)) => some_if!(self.clone(), a1 == a2),
+            (_, _) => {
+                // Eval should be specialized away when join is called.
+                debug_assert!(false, "unexpected AddressSpecifier::Eval found");
+                None
+            },
+        }
+    }
+
+    fn subsumes(&self, other: &Self) -> bool {
+        use AddressSpecifier::*;
+        match (self, other) {
+            (Any, _) => true,
+            (_, Any) => false,
+            (Literal(a1), Literal(a2)) => a1 == a2,
+            (_, _) => {
+                // Eval should be specialized away when subsumes is called.
+                debug_assert!(false, "unexpected AddressSpecifier::Eval found");
+                false
+            },
+        }
+    }
+}
+
+impl AddressSpecifierFunction {
+    pub fn parse(module_str: &str, fun_str: &str) -> Option<AddressSpecifierFunction> {
+        match (module_str, fun_str) {
+            ("0x1::signer", "address_of") => Some(AddressSpecifierFunction::SignerAddress),
+            ("0x1::object", "owner") => Some(AddressSpecifierFunction::ObjectAddress),
+            _ => None,
+        }
+    }
+
+    pub fn eval(&self, arg: Value) -> PartialVMResult<AccountAddress> {
+        use AddressSpecifierFunction::*;
+        match self {
+            Identity => arg.value_as::<AccountAddress>(),
+            SignerAddress => {
+                // See also: implementation of `signer::native_borrow_address`.
+                let signer_ref = arg.value_as::<SignerRef>()?;
+                signer_ref
+                    .borrow_signer()?
+                    .value_as::<Reference>()?
+                    .read_ref()?
+                    .value_as::<AccountAddress>()
+            },
+            ObjectAddress => Err(PartialVMError::new(
+                StatusCode::ACCESS_CONTROL_INVARIANT_VIOLATION,
+            )
+            .with_message(format!(
+                "unimplemented address specifier function `{:?}`",
+                self
+            ))),
+        }
+    }
+}
+
+impl AccessInstance {
+    pub fn new(kind: AccessKind, ty: &Type, address: AccountAddress) -> Option<Self> {
+        let (resource, instance) = match ty {
+            Type::Struct { name, .. } => (name.as_ref(), &[] as &[Type]),
+            Type::StructInstantiation { name, ty_args, .. } => (name.as_ref(), ty_args.as_slice()),
+            _ => return None,
+        };
+        Some(AccessInstance {
+            kind,
+            resource: resource.clone(),
+            instance: instance.to_vec(),
+            address,
+        })
+    }
+
+    pub fn read(ty: &Type, address: AccountAddress) -> Option<Self> {
+        Self::new(AccessKind::Reads, ty, address)
+    }
+
+    pub fn write(ty: &Type, address: AccountAddress) -> Option<Self> {
+        Self::new(AccessKind::Writes, ty, address)
+    }
+}
+
+impl fmt::Display for AccessInstance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            kind,
+            resource,
+            instance,
+            address,
+        } = self;
+        write!(
+            f,
+            "{} {}{}(@0x{})",
+            kind,
+            resource,
+            if !instance.is_empty() {
+                format!("<{}>", instance.iter().map(|t| t.to_string()).join(","))
+            } else {
+                "".to_owned()
+            },
+            address.short_str_lossless()
+        )
+    }
+}

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
@@ -102,7 +102,7 @@ pub trait AccessSpecifierEnv {
     ) -> PartialVMResult<AccountAddress>;
 }
 
-/// A struct to represent an access.
+/// A struct to represent an access instance (request).
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub struct AccessInstance {
     pub kind: AccessKind,
@@ -116,8 +116,8 @@ impl AccessSpecifier {
     /// may be under-approximated in the presence of exclusions. That is, if
     /// `!s.is_empty()`, it is still possible that all concrete accesses fail.
     pub fn is_empty(&self) -> bool {
-        if let AccessSpecifier::Constraint(incl, _) = self {
-            incl.is_empty()
+        if let AccessSpecifier::Constraint(incls, _) = self {
+            incls.is_empty()
         } else {
             false
         }
@@ -492,12 +492,12 @@ impl AddressSpecifierFunction {
 }
 
 impl AccessInstance {
-    pub fn new(kind: AccessKind, ty: &Type, address: AccountAddress) -> Option<Self> {
-        let (resource, instance) = match ty {
-            Type::Struct { name, .. } => (name.as_ref(), &[] as &[Type]),
-            Type::StructInstantiation { name, ty_args, .. } => (name.as_ref(), ty_args.as_slice()),
-            _ => return None,
-        };
+    pub fn new(
+        kind: AccessKind,
+        resource: &StructIdentifier,
+        instance: &[Type],
+        address: AccountAddress,
+    ) -> Option<Self> {
         Some(AccessInstance {
             kind,
             resource: resource.clone(),
@@ -506,12 +506,20 @@ impl AccessInstance {
         })
     }
 
-    pub fn read(ty: &Type, address: AccountAddress) -> Option<Self> {
-        Self::new(AccessKind::Reads, ty, address)
+    pub fn read(
+        resource: &StructIdentifier,
+        instance: &[Type],
+        address: AccountAddress,
+    ) -> Option<Self> {
+        Self::new(AccessKind::Reads, resource, instance, address)
     }
 
-    pub fn write(ty: &Type, address: AccountAddress) -> Option<Self> {
-        Self::new(AccessKind::Writes, ty, address)
+    pub fn write(
+        resource: &StructIdentifier,
+        instance: &[Type],
+        address: AccountAddress,
+    ) -> Option<Self> {
+        Self::new(AccessKind::Writes, resource, instance, address)
     }
 }
 

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
@@ -156,7 +156,8 @@ impl AccessSpecifier {
                 // Inclusions are disjunctions. The join of two disjunctions is
                 //   (a + b) * (c + d) = a*(c + d) + b*(c + d) = a*c + a*d + b*c + b*d
                 // For the exclusions, we can simply concatenate them.
-                // TODO: this is quadratic and  need to be metered
+                // TODO: this is quadratic and  need to be metered, OR protected by some
+                //   bound.
                 let mut new_incls = vec![];
                 for incl in incls {
                     for other_incl in other_incls {

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifier.rs
@@ -85,8 +85,11 @@ pub enum AddressSpecifier {
 /// Represents a well-known function used in an address specifier.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum AddressSpecifierFunction {
+    /// Identity function -- just returns the value of the parameter.
     Identity,
+    /// signer::address_of
     SignerAddress,
+    /// object::owner_of
     ObjectAddress,
 }
 

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
@@ -1,0 +1,194 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::loaded_data::{
+    runtime_access_specifier::{
+        AccessInstance, AccessSpecifier, AccessSpecifierClause, AddressSpecifier, ResourceSpecifier,
+    },
+    runtime_types::{StructIdentifier, Type},
+};
+use move_binary_format::file_format::AccessKind;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+};
+use proptest::{collection::vec, prelude::*};
+
+proptest! {
+    #![proptest_config(ProptestConfig{cases: 5000, verbose: 1, ..ProptestConfig::default()})]
+
+    /// Test in all combinations the semi-lattice properties of the join and subsumes.
+    /// Together with testing basic membership, this gives extensive coverage of the operators.
+    #[test]
+    fn access_specifier_semi_lattice_properties(
+        access in access_instance_strategy(),
+        s1 in access_specifier_strategy(4, 3),
+        s2 in access_specifier_strategy(4, 3)
+    ) {
+        //eprint!(".");
+        if s1.enables(&access) && s2.enables(&access) {
+            assert!(s1.join(&s2).enables(&access))
+        } else {
+            assert!(!s1.join(&s2).enables(&access))
+        }
+        if s1.subsumes(&s2).unwrap_or_default() && s2.enables(&access) {
+            assert!(s1.enables(&access))
+        }
+    }
+
+    /// Test membership, by constructing all combinations of specifiers derivable from a given
+    /// instance.
+    #[test]
+    fn access_specifier_enables(
+        (access1, clause1) in  access_to_matching_specifier_clause(access_instance_strategy()),
+        (access2, clause2) in  access_to_matching_specifier_clause(access_instance_strategy()),
+    ) {
+        //eprint!(".");
+        let clauses = vec![clause1, clause2];
+        let incl = AccessSpecifier::Constraint(clauses.clone(), vec![]);
+        let incl_excl = AccessSpecifier::Constraint(clauses.clone(), clauses.clone());
+        let excl = AccessSpecifier::Constraint(vec![], clauses.clone());
+        assert!(incl.enables(&access1));
+        assert!(incl.enables(&access2));
+        assert!(incl.join(&incl).enables(&access1));
+        assert!(incl.join(&incl).enables(&access2));
+        assert!(!incl_excl.enables(&access1));
+        assert!(!incl_excl.enables(&access2));
+        assert!(!excl.enables(&access1));
+        assert!(!excl.enables(&access2));
+    }
+}
+
+fn access_instance_strategy() -> impl Strategy<Value = AccessInstance> {
+    (
+        any::<AccessKind>(),
+        struct_id_strategy(),
+        type_args_strategy(),
+        address_strategy(),
+    )
+        .prop_map(|(kind, resource, instance, address)| AccessInstance {
+            kind,
+            resource,
+            instance,
+            address,
+        })
+}
+fn access_specifier_strategy(
+    incl_size: usize,
+    excl_size: usize,
+) -> impl Strategy<Value = AccessSpecifier> {
+    prop_oneof![
+        Just(AccessSpecifier::Any),
+        (
+            vec(access_specifier_clause_strategy(), 0..incl_size),
+            vec(access_specifier_clause_strategy(), 0..excl_size),
+        )
+            .prop_map(|(incls, excls)| AccessSpecifier::Constraint(incls, excls))
+    ]
+}
+
+fn access_specifier_clause_strategy() -> impl Strategy<Value = AccessSpecifierClause> {
+    (
+        any::<AccessKind>(),
+        resource_specifier_strategy(),
+        address_specifier_strategy(),
+    )
+        .prop_map(|(kind, resource, address)| AccessSpecifierClause {
+            kind,
+            resource,
+            address,
+        })
+}
+
+fn resource_specifier_strategy() -> impl Strategy<Value = ResourceSpecifier> {
+    prop_oneof![
+        Just(ResourceSpecifier::Any),
+        address_strategy().prop_map(ResourceSpecifier::DeclaredAtAddress),
+        module_id_strategy().prop_map(ResourceSpecifier::DeclaredInModule),
+        struct_id_strategy().prop_map(ResourceSpecifier::Resource),
+        (struct_id_strategy(), type_args_strategy())
+            .prop_map(|(s, ts)| ResourceSpecifier::ResourceInstantiation(s, ts)),
+    ]
+}
+
+fn address_specifier_strategy() -> impl Strategy<Value = AddressSpecifier> {
+    prop_oneof![
+        Just(AddressSpecifier::Any),
+        address_strategy().prop_map(AddressSpecifier::Literal) // Skip Eval as it is not appearing subsumes and join
+    ]
+}
+
+fn type_args_strategy() -> impl Strategy<Value = Vec<Type>> {
+    prop_oneof![
+        Just(vec![]),
+        Just(vec![Type::U8]),
+        Just(vec![Type::U16, Type::U32])
+    ]
+}
+
+fn struct_id_strategy() -> impl Strategy<Value = StructIdentifier> {
+    (module_id_strategy(), identifier_strategy())
+        .prop_map(|(module, name)| StructIdentifier { module, name })
+}
+
+fn module_id_strategy() -> impl Strategy<Value = ModuleId> {
+    (address_strategy(), identifier_strategy()).prop_map(|(a, i)| ModuleId::new(a, i))
+}
+
+fn identifier_strategy() -> impl Strategy<Value = Identifier> {
+    "[a-b]{1}[c-d]{1}".prop_map(|s| Identifier::new(s).unwrap())
+}
+
+fn address_strategy() -> impl Strategy<Value = AccountAddress> {
+    prop_oneof![
+        Just(AccountAddress::from_str_strict("0x1").unwrap()),
+        Just(AccountAddress::from_str_strict("0x2").unwrap()),
+        Just(AccountAddress::from_str_strict("0x3").unwrap())
+    ]
+}
+
+/// Map a strategy of instances to matching access specifier clauses.
+fn access_to_matching_specifier_clause(
+    instances: impl Strategy<Value = AccessInstance>,
+) -> impl Strategy<Value = (AccessInstance, AccessSpecifierClause)> {
+    instances.prop_flat_map(|inst| {
+        (
+            Just(inst.kind),
+            resource_to_matching_specifier(Just((inst.resource.clone(), inst.instance.clone()))),
+            address_to_matching_specifier(Just(inst.address)),
+        )
+            .prop_map(move |(kind, resource, address)| {
+                (inst.clone(), AccessSpecifierClause {
+                    kind,
+                    resource,
+                    address,
+                })
+            })
+    })
+}
+
+/// Map a strategy of resources to a strategy of specifiers which match them.
+fn resource_to_matching_specifier(
+    resources: impl Strategy<Value = (StructIdentifier, Vec<Type>)>,
+) -> impl Strategy<Value = ResourceSpecifier> {
+    resources.prop_flat_map(|(s, ts)| {
+        prop_oneof![
+            Just(ResourceSpecifier::Any),
+            Just(ResourceSpecifier::DeclaredAtAddress(s.module.address)),
+            Just(ResourceSpecifier::DeclaredInModule(s.module.clone())),
+            Just(ResourceSpecifier::Resource(s.clone())),
+            Just(ResourceSpecifier::ResourceInstantiation(s, ts))
+        ]
+    })
+}
+
+/// Map a strategy of addresses to a strategy of specifiers which match them.
+fn address_to_matching_specifier(
+    addresses: impl Strategy<Value = AccountAddress>,
+) -> impl Strategy<Value = AddressSpecifier> {
+    addresses.prop_flat_map(|a| {
+        prop_oneof![
+            Just(AddressSpecifier::Any),
+            Just(AddressSpecifier::Literal(a))
+        ]
+    })
+}

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
@@ -24,7 +24,6 @@ proptest! {
         s1 in access_specifier_strategy(4, 3),
         s2 in access_specifier_strategy(4, 3)
     ) {
-        //eprint!(".");
         if s1.enables(&access) && s2.enables(&access) {
             assert!(s1.join(&s2).enables(&access))
         } else {
@@ -42,7 +41,6 @@ proptest! {
         (access1, clause1) in  access_to_matching_specifier_clause(access_instance_strategy()),
         (access2, clause2) in  access_to_matching_specifier_clause(access_instance_strategy()),
     ) {
-        //eprint!(".");
         let clauses = vec![clause1, clause2];
         let incl = AccessSpecifier::Constraint(clauses.clone(), vec![]);
         let incl_excl = AccessSpecifier::Constraint(clauses.clone(), clauses.clone());

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -677,15 +677,15 @@ impl fmt::Display for Type {
             Address => f.write_str("address"),
             Signer => f.write_str("signer"),
             Vector(et) => write!(f, "vector<{}>", et),
-            Struct { name, ability: _ } => f.write_str(&name.to_string()),
+            Struct { idx, ability: _ } => write!(f, "s#{}", idx.0),
             StructInstantiation {
-                name,
+                idx,
                 ty_args,
                 ability: _,
             } => write!(
                 f,
-                "{}<{}>",
-                name,
+                "s#{}<{}>",
+                idx.0,
                 ty_args.iter().map(|t| t.to_string()).join(",")
             ),
             Reference(t) => write!(f, "&{}", t),

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::non_canonical_partial_ord_impl)]
 
 use derivative::Derivative;
+use itertools::Itertools;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{
@@ -21,6 +22,7 @@ use std::{
     cell::RefCell,
     cmp::max,
     collections::{btree_map, BTreeMap},
+    fmt,
     fmt::Debug,
 };
 use triomphe::Arc as TriompheArc;
@@ -646,6 +648,49 @@ mod unit_tests {
 
         for (ty, ty_args, expected) in cases {
             assert_eq!(ty.num_nodes_in_subst(&ty_args).unwrap(), expected);
+        }
+    }
+}
+
+impl fmt::Display for StructIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}::{}",
+            self.module.short_str_lossless(),
+            self.name.as_str()
+        )
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Type::*;
+        match self {
+            Bool => f.write_str("bool"),
+            U8 => f.write_str("u8"),
+            U16 => f.write_str("u16"),
+            U32 => f.write_str("u32"),
+            U64 => f.write_str("u64"),
+            U128 => f.write_str("u128"),
+            U256 => f.write_str("u256"),
+            Address => f.write_str("address"),
+            Signer => f.write_str("signer"),
+            Vector(et) => write!(f, "vector<{}>", et),
+            Struct { name, ability: _ } => f.write_str(&name.to_string()),
+            StructInstantiation {
+                name,
+                ty_args,
+                ability: _,
+            } => write!(
+                f,
+                "{}<{}>",
+                name,
+                ty_args.iter().map(|t| t.to_string()).join(",")
+            ),
+            Reference(t) => write!(f, "&{}", t),
+            MutableReference(t) => write!(f, "&mut {}", t),
+            TyParam(no) => write!(f, "_{}", no),
         }
     }
 }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -581,6 +581,49 @@ impl Type {
     }
 }
 
+impl fmt::Display for StructIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}::{}",
+            self.module.short_str_lossless(),
+            self.name.as_str()
+        )
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Type::*;
+        match self {
+            Bool => f.write_str("bool"),
+            U8 => f.write_str("u8"),
+            U16 => f.write_str("u16"),
+            U32 => f.write_str("u32"),
+            U64 => f.write_str("u64"),
+            U128 => f.write_str("u128"),
+            U256 => f.write_str("u256"),
+            Address => f.write_str("address"),
+            Signer => f.write_str("signer"),
+            Vector(et) => write!(f, "vector<{}>", et),
+            Struct { idx, ability: _ } => write!(f, "s#{}", idx.0),
+            StructInstantiation {
+                idx,
+                ty_args,
+                ability: _,
+            } => write!(
+                f,
+                "s#{}<{}>",
+                idx.0,
+                ty_args.iter().map(|t| t.to_string()).join(",")
+            ),
+            Reference(t) => write!(f, "&{}", t),
+            MutableReference(t) => write!(f, "&mut {}", t),
+            TyParam(no) => write!(f, "_{}", no),
+        }
+    }
+}
+
 #[cfg(test)]
 mod unit_tests {
     use super::*;
@@ -648,49 +691,6 @@ mod unit_tests {
 
         for (ty, ty_args, expected) in cases {
             assert_eq!(ty.num_nodes_in_subst(&ty_args).unwrap(), expected);
-        }
-    }
-}
-
-impl fmt::Display for StructIdentifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}::{}",
-            self.module.short_str_lossless(),
-            self.name.as_str()
-        )
-    }
-}
-
-impl fmt::Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Type::*;
-        match self {
-            Bool => f.write_str("bool"),
-            U8 => f.write_str("u8"),
-            U16 => f.write_str("u16"),
-            U32 => f.write_str("u32"),
-            U64 => f.write_str("u64"),
-            U128 => f.write_str("u128"),
-            U256 => f.write_str("u256"),
-            Address => f.write_str("address"),
-            Signer => f.write_str("signer"),
-            Vector(et) => write!(f, "vector<{}>", et),
-            Struct { idx, ability: _ } => write!(f, "s#{}", idx.0),
-            StructInstantiation {
-                idx,
-                ty_args,
-                ability: _,
-            } => write!(
-                f,
-                "s#{}<{}>",
-                idx.0,
-                ty_args.iter().map(|t| t.to_string()).join(",")
-            ),
-            Reference(t) => write!(f, "&{}", t),
-            MutableReference(t) => write!(f, "&mut {}", t),
-            TyParam(no) => write!(f, "_{}", no),
         }
     }
 }

--- a/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 anyhow = "1.0.52"
 clap = { version = "4.3.9", features = ["derive"] }
 colored = "2.0.0"
-move-binary-format = { path = "../../move-binary-format" }
+move-binary-format = { path = "../../move-binary-format", features = ["testing"] }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-bytecode-utils = { path = "../../tools/move-bytecode-utils" }
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -90,6 +90,12 @@ impl<'a, T: ModuleResolver + ?Sized> MoveValueAnnotator<'a, T> {
         }
     }
 
+    pub fn new_with_max_bytecode_version(view: &'a T, max_bytecode_version: u32) -> Self {
+        Self {
+            cache: Resolver::new_with_max_bytecode_version(view, max_bytecode_version),
+        }
+    }
+
     pub fn get_module(&self, module: &ModuleId) -> Result<Rc<CompiledModule>> {
         self.cache.get_module_by_id_or_err(module)
     }


### PR DESCRIPTION
Implements the runtime engine for resource access control:

- a representation of access control specifiers in `loaded_data::runtime_access_specifiers`.
- a loader for access specifiers in `runtime::loader::access_specifier_loader`.
- a new stateful object representing the access control logic in `runtime::access_control`.
- finally the use of the `AccessControlState` in `runtime::interpreter`
- unit test and combinatorial proptests
