### PR TITLE
[Node API] Use spawn_blocking for synchronous work

### DIFF
--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -7,7 +7,7 @@ use poem::{web::Accept, FromRequest, Request, RequestBody, Result};
 /// Accept types from input headers
 ///
 /// Determines the output type of each API
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AcceptType {
     /// Convert and resolve types to JSON
     Json,

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     failpoint::fail_point_poem,
     page::determine_limit,
     response::{
@@ -66,14 +66,13 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account")?;
         self.context
             .check_api_output_enabled("Get account", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            None,
-            None,
-        )?;
-        account.account(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(context, address.0, ledger_version.0, None, None)?;
+            account.account(&accept_type)
+        })
+        .await
     }
 
     /// Get account resources
@@ -113,14 +112,19 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account_resources")?;
         self.context
             .check_api_output_enabled("Get account resources", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            start.0.map(StateKey::from),
-            limit.0,
-        )?;
-        account.resources(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(
+                context,
+                address.0,
+                ledger_version.0,
+                start.0.map(StateKey::from),
+                limit.0,
+            )?;
+            account.resources(&accept_type)
+        })
+        .await
     }
 
     /// Get account modules
@@ -160,14 +164,19 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account_modules")?;
         self.context
             .check_api_output_enabled("Get account modules", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            start.0.map(StateKey::from),
-            limit.0,
-        )?;
-        account.modules(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(
+                context,
+                address.0,
+                ledger_version.0,
+                start.0.map(StateKey::from),
+                limit.0,
+            )?;
+            account.modules(&accept_type)
+        })
+        .await
     }
 }
 

--- a/api/src/basic.rs
+++ b/api/src/basic.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     generate_error_response, generate_success_response,
     response::{InternalError, ServiceUnavailableError},
     ApiTags,
@@ -83,7 +83,8 @@ impl BasicApi {
         /// If not provided, the healthcheck will always succeed
         duration_secs: Query<Option<u32>>,
     ) -> HealthCheckResult<HealthCheckSuccess> {
-        let ledger_info = self.context.get_latest_ledger_info()?;
+        let context = self.context.clone();
+        let ledger_info = api_spawn_blocking(move || context.get_latest_ledger_info()).await?;
 
         // If we have a duration, check that it's close to the current time, otherwise it's ok
         if let Some(duration) = duration_secs.0 {

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1297,3 +1297,16 @@ pub struct GasLimitCache {
     last_updated_epoch: Option<u64>,
     block_gas_limit: Option<u64>,
 }
+
+/// This function just calls tokio::task::spawn_blocking with the given closure and in
+/// the case of an error when joining the task converts it into a 500.
+pub async fn api_spawn_blocking<F, T, E>(func: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: InternalError + Send + 'static,
+{
+    tokio::task::spawn_blocking(func)
+        .await
+        .map_err(|err| E::internal_with_code_no_info(err, AptosErrorCode::InternalError))?
+}

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     response::{BasicResponse, BasicResponseStatus, BasicResult},
     ApiTags,
 };
@@ -36,7 +36,7 @@ impl IndexApi {
 
         let node_role = self.context.node_role();
 
-        match accept_type {
+        api_spawn_blocking(move || match accept_type {
             AcceptType::Json => {
                 let index_response = IndexResponse::new(
                     ledger_info.clone(),
@@ -53,6 +53,7 @@ impl IndexApi {
                 let index_response = IndexResponseBcs::new(ledger_info.clone(), node_role);
                 BasicResponse::try_from_bcs((index_response, &ledger_info, BasicResponseStatus::Ok))
             },
-        }
+        })
+        .await
     }
 }

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    context::api_spawn_blocking,
     failpoint::fail_point_poem,
     response::{
         api_forbidden, build_not_found, module_not_found, resource_not_found, table_item_not_found,
@@ -35,6 +36,7 @@ use poem_openapi::{
 use std::{convert::TryInto, sync::Arc};
 
 /// API for retrieving individual state
+#[derive(Clone)]
 pub struct StateApi {
     pub context: Arc<Context>,
 }
@@ -76,12 +78,17 @@ impl StateApi {
         fail_point_poem("endpoint_get_account_resource")?;
         self.context
             .check_api_output_enabled("Get account resource", &accept_type)?;
-        self.resource(
-            &accept_type,
-            address.0,
-            resource_type.0,
-            ledger_version.0.map(|inner| inner.0),
-        )
+
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.resource(
+                &accept_type,
+                address.0,
+                resource_type.0,
+                ledger_version.0.map(|inner| inner.0),
+            )
+        })
+        .await
     }
 
     /// Get account module
@@ -117,7 +124,11 @@ impl StateApi {
         fail_point_poem("endpoint_get_account_module")?;
         self.context
             .check_api_output_enabled("Get account module", &accept_type)?;
-        self.module(&accept_type, address.0, module_name.0, ledger_version.0)
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.module(&accept_type, address.0, module_name.0, ledger_version.0)
+        })
+        .await
     }
 
     /// Get table item
@@ -160,12 +171,16 @@ impl StateApi {
         fail_point_poem("endpoint_get_table_item")?;
         self.context
             .check_api_output_enabled("Get table item", &accept_type)?;
-        self.table_item(
-            &accept_type,
-            table_handle.0,
-            table_item_request.0,
-            ledger_version.0,
-        )
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.table_item(
+                &accept_type,
+                table_handle.0,
+                table_item_request.0,
+                ledger_version.0,
+            )
+        })
+        .await
     }
 
     /// Get raw table item
