### PR TITLE
Fix aptos-admin-service build on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4191,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
 dependencies = [
  "derive_arbitrary",
 ]

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-logger = { workspace = true }
-aptos-profiler = { workspace = true }
 aptos-runtimes = { workspace = true }
 async-mutex = { workspace = true }
 futures = { workspace = true }
@@ -24,6 +23,9 @@ http = { workspace = true }
 hyper = { workspace = true }
 lazy_static = { workspace = true }
 mime = { workspace = true }
-pprof = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+aptos-profiler = { workspace = true }
+pprof = { workspace = true }

--- a/crates/aptos/src/node/local_testnet/docker.rs
+++ b/crates/aptos/src/node/local_testnet/docker.rs
@@ -4,11 +4,13 @@
 use super::traits::ShutdownStep;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+#[cfg(unix)]
+use bollard::API_DEFAULT_VERSION;
 use bollard::{
     container::{RemoveContainerOptions, StopContainerOptions},
     image::CreateImageOptions,
     volume::{CreateVolumeOptions, RemoveVolumeOptions},
-    Docker, API_DEFAULT_VERSION,
+    Docker,
 };
 use futures::TryStreamExt;
 use std::{fs::create_dir_all, path::Path};


### PR DESCRIPTION
### Description
We were relying on deps without gating them by target OS.

I also fix a warning that only happens on Windows.

### Test Plan
Built on Windows successfully. CI for the rest.