### PR TITLE
[docker] release aptos-node and aptos-indexer-grpc separately

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-release.yaml
@@ -10,6 +10,7 @@ on:
       - preview
     tags:
       - aptos-node-v*
+      - aptos-indexer-grpc-v*
 
 permissions:
   contents: read

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -26,11 +26,29 @@
 //
 // Once you have all prerequisites fulfilled, you can run this script via:
 // GIT_SHA=${{ github.sha }} GCP_DOCKER_ARTIFACT_REPO="${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}" AWS_ACCOUNT_ID="${{ secrets.AWS_ECR_ACCOUNT_NUM }}" IMAGE_TAG_PREFIX="${{ inputs.image_tag_prefix }}" ./docker/release_images.sh --wait-for-image-seconds=1800
+//
+//
+// You can also run this script locally with the DRY_RUN flag to test it out:
+// IMAGE_TAG_PREFIX=devnet AWS_ACCOUNT_ID=bla GCP_DOCKER_ARTIFACT_REPO_US=bla GCP_DOCKER_ARTIFACT_REPO=bla GIT_SHA=bla ./docker/release-images.mjs --wait-for-image-seconds=3600 --dry-run
+//
+
+// When we release aptos-node, we also want to release related images for tooling, testing, etc. Similarly, other images have other related images
+// that we can release together, ie in a release group.
+const IMAGES_TO_RELEASE_BY_RELEASE_GROUP = {
+  "aptos-node": [
+    "validator",
+    "validator-testing",
+    "faucet",
+    "tools",
+  ],
+  "aptos-indexer-grpc": [
+    "indexer-grpc",
+  ],
+}
 
 const Features = {
   Default: "default",
 };
