### PR TITLE
[move-vm] Remove hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,12 +6519,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "serde",
- "signature 1.6.0",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -10309,6 +10309,7 @@ dependencies = [
  "proptest",
  "serde",
  "sha3 0.9.1",
+ "smallbitvec",
  "tracing",
 ]
 
@@ -10345,6 +10346,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "serde",
+ "smallbitvec",
  "smallvec",
 ]
 
@@ -13419,9 +13421,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -13550,6 +13552,12 @@ dependencies = [
  "futures-core",
  "futures-io",
 ]
+
+[[package]]
+name = "smallbitvec"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
 
 [[package]]
 name = "smallvec"

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.7.2"
 parking_lot = "0.11.1"
 serde = "1.0.149"
 sha3 = "0.9.1"
+smallbitvec = "2.5.1"
 tracing = "0.1.26"
 
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -20,19 +20,19 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{GlobalValue, Value},
 };
-use std::collections::{btree_map::BTreeMap, hash_map::HashMap};
+use std::collections::btree_map::BTreeMap;
 
 pub struct AccountDataCache {
     // The bool flag in the `data_map` indicates whether the resource contains
     // an aggregator or snapshot.
-    data_map: HashMap<Type, (MoveTypeLayout, GlobalValue, bool)>,
+    data_map: BTreeMap<Type, (MoveTypeLayout, GlobalValue, bool)>,
     module_map: BTreeMap<Identifier, (Bytes, bool)>,
 }
 
 impl AccountDataCache {
     fn new() -> Self {
         Self {
-            data_map: HashMap::new(),
+            data_map: BTreeMap::new(),
             module_map: BTreeMap::new(),
         }
     }

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -4,7 +4,7 @@
 use move_binary_format::{
     binary_views::BinaryIndexedView, errors::PartialVMResult, file_format::SignatureToken,
 };
-use move_vm_types::loaded_data::runtime_types::{StructIdentifier, Type};
+use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructIdentifier, Type};
 use std::sync::Arc;
 
 // `intern_type` converts a signature token into the in memory type representation used by the MoveVM.
@@ -40,7 +40,7 @@ pub fn intern_type(
             let struct_handle = module.struct_handle_at(*sh_idx);
             Type::Struct {
                 name: struct_name_table[sh_idx.0 as usize].clone(),
-                ability: struct_handle.abilities,
+                ability: AbilityInfo::struct_(struct_handle.abilities),
             }
         },
         SignatureToken::StructInstantiation(sh_idx, tys) => {
@@ -51,13 +51,15 @@ pub fn intern_type(
             let struct_handle = module.struct_handle_at(*sh_idx);
             Type::StructInstantiation {
                 name: struct_name_table[sh_idx.0 as usize].clone(),
-                base_ability_set: struct_handle.abilities,
                 ty_args: Arc::new(type_args),
-                phantom_ty_args_mask: struct_handle
-                    .type_parameters
-                    .iter()
-                    .map(|ty| ty.is_phantom)
-                    .collect(),
+                ability: AbilityInfo::generic_struct(
+                    struct_handle.abilities,
+                    struct_handle
+                        .type_parameters
+                        .iter()
+                        .map(|ty| ty.is_phantom)
+                        .collect(),
+                ),
             }
         },
     };

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -14,6 +14,7 @@ derivative = "2.2.0"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.124", features = ["derive", "rc"] }
+smallbitvec = "2.5.1"
 smallvec = "1.6.1"
 
 bcs = { workspace = true }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -190,25 +190,40 @@ pub enum Type {
     U256,
 }
 
-
 // Cache for the ability of struct. They will be ignored when comparing equality or Ord as they are just used for caching purpose.
 #[derive(Derivative)]
 #[derivative(Debug, Clone, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct AbilityInfo {
-    #[derivative(PartialEq = "ignore", Hash = "ignore", Ord = "ignore", PartialOrd = "ignore")]
+    #[derivative(
+        PartialEq = "ignore",
+        Hash = "ignore",
+        Ord = "ignore",
+        PartialOrd = "ignore"
+    )]
     base_ability_set: AbilitySet,
 
-    #[derivative(PartialEq = "ignore", Hash = "ignore", Ord = "ignore", PartialOrd = "ignore")]
+    #[derivative(
+        PartialEq = "ignore",
+        Hash = "ignore",
+        Ord = "ignore",
+        PartialOrd = "ignore"
+    )]
     phantom_ty_args_mask: SmallBitVec,
 }
 
 impl AbilityInfo {
     pub fn struct_(ability: AbilitySet) -> Self {
-        Self { base_ability_set: ability, phantom_ty_args_mask: SmallBitVec::new()}
+        Self {
+            base_ability_set: ability,
+            phantom_ty_args_mask: SmallBitVec::new(),
+        }
     }
 
     pub fn generic_struct(base_ability_set: AbilitySet, phantom_ty_args_mask: SmallBitVec) -> Self {
-        Self { base_ability_set, phantom_ty_args_mask }
+        Self {
+            base_ability_set,
+            phantom_ty_args_mask,
+        }
     }
 }
 
@@ -420,7 +435,11 @@ impl Type {
             Type::Struct { ability, .. } => Ok(ability.base_ability_set),
             Type::StructInstantiation {
                 ty_args,
-                ability: AbilityInfo { base_ability_set, phantom_ty_args_mask },
+                ability:
+                    AbilityInfo {
+                        base_ability_set,
+                        phantom_ty_args_mask,
+                    },
                 ..
             } => {
                 let type_argument_abilities = ty_args


### PR DESCRIPTION
### Description

Use back btreemap to replace hashmap due to potential non-determinism concern. Also use bit vector to replace the inefficient Vec<bool>

### Test Plan
We should run a replay on this.
