### PR TITLE
re-revert  Modify TokenV2 to add concurrent way of minting tokens using AggregarorV2

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -28,8 +28,11 @@ require adding the field original_name.
 -  [Struct `MutationEvent`](#0x4_collection_MutationEvent)
 -  [Resource `FixedSupply`](#0x4_collection_FixedSupply)
 -  [Resource `UnlimitedSupply`](#0x4_collection_UnlimitedSupply)
+-  [Resource `ConcurrentSupply`](#0x4_collection_ConcurrentSupply)
 -  [Struct `BurnEvent`](#0x4_collection_BurnEvent)
+-  [Struct `ConcurrentBurnEvent`](#0x4_collection_ConcurrentBurnEvent)
 -  [Struct `MintEvent`](#0x4_collection_MintEvent)
+-  [Struct `ConcurrentMintEvent`](#0x4_collection_ConcurrentMintEvent)
 -  [Constants](#@Constants_0)
 -  [Function `create_fixed_collection`](#0x4_collection_create_fixed_collection)
 -  [Function `create_unlimited_collection`](#0x4_collection_create_unlimited_collection)
@@ -38,8 +41,10 @@ require adding the field original_name.
 -  [Function `create_collection_address`](#0x4_collection_create_collection_address)
 -  [Function `create_collection_seed`](#0x4_collection_create_collection_seed)
 -  [Function `increment_supply`](#0x4_collection_increment_supply)
+-  [Function `increment_concurrent_supply`](#0x4_collection_increment_concurrent_supply)
 -  [Function `decrement_supply`](#0x4_collection_decrement_supply)
 -  [Function `generate_mutator_ref`](#0x4_collection_generate_mutator_ref)
+-  [Function `upgrade_to_concurrent`](#0x4_collection_upgrade_to_concurrent)
 -  [Function `check_collection_exists`](#0x4_collection_check_collection_exists)
 -  [Function `borrow`](#0x4_collection_borrow)
 -  [Function `count`](#0x4_collection_count)
@@ -52,8 +57,10 @@ require adding the field original_name.
 -  [Function `set_uri`](#0x4_collection_set_uri)
 
 
-<pre><code><b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<pre><code><b>use</b> <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2">0x1::aggregator_v2</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-framework/doc/event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-framework/doc/object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -275,6 +282,42 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 
 </details>
 
+<a name="0x4_collection_ConcurrentSupply"></a>
+
+## Resource `ConcurrentSupply`
+
+Supply tracker, useful for tracking amount of issued tokens.
+If max_value is not set to U64_MAX, this ensures that a limited number of tokens are minted.
+
+
+<pre><code>#[resource_group_member(#[group = <a href="../../aptos-framework/doc/object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>current_supply: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+ Total minted - total burned
+</dd>
+<dt>
+<code>total_minted: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="0x4_collection_BurnEvent"></a>
 
 ## Struct `BurnEvent`
@@ -293,6 +336,46 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 <dl>
 <dt>
 <code>index: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="token.md#0x4_token">token</a>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x4_collection_ConcurrentBurnEvent"></a>
+
+## Struct `ConcurrentBurnEvent`
+
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="collection.md#0x4_collection_ConcurrentBurnEvent">ConcurrentBurnEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>collection_addr: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;</code>
 </dt>
 <dd>
 
@@ -341,9 +424,58 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 
 </details>
 
+<a name="0x4_collection_ConcurrentMintEvent"></a>
+
+## Struct `ConcurrentMintEvent`
+
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+<b>struct</b> <a href="collection.md#0x4_collection_ConcurrentMintEvent">ConcurrentMintEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>collection_addr: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="token.md#0x4_token">token</a>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x4_collection_MAX_U64"></a>
+
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
 
 
 <a name="0x4_collection_EURI_TOO_LONG"></a>
@@ -361,6 +493,16 @@ The URI is over the maximum length
 
 
 <pre><code><b>const</b> <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
+<a name="0x4_collection_EALREADY_CONCURRENT"></a>
+
+Tried upgrading collection to concurrent, but collection is already concurrent
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_EALREADY_CONCURRENT">EALREADY_CONCURRENT</a>: u64 = 8;
 </code></pre>
 
 
@@ -391,6 +533,16 @@ The collection has reached its supply and no more tokens can be minted, unless s
 
 
 <pre><code><b>const</b> <a href="collection.md#0x4_collection_ECOLLECTION_SUPPLY_EXCEEDED">ECOLLECTION_SUPPLY_EXCEEDED</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x4_collection_ECONCURRENT_NOT_ENABLED"></a>
+
+Concurrent feature flag is not yet enabled, so the function cannot be performed
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_ECONCURRENT_NOT_ENABLED">ECONCURRENT_NOT_ENABLED</a>: u64 = 7;
 </code></pre>
 
 
@@ -466,23 +618,40 @@ Beyond that, it adds supply tracking with events.
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, collection_seed);
     <b>let</b> object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer">object::generate_signer</a>(&constructor_ref);
 
-    <b>let</b> supply = <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
-        current_supply: 0,
-        max_supply,
-        total_minted: 0,
-        burn_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
-        mint_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
-    };
+    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_concurrent_assets_enabled">features::concurrent_assets_enabled</a>()) {
+        <b>let</b> supply = <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
+            current_supply: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_aggregator">aggregator_v2::create_aggregator</a>(max_supply),
+            total_minted: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+        };
 
-    <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
-        creator,
-        constructor_ref,
-        description,
-        name,
-        <a href="royalty.md#0x4_royalty">royalty</a>,
-        uri,
-        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
-    )
+        <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
+            creator,
+            constructor_ref,
+            description,
+            name,
+            <a href="royalty.md#0x4_royalty">royalty</a>,
+            uri,
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
+        )
+    } <b>else</b> {
+        <b>let</b> supply = <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
+            current_supply: 0,
+            max_supply,
+            total_minted: 0,
+            burn_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+            mint_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+        };
+
+        <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
+            creator,
+            constructor_ref,
+            description,
+            name,
+            <a href="royalty.md#0x4_royalty">royalty</a>,
+            uri,
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
+        )
+    }
 }
 </code></pre>
 
@@ -518,22 +687,39 @@ the supply of tokens.
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, collection_seed);
     <b>let</b> object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer">object::generate_signer</a>(&constructor_ref);
 
-    <b>let</b> supply = <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
-        current_supply: 0,
-        total_minted: 0,
-        burn_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
-        mint_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
-    };
+    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_concurrent_assets_enabled">features::concurrent_assets_enabled</a>()) {
+        <b>let</b> supply = <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
+            current_supply: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+            total_minted: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+        };
 
-    <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
-        creator,
-        constructor_ref,
-        description,
-        name,
-        <a href="royalty.md#0x4_royalty">royalty</a>,
-        uri,
-        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
-    )
+        <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
+            creator,
+            constructor_ref,
+            description,
+            name,
+            <a href="royalty.md#0x4_royalty">royalty</a>,
+            uri,
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
+        )
+    } <b>else</b> {
+        <b>let</b> supply = <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+            current_supply: 0,
+            total_minted: 0,
+            burn_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+            mint_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+        };
+
+        <a href="collection.md#0x4_collection_create_collection_internal">create_collection_internal</a>(
+            creator,
+            constructor_ref,
+            description,
+            name,
+            <a href="royalty.md#0x4_royalty">royalty</a>,
+            uri,
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
+        )
+    }
 }
 </code></pre>
 
@@ -715,7 +901,40 @@ Called by token on mint to increment supply if there's an appropriate Supply str
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_increment_supply">increment_supply</a>(
     <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
     <a href="token.md#0x4_token">token</a>: <b>address</b>,
-): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>, <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
+    <b>let</b> index = <a href="collection.md#0x4_collection_increment_concurrent_supply">increment_concurrent_supply</a>(<a href="collection.md#0x4_collection">collection</a>, <a href="token.md#0x4_token">token</a>);
+    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&index)) {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    } <b>else</b> {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>&lt;u64&gt;(&<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_destroy_some">option::destroy_some</a>(index)))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x4_collection_increment_concurrent_supply"></a>
+
+## Function `increment_concurrent_supply`
+
+Called by token on mint to increment supply if there's an appropriate Supply struct.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_increment_concurrent_supply">increment_concurrent_supply</a>(<a href="collection.md#0x4_collection">collection</a>: &<a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="collection.md#0x4_collection_Collection">collection::Collection</a>&gt;, <a href="token.md#0x4_token">token</a>: <b>address</b>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_increment_concurrent_supply">increment_concurrent_supply</a>(
+    <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
+    <a href="token.md#0x4_token">token</a>: <b>address</b>,
+): Option&lt;AggregatorSnapshot&lt;u64&gt;&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>, <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
     <b>let</b> collection_addr = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="collection.md#0x4_collection">collection</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr);
@@ -731,7 +950,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
                 <a href="token.md#0x4_token">token</a>,
             },
         );