-
 const IMAGES_TO_RELEASE_ONLY_INTERNAL = ["validator-testing"];
 const IMAGES_TO_RELEASE = {
   validator: {
@@ -88,7 +106,7 @@ execSync("pnpm install --frozen-lockfile", { stdio: "inherit" });
 await import("zx/globals");
 
 const REQUIRED_ARGS = ["GIT_SHA", "GCP_DOCKER_ARTIFACT_REPO", "GCP_DOCKER_ARTIFACT_REPO_US", "AWS_ACCOUNT_ID", "IMAGE_TAG_PREFIX"];
-const OPTIONAL_ARGS = ["WAIT_FOR_IMAGE_SECONDS"];
+const OPTIONAL_ARGS = ["WAIT_FOR_IMAGE_SECONDS", "DRY_RUN"];
 
 const parsedArgs = {};
 
@@ -149,7 +167,23 @@ const ALL_TARGET_REGISTRIES = [
 // default 10 seconds
 parsedArgs.WAIT_FOR_IMAGE_SECONDS = parseInt(parsedArgs.WAIT_FOR_IMAGE_SECONDS ?? 10, 10);
 
-for (const [image, imageConfig] of Object.entries(IMAGES_TO_RELEASE)) {
+// dry run
+console.log(`INFO: dry run: ${parsedArgs.DRY_RUN}`);
+
+// get the appropriate release group based on the image tag prefix
+const imageReleaseGroup = getImageReleaseGroupByImageTagPrefix(parsedArgs.IMAGE_TAG_PREFIX);
+console.log(`INFO: image release group: ${imageReleaseGroup}`);
+
+// only release the images that are part of the release group
+const imageNamesToRelease = IMAGES_TO_RELEASE_BY_RELEASE_GROUP[imageReleaseGroup];
+console.log(`INFO: image names to release: ${JSON.stringify(imageNamesToRelease)}`);
+
+// iterate over all images to release, including their release configurations
+const imagesToRelease = {};
+for (const imageName of imageNamesToRelease) {
+  imagesToRelease[imageName] = IMAGES_TO_RELEASE[imageName];
+}
+for (const [image, imageConfig] of Object.entries(imagesToRelease)) {
   for (const [profile, features] of Object.entries(imageConfig)) {
     // build profiles that are not the default "release" will have a separate prefix
     const profilePrefix = profile === "release" ? "" : profile;
@@ -165,6 +199,9 @@ for (const [image, imageConfig] of Object.entries(IMAGES_TO_RELEASE)) {
         )}`;
         const imageTarget = `${targetRegistry}/${image}:${joinTagSegments(parsedArgs.IMAGE_TAG_PREFIX, profilePrefix, featureSuffix)}`;
         console.info(chalk.green(`INFO: copying ${imageSource} to ${imageTarget}`));
+        if (parsedArgs.DRY_RUN) {
+          continue;
+        }
         await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
         await $`${crane} copy ${imageSource} ${imageTarget}`;
         await $`${crane} copy ${imageSource} ${joinTagSegments(imageTarget, parsedArgs.GIT_SHA)}`;
@@ -176,6 +213,21 @@ for (const [image, imageConfig] of Object.entries(IMAGES_TO_RELEASE)) {
 // joinTagSegments joins tag segments with a dash, but only if the segment is not empty
 function joinTagSegments(...segments) {
   return segments.filter((s) => s).join("_");
+}
+
+// The image tag prefix is used to determine the release group. Examples:
+// * tag a release as "aptos-node-vX.Y.Z"
+// * tag a release as "aptos-indexer-grpc-vX.Y.Z"
+function getImageReleaseGroupByImageTagPrefix(prefix) {
+  // iterate over the keys in IMAGES_TO_RELEASE_BY_RELEASE_GROUP
+  // if the prefix includes the release group, then return the release group
+  for (const [imageReleaseGroup, imagesToRelease] of Object.entries(IMAGES_TO_RELEASE_BY_RELEASE_GROUP)) {
+    if (prefix.includes(imageReleaseGroup)) {
+      return imageReleaseGroup;
+    }
+  }
+  // if there's no match, then release aptos-node by default
+  return "aptos-node";
 }
 
 async function waitForImageToBecomeAvailable(imageToWaitFor, waitForImageSeconds) {


### PR DESCRIPTION
### Description

So we can have a separate indexer GRPC release process. This decouples the versioning of the node and indexer.

This PR introduces the concept of "release groups" within the release-images.mjs tool, which groups together images that are released together.
* aptos-node: validator (incl. validator-testing), faucet, tools
* aptos-indexer-grpc: indexer-grpc

### Test Plan

Add a new dry-run mode, and test from there.


Release with aptos network tag. This releases `aptos-node` 
```
$ IMAGE_TAG_PREFIX=devnet AWS_ACCOUNT_ID=bla GCP_DOCKER_ARTIFACT_REPO_US=bla GCP_DOCKER_ARTIFACT_REPO=bla GIT_SHA=bla ./docker/release-images.mjs --wait-for-image-seconds=3600 --dry-run
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 386ms
$ command -v crane
/opt/homebrew/bin/crane
INFO: dry run: true
INFO: image release group: aptos-node
INFO: image names to release: ["validator","validator-testing","faucet","tools"]
INFO: copying bla/validator:performance_bla to bla/validator:devnet_performance
INFO: copying bla/validator:performance_bla to bla/validator:devnet_performance
INFO: copying bla/validator:performance_bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:devnet_performance
INFO: copying bla/validator:performance_bla to docker.io/aptoslabs/validator:devnet_performance
INFO: copying bla/validator:bla to bla/validator:devnet
INFO: copying bla/validator:bla to bla/validator:devnet
INFO: copying bla/validator:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:devnet
INFO: copying bla/validator:bla to docker.io/aptoslabs/validator:devnet
INFO: copying bla/validator-testing:performance_bla to bla/validator-testing:devnet_performance
INFO: copying bla/validator-testing:performance_bla to bla/validator-testing:devnet_performance
INFO: copying bla/validator-testing:performance_bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator-testing:devnet_performance
INFO: copying bla/validator-testing:bla to bla/validator-testing:devnet
INFO: copying bla/validator-testing:bla to bla/validator-testing:devnet
INFO: copying bla/validator-testing:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator-testing:devnet
INFO: copying bla/faucet:bla to bla/faucet:devnet
INFO: copying bla/faucet:bla to bla/faucet:devnet
INFO: copying bla/faucet:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/faucet:devnet
INFO: copying bla/faucet:bla to docker.io/aptoslabs/faucet:devnet
INFO: copying bla/tools:bla to bla/tools:devnet
INFO: copying bla/tools:bla to bla/tools:devnet
INFO: copying bla/tools:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/tools:devnet
INFO: copying bla/tools:bla to docker.io/aptoslabs/tools:devnet
```

Release with `aptos-node-vX.Y.Z` tag. This releases aptos-node:
```
$ IMAGE_TAG_PREFIX=aptos-node-vX.Y.Z AWS_ACCOUNT_ID=bla GCP_DOCKER_ARTIFACT_REPO_US=bla GCP_DOCKER_ARTIFACT_REPO=bla GIT_SHA=bla ./docker/release-images.mjs --wait-for-image-seconds=3600 --dry-run        
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 357ms
$ command -v crane
/opt/homebrew/bin/crane
INFO: dry run: true
INFO: image release group: aptos-node
INFO: image names to release: ["validator","validator-testing","faucet","tools"]
INFO: copying bla/validator:performance_bla to bla/validator:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator:performance_bla to bla/validator:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator:performance_bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator:performance_bla to docker.io/aptoslabs/validator:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator:bla to bla/validator:aptos-node-vX.Y.Z
INFO: copying bla/validator:bla to bla/validator:aptos-node-vX.Y.Z
INFO: copying bla/validator:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:aptos-node-vX.Y.Z
INFO: copying bla/validator:bla to docker.io/aptoslabs/validator:aptos-node-vX.Y.Z
INFO: copying bla/validator-testing:performance_bla to bla/validator-testing:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator-testing:performance_bla to bla/validator-testing:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator-testing:performance_bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator-testing:aptos-node-vX.Y.Z_performance
INFO: copying bla/validator-testing:bla to bla/validator-testing:aptos-node-vX.Y.Z
INFO: copying bla/validator-testing:bla to bla/validator-testing:aptos-node-vX.Y.Z
INFO: copying bla/validator-testing:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator-testing:aptos-node-vX.Y.Z
INFO: copying bla/faucet:bla to bla/faucet:aptos-node-vX.Y.Z
INFO: copying bla/faucet:bla to bla/faucet:aptos-node-vX.Y.Z
INFO: copying bla/faucet:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/faucet:aptos-node-vX.Y.Z
INFO: copying bla/faucet:bla to docker.io/aptoslabs/faucet:aptos-node-vX.Y.Z
INFO: copying bla/tools:bla to bla/tools:aptos-node-vX.Y.Z
INFO: copying bla/tools:bla to bla/tools:aptos-node-vX.Y.Z
INFO: copying bla/tools:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/tools:aptos-node-vX.Y.Z
INFO: copying bla/tools:bla to docker.io/aptoslabs/tools:aptos-node-vX.Y.Z
```

NEW: release  with `aptos-indexer-grpc-vA.B.C`. This releases indexer grpc only:
```
$ IMAGE_TAG_PREFIX=aptos-indexer-grpc-vA.B.C AWS_ACCOUNT_ID=bla GCP_DOCKER_ARTIFACT_REPO_US=bla GCP_DOCKER_ARTIFACT_REPO=bla GIT_SHA=bla ./docker/release-images.mjs --wait-for-image-seconds=3600 --dry-run    
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 353ms
$ command -v crane
/opt/homebrew/bin/crane
INFO: dry run: true
INFO: image release group: aptos-indexer-grpc
INFO: image names to release: ["indexer-grpc"]
INFO: copying bla/indexer-grpc:bla to bla/indexer-grpc:aptos-indexer-grpc-vA.B.C
INFO: copying bla/indexer-grpc:bla to bla/indexer-grpc:aptos-indexer-grpc-vA.B.C
INFO: copying bla/indexer-grpc:bla to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/indexer-grpc:aptos-indexer-grpc-vA.B.C
INFO: copying bla/indexer-grpc:bla to docker.io/aptoslabs/indexer-grpc:aptos-indexer-grpc-vA.B.C
```



<!-- Please provide us with clear details for verifying that your changes work. -->
