### PR TITLE
[execution] change HashMap to BTreeMap in VMChangeSet #10582

### DIFF
--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     vm_status::{StatusCode, VMStatus},
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Testcases:
 /// ```text
@@ -89,7 +89,7 @@ macro_rules! write_set_2 {
 
 macro_rules! expected_write_set {
     ($d:ident) => {
-        HashMap::from([
+        BTreeMap::from([
             mock_create(format!("0{}", $d), 0),
             mock_modify(format!("1{}", $d), 1),
             mock_delete(format!("2{}", $d)),
@@ -166,13 +166,13 @@ fn test_successful_squash() {
         &expected_write_set!(descriptor)
     );
 
-    let expected_aggregator_write_set = HashMap::from([
+    let expected_aggregator_write_set = BTreeMap::from([
         mock_create("18a", 136),
         mock_modify("19a", 138),
         mock_modify("22a", 122),
         mock_delete("23a"),
     ]);
-    let expected_aggregator_delta_set = HashMap::from([
+    let expected_aggregator_delta_set = BTreeMap::from([
         mock_add("15a", 15),
         mock_add("16a", 116),
         mock_add("17a", 134),

--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -12,7 +12,7 @@ use aptos_types::{
 };
 use claims::{assert_err, assert_matches, assert_ok};
 use move_core_types::vm_status::{AbortLocation, VMStatus};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 fn assert_eq_outputs(vm_output: &VMOutput, txn_output: TransactionOutput) {
     let vm_output_writes = &vm_output
@@ -79,7 +79,8 @@ fn test_ok_output_equality_with_deltas() {
         .clone()
         .into_transaction_output_with_materialized_deltas(vec![mock_modify("3", 400)]);
 
-    let expected_aggregator_write_set = HashMap::from([mock_modify("2", 2), mock_modify("3", 400)]);
+    let expected_aggregator_write_set =
+        BTreeMap::from([mock_modify("2", 2), mock_modify("3", 400)]);
     assert_eq!(
         materialized_vm_output.change_set().resource_write_set(),
         vm_output.change_set().resource_write_set()

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::VMStatus,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub(crate) struct MockChangeSetChecker;
 
@@ -116,11 +116,11 @@ pub(crate) fn build_change_set(
     aggregator_delta_set: impl IntoIterator<Item = (StateKey, DeltaOp)>,
 ) -> VMChangeSet {
     VMChangeSet::new(
-        HashMap::from_iter(resource_write_set),
-        HashMap::from_iter(resource_group_write_set),
-        HashMap::from_iter(module_write_set),
-        HashMap::from_iter(aggregator_write_set),
-        HashMap::from_iter(aggregator_delta_set),
+        BTreeMap::from_iter(resource_write_set),
+        BTreeMap::from_iter(resource_group_write_set),
+        BTreeMap::from_iter(module_write_set),
+        BTreeMap::from_iter(aggregator_write_set),
+        BTreeMap::from_iter(aggregator_delta_set),
         vec![],
         &MockChangeSetChecker,
     )

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -32,7 +32,7 @@ use aptos_vm_types::output::VMOutput;
 use move_core_types::vm_status::VMStatus;
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 // Wrapper to avoid orphan rule
 #[derive(Debug)]
@@ -78,7 +78,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn resource_write_set(&self) -> HashMap<StateKey, WriteOp> {
+    fn resource_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
             .as_ref()
@@ -90,7 +90,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn module_write_set(&self) -> HashMap<StateKey, WriteOp> {
+    fn module_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
             .as_ref()
@@ -102,7 +102,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn aggregator_v1_write_set(&self) -> HashMap<StateKey, WriteOp> {
+    fn aggregator_v1_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
             .as_ref()
@@ -114,7 +114,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn aggregator_v1_delta_set(&self) -> HashMap<StateKey, DeltaOp> {
+    fn aggregator_v1_delta_set(&self) -> BTreeMap<StateKey, DeltaOp> {
         self.vm_output
             .lock()
             .as_ref()

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -243,7 +243,7 @@ mod test {
         identifier::Identifier,
         language_storage::{StructTag, TypeTag},
     };
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::BTreeMap;
 
     /// A mock for testing. Always succeeds on checking a change set.
     struct NoOpChangeSetChecker;
@@ -337,31 +337,31 @@ mod test {
         state_view.set_legacy(key("resource_group_base"), bcs::to_bytes(&tree).unwrap());
         state_view.set_legacy(key("resource_group_both"), bcs::to_bytes(&tree).unwrap());
 
-        let resource_write_set = HashMap::from([
+        let resource_write_set = BTreeMap::from([
             (key("resource_both"), write(80)),
             (key("resource_write_set"), write(90)),
         ]);
 
-        let module_write_set = HashMap::from([
+        let module_write_set = BTreeMap::from([
             (key("module_both"), write(100)),
             (key("module_write_set"), write(110)),
         ]);
 
-        let aggregator_write_set = HashMap::from([
+        let aggregator_write_set = BTreeMap::from([
             (key("aggregator_both"), write(120)),
             (key("aggregator_write_set"), write(130)),
         ]);
 
         let aggregator_delta_set =
-            HashMap::from([(key("aggregator_delta_set"), delta_add(1, 1000))]);
+            BTreeMap::from([(key("aggregator_delta_set"), delta_add(1, 1000))]);
 
-        let resource_group_write_set = HashMap::from([
+        let resource_group_write_set = BTreeMap::from([
             (
                 key("resource_group_both"),
                 GroupWrite::new(
                     WriteOp::Deletion,
                     0,
-                    HashMap::from([
+                    BTreeMap::from([
                         (mock_tag_0(), WriteOp::Modification(serialize(&1000).into())),
                         (mock_tag_2(), WriteOp::Modification(serialize(&300).into())),
                     ]),
@@ -372,7 +372,10 @@ mod test {
                 GroupWrite::new(
                     WriteOp::Deletion,
                     0,
-                    HashMap::from([(mock_tag_1(), WriteOp::Modification(serialize(&5000).into()))]),
+                    BTreeMap::from([(
+                        mock_tag_1(),
+                        WriteOp::Modification(serialize(&5000).into()),
+                    )]),
                 ),
             ),
         ]);

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -373,11 +373,11 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         ap_cache: &mut C,
         configs: &ChangeSetConfigs,
     ) -> Result<VMChangeSet, VMStatus> {
-        let mut resource_write_set = HashMap::new();
-        let mut resource_group_write_set = HashMap::new();
-        let mut module_write_set = HashMap::new();
-        let mut aggregator_write_set = HashMap::new();
-        let mut aggregator_delta_set = HashMap::new();
+        let mut resource_write_set = BTreeMap::new();
+        let mut resource_group_write_set = BTreeMap::new();
+        let mut module_write_set = BTreeMap::new();
+        let mut aggregator_write_set = BTreeMap::new();
+        let mut aggregator_delta_set = BTreeMap::new();
 
         for (addr, account_changeset) in change_set.into_inner() {
             let (modules, resources) = account_changeset.into_inner();

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -18,7 +18,7 @@ use move_core_types::{
     language_storage::StructTag,
     vm_status::{err_msg, StatusCode, VMStatus},
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 pub(crate) struct WriteOpConverter<'r> {
     remote: &'r dyn AptosMoveResolver,
@@ -85,7 +85,7 @@ impl<'r> WriteOpConverter<'r> {
             )
         })?;
 
-        let mut inner_ops = HashMap::new();
+        let mut inner_ops = BTreeMap::new();
 
         // STORAGE_ERROR is a placeholder. TODO: change to SPECULATIVE_EXECUTION_ABORT_ERROR, as
         // the error can happen due to speculative reads (in a non-speculative context, e.g.

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -28,7 +28,7 @@ use once_cell::sync::OnceCell;
 use proptest::{arbitrary::Arbitrary, collection::vec, prelude::*, proptest, sample::Index};
 use proptest_derive::Arbitrary;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeSet, HashMap},
+    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
     convert::TryInto,
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -631,7 +631,7 @@ where
 {
     type Txn = MockTransaction<K, V, E>;
 
-    fn resource_write_set(&self) -> HashMap<K, V> {
+    fn resource_write_set(&self) -> BTreeMap<K, V> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_none())
@@ -639,7 +639,7 @@ where
             .collect()
     }
 
-    fn module_write_set(&self) -> HashMap<K, V> {
+    fn module_write_set(&self) -> BTreeMap<K, V> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_some())
@@ -649,11 +649,11 @@ where
 
     // Aggregator v1 writes are included in resource_write_set for tests (writes are produced
     // for all keys including ones for v1_aggregators without distinguishing).
-    fn aggregator_v1_write_set(&self) -> HashMap<K, V> {
-        HashMap::new()
+    fn aggregator_v1_write_set(&self) -> BTreeMap<K, V> {
+        BTreeMap::new()
     }
 
-    fn aggregator_v1_delta_set(&self) -> HashMap<K, DeltaOp> {
+    fn aggregator_v1_delta_set(&self) -> BTreeMap<K, DeltaOp> {
         self.deltas.iter().cloned().collect()
     }
 

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -10,7 +10,7 @@ use aptos_types::{
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
-use std::{collections::HashMap, fmt::Debug};
+use std::{collections::BTreeMap, fmt::Debug};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -78,18 +78,18 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// aggregator_v1.
     fn resource_write_set(
         &self,
-    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+    ) -> BTreeMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
 
     fn module_write_set(
         &self,
-    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+    ) -> BTreeMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
 
     fn aggregator_v1_write_set(
         &self,
-    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+    ) -> BTreeMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
 
     /// Get the aggregator deltas of a transaction from its output.
-    fn aggregator_v1_delta_set(&self) -> HashMap<<Self::Txn as Transaction>::Key, DeltaOp>;
+    fn aggregator_v1_delta_set(&self) -> BTreeMap<<Self::Txn as Transaction>::Key, DeltaOp>;
 
     /// Get the events of a transaction from its output.
     fn get_events(&self) -> Vec<<Self::Txn as Transaction>::Event>;

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -15,7 +15,7 @@ use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;
 use dashmap::DashSet;
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::Debug,
     iter::{empty, Iterator},
     sync::{
@@ -112,7 +112,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 output.module_write_set()
             },
-            ExecutionStatus::Abort(_) => HashMap::new(),
+            ExecutionStatus::Abort(_) => BTreeMap::new(),
         };
 
         if !self.module_read_write_intersection.load(Ordering::Relaxed) {


### PR DESCRIPTION
### Description

Use BTreeMap which provides deterministic ordering instead of HashMap.

Cherry-pick of #10582 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Fixed tests.