### PR TITLE
[forge] Ability to set onchain config in tests

### DIFF
--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -7,6 +7,7 @@ use aptos_types::{
     account_address::{AccountAddress, AccountAddressWithChecks},
     chain_id::ChainId,
     network_address::{DnsName, NetworkAddress, Protocol},
+    on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig},
     transaction::authenticator::AuthenticationKey,
 };
 use aptos_vm_genesis::{AccountBalance, EmployeePool, Validator, ValidatorWithCommissionRate};
@@ -66,6 +67,12 @@ pub struct Layout {
     pub employee_vesting_start: Option<u64>,
     /// Duration of each vesting period (in seconds).
     pub employee_vesting_period_duration: Option<u64>,
+    /// Onchain Consensus Config
+    #[serde(default)]
+    pub on_chain_consensus_config: OnChainConsensusConfig,
+    /// Onchain Execution Config
+    #[serde(default = "OnChainExecutionConfig::default_for_genesis")]
+    pub on_chain_execution_config: OnChainExecutionConfig,
 }
 
 impl Layout {
@@ -103,6 +110,8 @@ impl Default for Layout {
             total_supply: None,
             employee_vesting_start: Some(1663456089),
             employee_vesting_period_duration: Some(5 * 60), // 5 minutes
+            on_chain_consensus_config: OnChainConsensusConfig::default(),
+            on_chain_execution_config: OnChainExecutionConfig::default_for_genesis(),
         }
     }
 }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -294,8 +294,8 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             voting_power_increase_limit: layout.voting_power_increase_limit,
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
-            consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default_for_genesis(),
+            consensus_config: layout.on_chain_consensus_config,
+            execution_config: layout.on_chain_execution_config,
             gas_schedule: default_gas_schedule(),
         },
     )?)

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -25,6 +25,12 @@ data:
     rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
     voting_duration_secs: {{ .Values.chain.voting_duration_secs | int }}
     voting_power_increase_limit: {{ .Values.chain.voting_power_increase_limit | int }}
+    {{- with .Values.chain.on_chain_consensus_config}}
+    on_chain_consensus_config: {{ . | toJson }}
+    {{- end}}
+    {{- with .Values.chain.on_chain_execution_config}}
+    on_chain_execution_config: {{ . | toJson }}
+    {{- end}}
 
 ---
 

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -31,6 +31,10 @@ chain:
   rewards_apy_percentage: 10
   # -- Minimum price per gas unit
   min_price_per_gas_unit: 1
+  # -- Onchain Consensus Config
+  on_chain_consensus_config:
+  # -- Onchain Execution Config
+  on_chain_execution_config:
 
 # -- Default image tag to use for all tools images
 imageTag: testnet

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -20,7 +20,11 @@ use aptos_forge::{
 };
 use aptos_logger::{info, Level};
 use aptos_rest_client::Client as RestClient;
-use aptos_sdk::{move_types::account_address::AccountAddress, transaction_builder::aptos_stdlib};
+use aptos_sdk::{
+    move_types::account_address::AccountAddress,
+    transaction_builder::aptos_stdlib,
+    types::on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig},
+};
 use aptos_testcases::{
     compatibility_test::SimpleValidatorUpgrade,
     consensus_reliability_tests::ChangingWorkingQuorumTest,
@@ -1775,6 +1779,11 @@ fn realistic_env_max_load_test(
             // Have single epoch change in land blocking, and a few on long-running
             helm_values["chain"]["epoch_duration_secs"] =
                 (if long_running { 600 } else { 300 }).into();
+            helm_values["chain"]["on_chain_consensus_config"] =
+                serde_yaml::to_value(OnChainConsensusConfig::default()).expect("must serialize");
+            helm_values["chain"]["on_chain_execution_config"] =
+                serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
+                    .expect("must serialize");
         }))
         // First start higher gas-fee traffic, to not cause issues with TxnEmitter setup - account creation
         .with_emit_job(


### PR DESCRIPTION
### Description

This PR enables setting on-chain consensus config in Forge tests as part of the genesis config.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Test in Forge
