### PR TITLE
[Compiler v2] Prefer specific Ld* over LdConst

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -16,7 +16,7 @@ use move_stackless_bytecode::{
     function_target::FunctionTarget,
     function_target_pipeline::FunctionVariant,
     livevar_analysis::LiveVarAnnotation,
-    stackless_bytecode::{Bytecode, Label, Operation},
+    stackless_bytecode::{Bytecode, Constant, Label, Operation},
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -219,36 +219,7 @@ impl<'a> FunctionGenerator<'a> {
             Bytecode::Call(_, dest, oper, source, None) => {
                 self.gen_operation(ctx, dest, oper, source)
             },
-            Bytecode::Load(_, dest, cons) => {
-                use move_stackless_bytecode::stackless_bytecode::Constant::*;
-                match cons {
-                    Bool(b) => {
-                        if *b {
-                            self.emit(FF::Bytecode::LdTrue)
-                        } else {
-                            self.emit(FF::Bytecode::LdFalse)
-                        }
-                    },
-                    U8(n) => self.emit(FF::Bytecode::LdU8(*n)),
-                    U16(n) => self.emit(FF::Bytecode::LdU16(*n)),
-                    U32(n) => self.emit(FF::Bytecode::LdU32(*n)),
-                    U64(n) => self.emit(FF::Bytecode::LdU64(*n)),
-                    U128(n) => self.emit(FF::Bytecode::LdU128(*n)),
-                    U256(n) => self.emit(FF::Bytecode::LdU256(
-                        move_core_types::u256::U256::from_le_bytes(&n.to_le_bytes()),
-                    )),
-                    _ => {
-                        let cons = self.gen.constant_index(
-                            &ctx.fun_ctx.module,
-                            &ctx.fun_ctx.loc,
-                            cons,
-                            ctx.fun_ctx.fun.get_local_type(*dest),
-                        );
-                        self.emit(FF::Bytecode::LdConst(cons));
-                    },
-                }
-                self.abstract_push_result(ctx, vec![*dest]);
-            },
+            Bytecode::Load(_, dest, cons) => self.gen_load(ctx, dest, cons),
             Bytecode::Label(_, label) => self.define_label(*label),
             Bytecode::Branch(_, if_true, if_false, cond) => {
                 // Ensure only `cond` is on the stack before branch.
@@ -645,6 +616,38 @@ impl<'a> FunctionGenerator<'a> {
         self.emit(bc);
         self.abstract_pop_n(ctx, source.len());
         self.abstract_push_result(ctx, dest)
+    }
+
+    /// Generate code for the load instruction.
+    fn gen_load(&mut self, ctx: &BytecodeContext, dest: &TempIndex, cons: &Constant) {
+        use Constant::*;
+        match cons {
+            Bool(b) => {
+                if *b {
+                    self.emit(FF::Bytecode::LdTrue)
+                } else {
+                    self.emit(FF::Bytecode::LdFalse)
+                }
+            },
+            U8(n) => self.emit(FF::Bytecode::LdU8(*n)),
+            U16(n) => self.emit(FF::Bytecode::LdU16(*n)),
+            U32(n) => self.emit(FF::Bytecode::LdU32(*n)),
+            U64(n) => self.emit(FF::Bytecode::LdU64(*n)),
+            U128(n) => self.emit(FF::Bytecode::LdU128(*n)),
+            U256(n) => self.emit(FF::Bytecode::LdU256(
+                move_core_types::u256::U256::from_le_bytes(&n.to_le_bytes()),
+            )),
+            _ => {
+                let cons = self.gen.constant_index(
+                    &ctx.fun_ctx.module,
+                    &ctx.fun_ctx.loc,
+                    cons,
+                    ctx.fun_ctx.fun.get_local_type(*dest),
+                );
+                self.emit(FF::Bytecode::LdConst(cons));
+            },
+        }
+        self.abstract_push_result(ctx, vec![*dest]);
     }
 
     /// Emits a file-format bytecode.

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -128,7 +128,7 @@ B0:
 }
 assign_int(Arg0: &mut u64) {
 B0:
-	0: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(42)
 	1: MoveLoc[0](Arg0: &mut u64)
 	2: WriteRef
 	3: Ret
@@ -143,8 +143,8 @@ B0:
 }
 assign_struct(Arg0: &mut S) {
 B0:
-	0: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(42)
+	1: LdU64(42)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: MoveLoc[0](Arg0: &mut S)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -232,7 +232,7 @@ B0:
 local(Arg0: u64): u64 {
 L0:	loc1: &u64
 B0:
-	0: LdConst[0](U64: [33, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: ImmBorrowLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &u64)
@@ -253,7 +253,7 @@ B0:
 	0: MoveLoc[0](Arg0: &mut S)
 	1: MutBorrowField[0](S.f: u64)
 	2: StLoc[1](loc0: &mut u64)
-	3: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	3: LdU64(22)
 	4: CopyLoc[1](loc0: &mut u64)
 	5: WriteRef
 	6: MoveLoc[1](loc0: &mut u64)
@@ -263,11 +263,11 @@ B0:
 mut_local(Arg0: u64): u64 {
 L0:	loc1: &mut u64
 B0:
-	0: LdConst[0](U64: [33, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &mut u64)
-	4: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	4: LdU64(22)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
@@ -278,7 +278,7 @@ mut_param(Arg0: u64): u64 {
 B0:
 	0: MutBorrowLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: &mut u64)
-	2: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	2: LdU64(22)
 	3: CopyLoc[1](loc0: &mut u64)
 	4: WriteRef
 	5: MoveLoc[1](loc0: &mut u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -1,0 +1,187 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun constant::test_constans() {
+     var $t0: bool
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: u8
+     var $t5: u8
+     var $t6: u16
+     var $t7: u16
+     var $t8: u32
+     var $t9: u32
+     var $t10: u64
+     var $t11: u64
+     var $t12: u128
+     var $t13: u128
+     var $t14: u256
+     var $t15: u256
+     var $t16: address
+     var $t17: address
+     var $t18: vector<u64>
+     var $t19: vector<u64>
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
+  0: $t1 := true
+  1: $t0 := move($t1)
+  2: $t3 := false
+  3: $t2 := move($t3)
+  4: $t5 := 1
+  5: $t4 := move($t5)
+  6: $t7 := 7086
+  7: $t6 := move($t7)
+  8: $t9 := 14593408
+  9: $t8 := move($t9)
+ 10: $t11 := 51966
+ 11: $t10 := move($t11)
+ 12: $t13 := 3735928559
+ 13: $t12 := move($t13)
+ 14: $t15 := 301490978409967
+ 15: $t14 := move($t15)
+ 16: $t17 := 0x42
+ 17: $t16 := move($t17)
+ 18: $t20 := 1
+ 19: $t21 := 2
+ 20: $t22 := 3
+ 21: $t19 := vector($t20, $t21, $t22)
+ 22: $t18 := move($t19)
+ 23: $t24 := [72, 101, 108, 108, 111, 33, 10]
+ 24: $t23 := move($t24)
+ 25: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun constant::test_constans() {
+     var $t0: bool
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: u8
+     var $t5: u8
+     var $t6: u16
+     var $t7: u16
+     var $t8: u32
+     var $t9: u32
+     var $t10: u64
+     var $t11: u64
+     var $t12: u128
+     var $t13: u128
+     var $t14: u256
+     var $t15: u256
+     var $t16: address
+     var $t17: address
+     var $t18: vector<u64>
+     var $t19: vector<u64>
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
+     # live vars:
+  0: $t1 := true
+     # live vars:
+  1: $t0 := move($t1)
+     # live vars:
+  2: $t3 := false
+     # live vars:
+  3: $t2 := move($t3)
+     # live vars:
+  4: $t5 := 1
+     # live vars:
+  5: $t4 := move($t5)
+     # live vars:
+  6: $t7 := 7086
+     # live vars:
+  7: $t6 := move($t7)
+     # live vars:
+  8: $t9 := 14593408
+     # live vars:
+  9: $t8 := move($t9)
+     # live vars:
+ 10: $t11 := 51966
+     # live vars:
+ 11: $t10 := move($t11)
+     # live vars:
+ 12: $t13 := 3735928559
+     # live vars:
+ 13: $t12 := move($t13)
+     # live vars:
+ 14: $t15 := 301490978409967
+     # live vars:
+ 15: $t14 := move($t15)
+     # live vars:
+ 16: $t17 := 0x42
+     # live vars:
+ 17: $t16 := move($t17)
+     # live vars:
+ 18: $t20 := 1
+     # live vars: $t20
+ 19: $t21 := 2
+     # live vars: $t20, $t21
+ 20: $t22 := 3
+     # live vars: $t20, $t21, $t22
+ 21: $t19 := vector($t20, $t21, $t22)
+     # live vars:
+ 22: $t18 := move($t19)
+     # live vars:
+ 23: $t24 := [72, 101, 108, 108, 111, 33, 10]
+     # live vars:
+ 24: $t23 := move($t24)
+     # live vars:
+ 25: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v4294967295
+module 42.constant {
+
+
+test_constans() {
+L0:	loc0: bool
+L1:	loc1: bool
+L2:	loc2: u8
+L3:	loc3: u16
+L4:	loc4: u32
+L5:	loc5: u64
+L6:	loc6: u128
+L7:	loc7: u256
+L8:	loc8: address
+L9:	loc9: vector<u64>
+L10:	loc10: vector<u8>
+B0:
+	0: LdTrue
+	1: StLoc[0](loc0: bool)
+	2: LdFalse
+	3: StLoc[1](loc1: bool)
+	4: LdU8(1)
+	5: StLoc[2](loc2: u8)
+	6: LdU16(7086)
+	7: StLoc[3](loc3: u16)
+	8: LdU32(14593408)
+	9: StLoc[4](loc4: u32)
+	10: LdU64(51966)
+	11: StLoc[5](loc5: u64)
+	12: LdU128(3735928559)
+	13: StLoc[6](loc6: u128)
+	14: LdU256(301490978409967)
+	15: StLoc[7](loc7: u256)
+	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	17: StLoc[8](loc8: address)
+	18: LdU64(1)
+	19: LdU64(2)
+	20: LdU64(3)
+	21: VecPack(1, 3)
+	22: StLoc[9](loc9: vector<u64>)
+	23: LdConst[1](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	24: StLoc[10](loc10: vector<u8>)
+	25: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.move
@@ -1,0 +1,15 @@
+module 0x42::constant {
+    fun test_constans() {
+        let const_true = true;
+        let const_false = false;
+        let hex_u8: u8 = 0x1;
+        let hex_u16: u16 = 0x1BAE;
+        let hex_u32: u32 = 0xDEAD80;
+        let hex_u64: u64 = 0xCAFE;
+        let hex_u128: u128 = 0xDEADBEEF;
+        let hex_u256: u256 = 0x1123_456A_BCDE_F;
+        let a = @0x42;
+        let vec = vector[1, 2, 3];
+        let s = b"Hello!\n";
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -302,12 +302,12 @@ write_local_direct(): S {
 L0:	loc0: S
 L1:	loc1: S
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
+	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: StLoc[0](loc0: S)
-	5: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	5: LdU64(42)
 	6: MutBorrowLoc[0](loc0: S)
 	7: MutBorrowField[0](S.g: T)
 	8: MutBorrowField[1](T.h: u64)
@@ -322,14 +322,14 @@ L0:	loc0: S
 L1:	loc1: &mut S
 L2:	loc2: S
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
+	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: StLoc[0](loc0: S)
 	5: MutBorrowLoc[0](loc0: S)
 	6: StLoc[1](loc1: &mut S)
-	7: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	7: LdU64(42)
 	8: MoveLoc[1](loc1: &mut S)
 	9: MutBorrowField[0](S.g: T)
 	10: MutBorrowField[1](T.h: u64)
@@ -341,7 +341,7 @@ B0:
 }
 write_param(Arg0: &mut S) {
 B0:
-	0: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(42)
 	1: MoveLoc[0](Arg0: &mut S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
@@ -350,7 +350,7 @@ B0:
 }
 write_val(Arg0: S): S {
 B0:
-	0: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(42)
 	1: MutBorrowLoc[0](Arg0: S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -134,7 +134,7 @@ B0:
 }
 publish(Arg0: &signer) {
 B0:
-	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(1)
 	1: Pack[0](R)
 	2: StLoc[1](loc0: R)
 	3: MoveLoc[0](Arg0: &signer)
@@ -157,11 +157,11 @@ B0:
 	0: MoveLoc[0](Arg0: address)
 	1: MutBorrowGlobal[0](R)
 	2: StLoc[2](loc0: &mut R)
-	3: LdConst[1](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	3: LdU64(2)
 	4: MoveLoc[2](loc0: &mut R)
 	5: MutBorrowField[0](R.f: u64)
 	6: WriteRef
-	7: LdConst[2](U64: [9, 0, 0, 0, 0, 0, 0, 0])
+	7: LdU64(9)
 	8: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -147,7 +147,7 @@ B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(9)
 B1:
-	2: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	2: LdU64(1)
 	3: StLoc[2](loc0: u64)
 	4: MoveLoc[1](Arg1: u64)
 	5: MoveLoc[2](loc0: u64)
@@ -155,7 +155,7 @@ B1:
 	7: StLoc[3](loc1: u64)
 	8: Branch(15)
 B2:
-	9: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	9: LdU64(1)
 	10: StLoc[4](loc2: u64)
 	11: MoveLoc[1](Arg1: u64)
 	12: MoveLoc[4](loc2: u64)
@@ -175,7 +175,7 @@ B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(9)
 B1:
-	2: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	2: LdU64(1)
 	3: StLoc[2](loc0: u64)
 	4: CopyLoc[1](Arg1: u64)
 	5: MoveLoc[2](loc0: u64)
@@ -183,21 +183,21 @@ B1:
 	7: StLoc[3](loc1: u64)
 	8: Branch(15)
 B2:
-	9: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	9: LdU64(1)
 	10: StLoc[4](loc2: u64)
 	11: CopyLoc[1](Arg1: u64)
 	12: MoveLoc[4](loc2: u64)
 	13: Sub
 	14: StLoc[3](loc1: u64)
 B3:
-	15: LdConst[1](U64: [10, 0, 0, 0, 0, 0, 0, 0])
+	15: LdU64(10)
 	16: StLoc[5](loc3: u64)
 	17: MoveLoc[3](loc1: u64)
 	18: MoveLoc[5](loc3: u64)
 	19: Gt
 	20: BrFalse(28)
 B4:
-	21: LdConst[2](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	21: LdU64(2)
 	22: StLoc[6](loc4: u64)
 	23: MoveLoc[1](Arg1: u64)
 	24: MoveLoc[6](loc4: u64)
@@ -205,7 +205,7 @@ B4:
 	26: StLoc[7](loc5: u64)
 	27: Branch(34)
 B5:
-	28: LdConst[2](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	28: LdU64(2)
 	29: StLoc[8](loc6: u64)
 	30: MoveLoc[1](Arg1: u64)
 	31: MoveLoc[8](loc6: u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -328,21 +328,21 @@ L1:	loc2: u64
 L2:	loc3: u64
 L3:	loc4: u64
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
 	1: StLoc[1](loc0: u64)
 	2: CopyLoc[0](Arg0: u64)
 	3: MoveLoc[1](loc0: u64)
 	4: Gt
 	5: BrFalse(30)
 B1:
-	6: LdConst[1](U64: [10, 0, 0, 0, 0, 0, 0, 0])
+	6: LdU64(10)
 	7: StLoc[2](loc1: u64)
 	8: CopyLoc[0](Arg0: u64)
 	9: MoveLoc[2](loc1: u64)
 	10: Gt
 	11: BrFalse(20)
 B2:
-	12: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	12: LdU64(1)
 	13: StLoc[3](loc2: u64)
 	14: MoveLoc[0](Arg0: u64)
 	15: MoveLoc[3](loc2: u64)
@@ -356,7 +356,7 @@ B4:
 B5:
 	21: Branch(6)
 B6:
-	22: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	22: LdU64(1)
 	23: StLoc[4](loc3: u64)
 	24: MoveLoc[0](Arg0: u64)
 	25: MoveLoc[4](loc3: u64)
@@ -379,14 +379,14 @@ while_loop(Arg0: u64): u64 {
 L0:	loc1: u64
 L1:	loc2: u64
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
 	1: StLoc[1](loc0: u64)
 	2: CopyLoc[0](Arg0: u64)
 	3: MoveLoc[1](loc0: u64)
 	4: Gt
 	5: BrFalse(13)
 B1:
-	6: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	6: LdU64(1)
 	7: StLoc[2](loc1: u64)
 	8: MoveLoc[0](Arg0: u64)
 	9: MoveLoc[2](loc1: u64)
@@ -409,14 +409,14 @@ L1:	loc2: u64
 L2:	loc3: u64
 L3:	loc4: u64
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
 	1: StLoc[1](loc0: u64)
 	2: CopyLoc[0](Arg0: u64)
 	3: MoveLoc[1](loc0: u64)
 	4: Gt
 	5: BrFalse(29)
 B1:
-	6: LdConst[3](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	6: LdU64(42)
 	7: StLoc[2](loc1: u64)
 	8: CopyLoc[0](Arg0: u64)
 	9: MoveLoc[2](loc1: u64)
@@ -427,7 +427,7 @@ B2:
 B3:
 	13: Branch(14)
 B4:
-	14: LdConst[4](U64: [21, 0, 0, 0, 0, 0, 0, 0])
+	14: LdU64(21)
 	15: StLoc[3](loc2: u64)
 	16: CopyLoc[0](Arg0: u64)
 	17: MoveLoc[3](loc2: u64)
@@ -438,7 +438,7 @@ B5:
 B6:
 	21: Branch(22)
 B7:
-	22: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	22: LdU64(1)
 	23: StLoc[4](loc3: u64)
 	24: MoveLoc[0](Arg0: u64)
 	25: MoveLoc[4](loc3: u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -429,13 +429,13 @@ B1:
 	3: StLoc[2](loc0: bool)
 	4: Branch(7)
 B2:
-	5: LdConst[0](Bool: [0])
+	5: LdFalse
 	6: StLoc[2](loc0: bool)
 B3:
 	7: MoveLoc[2](loc0: bool)
 	8: BrFalse(12)
 B4:
-	9: LdConst[1](Bool: [1])
+	9: LdTrue
 	10: StLoc[3](loc1: bool)
 	11: Branch(20)
 B5:
@@ -447,13 +447,13 @@ B6:
 	16: StLoc[3](loc1: bool)
 	17: Branch(20)
 B7:
-	18: LdConst[0](Bool: [0])
+	18: LdFalse
 	19: StLoc[3](loc1: bool)
 B8:
 	20: MoveLoc[3](loc1: bool)
 	21: BrFalse(25)
 B9:
-	22: LdConst[1](Bool: [1])
+	22: LdTrue
 	23: StLoc[4](loc2: bool)
 	24: Branch(33)
 B10:
@@ -465,13 +465,13 @@ B11:
 	29: StLoc[4](loc2: bool)
 	30: Branch(33)
 B12:
-	31: LdConst[0](Bool: [0])
+	31: LdFalse
 	32: StLoc[4](loc2: bool)
 B13:
 	33: MoveLoc[4](loc2: bool)
 	34: BrFalse(38)
 B14:
-	35: LdConst[1](Bool: [1])
+	35: LdTrue
 	36: StLoc[5](loc3: bool)
 	37: Branch(47)
 B15:
@@ -484,7 +484,7 @@ B16:
 	43: StLoc[5](loc3: bool)
 	44: Branch(47)
 B17:
-	45: LdConst[0](Bool: [0])
+	45: LdFalse
 	46: StLoc[5](loc3: bool)
 B18:
 	47: MoveLoc[5](loc3: bool)
@@ -518,7 +518,7 @@ B1:
 	7: StLoc[2](loc0: bool)
 	8: Branch(11)
 B2:
-	9: LdConst[0](Bool: [0])
+	9: LdFalse
 	10: StLoc[2](loc0: bool)
 B3:
 	11: MoveLoc[2](loc0: bool)
@@ -531,7 +531,7 @@ B4:
 	17: StLoc[3](loc1: bool)
 	18: Branch(21)
 B5:
-	19: LdConst[0](Bool: [0])
+	19: LdFalse
 	20: StLoc[3](loc1: bool)
 B6:
 	21: MoveLoc[3](loc1: bool)
@@ -544,7 +544,7 @@ B7:
 	27: StLoc[4](loc2: bool)
 	28: Branch(31)
 B8:
-	29: LdConst[0](Bool: [0])
+	29: LdFalse
 	30: StLoc[4](loc2: bool)
 B9:
 	31: MoveLoc[4](loc2: bool)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -41,9 +41,9 @@ module 42.vector {
 
 create(): vector<u64> {
 B0:
-	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[1](U64: [2, 0, 0, 0, 0, 0, 0, 0])
-	2: LdConst[2](U64: [3, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
 	3: VecPack(2, 3)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -305,12 +305,12 @@ B0:
 	8: Neq
 	9: BrFalse(13)
 B1:
-	10: LdConst[0](Bool: [0])
+	10: LdFalse
 	11: Ret
 B2:
 	12: Branch(13)
 B3:
-	13: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	13: LdU64(0)
 	14: StLoc[4](loc2: u64)
 B4:
 	15: CopyLoc[4](loc2: u64)
@@ -329,12 +329,12 @@ B5:
 	27: Neq
 	28: BrFalse(32)
 B6:
-	29: LdConst[0](Bool: [0])
+	29: LdFalse
 	30: Ret
 B7:
 	31: Branch(32)
 B8:
-	32: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	32: LdU64(1)
 	33: StLoc[5](loc3: u64)
 	34: MoveLoc[4](loc2: u64)
 	35: MoveLoc[5](loc3: u64)
@@ -346,28 +346,28 @@ B9:
 B10:
 	40: Branch(15)
 B11:
-	41: LdConst[3](Bool: [1])
+	41: LdTrue
 	42: Ret
 }
 create1(): vector<u64> {
 B0:
-	0: LdConst[4](U64: [3, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[5](U64: [2, 0, 0, 0, 0, 0, 0, 0])
-	2: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
-	3: LdConst[6](U64: [5, 0, 0, 0, 0, 0, 0, 0])
-	4: LdConst[7](U64: [8, 0, 0, 0, 0, 0, 0, 0])
-	5: LdConst[8](U64: [4, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(3)
+	1: LdU64(2)
+	2: LdU64(1)
+	3: LdU64(5)
+	4: LdU64(8)
+	5: LdU64(4)
 	6: VecPack(2, 6)
 	7: Ret
 }
 create2(): vector<u64> {
 B0:
-	0: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
-	1: LdConst[5](U64: [2, 0, 0, 0, 0, 0, 0, 0])
-	2: LdConst[4](U64: [3, 0, 0, 0, 0, 0, 0, 0])
-	3: LdConst[8](U64: [4, 0, 0, 0, 0, 0, 0, 0])
-	4: LdConst[6](U64: [5, 0, 0, 0, 0, 0, 0, 0])
-	5: LdConst[7](U64: [8, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: LdU64(4)
+	4: LdU64(5)
+	5: LdU64(8)
 	6: VecPack(2, 6)
 	7: Ret
 }
@@ -390,7 +390,7 @@ B0:
 B1:
 	11: Branch(14)
 B2:
-	12: LdConst[9](U64: [23, 0, 0, 0, 0, 0, 0, 0])
+	12: LdU64(23)
 	13: Abort
 B3:
 	14: ImmBorrowLoc[1](loc1: vector<u64>)
@@ -400,7 +400,7 @@ B3:
 B4:
 	18: Branch(21)
 B5:
-	19: LdConst[10](U64: [29, 0, 0, 0, 0, 0, 0, 0])
+	19: LdU64(29)
 	20: Abort
 B6:
 	21: MutBorrowLoc[0](loc0: vector<u64>)
@@ -412,7 +412,7 @@ B6:
 B7:
 	27: Branch(30)
 B8:
-	28: LdConst[11](U64: [31, 0, 0, 0, 0, 0, 0, 0])
+	28: LdU64(31)
 	29: Abort
 B9:
 	30: ImmBorrowLoc[0](loc0: vector<u64>)
@@ -422,7 +422,7 @@ B9:
 B10:
 	34: Branch(37)
 B11:
-	35: LdConst[10](U64: [29, 0, 0, 0, 0, 0, 0, 0])
+	35: LdU64(29)
 	36: Abort
 B12:
 	37: ImmBorrowLoc[0](loc0: vector<u64>)
@@ -433,7 +433,7 @@ B12:
 B13:
 	42: Branch(45)
 B14:
-	43: LdConst[11](U64: [31, 0, 0, 0, 0, 0, 0, 0])
+	43: LdU64(31)
 	44: Abort
 B15:
 	45: Ret
@@ -446,7 +446,7 @@ L3:	loc4: u64
 L4:	loc5: u64
 L5:	loc6: u64
 B0:
-	0: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
 	1: StLoc[1](loc0: u64)
 B1:
 	2: CopyLoc[0](Arg0: &mut vector<u64>)
@@ -458,7 +458,7 @@ B1:
 	8: Lt
 	9: BrFalse(57)
 B2:
-	10: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	10: LdU64(1)
 	11: StLoc[3](loc2: u64)
 	12: CopyLoc[1](loc0: u64)
 	13: MoveLoc[3](loc2: u64)
@@ -493,7 +493,7 @@ B5:
 	39: VecSwap(2)
 	40: Branch(41)
 B6:
-	41: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	41: LdU64(1)
 	42: StLoc[6](loc5: u64)
 	43: MoveLoc[4](loc3: u64)
 	44: MoveLoc[6](loc5: u64)
@@ -505,7 +505,7 @@ B7:
 B8:
 	49: Branch(16)
 B9:
-	50: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	50: LdU64(1)
 	51: StLoc[7](loc6: u64)
 	52: MoveLoc[1](loc0: u64)
 	53: MoveLoc[7](loc6: u64)
@@ -527,7 +527,7 @@ L3:	loc4: vector<u64>
 B0:
 	0: VecPack(2, 0)
 	1: StLoc[1](loc0: vector<u64>)
-	2: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 	4: CopyLoc[0](Arg0: &vector<u64>)
 	5: VecLen(2)
@@ -544,7 +544,7 @@ B2:
 	14: VecImmBorrow(2)
 	15: ReadRef
 	16: VecPushBack(2)
-	17: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	17: LdU64(1)
 	18: StLoc[4](loc3: u64)
 	19: MoveLoc[2](loc1: u64)
 	20: MoveLoc[4](loc3: u64)

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.exp
@@ -18,7 +18,7 @@ module 3.N {
 
 entry public ex(Arg0: signer, Arg1: u64) {
 B0:
-	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	0: LdU64(0)
 	1: Abort
 B1:
 	2: Ret


### PR DESCRIPTION
### Description

Compiler v2 currently uses LdConst to load all kinds of constants. However, we should prefer specific load instructions (e.g., LdTrue) for better efficiency and gas usage.

### Test Plan
Existing compiler v2 tests, plus a new `file-format-generator/const.exp` test showing how constants are compiled.

### Related Issues
closes https://github.com/aptos-labs/aptos-core/issues/9614
