### PR TITLE
Fix build for tools image by upgrading libtinfo6 version

### DIFF
--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget \
     curl \
     perl-base=5.32.1-4+deb11u1 \
-    libtinfo6=6.2+20201114-2+deb11u1 \
+    libtinfo6=6.2+20201114-2+deb11u2 \
     git \
     libssl1.1 \
     ca-certificates \


### PR DESCRIPTION
cherry-pick a fix for the tools image. symptoms: https://github.com/aptos-labs/aptos-core/actions/runs/6568737058/job/17843597184