### PR TITLE
[agg_v2] categorize all TODOs, and fix a few inline

### DIFF
--- a/aptos-move/aptos-aggregator/Cargo.toml
+++ b/aptos-move/aptos-aggregator/Cargo.toml
@@ -22,6 +22,7 @@ claims = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/aptos-move/aptos-aggregator/src/delayed_change.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_change.rs
@@ -185,7 +185,7 @@ impl<I: Copy + Clone> DelayedChange<I> {
     }
 }
 
-// TODO: See if we need these separate/duplicate classes or not
+// TODO[agg_v2](cleanup): See if we need these separate/duplicate classes or not
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DelayedApplyEntry<I: Clone> {

--- a/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
@@ -19,7 +19,6 @@ fn get_delayed_field_value_from_storage(
     id: &DelayedFieldID,
     resolver: &dyn DelayedFieldResolver,
 ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
-    // TODO transform unexpected errors into PanicError
     resolver
         .get_delayed_field_value(id)
         .map_err(|_err| PanicOr::Or(DelayedFieldsSpeculativeError::NotFound(*id)))

--- a/aptos-move/aptos-aggregator/src/lib.rs
+++ b/aptos-move/aptos-aggregator/src/lib.rs
@@ -7,6 +7,7 @@ pub mod delayed_change;
 pub mod delayed_field_extension;
 pub mod delta_change_set;
 pub mod delta_math;
+mod module;
 pub mod resolver;
 pub mod types;
 pub mod utils;

--- a/aptos-move/aptos-aggregator/src/module.rs
+++ b/aptos-move/aptos-aggregator/src/module.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::account_config::CORE_CODE_ADDRESS;
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::ModuleId};
+use once_cell::sync::Lazy;
+
+pub(crate) const AGGREGATOR_MODULE_IDENTIFIER: &IdentStr = ident_str!("aggregator");
+pub(crate) static AGGREGATOR_MODULE: Lazy<ModuleId> =
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, AGGREGATOR_MODULE_IDENTIFIER.to_owned()));

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -20,7 +20,9 @@ pub fn aggregator_v1_state_key_for_test(key: u128) -> StateKey {
 }
 
 pub struct FakeAggregatorView {
-    // TODO: consider adding deltas to test different read modes.
+    // TODO[agg_v2](test): consider whether it is useful (in addition to tests in view.rs)
+    // to add some DelayedChanges, to have get_delayed_field_value and
+    // delayed_field_try_add_delta_outcome operate on different state
     v1_store: HashMap<StateKey, StateValue>,
     v2_store: HashMap<DelayedFieldID, DelayedFieldValue>,
     counter: RefCell<u32>,

--- a/aptos-move/aptos-aggregator/src/types.rs
+++ b/aptos-move/aptos-aggregator/src/types.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::{bytes_to_string, is_string_layout, string_to_bytes},
 };
 use aptos_logger::error;
