### PR TITLE
[move-vm] A few perf optimizations for the loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10449,6 +10449,7 @@ dependencies = [
  "sha3 0.9.1",
  "smallbitvec",
  "tracing",
+ "triomphe",
 ]
 
 [[package]]
@@ -10486,6 +10487,7 @@ dependencies = [
  "serde",
  "smallbitvec",
  "smallvec",
+ "triomphe",
 ]
 
 [[package]]
@@ -15028,6 +15030,10 @@ name = "triomphe"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "try-lock"

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -197,12 +197,10 @@ pub(crate) fn is_valid_txn_arg(
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
         Vector(inner) => is_valid_txn_arg(session, inner, allowed_structs),
         Struct { idx, .. } | StructInstantiation { idx, .. } => {
-            if let Some(st) = session.get_struct_type(*idx) {
+            session.get_struct_type(*idx).is_some_and(|st| {
                 let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
                 allowed_structs.contains_key(&full_name)
-            } else {
-                false
-            }
+            })
         },
         Signer | Reference(_) | MutableReference(_) | TyParam(_) => false,
     }
@@ -326,8 +324,7 @@ pub(crate) fn recursively_construct_arg(
             let st = session
                 .get_struct_type(*idx)
                 .ok_or_else(invalid_signature)?;
-            // validate the struct value, we use `expect()` because that check was already
-            // performed in `is_valid_txn_arg`
+
             let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
             let constructor = allowed_structs
                 .get(&full_name)

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0.149"
 sha3 = "0.9.1"
 smallbitvec = "2.5.1"
 tracing = "0.1.26"
+triomphe = "0.1.9"
 
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-core-types = { path = "../../move-core/types" }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1053,9 +1053,10 @@ fn check_depth_of_type_impl(
         | Type::Signer => check_depth!(0),
         // Even though this is recursive this is OK since the depth of this recursion is
         // bounded by the depth of the type arguments, which we have already checked.
-        Type::Reference(ty) | Type::MutableReference(ty) | Type::Vector(ty) => {
+        Type::Reference(ty) | Type::MutableReference(ty) => {
             check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?
         },
+        Type::Vector(ty) => check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?,
         Type::Struct { idx: name, .. } => {
             let formula = resolver.loader().calculate_depth_of_struct(*name)?;
             check_depth!(formula.solve(&[]))
@@ -1655,7 +1656,7 @@ impl Frame {
                 }
                 interpreter
                     .operand_stack
-                    .push_ty(Type::Vector(Box::new(ty)))?;
+                    .push_ty(Type::Vector(Arc::new(ty)))?;
             },
             Bytecode::VecLen(si) => {
                 let ty = resolver.instantiate_single_type(*si, ty_args)?;

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1656,7 +1656,7 @@ impl Frame {
                 }
                 interpreter
                     .operand_stack
-                    .push_ty(Type::Vector(Arc::new(ty)))?;
+                    .push_ty(Type::Vector(triomphe::Arc::new(ty)))?;
             },
             Bytecode::VecLen(si) => {
                 let ty = resolver.instantiate_single_type(*si, ty_args)?;

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1057,14 +1057,12 @@ fn check_depth_of_type_impl(
             check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?
         },
         Type::Vector(ty) => check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?,
-        Type::Struct { idx: name, .. } => {
-            let formula = resolver.loader().calculate_depth_of_struct(*name)?;
+        Type::Struct { idx, .. } => {
+            let formula = resolver.loader().calculate_depth_of_struct(*idx)?;
             check_depth!(formula.solve(&[]))
         },
         // NB: substitution must be performed before calling this function
-        Type::StructInstantiation {
-            idx: name, ty_args, ..
-        } => {
+        Type::StructInstantiation { idx, ty_args, .. } => {
             // Calculate depth of all type arguments, and make sure they themselves are not too deep.
             let ty_arg_depths = ty_args
                 .iter()
@@ -1073,7 +1071,7 @@ fn check_depth_of_type_impl(
                     check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(0))
                 })
                 .collect::<PartialVMResult<Vec<_>>>()?;
-            let formula = resolver.loader().calculate_depth_of_struct(*name)?;
+            let formula = resolver.loader().calculate_depth_of_struct(*idx)?;
             check_depth!(formula.solve(&ty_arg_depths))
         },
         Type::TyParam(_) => {

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1056,12 +1056,14 @@ fn check_depth_of_type_impl(
         Type::Reference(ty) | Type::MutableReference(ty) | Type::Vector(ty) => {
             check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?
         },
-        Type::Struct { name, .. } => {
-            let formula = resolver.loader().calculate_depth_of_struct(name)?;
+        Type::Struct { idx: name, .. } => {
+            let formula = resolver.loader().calculate_depth_of_struct(*name)?;
             check_depth!(formula.solve(&[]))
         },
         // NB: substitution must be performed before calling this function
-        Type::StructInstantiation { name, ty_args, .. } => {
+        Type::StructInstantiation {
+            idx: name, ty_args, ..
+        } => {
             // Calculate depth of all type arguments, and make sure they themselves are not too deep.
             let ty_arg_depths = ty_args
                 .iter()
@@ -1070,7 +1072,7 @@ fn check_depth_of_type_impl(
                     check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(0))
                 })
                 .collect::<PartialVMResult<Vec<_>>>()?;
-            let formula = resolver.loader().calculate_depth_of_struct(name)?;
+            let formula = resolver.loader().calculate_depth_of_struct(*name)?;
             check_depth!(formula.solve(&ty_arg_depths))
         },
         Type::TyParam(_) => {

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -28,9 +28,9 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_types::loaded_data::runtime_types::{
-    AbilityInfo, DepthFormula, StructIdentifier, StructType, Type,
+    AbilityInfo, DepthFormula, StructIdentifier, StructNameIndex, StructType, Type,
 };
-use parking_lot::RwLock;
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 use sha3::{Digest, Sha3_256};
 use std::{
     collections::{btree_map, BTreeMap, BTreeSet, HashMap},
@@ -127,6 +127,48 @@ impl ScriptCache {
     }
 }
 
+pub(crate) struct StructNameCache {
+    data: RwLock<(
+        BTreeMap<StructIdentifier, StructNameIndex>,
+        Vec<StructIdentifier>,
+    )>,
+}
+
+impl Clone for StructNameCache {
+    fn clone(&self) -> Self {
+        let inner = self.data.read();
+        Self {
+            data: RwLock::new((inner.0.clone(), inner.1.clone())),
+        }
+    }
+}
+
+impl StructNameCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            data: RwLock::new((BTreeMap::new(), vec![])),
+        }
+    }
+
+    pub(crate) fn insert_or_get(&self, name: StructIdentifier) -> StructNameIndex {
+        if let Some(idx) = self.data.read().0.get(&name) {
+            return *idx;
+        }
+        let mut inner_data = self.data.write();
+        let idx = StructNameIndex(inner_data.1.len());
+        inner_data.0.insert(name.clone(), idx);
+        inner_data.1.push(name);
+        idx
+    }
+
+    pub(crate) fn idx_to_identifier(
+        &self,
+        idx: StructNameIndex,
+    ) -> MappedRwLockReadGuard<StructIdentifier> {
+        RwLockReadGuard::map(self.data.read(), |inner| &inner.1[idx.0])
+    }
+}
+
 //
 // Loader
 //
@@ -140,6 +182,7 @@ pub(crate) struct Loader {
     module_cache: RwLock<ModuleCache>,
     type_cache: RwLock<TypeCache>,
     natives: NativeFunctions,
+    name_cache: StructNameCache,
 
     // The below field supports a hack to workaround well-known issues with the
     // loader cache. This cache is not designed to support module upgrade or deletion.
@@ -183,6 +226,7 @@ impl Clone for Loader {
             module_cache: RwLock::new(self.module_cache.read().clone()),
             type_cache: RwLock::new(self.type_cache.read().clone()),
             natives: self.natives.clone(),
+            name_cache: self.name_cache.clone(),
             invalidated: RwLock::new(*self.invalidated.read()),
             module_cache_hits: RwLock::new(self.module_cache_hits.read().clone()),
             vm_config: self.vm_config.clone(),
@@ -196,6 +240,7 @@ impl Loader {
             scripts: RwLock::new(ScriptCache::new()),
             module_cache: RwLock::new(ModuleCache::new()),
             type_cache: RwLock::new(TypeCache::new()),
+            name_cache: StructNameCache::new(),
             natives,
             invalidated: RwLock::new(false),
             module_cache_hits: RwLock::new(BTreeSet::new()),
@@ -285,7 +330,12 @@ impl Loader {
             Some(cached) => cached,
             None => {
                 let ver_script = self.deserialize_and_verify_script(script_blob, data_store)?;
-                let script = Script::new(ver_script, &hash_value, &self.module_cache.read())?;
+                let script = Script::new(
+                    ver_script,
+                    &hash_value,
+                    &self.module_cache.read(),
+                    &self.name_cache,
+                )?;
                 scripts.insert(hash_value, script)
             },
         };
@@ -426,20 +476,20 @@ impl Loader {
             // Abilities should not contribute to the equality check as they just serve for caching computations.
             // For structs the both need to be the same struct.
             (
-                Type::Struct { name: ret_idx, .. },
+                Type::Struct { idx: ret_idx, .. },
                 Type::Struct {
-                    name: expected_idx, ..
+                    idx: expected_idx, ..
                 },
             ) => *ret_idx == *expected_idx,
             // For struct instantiations we need to additionally match all type arguments
             (
                 Type::StructInstantiation {
-                    name: ret_idx,
+                    idx: ret_idx,
                     ty_args: ret_fields,
                     ..
                 },
                 Type::StructInstantiation {
-                    name: expected_idx,
+                    idx: expected_idx,
                     ty_args: expected_fields,
                     ..
                 },
@@ -752,7 +802,7 @@ impl Loader {
                     .map_err(|e| e.finish(Location::Undefined))?;
                 if struct_type.type_parameters.is_empty() && struct_tag.type_params.is_empty() {
                     Type::Struct {
-                        name: struct_type.name.clone(),
+                        idx: struct_type.idx,
                         ability: AbilityInfo::struct_(struct_type.abilities),
                     }
                 } else {
@@ -763,7 +813,7 @@ impl Loader {
                     self.verify_ty_args(struct_type.type_param_constraints(), &type_params)
                         .map_err(|e| e.finish(Location::Undefined))?;
                     Type::StructInstantiation {
-                        name: struct_type.name.clone(),
+                        idx: struct_type.idx,
                         ty_args: Arc::new(type_params),
                         ability: AbilityInfo::generic_struct(
                             struct_type.abilities,
@@ -903,7 +953,8 @@ impl Loader {
 
         // if linking goes well, insert the module to the code cache
         let mut locked_cache = self.module_cache.write();
-        let module_ref = locked_cache.insert(&self.natives, id.clone(), module)?;
+        let module_ref =
+            locked_cache.insert(&self.natives, id.clone(), module, &self.name_cache)?;
         drop(locked_cache); // explicit unlock
 
         Ok(module_ref)
@@ -1179,6 +1230,16 @@ impl Loader {
             .read()
             .resolve_struct_by_name(&name.name, &name.module)
     }
+
+    pub(crate) fn get_struct_type_by_idx(
+        &self,
+        idx: StructNameIndex,
+    ) -> PartialVMResult<Arc<StructType>> {
+        let name = self.name_cache.idx_to_identifier(idx);
+        self.module_cache
+            .read()
+            .resolve_struct_by_name(&name.name, &name.module)
+    }
 }
 
 //
@@ -1291,7 +1352,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
         Ok(Type::Struct {
-            name: struct_def.name.clone(),
+            idx: struct_def.idx,
             ability: AbilityInfo::struct_(struct_def.abilities),
         })
     }
@@ -1320,7 +1381,7 @@ impl<'a> Resolver<'a> {
 
         let struct_ = &struct_inst.definition_struct_type;
         Ok(Type::StructInstantiation {
-            name: struct_.name.clone(),
+            idx: struct_.idx,
             ty_args: Arc::new(
                 struct_inst
                     .instantiation
@@ -1459,7 +1520,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => {
                 let struct_ = &module.field_handles[idx.0 as usize].definition_struct_type;
                 Ok(Type::Struct {
-                    name: struct_.name.clone(),
+                    idx: struct_.idx,
                     ability: AbilityInfo::struct_(struct_.abilities),
                 })
             },
@@ -1476,7 +1537,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => {
                 let struct_ = &module.field_instantiations[idx.0 as usize].definition_struct_type;
                 Ok(Type::StructInstantiation {
-                    name: struct_.name.clone(),
+                    idx: struct_.idx,
                     ty_args: Arc::new(
                         module.field_instantiations[idx.0 as usize]
                             .instantiation
@@ -1551,6 +1612,7 @@ impl Script {
         script: CompiledScript,
         script_hash: &ScriptHash,
         cache: &ModuleCache,
+        name_cache: &StructNameCache,
     ) -> VMResult<Self> {
         let mut struct_names = vec![];
         for struct_handle in script.struct_handles() {
@@ -1563,7 +1625,7 @@ impl Script {
                 .check_compatibility(struct_handle)
                 .map_err(|err| err.finish(Location::Script))?;
 
-            struct_names.push(Arc::new(StructIdentifier {
+            struct_names.push(name_cache.insert_or_get(StructIdentifier {
                 module: module_id,
                 name: struct_name.to_owned(),
             }));
@@ -1792,10 +1854,11 @@ impl PseudoGasContext {
 impl Loader {
     fn struct_name_to_type_tag(
         &self,
-        name: &StructIdentifier,
+        struct_idx: StructNameIndex,
         ty_args: &[Type],
         gas_context: &mut PseudoGasContext,
     ) -> PartialVMResult<StructTag> {
+        let name = &*self.name_cache.idx_to_identifier(struct_idx);
         if let Some(struct_map) = self.type_cache.read().structs.get(name) {
             if let Some(struct_info) = struct_map.get(ty_args) {
                 if let Some((struct_tag, gas)) = &struct_info.struct_tag {
@@ -1850,14 +1913,16 @@ impl Loader {
             Type::Address => TypeTag::Address,
             Type::Signer => TypeTag::Signer,
             Type::Vector(ty) => TypeTag::Vector(Box::new(self.type_to_type_tag(ty)?)),
-            Type::Struct { name, .. } => TypeTag::Struct(Box::new(self.struct_name_to_type_tag(
-                name,
-                &[],
+            Type::Struct { idx: name, .. } => TypeTag::Struct(Box::new(
+                self.struct_name_to_type_tag(*name, &[], gas_context)?,
+            )),
+            Type::StructInstantiation {
+                idx: name, ty_args, ..
+            } => TypeTag::Struct(Box::new(self.struct_name_to_type_tag(
+                *name,
+                ty_args,
                 gas_context,
             )?)),
-            Type::StructInstantiation { name, ty_args, .. } => TypeTag::Struct(Box::new(
-                self.struct_name_to_type_tag(name, ty_args, gas_context)?,
-            )),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -1890,11 +1955,12 @@ impl Loader {
 
     fn struct_name_to_type_layout(
         &self,
-        name: &StructIdentifier,
+        struct_idx: StructNameIndex,
         ty_args: &[Type],
         count: &mut u64,
         depth: u64,
     ) -> PartialVMResult<(MoveStructLayout, bool)> {
+        let name = &*self.name_cache.idx_to_identifier(struct_idx);
         if let Some(struct_map) = self.type_cache.read().structs.get(name) {
             if let Some(struct_info) = struct_map.get(ty_args) {
                 if let Some(struct_layout_info) = &struct_info.struct_layout_info {
@@ -2046,18 +2112,20 @@ impl Loader {
                     has_identifier_mappings,
                 )
             },
-            Type::Struct { name, .. } => {
+            Type::Struct { idx: name, .. } => {
                 *count += 1;
                 // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
-                    self.struct_name_to_type_layout(name, &[], count, depth)?;
+                    self.struct_name_to_type_layout(*name, &[], count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)
             },
-            Type::StructInstantiation { name, ty_args, .. } => {
+            Type::StructInstantiation {
+                idx: name, ty_args, ..
+            } => {
                 *count += 1;
                 // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
-                    self.struct_name_to_type_layout(name, ty_args, count, depth)?;
+                    self.struct_name_to_type_layout(*name, ty_args, count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)
             },
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
@@ -2071,11 +2139,12 @@ impl Loader {
 
     fn struct_name_to_fully_annotated_layout(
         &self,
-        name: &StructIdentifier,
+        struct_idx: StructNameIndex,
         ty_args: &[Type],
         count: &mut u64,
         depth: u64,
     ) -> PartialVMResult<MoveStructLayout> {
+        let name = &*self.name_cache.idx_to_identifier(struct_idx);
         if let Some(struct_map) = self.type_cache.read().structs.get(name) {
             if let Some(struct_info) = struct_map.get(ty_args) {
                 if let Some(annotated_node_count) = &struct_info.annotated_node_count {
@@ -2104,7 +2173,7 @@ impl Loader {
             cost_base: self.vm_config.type_base_cost,
             cost_per_byte: self.vm_config.type_byte_cost,
         };
-        let struct_tag = self.struct_name_to_type_tag(name, ty_args, &mut gas_context)?;
+        let struct_tag = self.struct_name_to_type_tag(struct_idx, ty_args, &mut gas_context)?;
         let field_layouts = struct_type
             .field_names
             .iter()
@@ -2156,11 +2225,13 @@ impl Loader {
             Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Struct { name, .. } => MoveTypeLayout::Struct(
-                self.struct_name_to_fully_annotated_layout(name, &[], count, depth)?,
+            Type::Struct { idx: name, .. } => MoveTypeLayout::Struct(
+                self.struct_name_to_fully_annotated_layout(*name, &[], count, depth)?,
             ),
-            Type::StructInstantiation { name, ty_args, .. } => MoveTypeLayout::Struct(
-                self.struct_name_to_fully_annotated_layout(name, ty_args, count, depth)?,
+            Type::StructInstantiation {
+                idx: name, ty_args, ..
+            } => MoveTypeLayout::Struct(
+                self.struct_name_to_fully_annotated_layout(*name, ty_args, count, depth)?,
             ),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -2173,8 +2244,9 @@ impl Loader {
 
     pub(crate) fn calculate_depth_of_struct(
         &self,
-        name: &StructIdentifier,
+        struct_idx: StructNameIndex,
     ) -> PartialVMResult<DepthFormula> {
+        let name = &*self.name_cache.idx_to_identifier(struct_idx);
         if let Some(depth_formula) = self.type_cache.read().depth_formula.get(name) {
             return Ok(depth_formula.clone());
         }
@@ -2218,13 +2290,15 @@ impl Loader {
                 inner
             },
             Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
-            Type::Struct { name, .. } => {
-                let mut struct_formula = self.calculate_depth_of_struct(name)?;
+            Type::Struct { idx: name, .. } => {
+                let mut struct_formula = self.calculate_depth_of_struct(*name)?;
                 debug_assert!(struct_formula.terms.is_empty());
                 struct_formula.scale(1);
                 struct_formula
             },
-            Type::StructInstantiation { name, ty_args, .. } => {
+            Type::StructInstantiation {
+                idx: name, ty_args, ..
+            } => {
                 let ty_arg_map = ty_args
                     .iter()
                     .enumerate()
@@ -2233,7 +2307,7 @@ impl Loader {
                         Ok((var, self.calculate_depth_of_type(ty)?))
                     })
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
-                let struct_formula = self.calculate_depth_of_struct(name)?;
+                let struct_formula = self.calculate_depth_of_struct(*name)?;
                 let mut subst_struct_formula = struct_formula.subst(ty_arg_map)?;
                 subst_struct_formula.scale(1);
                 subst_struct_formula

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -792,7 +792,9 @@ impl Loader {
             TypeTag::U256 => Type::U256,
             TypeTag::Address => Type::Address,
             TypeTag::Signer => Type::Signer,
-            TypeTag::Vector(tt) => Type::Vector(Arc::new(self.load_type(tt, data_store)?)),
+            TypeTag::Vector(tt) => {
+                Type::Vector(triomphe::Arc::new(self.load_type(tt, data_store)?))
+            },
             TypeTag::Struct(struct_tag) => {
                 let module_id = ModuleId::new(struct_tag.address, struct_tag.module.clone());
                 self.load_module(&module_id, data_store)?;
@@ -816,7 +818,7 @@ impl Loader {
                         .map_err(|e| e.finish(Location::Undefined))?;
                     Type::StructInstantiation {
                         idx: struct_type.idx,
-                        ty_args: Arc::new(type_params),
+                        ty_args: triomphe::Arc::new(type_params),
                         ability: AbilityInfo::generic_struct(
                             struct_type.abilities,
                             struct_type.phantom_ty_args_mask.clone(),
@@ -1384,7 +1386,7 @@ impl<'a> Resolver<'a> {
         let struct_ = &struct_inst.definition_struct_type;
         Ok(Type::StructInstantiation {
             idx: struct_.idx,
-            ty_args: Arc::new(
+            ty_args: triomphe::Arc::new(
                 struct_inst
                     .instantiation
                     .iter()
@@ -1540,7 +1542,7 @@ impl<'a> Resolver<'a> {
                 let struct_ = &module.field_instantiations[idx.0 as usize].definition_struct_type;
                 Ok(Type::StructInstantiation {
                     idx: struct_.idx,
-                    ty_args: Arc::new(
+                    ty_args: triomphe::Arc::new(
                         module.field_instantiations[idx.0 as usize]
                             .instantiation
                             .iter()

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -129,7 +129,7 @@ impl ModuleCache {
 
     // Given a ModuleId::struct_name, retrieve the `StructType` and the index associated.
     // Return and error if the type has not been loaded
-    pub(crate) fn resolve_struct_by_name(
+    pub(crate) fn get_struct_type_by_identifier(
         &self,
         struct_name: &IdentStr,
         module_id: &ModuleId,
@@ -278,7 +278,7 @@ impl Module {
 
                 if module_handle != module.self_handle() {
                     cache
-                        .resolve_struct_by_name(struct_name, &module_id)?
+                        .get_struct_type_by_identifier(struct_name, &module_id)?
                         .check_compatibility(struct_handle)?;
                 }
                 struct_idxs.push(name_cache.insert_or_get(StructIdentifier {

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -4,14 +4,14 @@
 use move_binary_format::{
     binary_views::BinaryIndexedView, errors::PartialVMResult, file_format::SignatureToken,
 };
-use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructIdentifier, Type};
+use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructNameIndex, Type};
 use std::sync::Arc;
 
 // `intern_type` converts a signature token into the in memory type representation used by the MoveVM.
 pub fn intern_type(
     module: BinaryIndexedView,
     tok: &SignatureToken,
-    struct_name_table: &[Arc<StructIdentifier>],
+    struct_name_table: &[StructNameIndex],
 ) -> PartialVMResult<Type> {
     let res = match tok {
         SignatureToken::Bool => Type::Bool,
@@ -39,7 +39,7 @@ pub fn intern_type(
         SignatureToken::Struct(sh_idx) => {
             let struct_handle = module.struct_handle_at(*sh_idx);
             Type::Struct {
-                name: struct_name_table[sh_idx.0 as usize].clone(),
+                idx: struct_name_table[sh_idx.0 as usize],
                 ability: AbilityInfo::struct_(struct_handle.abilities),
             }
         },
@@ -50,7 +50,7 @@ pub fn intern_type(
                 .collect::<PartialVMResult<_>>()?;
             let struct_handle = module.struct_handle_at(*sh_idx);
             Type::StructInstantiation {
-                name: struct_name_table[sh_idx.0 as usize].clone(),
+                idx: struct_name_table[sh_idx.0 as usize],
                 ty_args: Arc::new(type_args),
                 ability: AbilityInfo::generic_struct(
                     struct_handle.abilities,

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -5,7 +5,7 @@ use move_binary_format::{
     binary_views::BinaryIndexedView, errors::PartialVMResult, file_format::SignatureToken,
 };
 use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructNameIndex, Type};
-use triomphe::Arc;
+use triomphe::Arc as TriompheArc;
 
 // `intern_type` converts a signature token into the in memory type representation used by the MoveVM.
 pub fn intern_type(
@@ -26,7 +26,7 @@ pub fn intern_type(
         SignatureToken::TypeParameter(idx) => Type::TyParam(*idx),
         SignatureToken::Vector(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;
-            Type::Vector(Arc::new(inner_type))
+            Type::Vector(TriompheArc::new(inner_type))
         },
         SignatureToken::Reference(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;
@@ -51,7 +51,7 @@ pub fn intern_type(
             let struct_handle = module.struct_handle_at(*sh_idx);
             Type::StructInstantiation {
                 idx: struct_name_table[sh_idx.0 as usize],
-                ty_args: Arc::new(type_args),
+                ty_args: TriompheArc::new(type_args),
                 ability: AbilityInfo::generic_struct(
                     struct_handle.abilities,
                     struct_handle

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -5,7 +5,7 @@ use move_binary_format::{
     binary_views::BinaryIndexedView, errors::PartialVMResult, file_format::SignatureToken,
 };
 use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructNameIndex, Type};
-use std::sync::Arc;
+use triomphe::Arc;
 
 // `intern_type` converts a signature token into the in memory type representation used by the MoveVM.
 pub fn intern_type(

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -26,7 +26,7 @@ pub fn intern_type(
         SignatureToken::TypeParameter(idx) => Type::TyParam(*idx),
         SignatureToken::Vector(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;
-            Type::Vector(Box::new(inner_type))
+            Type::Vector(Arc::new(inner_type))
         },
         SignatureToken::Reference(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -22,10 +22,10 @@ use move_core_types::{
 };
 use move_vm_types::{
     gas::GasMeter,
-    loaded_data::runtime_types::Type,
+    loaded_data::runtime_types::{StructNameIndex, StructType, Type},
     values::{GlobalValue, Value},
 };
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
 pub struct Session<'r, 'l> {
     pub(crate) move_vm: &'l MoveVM,
@@ -416,6 +416,14 @@ impl<'r, 'l> Session<'r, 'l> {
 
     pub fn get_vm_config(&self) -> &'l VMConfig {
         self.move_vm.runtime.loader().vm_config()
+    }
+
+    pub fn get_struct_type(&self, index: StructNameIndex) -> Option<Arc<StructType>> {
+        self.move_vm
+            .runtime
+            .loader()
+            .get_struct_type_by_idx(index)
+            .ok()
     }
 }
 

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -16,6 +16,7 @@ proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", features = ["derive", "rc"] }
 smallbitvec = "2.5.1"
 smallvec = "1.6.1"
+triomphe = "0.1.9"
 
 bcs = { workspace = true }
 move-binary-format = { path = "../../move-binary-format" }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -174,7 +174,7 @@ pub enum Type {
     U128,
     Address,
     Signer,
-    Vector(Box<Type>),
+    Vector(Arc<Type>),
     Struct {
         idx: StructNameIndex,
         ability: AbilityInfo,
@@ -255,7 +255,7 @@ impl Type {
             Type::U256 => Type::U256,
             Type::Address => Type::Address,
             Type::Signer => Type::Signer,
-            Type::Vector(ty) => Type::Vector(Box::new(ty.apply_subst(subst, depth + 1)?)),
+            Type::Vector(ty) => Type::Vector(Arc::new(ty.apply_subst(subst, depth + 1)?)),
             Type::Reference(ty) => Type::Reference(Box::new(ty.apply_subst(subst, depth + 1)?)),
             Type::MutableReference(ty) => {
                 Type::MutableReference(Box::new(ty.apply_subst(subst, depth + 1)?))
@@ -311,9 +311,8 @@ impl Type {
             TyParam(_) | Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer => {
                 Self::LEGACY_BASE_MEMORY_SIZE
             },
-            Vector(ty) | Reference(ty) | MutableReference(ty) => {
-                Self::LEGACY_BASE_MEMORY_SIZE + ty.size()
-            },
+            Reference(ty) | MutableReference(ty) => Self::LEGACY_BASE_MEMORY_SIZE + ty.size(),
+            Vector(ty) => Self::LEGACY_BASE_MEMORY_SIZE + ty.size(),
             Struct { .. } => Self::LEGACY_BASE_MEMORY_SIZE,
             StructInstantiation { ty_args: tys, .. } => tys
                 .iter()
@@ -334,7 +333,7 @@ impl Type {
             S::U128 => L::U128,
             S::U256 => L::U256,
             S::Address => L::Address,
-            S::Vector(inner) => L::Vector(Box::new(Self::from_const_signature(inner)?)),
+            S::Vector(inner) => L::Vector(Arc::new(Self::from_const_signature(inner)?)),
             // Not yet supported
             S::Struct(_) | S::StructInstantiation(_, _) => {
                 return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -15,7 +15,7 @@ use move_core_types::{
 };
 use smallbitvec::SmallBitVec;
 use std::{cmp::max, collections::BTreeMap, fmt::Debug};
-use triomphe::Arc;
+use triomphe::Arc as TriompheArc;
 
 pub const TYPE_DEPTH_MAX: usize = 256;
 
@@ -175,14 +175,14 @@ pub enum Type {
     U128,
     Address,
     Signer,
-    Vector(Arc<Type>),
+    Vector(TriompheArc<Type>),
     Struct {
         idx: StructNameIndex,
         ability: AbilityInfo,
     },
     StructInstantiation {
         idx: StructNameIndex,
-        ty_args: Arc<Vec<Type>>,
+        ty_args: TriompheArc<Vec<Type>>,
         ability: AbilityInfo,
     },
     Reference(Box<Type>),
@@ -256,7 +256,7 @@ impl Type {
             Type::U256 => Type::U256,
             Type::Address => Type::Address,
             Type::Signer => Type::Signer,
-            Type::Vector(ty) => Type::Vector(Arc::new(ty.apply_subst(subst, depth + 1)?)),
+            Type::Vector(ty) => Type::Vector(TriompheArc::new(ty.apply_subst(subst, depth + 1)?)),
             Type::Reference(ty) => Type::Reference(Box::new(ty.apply_subst(subst, depth + 1)?)),
             Type::MutableReference(ty) => {
                 Type::MutableReference(Box::new(ty.apply_subst(subst, depth + 1)?))
@@ -276,7 +276,7 @@ impl Type {
                 }
                 Type::StructInstantiation {
                     idx: *idx,
-                    ty_args: Arc::new(inst),
+                    ty_args: TriompheArc::new(inst),
                     ability: ability.clone(),
                 }
             },
@@ -334,7 +334,7 @@ impl Type {
             S::U128 => L::U128,
             S::U256 => L::U256,
             S::Address => L::Address,
-            S::Vector(inner) => L::Vector(Arc::new(Self::from_const_signature(inner)?)),
+            S::Vector(inner) => L::Vector(TriompheArc::new(Self::from_const_signature(inner)?)),
             // Not yet supported
             S::Struct(_) | S::StructInstantiation(_, _) => {
                 return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -14,7 +14,8 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use smallbitvec::SmallBitVec;
-use std::{cmp::max, collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{cmp::max, collections::BTreeMap, fmt::Debug};
+use triomphe::Arc;
 
 pub const TYPE_DEPTH_MAX: usize = 256;
 

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -2175,9 +2175,7 @@ impl Vector {
             | Type::Vector(_)
             | Type::Struct { .. }
             | Type::StructInstantiation {
-                name: _,
-                ty_args: _,
-                ..
+                idx: _, ty_args: _, ..
             } => Value(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
                 elements.into_iter().map(|v| v.0).collect(),
             ))))),


### PR DESCRIPTION
### Description
Improve the performance of the loader by:
1. Use index for struct identifiers instead of Arc.
2. Use `Arc` instead of `Box` to make cloning `Type` trivial.

### Test Plan

Ran the performance benchmark on the p2p workflow and observed getting the performance regression back from the new loader