-        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.total_minted)
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>&lt;u64&gt;(supply.total_minted))
     } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr);
         supply.current_supply = supply.current_supply + 1;
@@ -743,7 +962,22 @@ Called by token on mint to increment supply if there's an appropriate Supply str
                 <a href="token.md#0x4_token">token</a>,
             },
         );
-        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.total_minted)
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>&lt;u64&gt;(supply.total_minted))
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_addr)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_addr);
+        <b>assert</b>!(
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_try_add">aggregator_v2::try_add</a>(&<b>mut</b> supply.current_supply, 1),
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ECOLLECTION_SUPPLY_EXCEEDED">ECOLLECTION_SUPPLY_EXCEEDED</a>),
+        );
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_add">aggregator_v2::add</a>(&<b>mut</b> supply.total_minted, 1);
+        <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(
+            <a href="collection.md#0x4_collection_ConcurrentMintEvent">ConcurrentMintEvent</a> {
+                collection_addr,
+                index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_snapshot">aggregator_v2::snapshot</a>(&supply.total_minted),
+                <a href="token.md#0x4_token">token</a>,
+            },
+        );
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_snapshot">aggregator_v2::snapshot</a>(&supply.total_minted))
     } <b>else</b> {
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
     }
@@ -774,7 +1008,7 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
     <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
     <a href="token.md#0x4_token">token</a>: <b>address</b>,
     index: Option&lt;u64&gt;,
-) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>, <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
     <b>let</b> collection_addr = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="collection.md#0x4_collection">collection</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr);
@@ -793,6 +1027,16 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
             &<b>mut</b> supply.burn_events,
             <a href="collection.md#0x4_collection_BurnEvent">BurnEvent</a> {
                 index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
+                <a href="token.md#0x4_token">token</a>,
+            },
+        );
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_addr)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_addr);
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_sub">aggregator_v2::sub</a>(&<b>mut</b> supply.current_supply, 1);
+        <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(
+            <a href="collection.md#0x4_collection_ConcurrentBurnEvent">ConcurrentBurnEvent</a> {
+                collection_addr,
+                index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(*<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index)),
                 <a href="token.md#0x4_token">token</a>,
             },
         );
@@ -823,6 +1067,80 @@ Creates a MutatorRef, which gates the ability to mutate any fields that support 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_generate_mutator_ref">generate_mutator_ref</a>(ref: &ConstructorRef): <a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a> {
     <b>let</b> <a href="../../aptos-framework/doc/object.md#0x1_object">object</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_object_from_constructor_ref">object::object_from_constructor_ref</a>&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;(ref);
     <a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a> { self: <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="../../aptos-framework/doc/object.md#0x1_object">object</a>) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x4_collection_upgrade_to_concurrent"></a>
+
+## Function `upgrade_to_concurrent`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_upgrade_to_concurrent">upgrade_to_concurrent</a>(ref: &<a href="../../aptos-framework/doc/object.md#0x1_object_ExtendRef">object::ExtendRef</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_upgrade_to_concurrent">upgrade_to_concurrent</a>(
+    ref: &ExtendRef,
+) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+    <b>let</b> metadata_object_address = <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_extend_ref">object::address_from_extend_ref</a>(ref);
+    <b>let</b> metadata_object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(ref);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_concurrent_assets_enabled">features::concurrent_assets_enabled</a>(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="collection.md#0x4_collection_ECONCURRENT_NOT_ENABLED">ECONCURRENT_NOT_ENABLED</a>));
+
+    <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(metadata_object_address)) {
+        <b>let</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
+            current_supply,
+            max_supply,
+            total_minted,
+            burn_events,
+            mint_events,
+        } = <b>move_from</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(metadata_object_address);
+
+        <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(burn_events);
+        <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(mint_events);
+
+        <b>let</b> supply = <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
+            current_supply: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_aggregator">aggregator_v2::create_aggregator</a>(max_supply),
+            total_minted: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+        };
+
+        // <b>update</b> current state:
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_add">aggregator_v2::add</a>(&<b>mut</b> supply.current_supply, current_supply);
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_add">aggregator_v2::add</a>(&<b>mut</b> supply.total_minted, total_minted);
+        <b>move_to</b>(&metadata_object_signer, supply);
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(metadata_object_address)) {
+        <b>let</b> <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+            current_supply,
+            total_minted,
+            burn_events,
+            mint_events,
+        } = <b>move_from</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(metadata_object_address);
+
+        <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(burn_events);
+        <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(mint_events);
+
+        <b>let</b> supply = <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
+            current_supply: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+            total_minted: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">aggregator_v2::create_unbounded_aggregator</a>(),
+        };
+
+        // <b>update</b> current state:
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_add">aggregator_v2::add</a>(&<b>mut</b> supply.current_supply, current_supply);
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_add">aggregator_v2::add</a>(&<b>mut</b> supply.total_minted, total_minted);
+        <b>move_to</b>(&metadata_object_signer, supply);
+    } <b>else</b> {
+        // untracked <a href="collection.md#0x4_collection">collection</a> is already concurrent, and other variants too.
+        <b>abort</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="collection.md#0x4_collection_EALREADY_CONCURRENT">EALREADY_CONCURRENT</a>)
+    }
 }
 </code></pre>
 
@@ -889,6 +1207,9 @@ Creates a MutatorRef, which gates the ability to mutate any fields that support 
 
 Provides the count of the current selection if supply tracking is used
 
+Note: Calling this method from transaction that also mints/burns, prevents
+it from being parallelized.
+
 
 <pre><code>#[view]
 <b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_count">count</a>&lt;T: key&gt;(<a href="collection.md#0x4_collection">collection</a>: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
@@ -900,7 +1221,7 @@ Provides the count of the current selection if supply tracking is used
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_count">count</a>&lt;T: key&gt;(<a href="collection.md#0x4_collection">collection</a>: Object&lt;T&gt;): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_count">count</a>&lt;T: key&gt;(<a href="collection.md#0x4_collection">collection</a>: Object&lt;T&gt;): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>, <a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a> {
     <b>let</b> collection_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="collection.md#0x4_collection">collection</a>);
     <a href="collection.md#0x4_collection_check_collection_exists">check_collection_exists</a>(collection_address);
 
@@ -910,6 +1231,9 @@ Provides the count of the current selection if supply tracking is used
     } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_address)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_address);
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.current_supply)
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_address)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_ConcurrentSupply">ConcurrentSupply</a>&gt;(collection_address);
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read">aggregator_v2::read</a>(&supply.current_supply))
     } <b>else</b> {
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
     }

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -375,7 +375,7 @@ If max_value is not set to U64_MAX, this ensures that a limited number of tokens
 
 </dd>
 <dt>
-<code>index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;</code>
+<code>index: u64</code>
 </dt>
 <dd>
 