@@ -207,12 +222,16 @@ impl StateApi {
         self.context
             .check_api_output_enabled("Get raw table item", &accept_type)?;
 
-        self.raw_table_item(
-            &accept_type,
-            table_handle.0,
-            table_item_request.0,
-            ledger_version.0,
-        )
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.raw_table_item(
+                &accept_type,
+                table_handle.0,
+                table_item_request.0,
+                ledger_version.0,
+            )
+        })
+        .await
     }
 
     /// Get raw state value.
@@ -250,7 +269,8 @@ impl StateApi {
         self.context
             .check_api_output_enabled("Get raw state value", &accept_type)?;
 
-        self.raw_value(&accept_type, request.0, ledger_version.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.raw_value(&accept_type, request.0, ledger_version.0)).await
     }
 }
 

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -6,7 +6,7 @@ use crate::{
     accept_type::AcceptType,
     accounts::Account,
     bcs_payload::Bcs,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     failpoint::fail_point_poem,
     generate_error_response, generate_success_response,
     page::Page,
@@ -128,6 +128,7 @@ impl VerifyInput for SubmitTransactionsBatchPost {
 }
 
 /// API for interacting with transactions
+#[derive(Clone)]
 pub struct TransactionsApi {
     pub context: Arc<Context>,
 }
@@ -168,7 +169,9 @@ impl TransactionsApi {
             limit.0,
             self.context.max_transactions_page_size(),
         );
-        self.list(&accept_type, page)
+
+        let api = self.clone();
+        api_spawn_blocking(move || api.list(&accept_type, page)).await
     }
 
     /// Get transaction by hash
@@ -224,8 +227,11 @@ impl TransactionsApi {
         fail_point_poem("endpoint_transaction_by_version")?;
         self.context
             .check_api_output_enabled("Get transactions by version", &accept_type)?;
-        self.get_transaction_by_version_inner(&accept_type, txn_version.0)
-            .await
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.get_transaction_by_version_inner(&accept_type, txn_version.0)
+        })
+        .await
     }
 
     /// Get account transactions
@@ -264,7 +270,8 @@ impl TransactionsApi {
             limit.0,
             self.context.max_transactions_page_size(),
         );
-        self.list_by_account(&accept_type, page, address.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.list_by_account(&accept_type, page, address.0)).await
     }
 
     /// Submit transaction
@@ -428,101 +435,107 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Simulate transaction", &accept_type)?;
-        let ledger_info = self.context.get_latest_ledger_info()?;
-        let mut signed_transaction = self.get_signed_transaction(&ledger_info, data)?;
 
-        let estimated_gas_unit_price = match (
-            estimate_gas_unit_price.0.unwrap_or_default(),
-            estimate_prioritized_gas_unit_price.0.unwrap_or_default(),
-        ) {
-            (_, true) => {
-                let gas_estimation = self.context.estimate_gas_price(&ledger_info)?;
-                // The prioritized gas estimate should always be set, but if it's not use the gas estimate
-                Some(
-                    gas_estimation
-                        .prioritized_gas_estimate
-                        .unwrap_or(gas_estimation.gas_estimate),
-                )
-            },
-            (true, false) => Some(self.context.estimate_gas_price(&ledger_info)?.gas_estimate),
-            (false, false) => None,
-        };
+        let api = self.clone();
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let ledger_info = context.get_latest_ledger_info()?;
+            let mut signed_transaction = api.get_signed_transaction(&ledger_info, data)?;
 
