### PR TITLE
[agg_v2] Use aggregator v2 fallback when resolver is not "delayed field capable"

### DIFF
--- a/aptos-move/aptos-aggregator/src/aggregator_v1_extension.rs
+++ b/aptos-move/aptos-aggregator/src/aggregator_v1_extension.rs
@@ -4,7 +4,7 @@
 use crate::{
     bounded_math::{BoundedMath, BoundedMathError, SignedU128},
     delta_math::DeltaHistory,
-    resolver::DelayedFieldResolver,
+    resolver::AggregatorV1Resolver,
     types::{expect_ok, DelayedFieldsSpeculativeError, DeltaApplicationFailureReason},
 };
 use aptos_types::{
@@ -219,7 +219,7 @@ impl Aggregator {
     /// `Data`).
     pub fn read_and_materialize(
         &mut self,
-        resolver: &dyn DelayedFieldResolver,
+        resolver: &dyn AggregatorV1Resolver,
         id: &AggregatorID,
     ) -> PartialVMResult<u128> {
         // If aggregator has already been read, return immediately.

--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -502,7 +502,7 @@ mod test {
         type Identifier = ();
 
         fn is_delayed_field_optimization_capable(&self) -> bool {
-            false
+            unimplemented!("Irrelevant for the test")
         }
 
         fn get_delayed_field_value(

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -17,15 +17,8 @@ use aptos_types::{
 use move_binary_format::errors::{Location, PartialVMError};
 use move_core_types::vm_status::{StatusCode, VMStatus};
 
-/// Allows to query aggregator values from the state storage.
-/// Because there are two types of aggregators in the system, V1 and V2, we use
-/// different code paths for each.
-pub trait TDelayedFieldView {
-    // We differentiate between two possible ways to identify an aggregator in
-    // storage for now (V1 or V2) so that the APIs are completely separate and
-    // we can delete all V1 code when necessary.
-    type IdentifierV1;
-    type IdentifierV2;
+pub trait TAggregatorV1View {
+    type Identifier;
 
     /// Aggregator V1 is implemented as a state item, and therefore the API has
     /// the same pattern as for modules or resources:
@@ -35,10 +28,10 @@ pub trait TDelayedFieldView {
     ///                       application).
     fn get_aggregator_v1_state_value(
         &self,
-        id: &Self::IdentifierV1,
+        id: &Self::Identifier,
     ) -> anyhow::Result<Option<StateValue>>;
 
-    fn get_aggregator_v1_value(&self, id: &Self::IdentifierV1) -> anyhow::Result<Option<u128>> {
+    fn get_aggregator_v1_value(&self, id: &Self::Identifier) -> anyhow::Result<Option<u128>> {
         let maybe_state_value = self.get_aggregator_v1_state_value(id)?;
         match maybe_state_value {
             Some(state_value) => Ok(Some(bcs::from_bytes(state_value.bytes())?)),
@@ -50,7 +43,7 @@ pub trait TDelayedFieldView {
     /// example used to calculate storage refunds).
     fn get_aggregator_v1_state_value_metadata(
         &self,
-        id: &Self::IdentifierV1,
+        id: &Self::Identifier,
     ) -> anyhow::Result<Option<StateValueMetadataKind>> {
         // When getting state value metadata for aggregator V1, we need to do a
         // precise read.
@@ -58,44 +51,12 @@ pub trait TDelayedFieldView {
         Ok(maybe_state_value.map(StateValue::into_metadata))
     }
 
-    /// Fetch a value of a DelayedField.
-    fn get_delayed_field_value(
-        &self,
-        id: &Self::IdentifierV2,
-    ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>>;
-
-    /// Fetch an outcome of whether additional delta can be applied.
-    /// `base_delta` argument represents a cumulative value that we previously checked,
-    /// and `delta` argument represents a new increment.
-    /// (This allows method to be stateless, and not require it to store previous calls,
-    /// i.e. for sequential execution)
-    ///
-    /// For example, calls would go like this:
-    /// try_add_delta_outcome(base_delta = 0, delta = 5) -> true
-    /// try_add_delta_outcome(base_delta = 5, delta = 3) -> true
-    /// try_add_delta_outcome(base_delta = 8, delta = 2) -> false
-    /// try_add_delta_outcome(base_delta = 8, delta = 3) -> false
-    /// try_add_delta_outcome(base_delta = 8, delta = -3) -> true
-    /// try_add_delta_outcome(base_delta = 5, delta = 2) -> true
-    /// ...
-    fn delayed_field_try_add_delta_outcome(
-        &self,
-        id: &Self::IdentifierV2,
-        base_delta: &SignedU128,
-        delta: &SignedU128,
-        max_value: u128,
-    ) -> Result<bool, PanicOr<DelayedFieldsSpeculativeError>>;
-
-    /// Returns a unique per-block identifier that can be used when creating a
-    /// new aggregator V2.
-    fn generate_delayed_field_id(&self) -> Self::IdentifierV2;
-
     /// Consumes a single delta of aggregator V1, and tries to materialize it
     /// with a given identifier (state key). If materialization succeeds, a
     /// write op is produced.
     fn try_convert_aggregator_v1_delta_into_write_op(
         &self,
-        id: &Self::IdentifierV1,
+        id: &Self::Identifier,
         delta_op: &DeltaOp,
     ) -> anyhow::Result<WriteOp, VMStatus> {
         let base = self
@@ -120,33 +81,86 @@ pub trait TDelayedFieldView {
     }
 }
 
-pub trait DelayedFieldResolver:
-    TDelayedFieldView<IdentifierV1 = StateKey, IdentifierV2 = DelayedFieldID>
+pub trait AggregatorV1Resolver: TAggregatorV1View<Identifier = StateKey> {}
+
+impl<T> AggregatorV1Resolver for T where T: TAggregatorV1View<Identifier = StateKey> {}
+
+impl<S> TAggregatorV1View for S
+where
+    S: StateView,
 {
+    type Identifier = StateKey;
+
+    fn get_aggregator_v1_state_value(
+        &self,
+        state_key: &Self::Identifier,
+    ) -> anyhow::Result<Option<StateValue>> {
+        self.get_state_value(state_key)
+    }
 }
 
-impl<T> DelayedFieldResolver for T where
-    T: TDelayedFieldView<IdentifierV1 = StateKey, IdentifierV2 = DelayedFieldID>
-{
+/// Allows to query aggregator values from the state storage.
+/// Because there are two types of aggregators in the system, V1 and V2, we use
+/// different code paths for each.
+pub trait TDelayedFieldView {
+    // We differentiate between two possible ways to identify an aggregator in
+    // storage for now (V1 or V2) so that the APIs are completely separate and
+    // we can delete all V1 code when necessary.
+    type Identifier;
+
+    fn is_delayed_field_optimization_capable(&self) -> bool;
+
+    /// Fetch a value of a DelayedField.
+    fn get_delayed_field_value(
+        &self,
+        id: &Self::Identifier,
+    ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>>;
+
+    /// Fetch an outcome of whether additional delta can be applied.
+    /// `base_delta` argument represents a cumulative value that we previously checked,
+    /// and `delta` argument represents a new increment.
+    /// (This allows method to be stateless, and not require it to store previous calls,
+    /// i.e. for sequential execution)
+    ///
+    /// For example, calls would go like this:
+    /// try_add_delta_outcome(base_delta = 0, delta = 5) -> true
+    /// try_add_delta_outcome(base_delta = 5, delta = 3) -> true
+    /// try_add_delta_outcome(base_delta = 8, delta = 2) -> false
+    /// try_add_delta_outcome(base_delta = 8, delta = 3) -> false
+    /// try_add_delta_outcome(base_delta = 8, delta = -3) -> true
+    /// try_add_delta_outcome(base_delta = 5, delta = 2) -> true
+    /// ...
+    fn delayed_field_try_add_delta_outcome(
+        &self,
+        id: &Self::Identifier,
+        base_delta: &SignedU128,
+        delta: &SignedU128,
+        max_value: u128,
+    ) -> Result<bool, PanicOr<DelayedFieldsSpeculativeError>>;
+
+    /// Returns a unique per-block identifier that can be used when creating a
+    /// new aggregator V2.
+    fn generate_delayed_field_id(&self) -> Self::Identifier;
 }
+
+pub trait DelayedFieldResolver: TDelayedFieldView<Identifier = DelayedFieldID> {}
+
+impl<T> DelayedFieldResolver for T where T: TDelayedFieldView<Identifier = DelayedFieldID> {}
 
 impl<S> TDelayedFieldView for S
 where
     S: StateView,
 {
-    type IdentifierV1 = StateKey;
-    type IdentifierV2 = DelayedFieldID;
+    type Identifier = DelayedFieldID;
 
-    fn get_aggregator_v1_state_value(
-        &self,
-        state_key: &Self::IdentifierV1,
-    ) -> anyhow::Result<Option<StateValue>> {
-        self.get_state_value(state_key)
+    fn is_delayed_field_optimization_capable(&self) -> bool {
+        // For resolvers that are not capable, it cannot be enabled
+        false
     }
 
     fn get_delayed_field_value(
         &self,
-        _id: &Self::IdentifierV2,
+        _id: &Self::Identifier,
     ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
         // TODO check if any of these methods need to be implemented
         unimplemented!("get_delayed_field_value not implemented")
@@ -154,7 +168,7 @@ where
 
     fn delayed_field_try_add_delta_outcome(
         &self,
-        _id: &Self::IdentifierV2,
+        _id: &Self::Identifier,
         _base_delta: &SignedU128,
         _delta: &SignedU128,
         _max_value: u128,
@@ -164,7 +178,7 @@ where
 
     /// Returns a unique per-block identifier that can be used when creating a
     /// new aggregator V2.
-    fn generate_delayed_field_id(&self) -> Self::IdentifierV2 {
+    fn generate_delayed_field_id(&self) -> Self::Identifier {
         unimplemented!("generate_delayed_field_id not implemented")
     }
 }

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -17,6 +17,10 @@ use aptos_types::{
 use move_binary_format::errors::{Location, PartialVMError};
 use move_core_types::vm_status::{StatusCode, VMStatus};
 
+/// We differentiate between deprecated way to interact with aggregators (TAggregatorV1View),
+/// and new, more general, TDelayedFieldView.
+
+/// Allows to query AggregatorV1 values from the state storage.
 pub trait TAggregatorV1View {
     type Identifier;
 
@@ -99,13 +103,9 @@ where
     }
 }
 
-/// Allows to query aggregator values from the state storage.
-/// Because there are two types of aggregators in the system, V1 and V2, we use
-/// different code paths for each.
+/// Allows to query DelayedFields (AggregatorV2/AggregatorSnapshots) values
+/// from the state storage.
 pub trait TDelayedFieldView {
-    // We differentiate between two possible ways to identify an aggregator in
-    // storage for now (V1 or V2) so that the APIs are completely separate and
-    // we can delete all V1 code when necessary.
     type Identifier;
 
     fn is_delayed_field_optimization_capable(&self) -> bool;

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -119,14 +119,14 @@ impl VMOutput {
                 .change_set()
                 .delayed_field_change_set()
                 .is_empty(),
-            "Aggregator deltas must be empty after materialization."
+            "Delayed fields must be empty after materialization."
         );
         debug_assert!(
             materialized_output
                 .change_set()
                 .resource_group_write_set()
                 .is_empty(),
-            "Aggregator deltas must be empty after materialization."
+            "Resource Groups must be empty after materialization."
         );
         let (vm_change_set, gas_used, status) = materialized_output.unpack();
         let (write_set, events) = vm_change_set.try_into_storage_change_set()?.into_inner();
@@ -190,6 +190,8 @@ impl VMOutput {
             "Different number of events and patched events in the output."
         );
         self.change_set.set_events(patched_events.into_iter());
+        // TODO[agg_v2](cleanup) move drain to happen when getting what to materialize.
+        let _ = self.change_set.drain_delayed_field_change_set();
 
         let (vm_change_set, gas_used, status) = self.unpack();
         let (write_set, events) = vm_change_set

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::{resolver::TDelayedFieldView, types::DelayedFieldID};
+use aptos_aggregator::{
+    resolver::{TAggregatorV1View, TDelayedFieldView},
+    types::DelayedFieldID,
+};
 use aptos_state_view::{StateView, StateViewId};
 use aptos_types::state_store::{
     state_key::StateKey,
@@ -185,7 +188,8 @@ pub trait StateStorageView {
 pub trait TExecutorView<K, T, L, I>:
     TResourceView<Key = K, Layout = L>
     + TModuleView<Key = K>
-    + TDelayedFieldView<IdentifierV1 = K, IdentifierV2 = I>
+    + TAggregatorV1View<Identifier = K>
+    + TDelayedFieldView<Identifier = I>
     + StateStorageView
 {
 }
@@ -193,7 +197,8 @@ pub trait TExecutorView<K, T, L, I>:
 impl<A, K, T, L, I> TExecutorView<K, T, L, I> for A where
     A: TResourceView<Key = K, Layout = L>
         + TModuleView<Key = K>
-        + TDelayedFieldView<IdentifierV1 = K, IdentifierV2 = I>
+        + TAggregatorV1View<Identifier = K>
+        + TDelayedFieldView<Identifier = I>
         + StateStorageView
 {
 }

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -400,7 +400,8 @@ fn test_roundtrip_to_storage_change_set() {
     let storage_change_set_before = StorageChangeSet::new(write_set, vec![]);
     let change_set = assert_ok!(VMChangeSet::try_from_storage_change_set(
         storage_change_set_before.clone(),
-        &MockChangeSetChecker
+        &MockChangeSetChecker,
+        false,
     ));
     let storage_change_set_after = assert_ok!(change_set.try_into_storage_change_set());
     assert_eq!(storage_change_set_before, storage_change_set_after)

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1267,9 +1267,11 @@ impl AptosVM {
             ChangeSetConfigs::unlimited_at_gas_feature_version(self.0.get_gas_feature_version());
 
         match write_set_payload {
-            WriteSetPayload::Direct(change_set) => {
-                VMChangeSet::try_from_storage_change_set(change_set.clone(), &change_set_configs)
-            },
+            WriteSetPayload::Direct(change_set) => VMChangeSet::try_from_storage_change_set(
+                change_set.clone(),
+                &change_set_configs,
+                resolver.is_delayed_field_optimization_capable(),
+            ),
             WriteSetPayload::Script { script, execute_as } => {
                 let mut tmp_session = self.0.new_session(resolver, session_id);
                 let senders = match txn_sender {

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -45,9 +45,17 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         txn_idx: TxnIndex,
         materialize_deltas: bool,
     ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
-        if txn.is_valid() && executor_with_group_view.is_delayed_field_optimization_capable() {
+        // TODO[agg_v2](fix) look at whether it is enabled, not just capable.
+        // if it is disabled, no need to fallback.
+        #[allow(clippy::overly_complex_bool_expr)]
+        if false
+            && txn.is_valid()
+            && executor_with_group_view.is_delayed_field_optimization_capable()
+        {
             if let Transaction::GenesisTransaction(WriteSetPayload::Direct(_)) = txn.expect_valid()
             {
+                // WriteSetPayload::Direct cannot be handled in mode where delayed_field_optimization is enabled
+                // And we need to communicate to the BlockExecutor, so they can retry with capability disabled
                 return ExecutionStatus::DirectWriteSetTransactionNotCapableError;
             }
         }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -14,7 +14,7 @@ use crate::{
 use anyhow::{bail, Error};
 use aptos_aggregator::{
     bounded_math::SignedU128,
-    resolver::TDelayedFieldView,
+    resolver::{TAggregatorV1View, TDelayedFieldView},
     types::{DelayedFieldID, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
 use aptos_state_view::{StateView, StateViewId};
@@ -264,27 +264,34 @@ impl<'e, E: ExecutorView> TableResolver for StorageAdapter<'e, E> {
     }
 }
 
-impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
-    type IdentifierV1 = StateKey;
-    type IdentifierV2 = DelayedFieldID;
+impl<'e, E: ExecutorView> TAggregatorV1View for StorageAdapter<'e, E> {
+    type Identifier = StateKey;
 
     fn get_aggregator_v1_state_value(
         &self,
-        id: &Self::IdentifierV1,
+        id: &Self::Identifier,
     ) -> anyhow::Result<Option<StateValue>> {
         self.executor_view.get_aggregator_v1_state_value(id)
+    }
+}
+
+impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
+    type Identifier = DelayedFieldID;
+
+    fn is_delayed_field_optimization_capable(&self) -> bool {
+        self.executor_view.is_delayed_field_optimization_capable()
     }
 
     fn get_delayed_field_value(
         &self,
-        id: &Self::IdentifierV2,
+        id: &Self::Identifier,
     ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
         self.executor_view.get_delayed_field_value(id)
     }
 
     fn delayed_field_try_add_delta_outcome(
         &self,
-        id: &Self::IdentifierV2,
+        id: &Self::Identifier,
         base_delta: &SignedU128,
         delta: &SignedU128,
         max_value: u128,
@@ -293,7 +300,7 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
             .delayed_field_try_add_delta_outcome(id, base_delta, delta, max_value)
     }
 
-    fn generate_delayed_field_id(&self) -> Self::IdentifierV2 {
+    fn generate_delayed_field_id(&self) -> Self::Identifier {
         self.executor_view.generate_delayed_field_id()
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::resolver::DelayedFieldResolver;
+use aptos_aggregator::resolver::{AggregatorV1Resolver, DelayedFieldResolver};
 use aptos_table_natives::TableResolver;
 use aptos_types::{on_chain_config::ConfigStorage, state_store::state_key::StateKey};
 use aptos_vm_types::resolver::{
@@ -15,13 +15,14 @@ use std::collections::{BTreeMap, HashMap};
 /// top of storage, e.g. get resources from resource groups, etc.
 /// MoveResolver implements ResourceResolver and ModuleResolver
 pub trait AptosMoveResolver:
-    DelayedFieldResolver
-    + ResourceGroupResolver
+    AggregatorV1Resolver
     + ConfigStorage
+    + DelayedFieldResolver
     + MoveResolver
-    + TableResolver
+    + ResourceGroupResolver
     + StateValueMetadataResolver
     + StateStorageView
+    + TableResolver
     + AsExecutorView
     + AsResourceGroupView
 {

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -171,7 +171,7 @@ impl MoveVmExt {
         extensions.add(NativeTableContext::new(txn_hash, resolver));
         extensions.add(NativeRistrettoPointContext::new());
         extensions.add(AlgebraContext::new());
-        extensions.add(NativeAggregatorContext::new(txn_hash, resolver));
+        extensions.add(NativeAggregatorContext::new(txn_hash, resolver, resolver));
 
         let script_hash = match session_id {
             SessionId::Txn {

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -4,6 +4,7 @@
 
 #[cfg(feature = "testing")]
 use anyhow::Error;
+#[cfg(feature = "testing")]
 use aptos_aggregator::resolver::TAggregatorV1View;
 #[cfg(feature = "testing")]
 use aptos_aggregator::{
@@ -32,6 +33,7 @@ use aptos_types::{
 };
 #[cfg(feature = "testing")]
 use bytes::Bytes;
+#[cfg(feature = "testing")]
 use move_core_types::value::MoveTypeLayout;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 #[cfg(feature = "testing")]

--- a/aptos-move/aptos-vm/src/storage_adapter/executor_view_base.rs
+++ b/aptos-move/aptos-vm/src/storage_adapter/executor_view_base.rs
@@ -44,32 +44,39 @@ impl<S: StateView> AsExecutorView<S> for S {
     }
 }
 
-impl<'s, S: StateView> TDelayedFieldView for ExecutorViewBase<'s, S> {
-    type IdentifierV1 = StateKey;
-    type IdentifierV2 = DelayedFieldID;
+impl<'s, S: StateView> TAggregatorV1View for ExecutorViewBase<'s, S> {
+    type Identifier = StateKey;
 
     fn get_aggregator_v1_state_value(
         &self,
-        state_key: &Self::IdentifierV1,
+        state_key: &Self::Identifier,
         // Reading from StateView can be in precise mode only.
     ) -> anyhow::Result<Option<StateValue>> {
         self.base.get_state_value(state_key)
     }
+}
 
-    fn generate_delayed_field_id(&self) -> Self::IdentifierV2 {
+impl<'s, S: StateView> TDelayedFieldView for ExecutorViewBase<'s, S> {
+    type Identifier = DelayedFieldID;
+
+    fn is_aggregator_v2_delayed_fields_enabled(&self) -> bool {
+        false
+    }
+
+    fn generate_delayed_field_id(&self) -> Self::Identifier {
         (self.counter.fetch_add(1, Ordering::SeqCst) as u64).into()
     }
 
     fn get_delayed_field_value(
         &self,
-        _id: &Self::IdentifierV2,
+        _id: &Self::Identifier,
     ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
         unimplemented!()
     }
 
     fn delayed_field_try_add_delta_outcome(
         &self,
-        _id: &Self::IdentifierV2,
+        _id: &Self::Identifier,
         _base_delta: &SignedU128,
         _delta: &SignedU128,
         _max_value: u128,

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -12,6 +12,10 @@ pub enum IntentionalFallbackToSequential {
     /// TODO: (short-mid term) relax the limitation, and (mid-long term) provide proper multi-versioning
     /// for code (like data) for the cache.
     ModulePathReadWrite,
+    // WriteSetPayload::Direct cannot be handled in mode where delayed_field_optimization is enabled,
+    // because delayed fields do value->identifier exchange on reads, and identifier->value exhcange
+    // on writes. WriteSetPayload::Direct cannot be processed to do so, as we get outputs directly.
+    // We communicate to the executor to retry with capability disabled.
     DirectWriteSetTransaction,
 }
 

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -4,17 +4,20 @@
 
 use aptos_aggregator::types::PanicOr;
 
-/// The same module access path for module was both read & written during speculative executions.
-/// This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
-/// aborting the parallel execution pipeline and falling back to the sequential execution.
-/// TODO: (short-mid term) relax the limitation, and (mid-long term) provide proper multi-versioning
-/// for code (like data) for the cache.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct ModulePathReadWrite;
+pub enum IntentionalFallbackToSequential {
+    /// The same module access path for module was both read & written during speculative executions.
+    /// This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
+    /// aborting the parallel execution pipeline and falling back to the sequential execution.
+    /// TODO: (short-mid term) relax the limitation, and (mid-long term) provide proper multi-versioning
+    /// for code (like data) for the cache.
+    ModulePathReadWrite,
+    DirectWriteSetTransaction,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error<E> {
-    FallbackToSequential(PanicOr<ModulePathReadWrite>),
+    FallbackToSequential(PanicOr<IntentionalFallbackToSequential>),
     /// Execution of a thread yields a non-recoverable error, such error will be propagated back to
     /// the caller.
     UserError(E),

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::{Error, ModulePathReadWrite},
+    errors::{Error, IntentionalFallbackToSequential},
     executor::BlockExecutor,
     proptest_types::{
         baseline::BaselineOutput,
@@ -84,7 +84,9 @@ fn run_transactions<K, V, E>(
         if module_access.0 && module_access.1 {
             assert_eq!(
                 output.unwrap_err(),
-                Error::FallbackToSequential(PanicOr::Or(ModulePathReadWrite))
+                Error::FallbackToSequential(PanicOr::Or(
+                    IntentionalFallbackToSequential::ModulePathReadWrite
+                ))
             );
             continue;
         }
@@ -471,7 +473,9 @@ fn publishing_fixed_params_with_block_gas_limit(
 
         assert_eq!(
             output.unwrap_err(),
-            Error::FallbackToSequential(PanicOr::Or(ModulePathReadWrite))
+            Error::FallbackToSequential(PanicOr::Or(
+                IntentionalFallbackToSequential::ModulePathReadWrite
+            ))
         );
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -110,7 +110,7 @@ pub(crate) struct KeyType<K: Hash + Clone + Debug + PartialOrd + Ord + Eq>(
     pub K,
     /// The bool field determines for testing purposes, whether the key will be interpreted
     /// as a module access path. In this case, if a module path is both read and written
-    /// during parallel execution, Error::ModulePathReadWrite must be returned and the
+    /// during parallel execution, ModulePathReadWrite must be returned and the
     /// block execution must fall back to the sequential execution.
     pub bool,
 );

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -23,6 +23,8 @@ pub enum ExecutionStatus<O, E> {
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list
     SkipRest(O),
+    /// There is a DirectWriteTransaction with resolver not capable to handle it
+    DirectWriteSetTransactionNotCapableError,
     /// During transaction execution, it detected that it is in inconsistent state
     /// due to speculative reads it did, and needs to be re-executed
     SpeculativeExecutionAbortError(String),

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -492,6 +492,7 @@ pub(crate) struct SequentialState<'a, T: Transaction, X: Executable> {
     pub(crate) unsync_map: &'a UnsyncMap<T::Key, T::Value, X, T::Identifier>,
     pub(crate) read_set: RefCell<HashSet<T::Key>>,
     pub(crate) counter: &'a RefCell<u32>,
+    pub(crate) dynamic_change_set_optimizations_enabled: bool,
 }
 
 impl<'a, T: Transaction, X: Executable> SequentialState<'a, T, X> {
@@ -709,39 +710,47 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                     None => {
                         let from_storage = self.get_base_value(state_key)?;
 
-                        Ok(match (kind.clone(), from_storage, maybe_layout) {
-                            (ReadKind::Value, Some(state_value), Some(layout)) => {
-                                let res = self.replace_values_with_identifiers(state_value, layout);
-                                let patched_state_value = match res {
-                                    Ok((patched_state_value, _)) => {
-                                        state.read_set.borrow_mut().insert(state_key.clone());
-                                        state.unsync_map.write(
-                                            state_key.clone(),
-                                            TransactionWrite::from_state_value(Some(
-                                                patched_state_value.clone(),
-                                            )),
-                                            maybe_layout.map(|layout| Arc::new(layout.clone())),
-                                        );
-                                        Some(patched_state_value)
-                                    },
-                                    Err(err) => {
-                                        let log_context = AdapterLogSchema::new(
-                                            self.base_view.id(),
-                                            self.txn_idx as usize,
-                                        );
-                                        alert!(
+                        Ok(
+                            match (
+                                kind.clone(),
+                                from_storage,
+                                maybe_layout,
+                                state.dynamic_change_set_optimizations_enabled,
+                            ) {
+                                (ReadKind::Value, Some(state_value), Some(layout), true) => {
+                                    let res =
+                                        self.replace_values_with_identifiers(state_value, layout);
+                                    let patched_state_value = match res {
+                                        Ok((patched_state_value, _)) => {
+                                            state.read_set.borrow_mut().insert(state_key.clone());
+                                            state.unsync_map.write(
+                                                state_key.clone(),
+                                                TransactionWrite::from_state_value(Some(
+                                                    patched_state_value.clone(),
+                                                )),
+                                                maybe_layout.map(|layout| Arc::new(layout.clone())),
+                                            );
+                                            Some(patched_state_value)
+                                        },
+                                        Err(err) => {
+                                            let log_context = AdapterLogSchema::new(
+                                                self.base_view.id(),
+                                                self.txn_idx as usize,
+                                            );
+                                            alert!(
                                             log_context,
                                             "[VM, ResourceView] Error during value to id replacement for {:?}: {}",
                                             state_key,
                                             err
                                         );
-                                        None
-                                    },
-                                };
-                                patched_state_value
+                                            None
+                                        },
+                                    };
+                                    patched_state_value
+                                },
+                                (_, maybe_state_value, _, _) => maybe_state_value,
                             },
-                            (_, maybe_state_value, _) => maybe_state_value,
-                        })
+                        )
                     },
                 };
                 ret.map(|maybe_state_value| match kind {
@@ -913,7 +922,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
     type Identifier = T::Identifier;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
-        true
+        match &self.latest_view {
+            ViewState::Sync(_) => true,
+            ViewState::Unsync(state) => state.dynamic_change_set_optimizations_enabled,
+        }
     }
 
     fn get_delayed_field_value(
@@ -1666,6 +1678,7 @@ mod test {
                 unsync_map: &unsync_map,
                 counter: &counter,
                 read_set: RefCell::new(HashSet::new()),
+                dynamic_change_set_optimizations_enabled: true,
             }),
             1,
         );

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -10,7 +10,7 @@ use aptos_aggregator::{
     bounded_math::{ok_overflow, BoundedMath, SignedU128},
     delta_change_set::serialize,
     delta_math::DeltaHistory,
-    resolver::TDelayedFieldView,
+    resolver::{TAggregatorV1View, TDelayedFieldView},
     types::{
         code_invariant_error, expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr,
         ReadPosition, TryFromMoveValue, TryIntoMoveValue,
@@ -566,7 +566,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             );
         }
 
-        // TODO: AggregatorID in V2 can be replaced here.
         ret
     }
 
@@ -640,7 +639,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                 let mut ret = state.read_data_by_kind(state_key, self.txn_idx, kind.clone());
 
                 if matches!(ret, ReadResult::Uninitialized) {
-                    let from_storage = self.base_view.get_state_value(state_key)?;
+                    let from_storage = self.get_base_value(state_key)?;
                     let maybe_patched_from_storage = match (from_storage, maybe_layout) {
                         // There are aggregators / aggregator snapshots in the
                         // resource, so we have to replace the actual values with
@@ -708,41 +707,41 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                         Ok(v.as_state_value())
                     },
                     None => {
-                        self.get_base_value(state_key).map(
-                            |maybe_state_value| {
-                                match (kind.clone(), maybe_state_value, maybe_layout) {
-                                    (ReadKind::Value, Some(state_value), Some(layout)) => {
-                                        let res = self.replace_values_with_identifiers(state_value, layout);
-                                        let patched_state_value = match res {
-                                            Ok((patched_state_value, _)) => {
-                                                state.read_set
-                                                    .borrow_mut()
-                                                    .insert(state_key.clone());
-                                                state.unsync_map.write(state_key.clone(),
-                                                    TransactionWrite::from_state_value(Some(patched_state_value.clone())),
-                                                    maybe_layout.map(|layout| Arc::new(layout.clone())));
-                                                Some(patched_state_value)
-                                            }
-                                            Err(err) => {
-                                                let log_context = AdapterLogSchema::new(
-                                                    self.base_view.id(),
-                                                    self.txn_idx as usize,
-                                                );
-                                                alert!(
-                                                    log_context,
-                                                    "[VM, ResourceView] Error during value to id replacement for {:?}: {}",
-                                                    state_key,
-                                                    err
-                                                );
-                                                None
-                                            }
-                                        };
-                                        patched_state_value
+                        let from_storage = self.get_base_value(state_key)?;
+
+                        Ok(match (kind.clone(), from_storage, maybe_layout) {
+                            (ReadKind::Value, Some(state_value), Some(layout)) => {
+                                let res = self.replace_values_with_identifiers(state_value, layout);
+                                let patched_state_value = match res {
+                                    Ok((patched_state_value, _)) => {
+                                        state.read_set.borrow_mut().insert(state_key.clone());
+                                        state.unsync_map.write(
+                                            state_key.clone(),
+                                            TransactionWrite::from_state_value(Some(
+                                                patched_state_value.clone(),
+                                            )),
+                                            maybe_layout.map(|layout| Arc::new(layout.clone())),
+                                        );
+                                        Some(patched_state_value)
                                     },
-                                    (_, maybe_state_value, _) => {maybe_state_value}
-                                }
-                            }
-                        )
+                                    Err(err) => {
+                                        let log_context = AdapterLogSchema::new(
+                                            self.base_view.id(),
+                                            self.txn_idx as usize,
+                                        );
+                                        alert!(
+                                            log_context,
+                                            "[VM, ResourceView] Error during value to id replacement for {:?}: {}",
+                                            state_key,
+                                            err
+                                        );
+                                        None
+                                    },
+                                };
+                                patched_state_value
+                            },
+                            (_, maybe_state_value, _) => maybe_state_value,
+                        })
                     },
                 };
                 ret.map(|maybe_state_value| match kind {
@@ -868,7 +867,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TModuleView
                         // because parallel execution will fall back to sequential anyway.
                         Ok(None)
                     },
-                    Err(NotFound) => self.base_view.get_state_value(state_key),
+                    Err(NotFound) => self.get_base_value(state_key),
                 }
             },
             ViewState::Unsync(state) => state.unsync_map.fetch_data(state_key).map_or_else(
@@ -891,15 +890,14 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> StateStorag
     }
 }
 
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFieldView
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TAggregatorV1View
     for LatestView<'a, T, S, X>
 {
-    type IdentifierV1 = T::Key;
-    type IdentifierV2 = T::Identifier;
+    type Identifier = T::Key;
 
     fn get_aggregator_v1_state_value(
         &self,
-        state_key: &Self::IdentifierV1,
+        state_key: &Self::Identifier,
     ) -> anyhow::Result<Option<StateValue>> {
         // TODO: Integrate aggregators V1. That is, we can lift the u128 value
         //       from the state item by passing the right layout here. This can
@@ -907,10 +905,20 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
         // self.get_resource_state_value(state_key, Some(&MoveTypeLayout::U128))
         self.get_resource_state_value(state_key, None)
     }
+}
+
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFieldView
+    for LatestView<'a, T, S, X>
+{
+    type Identifier = T::Identifier;
+
+    fn is_delayed_field_optimization_capable(&self) -> bool {
+        true
+    }
 
     fn get_delayed_field_value(
         &self,
-        id: &Self::IdentifierV2,
+        id: &Self::Identifier,
     ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
         match &self.latest_view {
             ViewState::Sync(state) => get_delayed_field_value_impl(&state.captured_reads, state.versioned_map.delayed_fields(), state.scheduler, id, self.txn_idx),
@@ -922,7 +930,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
 
     fn delayed_field_try_add_delta_outcome(
         &self,
-        id: &Self::IdentifierV2,
+        id: &Self::Identifier,
         base_delta: &SignedU128,
         delta: &SignedU128,
         max_value: u128,
@@ -957,7 +965,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
         }
     }
 
-    fn generate_delayed_field_id(&self) -> Self::IdentifierV2 {
+    fn generate_delayed_field_id(&self) -> Self::Identifier {
         match &self.latest_view {
             ViewState::Sync(state) => (state.counter.fetch_add(1, Ordering::SeqCst) as u64).into(),
             ViewState::Unsync(state) => {

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
@@ -39,7 +39,7 @@ fn native_add(
 
     // Get aggregator.
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
-    let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
+    let mut aggregator_data = aggregator_context.aggregator_v1_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id, max_value)?;
 
     aggregator.add(input)?;
@@ -67,10 +67,10 @@ fn native_read(
 
     // Get aggregator.
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
-    let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
+    let mut aggregator_data = aggregator_context.aggregator_v1_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id.clone(), max_value)?;
 
-    let value = aggregator.read_and_materialize(aggregator_context.resolver, &id)?;
+    let value = aggregator.read_and_materialize(aggregator_context.aggregator_v1_resolver, &id)?;
 
     Ok(smallvec![Value::u128(value)])
 }
@@ -97,7 +97,7 @@ fn native_sub(
 
     // Get aggregator.
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
-    let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
+    let mut aggregator_data = aggregator_context.aggregator_v1_data.borrow_mut();
     let aggregator = aggregator_data.get_aggregator(id, max_value)?;
 
     aggregator.sub(input)?;
@@ -126,7 +126,7 @@ fn native_destroy(
 
     // Get aggregator data.
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
-    let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
+    let mut aggregator_data = aggregator_context.aggregator_v1_data.borrow_mut();
 
     // Actually remove the aggregator.
     let id = AggregatorID::new(handle, key);

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_factory.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_factory.rs
@@ -39,7 +39,7 @@ fn native_new_aggregator(
 
     // Get the current aggregator data.
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
-    let mut aggregator_data = aggregator_context.aggregator_data.borrow_mut();
+    let mut aggregator_data = aggregator_context.aggregator_v1_data.borrow_mut();
 
     // Every aggregator instance uses a unique key in its id. Here we can reuse
     // the strategy from `table` implementation: taking hash of transaction and


### PR DESCRIPTION
DelayedFields is an optimization within BlockExecutor.

For resolvers that are not coming from BlockExecutor, they wouldn't know how to handle it - how to do the exchanges or materialize the output. And so add additional function within the TDelayedFieldView - is_delayed_field_optimization_capable - that will tell native code whether it can use delayed fields, or should directly execute operations on move values.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
