### PR TITLE
[aptos-debugger] introduce remote-gas-profiler binary

### DIFF
--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -42,3 +42,6 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+
+[[bin]]
+name = "remote-gas-profiler"

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -226,6 +226,24 @@ impl AptosDebugger {
             .await
     }
 
+    pub async fn get_committed_transaction_at_version(
+        &self,
+        version: Version,
+    ) -> Result<(Transaction, TransactionInfo)> {
+        let (mut txns, mut info) = self.debugger.get_committed_transactions(version, 1).await?;
+
+        let txn = txns.pop().expect("there must be exactly 1 txn in the vec");
+        let info = info
+            .pop()
+            .expect("there must be exactly 1 txn info in the vec");
+
+        Ok((txn, info))
+    }
+
+    pub fn state_view_at_version(&self, version: Version) -> DebuggerStateView {
+        DebuggerStateView::new(self.debugger.clone(), version)
+    }
+
     pub fn run_session_at_version<F>(&self, version: Version, f: F) -> Result<VMChangeSet>
     where
         F: FnOnce(&mut SessionExt) -> VMResult<()>,

--- a/aptos-move/aptos-debugger/src/bin/remote-gas-profiler.rs
+++ b/aptos-move/aptos-debugger/src/bin/remote-gas-profiler.rs
@@ -1,0 +1,75 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use aptos_move_debugger::aptos_debugger::AptosDebugger;
+use aptos_rest_client::Client;
+use aptos_types::transaction::Transaction;
+use aptos_vm::AptosVM;
+use clap::{Parser, Subcommand};
+use std::path::{Path, PathBuf};
+use url::Url;
+
+#[derive(Subcommand)]
+pub enum Target {
+    /// Use full node's rest api as query endpoint.
+    Rest { endpoint: String },
+    /// Use a local db instance to serve as query endpoint.
+    DB { path: PathBuf },
+}
+
+#[derive(Parser)]
+pub struct Args {
+    #[clap(subcommand)]
+    target: Target,
+
+    #[clap(long)]
+    version: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Parse the commandline args
+    let args = Args::parse();
+    let version = args.version;
+
+    // Initialize the debugger
+    aptos_logger::Logger::new().init();
+    AptosVM::set_concurrency_level_once(1);
+
+    let debugger = match args.target {
+        Target::Rest { endpoint } => {
+            AptosDebugger::rest_client(Client::new(Url::parse(&endpoint)?))?
+        },
+        Target::DB { path } => AptosDebugger::db(path)?,
+    };
+
+    // Execute the transaction w/ the gas profiler
+    let (txn, _txn_info) = debugger
+        .get_committed_transaction_at_version(version)
+        .await?;
+
+    let txn = match txn {
+        Transaction::UserTransaction(txn) => txn,
+        _ => bail!("not a user transaction"),
+    };
+
+    let (_status, output, gas_log) =
+        debugger.execute_transaction_at_version_with_gas_profiler(version, txn)?;
+
+    let txn_output =
+        output.try_materialize_into_transaction_output(&debugger.state_view_at_version(version))?;
+
+    // Show results to the user
+    println!("{:#?}", txn_output);
+
+    let report_path = Path::new("gas-profiling").join(format!("txn-{}", version));
+    gas_log.generate_html_report(
+        &report_path,
+        format!("Gas Report - Transaction {}", version),
+    )?;
+
+    println!("Gas profiling report saved to {}.", report_path.display());
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a new binary `remote-gas-profiler` to the `aptos-debugger` crate. The tool allows you to generate a gas profiling report for a committed transaction.

Here's an example command:
```
cargo run -p aptos-move-debugger --bin remote-gas-profiler -- --version 721512672
 rest https://testnet.aptoslabs.com/v1
```