-        // If estimate max gas amount is provided, we will just make it the maximum value
-        let estimated_max_gas_amount = if estimate_max_gas_amount.0.unwrap_or_default() {
-            // Retrieve max possible gas units
-            let (_, gas_params) = self.context.get_gas_schedule(&ledger_info)?;
-            let min_number_of_gas_units = u64::from(gas_params.vm.txn.min_transaction_gas_units)
-                / u64::from(gas_params.vm.txn.gas_unit_scaling_factor);
-            let max_number_of_gas_units = u64::from(gas_params.vm.txn.maximum_number_of_gas_units);
-
-            // Retrieve account balance to determine max gas available
-            let account_state = self
-                .context
-                .get_account_state(
-                    signed_transaction.sender(),
-                    ledger_info.version(),
-                    &ledger_info,
-                )?
-                .ok_or_else(|| {
-                    SubmitTransactionError::bad_request_with_code(
-                        "Account not found",
-                        AptosErrorCode::InvalidInput,
-                        &ledger_info,
+            let estimated_gas_unit_price = match (
+                estimate_gas_unit_price.0.unwrap_or_default(),
+                estimate_prioritized_gas_unit_price.0.unwrap_or_default(),
+            ) {
+                (_, true) => {
+                    let gas_estimation = context.estimate_gas_price(&ledger_info)?;
+                    // The prioritized gas estimate should always be set, but if it's not use the gas estimate
+                    Some(
+                        gas_estimation
+                            .prioritized_gas_estimate
+                            .unwrap_or(gas_estimation.gas_estimate),
                     )
-                })?;
-            let coin_store: CoinStoreResource = account_state
-                .get_coin_store_resource()
-                .and_then(|inner| {
-                    inner.ok_or_else(|| {
-                        anyhow!(
-                            "No coin store found for account {}",
-                            signed_transaction.sender()
-                        )
-                    })
-                })
-                .map_err(|err| {
-                    SubmitTransactionError::internal_with_code(
-                        format!("Failed to get coin store resource {}", err),
-                        AptosErrorCode::InternalError,
-                        &ledger_info,
-                    )
-                })?;
-
-            let gas_unit_price =
-                estimated_gas_unit_price.unwrap_or_else(|| signed_transaction.gas_unit_price());
-
-            // With 0 gas price, we set it to max gas units, since we can't divide by 0
-            let max_account_gas_units = if gas_unit_price == 0 {
-                coin_store.coin()
-            } else {
-                coin_store.coin() / gas_unit_price
+                },
+                (true, false) => Some(context.estimate_gas_price(&ledger_info)?.gas_estimate),
+                (false, false) => None,
             };
 
-            // To give better error messaging, we should not go below the minimum number of gas units
-            let max_account_gas_units =
-                std::cmp::max(min_number_of_gas_units, max_account_gas_units);
+            // If estimate max gas amount is provided, we will just make it the maximum value
+            let estimated_max_gas_amount = if estimate_max_gas_amount.0.unwrap_or_default() {
+                // Retrieve max possible gas units
+                let (_, gas_params) = context.get_gas_schedule(&ledger_info)?;
+                let min_number_of_gas_units =
+                    u64::from(gas_params.vm.txn.min_transaction_gas_units)
+                        / u64::from(gas_params.vm.txn.gas_unit_scaling_factor);
+                let max_number_of_gas_units =
+                    u64::from(gas_params.vm.txn.maximum_number_of_gas_units);
 
-            // Minimum of the max account and the max total needs to be used for estimation
-            Some(std::cmp::min(
-                max_account_gas_units,
-                max_number_of_gas_units,
-            ))
-        } else {
-            None
-        };
+                // Retrieve account balance to determine max gas available
+                let account_state = context
+                    .get_account_state(
+                        signed_transaction.sender(),
+                        ledger_info.version(),
+                        &ledger_info,
+                    )?
+                    .ok_or_else(|| {
+                        SubmitTransactionError::bad_request_with_code(
+                            "Account not found",
+                            AptosErrorCode::InvalidInput,
+                            &ledger_info,
+                        )
+                    })?;
+                let coin_store: CoinStoreResource = account_state
+                    .get_coin_store_resource()
+                    .and_then(|inner| {
+                        inner.ok_or_else(|| {
+                            anyhow!(
+                                "No coin store found for account {}",
+                                signed_transaction.sender()
+                            )
+                        })
+                    })
+                    .map_err(|err| {
+                        SubmitTransactionError::internal_with_code(
+                            format!("Failed to get coin store resource {}", err),
+                            AptosErrorCode::InternalError,
+                            &ledger_info,
+                        )
+                    })?;
 
-        // If there is an estimation of either, replace the values
-        if estimated_max_gas_amount.is_some() || estimated_gas_unit_price.is_some() {
-            signed_transaction = override_gas_parameters(
-                &signed_transaction,
-                estimated_max_gas_amount,
-                estimated_gas_unit_price,
-            );
-        }
+                let gas_unit_price =
+                    estimated_gas_unit_price.unwrap_or_else(|| signed_transaction.gas_unit_price());
 
-        self.simulate(&accept_type, ledger_info, signed_transaction)
-            .await
+                // With 0 gas price, we set it to max gas units, since we can't divide by 0
+                let max_account_gas_units = if gas_unit_price == 0 {
+                    coin_store.coin()
+                } else {
+                    coin_store.coin() / gas_unit_price
+                };
+
+                // To give better error messaging, we should not go below the minimum number of gas units
+                let max_account_gas_units =
+                    std::cmp::max(min_number_of_gas_units, max_account_gas_units);
+
+                // Minimum of the max account and the max total needs to be used for estimation
+                Some(std::cmp::min(
+                    max_account_gas_units,
+                    max_number_of_gas_units,
+                ))
+            } else {
+                None
+            };
+
+            // If there is an estimation of either, replace the values
+            if estimated_max_gas_amount.is_some() || estimated_gas_unit_price.is_some() {
+                signed_transaction = override_gas_parameters(
+                    &signed_transaction,
+                    estimated_max_gas_amount,
+                    estimated_gas_unit_price,
+                );
+            }
+
+            api.simulate(&accept_type, ledger_info, signed_transaction)
+        })
+        .await
     }
 
     /// Encode submission