@@ -1036,7 +1036,7 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(
             <a href="collection.md#0x4_collection_ConcurrentBurnEvent">ConcurrentBurnEvent</a> {
                 collection_addr,
-                index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(*<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index)),
+                index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
                 <a href="token.md#0x4_token">token</a>,
             },
         );

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -11,12 +11,14 @@ token are:
 
 
 -  [Resource `Token`](#0x4_token_Token)
+-  [Resource `TokenConcurrentFieldsAppendix`](#0x4_token_TokenConcurrentFieldsAppendix)
 -  [Struct `BurnRef`](#0x4_token_BurnRef)
 -  [Struct `MutatorRef`](#0x4_token_MutatorRef)
 -  [Struct `MutationEvent`](#0x4_token_MutationEvent)
 -  [Constants](#@Constants_0)
 -  [Function `create_common`](#0x4_token_create_common)
 -  [Function `create`](#0x4_token_create)
+-  [Function `create_numbered_token`](#0x4_token_create_numbered_token)
 -  [Function `create_named_token`](#0x4_token_create_named_token)
 -  [Function `create_from_account`](#0x4_token_create_from_account)
 -  [Function `create_token_address`](#0x4_token_create_token_address)
@@ -32,6 +34,7 @@ token are:
 -  [Function `name`](#0x4_token_name)
 -  [Function `uri`](#0x4_token_uri)
 -  [Function `royalty`](#0x4_token_royalty)
+-  [Function `index`](#0x4_token_index)
 -  [Function `borrow_mut`](#0x4_token_borrow_mut)
 -  [Function `burn`](#0x4_token_burn)
 -  [Function `set_description`](#0x4_token_set_description)
@@ -39,12 +42,15 @@ token are:
 -  [Function `set_uri`](#0x4_token_set_uri)
 
 
-<pre><code><b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<pre><code><b>use</b> <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2">0x1::aggregator_v2</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-framework/doc/event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-framework/doc/object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/doc/string_utils.md#0x1_string_utils">0x1::string_utils</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 <b>use</b> <a href="collection.md#0x4_collection">0x4::collection</a>;
 <b>use</b> <a href="royalty.md#0x4_royalty">0x4::royalty</a>;
@@ -80,6 +86,9 @@ Represents the common fields to all tokens.
 <code>index: u64</code>
 </dt>
 <dd>
+ Deprecated in favor of <code>index</code> inside TokenConcurrentFieldsAppendix.
+ Will be populated until concurrent_assets_enabled feature flag is enabled.
+
  Unique identifier within the collection, optional, 0 means unassigned
 </dd>
 <dt>
@@ -92,6 +101,9 @@ Represents the common fields to all tokens.
 <code>name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
+ Deprecated in favor of <code>name</code> inside TokenConcurrentFieldsAppendix.
+ Will be populated until concurrent_assets_enabled feature flag is enabled.
+
  The name of the token, which should be unique within the collection; the length of name
  should be smaller than 128, characters, eg: "Aptos Animal #1234"
 </dd>
@@ -107,6 +119,43 @@ Represents the common fields to all tokens.
 </dt>
 <dd>
  Emitted upon any mutation of the token.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x4_token_TokenConcurrentFieldsAppendix"></a>
+
+## Resource `TokenConcurrentFieldsAppendix`
+
+Represents first addition to the common fields for all tokens
+Starts being populated once aggregator_snapshots_enabled is enabled.
+
+
+<pre><code>#[resource_group_member(#[group = <a href="../../aptos-framework/doc/object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+<b>struct</b> <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>index: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+ Unique identifier within the collection, optional, 0 means unassigned
+</dd>
+<dt>
+<code>name: <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;</code>
+</dt>
+<dd>
+ The name of the token, which should be unique within the collection; the length of name
+ should be smaller than 128, characters, eg: "Aptos Animal #1234"
 </dd>
 </dl>
 
@@ -316,7 +365,7 @@ The token name is over the maximum length
 
 
 
-<pre><code><b>fun</b> <a href="token.md#0x4_token_create_common">create_common</a>(constructor_ref: &<a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, creator_address: <b>address</b>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
+<pre><code><b>fun</b> <a href="token.md#0x4_token_create_common">create_common</a>(constructor_ref: &<a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, creator_address: <b>address</b>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name_prefix: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name_with_index_suffix: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
 
@@ -330,11 +379,17 @@ The token name is over the maximum length
     creator_address: <b>address</b>,
     collection_name: String,
     description: String,
-    name: String,
+    name_prefix: String,
+    name_with_index_suffix: Option&lt;String&gt;,
     <a href="royalty.md#0x4_royalty">royalty</a>: Option&lt;Royalty&gt;,
     uri: String,
 ) {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
+    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&name_with_index_suffix)) {
+        // Be conservative, <b>as</b> we don't know what length the index will be, and <b>assume</b> worst case (20 chars in MAX_U64)
+        <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name_prefix) + 20 + <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&name_with_index_suffix)) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
+    } <b>else</b> {
+        <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name_prefix) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
+    };
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt;= <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt;= <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>));
 
@@ -342,13 +397,65 @@ The token name is over the maximum length
 
     <b>let</b> collection_addr = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator_address, &collection_name);
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Collection&gt;(collection_addr);
-    <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
+
+    // once this flag is enabled, cleanup <a href="../../aptos-framework/doc/code.md#0x1_code">code</a> for aggregator_api_enabled = <b>false</b>.
+    <b>let</b> aggregator_api_enabled = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_aggregator_snapshots_enabled">features::aggregator_snapshots_enabled</a>();
+    <b>let</b> concurrent_assets_enabled = aggregator_api_enabled && <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_concurrent_assets_enabled">features::concurrent_assets_enabled</a>();
+
+    <b>let</b> (deprecated_index, deprecated_name) = <b>if</b> (aggregator_api_enabled) {
+        <b>let</b> index = <b>if</b> (concurrent_assets_enabled) {
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_destroy_with_default">option::destroy_with_default</a>(
+                <a href="collection.md#0x4_collection_increment_concurrent_supply">collection::increment_concurrent_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer)),
+                <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>&lt;u64&gt;(0)
+            )
+        } <b>else</b> {
+            <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0))
+        };
+
+        <b>let</b> name = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&name_with_index_suffix)) {
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_string_concat">aggregator_v2::string_concat</a>(name_prefix, &index, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> name_with_index_suffix))
+        } <b>else</b> {
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(name_prefix)
+        };
+
+        <b>let</b> deprecated_index = <b>if</b> (concurrent_assets_enabled) {
+            0
+        } <b>else</b> {
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&index)
+        };
+
+        <b>let</b> deprecated_name = <b>if</b> (concurrent_assets_enabled) {
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"")
+        } <b>else</b> {
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&name)
+        };
+
+        <b>let</b> token_concurrent = <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+            index,
+            name,
+        };
+        <b>move_to</b>(&object_signer, token_concurrent);
+
+        (deprecated_index, deprecated_name)
+    } <b>else</b> {
+        <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
+        <b>let</b> index = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0);
+
+        <b>let</b> name = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&name_with_index_suffix)) {
+            <a href="../../aptos-framework/../aptos-stdlib/doc/string_utils.md#0x1_string_utils_format3">string_utils::format3</a>(&b"{}{}{}", name_prefix, index, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> name_with_index_suffix))
+        } <b>else</b> {
+            name_prefix
+        };
+
+        (index, name)
+    };
 
     <b>let</b> <a href="token.md#0x4_token">token</a> = <a href="token.md#0x4_token_Token">Token</a> {
         <a href="collection.md#0x4_collection">collection</a>,
-        index: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0),
+        index: deprecated_index,
         description,
-        name,
+        name: deprecated_name,
         uri,
         mutation_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
     };
@@ -391,7 +498,47 @@ for additional specialization.
 ): ConstructorRef {
     <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_object">object::create_object</a>(creator_address);
-    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    constructor_ref
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x4_token_create_numbered_token"></a>
+
+## Function `create_numbered_token`
+
+Creates a new token object with a unique address and returns the ConstructorRef
+for additional specialization.
+The name is created by concatenating the (name_prefix, index, name_suffix).
+After flag concurrent_assets_enabled is enabled, this function will allow
+creating tokens in parallel, from the same collection, while providing sequential names.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_numbered_token">create_numbered_token</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name_with_index_preffix: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name_with_index_suffix: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_numbered_token">create_numbered_token</a>(
+    creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    collection_name: String,
+    description: String,
+    name_with_index_preffix: String,
+    name_with_index_suffix: String,
+    <a href="royalty.md#0x4_royalty">royalty</a>: Option&lt;Royalty&gt;,
+    uri: String,
+): ConstructorRef {
+    <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
+    <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_object">object::create_object</a>(creator_address);
+    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name_with_index_preffix, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(name_with_index_suffix), <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>
@@ -429,7 +576,7 @@ additional specialization.
     <b>let</b> seed = <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(&collection_name, &name);
 
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, seed);
-    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>
@@ -468,7 +615,7 @@ additional specialization.
 ): ConstructorRef {
     <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_object_from_account">object::create_object_from_account</a>(creator);
-    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    <a href="token.md#0x4_token_create_common">create_common</a>(&constructor_ref, creator_address, collection_name, description, name, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>
@@ -751,6 +898,8 @@ Extracts the tokens address from a BurnRef.
 
 ## Function `name`
 
+Avoid this method in the same transaction as the token is minted
+as that would prohibit transactions to be executed in parallel.
 
 
 <pre><code>#[view]
@@ -763,8 +912,13 @@ Extracts the tokens address from a BurnRef.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_name">name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): String <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).name
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_name">name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): String <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+    <b>let</b> token_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="token.md#0x4_token">token</a>);
+    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address)) {
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address).name)
+    } <b>else</b> {
+        <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).name
+    }
 }
 </code></pre>
 
@@ -832,6 +986,38 @@ Extracts the tokens address from a BurnRef.
 
 </details>
 
+<a name="0x4_token_index"></a>
+
+## Function `index`
+
+Avoid this method in the same transaction as the token is minted
+as that would prohibit transactions to be executed in parallel.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="token.md#0x4_token_index">index</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_index">index</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): u64 <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+    <b>let</b> token_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="token.md#0x4_token">token</a>);
+    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address)) {
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address).index)
+    } <b>else</b> {
+        <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).index
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x4_token_borrow_mut"></a>
 
 ## Function `borrow_mut`
