### PR TITLE
drop smt in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,6 +3336,7 @@ name = "aptos-scratchpad"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
+ "aptos-drop-helper",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-metrics-core",

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -10,7 +10,7 @@ use aptos_metrics_core::TimerHelper;
 use once_cell::sync::Lazy;
 use std::sync::mpsc::{channel, Receiver, Sender};
 
-pub static DEFAULT_DROP_HELPER: Lazy<DropHelper> = Lazy::new(|| DropHelper::new("default", 128));
+pub static DEFAULT_DROP_HELPER: Lazy<DropHelper> = Lazy::new(|| DropHelper::new("default", 32));
 
 /// A helper to send things to a thread pool for asynchronous dropping.
 ///

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -28,7 +28,9 @@ impl DropHelper {
     pub fn new(name: &'static str, max_concurrent_drops: usize) -> Self {
         let (token_tx, token_rx) = channel();
         for _ in 0..max_concurrent_drops {
-            token_tx.send(()).expect("Failed to buffer initial tokens.");
+            token_tx
+                .send(())
+                .expect("DropHelper: Failed to buffer initial tokens.");
         }
         Self {
             name,

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-crypto = { workspace = true }
+aptos-drop-helper = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -30,24 +30,24 @@ use aptos_types::proof::{SparseMerkleInternalNode, SparseMerkleLeafNode};
 use std::sync::{Arc, Weak};
 
 #[derive(Clone, Debug)]
-pub(crate) struct InternalNode<V> {
+pub(crate) struct InternalNode<V: Send + Sync + 'static> {
     pub left: SubTree<V>,
     pub right: SubTree<V>,
 }
 
-impl<V: CryptoHash> InternalNode<V> {
+impl<V: CryptoHash + Send + Sync + 'static> InternalNode<V> {
     pub fn calc_hash(&self) -> HashValue {
         SparseMerkleInternalNode::new(self.left.hash(), self.right.hash()).hash()
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct LeafNode<V> {
+pub(crate) struct LeafNode<V: Send + Sync + 'static> {
     pub key: HashValue,
     pub value: LeafValue<V>,
 }
 
-impl<V> LeafNode<V> {
+impl<V: Send + Sync + 'static> LeafNode<V> {
     pub fn new(key: HashValue, value: LeafValue<V>) -> Self {
         Self { key, value }
     }
@@ -60,13 +60,13 @@ impl<V> LeafNode<V> {
     }
 }
 
-impl<V: CryptoHash> LeafNode<V> {
+impl<V: CryptoHash + Send + Sync + 'static> LeafNode<V> {
     pub fn calc_hash(&self) -> HashValue {
         SparseMerkleLeafNode::new(self.key, self.value.hash).hash()
     }
 }
 
-impl<V> From<&SparseMerkleLeafNode> for LeafNode<V>
+impl<V: Send + Sync + 'static> From<&SparseMerkleLeafNode> for LeafNode<V>
 where
     V: CryptoHash,
 {
@@ -79,18 +79,18 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) enum NodeInner<V> {
+pub(crate) enum NodeInner<V: Send + Sync + 'static> {
     Internal(InternalNode<V>),
     Leaf(LeafNode<V>),
 }
 
 #[derive(Debug)]
-pub(crate) struct Node<V> {
+pub(crate) struct Node<V: Send + Sync + 'static> {
     generation: u64,
     inner: NodeInner<V>,
 }
 
-impl<V: CryptoHash> Node<V> {
+impl<V: CryptoHash + Send + Sync + 'static> Node<V> {
     pub fn calc_hash(&self) -> HashValue {
         match &self.inner {
             NodeInner::Internal(internal_node) => internal_node.calc_hash(),
@@ -99,7 +99,7 @@ impl<V: CryptoHash> Node<V> {
     }
 }
 
-impl<V> Node<V> {
+impl<V: Send + Sync + 'static> Node<V> {
     pub fn new_leaf(key: HashValue, value: LeafValue<V>, generation: u64) -> Self {
         Self {
             generation,
@@ -176,7 +176,7 @@ impl<R> Clone for Ref<R> {
 pub(crate) type NodeHandle<V> = Ref<Node<V>>;
 
 #[derive(Clone, Debug)]
-pub(crate) enum SubTree<V> {
+pub(crate) enum SubTree<V: Send + Sync + 'static> {
     Empty,
     NonEmpty {
         hash: HashValue,
@@ -184,7 +184,7 @@ pub(crate) enum SubTree<V> {
     },
 }
 
-impl<V: CryptoHash> SubTree<V> {
+impl<V: CryptoHash + Send + Sync + 'static> SubTree<V> {
     pub fn new_empty() -> Self {
         Self::Empty
     }
@@ -272,12 +272,12 @@ impl<V: CryptoHash> SubTree<V> {
 }
 
 #[derive(Clone, Debug)]
-pub struct LeafValue<V> {
+pub struct LeafValue<V: Send + Sync + 'static> {
     pub hash: HashValue,
     pub data: Ref<V>,
 }
 
-impl<V> LeafValue<V> {
+impl<V: Send + Sync + 'static> LeafValue<V> {
     pub fn new_with_value(value: V) -> Self
     where
         V: CryptoHash,

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -438,6 +438,7 @@ fn update(smt: &SparseMerkleTree) -> SparseMerkleTree {
 }
 
 #[test]
+#[ignore] // gonna remove this functionality
 fn test_get_oldest_ancestor() {
     // smt0 - smt00 - smt000 - smt0000 - smt00000
     //              \

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -128,13 +128,13 @@ trait AssertNoExternalStrongRef {
     fn assert_no_external_strong_ref(&self);
 }
 
-impl<V> AssertNoExternalStrongRef for SparseMerkleTree<V> {
+impl<V: Send + Sync + 'static> AssertNoExternalStrongRef for SparseMerkleTree<V> {
     fn assert_no_external_strong_ref(&self) {
         assert_subtree_sole_strong_ref(&self.inner.root);
     }
 }
 
-fn assert_subtree_sole_strong_ref<V>(subtree: &SubTree<V>) {
+fn assert_subtree_sole_strong_ref<V: Send + Sync + 'static>(subtree: &SubTree<V>) {
     if let SubTree::NonEmpty {
         root: NodeHandle::Shared(arc),
         ..

--- a/storage/scratchpad/src/sparse_merkle/updater.rs
+++ b/storage/scratchpad/src/sparse_merkle/updater.rs
@@ -24,7 +24,7 @@ type InMemSubTree<V> = super::node::SubTree<V>;
 type InMemInternal<V> = super::node::InternalNode<V>;
 
 #[derive(Clone)]
-enum InMemSubTreeInfo<V> {
+enum InMemSubTreeInfo<V: Send + Sync + 'static> {
     Internal {
         subtree: InMemSubTree<V>,
         node: InMemInternal<V>,
@@ -39,7 +39,7 @@ enum InMemSubTreeInfo<V> {
     Empty,
 }
 
-impl<V: Clone + CryptoHash> InMemSubTreeInfo<V> {
+impl<V: Clone + CryptoHash + Send + Sync + 'static> InMemSubTreeInfo<V> {
     fn create_leaf_with_update(update: (HashValue, &V), generation: u64) -> Self {
         let subtree = InMemSubTree::new_leaf_with_value(update.0, (*update.1).clone(), generation);
         Self::Leaf {
@@ -105,12 +105,12 @@ enum PersistedSubTreeInfo<'a> {
 }
 
 #[derive(Clone)]
-enum SubTreeInfo<'a, V> {
+enum SubTreeInfo<'a, V: Send + Sync + 'static> {
     InMem(InMemSubTreeInfo<V>),
     Persisted(PersistedSubTreeInfo<'a>),
 }
 
-impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
+impl<'a, V: Clone + CryptoHash + Send + Sync + 'static> SubTreeInfo<'a, V> {
     fn new_empty() -> Self {
         Self::InMem(InMemSubTreeInfo::Empty)
     }
@@ -274,14 +274,14 @@ impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
     }
 }
 
-pub struct SubTreeUpdater<'a, V> {
+pub struct SubTreeUpdater<'a, V: Send + Sync + 'static> {
     depth: usize,
     info: SubTreeInfo<'a, V>,
     updates: &'a [(HashValue, Option<&'a V>)],
     generation: u64,
 }
 
-impl<'a, V: Send + Sync + Clone + CryptoHash> SubTreeUpdater<'a, V> {
+impl<'a, V: Send + Sync + 'static + Clone + CryptoHash> SubTreeUpdater<'a, V> {
     pub(crate) fn update(
         root: InMemSubTree<V>,
         updates: &'a [(HashValue, Option<&'a V>)],


### PR DESCRIPTION
hen a old SMT drops late (many descendants droped early), a long chain
of `Inner`s drop sequantially in the current implementation. This Makes that
concurrent.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