@@ -571,7 +584,8 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Encode submission", &accept_type)?;
-        self.get_signing_message(&accept_type, data.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.get_signing_message(&accept_type, data.0)).await
     }
 
     /// Estimate gas price
@@ -597,26 +611,31 @@ impl TransactionsApi {
         fail_point_poem("endpoint_encode_submission")?;
         self.context
             .check_api_output_enabled("Estimate gas price", &accept_type)?;
-        let latest_ledger_info = self.context.get_latest_ledger_info()?;
-        let gas_estimation = self.context.estimate_gas_price(&latest_ledger_info)?;
 
-        match accept_type {
-            AcceptType::Json => BasicResponse::try_from_json((
-                gas_estimation,
-                &latest_ledger_info,
-                BasicResponseStatus::Ok,
-            )),
-            AcceptType::Bcs => {
-                let gas_estimation_bcs = GasEstimationBcs {
-                    gas_estimate: gas_estimation.gas_estimate,
-                };
-                BasicResponse::try_from_bcs((
-                    gas_estimation_bcs,
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let latest_ledger_info = context.get_latest_ledger_info()?;
+            let gas_estimation = context.estimate_gas_price(&latest_ledger_info)?;
+
+            match accept_type {
+                AcceptType::Json => BasicResponse::try_from_json((
+                    gas_estimation,
                     &latest_ledger_info,
                     BasicResponseStatus::Ok,
-                ))
-            },
-        }
+                )),
+                AcceptType::Bcs => {
+                    let gas_estimation_bcs = GasEstimationBcs {
+                        gas_estimate: gas_estimation.gas_estimate,
+                    };
+                    BasicResponse::try_from_bcs((
+                        gas_estimation_bcs,
+                        &latest_ledger_info,
+                        BasicResponseStatus::Ok,
+                    ))
+                },
+            }
+        })
+        .await
     }
 }
 
