### PR TITLE
Deal with ExecutionPipeline reset

### DIFF
--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -39,7 +39,10 @@ impl ExecutionPipeline {
         let (prepare_block_tx, prepare_block_rx) = mpsc::unbounded_channel();
         let (execute_block_tx, execute_block_rx) = mpsc::unbounded_channel();
         let (ledger_apply_tx, ledger_apply_rx) = mpsc::unbounded_channel();
-        runtime.spawn(Self::prepare_block(prepare_block_rx, execute_block_tx));
+        runtime.spawn(Self::prepare_block_stage(
+            prepare_block_rx,
+            execute_block_tx,
+        ));
         runtime.spawn(Self::execute_stage(
             execute_block_rx,
             ledger_apply_tx,
@@ -79,7 +82,7 @@ impl ExecutionPipeline {
         })
     }
 
-    async fn prepare_block(
+    async fn prepare_block_stage(
         mut prepare_block_rx: mpsc::UnboundedReceiver<PrepareBlockCommand>,
         execute_block_tx: mpsc::UnboundedSender<ExecuteBlockCommand>,
     ) {

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -230,6 +230,7 @@ impl BufferManager {
 
         let request = self.create_new_request(ExecutionRequest {
             ordered_blocks: ordered_blocks.clone(),
+            lifetime_guard: self.create_new_request(()),
         });
         self.execution_schedule_phase_tx
             .send(request)
@@ -259,7 +260,10 @@ impl BufferManager {
             // is not expected nor retryable in reality, I'd rather remove retrying or do it more
             // properly than complicating it here.
             let ordered_blocks = self.buffer.get(&self.execution_root).get_blocks().clone();
-            let request = self.create_new_request(ExecutionRequest { ordered_blocks });
+            let request = self.create_new_request(ExecutionRequest {
+                ordered_blocks,
+                lifetime_guard: self.create_new_request(()),
+            });
             let sender = self.execution_schedule_phase_tx.clone();
             Self::spawn_retry_request(sender, request, Duration::from_millis(100));
         }

--- a/execution/executor-types/src/error.rs
+++ b/execution/executor-types/src/error.rs
@@ -5,6 +5,7 @@
 use aptos_crypto::HashValue;
 use aptos_types::transaction::Version;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use thiserror::Error;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
@@ -59,6 +60,14 @@ impl From<aptos_secure_net::Error> for ExecutorError {
     fn from(error: aptos_secure_net::Error) -> Self {
         Self::InternalError {
             error: format!("{}", error),
+        }
+    }
+}
+
+impl ExecutorError {
+    pub fn internal_err<E: Display>(e: E) -> Self {
+        Self::InternalError {
+            error: format!("{}", e),
         }
     }
 }


### PR DESCRIPTION
### Description

When consensus switches off to state sync, currently it's not guaranteed that there's no in flight blocks in the execution pipeline. This tries to address that by utilizing the CountedRequest mechanism in place.

### Test Plan
unit tests and forge
<!-- Please provide us with clear details for verifying that your changes work. -->
