### PR TITLE
realistic_network_tuned_for_throughput: try not to query the event indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,6 +3758,7 @@ dependencies = [
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-transaction-generator-lib",
+ "aptos-types",
  "async-trait",
  "clap 4.3.21",
  "futures",

--- a/crates/transaction-emitter-lib/Cargo.toml
+++ b/crates/transaction-emitter-lib/Cargo.toml
@@ -23,6 +23,7 @@ aptos-logger = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-transaction-generator-lib = { workspace = true }
+aptos-types = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1880,11 +1880,12 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
             .with_success_criteria(
                 SuccessCriteria::new(25000)
                     .add_no_restarts()
-                    .add_wait_for_catchup_s(60)
-                    .add_chain_progress(StateProgressThreshold {
-                        max_no_progress_secs: 10.0,
-                        max_round_gap: 4,
-                    }),
+                    .add_wait_for_catchup_s(60), /* Doesn't work with out event indices
+                                                 .add_chain_progress(StateProgressThreshold {
+                                                     max_no_progress_secs: 10.0,
+                                                     max_round_gap: 4,
+                                                 }),
+                                                  */
             );
     } else {
         forge_config = forge_config.with_success_criteria(
@@ -1898,11 +1899,12 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                     MetricsThreshold::new(14.0, 30),
                     // Check that we don't use more than 10 GB of memory for 30% of the time.
                     MetricsThreshold::new_gb(10.0, 30),
-                ))
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                )), /* Doens't work without event indices
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 10.0,
+                        max_round_gap: 4,
+                    }),
+                    */
         );
     }
 


### PR DESCRIPTION
failing due to lack of event indices, which resulted in inability to query `NewBlockEvent`s

The PR does these two things to avoid querying the event indices:
1. skip chain progress checking
2. submit_and_wait uses bcs version of get_txn_by_hash which doesn't query the block timestamp

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
https://github.com/aptos-labs/aptos-core/actions/runs/6551209062
