### PR TITLE
MoveHarness improvements - execution mode and block splitting

### DIFF
--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -30,6 +30,7 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 aptos-vm-genesis = { workspace = true }
 bcs = { workspace = true }
+claims = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
 move-binary-format = { workspace = true }
@@ -43,6 +44,7 @@ rand = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
+test-case = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }

--- a/aptos-move/e2e-move-tests/proptest-regressions/tests/aggregator.txt
+++ b/aptos-move/e2e-move-tests/proptest-regressions/tests/aggregator.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 29ff577b59ed799377eed4cc25edb500730068f10c46b66793fa70c0bbc8e0b6 # shrinks to block_split = Whole
+cc 0236a1bba591a25b2aa4e0cc78bb87c3475f8da01aeb46cf9ea9eb3cbeeca7d0 # shrinks to block_split = Whole

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -39,6 +39,7 @@ use move_core_types::{
 use move_package::package_hooks::register_package_hooks;
 use once_cell::sync::Lazy;
 use project_root::get_project_root;
+use proptest::strategy::{BoxedStrategy, Just, Strategy};
 use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
@@ -77,6 +78,13 @@ pub struct MoveHarness {
     txn_seq_no: BTreeMap<AccountAddress, u64>,
 
     default_gas_unit_price: u64,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BlockSplit {
+    Whole,
+    SingleTxnPerBlock,
+    SplitIntoThree { first_len: usize, second_len: usize },
 }
 
 impl MoveHarness {
@@ -696,6 +704,116 @@ impl MoveHarness {
         self.executor
             .execute_view_function(fun.module_id, fun.member_id, type_args, arguments)
     }
+
+    /// Splits transactions into blocks based on passed `block_split``, and
+    /// checks whether each transaction aborted based on passed in
+    /// move abort code (if >0), or succeeded (if ==0).
+    /// `txn_block` is vector of (abort code, transaction) tuples.
+    ///
+    /// This is useful when testing that different block boundaries
+    /// work correctly.
+    pub fn run_block_in_parts_and_check(
+        &mut self,
+        block_split: BlockSplit,
+        txn_block: Vec<(u64, SignedTransaction)>,
+    ) -> Vec<TransactionStatus> {
+        fn run_and_check_block(
+            harness: &mut MoveHarness,
+            txn_block: Vec<(u64, SignedTransaction)>,
+            offset: usize,
+        ) -> Vec<TransactionStatus> {
+            use crate::assert_abort_ref;
+
+            if txn_block.is_empty() {
+                return vec![];
+            }
+            let (errors, txns): (Vec<_>, Vec<_>) = txn_block.into_iter().unzip();
+            println!(
+                "=== Running block from {} with {} tnx ===",
+                offset,
+                txns.len()
+            );
+            let outputs = harness.run_block(txns);
+            for (idx, (error, status)) in errors.into_iter().zip(outputs.iter()).enumerate() {
+                if error > 0 {
+                    assert_abort_ref!(
+                        status,
+                        error,
+                        "Error code missmaptch on txn {} that should've failed, with block starting at {}. Expected {}, gotten {:?}",
+                        idx + offset,
+                        offset,
+                        error,
+                        status,
+                    );
+                } else {
+                    assert_success!(
+                        status.clone(),
+                        "Didn't succeed on txn {}, with block starting at {}",
+                        idx + offset,
+                        offset,
+                    );
+                }
+            }
+            outputs
+        }
+
+        match block_split {
+            BlockSplit::Whole => run_and_check_block(self, txn_block, 0),
+            BlockSplit::SingleTxnPerBlock => {
+                let mut outputs = vec![];
+                for (idx, (error, status)) in txn_block.into_iter().enumerate() {
+                    outputs.append(&mut run_and_check_block(self, vec![(error, status)], idx));
+                }
+                outputs
+            },
+            BlockSplit::SplitIntoThree {
+                first_len,
+                second_len,
+            } => {
+                assert!(first_len + second_len <= txn_block.len());
+                let (left, rest) = txn_block.split_at(first_len);
+                let (mid, right) = rest.split_at(second_len);
+
+                let mut outputs = vec![];
+                outputs.append(&mut run_and_check_block(self, left.to_vec(), 0));
+                outputs.append(&mut run_and_check_block(self, mid.to_vec(), first_len));
+                outputs.append(&mut run_and_check_block(
+                    self,
+                    right.to_vec(),
+                    first_len + second_len,
+                ));
+                outputs
+            },
+        }
+    }
+}
+
+impl BlockSplit {
+    pub fn arbitrary(len: usize) -> BoxedStrategy<BlockSplit> {
+        // skip last choice if lenght is not big enough for it.
+        (0..(if len > 1 { 3 } else { 2 }))
+            .prop_flat_map(move |enum_type| {
+                // making running a test with a full block likely
+                match enum_type {
+                    0 => Just(BlockSplit::Whole).boxed(),
+                    1 => Just(BlockSplit::SingleTxnPerBlock).boxed(),
+                    _ => {
+                        // First is non-empty, and not the whole block here: [1, len)
+                        (1usize..len)
+                            .prop_flat_map(move |first| {
+                                // Second is non-empty, but can finish the block: [1, len - first]
+                                (Just(first), 1usize..len - first + 1)
+                            })
+                            .prop_map(|(first, second)| BlockSplit::SplitIntoThree {
+                                first_len: first,
+                                second_len: second,
+                            })
+                            .boxed()
+                    },
+                }
+            })
+            .boxed()
+    }
 }
 
 impl Default for MoveHarness {
@@ -749,6 +867,7 @@ macro_rules! assert_success {
 }
 
 /// Helper to assert transaction aborts.
+/// TODO merge/replace with assert_abort_ref
 #[macro_export]
 macro_rules! assert_abort {
     // identity needs to be before pattern (both with and without message),
@@ -798,6 +917,7 @@ macro_rules! assert_abort {
 }
 
 /// Helper to assert transaction aborts.
+/// Takes reference, as then we can get a better error message.
 #[macro_export]
 macro_rules! assert_abort_ref {
     // identity needs to be before pattern (both with and without message),

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -81,6 +81,8 @@ static RNG_SEED: [u8; 32] = [9u8; 32];
 
 const ENV_TRACE_DIR: &str = "TRACE";
 
+// Enables running parallel, in addition to sequential, in a
+// BothComparison mode.
 const ENV_ENABLE_PARALLEL: &str = "E2E_PARALLEL_EXEC";
 
 /// Directory structure of the trace dir


### PR DESCRIPTION
- cleaning up of execution mode - use parallel was confusing - as it was running both sequential and parallel. adding three modes - SequentialOnly, ParallelOnly and BothComparison

- adding ability to execute and check a set of transactions with a given BlockSplit. For tests when block boundary matters (i.e. testing path of reading from storage), ability to vary this easily (via test_case or proptest is useful). provided example from aggregator v1 test.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
