### PR TITLE
[authenticator] add sanity checks to multiauth

### DIFF
--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -1341,7 +1341,7 @@ impl TryFrom<MultiKeySignature> for AccountAuthenticator {
             signatures.push((indexed_signature.index, signature));
         }
 
-        let multi_key = MultiKey::new(public_keys, value.signatures_required);
+        let multi_key = MultiKey::new(public_keys, value.signatures_required)?;
         let auth = MultiKeyAuthenticator::new(multi_key, signatures)?;
         Ok(AccountAuthenticator::multi_key(auth))
     }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -786,6 +786,16 @@ impl MultiKeyAuthenticator {
 
     pub fn verify<T: Serialize + CryptoHash>(&self, message: &T) -> Result<()> {
         ensure!(
+            self.signatures_bitmap.last_set_bit().is_some(),
+            "There were no signatures set in the bitmap."
+        );
+
+        ensure!(
+            (self.signatures_bitmap.last_set_bit().unwrap() as usize) < self.public_keys.len(),
+            "Mismatch in the position of the last signature and the number of PKs, {} >= {}.",
+            self.signatures_bitmap.last_set_bit().unwrap(), self.public_keys.len(),
+        );
+        ensure!(
             self.signatures_bitmap.count_ones() as usize == self.signatures.len(),
             "Mismatch in number of signatures and the number of bits set in the signatures_bitmap, {} != {}.", self.signatures_bitmap.count_ones(), self.signatures.len(),
         );
@@ -820,11 +830,22 @@ pub struct MultiKey {
 }
 
 impl MultiKey {
-    pub fn new(public_keys: Vec<AnyPublicKey>, signatures_required: u8) -> Self {
-        Self {
+    pub fn new(public_keys: Vec<AnyPublicKey>, signatures_required: u8) -> Result<Self> {
+        ensure!(
+            signatures_required > 0,
+            "The number of required signatures is 0."
+        );
+
+        ensure!(
+            public_keys.len() >= signatures_required as usize,
+            "The number of public keys is smaller than the number of required signatures, {} < {}",
+            public_keys.len(), signatures_required
+        );
+
+        Ok(Self {
             public_keys,
             signatures_required,
-        }
+        })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1039,7 +1060,7 @@ mod tests {
             any_sender1_pub.clone(),
             any_sender1_pub.clone(),
         ];
-        let multi_key = MultiKey::new(keys, 2);
+        let multi_key = MultiKey::new(keys, 2).unwrap();
 
         let sender_auth = AuthenticationKey::multi_key(multi_key.clone());
         let sender_addr = sender_auth.account_address();

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -793,7 +793,8 @@ impl MultiKeyAuthenticator {
         ensure!(
             (self.signatures_bitmap.last_set_bit().unwrap() as usize) < self.public_keys.len(),
             "Mismatch in the position of the last signature and the number of PKs, {} >= {}.",
-            self.signatures_bitmap.last_set_bit().unwrap(), self.public_keys.len(),
+            self.signatures_bitmap.last_set_bit().unwrap(),
+            self.public_keys.len(),
         );
         ensure!(
             self.signatures_bitmap.count_ones() as usize == self.signatures.len(),
@@ -839,7 +840,8 @@ impl MultiKey {
         ensure!(
             public_keys.len() >= signatures_required as usize,
             "The number of public keys is smaller than the number of required signatures, {} < {}",
-            public_keys.len(), signatures_required
+            public_keys.len(),
+            signatures_required
         );
 
         Ok(Self {


### PR DESCRIPTION
### Description

A few small fixes for #10519:
 - Make sure that when we create a multiauth address, the # of signatures required is $> 0$.
 - Make sure that when we create a multiauth address, the # of PKs is $\ge$ to the # of signatures required.
 - Make sure that when we verify a multiauth signature, the signature bitmap is not empty
 - Make sure that when we verify a multiauth signature, the signature bitmap does not have out-of-bounds indices