@@ -666,7 +685,11 @@ impl TransactionsApi {
         accept_type: &AcceptType,
         hash: HashValue,
     ) -> BasicResultWith404<Transaction> {
-        let ledger_info = self.context.get_latest_ledger_info()?;
+        let context = self.context.clone();
+        let accept_type = accept_type.clone();
+
+        let ledger_info = api_spawn_blocking(move || context.get_latest_ledger_info()).await?;
+
         let txn_data = self
             .get_by_hash(hash.into(), &ledger_info)
             .await
@@ -681,11 +704,12 @@ impl TransactionsApi {
             .context(format!("Failed to find transaction with hash: {}", hash))
             .map_err(|_| transaction_not_found_by_hash(hash, &ledger_info))?;
 
-        self.get_transaction_inner(accept_type, txn_data, &ledger_info)
+        let api = self.clone();
+        api_spawn_blocking(move || api.get_transaction_inner(&accept_type, txn_data, &ledger_info))
             .await
     }
 
-    async fn get_transaction_by_version_inner(
+    fn get_transaction_by_version_inner(
         &self,
         accept_type: &AcceptType,
         version: U64,
@@ -705,7 +729,6 @@ impl TransactionsApi {
         match txn_data {
             GetByVersionResponse::Found(txn_data) => {
                 self.get_transaction_inner(accept_type, txn_data, &ledger_info)
-                    .await
             },
             GetByVersionResponse::VersionTooNew => {
                 Err(transaction_not_found_by_version(version.0, &ledger_info))
@@ -715,7 +738,7 @@ impl TransactionsApi {
     }
 
     /// Converts a transaction into the outgoing type
-    async fn get_transaction_inner(
+    fn get_transaction_inner(
         &self,
         accept_type: &AcceptType,
         transaction_data: TransactionData,
@@ -792,9 +815,13 @@ impl TransactionsApi {
         hash: aptos_crypto::HashValue,
         ledger_info: &LedgerInfo,
     ) -> anyhow::Result<Option<TransactionData>> {
-        let from_db = self
-            .context
-            .get_transaction_by_hash(hash, ledger_info.version())?;
+        let context = self.context.clone();
+        let version = ledger_info.version();
+        let from_db =
+            tokio::task::spawn_blocking(move || context.get_transaction_by_hash(hash, version))
+                .await
+                .context("Failed to join task to read transaction by hash")?
+                .context("Failed to read transaction by hash from DB")?;
         Ok(match from_db {
             None => self
                 .context
@@ -1170,7 +1197,7 @@ impl TransactionsApi {
     ///
     /// Note: this returns a `Vec<UserTransaction>`, but for backwards compatibility, this can't
     /// be removed even though, there is only one possible transaction
-    pub async fn simulate(
+    pub fn simulate(
         &self,
         accept_type: &AcceptType,
         ledger_info: LedgerInfo,

--- a/api/src/view_function.rs
+++ b/api/src/view_function.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    context::api_spawn_blocking,
     failpoint::fail_point_poem,
     response::{
         BadRequestError, BasicErrorWith404, BasicResponse, BasicResponseStatus, BasicResultWith404,
@@ -16,6 +17,7 @@ use poem_openapi::{param::Query, payload::Json, OpenApi};
 use std::sync::Arc;
 
 /// API for executing Move view function.
+#[derive(Clone)]
 pub struct ViewFunctionApi {
     pub context: Arc<Context>,
 }
@@ -48,87 +50,91 @@ impl ViewFunctionApi {
         self.context
             .check_api_output_enabled("View function", &accept_type)?;
 
-        let (ledger_info, requested_version) = self
-            .context
-            .get_latest_ledger_info_and_verify_lookup_version(
-                ledger_version.map(|inner| inner.0),
-            )?;
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let (ledger_info, requested_version) = context
+                .get_latest_ledger_info_and_verify_lookup_version(
+                    ledger_version.map(|inner| inner.0),
+                )?;
 
-        let state_view = self.context.latest_state_view_poem(&ledger_info)?;
-        let resolver = state_view.as_move_resolver();
+            let state_view = context.latest_state_view_poem(&ledger_info)?;
+            let resolver = state_view.as_move_resolver();
 
-        let entry_func = resolver
-            .as_converter(self.context.db.clone())
-            .convert_view_function(request.0)
+            let entry_func = resolver
+                .as_converter(context.db.clone())
+                .convert_view_function(request.0)
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InvalidInput,
+                        &ledger_info,
+                    )
+                })?;
+            let state_view = context
+                .state_view_at_version(requested_version)
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InternalError,
+                        &ledger_info,
+                    )
+                })?;
+
+            let return_vals = AptosVM::execute_view_function(
+                &state_view,
+                entry_func.module().clone(),
+                entry_func.function().to_owned(),
+                entry_func.ty_args().to_owned(),
+                entry_func.args().to_owned(),
+                context.node_config.api.max_gas_view_function,
+            )
             .map_err(|err| {
-                BasicErrorWith404::bad_request_with_code(
-                    err,
-                    AptosErrorCode::InvalidInput,
-                    &ledger_info,
-                )
+                BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
             })?;
-        let state_view = self
-            .context
-            .state_view_at_version(requested_version)
-            .map_err(|err| {
-                BasicErrorWith404::bad_request_with_code(
-                    err,
-                    AptosErrorCode::InternalError,
+            match accept_type {
+                AcceptType::Bcs => BasicResponse::try_from_bcs((
+                    return_vals,
                     &ledger_info,
-                )
-            })?;
+                    BasicResponseStatus::Ok,
+                )),
+                AcceptType::Json => {
+                    let return_types = resolver
+                        .as_converter(context.db.clone())
+                        .function_return_types(&entry_func)
+                        .and_then(|tys| {
+                            tys.into_iter()
+                                .map(TypeTag::try_from)
+                                .collect::<anyhow::Result<Vec<_>>>()
+                        })
+                        .map_err(|err| {
+                            BasicErrorWith404::bad_request_with_code(
+                                err,
+                                AptosErrorCode::InternalError,
+                                &ledger_info,
+                            )
+                        })?;
 
-        let return_vals = AptosVM::execute_view_function(
-            &state_view,
-            entry_func.module().clone(),
-            entry_func.function().to_owned(),
-            entry_func.ty_args().to_owned(),
-            entry_func.args().to_owned(),
-            self.context.node_config.api.max_gas_view_function,
-        )
-        .map_err(|err| {
-            BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
-        })?;
-        match accept_type {
-            AcceptType::Bcs => {
-                BasicResponse::try_from_bcs((return_vals, &ledger_info, BasicResponseStatus::Ok))
-            },
-            AcceptType::Json => {
-                let return_types = resolver
-                    .as_converter(self.context.db.clone())
-                    .function_return_types(&entry_func)
-                    .and_then(|tys| {
-                        tys.into_iter()
-                            .map(TypeTag::try_from)
-                            .collect::<anyhow::Result<Vec<_>>>()
-                    })
-                    .map_err(|err| {
-                        BasicErrorWith404::bad_request_with_code(
-                            err,
-                            AptosErrorCode::InternalError,
-                            &ledger_info,
-                        )
-                    })?;
+                    let move_vals = return_vals
+                        .into_iter()
+                        .zip(return_types.into_iter())
+                        .map(|(v, ty)| {
+                            resolver
+                                .as_converter(context.db.clone())
+                                .try_into_move_value(&ty, &v)
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()
+                        .map_err(|err| {
+                            BasicErrorWith404::bad_request_with_code(
+                                err,
+                                AptosErrorCode::InternalError,
+                                &ledger_info,
+                            )
+                        })?;
 
-                let move_vals = return_vals
-                    .into_iter()
-                    .zip(return_types.into_iter())
-                    .map(|(v, ty)| {
-                        resolver
-                            .as_converter(self.context.db.clone())
-                            .try_into_move_value(&ty, &v)
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()
-                    .map_err(|err| {
-                        BasicErrorWith404::bad_request_with_code(
-                            err,
-                            AptosErrorCode::InternalError,
-                            &ledger_info,
-                        )
-                    })?;
-
-                BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
-            },
-        }
+                    BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
+                },
+            }
+        })
+        .await
     }
 }


### PR DESCRIPTION
### Description
This PR makes it that the API handlers use spawn_blocking for any synchronous segments of the inner handler code.

Alternatives that don't really work:
- Make the handlers sync: Poem requires that the handlers be async. Beyond that, some functions are actually properly async, e.g. the submit transaction function, in which the underlying component (mempool) exposes an async interface.
- Macro magic: This would just macro-ify what I'm doing somewhat by hand here. It could work but the downside is you can't do it for the properly async handlers (bc you'd end up calling async functions inside a sync function) and it also puts more stuff inside the spawned task than necessary (e.g. some of the checks for fail points / whether the output style is enabled / some verification stuff).

Fortunately some async functions in here don't actually need to be so I just changed them to be synchronous.

### Test Plan
Let's see how it looks in CI to start with. After that we'll want to benchmark this against what we have now to see if it actually helps prevent lock ups when under high load.