### PR TITLE
Visibility Analysis for compiler v2

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -75,7 +75,7 @@ pub struct ModuleGenerator {
     pub source_map: SourceMap,
 }
 
-/// Immutable context for a module code generation, seperated from the mutable generator
+/// Immutable context for a module code generation, separated from the mutable generator
 /// state to reduce borrow conflicts.
 #[derive(Debug, Clone)]
 pub struct ModuleContext<'env> {

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -2,3 +2,4 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 pub mod livevar_analysis_processor;
+pub mod visibility_checker;

--- a/third_party/move/move-compiler-v2/src/pipeline/visibility_checker.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/visibility_checker.rs
@@ -1,0 +1,96 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements a visibility checker, checking for visibility violations at function callsites.
+
+use move_binary_format::file_format::Visibility;
+use move_model::model::FunctionEnv;
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{Bytecode, Operation},
+};
+pub struct VisibilityChecker();
+
+impl FunctionTargetProcessor for VisibilityChecker {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv,
+        data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if fun_env.is_native() {
+            // We don't have to look inside native functions.
+            return data;
+        }
+        let func_target = FunctionTarget::new(fun_env, &data);
+        let global_env = func_target.global_env();
+        let caller_mod_name = func_target.module_env().get_name();
+        let caller_mod_id = func_target.module_env().get_id();
+        for bytecode in func_target.get_bytecode() {
+            if let Bytecode::Call(
+                attr_id,
+                _,
+                Operation::Function(callee_mod_id, callee_fun_id, _),
+                _,
+                _,
+            ) = bytecode
+            {
+                if *callee_mod_id == caller_mod_id {
+                    // If the callee is in the same module as the caller, it is visible.
+                    continue;
+                }
+                let callee_env = global_env.get_function(callee_mod_id.qualified(*callee_fun_id));
+                match callee_env.visibility() {
+                    Visibility::Public => {
+                        // Public functions are visible from any caller.
+                        continue;
+                    },
+                    _ if func_target.module_env().is_script_module() => {
+                        // Only public functions are visible from scripts.
+                        global_env.error(
+                            &func_target.get_bytecode_loc(*attr_id),
+                            &format!(
+                                "function `{}` cannot be called from a script, because it is not public",
+                                callee_env.get_full_name_with_address()
+                            ),
+                        );
+                    },
+                    Visibility::Friend => {
+                        // Friend functions are visible from a caller whose module is a friend of the callee's module.
+                        // For the purposes of this check, we assume friend declarations are valid.
+                        // Validity of friend declarations should be checked elsewhere.
+                        if !callee_env.module_env.has_friend(&caller_mod_id) {
+                            global_env.error(
+                                &func_target.get_bytecode_loc(*attr_id),
+                                &format!(
+                                    "friend function `{}` cannot be called here because `{}` is not a friend of `{}`",
+                                    callee_env.get_full_name_with_address(),
+                                    caller_mod_name.display_full(global_env),
+                                    callee_env.module_env.get_full_name_str()
+                                ),
+                            );
+                        }
+                    },
+                    Visibility::Private => {
+                        // Private functions are not visible outside of the callee's module.
+                        global_env.error(
+                            &func_target.get_bytecode_loc(*attr_id),
+                            &format!(
+                                "function `{}` cannot be called here because it is private to module `{}`",
+                                callee_env.get_full_name_with_address(),
+                                callee_env.module_env.get_full_name_str()
+                            ),
+                        );
+                    },
+                }
+            }
+        }
+        data
+    }
+
+    fn name(&self) -> String {
+        "VisibilityChecker".to_owned()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_internal.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_internal.exp
@@ -1,12 +1,13 @@
-// ---- Model Dump
-module 0x2::X {
-} // end 0x2::X
-module 0x2::M {
-    use 0x2::X::{Self, C}; // resolved as: 0x2::X
-    private fun foo() {
-        0;
-        0;
-        Tuple()
-    }
-    spec fun $foo();
-} // end 0x2::M
+
+Diagnostics:
+error: constant `0x2::X::C` cannot be used here because it is private to the module `0x2::X`
+   ┌─ tests/checking/typing/constant_internal.move:10:9
+   │
+10 │         X::C;
+   │         ^^^^
+
+error: constant `0x2::X::C` cannot be used here because it is private to the module `0x2::X`
+   ┌─ tests/checking/typing/constant_internal.move:11:9
+   │
+11 │         C;
+   │         ^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/call_friend_only.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/call_friend_only.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: friend function `0xdeadbeef::M::id` cannot be called here because `0xdeadbeef::Q` is not a friend of `0xdeadbeef::M`
+   ┌─ tests/visibility-checker/call_friend_only.move:46:9
+   │
+46 │         M::id(5) + bar()
+   │         ^^^^^^^^
+
+error: friend function `0xdeadbeef::M::bar` cannot be called here because `0xdeadbeef::Q` is not a friend of `0xdeadbeef::M`
+   ┌─ tests/visibility-checker/call_friend_only.move:46:20
+   │
+46 │         M::id(5) + bar()
+   │                    ^^^^^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/call_friend_only.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/call_friend_only.move
@@ -1,0 +1,48 @@
+module 0xdeadbeef::M {
+    friend 0xdeadbeef::N;
+    use 0xdeadbeef::O as OO;
+    use 0xdeadbeef::P;
+    friend OO;
+    friend P;
+    fun foo(): u64 { 1 }
+
+    public(friend) fun bar(): u64 { foo() }
+    public(friend) fun id<T>(x: T): T { x  }
+}
+
+module 0xdeadbeef::N {
+    fun foo(): u64 { 2 }
+
+    fun calls_bar(): u64 {
+        0xdeadbeef::M::bar() + 0xdeadbeef::M::id(foo())
+    }
+}
+
+module 0xdeadbeef::O {
+    use 0xdeadbeef::M as MM;
+    use 0xdeadbeef::M::bar;
+    use 0xdeadbeef::M::bar as mbar;
+
+    fun foo(): u64 { 3 }
+
+    fun calls_bar(): u64 {
+        MM::bar() + MM::id(foo()) + mbar() + bar()
+    }
+}
+
+module 0xdeadbeef::P {
+    use 0xdeadbeef::M;
+    fun my_foo(): u64 { 4 }
+
+    fun calls_bar(): u64 {
+        M::bar() + M::id(my_foo()) + 0xdeadbeef::M::bar()
+    }
+}
+
+module 0xdeadbeef::Q {
+    use 0xdeadbeef::M::{Self, bar};
+
+    fun calls_bar(): u64 {
+        M::id(5) + bar()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/call_private_function.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/call_private_function.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: function `0xdeadbeef::M::foo` cannot be called here because it is private to module `0xdeadbeef::M`
+  ┌─ tests/visibility-checker/call_private_function.move:9:9
+  │
+9 │         0xdeadbeef::M::foo() + my_foo()
+  │         ^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/call_private_function.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/call_private_function.move
@@ -1,0 +1,11 @@
+module 0xdeadbeef::M {
+    fun foo(): u64 { 1 }
+}
+
+module 0xdeadbeef::N {
+    fun my_foo(): u64 { 2 }
+
+    fun calls_foo(): u64 {
+        0xdeadbeef::M::foo() + my_foo()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/constant_use_across_mod.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/constant_use_across_mod.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: constant `0xdeadbeef::M::FIVE` cannot be used here because it is private to the module `0xdeadbeef::M`
+   ┌─ tests/visibility-checker/constant_use_across_mod.move:18:9
+   │
+18 │         FIVE
+   │         ^^^^
+
+error: constant `0xdeadbeef::M::FIVE` cannot be used here because it is private to the module `0xdeadbeef::M`
+   ┌─ tests/visibility-checker/constant_use_across_mod.move:13:9
+   │
+13 │         M::FIVE
+   │         ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/constant_use_across_mod.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/constant_use_across_mod.move
@@ -1,0 +1,20 @@
+module 0xdeadbeef::M {
+    const FIVE: u64 = 5;
+
+    public fun five(): u64 {
+        FIVE
+    }
+}
+
+module 0xdeadbeef::N {
+    use 0xdeadbeef::M;
+
+    public fun five(): u64 {
+        M::FIVE
+    }
+
+    public fun another_five(): u64 {
+        use 0xdeadbeef::M::FIVE;
+        FIVE
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/main_call_visibility_friend.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/main_call_visibility_friend.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: function `0x2::X::foo` cannot be called from a script, because it is not public
+   ┌─ tests/visibility-checker/main_call_visibility_friend.move:13:5
+   │
+13 │     0x2::X::foo();
+   │     ^^^^^^^^^^^^^
+
+error: function `0x2::X::foo` cannot be called from a script, because it is not public
+   ┌─ tests/visibility-checker/main_call_visibility_friend.move:15:5
+   │
+15 │     0x2::X::foo();
+   │     ^^^^^^^^^^^^^
+
+error: function `0x2::X::baz` cannot be called from a script, because it is not public
+   ┌─ tests/visibility-checker/main_call_visibility_friend.move:16:5
+   │
+16 │     0x2::X::baz();
+   │     ^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/main_call_visibility_friend.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/main_call_visibility_friend.move
@@ -1,0 +1,18 @@
+address 0x2 {
+module X {
+    public(friend) fun foo() {}
+
+    public fun bar() {}
+
+    fun baz() {}
+}
+}
+
+script {
+fun main() {
+    0x2::X::foo();
+    0x2::X::bar();
+    0x2::X::foo();
+    0x2::X::baz();
+}
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend.move
@@ -1,0 +1,43 @@
+address 0x2 {
+
+module X {
+    public fun f_public() {}
+}
+
+module Y {
+    friend 0x2::M;
+    public(friend) fun f_friend() {}
+}
+
+module M {
+    use 0x2::X;
+    use 0x2::Y;
+
+    public fun f_public() {}
+    public(friend) fun f_friend() {}
+    fun f_private() {}
+
+    // a public(friend) fun can call public funs in another module
+    public(friend) fun f_friend_call_public() { X::f_public() }
+
+    // a public(friend) fun can call private and public funs defined in its own module
+    public(friend) fun f_friend_call_self_private() { Self::f_private() }
+    public(friend) fun f_friend_call_self_public() { Self::f_public() }
+
+    // a public functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    public fun f_public_call_friend() { Y::f_friend() }
+    public fun f_public_call_self_friend() { Self::f_friend() }
+
+    // a public(friend) functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    public(friend) fun f_friend_call_friend() { Y::f_friend() }
+    public(friend) fun f_friend_call_self_friend() { Self::f_friend() }
+
+    // a private functions can call a public(friend) function defined in the same module
+    // as well as friend functions defined in other modules (subject to friend list)
+    fun f_private_call_friend() { Y::f_friend() }
+    fun f_private_call_self_friend() { Self::f_friend() }
+}
+
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend_invalid.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: friend function `0x2::X::f_friend` cannot be called here because `0x2::M` is not a friend of `0x2::X`
+   ┌─ tests/visibility-checker/module_call_visibility_friend_invalid.move:18:49
+   │
+18 │     public(friend) fun f_friend_call_friend() { X::f_friend() }
+   │                                                 ^^^^^^^^^^^^^
+
+error: function `0x2::X::f_private` cannot be called here because it is private to module `0x2::X`
+   ┌─ tests/visibility-checker/module_call_visibility_friend_invalid.move:22:52
+   │
+22 │     public(friend) fun f_friend_call_private_1() { X::f_private() }
+   │                                                    ^^^^^^^^^^^^^^
+
+error: function `0x2::Y::f_private` cannot be called here because it is private to module `0x2::Y`
+   ┌─ tests/visibility-checker/module_call_visibility_friend_invalid.move:23:52
+   │
+23 │     public(friend) fun f_friend_call_private_2() { Y::f_private() }
+   │                                                    ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/module_call_visibility_friend_invalid.move
@@ -1,0 +1,26 @@
+address 0x2 {
+
+module X {
+    fun f_private() {}
+    public(friend) fun f_friend() {}
+}
+
+module Y {
+    friend 0x2::M;
+    fun f_private() {}
+}
+
+module M {
+    use 0x2::X;
+    use 0x2::Y;
+
+    // a public(friend) fun cannot call friend funs in other modules if not being in the friend list
+    public(friend) fun f_friend_call_friend() { X::f_friend() }
+
+    // a public(friend) fun cannot call private funs in other modules, regardless of whether being
+    // in the friend list of not.
+    public(friend) fun f_friend_call_private_1() { X::f_private() }
+    public(friend) fun f_friend_call_private_2() { Y::f_private() }
+}
+
+}

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -388,6 +388,20 @@ pub struct UseDecl {
 }
 
 // =================================================================================================
+/// # Friend Declarations
+
+/// Represents a `friend` declaration in the source.
+#[derive(Debug, Clone)]
+pub struct FriendDecl {
+    /// Location covered by this declaration.
+    pub loc: Loc,
+    /// The name of the friend module.
+    pub module_name: ModuleName,
+    /// The resolved module id, if it is known.
+    pub module_id: Option<ModuleId>,
+}
+
+// =================================================================================================
 /// # Access Specifiers
 
 /// Access specifier

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -57,6 +57,8 @@ pub(crate) struct ModelBuilder<'env> {
     pub move_fun_call_graph: BTreeMap<QualifiedId<SpecFunId>, BTreeSet<QualifiedId<SpecFunId>>>,
     /// A list of intrinsic declarations
     pub intrinsics: Vec<IntrinsicDecl>,
+    /// A module lookup table from names to their ids.
+    pub module_table: BTreeMap<ModuleName, ModuleId>,
 }
 
 /// A declaration of a specification function or operator in the builders state.
@@ -194,7 +196,8 @@ impl<'env> ModelBuilder<'env> {
             fun_table: BTreeMap::new(),
             const_table: BTreeMap::new(),
             move_fun_call_graph: BTreeMap::new(),
-            intrinsics: Default::default(),
+            intrinsics: Vec::new(),
+            module_table: BTreeMap::new(),
         };
         builtins::declare_builtins(&mut translator);
         translator

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -18,8 +18,8 @@
 use crate::{
     ast::{
         AccessSpecifier, Address, AddressSpecifier, Attribute, ConditionKind, Exp, ExpData,
-        FriendDecl, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, ResourceSpecifier, Spec,
-        SpecBlockInfo, SpecFunDecl, SpecVarDecl, UseDecl, Value,
+        FriendDecl, GlobalInvariant, ModuleName, PropertyBag, PropertyValue, ResourceSpecifier,
+        Spec, SpecBlockInfo, SpecFunDecl, SpecVarDecl, UseDecl, Value,
     },
     code_writer::CodeWriter,
     emit, emitln,


### PR DESCRIPTION
Compiler v2 now checks that function calls and const uses respect visibility rules.

### Description
We now do the following checks:
* Private functions cannot be called outside the module
* Public friend functions cannot be be called from non-friend modules.
* Constants can only be used directly within the module.

We perform all the function visibility checks as a pass on the stackless bytecode. However, it is too late to do the constant visibility check at this point, as constants have been converted to their values by then, so this is done at an earlier stage (expression builder when building the move model). @brmataptos : inlining implementation could affect this check - something to keep in mind when that implementation rolls in.

### Not in this PR
* Various checks on validity of a friend declaration.
* Fixing (incorrectly flagged) errors in stackless bytecode generation on successfully typechecked programs (there will be a separate issue on this)
* Remove some deadcode identified (we may discuss some of it in this PR)

### Test Plan
* Added new test cases targeting visibility checks.
* Moved over some tests from compiler v1 that also seemed to target visibility rules.