### PR TITLE
 FrozenSmt not holding oldest ancester 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,7 @@ dependencies = [
  "aptos-drop-helper",
  "aptos-experimental-runtimes",
  "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bitvec 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
  "once_cell",
+ "threadpool",
 ]
 
 [[package]]

--- a/crates/aptos-drop-helper/Cargo.toml
+++ b/crates/aptos-drop-helper/Cargo.toml
@@ -17,3 +17,4 @@ aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-metrics-core = { workspace = true }
 once_cell = { workspace = true }
+threadpool = { workspace = true }

--- a/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
+++ b/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
@@ -1,0 +1,105 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics::TIMER;
+use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
+use aptos_infallible::Mutex;
+use aptos_metrics_core::TimerHelper;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+/// A helper to send things to a thread pool for asynchronous dropping.
+///
+/// Be aware that there is a bounded number of concurrent drops, as a result:
+///   1. when it's "out of capacity", `schedule_drop` will block until a slot to be available.
+///   2. if the `Drop` implementation tries to lock things, there can be a potential dead lock due
+///      to another thing being waiting for a slot to be available.
+pub struct AsyncConcurrentDropper {
+    name: &'static str,
+    token_tx: Sender<()>,
+    token_rx: Mutex<Receiver<()>>,
+}
+
+impl AsyncConcurrentDropper {
+    pub fn new(name: &'static str, max_concurrent_drops: usize) -> Self {
+        let (token_tx, token_rx) = channel();
+        for _ in 0..max_concurrent_drops {
+            token_tx
+                .send(())
+                .expect("DropHelper: Failed to buffer initial tokens.");
+        }
+        Self {
+            name,
+            token_tx,
+            token_rx: Mutex::new(token_rx),
+        }
+    }
+
+    pub fn schedule_drop<V: Send + 'static>(&self, v: V) {
+        self.schedule_drop_impl(v, None)
+    }
+
+    pub fn schedule_drop_with_waiter<V: Send + 'static>(&self, v: V) -> Receiver<()> {
+        let (tx, rx) = channel();
+        self.schedule_drop_impl(v, Some(tx));
+        rx
+    }
+
+    fn schedule_drop_impl<V: Send + 'static>(&self, v: V, notif_sender_opt: Option<Sender<()>>) {
+        let _timer = TIMER.timer_with(&[self.name, "enqueue_drop"]);
+
+        self.token_rx.lock().recv().unwrap();
+
+        let token_tx = self.token_tx.clone();
+        let name = self.name;
+        THREAD_MANAGER.get_non_exe_cpu_pool().spawn(move || {
+            let _timer = TIMER.timer_with(&[name, "real_drop"]);
+
+            drop(v);
+
+            if let Some(sender) = notif_sender_opt {
+                sender.send(()).ok();
+            }
+
+            token_tx.send(()).ok();
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AsyncConcurrentDropper;
+    use std::{thread::sleep, time::Duration};
+
+    struct SlowDropper;
+
+    impl Drop for SlowDropper {
+        fn drop(&mut self) {
+            sleep(Duration::from_secs(1));
+        }
+    }
+
+    #[test]
+    fn test_concurrency_limit_hit() {
+        let s = AsyncConcurrentDropper::new("test", 8);
+        let now = std::time::Instant::now();
+        let rx = s.schedule_drop_with_waiter(SlowDropper);
+        for _ in 1..8 {
+            s.schedule_drop(SlowDropper);
+        }
+        assert!(now.elapsed() < Duration::from_millis(500));
+        rx.recv().unwrap();
+        assert!(now.elapsed() > Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_within_concurrency_limit() {
+        let s = AsyncConcurrentDropper::new("test", 8);
+        let now = std::time::Instant::now();
+        for _ in 0..8 {
+            s.schedule_drop(SlowDropper);
+        }
+        assert!(now.elapsed() < Duration::from_millis(500));
+        s.schedule_drop(SlowDropper);
+        assert!(now.elapsed() > Duration::from_secs(1));
+    }
+}

--- a/crates/aptos-drop-helper/src/async_drop_queue.rs
+++ b/crates/aptos-drop-helper/src/async_drop_queue.rs
@@ -7,6 +7,7 @@ use aptos_metrics_core::TimerHelper;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use threadpool::ThreadPool;
 
+#[derive(Debug)]
 pub struct AsyncDropQueue {
     name: &'static str,
     token_tx: Sender<()>,

--- a/crates/aptos-drop-helper/src/async_drop_queue.rs
+++ b/crates/aptos-drop-helper/src/async_drop_queue.rs
@@ -1,0 +1,91 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics::TIMER;
+use aptos_infallible::Mutex;
+use aptos_metrics_core::TimerHelper;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use threadpool::ThreadPool;
+
+pub struct AsyncDropQueue {
+    name: &'static str,
+    token_tx: Sender<()>,
+    token_rx: Mutex<Receiver<()>>,
+    thread: ThreadPool,
+}
+
+impl AsyncDropQueue {
+    pub fn new(name: &'static str, max_pending_drops: usize) -> Self {
+        let (token_tx, token_rx) = channel();
+        for _ in 0..max_pending_drops {
+            token_tx
+                .send(())
+                .expect("AsyncDropQueue: Failed to buffer initial tokens.");
+        }
+        // single threaded threadpool
+        let thread = ThreadPool::new(1);
+        Self {
+            name,
+            token_tx,
+            token_rx: Mutex::new(token_rx),
+            thread,
+        }
+    }
+
+    pub fn enqueue_drop<V: Send + 'static>(&self, v: V) {
+        let _timer = TIMER.timer_with(&[self.name, "enqueue_drop"]);
+
+        self.token_rx.lock().recv().unwrap();
+
+        let token_tx = self.token_tx.clone();
+        let name = self.name;
+        self.thread.execute(move || {
+            let _timer = TIMER.timer_with(&[name, "real_drop"]);
+
+            drop(v);
+
+            token_tx.send(()).ok();
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::async_drop_queue::AsyncDropQueue;
+    use std::{
+        sync::mpsc::{channel, Sender},
+        thread::sleep,
+        time::Duration,
+    };
+
+    struct SendBackOnDrop {
+        id: usize,
+        tx: Sender<usize>,
+    }
+
+    impl Drop for SendBackOnDrop {
+        fn drop(&mut self) {
+            sleep(Duration::from_millis(200));
+            self.tx.send(self.id).unwrap()
+        }
+    }
+
+    #[test]
+    fn test_queue() {
+        let q = AsyncDropQueue::new("test", 4);
+        let now = std::time::Instant::now();
+        let (tx, rx) = channel();
+        for id in 0..4 {
+            q.enqueue_drop(SendBackOnDrop { id, tx: tx.clone() });
+        }
+        assert!(now.elapsed() < Duration::from_millis(200));
+        q.enqueue_drop(SendBackOnDrop {
+            id: 4,
+            tx: tx.clone(),
+        });
+        assert!(now.elapsed() > Duration::from_millis(200));
+        drop(tx);
+        assert_eq!(rx.iter().collect::<Vec<_>>(), (0..5).collect::<Vec<_>>(),);
+        assert!(now.elapsed() > Duration::from_secs(1));
+    }
+}

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -1,110 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::async_concurrent_dropper::AsyncConcurrentDropper;
+use once_cell::sync::Lazy;
+
+mod async_concurrent_dropper;
 mod metrics;
 
-use crate::metrics::TIMER;
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
-use aptos_infallible::Mutex;
-use aptos_metrics_core::TimerHelper;
-use once_cell::sync::Lazy;
-use std::sync::mpsc::{channel, Receiver, Sender};
-
-pub static DEFAULT_DROP_HELPER: Lazy<DropHelper> = Lazy::new(|| DropHelper::new("default", 32));
-
-/// A helper to send things to a thread pool for asynchronous dropping.
-///
-/// Be aware that there is a bounded number of concurrent drops, as a result:
-///   1. when it's "out of capacity", `schedule_drop` will block until a slot to be available.
-///   2. if the `Drop` implementation tries to lock things, there can be a potential dead lock due
-///      to another thing being waiting for a slot to be available.
-pub struct DropHelper {
-    name: &'static str,
-    token_tx: Sender<()>,
-    token_rx: Mutex<Receiver<()>>,
-}
-
-impl DropHelper {
-    pub fn new(name: &'static str, max_concurrent_drops: usize) -> Self {
-        let (token_tx, token_rx) = channel();
-        for _ in 0..max_concurrent_drops {
-            token_tx
-                .send(())
-                .expect("DropHelper: Failed to buffer initial tokens.");
-        }
-        Self {
-            name,
-            token_tx,
-            token_rx: Mutex::new(token_rx),
-        }
-    }
-
-    pub fn schedule_drop<V: Send + 'static>(&self, v: V) {
-        self.schedule_drop_impl(v, None)
-    }
-
-    pub fn schedule_drop_with_waiter<V: Send + 'static>(&self, v: V) -> Receiver<()> {
-        let (tx, rx) = channel();
-        self.schedule_drop_impl(v, Some(tx));
-        rx
-    }
-
-    fn schedule_drop_impl<V: Send + 'static>(&self, v: V, notif_sender_opt: Option<Sender<()>>) {
-        let _timer = TIMER.timer_with(&[self.name, "enqueue_drop"]);
-
-        self.token_rx.lock().recv().unwrap();
-
-        let token_tx = self.token_tx.clone();
-        let name = self.name;
-        THREAD_MANAGER.get_non_exe_cpu_pool().spawn(move || {
-            let _timer = TIMER.timer_with(&[name, "real_drop"]);
-
-            drop(v);
-
-            if let Some(sender) = notif_sender_opt {
-                sender.send(()).ok();
-            }
-
-            token_tx.send(()).ok();
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::DropHelper;
-    use std::{thread::sleep, time::Duration};
-
-    struct SlowDropper;
-
-    impl Drop for SlowDropper {
-        fn drop(&mut self) {
-            sleep(Duration::from_secs(1));
-        }
-    }
-
-    #[test]
-    fn test_queue_not_full() {
-        let s = DropHelper::new("test", 8);
-        let now = std::time::Instant::now();
-        let rx = s.schedule_drop_with_waiter(SlowDropper);
-        for _ in 1..8 {
-            s.schedule_drop(SlowDropper);
-        }
-        assert!(now.elapsed() < Duration::from_millis(500));
-        rx.recv().unwrap();
-        assert!(now.elapsed() > Duration::from_secs(1));
-    }
-
-    #[test]
-    fn test_queue_full() {
-        let s = DropHelper::new("test", 8);
-        let now = std::time::Instant::now();
-        for _ in 0..8 {
-            s.schedule_drop(SlowDropper);
-        }
-        assert!(now.elapsed() < Duration::from_millis(500));
-        s.schedule_drop(SlowDropper);
-        assert!(now.elapsed() > Duration::from_secs(1));
-    }
-}
+pub static DEFAULT_DROPPER: Lazy<AsyncConcurrentDropper> =
+    Lazy::new(|| AsyncConcurrentDropper::new("default", 32));

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -4,7 +4,8 @@
 use crate::async_concurrent_dropper::AsyncConcurrentDropper;
 use once_cell::sync::Lazy;
 
-mod async_concurrent_dropper;
+pub mod async_concurrent_dropper;
+pub mod async_drop_queue;
 mod metrics;
 
 pub static DEFAULT_DROPPER: Lazy<AsyncConcurrentDropper> =

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -74,6 +74,7 @@ impl InMemoryStateCalculator {
             updates_since_base,
         } = base.clone();
 
+        let latest = current.freeze(&frozen_base.base_smt);
         Self {
             _frozen_base: frozen_base,
             proof_reader: ProofReader::new(proofs),
@@ -85,7 +86,7 @@ impl InMemoryStateCalculator {
 
             checkpoint: base,
             checkpoint_version: base_version,
-            latest: current.freeze(),
+            latest,
             updates_between_checkpoint_and_latest: updates_since_base,
         }
     }

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -11,7 +11,7 @@ use crate::logging::{LogEntry, LogSchema};
 use anyhow::{anyhow, ensure, Result};
 use aptos_consensus_types::block::Block as ConsensusBlock;
 use aptos_crypto::HashValue;
-use aptos_drop_helper::DEFAULT_DROP_HELPER;
+use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_executor_types::{execution_output::ExecutionOutput, ExecutorError, LedgerUpdateOutput};
 use aptos_infallible::Mutex;
 use aptos_logger::{debug, info};
@@ -282,7 +282,7 @@ impl BlockTree {
             old_root
         };
 
-        Ok(DEFAULT_DROP_HELPER.schedule_drop_with_waiter(old_root))
+        Ok(DEFAULT_DROPPER.schedule_drop_with_waiter(old_root))
     }
 
     pub fn add_block(

--- a/execution/executor/src/components/in_memory_state_calculator_v2.rs
+++ b/execution/executor/src/components/in_memory_state_calculator_v2.rs
@@ -4,7 +4,7 @@
 use crate::metrics::APTOS_EXECUTOR_OTHER_TIMERS_SECONDS;
 use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_drop_helper::DEFAULT_DROP_HELPER;
+use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_executor_types::{
     parsed_transaction_output::TransactionsWithParsedOutput, ParsedTransactionOutput, ProofReader,
 };
@@ -183,7 +183,7 @@ impl InMemoryStateCalculatorV2 {
             )?
         };
 
-        DEFAULT_DROP_HELPER.schedule_drop(frozen_base);
+        DEFAULT_DROPPER.schedule_drop(frozen_base);
 
         let updates_since_latest_checkpoint = if last_checkpoint_index.is_some() {
             updates_after_last_checkpoint

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -85,6 +85,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{SchemaBatch, DB};
+use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
     cached_state_view::ShardedStateCache, state_delta::StateDelta, state_view::DbStateView,
     DbReader, DbWriter, ExecutedTrees, Order, StateSnapshotReceiver, MAX_REQUEST_LIMIT,
@@ -1825,6 +1826,12 @@ impl DbReader for AptosDB {
                 transaction_accumulator,
             );
             Ok(executed_trees)
+        })
+    }
+
+    fn get_buffered_state_base(&self) -> Result<SparseMerkleTree<StateValue>> {
+        gauged_api("get_buffered_state_base", || {
+            self.state_store.get_buffered_state_base()
         })
     }
 

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -38,6 +38,7 @@ use aptos_infallible::Mutex;
 use aptos_jellyfish_merkle::iterator::JellyfishMerkleIterator;
 use aptos_logger::info;
 use aptos_schemadb::{ReadOptions, SchemaBatch};
+use aptos_scratchpad::{SmtAncestors, SparseMerkleTree};
 use aptos_state_view::StateViewId;
 use aptos_storage_interface::{
     async_proof_fetcher::AsyncProofFetcher,
@@ -95,6 +96,7 @@ pub(crate) struct StateStore {
     // write set stored in ledger_db.
     buffered_state: Mutex<BufferedState>,
     buffered_state_target_items: usize,
+    smt_ancestors: Mutex<SmtAncestors<StateValue>>,
 }
 
 impl Deref for StateStore {
@@ -224,6 +226,10 @@ impl StateDb {
 }
 
 impl DbReader for StateStore {
+    fn get_buffered_state_base(&self) -> Result<SparseMerkleTree<StateValue>> {
+        Ok(self.smt_ancestors.lock().get_youngest()?)
+    }
+
     /// Returns the latest state snapshot strictly before `next_version` if any.
     fn get_state_snapshot_before(
         &self,
@@ -323,32 +329,27 @@ impl StateStore {
             state_kv_pruner,
             skip_usage,
         });
-        if empty_buffered_state_for_restore {
-            let buffered_state = Mutex::new(BufferedState::new(
+        let (buffered_state, smt_ancestors) = if empty_buffered_state_for_restore {
+            BufferedState::new(
                 &state_db,
                 StateDelta::new_empty(),
                 buffered_state_target_items,
-            ));
-            Self {
-                state_db,
-                buffered_state,
-                buffered_state_target_items,
-            }
+            )
         } else {
-            let buffered_state = Mutex::new(
-                Self::create_buffered_state_from_latest_snapshot(
-                    &state_db,
-                    buffered_state_target_items,
-                    hack_for_tests,
-                    /*check_max_versions_after_snapshot=*/ true,
-                )
-                .expect("buffered state creation failed."),
-            );
-            Self {
-                state_db,
-                buffered_state,
+            Self::create_buffered_state_from_latest_snapshot(
+                &state_db,
                 buffered_state_target_items,
-            }
+                hack_for_tests,
+                /*check_max_versions_after_snapshot=*/ true,
+            )
+            .expect("buffered state creation failed.")
+        };
+
+        Self {
+            state_db,
+            buffered_state: Mutex::new(buffered_state),
+            buffered_state_target_items,
+            smt_ancestors: Mutex::new(smt_ancestors),
         }
     }
 
@@ -447,7 +448,7 @@ impl StateStore {
             state_kv_pruner,
             skip_usage: false,
         });
-        let buffered_state = Self::create_buffered_state_from_latest_snapshot(
+        let (buffered_state, _) = Self::create_buffered_state_from_latest_snapshot(
             &state_db, 0, /*hack_for_tests=*/ false,
             /*check_max_versions_after_snapshot=*/ false,
         )?;
@@ -459,7 +460,7 @@ impl StateStore {
         buffered_state_target_items: usize,
         hack_for_tests: bool,
         check_max_versions_after_snapshot: bool,
-    ) -> Result<BufferedState> {
+    ) -> Result<(BufferedState, SmtAncestors<StateValue>)> {
         let ledger_store = LedgerStore::new(Arc::clone(&state_db.ledger_db));
         let num_transactions = ledger_store.get_latest_version().map_or(0, |v| v + 1);
 
@@ -482,7 +483,7 @@ impl StateStore {
             *SPARSE_MERKLE_PLACEHOLDER_HASH
         };
         let usage = state_db.get_state_storage_usage(latest_snapshot_version)?;
-        let mut buffered_state = BufferedState::new(
+        let (mut buffered_state, smt_ancestors) = BufferedState::new(
             state_db,
             StateDelta::new_at_checkpoint(
                 latest_snapshot_root_hash,
@@ -494,7 +495,7 @@ impl StateStore {
 
         // In some backup-restore tests we hope to open the db without consistency check.
         if hack_for_tests {
-            return Ok(buffered_state);
+            return Ok((buffered_state, smt_ancestors));
         }
 
         // Make sure the committed transactions is ahead of the latest snapshot.
@@ -519,13 +520,17 @@ impl StateStore {
                     num_transactions,
                 );
             }
-            let latest_snapshot_state_view = CachedStateView::new(
+            let snapshot = state_db.get_state_snapshot_before(num_transactions)?;
+            let speculative_state = buffered_state
+                .current_state()
+                .current
+                .freeze(&buffered_state.current_state().base);
+            let latest_snapshot_state_view = CachedStateView::new_impl(
                 StateViewId::Miscellaneous,
-                state_db.clone(),
-                num_transactions,
-                buffered_state.current_state().current.clone(),
+                snapshot,
+                speculative_state,
                 Arc::new(AsyncProofFetcher::new(state_db.clone())),
-            )?;
+            );
             let write_sets = TransactionStore::new(Arc::clone(&state_db.ledger_db))
                 .get_write_sets(snapshot_next_version, num_transactions)?;
             let txn_info_iter =
@@ -562,17 +567,19 @@ impl StateStore {
             latest_in_memory_root_hash = buffered_state.current_state().current.root_hash(),
             "StateStore initialization finished.",
         );
-        Ok(buffered_state)
+        Ok((buffered_state, smt_ancestors))
     }
 
     pub fn reset(&self) {
-        *self.buffered_state.lock() = Self::create_buffered_state_from_latest_snapshot(
+        let (buffered_state, smt_ancestors) = Self::create_buffered_state_from_latest_snapshot(
             &self.state_db,
             self.buffered_state_target_items,
             false,
             true,
         )
         .expect("buffered state creation failed.");
+        *self.buffered_state.lock() = buffered_state;
+        *self.smt_ancestors.lock() = smt_ancestors;
     }
 
     pub fn buffered_state(&self) -> &Mutex<BufferedState> {

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -14,9 +14,11 @@ use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::HashValue;
 use aptos_jellyfish_merkle::node_type::NodeKey;
 use aptos_logger::{info, trace};
+use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::SchemaBatch;
+use aptos_scratchpad::SmtAncestors;
 use aptos_storage_interface::state_delta::StateDelta;
-use aptos_types::state_store::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue};
 use std::sync::{mpsc::Receiver, Arc};
 
 pub struct StateMerkleBatch {
@@ -29,21 +31,25 @@ pub struct StateMerkleBatch {
 pub(crate) struct StateMerkleBatchCommitter {
     state_db: Arc<StateDb>,
     state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleBatch>>,
+    smt_ancestors: SmtAncestors<StateValue>,
 }
 
 impl StateMerkleBatchCommitter {
     pub fn new(
         state_db: Arc<StateDb>,
         state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleBatch>>,
+        smt_ancestors: SmtAncestors<StateValue>,
     ) -> Self {
         Self {
             state_db,
             state_merkle_batch_receiver,
+            smt_ancestors,
         }
     }
 
     pub fn run(self) {
         while let Ok(msg) = self.state_merkle_batch_receiver.recv() {
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["batch_committer_work"]);
             match msg {
                 CommitMessage::Data(state_merkle_batch) => {
                     let StateMerkleBatch {
@@ -95,6 +101,8 @@ impl StateMerkleBatchCommitter {
                     state_delta
                         .current
                         .log_generation("buffered_state_in_mem_base");
+
+                    self.smt_ancestors.add(state_delta.current.clone());
                 },
                 CommitMessage::Sync(finish_sender) => finish_sender.send(()).unwrap(),
                 CommitMessage::Exit => {

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -15,7 +15,9 @@ use crate::{
 use anyhow::Result;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::trace;
+use aptos_scratchpad::SmtAncestors;
 use aptos_storage_interface::{jmt_update_refs, jmt_updates, state_delta::StateDelta};
+use aptos_types::state_store::state_value::StateValue;
 use rayon::prelude::*;
 use static_assertions::const_assert;
 use std::{
@@ -40,6 +42,7 @@ impl StateSnapshotCommitter {
     pub fn new(
         state_db: Arc<StateDb>,
         state_snapshot_commit_receiver: Receiver<CommitMessage<Arc<StateDelta>>>,
+        smt_ancestors: SmtAncestors<StateValue>,
     ) -> Self {
         // Note: This is to ensure we cache nodes in memory from previous batches before they get committed to DB.
         const_assert!(
@@ -55,6 +58,7 @@ impl StateSnapshotCommitter {
                 let committer = StateMerkleBatchCommitter::new(
                     arc_state_db,
                     state_merkle_batch_commit_receiver,
+                    smt_ancestors,
                 );
                 committer.run();
             })
@@ -96,12 +100,7 @@ impl StateSnapshotCommitter {
                                 .map(|shard_id| {
                                     let node_hashes = delta_to_commit
                                         .current
-                                        .clone()
-                                        .freeze()
-                                        .new_node_hashes_since(
-                                            &delta_to_commit.base.clone().freeze(),
-                                            shard_id,
-                                        );
+                                        .new_node_hashes_since(&delta_to_commit.base, shard_id);
                                     self.state_db.state_merkle_db.merklize_value_set_for_shard(
                                         shard_id,
                                         jmt_update_refs(&jmt_updates(

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -17,6 +17,7 @@ aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-types = { workspace = true }
 bitvec = { workspace = true }

--- a/storage/scratchpad/src/lib.rs
+++ b/storage/scratchpad/src/lib.rs
@@ -9,6 +9,6 @@ mod sparse_merkle;
 #[cfg(any(test, feature = "bench", feature = "fuzzing"))]
 pub use crate::sparse_merkle::test_utils;
 pub use crate::sparse_merkle::{
-    utils::get_state_shard_id, FrozenSparseMerkleTree, ProofRead, SparseMerkleTree,
-    StateStoreStatus,
+    ancestors::SmtAncestors, utils::get_state_shard_id, FrozenSparseMerkleTree, ProofRead,
+    SparseMerkleTree, StateStoreStatus,
 };

--- a/storage/scratchpad/src/sparse_merkle/ancestors.rs
+++ b/storage/scratchpad/src/sparse_merkle/ancestors.rs
@@ -1,0 +1,98 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{sparse_merkle::metrics::TIMER, SparseMerkleTree};
+use aptos_crypto::hash::CryptoHash;
+use aptos_drop_helper::async_drop_queue::AsyncDropQueue;
+use aptos_infallible::Mutex;
+use aptos_logger::prelude::*;
+use aptos_metrics_core::TimerHelper;
+use std::{
+    collections::VecDeque,
+    sync::{Arc, MutexGuard},
+    time::Duration,
+};
+
+type Result<V> = std::result::Result<V, Error>;
+
+/// Keep the oldest SMTs in a central place so that:
+/// 1. elsewhere, dropping the SMT will be fast since this indirectly holds a ref to every tree in
+///    the entire forest.
+/// 2. this must be invoked somewhere in the critical path so that it can provide some
+///    back pressure to slow things down to prevent from leaking memory
+#[derive(Clone, Debug)]
+pub struct SmtAncestors<V: Clone + Send + Sync + 'static> {
+    /// Keep a queue of ancestors, in hope that the when the oldest is being evicted, it's the
+    /// the last ref of it, which means the drop latency doesn't impact other code paths.
+    ancestors: Arc<Mutex<VecDeque<SparseMerkleTree<V>>>>,
+    /// Drop the oldest ancestor asynchronously in good cases, with limited backlog, providing
+    /// back pressure when the drops are slow in order to avoid memory leak.
+    drop_queue: Arc<AsyncDropQueue>,
+}
+
+impl<V: CryptoHash + Clone + Send + Sync + 'static> SmtAncestors<V> {
+    const MAX_PENDING_DROPS: usize = 4;
+    const NUM_ANCESTORS: usize = 8;
+
+    pub fn new(ancestor: SparseMerkleTree<V>) -> Self {
+        Self {
+            ancestors: Arc::new(Mutex::new(VecDeque::from(vec![ancestor]))),
+            drop_queue: Arc::new(AsyncDropQueue::new(
+                "smt_ancestors",
+                Self::MAX_PENDING_DROPS,
+            )),
+        }
+    }
+
+    fn ancestors(&self) -> MutexGuard<VecDeque<SparseMerkleTree<V>>> {
+        self.ancestors.lock()
+    }
+
+    pub fn get_youngest(&self) -> Result<SparseMerkleTree<V>> {
+        self.ancestors()
+            .back()
+            .map(SparseMerkleTree::clone)
+            .ok_or(Error::NotFound)
+    }
+
+    pub fn add(&self, youngest: SparseMerkleTree<V>) {
+        let _timer = TIMER.timer_with(&["add_smt_ancestor"]);
+
+        let mut ancestors = self.ancestors();
+        ancestors.push_back(youngest);
+
+        if ancestors.len() > Self::NUM_ANCESTORS {
+            let oldest = ancestors.pop_front().unwrap();
+            oldest.log_generation("evict_ancestor");
+            if !oldest.is_the_only_ref() {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(1)),
+                    error!(
+                        "Oldest SMT being tracked by SmtAncestors is still referenced elsewhere. Potential memory leak.",
+                    )
+                );
+            } else {
+                self.drop_queue.enqueue_drop(oldest);
+            }
+        }
+    }
+
+    pub fn replace_with(&self, other: SmtAncestors<V>) {
+        let Self {
+            ancestors,
+            drop_queue: _drop_queue,
+        } = other;
+
+        *self.ancestors.lock() = Arc::into_inner(ancestors)
+            .expect("Not the only ref.")
+            .into_inner();
+    }
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum Error {
+    #[error("Ancestor SMT not found.")]
+    NotFound,
+}

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -228,7 +228,7 @@ impl<V: Send + Sync + 'static> Drop for Inner<V> {
         // Send the Arc to multiple threads so that the dropping happens in parallel (specifically,
         // dropping of the SMTs).
         for descendant_arc in processed_descendants {
-            aptos_drop_helper::DEFAULT_DROP_HELPER.schedule_drop(descendant_arc)
+            aptos_drop_helper::DEFAULT_DROPPER.schedule_drop(descendant_arc)
         }
 
         self.log_generation("drop");

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -49,6 +49,7 @@ pub mod state_delta;
 pub mod state_view;
 
 use crate::state_delta::StateDelta;
+use aptos_scratchpad::SparseMerkleTree;
 pub use executed_trees::ExecutedTrees;
 
 // This is last line of defense against large queries slipping through external facing interfaces,
@@ -370,6 +371,9 @@ pub trait DbReader: Send + Sync {
         /// Gets the latest ExecutedTrees no matter if db has been bootstrapped.
         /// Used by the Db-bootstrapper.
         fn get_latest_executed_trees(&self) -> Result<ExecutedTrees>;
+
+        /// Get the oldest in memory state tree.
+        fn get_buffered_state_base(&self) -> Result<SparseMerkleTree<StateValue>>;
 
         /// Get the ledger info of the epoch that `known_version` belongs to.
         fn get_epoch_ending_ledger_info(

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -35,6 +35,7 @@ impl StateDelta {
         current_version: Option<Version>,
         updates_since_base: ShardedStateUpdates,
     ) -> Self {
+        assert!(base.is_family(&current));
         assert!(base_version.map_or(0, |v| v + 1) <= current_version.map_or(0, |v| v + 1));
         Self {
             base,


### PR DESCRIPTION
### Description
Now that ledger update is a seperate stage, the oldest ancester is held                                                                                                                                  from multiple threads, which can result in it not being freed when the                                                                                                                                   pipeline is busy.    

### Test Plan
On certain machines where we used to observe high memory usage, it's now good.
Local benchmark runs didn't observe regression.
Unit tests.