### PR TITLE
fix `get_symbol` in FungibleAssetMetadata

### DIFF
--- a/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
+++ b/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
@@ -68,7 +68,7 @@ impl FungibleAssetMetadata {
     }
 
     pub fn get_symbol(&self) -> String {
-        truncate_str(&self.name, FUNGIBLE_ASSET_SYMBOL)
+        truncate_str(&self.symbol, FUNGIBLE_ASSET_SYMBOL)
     }
 
     pub fn get_icon_uri(&self) -> String {


### PR DESCRIPTION
### Bug Description
After creating a Fungible Asset, the symbol is being returned as the name truncated while querying the indexer (max 10 chars).

### Observation
I am including the following details of the bug after creating a Fungible Asset from a Move contract:

- Fungible Asset Metadata when reading from onchain data
![i1](https://github.com/aptos-labs/aptos-core/assets/22060043/23e38339-253c-431a-8540-0597447406e5)

- Fungible Asset Metadata when reading from the indexer
![i2](https://github.com/aptos-labs/aptos-core/assets/22060043/ee857e90-216b-47ee-bf77-9fce06516571)

I am not sure how to apply these changes to be reflected in the indexer.
cc @bowenyang007 