@@ -875,7 +1061,7 @@ Extracts the tokens address from a BurnRef.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_burn">burn</a>(burn_ref: <a href="token.md#0x4_token_BurnRef">BurnRef</a>) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_burn">burn</a>(burn_ref: <a href="token.md#0x4_token_BurnRef">BurnRef</a>) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
     <b>let</b> addr = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&burn_ref.inner)) {
         <b>let</b> delete_ref = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> burn_ref.inner);
         <b>let</b> addr = <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_delete_ref">object::address_from_delete_ref</a>(&delete_ref);
@@ -891,12 +1077,22 @@ Extracts the tokens address from a BurnRef.
 
     <b>let</b> <a href="token.md#0x4_token_Token">Token</a> {
         <a href="collection.md#0x4_collection">collection</a>,
-        index,
+        index: deprecated_index,
         description: _,
         name: _,
         uri: _,
         mutation_events,
     } = <b>move_from</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(addr);
+
+    <b>let</b> index = <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(addr)) {
+        <b>let</b> <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+            index,
+            name: _,
+        } = <b>move_from</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(addr);
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&index)
+    } <b>else</b> {
+        deprecated_index
+    };
 
     <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(mutation_events);
     <a href="collection.md#0x4_collection_decrement_supply">collection::decrement_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, addr, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(index));

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -11,7 +11,7 @@ token are:
 
 
 -  [Resource `Token`](#0x4_token_Token)
--  [Resource `TokenConcurrentFieldsAppendix`](#0x4_token_TokenConcurrentFieldsAppendix)
+-  [Resource `ConcurrentTokenIdentifiers`](#0x4_token_ConcurrentTokenIdentifiers)
 -  [Struct `BurnRef`](#0x4_token_BurnRef)
 -  [Struct `MutatorRef`](#0x4_token_MutatorRef)
 -  [Struct `MutationEvent`](#0x4_token_MutationEvent)
@@ -86,7 +86,7 @@ Represents the common fields to all tokens.
 <code>index: u64</code>
 </dt>
 <dd>
- Deprecated in favor of <code>index</code> inside TokenConcurrentFieldsAppendix.
+ Deprecated in favor of <code>index</code> inside ConcurrentTokenIdentifiers.
  Will be populated until concurrent_assets_enabled feature flag is enabled.
 
  Unique identifier within the collection, optional, 0 means unassigned
@@ -101,7 +101,7 @@ Represents the common fields to all tokens.
 <code>name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
- Deprecated in favor of <code>name</code> inside TokenConcurrentFieldsAppendix.
+ Deprecated in favor of <code>name</code> inside ConcurrentTokenIdentifiers.
  Will be populated until concurrent_assets_enabled feature flag is enabled.
 
  The name of the token, which should be unique within the collection; the length of name
@@ -125,16 +125,16 @@ Represents the common fields to all tokens.
 
 </details>
 
-<a name="0x4_token_TokenConcurrentFieldsAppendix"></a>
+<a name="0x4_token_ConcurrentTokenIdentifiers"></a>
 
-## Resource `TokenConcurrentFieldsAppendix`
+## Resource `ConcurrentTokenIdentifiers`
 
 Represents first addition to the common fields for all tokens
 Starts being populated once aggregator_v2_api_enabled is enabled.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="../../aptos-framework/doc/object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> <b>has</b> key
+<b>struct</b> <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> <b>has</b> key
 </code></pre>
 
 
@@ -380,6 +380,8 @@ The token name is over the maximum length
     collection_name: String,
     description: String,
     name_prefix: String,
+    // If <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>, numbered <a href="token.md#0x4_token">token</a> is created - i.e. index is appended <b>to</b> the name.
+    // If <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>, name_prefix is the full name of the <a href="token.md#0x4_token">token</a>.
     name_with_index_suffix: Option&lt;String&gt;,
     <a href="royalty.md#0x4_royalty">royalty</a>: Option&lt;Royalty&gt;,
     uri: String,
@@ -398,40 +400,41 @@ The token name is over the maximum length
     <b>let</b> collection_addr = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator_address, &collection_name);
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Collection&gt;(collection_addr);
 
-    // once this flag is enabled, cleanup <a href="../../aptos-framework/doc/code.md#0x1_code">code</a> for aggregator_api_enabled = <b>false</b>.
+    // TODO[agg_v2](cleanup) once this flag is enabled, cleanup <a href="../../aptos-framework/doc/code.md#0x1_code">code</a> for aggregator_api_enabled = <b>false</b>.
+    // Flag which controls whether <a href="../../aptos-framework/../aptos-stdlib/doc/any.md#0x1_any">any</a> functions from <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2">aggregator_v2</a> <b>module</b> can be called.
     <b>let</b> aggregator_api_enabled = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_aggregator_v2_api_enabled">features::aggregator_v2_api_enabled</a>();
+    // Flag which controls whether we are going <b>to</b> still <b>continue</b> writing <b>to</b> deprecated fields.
     <b>let</b> concurrent_assets_enabled = aggregator_api_enabled && <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_concurrent_assets_enabled">features::concurrent_assets_enabled</a>();
 
     <b>let</b> (deprecated_index, deprecated_name) = <b>if</b> (aggregator_api_enabled) {
-        <b>let</b> index = <b>if</b> (concurrent_assets_enabled) {
-            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_destroy_with_default">option::destroy_with_default</a>(
-                <a href="collection.md#0x4_collection_increment_concurrent_supply">collection::increment_concurrent_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer)),
-                <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>&lt;u64&gt;(0)
-            )
-        } <b>else</b> {
-            <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
-            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0))
-        };
+        <b>let</b> index = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_destroy_with_default">option::destroy_with_default</a>(
+            <a href="collection.md#0x4_collection_increment_concurrent_supply">collection::increment_concurrent_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer)),
+            <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>&lt;u64&gt;(0)
+        );
 
+        // If create_numbered_token called us, add index <b>to</b> the name.
         <b>let</b> name = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&name_with_index_suffix)) {
             <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_string_concat">aggregator_v2::string_concat</a>(name_prefix, &index, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> name_with_index_suffix))
         } <b>else</b> {
             <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(name_prefix)
         };
 
+        // Until concurrent_assets_enabled is enabled, we still need <b>to</b> write <b>to</b> deprecated fields.
+        // Otherwise we put empty values there.
+        // (we need <b>to</b> do these calls before creating token_concurrent, <b>to</b> avoid copying objects)
         <b>let</b> deprecated_index = <b>if</b> (concurrent_assets_enabled) {
             0
         } <b>else</b> {
             <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&index)
         };
-
         <b>let</b> deprecated_name = <b>if</b> (concurrent_assets_enabled) {
             <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"")
         } <b>else</b> {
             <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&name)
         };
 
-        <b>let</b> token_concurrent = <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+        // If aggregator_api_enabled, we always populate newly added fields
+        <b>let</b> token_concurrent = <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
             index,
             name,
         };
@@ -439,9 +442,12 @@ The token name is over the maximum length
 
         (deprecated_index, deprecated_name)
     } <b>else</b> {
+        // If aggregator_api_enabled is disabled, we cannot <b>use</b> increment_concurrent_supply or
+        // create <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>, so we fallback <b>to</b> the <b>old</b> behavior.
         <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
         <b>let</b> index = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0);
 
+        // If create_numbered_token called us, add index <b>to</b> the name.
         <b>let</b> name = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&name_with_index_suffix)) {
             <b>let</b> name = name_prefix;
             <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_append">string::append</a>(&<b>mut</b> name, to_string&lt;u64&gt;(&index));
@@ -915,10 +921,10 @@ as that would prohibit transactions to be executed in parallel.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_name">name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): String <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_name">name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): String <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
     <b>let</b> token_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="token.md#0x4_token">token</a>);
-    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address)) {
-        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address).name)
+    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(token_address)) {
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(token_address).name)
     } <b>else</b> {
         <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).name
     }
@@ -1007,10 +1013,10 @@ as that would prohibit transactions to be executed in parallel.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_index">index</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): u64 <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_index">index</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): u64 <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
     <b>let</b> token_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="token.md#0x4_token">token</a>);
-    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address)) {
-        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(token_address).index)
+    <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(token_address)) {
+        <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&<b>borrow_global</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(token_address).index)
     } <b>else</b> {
         <a href="token.md#0x4_token_borrow">borrow</a>(&<a href="token.md#0x4_token">token</a>).index
     }
@@ -1064,7 +1070,7 @@ as that would prohibit transactions to be executed in parallel.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_burn">burn</a>(burn_ref: <a href="token.md#0x4_token_BurnRef">BurnRef</a>) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_burn">burn</a>(burn_ref: <a href="token.md#0x4_token_BurnRef">BurnRef</a>) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
     <b>let</b> addr = <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&burn_ref.inner)) {
         <b>let</b> delete_ref = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> burn_ref.inner);
         <b>let</b> addr = <a href="../../aptos-framework/doc/object.md#0x1_object_address_from_delete_ref">object::address_from_delete_ref</a>(&delete_ref);
