### PR TITLE
[move-vm] Fix compatibility issue

### DIFF
--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests_modules.move
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests_modules.move
@@ -174,5 +174,9 @@ address 0x2 {
         struct S<phantom T> {
             f1: u64,
         }
+
+        struct F<phantom T> has copy{
+            f1: u64,
+        }
     }
 }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -127,7 +127,7 @@ impl StructType {
 
     // Check if the local struct handle is compatible with the defined struct type.
     pub fn check_compatibility(&self, struct_handle: &StructHandle) -> PartialVMResult<()> {
-        if !self.abilities.is_subset(struct_handle.abilities) {
+        if !struct_handle.abilities.is_subset(self.abilities) {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("Ability definition of module mismatch".to_string()),


### PR DESCRIPTION
### Description

The compatibility rule causes the loader paranoid check to break. Fix this issue.

### Test Plan

Added a replay.

We need to wait to see if this fix replay issues.
