### PR TITLE
[CLI] Add support for setting an API key

### DIFF
--- a/crates/aptos-rest-client/src/client_builder.rs
+++ b/crates/aptos-rest-client/src/client_builder.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use aptos_api_types::X_APTOS_CLIENT;
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue},
+    header::{self, HeaderMap, HeaderName, HeaderValue},
     Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder,
 };
 use std::{str::FromStr, time::Duration};
@@ -74,6 +74,14 @@ impl ClientBuilder {
         self.headers.insert(
             HeaderName::from_str(header_key)?,
             HeaderValue::from_str(header_val)?,
+        );
+        Ok(self)
+    }
+
+    pub fn api_key(mut self, api_key: &str) -> Result<Self> {
+        self.headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", api_key))?,
         );
         Ok(self)
     }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Added `--node-api-key`. This lets you set an API key for the purpose of not being ratelimited.
 
 ## [2.2.2] - 2023/10/16
 ### Updated

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -972,6 +972,12 @@ pub struct RestOptions {
     /// Connection timeout in seconds, used for the REST endpoint of the fullnode
     #[clap(long, default_value_t = DEFAULT_EXPIRATION_SECS, alias = "connection-timeout-s")]
     pub connection_timeout_secs: u64,
+
+    /// Key to use for ratelimiting purposes with the node API. This value will be used
+    /// as `Authorization: Bearer <key>`. You may also set this with the NODE_API_KEY
+    /// environment variable.
+    #[clap(long, env)]
+    pub node_api_key: Option<String>,
 }
 
 impl RestOptions {
@@ -979,6 +985,7 @@ impl RestOptions {
         RestOptions {
             url,
             connection_timeout_secs: connection_timeout_secs.unwrap_or(DEFAULT_EXPIRATION_SECS),
+            node_api_key: None,
         }
     }
 
@@ -1000,10 +1007,13 @@ impl RestOptions {
     }
 
     pub fn client(&self, profile: &ProfileOptions) -> CliTypedResult<Client> {
-        Ok(Client::builder(AptosBaseUrl::Custom(self.url(profile)?))
+        let mut client = Client::builder(AptosBaseUrl::Custom(self.url(profile)?))
             .timeout(Duration::from_secs(self.connection_timeout_secs))
-            .header(aptos_api_types::X_APTOS_CLIENT, X_APTOS_CLIENT_VALUE)?
-            .build())
+            .header(aptos_api_types::X_APTOS_CLIENT, X_APTOS_CLIENT_VALUE)?;
+        if let Some(node_api_key) = &self.node_api_key {
+            client = client.api_key(node_api_key)?;
+        }
+        Ok(client.build())
     }
 }
 


### PR DESCRIPTION
### Description
This is required as we gradually migrate to use the API gateway.

Note: When rejected, the error message isn't very helpful:
```
"Error": "API error: HTTP error 401 Unauthorized: error decoding response body: EOF while parsing a value at line 1 column 0"
```

I'm not sure right now if this comes from the CLI or the API gateway.

### Test Plan
```
$ cargo run -p aptos -- account list --account 0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630 --url https://api.mainnet.aptoslabs.com
{
  "Error": "API error: HTTP error 401 Unauthorized: error decoding response body: EOF while parsing a value at line 1 column 0"
}
```
```
$ cargo run -p aptos -- account list --account 0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630 --url https://api.mainnet.aptoslabs.com --node-api-key <key>
{
  "Result": [
    {
      "0x1::account::Account": {
        "authentication_key": "0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630",
        "coin_register_events": {
          "counter": "1",
          "guid": {
            "id": {
              "addr": "0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630",
              "creation_num": "0"
            }
          }
        },
        "guid_creation_num": "4",
        "key_rotation_events": {
          "counter": "0",
          "guid": {
            "id": {
              "addr": "0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630",
              "creation_num": "1"
            }
          }
        },
        "rotation_capability_offer": {
          "for": {
            "vec": []
          }
        },
        "sequence_number": "81",
        "signer_capability_offer": {
          "for": {
            "vec": []
          }
        }
      }
    },
    {
      "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>": {
        "coin": {
          "value": "951400"
        },
        "deposit_events": {
          "counter": "36",
          "guid": {
            "id": {
              "addr": "0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630",
              "creation_num": "2"
            }
          }
        },
        "frozen": false,
        "withdraw_events": {
          "counter": "81",
          "guid": {
            "id": {
              "addr": "0x6a124da893602cf136d600832a7e8946e1f489ad9a8128b9a71b11da456d6630",
              "creation_num": "3"
            }
          }
        }
      }
    }
  ]
}
```