@@ -1087,11 +1093,11 @@ as that would prohibit transactions to be executed in parallel.
         mutation_events,
     } = <b>move_from</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(addr);
 
-    <b>let</b> index = <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(addr)) {
-        <b>let</b> <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+    <b>let</b> index = <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(addr)) {
+        <b>let</b> <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
             index,
             name: _,
-        } = <b>move_from</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(addr);
+        } = <b>move_from</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(addr);
         <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&index)
     } <b>else</b> {
         deprecated_index
@@ -1155,13 +1161,13 @@ as that would prohibit transactions to be executed in parallel.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a>, <a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a> {
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
 
     <b>let</b> <a href="token.md#0x4_token">token</a> = <a href="token.md#0x4_token_borrow_mut">borrow_mut</a>(mutator_ref);
 
-    <b>let</b> old_name = <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(mutator_ref.self)) {
-        <b>let</b> token_concurrent = <b>borrow_global_mut</b>&lt;<a href="token.md#0x4_token_TokenConcurrentFieldsAppendix">TokenConcurrentFieldsAppendix</a>&gt;(mutator_ref.self);
+    <b>let</b> old_name = <b>if</b> (<b>exists</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(mutator_ref.self)) {
+        <b>let</b> token_concurrent = <b>borrow_global_mut</b>&lt;<a href="token.md#0x4_token_ConcurrentTokenIdentifiers">ConcurrentTokenIdentifiers</a>&gt;(mutator_ref.self);
         <b>let</b> old_name = <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_read_snapshot">aggregator_v2::read_snapshot</a>(&token_concurrent.name);
         token_concurrent.name = <a href="../../aptos-framework/doc/aggregator_v2.md#0x1_aggregator_v2_create_snapshot">aggregator_v2::create_snapshot</a>(name);
         old_name

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -18,11 +18,13 @@
 /// * Add aggregator support when added to framework
 module aptos_token_objects::collection {
     use std::error;
+    use std::features;
     use std::option::{Self, Option};
     use std::signer;
     use std::string::{Self, String};
+    use aptos_framework::aggregator_v2::{Self, Aggregator, AggregatorSnapshot};
     use aptos_framework::event;
-    use aptos_framework::object::{Self, ConstructorRef, Object};
+    use aptos_framework::object::{Self, ConstructorRef, ExtendRef, Object};
 
     use aptos_token_objects::royalty::{Self, Royalty};
 
@@ -40,10 +42,16 @@ module aptos_token_objects::collection {
     const EDESCRIPTION_TOO_LONG: u64 = 5;
     /// The max supply must be positive
     const EMAX_SUPPLY_CANNOT_BE_ZERO: u64 = 6;
+    /// Concurrent feature flag is not yet enabled, so the function cannot be performed
+    const ECONCURRENT_NOT_ENABLED: u64 = 7;
+    /// Tried upgrading collection to concurrent, but collection is already concurrent
+    const EALREADY_CONCURRENT: u64 = 8;
 
     const MAX_COLLECTION_NAME_LENGTH: u64 = 128;
     const MAX_URI_LENGTH: u64 = 512;
     const MAX_DESCRIPTION_LENGTH: u64 = 2048;
+
+    const MAX_U64: u64 = 18446744073709551615;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Represents the common fields for a collection.
@@ -97,13 +105,36 @@ module aptos_token_objects::collection {
         mint_events: event::EventHandle<MintEvent>,
     }
 
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Supply tracker, useful for tracking amount of issued tokens.
+    /// If max_value is not set to U64_MAX, this ensures that a limited number of tokens are minted.
+    struct ConcurrentSupply has key {
+        /// Total minted - total burned
+        current_supply: Aggregator<u64>,
+        total_minted: Aggregator<u64>,
+    }
+
     struct BurnEvent has drop, store {
         index: u64,
         token: address,
     }
 
+    #[event]
+    struct ConcurrentBurnEvent has drop, store {
+        collection_addr: address,
+        index: AggregatorSnapshot<u64>,
+        token: address,
+    }
+
     struct MintEvent has drop, store {
         index: u64,
+        token: address,
+    }
+
+    #[event]
+    struct ConcurrentMintEvent has drop, store {
+        collection_addr: address,
+        index: AggregatorSnapshot<u64>,
         token: address,
     }
 
@@ -125,23 +156,40 @@ module aptos_token_objects::collection {
         let constructor_ref = object::create_named_object(creator, collection_seed);
         let object_signer = object::generate_signer(&constructor_ref);
 
-        let supply = FixedSupply {
-            current_supply: 0,
-            max_supply,
-            total_minted: 0,
-            burn_events: object::new_event_handle(&object_signer),
-            mint_events: object::new_event_handle(&object_signer),
-        };
+        if (features::concurrent_assets_enabled()) {
+            let supply = ConcurrentSupply {
+                current_supply: aggregator_v2::create_aggregator(max_supply),
+                total_minted: aggregator_v2::create_unbounded_aggregator(),
+            };
 
-        create_collection_internal(
-            creator,
-            constructor_ref,
-            description,
-            name,
-            royalty,
-            uri,
-            option::some(supply),
-        )
+            create_collection_internal(
+                creator,
+                constructor_ref,
+                description,
+                name,
+                royalty,
+                uri,
+                option::some(supply),
+            )
+        } else {
+            let supply = FixedSupply {
+                current_supply: 0,
+                max_supply,
+                total_minted: 0,
+                burn_events: object::new_event_handle(&object_signer),
+                mint_events: object::new_event_handle(&object_signer),
+            };
+
+            create_collection_internal(
+                creator,
+                constructor_ref,
+                description,
+                name,
+                royalty,
+                uri,
+                option::some(supply),
+            )
+        }
     }
 
     /// Creates an unlimited collection. This has support for supply tracking but does not limit
@@ -157,22 +205,39 @@ module aptos_token_objects::collection {
         let constructor_ref = object::create_named_object(creator, collection_seed);
         let object_signer = object::generate_signer(&constructor_ref);
 
-        let supply = UnlimitedSupply {
-            current_supply: 0,
-            total_minted: 0,
-            burn_events: object::new_event_handle(&object_signer),
-            mint_events: object::new_event_handle(&object_signer),
-        };
+        if (features::concurrent_assets_enabled()) {
+            let supply = ConcurrentSupply {
+                current_supply: aggregator_v2::create_unbounded_aggregator(),
+                total_minted: aggregator_v2::create_unbounded_aggregator(),
+            };
 
-        create_collection_internal(
-            creator,
-            constructor_ref,
-            description,
-            name,
-            royalty,
-            uri,
-            option::some(supply),
-        )
+            create_collection_internal(
+                creator,
+                constructor_ref,
+                description,
+                name,
+                royalty,
+                uri,
+                option::some(supply),
+            )
+        } else {
+            let supply = UnlimitedSupply {
+                current_supply: 0,
+                total_minted: 0,
+                burn_events: object::new_event_handle(&object_signer),
+                mint_events: object::new_event_handle(&object_signer),
+            };
+
+            create_collection_internal(
+                creator,
+                constructor_ref,
+                description,
+                name,
+                royalty,
+                uri,
+                option::some(supply),
+            )
+        }
     }
 
     /// Creates an untracked collection, or a collection that supports an arbitrary amount of
@@ -254,7 +319,20 @@ module aptos_token_objects::collection {
     public(friend) fun increment_supply(
         collection: &Object<Collection>,
         token: address,
-    ): Option<u64> acquires FixedSupply, UnlimitedSupply {
+    ): Option<u64> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+        let index = increment_concurrent_supply(collection, token);
+        if (option::is_none(&index)) {
+            option::none()
+        } else {
+            option::some(aggregator_v2::read_snapshot<u64>(&option::destroy_some(index)))
+        }
+    }
+
+    /// Called by token on mint to increment supply if there's an appropriate Supply struct.
+    public(friend) fun increment_concurrent_supply(
+        collection: &Object<Collection>,
+        token: address,
+    ): Option<AggregatorSnapshot<u64>> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let collection_addr = object::object_address(collection);
         if (exists<FixedSupply>(collection_addr)) {
             let supply = borrow_global_mut<FixedSupply>(collection_addr);
@@ -270,7 +348,7 @@ module aptos_token_objects::collection {
                     token,
                 },
             );
-            option::some(supply.total_minted)
+            option::some(aggregator_v2::create_snapshot<u64>(supply.total_minted))
         } else if (exists<UnlimitedSupply>(collection_addr)) {
             let supply = borrow_global_mut<UnlimitedSupply>(collection_addr);
             supply.current_supply = supply.current_supply + 1;
@@ -282,7 +360,22 @@ module aptos_token_objects::collection {
                     token,
                 },
             );
-            option::some(supply.total_minted)
+            option::some(aggregator_v2::create_snapshot<u64>(supply.total_minted))
+        } else if (exists<ConcurrentSupply>(collection_addr)) {
+            let supply = borrow_global_mut<ConcurrentSupply>(collection_addr);
+            assert!(
+                aggregator_v2::try_add(&mut supply.current_supply, 1),
+                error::out_of_range(ECOLLECTION_SUPPLY_EXCEEDED),
+            );
+            aggregator_v2::add(&mut supply.total_minted, 1);
+            event::emit(
+                ConcurrentMintEvent {
+                    collection_addr,
+                    index: aggregator_v2::snapshot(&supply.total_minted),
+                    token,
+                },
+            );
+            option::some(aggregator_v2::snapshot(&supply.total_minted))
         } else {
             option::none()
         }
@@ -293,7 +386,7 @@ module aptos_token_objects::collection {
         collection: &Object<Collection>,
         token: address,
         index: Option<u64>,
-    ) acquires FixedSupply, UnlimitedSupply {
+    ) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let collection_addr = object::object_address(collection);
         if (exists<FixedSupply>(collection_addr)) {
             let supply = borrow_global_mut<FixedSupply>(collection_addr);
@@ -315,6 +408,16 @@ module aptos_token_objects::collection {
                     token,
                 },
             );
+        } else if (exists<ConcurrentSupply>(collection_addr)) {
+            let supply = borrow_global_mut<ConcurrentSupply>(collection_addr);
+            aggregator_v2::sub(&mut supply.current_supply, 1);
+            event::emit(
+                ConcurrentBurnEvent {
+                    collection_addr,
+                    index: aggregator_v2::create_snapshot(*option::borrow(&index)),
+                    token,
+                },
+            );
         }
     }
 
@@ -322,6 +425,60 @@ module aptos_token_objects::collection {
     public fun generate_mutator_ref(ref: &ConstructorRef): MutatorRef {
         let object = object::object_from_constructor_ref<Collection>(ref);
         MutatorRef { self: object::object_address(&object) }
+    }
+
+    public fun upgrade_to_concurrent(
+        ref: &ExtendRef,
+    ) acquires FixedSupply, UnlimitedSupply {
+        let metadata_object_address = object::address_from_extend_ref(ref);
+        let metadata_object_signer = object::generate_signer_for_extending(ref);
+        assert!(features::concurrent_assets_enabled(), error::invalid_argument(ECONCURRENT_NOT_ENABLED));
+
+        if (exists<FixedSupply>(metadata_object_address)) {
+            let FixedSupply {
+                current_supply,
+                max_supply,
+                total_minted,
+                burn_events,
+                mint_events,
+            } = move_from<FixedSupply>(metadata_object_address);
+
+            event::destroy_handle(burn_events);
+            event::destroy_handle(mint_events);
+
+            let supply = ConcurrentSupply {
+                current_supply: aggregator_v2::create_aggregator(max_supply),
+                total_minted: aggregator_v2::create_unbounded_aggregator(),
+            };
+
+            // update current state:
+            aggregator_v2::add(&mut supply.current_supply, current_supply);
+            aggregator_v2::add(&mut supply.total_minted, total_minted);
+            move_to(&metadata_object_signer, supply);
+        } else if (exists<UnlimitedSupply>(metadata_object_address)) {
+            let UnlimitedSupply {
+                current_supply,
+                total_minted,
+                burn_events,
+                mint_events,
+            } = move_from<UnlimitedSupply>(metadata_object_address);
+
+            event::destroy_handle(burn_events);
+            event::destroy_handle(mint_events);
+
+            let supply = ConcurrentSupply {
+                current_supply: aggregator_v2::create_unbounded_aggregator(),
+                total_minted: aggregator_v2::create_unbounded_aggregator(),
+            };
+
+            // update current state:
+            aggregator_v2::add(&mut supply.current_supply, current_supply);
+            aggregator_v2::add(&mut supply.total_minted, total_minted);
+            move_to(&metadata_object_signer, supply);
+        } else {
+            // untracked collection is already concurrent, and other variants too.
+            abort error::invalid_argument(EALREADY_CONCURRENT)
+        }
     }
 
     // Accessors
@@ -341,7 +498,10 @@ module aptos_token_objects::collection {
 
     #[view]
     /// Provides the count of the current selection if supply tracking is used
-    public fun count<T: key>(collection: Object<T>): Option<u64> acquires FixedSupply, UnlimitedSupply {
+    ///
+    /// Note: Calling this method from transaction that also mints/burns, prevents
+    /// it from being parallelized.
+    public fun count<T: key>(collection: Object<T>): Option<u64> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let collection_address = object::object_address(&collection);
         check_collection_exists(collection_address);
 
@@ -351,6 +511,9 @@ module aptos_token_objects::collection {
         } else if (exists<UnlimitedSupply>(collection_address)) {
             let supply = borrow_global_mut<UnlimitedSupply>(collection_address);
             option::some(supply.current_supply)
+        } else if (exists<ConcurrentSupply>(collection_address)) {
+            let supply = borrow_global_mut<ConcurrentSupply>(collection_address);
+            option::some(aggregator_v2::read(&supply.current_supply))
         } else {
             option::none()
         }

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -122,7 +122,7 @@ module aptos_token_objects::collection {
     #[event]
     struct ConcurrentBurnEvent has drop, store {
         collection_addr: address,
-        index: AggregatorSnapshot<u64>,
+        index: u64,
         token: address,
     }
 
@@ -414,7 +414,7 @@ module aptos_token_objects::collection {
             event::emit(
                 ConcurrentBurnEvent {
                     collection_addr,
-                    index: aggregator_v2::create_snapshot(*option::borrow(&index)),
+                    index: *option::borrow(&index),
                     token,
                 },
             );
@@ -569,7 +569,7 @@ module aptos_token_objects::collection {
     // Tests
 
     #[test(creator = @0x123)]
-    fun test_create_mint_burn_for_unlimited(creator: &signer) acquires FixedSupply, UnlimitedSupply {
+    fun test_create_mint_burn_for_unlimited(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
         create_unlimited_collection(creator, string::utf8(b""), name, option::none(), string::utf8(b""));
@@ -585,7 +585,7 @@ module aptos_token_objects::collection {
     }
 
     #[test(creator = @0x123)]
-    fun test_create_mint_burn_for_fixed(creator: &signer) acquires FixedSupply, UnlimitedSupply {
+    fun test_create_mint_burn_for_fixed(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
         create_fixed_collection(creator, string::utf8(b""), 1, name, option::none(), string::utf8(b""));

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -7,11 +7,14 @@
 module aptos_token_objects::token {
     use std::error;
     use std::option::{Self, Option};
+    use std::features;
     use std::string::{Self, String};
     use std::signer;
     use std::vector;
+    use aptos_framework::aggregator_v2::{Self, AggregatorSnapshot};
     use aptos_framework::event;
     use aptos_framework::object::{Self, ConstructorRef, Object};
+    use aptos_std::string_utils;
     use aptos_token_objects::collection::{Self, Collection};
     use aptos_token_objects::royalty::{Self, Royalty};
 
@@ -37,18 +40,35 @@ module aptos_token_objects::token {
     struct Token has key {
         /// The collection from which this token resides.
         collection: Object<Collection>,
+        /// Deprecated in favor of `index` inside TokenConcurrentFieldsAppendix.
+        /// Will be populated until concurrent_assets_enabled feature flag is enabled.
+        ///
         /// Unique identifier within the collection, optional, 0 means unassigned
-        index: u64,
+        index: u64, // DEPRECATED
         /// A brief description of the token.
         description: String,
+        /// Deprecated in favor of `name` inside TokenConcurrentFieldsAppendix.
+        /// Will be populated until concurrent_assets_enabled feature flag is enabled.
+        ///
         /// The name of the token, which should be unique within the collection; the length of name
         /// should be smaller than 128, characters, eg: "Aptos Animal #1234"
-        name: String,
+        name: String,  // DEPRECATED
         /// The Uniform Resource Identifier (uri) pointing to the JSON file stored in off-chain
         /// storage; the URL length will likely need a maximum any suggestions?
         uri: String,
         /// Emitted upon any mutation of the token.
         mutation_events: event::EventHandle<MutationEvent>,
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Represents first addition to the common fields for all tokens
+    /// Starts being populated once aggregator_snapshots_enabled is enabled.
+    struct TokenConcurrentFieldsAppendix has key {
+        /// Unique identifier within the collection, optional, 0 means unassigned
+        index: AggregatorSnapshot<u64>,
+        /// The name of the token, which should be unique within the collection; the length of name
+        /// should be smaller than 128, characters, eg: "Aptos Animal #1234"
+        name: AggregatorSnapshot<String>,
     }
 
     /// This enables burning an NFT, if possible, it will also delete the object. Note, the data
@@ -77,11 +97,17 @@ module aptos_token_objects::token {
         creator_address: address,
         collection_name: String,
         description: String,
-        name: String,
+        name_prefix: String,
+        name_with_index_suffix: Option<String>,
         royalty: Option<Royalty>,
         uri: String,
     ) {
-        assert!(string::length(&name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        if (option::is_some(&name_with_index_suffix)) {
+            // Be conservative, as we don't know what length the index will be, and assume worst case (20 chars in MAX_U64)
+            assert!(string::length(&name_prefix) + 20 + string::length(option::borrow(&name_with_index_suffix)) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        } else {
+            assert!(string::length(&name_prefix) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        };
         assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
 
@@ -89,13 +115,65 @@ module aptos_token_objects::token {
 
         let collection_addr = collection::create_collection_address(&creator_address, &collection_name);
         let collection = object::address_to_object<Collection>(collection_addr);
-        let id = collection::increment_supply(&collection, signer::address_of(&object_signer));
+
+        // once this flag is enabled, cleanup code for aggregator_api_enabled = false.
+        let aggregator_api_enabled = features::aggregator_snapshots_enabled();
+        let concurrent_assets_enabled = aggregator_api_enabled && features::concurrent_assets_enabled();
+
+        let (deprecated_index, deprecated_name) = if (aggregator_api_enabled) {
+            let index = if (concurrent_assets_enabled) {
+                option::destroy_with_default(
+                    collection::increment_concurrent_supply(&collection, signer::address_of(&object_signer)),
+                    aggregator_v2::create_snapshot<u64>(0)
+                )
+            } else {
+                let id = collection::increment_supply(&collection, signer::address_of(&object_signer));
+                aggregator_v2::create_snapshot(option::get_with_default(&mut id, 0))
+            };
+
+            let name = if (option::is_some(&name_with_index_suffix)) {
+                aggregator_v2::string_concat(name_prefix, &index, option::extract(&mut name_with_index_suffix))
+            } else {
+                aggregator_v2::create_snapshot(name_prefix)
+            };
+
+            let deprecated_index = if (concurrent_assets_enabled) {
+                0
+            } else {
+                aggregator_v2::read_snapshot(&index)
+            };
+
+            let deprecated_name = if (concurrent_assets_enabled) {
+                string::utf8(b"")
+            } else {
+                aggregator_v2::read_snapshot(&name)
+            };
+
+            let token_concurrent = TokenConcurrentFieldsAppendix {
+                index,
+                name,
+            };
+            move_to(&object_signer, token_concurrent);
+
+            (deprecated_index, deprecated_name)
+        } else {
+            let id = collection::increment_supply(&collection, signer::address_of(&object_signer));
+            let index = option::get_with_default(&mut id, 0);
+
+            let name = if (option::is_some(&name_with_index_suffix)) {
+                string_utils::format3(&b"{}{}{}", name_prefix, index, option::extract(&mut name_with_index_suffix))
+            } else {
+                name_prefix
+            };
+
+            (index, name)
+        };
 
         let token = Token {
             collection,
-            index: option::get_with_default(&mut id, 0),
+            index: deprecated_index,
             description,
-            name,
+            name: deprecated_name,
             uri,
             mutation_events: object::new_event_handle(&object_signer),
         };
@@ -118,7 +196,27 @@ module aptos_token_objects::token {
     ): ConstructorRef {
         let creator_address = signer::address_of(creator);
         let constructor_ref = object::create_object(creator_address);
-        create_common(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
+        create_common(&constructor_ref, creator_address, collection_name, description, name, option::none(), royalty, uri);
+        constructor_ref
+    }
+
+    /// Creates a new token object with a unique address and returns the ConstructorRef
+    /// for additional specialization.
+    /// The name is created by concatenating the (name_prefix, index, name_suffix).
+    /// After flag concurrent_assets_enabled is enabled, this function will allow
+    /// creating tokens in parallel, from the same collection, while providing sequential names.
+    public fun create_numbered_token(
+        creator: &signer,
+        collection_name: String,
+        description: String,
+        name_with_index_preffix: String,
+        name_with_index_suffix: String,
+        royalty: Option<Royalty>,
+        uri: String,
+    ): ConstructorRef {
+        let creator_address = signer::address_of(creator);
+        let constructor_ref = object::create_object(creator_address);
+        create_common(&constructor_ref, creator_address, collection_name, description, name_with_index_preffix, option::some(name_with_index_suffix), royalty, uri);
         constructor_ref
     }
 
@@ -136,7 +234,7 @@ module aptos_token_objects::token {
         let seed = create_token_seed(&collection_name, &name);
 
         let constructor_ref = object::create_named_object(creator, seed);
-        create_common(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
+        create_common(&constructor_ref, creator_address, collection_name, description, name, option::none(), royalty, uri);
         constructor_ref
     }
 
@@ -155,7 +253,7 @@ module aptos_token_objects::token {
     ): ConstructorRef {
         let creator_address = signer::address_of(creator);
         let constructor_ref = object::create_object_from_account(creator);
-        create_common(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
+        create_common(&constructor_ref, creator_address, collection_name, description, name, option::none(), royalty, uri);
         constructor_ref
     }
 
@@ -231,9 +329,28 @@ module aptos_token_objects::token {
         borrow(&token).description
     }
 
+    // To be added if/when needed
+    //
+    // /// This method allows minting to happen in parallel, making it efficient.
+    // fun name_snapshot<T: key>(token: &Object<T>): AggregatorSnapshot<String> acquires Token, TokenConcurrentFieldsAppendix {
+    //     let token_address = object::object_address(token);
+    //     if (exists<TokenConcurrentFieldsAppendix>(token_address)) {
+    //         aggregator_v2::copy_snapshot(&borrow_global<TokenConcurrentFieldsAppendix>(token_address).name)
+    //     } else {
+    //         aggregator_v2::create_snapshot(borrow(token).name)
+    //     }
+    // }
+
     #[view]
-    public fun name<T: key>(token: Object<T>): String acquires Token {
-        borrow(&token).name
+    /// Avoid this method in the same transaction as the token is minted
+    /// as that would prohibit transactions to be executed in parallel.
+    public fun name<T: key>(token: Object<T>): String acquires Token, TokenConcurrentFieldsAppendix {
+        let token_address = object::object_address(&token);
+        if (exists<TokenConcurrentFieldsAppendix>(token_address)) {
+            aggregator_v2::read_snapshot(&borrow_global<TokenConcurrentFieldsAppendix>(token_address).name)
+        } else {
+            borrow(&token).name
+        }
     }
 
     #[view]
@@ -256,6 +373,30 @@ module aptos_token_objects::token {
         }
     }
 
+    // To be added if/when needed
+    //
+    // /// This method allows minting to happen in parallel, making it efficient.
+    // fun index_snapshot<T: key>(token: &Object<T>): AggregatorSnapshot<u64> acquires Token, TokenConcurrentFieldsAppendix {
+    //     let token_address = object::object_address(token);
+    //     if (exists<TokenConcurrentFieldsAppendix>(token_address)) {
+    //         aggregator_v2::copy_snapshot(&borrow_global<TokenConcurrentFieldsAppendix>(token_address).index)
+    //     } else {
+    //         aggregator_v2::create_snapshot(borrow(token).index)
+    //     }
+    // }
+
+    #[view]
+    /// Avoid this method in the same transaction as the token is minted
+    /// as that would prohibit transactions to be executed in parallel.
+    public fun index<T: key>(token: Object<T>): u64 acquires Token, TokenConcurrentFieldsAppendix {
+        let token_address = object::object_address(&token);
+        if (exists<TokenConcurrentFieldsAppendix>(token_address)) {
+            aggregator_v2::read_snapshot(&borrow_global<TokenConcurrentFieldsAppendix>(token_address).index)
+        } else {
+            borrow(&token).index
+        }
+    }
+
     // Mutators
 
     inline fun borrow_mut(mutator_ref: &MutatorRef): &mut Token acquires Token {
@@ -266,7 +407,7 @@ module aptos_token_objects::token {
         borrow_global_mut<Token>(mutator_ref.self)
     }
 
-    public fun burn(burn_ref: BurnRef) acquires Token {
+    public fun burn(burn_ref: BurnRef) acquires Token, TokenConcurrentFieldsAppendix {
         let addr = if (option::is_some(&burn_ref.inner)) {
             let delete_ref = option::extract(&mut burn_ref.inner);
             let addr = object::address_from_delete_ref(&delete_ref);
@@ -282,12 +423,22 @@ module aptos_token_objects::token {
 
         let Token {
             collection,
-            index,
+            index: deprecated_index,
             description: _,
             name: _,
             uri: _,
             mutation_events,
         } = move_from<Token>(addr);
+
+        let index = if (exists<TokenConcurrentFieldsAppendix>(addr)) {
+            let TokenConcurrentFieldsAppendix {
+                index,
+                name: _,
+            } = move_from<TokenConcurrentFieldsAppendix>(addr);
+            aggregator_v2::read_snapshot(&index)
+        } else {
+            deprecated_index
+        };
 
         event::destroy_handle(mutation_events);
         collection::decrement_supply(&collection, addr, option::some(index));

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -13,8 +13,8 @@ module aptos_token_objects::token {
     use std::vector;
     use aptos_framework::aggregator_v2::{Self, AggregatorSnapshot};
     use aptos_framework::event;
-    use aptos_framework::object::{Self, ConstructorRef, Object};
-    use aptos_std::string_utils;
+    use aptos_framework::object::{Self, ConstructorRef, ExtendRef, Object};
+    use aptos_std::string_utils::{to_string};
     use aptos_token_objects::collection::{Self, Collection};
     use aptos_token_objects::royalty::{Self, Royalty};
 
@@ -62,7 +62,7 @@ module aptos_token_objects::token {
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Represents first addition to the common fields for all tokens
-    /// Starts being populated once aggregator_snapshots_enabled is enabled.
+    /// Starts being populated once aggregator_v2_api_enabled is enabled.
     struct TokenConcurrentFieldsAppendix has key {
         /// Unique identifier within the collection, optional, 0 means unassigned
         index: AggregatorSnapshot<u64>,
@@ -117,7 +117,7 @@ module aptos_token_objects::token {
         let collection = object::address_to_object<Collection>(collection_addr);
 
         // once this flag is enabled, cleanup code for aggregator_api_enabled = false.
-        let aggregator_api_enabled = features::aggregator_snapshots_enabled();
+        let aggregator_api_enabled = features::aggregator_v2_api_enabled();
         let concurrent_assets_enabled = aggregator_api_enabled && features::concurrent_assets_enabled();
 
         let (deprecated_index, deprecated_name) = if (aggregator_api_enabled) {
@@ -161,7 +161,10 @@ module aptos_token_objects::token {
             let index = option::get_with_default(&mut id, 0);
 
             let name = if (option::is_some(&name_with_index_suffix)) {
-                string_utils::format3(&b"{}{}{}", name_prefix, index, option::extract(&mut name_with_index_suffix))
+                let name = name_prefix;
+                string::append(&mut name, to_string<u64>(&index));
+                string::append(&mut name, option::extract(&mut name_with_index_suffix));
+                name
             } else {
                 name_prefix
             };
@@ -458,18 +461,30 @@ module aptos_token_objects::token {
         token.description = description;
     }
 
-    public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token {
+    public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token, TokenConcurrentFieldsAppendix {
         assert!(string::length(&name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+
         let token = borrow_mut(mutator_ref);
+
+        let old_name = if (exists<TokenConcurrentFieldsAppendix>(mutator_ref.self)) {
+            let token_concurrent = borrow_global_mut<TokenConcurrentFieldsAppendix>(mutator_ref.self);
+            let old_name = aggregator_v2::read_snapshot(&token_concurrent.name);
+            token_concurrent.name = aggregator_v2::create_snapshot(name);
+            old_name
+        } else {
+            let old_name = token.name;
+            token.name = name;
+            old_name
+        };
+
         event::emit_event(
             &mut token.mutation_events,
             MutationEvent {
                 mutated_field_name: string::utf8(b"name"),
-                old_value: token.name,
+                old_value: old_name,
                 new_value: name
             },
         );
-        token.name = name;
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Token {
@@ -603,7 +618,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123)]
-    fun test_set_name(creator: &signer) acquires Token {
+    fun test_set_name(creator: &signer) acquires Token, TokenConcurrentFieldsAppendix {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
@@ -637,7 +652,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123)]
-    fun test_burn_without_royalty(creator: &signer) acquires Token {
+    fun test_burn_without_royalty(creator: &signer) acquires Token, TokenConcurrentFieldsAppendix {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
@@ -660,7 +675,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123)]
-    fun test_burn_with_royalty(creator: &signer) acquires Token {
+    fun test_burn_with_royalty(creator: &signer) acquires Token, TokenConcurrentFieldsAppendix {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
@@ -684,7 +699,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123)]
-    fun test_create_from_account_burn_and_delete(creator: &signer) acquires Token {
+    fun test_create_from_account_burn_and_delete(creator: &signer) acquires Token, TokenConcurrentFieldsAppendix {
         use aptos_framework::account;
 
         let collection_name = string::utf8(b"collection name");
@@ -709,7 +724,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123,fx = @std)]
-    fun test_create_burn_and_delete(creator: &signer, fx: signer) acquires Token {
+    fun test_create_burn_and_delete(creator: &signer, fx: signer) acquires Token, TokenConcurrentFieldsAppendix {
         use aptos_framework::account;
         use std::features;
 
@@ -737,9 +752,34 @@ module aptos_token_objects::token {
         assert!(!object::is_object(token_addr), 2);
     }
 
+    #[test(fx = @aptos_framework, creator = @0x123, trader = @0x456)]
+    fun test_upgrade_to_concurrent_and_numbered_tokens(fx: &signer, creator: &signer) acquires Token, TokenConcurrentFieldsAppendix {
+        use std::debug;
+
+        let feature = features::get_concurrent_assets_feature();
+        let auid_feature = features::get_auids();
+        let module_event_feature = features::get_module_event_feature();
+        features::change_feature_flags(fx, vector[auid_feature, module_event_feature], vector[feature]);
+
+        let collection_name = string::utf8(b"collection name");
+        let token_name = string::utf8(b"token name");
+
+        let extend_ref = create_collection_helper(creator, collection_name, 2);
+        let token_1_ref = create_numbered_token_helper(creator, collection_name, token_name);
+        let token_1_name = name(object::object_from_constructor_ref<Token>(&token_1_ref));
+        debug::print(&token_1_name);
+        assert!(token_1_name == std::string::utf8(b"token name1"), 1);
+
+        features::change_feature_flags(fx, vector[feature], vector[]);
+        collection::upgrade_to_concurrent(&extend_ref);
+
+        let token_2_ref = create_numbered_token_helper(creator, collection_name, token_name);
+        assert!(name(object::object_from_constructor_ref<Token>(&token_2_ref)) == std::string::utf8(b"token name2"), 1);
+    }
+
     #[test_only]
-    fun create_collection_helper(creator: &signer, collection_name: String, max_supply: u64) {
-        collection::create_fixed_collection(
+    fun create_collection_helper(creator: &signer, collection_name: String, max_supply: u64): ExtendRef {
+        let constructor_ref = collection::create_fixed_collection(
             creator,
             string::utf8(b"collection description"),
             max_supply,
@@ -747,6 +787,7 @@ module aptos_token_objects::token {
             option::none(),
             string::utf8(b"collection uri"),
         );
+        object::generate_extend_ref(&constructor_ref)
     }
 
     #[test_only]
@@ -756,6 +797,19 @@ module aptos_token_objects::token {
             collection_name,
             string::utf8(b"token description"),
             token_name,
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
+        )
+    }
+
+    #[test_only]
+    fun create_numbered_token_helper(creator: &signer, collection_name: String, token_prefix: String): ConstructorRef {
+        create_numbered_token(
+            creator,
+            collection_name,
+            string::utf8(b"token description"),
+            token_prefix,
+            string::utf8(b""),
             option::some(royalty::create(25, 10000, signer::address_of(creator))),
             string::utf8(b"uri"),
         )

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -433,7 +433,6 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SINGLE_SENDER_AUTHENTICATOR,
         FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
         FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
-        FeatureFlag::CONCURRENT_ASSETS,
     ]
 }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -59,7 +59,7 @@ pub struct Features {
 impl Default for Features {
     fn default() -> Self {
         Features {
-            features: vec![0b00100000, 0b00100000, 0b00001100, 0b01100000, 0b00100000],
+            features: vec![0b00100000, 0b00100000, 0b10001100, 0b01100000, 0b00100000],
         }
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -59,7 +59,7 @@ pub struct Features {
 impl Default for Features {
     fn default() -> Self {
         Features {
-            features: vec![0b00100000, 0b00100000, 0b10001100, 0b01100000, 0b00100000],
+            features: vec![0b00100000, 0b00100000, 0b10001100, 0b01100000, 0b00000000],
         }
     }
 }


### PR DESCRIPTION
e2e indexer tests failed because CONCURRENT_ASSETS flag was made default and so enabled for testing (not for release)

redo the identical PR (https://github.com/aptos-labs/aptos-core/pull/10632), without making CONCURRENT_ASSETS default

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