-// TODO: After aggregators_v2 branch land, consolidate these, instead of using alias here
+// TODO[agg_v2](cleanup): After aggregators_v2 branch land, consolidate these, instead of using alias here
 pub use aptos_types::aggregator::{DelayedFieldID, PanicError, TryFromMoveValue, TryIntoMoveValue};
 use move_binary_format::errors::PartialVMError;
 use move_core_types::{
@@ -160,7 +160,7 @@ impl NonPanic for DelayedFieldsSpeculativeError {}
 pub enum DelayedFieldValue {
     Aggregator(u128),
     Snapshot(u128),
-    // TODO probably change to Derived(Arc<Vec<u8>>) to make copying predictably costly
+    // TODO[agg_v2](optimize) probably change to Derived(Arc<Vec<u8>>) to make copying predictably costly
     Derived(Vec<u8>),
 }
 
@@ -228,7 +228,8 @@ impl TryIntoMoveValue for DelayedFieldValue {
 impl TryFromMoveValue for DelayedFieldValue {
     type Error = PartialVMError;
     // Need to distinguish between aggregators and snapshots of integer types.
-    // TODO: We only need that because of the current enum-based implementations.
+    // TODO[agg_v2](cleanup): We only need that because of the current enum-based
+    // implementations. See if we want to keep that separation, or clean it up.
     type Hint = IdentifierMappingKind;
 
     fn try_from_move_value(
@@ -261,7 +262,8 @@ impl TryFromMoveValue for DelayedFieldValue {
     }
 }
 
-// TODO see if we need both AggregatorValue and SnapshotValue. Also, maybe they should be nested
+// TODO[agg_v2](cleanup) see if we need both AggregatorValue and SnapshotValue.
+// Or alternatively, maybe they should be nested (i.e. DelayedFieldValue::Snapshot(SnapshotValue))
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SnapshotValue {
     Integer(u128),

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -75,6 +75,7 @@ impl VMOutput {
     /// Materializes delta sets.
     /// Guarantees that if deltas are materialized successfully, the output
     /// has an empty delta set.
+    /// TODO[agg_v2](fix) organize materialization paths better.
     pub fn try_materialize(
         self,
         resolver: &impl AggregatorV1Resolver,
@@ -92,7 +93,7 @@ impl VMOutput {
         let (change_set, fee_statement, status) = self.unpack_with_fee_statement();
         let materialized_change_set =
             change_set.try_materialize_aggregator_v1_delta_set(resolver)?;
-        // TODO do something
+        // TODO[agg_v2](fix) shouldn't be needed when reorganized
         //     .try_materialize_aggregator_v2_changes(state_view)?;
         Ok(VMOutput::new(
             materialized_change_set,

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -69,7 +69,7 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
             .execute_single_transaction(txn, &resolver, &log_context)
         {
             Ok((vm_status, mut vm_output, sender)) => {
-                // TODO: move materialize deltas outside, into sequential execution.
+                // TODO[agg_v2](cleanup): move materialize deltas outside, into sequential execution.
                 if materialize_deltas {
                     vm_output = vm_output
                         .try_materialize(&resolver)

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -101,7 +101,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
         Self::new(executor_view, max_binary_version, resource_group_adapter)
     }
 
-    // TODO(gelash, georgemitenkov): delete after simulation uses block executor.
+    // TODO[agg_v2](fix): delete after simulation uses block executor.
     pub(crate) fn from_borrowed(executor_view: &'e E) -> Self {
         let config_view = ConfigAdapter(executor_view);
         let (_, gas_feature_version) = gas_config(&config_view);
@@ -133,7 +133,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
     ) -> Result<(Option<Bytes>, usize), VMError> {
         let resource_group = get_resource_group_from_metadata(struct_tag, metadata);
         if let Some(resource_group) = resource_group {
-            // TODO pass the layout to resource groups
+            // TODO[agg_v2](fix) pass the layout to resource groups
 
             let key = StateKey::access_path(AccessPath::resource_group_access_path(
                 *address,
@@ -361,7 +361,7 @@ impl<'e, E: ExecutorView> StateValueMetadataResolver for StorageAdapter<'e, E> {
         &self,
         _state_key: &StateKey,
     ) -> anyhow::Result<Option<StateValueMetadataKind>> {
-        // TODO: forward to self.executor_view.
+        // TODO[agg_v2](fix): forward to self.executor_view.
         unimplemented!("Resource group metadata handling not yet implemented");
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -525,5 +525,5 @@ mod test {
         );
     }
 
-    // TODO add delayed field tests
+    // TODO[agg_v2](tests) add delayed field tests
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -292,7 +292,7 @@ impl<'r, 'l> SessionExt<'r, 'l> {
     ///
     /// V1 Resource group change set behavior keeps ops for individual resources separate, not
     /// merging them into the a single op corresponding to the whole resource group (V0).
-    /// TODO: Resource groups are currently not handled correctly in terms of propagating MoveTypeLayout
+    /// TODO[agg_v2](fix) Resource groups are currently not handled correctly in terms of propagating MoveTypeLayout
     fn split_and_merge_resource_groups<C: AccessPathCache>(
         runtime: &MoveVM,
         remote: &dyn AptosMoveResolver,

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -60,7 +60,8 @@ pub(crate) enum DataRead<V> {
     ),
     Metadata(Option<StateValueMetadataKind>),
     Exists(bool),
-    /// Read resolved an aggregatorV1 delta to a value. TODO: deprecate.
+    /// Read resolved an aggregatorV1 delta to a value.
+    /// TODO[agg_v1](cleanup): deprecate.
     Resolved(u128),
 }
 
@@ -236,7 +237,6 @@ impl DelayedFieldRead {
                     max_value: m2,
                 },
             ) => {
-                // TODO see if we want to perform checks on max value/delta
                 if v1 == v2 && m1 == m2 && h1.stricter_than(h2) {
                     DataReadComparison::Contains
                 } else {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -154,7 +154,7 @@ where
 
             let delayed_field_change_set = output.delayed_field_change_set();
 
-            // TODO: see if/how we want to incorporate DeltaHistory from read set into versoined_delayed_fields.
+            // TODO[agg_v2](optimize): see if/how we want to incorporate DeltaHistory from read set into versoined_delayed_fields.
             // Without that, currently materialized reads cannot check history and fail early.
             //
             // We can extract histories with something like the code below,
@@ -171,7 +171,7 @@ where
 
                 let entry = change.into_entry_no_additional_history();
 
-                // TODO: figure out if change should update updates_outside
+                // TODO[agg_v2](optimize): figure out if it is useful for change to update updates_outside
                 if let Err(e) =
                     versioned_cache
                         .delayed_fields()
@@ -272,8 +272,8 @@ where
         }
 
         // Note: we validate delayed field reads only at try_commit.
-        // TODO: potentially add some basic validation.
-        // TODO: potentially add more sophisticated validation, but if it fails,
+        // TODO[agg_v2](optimize): potentially add some basic validation.
+        // TODO[agg_v2](optimize): potentially add more sophisticated validation, but if it fails,
         // we mark it as a soft failure, requires some new statuses in the scheduler
         // (i.e. not re-execute unless some other part of the validation fails or
         // until commit, but mark as estimates).
@@ -558,7 +558,7 @@ where
                 Err(_) => unreachable!("Failed to replace identifiers with values in read set"),
             }
         } else {
-            // TODO: Is this unreachable?
+            // TODO[agg_v2](fix): Is this unreachable?
             unreachable!("Data read value must exist");
         }
     }
@@ -682,8 +682,8 @@ where
                 .data()
                 .materialize_delta(&k, txn_idx)
                 .unwrap_or_else(|op| {
-                    // TODO: this logic should improve with the new AGGR data structure
-                    // TODO: and the ugly base_view parameter will also disappear.
+                    // TODO[agg_v1](cleanup): this logic should improve with the new AGGR data structure
+                    // TODO[agg_v1](cleanup): and the ugly base_view parameter will also disappear.
                     let storage_value = base_view
                         .get_state_value(&k)
                         .expect("Error reading the base value for committed delta in storage");
@@ -993,8 +993,6 @@ where
             unsync_map.write(key, write_op, None);
         }
 
-        // TODO for materialization, we need to understand what we read,
-        // or do exchange on every transaction, so this logic might change
         let mut second_phase = Vec::new();
         let mut updates = HashMap::new();
         for (id, change) in output.delayed_field_change_set().into_iter() {

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -635,9 +635,9 @@ where
 {
     type Txn = MockTransaction<K, V, E>;
 
-    // TODO: Assigning MoveTypeLayout as None for all the writes for now. That means, the
-    // the resources do not have any aggregators embededded in them. Change it to test
-    // resources with aggregators as well.
+    // TODO[agg_v2](tests): Assigning MoveTypeLayout as None for all the writes for now.
+    // That means, the resources do not have any DelayedFields embededded in them.
+    // Change it to test resources with DelayedFields as well.
     fn resource_write_set(&self) -> BTreeMap<K, (V, Option<Arc<MoveTypeLayout>>)> {
         self.writes
             .iter()
@@ -671,11 +671,11 @@ where
         <Self::Txn as Transaction>::Identifier,
         DelayedChange<<Self::Txn as Transaction>::Identifier>,
     > {
-        // TODO: add aggregators V2 to the proptest?
+        // TODO[agg_v2](tests): add aggregators V2 to the proptest?
         BTreeMap::new()
     }
 
-    // TODO: Currently, appending None to all events, which means none of the
+    // TODO[agg_v2](tests): Currently, appending None to all events, which means none of the
     // events have aggregators. Test it with aggregators as well.
     fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
         self.events.iter().map(|e| (e.clone(), None)).collect()
@@ -702,7 +702,7 @@ where
         _patched_events: Vec<<Self::Txn as Transaction>::Event>,
     ) {
         assert_ok!(self.materialized_delta_writes.set(aggregator_v1_writes));
-        // TODO: Set the patched resource write set and events. But that requires the function
+        // TODO[agg_v2](tests): Set the patched resource write set and events. But that requires the function
         // to take &mut self as input
     }
 

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -138,7 +138,8 @@ enum ExecutionStatus {
     Executing(Incarnation),
     Suspended(Incarnation, DependencyCondvar),
     Executed(Incarnation),
-    // TODO: rename to Finalized or ReadyToCommit / CommitReady? it gets committed later, without scheduler tracking.
+    // TODO[agg_v2](cleanup): rename to Finalized or ReadyToCommit / CommitReady?
+    // it gets committed later, without scheduler tracking.
     Committed(Incarnation),
     Aborting(Incarnation),
     ExecutionHalted,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -79,7 +79,7 @@ impl ReadResult {
         match data {
             DataRead::Versioned(_, v, layout) => ReadResult::Value(v.as_state_value(), layout),
             DataRead::Resolved(v) => {
-                // TODO confirm None layout for V1 aggregators is OK
+                // TODO[agg_v1](cleanup): Move AggV1 to Delayed fields, and then handle the layout if needed
                 ReadResult::Value(Some(StateValue::new_legacy(serialize(&v).into())), None)
             },
             DataRead::Metadata(maybe_metadata) => ReadResult::Metadata(maybe_metadata),
@@ -137,7 +137,7 @@ fn get_delayed_field_value_impl<T: Transaction>(
             },
             Err(PanicOr::Or(MVDelayedFieldsError::Dependency(dep_idx))) => {
                 if !wait_for_dependency(wait_for, txn_idx, dep_idx) {
-                    // TODO think of correct return type
+                    // TODO[agg_v2](cleanup): think of correct return type
                     return Err(PanicOr::Or(DelayedFieldsSpeculativeError::InconsistentRead));
                 }
             },
@@ -145,7 +145,7 @@ fn get_delayed_field_value_impl<T: Transaction>(
                 captured_reads
                     .borrow_mut()
                     .capture_delayed_field_read_error(&e);
-                // TODO think of correct return type
+                // TODO[agg_v2](cleanup): think of correct return type
                 return Err(e.map_non_panic(|_| DelayedFieldsSpeculativeError::InconsistentRead));
             },
         }
@@ -231,7 +231,8 @@ fn compute_delayed_field_try_add_delta_outcome_first_time(
         inner_aggregator_value: base_aggregator_value,
     }))
 }
-// TODO: see about simplifying / split with CapturedReads
+// TODO[agg_v2](cleanup): see about the split with CapturedReads,
+// and whether anything should be moved there.
 fn delayed_field_try_add_delta_outcome_impl<T: Transaction>(
     captured_reads: &RefCell<CapturedReads<T>>,
     versioned_delayed_fields: &dyn TVersionedDelayedFieldView<T::Identifier>,
@@ -302,7 +303,7 @@ fn delayed_field_try_add_delta_outcome_impl<T: Transaction>(
                     Ok(v) => break v,
                     Err(MVDelayedFieldsError::Dependency(dep_idx)) => {
                         if !wait_for_dependency(wait_for, txn_idx, dep_idx) {
-                            // TODO think of correct return type
+                            // TODO[agg_v2](cleanup): think of correct return type
                             return Err(PanicOr::Or(
                                 DelayedFieldsSpeculativeError::InconsistentRead,
                             ));
@@ -650,7 +651,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                             match res {
                                 Ok((value, _)) => Some(value),
                                 Err(err) => {
-                                    // TODO(aggregator): This means replacement failed
+                                    // TODO[agg_v2](fix): This means replacement failed
                                     //       and most likely there is a bug. Log the error
                                     //       for now, and add recovery mechanism later.
                                     let log_context = AdapterLogSchema::new(
@@ -701,8 +702,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             },
             ViewState::Unsync(state) => {
                 let ret = match state.unsync_map.fetch_data(state_key) {
-                    // TODO: Should we ignore the layout from fetch_data?
-                    // What if it doesn't match with the maybe_layout given as input to this function?
+                    // TODO[agg_v2](fix): Add a check that layout matches from the one from fetch_data
                     Some((v, _)) => {
                         state.read_set.borrow_mut().insert(state_key.clone());
                         Ok(v.as_state_value())
@@ -754,8 +754,9 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                     },
                 };
                 ret.map(|maybe_state_value| match kind {
-                    // TODO: check if we need to track layout for unsync
-                    ReadKind::Value => ReadResult::Value(maybe_state_value, None),
+                    ReadKind::Value => {
+                        ReadResult::Value(maybe_state_value, maybe_layout.cloned().map(Arc::new))
+                    },
                     ReadKind::Metadata => {
                         ReadResult::Metadata(maybe_state_value.map(StateValue::into_metadata))
                     },
@@ -791,7 +792,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceVi
         &self,
         state_key: &Self::Key,
     ) -> anyhow::Result<Option<StateValueMetadataKind>> {
-        // TODO check that passing None here is correct
+        // TODO[agg_v2](fix) check that passing None here is correct
         self.get_resource_state_value_impl(state_key, None, ReadKind::Metadata)
             .map(|res| {
                 if let ReadResult::Metadata(v) = res {
@@ -908,9 +909,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TAggregator
         &self,
         state_key: &Self::Identifier,
     ) -> anyhow::Result<Option<StateValue>> {
-        // TODO: Integrate aggregators V1. That is, we can lift the u128 value
-        //       from the state item by passing the right layout here. This can
-        //       be useful for cross-testing the old and the new flows.
+        // TODO[agg_v1](cleanup):
+        // Integrate aggregators V1. That is, we can lift the u128 value
+        // from the state item by passing the right layout here. This can
+        // be useful for cross-testing the old and the new flows.
         // self.get_resource_state_value(state_key, Some(&MoveTypeLayout::U128))
         self.get_resource_state_value(state_key, None)
     }

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -115,7 +115,7 @@ mod test_cases {
 
         run_block_in_parts(&mut h.harness, BlockSplit::Whole, txns);
 
-        // TODO: proptests with random transaction generator might be useful here.
+        // TODO[agg_v2](test): proptests with random transaction generator might be useful here.
         let txns = (0..block_size)
             .map(|i| match i % 4 {
                 0 => (
@@ -295,7 +295,7 @@ fn arb_use_type() -> BoxedStrategy<UseType> {
     prop_oneof![
         Just(UseType::UseResourceType),
         Just(UseType::UseTableType),
-        // TODO add back once ResourceGroups are supported
+        // TODO[agg_v2](fix) add back once ResourceGroups are supported
         // Just(UseType::UseResourceGroupType),
     ]
     .boxed()
@@ -305,8 +305,9 @@ proptest! {
     #![proptest_config(ProptestConfig {
         // Cases are expensive, few cases is enough.
         // We will test a few more comprehensive tests more times, and the rest even fewer.
-        cases: 200,
-        // result_cache: prop::test_runner::basic_result_cache,
+        // when trying to stress-test, increase (to 200 or more), and disable result cache.
+        cases: 10,
+        result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 
@@ -405,8 +406,9 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig {
         // Cases are expensive, few cases is enough for these
-        cases: 200,
-        // result_cache: prop::test_runner::basic_result_cache,
+        // when trying to stress-test, increase (to 200 or more), and disable result cache.
+        cases: 5,
+        result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 

--- a/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
@@ -34,6 +34,7 @@ operation that also reduced parallelism, and should be avoided as much as possib
 -  [Function `test_aggregator_valid_type`](#0x1_aggregator_v2_test_aggregator_valid_type)
 -  [Specification](#@Specification_1)
     -  [Function `create_aggregator`](#@Specification_1_create_aggregator)
+    -  [Function `create_unbounded_aggregator`](#@Specification_1_create_unbounded_aggregator)
     -  [Function `try_add`](#@Specification_1_try_add)
     -  [Function `try_sub`](#@Specification_1_try_sub)
     -  [Function `read`](#@Specification_1_read)
@@ -553,6 +554,22 @@ If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(max_value: IntElement): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_create_unbounded_aggregator"></a>
+
+### Function `create_unbounded_aggregator`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement: <b>copy</b>, drop&gt;(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.spec.move
@@ -4,10 +4,10 @@ spec aptos_framework::aggregator_v2 {
         pragma opaque;
     }
 
-    // spec create_unbounded_aggregator {
-    //     // TODO: temporary mockup.
-    //     pragma opaque;
-    // }
+    spec create_unbounded_aggregator {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
 
     spec try_add {
         // TODO: temporary mockup.

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -305,7 +305,8 @@ fn native_format_impl(
         },
         MoveTypeLayout::Tagged(tag, ty) => match tag {
             // There is no need to show any lifting information!
-            // TODO(aggregator): How does printing work with ephemeral identifiers?
+            // TODO[agg_v2](cleanup): How does printing work with ephemeral identifiers?
+            // Can we modify this to print tagging info, or is this something that cannot be changed
             LayoutTag::IdentifierMapping(_) => native_format_impl(context, ty, val, depth, out)?,
         },
     };

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -137,8 +137,6 @@ impl<'a> NativeTableContext<'a> {
                     None => continue,
                 };
 
-                // TODO(aggregator): we should attach type layout to the outputs
-                // if there are lifted values.
                 match op {
                     Op::New(val) => {
                         let bytes = serialize(&value_layout_info.layout, &val)?;

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -87,8 +87,8 @@ pub enum MVModulesOutput<M, X> {
     Module((Arc<M>, HashValue)),
 }
 
-// TODO: once VersionedAggregators is separated from the MVHashMap, seems that
-// MVDataError and MVModulesError can be unified and simplified.
+// TODO[agg_v2](cleanup): once VersionedAggregators is separated from the MVHashMap,
+// seems that MVDataError and MVModulesError can be unified and simplified.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MVDelayedFieldsError {
     /// No prior entry is found. This can happen if the aggregator was created

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -39,7 +39,7 @@ fn unsync_map_data_basic() {
     // Reads that should go the DB return None
     assert_none!(map.fetch_data(&ap));
     // Ensure write registers the new value.
-    //TODO: Hardocoding layout to None. Test when layout is Some(.) as well.
+    //TODO[agg_v2](tests): Hardocoding layout to None. Test when layout is Some(.) as well.
     map.write(ap.clone(), value_for(10, 1), None);
     assert_some_eq!(map.fetch_data(&ap), (Arc::new(value_for(10, 1)), None));
     // Ensure the next write overwrites the value.

--- a/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
+++ b/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
@@ -125,7 +125,13 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
         self.read_estimate_deltas = false;
     }
 
-    fn insert(&mut self, txn_idx: TxnIndex, entry: VersionEntry<K>) {
+    // Insert value computed from speculative transaction execution,
+    // potentially overwritting a previous entry.
+    fn insert_speculative_value(
+        &mut self,
+        txn_idx: TxnIndex,
+        entry: VersionEntry<K>,
+    ) -> Result<(), PanicError> {
         use EstimatedEntry::*;
         use VersionEntry::*;
 
@@ -143,11 +149,10 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
                         if variant_eq(apply_l, apply_r) {
                             *apply_l == *apply_r
                         } else {
-                            // TODO: change to code_invariant_error
-                            unreachable!(
+                            return Err(code_invariant_error(format!(
                                 "Storing {:?} for aggregator ID that previously had a different type of entry - {:?}",
                                 apply_r, apply_l,
-                            )
+                            )));
                         }
                     },
                     // There was a value without fallback delta bypass before and still.
@@ -155,12 +160,14 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
                     // Bypass stored in the estimate does not match the new entry.
                     (Estimate(_), _) => false,
 
-                    // TODO: change to code_invariant_error
                     (cur, new) => {
-                        unreachable!("Replaced entry must be an Estimate, {:?} to {:?}", cur, new,)
+                        return Err(code_invariant_error(format!(
+                            "Replaced entry must be an Estimate, {:?} to {:?}",
+                            cur, new,
+                        )))
                     },
                 } {
-                    // TODO: handle invalidation when we change read_estimate_deltas
+                    // TODO[agg_v2](fix): handle invalidation when we change read_estimate_deltas
                     self.read_estimate_deltas = false;
                 }
                 o.insert(CachePadded::new(entry));
@@ -169,6 +176,7 @@ impl<K: Copy + Clone + Debug + Eq> VersionedValue<K> {
                 v.insert(CachePadded::new(entry));
             },
         }
+        Ok(())
     }
 
     fn insert_final_value(&mut self, txn_idx: TxnIndex, value: DelayedFieldValue) {
@@ -404,7 +412,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedDelayedFields<K> {
         value: DelayedFieldValue,
     ) -> Result<(), PanicError> {
         let mut created = VersionedValue::new(None);
-        created.insert(txn_idx, VersionEntry::Value(value, None));
+        created.insert_speculative_value(txn_idx, VersionEntry::Value(value, None))?;
 
         if self.values.insert(id, created).is_some() {
             Err(code_invariant_error(
@@ -425,7 +433,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedDelayedFields<K> {
         apply: DelayedApplyEntry<K>,
     ) -> Result<(), PanicError> {
         let mut created = VersionedValue::new(None);
-        created.insert(txn_idx, VersionEntry::Apply(apply));
+        created.insert_speculative_value(txn_idx, VersionEntry::Apply(apply))?;
 
         if self.values.insert(id, created).is_some() {
             Err(code_invariant_error("VersionedValue when initializing dependent delayed field may not already exist for same id"))
@@ -447,7 +455,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedDelayedFields<K> {
                     .values
                     .get_mut(&id)
                     .ok_or(PanicOr::Or(MVDelayedFieldsError::NotFound))?
-                    .insert(txn_idx, VersionEntry::Apply(apply)),
+                    .insert_speculative_value(txn_idx, VersionEntry::Apply(apply))?,
                 DelayedApplyEntry::SnapshotDelta { .. }
                 | DelayedApplyEntry::SnapshotDerived { .. } => {
                     self.initialize_dependent_delayed_field(id, txn_idx, apply)?
@@ -617,15 +625,12 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedDelayedFields<K> {
 
         Ok(())
     }
-}
 
-impl<K: Eq + Hash + Clone + Debug + Copy> TVersionedDelayedFieldView<K>
-    for VersionedDelayedFields<K>
-{
-    fn read(
+    fn read_checked_depth(
         &self,
         id: &K,
         txn_idx: TxnIndex,
+        cur_depth: usize,
     ) -> Result<DelayedFieldValue, PanicOr<MVDelayedFieldsError>> {
         let read_res = self
             .values
@@ -646,15 +651,35 @@ impl<K: Eq + Hash + Clone + Debug + Copy> TVersionedDelayedFieldView<K>
                     .into());
                 }
 
+                if cur_depth > 2 {
+                    return Err(code_invariant_error(format!(
+                        "Recursive depth for read(), {:?} for {:?}",
+                        VersionedRead::DependentApply(dependent_id, dependent_txn_idx, apply),
+                        id
+                    ))
+                    .into());
+                }
                 // Read the source aggregator of snapshot.
-                // TODO: check/limit recursion depth is not more than 2
-                let source_value = self.read(&dependent_id, dependent_txn_idx)?;
+                let source_value =
+                    self.read_checked_depth(&dependent_id, dependent_txn_idx, cur_depth + 1)?;
 
                 apply
                     .apply_to_base(source_value)
                     .map_err(MVDelayedFieldsError::from_panic_or)
             },
         }
+    }
+}
+
+impl<K: Eq + Hash + Clone + Debug + Copy> TVersionedDelayedFieldView<K>
+    for VersionedDelayedFields<K>
+{
+    fn read(
+        &self,
+        id: &K,
+        txn_idx: TxnIndex,
+    ) -> Result<DelayedFieldValue, PanicOr<MVDelayedFieldsError>> {
+        self.read_checked_depth(id, txn_idx, 0)
     }
 
     /// Returns the committed value from largest transaction index that is
@@ -864,10 +889,10 @@ mod test {
     fn mark_estimate_no_entry(type_index: usize) {
         let mut v = VersionedValue::new(None);
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(10, entry);
+            v.insert_speculative_value(10, entry).unwrap();
         }
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(3, entry);
+            v.insert_speculative_value(3, entry).unwrap();
         }
         v.mark_estimate(5);
     }
@@ -876,7 +901,8 @@ mod test {
     #[test]
     fn mark_estimate_wrong_entry() {
         let mut v = VersionedValue::new(None);
-        v.insert(3, aggregator_entry(VALUE_AGGREGATOR).unwrap());
+        v.insert_speculative_value(3, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
         v.mark_estimate(3);
 
         // Marking an Estimate (first we confirm) as estimate is not allowed.
@@ -894,22 +920,27 @@ mod test {
     #[test]
     fn insert_estimate() {
         let mut v = VersionedValue::new(None);
-        v.insert(3, aggregator_entry(ESTIMATE_NO_BYPASS).unwrap());
+        v.insert_speculative_value(3, aggregator_entry(ESTIMATE_NO_BYPASS).unwrap())
+            .unwrap();
     }
 
     #[test]
     fn estimate_bypass() {
         let mut v = VersionedValue::new(None);
-        v.insert(2, aggregator_entry(VALUE_AGGREGATOR).unwrap());
-        v.insert(
+        v.insert_speculative_value(2, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(
             3,
             aggregator_entry_aggregator_value_and_delta(15, test_delta()),
-        );
-        v.insert(4, aggregator_entry(APPLY_AGGREGATOR).unwrap());
-        v.insert(
+        )
+        .unwrap();
+        v.insert_speculative_value(4, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(
             10,
             aggregator_entry_aggregator_value_and_delta(15, test_delta()),
-        );
+        )
+        .unwrap();
 
         // Delta + Value(15)
         assert_read_aggregator_value!(v.read(5), 45);
@@ -950,20 +981,24 @@ mod test {
         // Next, ensure read_estimate_deltas remains true if entries are overwritten
         // with matching deltas. Check at each point to not rely on the invariant that
         // read_estimate_deltas can only become false from true.
-        v.insert(2, aggregator_entry(VALUE_AGGREGATOR).unwrap());
+        v.insert_speculative_value(2, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
         assert!(v.read_estimate_deltas);
-        v.insert(
+        v.insert_speculative_value(
             3,
             aggregator_entry_aggregator_value_and_delta(15, test_delta()),
-        );
+        )
+        .unwrap();
         assert!(v.read_estimate_deltas);
-        v.insert(4, aggregator_entry(APPLY_AGGREGATOR).unwrap());
+        v.insert_speculative_value(4, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
         assert!(v.read_estimate_deltas);
 
         // Previously value with delta fallback was converted to the delta bypass in
         // the Estimate. It can match a delta too and not disable read_estimate_deltas.
         v.mark_estimate(10);
-        v.insert(10, aggregator_entry(APPLY_AGGREGATOR).unwrap());
+        v.insert_speculative_value(10, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
         assert!(v.read_estimate_deltas);
     }
 
@@ -972,7 +1007,8 @@ mod test {
         {
             let mut v = VersionedValue::new(None);
 
-            v.insert(6, aggregator_entry(VALUE_SNAPSHOT).unwrap());
+            v.insert_speculative_value(6, aggregator_entry(VALUE_SNAPSHOT).unwrap())
+                .unwrap();
             assert_read_snapshot_value!(v.read(7), 13);
 
             v.mark_estimate(6);
@@ -987,10 +1023,11 @@ mod test {
 
         {
             let mut v = VersionedValue::new(None);
-            v.insert(
+            v.insert_speculative_value(
                 8,
                 aggregator_entry_snapshot_value_and_delta(13, test_delta(), DelayedFieldID::new(2)),
-            );
+            )
+            .unwrap();
 
             assert_read_snapshot_value!(v.read(9), 13);
 
@@ -1006,14 +1043,16 @@ mod test {
 
             assert_read_snapshot_dependent_apply!(v.read(9), 2, 8, test_delta());
 
-            v.insert(6, aggregator_entry(VALUE_SNAPSHOT).unwrap());
+            v.insert_speculative_value(6, aggregator_entry(VALUE_SNAPSHOT).unwrap())
+                .unwrap();
             assert!(v.read_estimate_deltas);
         }
 
         {
             // old value shouldn't affect snapshot computation, as it depends on aggregator value.
             let mut v = VersionedValue::new(Some(DelayedFieldValue::Snapshot(3)));
-            v.insert(10, aggregator_entry(APPLY_SNAPSHOT).unwrap());
+            v.insert_speculative_value(10, aggregator_entry(APPLY_SNAPSHOT).unwrap())
+                .unwrap();
 
             assert_read_snapshot_dependent_apply!(v.read(12), 2, 10, test_delta());
         }
@@ -1024,7 +1063,8 @@ mod test {
         {
             let mut v = VersionedValue::new(None);
 
-            v.insert(6, aggregator_entry(VALUE_DERIVED).unwrap());
+            v.insert_speculative_value(6, aggregator_entry(VALUE_DERIVED).unwrap())
+                .unwrap();
             assert_read_derived_value!(v.read(7), vec![70, 80, 90]);
 
             v.mark_estimate(6);
@@ -1039,14 +1079,15 @@ mod test {
 
         {
             let mut v = VersionedValue::new(None);
-            v.insert(
+            v.insert_speculative_value(
                 8,
                 aggregator_entry_derived_value_and_delta(
                     vec![70, 80, 90],
                     test_formula(),
                     DelayedFieldID::new(3),
                 ),
-            );
+            )
+            .unwrap();
 
             assert_read_derived_value!(v.read(10), vec![70, 80, 90]);
 
@@ -1062,14 +1103,16 @@ mod test {
 
             assert_read_derived_dependent_apply!(v.read(10), 3, 9, test_formula());
 
-            v.insert(6, aggregator_entry(VALUE_SNAPSHOT).unwrap());
+            v.insert_speculative_value(6, aggregator_entry(VALUE_SNAPSHOT).unwrap())
+                .unwrap();
             assert!(v.read_estimate_deltas);
         }
 
         {
             // old value shouldn't affect derived computation, as it depends on Snapshot value.
             let mut v = VersionedValue::new(Some(DelayedFieldValue::Derived(vec![80])));
-            v.insert(10, aggregator_entry(APPLY_DERIVED).unwrap());
+            v.insert_speculative_value(10, aggregator_entry(APPLY_DERIVED).unwrap())
+                .unwrap();
 
             assert_read_derived_dependent_apply!(v.read(12), 3, 11, test_formula());
         }
@@ -1086,7 +1129,7 @@ mod test {
     fn remove_non_estimate(type_index: usize) {
         let mut v = VersionedValue::new(None);
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(10, entry);
+            v.insert_speculative_value(10, entry).unwrap();
         }
         v.remove(10);
     }
@@ -1094,7 +1137,8 @@ mod test {
     #[test]
     fn remove_estimate() {
         let mut v = VersionedValue::new(None);
-        v.insert(3, aggregator_entry(VALUE_AGGREGATOR).unwrap());
+        v.insert_speculative_value(3, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
         v.mark_estimate(3);
         v.remove(3);
         assert!(!v.read_estimate_deltas);
@@ -1107,12 +1151,12 @@ mod test {
     fn insert_twice_no_value(type_index: usize) {
         let mut v = VersionedValue::new(None);
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(10, entry);
+            v.insert_speculative_value(10, entry).unwrap();
         }
         // Should fail because inserting can only overwrite an Estimate entry or
         // be inserting a Value when the transaction commits.
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(10, entry);
+            v.insert_speculative_value(10, entry).unwrap();
         }
     }
 
@@ -1123,7 +1167,7 @@ mod test {
     fn read_committed_not_value(type_index: usize) {
         let mut v = VersionedValue::new(None);
         if let Some(entry) = aggregator_entry(type_index) {
-            v.insert(10, entry);
+            v.insert_speculative_value(10, entry).unwrap();
         }
         let _ = v.read_latest_committed_value(11);
     }
@@ -1132,7 +1176,8 @@ mod test {
     #[test]
     fn read_committed_estimate() {
         let mut v = VersionedValue::new(None);
-        v.insert(3, aggregator_entry(VALUE_AGGREGATOR).unwrap());
+        v.insert_speculative_value(3, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
         v.mark_estimate(3);
         let _ = v.read_latest_committed_value(11);
     }
@@ -1140,11 +1185,13 @@ mod test {
     #[test]
     fn read_latest_committed_value() {
         let mut v = VersionedValue::new(Some(DelayedFieldValue::Aggregator(5)));
-        v.insert(2, aggregator_entry(VALUE_AGGREGATOR).unwrap());
-        v.insert(
+        v.insert_speculative_value(2, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(
             4,
             aggregator_entry_aggregator_value_and_delta(15, test_delta()),
-        );
+        )
+        .unwrap();
 
         assert_ok_eq!(
             v.read_latest_committed_value(5),
@@ -1163,10 +1210,14 @@ mod test {
     #[test]
     fn read_delta_chain() {
         let mut v = VersionedValue::new(Some(DelayedFieldValue::Aggregator(5)));
-        v.insert(4, aggregator_entry(APPLY_AGGREGATOR).unwrap());
-        v.insert(8, aggregator_entry(APPLY_AGGREGATOR).unwrap());
-        v.insert(12, aggregator_entry(APPLY_AGGREGATOR).unwrap());
-        v.insert(16, aggregator_entry(APPLY_AGGREGATOR).unwrap());
+        v.insert_speculative_value(4, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(8, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(12, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
+        v.insert_speculative_value(16, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap();
 
         assert_read_aggregator_value!(v.read(0), 5);
         assert_read_aggregator_value!(v.read(5), 35);
@@ -1178,34 +1229,38 @@ mod test {
     #[test]
     fn read_errors() {
         let mut v = VersionedValue::new(None);
-        v.insert(2, aggregator_entry(VALUE_AGGREGATOR).unwrap());
+        v.insert_speculative_value(2, aggregator_entry(VALUE_AGGREGATOR).unwrap())
+            .unwrap();
 
         assert_err_eq!(v.read(1), PanicOr::Or(MVDelayedFieldsError::NotFound));
 
-        v.insert(
+        v.insert_speculative_value(
             8,
             VersionEntry::Apply(DelayedApplyEntry::AggregatorDelta {
                 delta: negative_delta(),
             }),
-        );
+        )
+        .unwrap();
         assert_err_eq!(
             v.read(9),
             PanicOr::Or(MVDelayedFieldsError::DeltaApplicationFailure)
         );
         // Ensure without underflow there would not be a failure.
 
-        v.insert(4, aggregator_entry(APPLY_AGGREGATOR).unwrap()); // adds 30.
+        v.insert_speculative_value(4, aggregator_entry(APPLY_AGGREGATOR).unwrap())
+            .unwrap(); // adds 30.
         assert_read_aggregator_value!(v.read(9), 10);
 
-        v.insert(
+        v.insert_speculative_value(
             6,
             VersionEntry::Value(DelayedFieldValue::Aggregator(35), None),
-        );
+        )
+        .unwrap();
         assert_read_aggregator_value!(v.read(9), 5);
 
         v.mark_estimate(2);
         assert_err_eq!(v.read(3), PanicOr::Or(MVDelayedFieldsError::Dependency(2)));
     }
 
-    // TODO : add tests for try-commit
+    // TODO[agg_v2](tests): add tests for try-commit
 }

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -80,7 +80,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
     fn set_base_values(
         &mut self,
         shifted_idx: ShiftedTxnIndex,
-        // TODO add layout to values
+        // TODO[agg_v2](fix) add layout to values
         values: impl IntoIterator<Item = (T, V)>,
     ) {
         match self.idx_to_update.get(&shifted_idx) {
@@ -109,7 +109,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
         &mut self,
         shifted_idx: ShiftedTxnIndex,
         incarnation: Incarnation,
-        // TODO add layout to values
+        // TODO[agg_v2](fix) add layout to values
         values: impl IntoIterator<Item = (T, V)>,
     ) {
         let arc_map = values
@@ -121,7 +121,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                 let tag_entry = self.versioned_map.entry(tag.clone()).or_default();
                 tag_entry.insert(
                     shifted_idx.clone(),
-                    // TODO layout shouldn't be none
+                    // TODO[agg_v2](fix) layout shouldn't be none
                     CachePadded::new(GroupEntry::new(incarnation, arc_v.clone(), None)),
                 );
 

--- a/third_party/move/move-core/types/src/resolver.rs
+++ b/third_party/move/move-core/types/src/resolver.rs
@@ -42,7 +42,7 @@ pub fn resource_size(resource: &Option<Bytes>) -> usize {
 ///                       are always structurally valid)
 ///                    - storage encounters internal error
 pub trait ResourceResolver {
-    // TODO: this can return Value, so that we can push deserialization to
+    // TODO[move_values](optimize): this can return Value, so that we can push deserialization to
     // implementations of `ResourceResolver`.
     fn get_resource_bytes_with_metadata_and_layout(
         &self,

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1953,7 +1953,7 @@ impl Loader {
         Ok((struct_layout, has_identifier_mappings))
     }
 
-    // TODO(aggregator):
+    // TODO[agg_v2](cleanup):
     // Currently aggregator checks are hardcoded and leaking to loader.
     // It seems that this is only because there is no support for native
     // types.
@@ -2042,14 +2042,14 @@ impl Loader {
             },
             Type::Struct { name, .. } => {
                 *count += 1;
-                // TODO why does struct not increase depth?
+                // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
                     self.struct_name_to_type_layout(name, &[], count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)
             },
             Type::StructInstantiation { name, ty_args, .. } => {
                 *count += 1;
-                // TODO why does struct not increase depth?
+                // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
                     self.struct_name_to_type_layout(name, ty_args, count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -3053,7 +3053,7 @@ impl<'t, 'l, 'v> serde::Serialize for AnnotatedValue<'t, 'l, 'v, MoveTypeLayout,
                 Some(transformation) if transformation.matches(tag) => {
                     // If values are supposed to be transformed, first clone
                     // ValueImpl to construct a Value.
-                    // TODO: Clone is cheap for current use cases, revisit if needed.
+                    // TODO[agg_v2](optimize)(?): Clone is cheap for current use cases, revisit if needed.
                     let value_to_transform =
                         Value(value_impl.copy_value().map_err(serde::ser::Error::custom)?);
                     let transformed_value = transformation


### PR DESCRIPTION
squashed all changes on our branch, and searched for every TODO

Categorized into
* fix - needed before we can enable agg_v2
* cleanup - what we can get to later
* test - unit tests we want to add

take a look through each, and add more context if it's missing from the comment

all todos are either TODO[agg_v2] or TODO[agg_v1] so we can search them easily

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
