### PR TITLE
[Docs] Update SDK usage docs

### DIFF
--- a/developer-docs-site/docs/sdks/rust-sdk.md
+++ b/developer-docs-site/docs/sdks/rust-sdk.md
@@ -5,9 +5,9 @@ slug: "rust-sdk"
 
 # Aptos Rust SDK
 
-### Installing Rust SDK
+## Installing Rust SDK
 
-Aptos provides an official Rust SDK in the [Aptos-core GitHub](https://github.com/aptos-labs/aptos-core/tree/main/sdk) repository. To use the Rust SDK, add the following dependency and patches on the git repo directly, like this:
+Aptos provides an official Rust SDK in the [Aptos-core GitHub](https://github.com/aptos-labs/aptos-core/tree/main/sdk) repository. To use the Rust SDK, add the following dependency and patches on the git repo directly in your `Cargo.toml`, like this:
 
 ```toml
 [dependencies]
@@ -17,7 +17,11 @@ aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", branch = "devnet
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 ```
 
-
+You must also create a `.cargo/config.toml` file with this content:
+```toml
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+```
 
 The source code for the official Rust SDK is available in the [aptos-core GitHub repository](https://github.com/aptos-labs/aptos-core/tree/main/sdk).
 


### PR DESCRIPTION
### Description
The guidance for the Rust SDK today doesn't actually work out of the box, you need to set tokio_unstable. This PR updates the docs accordingly.

### Test Plan
Docs.