### PR TITLE
[spec] specify functions in framework modules

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/chain_id.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_id.md
@@ -127,6 +127,7 @@ Return the chain ID of this instance.
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(addr);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -153,6 +153,7 @@ Aborts if StateStorageUsage already exists.
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework);
 <b>aborts_if</b> !(len(config) &gt; 0);
+<b>ensures</b>  <b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework);
 </code></pre>
 
 
@@ -181,6 +182,7 @@ When setting now time must be later than last_reconfiguration_time.
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
+<b>ensures</b> <b>global</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework).config == config;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -274,10 +274,11 @@ This can be called by on-chain governance to update the gas schedule.
 
 
 
-<pre><code><b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
+<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
 <b>aborts_if</b> len(gas_schedule_blob) == 0;
-<b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
-<b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
+<b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(addr);
+<b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(addr);
 </code></pre>
 
 
@@ -303,6 +304,7 @@ This can be called by on-chain governance to update the gas schedule.
 <b>let</b> new_gas_schedule = <a href="util.md#0x1_util_spec_from_bytes">util::spec_from_bytes</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(gas_schedule_blob);
 <b>let</b> <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a> = <b>global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) && new_gas_schedule.feature_version &lt; <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>.feature_version;
+<b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) ==&gt; <b>global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) == new_gas_schedule;
 <b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -23,6 +23,11 @@
 -  [Function `set_genesis_end`](#0x1_genesis_set_genesis_end)
 -  [Function `initialize_for_verification`](#0x1_genesis_initialize_for_verification)
 -  [Specification](#@Specification_1)
+    -  [Function `initialize`](#@Specification_1_initialize)
+    -  [Function `initialize_aptos_coin`](#@Specification_1_initialize_aptos_coin)
+    -  [Function `create_initialize_validators_with_commission`](#@Specification_1_create_initialize_validators_with_commission)
+    -  [Function `create_initialize_validators`](#@Specification_1_create_initialize_validators)
+    -  [Function `create_initialize_validator`](#@Specification_1_create_initialize_validator)
     -  [Function `initialize_for_verification`](#@Specification_1_initialize_for_verification)
 
 
@@ -890,7 +895,109 @@ The last step of genesis.
 
 
 
-<pre><code><b>pragma</b> verify = <b>false</b>;
+<pre><code><b>pragma</b> verify = <b>true</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_initialize"></a>
+
+### Function `initialize`
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="genesis.md#0x1_genesis_InitalizeRequires">InitalizeRequires</a>;
+<b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_GovernanceResponsbility">aptos_governance::GovernanceResponsbility</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">consensus_config::ConsensusConfig</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">execution_config::ExecutionConfig</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="version.md#0x1_version_Version">version::Version</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">stake::ValidatorSet</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="storage_gas.md#0x1_storage_gas_StorageGasConfig">storage_gas::StorageGasConfig</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="storage_gas.md#0x1_storage_gas_StorageGas">storage_gas::StorageGas</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">gas_schedule::GasScheduleV2</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="aggregator_factory.md#0x1_aggregator_factory_AggregatorFactory">aggregator_factory::AggregatorFactory</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_SupplyConfig">coin::SupplyConfig</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">chain_id::ChainId</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">reconfiguration::Configuration</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">block::BlockResource</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="state_storage.md#0x1_state_storage_StateStorageUsage">state_storage::StateStorageUsage</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a name="@Specification_1_initialize_aptos_coin"></a>
+
+### Function `initialize_aptos_coin`
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_aptos_coin">initialize_aptos_coin</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>requires</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">stake::AptosCoinCapabilities</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">stake::AptosCoinCapabilities</a>&gt;(@aptos_framework);
+<b>requires</b> <b>exists</b>&lt;<a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabilities">transaction_fee::AptosCoinCapabilities</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabilities">transaction_fee::AptosCoinCapabilities</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a name="@Specification_1_create_initialize_validators_with_commission"></a>
+
+### Function `create_initialize_validators_with_commission`
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_initialize_validators_with_commission">create_initialize_validators_with_commission</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, use_staking_contract: bool, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">stake::ResourceRequirement</a>;
+<b>include</b> <a href="genesis.md#0x1_genesis_CompareTimeRequires">CompareTimeRequires</a>;
+</code></pre>
+
+
+
+<a name="@Specification_1_create_initialize_validators"></a>
+
+### Function `create_initialize_validators`
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_initialize_validators">create_initialize_validators</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfiguration">genesis::ValidatorConfiguration</a>&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">stake::ResourceRequirement</a>;
+<b>include</b> <a href="genesis.md#0x1_genesis_CompareTimeRequires">CompareTimeRequires</a>;
+</code></pre>
+
+
+
+<a name="@Specification_1_create_initialize_validator"></a>
+
+### Function `create_initialize_validator`
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_initialize_validator">create_initialize_validator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, commission_config: &<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>, use_staking_contract: bool)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">stake::ResourceRequirement</a>;
 </code></pre>
 
 
@@ -907,7 +1014,38 @@ The last step of genesis.
 
 
 
-<pre><code><b>pragma</b> verify = <b>true</b>;
+<pre><code><b>include</b> <a href="genesis.md#0x1_genesis_InitalizeRequires">InitalizeRequires</a>;
+</code></pre>
+
+
+
+
+<a name="0x1_genesis_InitalizeRequires"></a>
+
+
+<pre><code><b>schema</b> <a href="genesis.md#0x1_genesis_InitalizeRequires">InitalizeRequires</a> {
+    <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <b>requires</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(@aptos_framework);
+    <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+    <b>requires</b> len(<a href="execution_config.md#0x1_execution_config">execution_config</a>) &gt; 0;
+    <b>requires</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;AptosCoin&gt;&gt;(@aptos_framework);
+    <b>include</b> <a href="genesis.md#0x1_genesis_CompareTimeRequires">CompareTimeRequires</a>;
+    <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_genesis_CompareTimeRequires"></a>
+
+
+<pre><code><b>schema</b> <a href="genesis.md#0x1_genesis_CompareTimeRequires">CompareTimeRequires</a> {
+    <b>let</b> staking_rewards_config = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework);
+    <b>requires</b> staking_rewards_config.last_rewards_rate_period_start_in_secs &lt;= <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>();
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/guid.md
+++ b/aptos-move/framework/aptos-framework/doc/guid.md
@@ -19,6 +19,12 @@ A module for generating globally unique identifiers
 -  [Function `eq_id`](#0x1_guid_eq_id)
 -  [Specification](#@Specification_1)
     -  [Function `create`](#@Specification_1_create)
+    -  [Function `id`](#@Specification_1_id)
+    -  [Function `creator_address`](#@Specification_1_creator_address)
+    -  [Function `id_creator_address`](#@Specification_1_id_creator_address)
+    -  [Function `creation_num`](#@Specification_1_creation_num)
+    -  [Function `id_creation_num`](#@Specification_1_id_creation_num)
+    -  [Function `eq_id`](#@Specification_1_eq_id)
 
 
 <pre><code></code></pre>
@@ -335,6 +341,102 @@ Return true if the GUID's ID is <code>id</code>
 <pre><code><b>aborts_if</b> creation_num_ref + 1 &gt; MAX_U64;
 <b>ensures</b> result.id.creation_num == <b>old</b>(creation_num_ref);
 <b>ensures</b> creation_num_ref == <b>old</b>(creation_num_ref) + 1;
+</code></pre>
+
+
+
+<a name="@Specification_1_id"></a>
+
+### Function `id`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_id">id</a>(<a href="guid.md#0x1_guid">guid</a>: &<a href="guid.md#0x1_guid_GUID">guid::GUID</a>): <a href="guid.md#0x1_guid_ID">guid::ID</a>
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_creator_address"></a>
+
+### Function `creator_address`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_creator_address">creator_address</a>(<a href="guid.md#0x1_guid">guid</a>: &<a href="guid.md#0x1_guid_GUID">guid::GUID</a>): <b>address</b>
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_id_creator_address"></a>
+
+### Function `id_creator_address`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_id_creator_address">id_creator_address</a>(id: &<a href="guid.md#0x1_guid_ID">guid::ID</a>): <b>address</b>
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_creation_num"></a>
+
+### Function `creation_num`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_creation_num">creation_num</a>(<a href="guid.md#0x1_guid">guid</a>: &<a href="guid.md#0x1_guid_GUID">guid::GUID</a>): u64
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_id_creation_num"></a>
+
+### Function `id_creation_num`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_id_creation_num">id_creation_num</a>(id: &<a href="guid.md#0x1_guid_ID">guid::ID</a>): u64
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_eq_id"></a>
+
+### Function `eq_id`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="guid.md#0x1_guid_eq_id">eq_id</a>(<a href="guid.md#0x1_guid">guid</a>: &<a href="guid.md#0x1_guid_GUID">guid::GUID</a>, id: &<a href="guid.md#0x1_guid_ID">guid::ID</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -966,7 +966,7 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 <pre><code><b>invariant</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
-<b>pragma</b> verify = ture;
+<b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
 
@@ -1118,6 +1118,7 @@ StakingConfig does not exist under the aptos_framework before creating it.
 <b>aborts_if</b> rewards_rate &gt; <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
 <b>aborts_if</b> rewards_rate &gt; rewards_rate_denominator;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(addr);
+<b>ensures</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(addr);
 </code></pre>
 
 
@@ -1143,6 +1144,7 @@ StakingRewardsConfig does not exist under the aptos_framework before creating it
 <b>aborts_if</b> last_rewards_rate_period_start_in_secs &gt; <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>();
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
+<b>ensures</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
 </code></pre>
 
 
@@ -1302,7 +1304,7 @@ StakingRewardsConfig is under the @aptos_framework.
 
 <pre><code><b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
-<b>let</b> staking_reward_config = <b>borrow_global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+<b>let</b> staking_reward_config = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> staking_reward_config.rewards_rate_period_in_secs != rewards_rate_period_in_secs;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -225,6 +225,8 @@ Abort if resource already exists in <code>@aptos_framwork</code> when initializi
 <pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework) != @aptos_framework;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(@aptos_framework);
 </code></pre>
 
 
@@ -251,6 +253,7 @@ Abort if resource already exists in <code>@aptos_framwork</code> when initializi
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework);
 <b>let</b> old_major = <b>global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major;
 <b>aborts_if</b> !(old_major &lt; major);
+<b>ensures</b> <b>global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major == major;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/chain_id.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_id.spec.move
@@ -9,6 +9,7 @@ spec aptos_framework::chain_id {
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
         aborts_if exists<ChainId>(@aptos_framework);
+        ensures exists<ChainId>(addr);
     }
 
     spec get {

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
@@ -12,6 +12,7 @@ spec aptos_framework::consensus_config {
         aborts_if !system_addresses::is_aptos_framework_address(addr);
         aborts_if exists<ConsensusConfig>(@aptos_framework);
         aborts_if !(len(config) > 0);
+        ensures  exists<ConsensusConfig>(@aptos_framework);
     }
 
     /// Ensure the caller is admin and `ConsensusConfig` should be existed.
@@ -39,5 +40,6 @@ spec aptos_framework::consensus_config {
         requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
+        ensures global<ConsensusConfig>(@aptos_framework).config == config;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
@@ -7,10 +7,11 @@ spec aptos_framework::gas_schedule {
     spec initialize(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
         use std::signer;
 
+        let addr = signer::address_of(aptos_framework);
         include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
         aborts_if len(gas_schedule_blob) == 0;
-        aborts_if exists<GasScheduleV2>(signer::address_of(aptos_framework));
-        ensures exists<GasScheduleV2>(signer::address_of(aptos_framework));
+        aborts_if exists<GasScheduleV2>(addr);
+        ensures exists<GasScheduleV2>(addr);
     }
 
     spec set_gas_schedule(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
@@ -21,6 +22,7 @@ spec aptos_framework::gas_schedule {
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
         use aptos_framework::staking_config;
+
         pragma verify_duration_estimate = 120;
 
         requires exists<stake::ValidatorFees>(@aptos_framework);
@@ -33,6 +35,7 @@ spec aptos_framework::gas_schedule {
         let new_gas_schedule = util::spec_from_bytes<GasScheduleV2>(gas_schedule_blob);
         let gas_schedule = global<GasScheduleV2>(@aptos_framework);
         aborts_if exists<GasScheduleV2>(@aptos_framework) && new_gas_schedule.feature_version < gas_schedule.feature_version;
+        ensures exists<GasScheduleV2>(@aptos_framework) ==> global<GasScheduleV2>(@aptos_framework) == new_gas_schedule;
         ensures exists<GasScheduleV2>(signer::address_of(aptos_framework));
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -2,7 +2,7 @@ spec aptos_framework::staking_config {
     spec module {
         use aptos_framework::chain_status;
         invariant chain_status::is_operating() ==> exists<StakingConfig>(@aptos_framework);
-        pragma verify = ture;
+        pragma verify = true;
         pragma aborts_if_is_strict;
     }
 
@@ -51,6 +51,7 @@ spec aptos_framework::staking_config {
         aborts_if rewards_rate > MAX_REWARDS_RATE;
         aborts_if rewards_rate > rewards_rate_denominator;
         aborts_if exists<StakingConfig>(addr);
+        ensures exists<StakingConfig>(addr);
     }
 
     /// Caller must be @aptos_framework.
@@ -72,6 +73,7 @@ spec aptos_framework::staking_config {
         aborts_if last_rewards_rate_period_start_in_secs > timestamp::spec_now_seconds();
         include StakingRewardsConfigValidationAbortsIf;
         aborts_if exists<StakingRewardsConfig>(addr);
+        ensures exists<StakingRewardsConfig>(addr);
     }
 
     spec get(): StakingConfig {
@@ -156,7 +158,7 @@ spec aptos_framework::staking_config {
         use std::signer;
         include StakingRewardsConfigRequirement;
         let addr = signer::address_of(aptos_framework);
-        let staking_reward_config = borrow_global<StakingRewardsConfig>(@aptos_framework);
+        let staking_reward_config = global<StakingRewardsConfig>(@aptos_framework);
 
         aborts_if addr != @aptos_framework;
         aborts_if staking_reward_config.rewards_rate_period_in_secs != rewards_rate_period_in_secs;

--- a/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
@@ -27,6 +27,8 @@ spec aptos_framework::version {
 
         let old_major = global<Version>(@aptos_framework).major;
         aborts_if !(old_major < major);
+
+        ensures global<Version>(@aptos_framework).major == major;
     }
 
     /// Abort if resource already exists in `@aptos_framwork` when initializing.
@@ -36,6 +38,8 @@ spec aptos_framework::version {
         aborts_if signer::address_of(aptos_framework) != @aptos_framework;
         aborts_if exists<Version>(@aptos_framework);
         aborts_if exists<SetVersionCapability>(@aptos_framework);
+        ensures exists<Version>(@aptos_framework);
+        ensures exists<SetVersionCapability>(@aptos_framework);
     }
 
     /// This module turns on `aborts_if_is_strict`, so need to add spec for test function `initialize_for_test`.

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -1,14 +1,70 @@
 spec aptos_framework::genesis {
     spec module {
-        // We are not proving each genesis step individually. Instead, we construct
-        // and prove `initialize_for_verification` which is a "#[verify_only]" function that
-        // simulates the genesis encoding process in `vm-genesis` (written in Rust).
-        // So, we turn off the verification at the module level, but turn it on for
-        // the verification-only function `initialize_for_verification`.
-        pragma verify = false;
+        pragma verify = true;
+    }
+
+    spec initialize {
+        include InitalizeRequires;
+        ensures exists<aptos_governance::GovernanceResponsbility>(@aptos_framework);
+        ensures exists<consensus_config::ConsensusConfig>(@aptos_framework);
+        ensures exists<execution_config::ExecutionConfig>(@aptos_framework);
+        ensures exists<version::Version>(@aptos_framework);
+        ensures exists<stake::ValidatorSet>(@aptos_framework);
+        ensures exists<stake::ValidatorPerformance>(@aptos_framework);
+        ensures exists<storage_gas::StorageGasConfig>(@aptos_framework);
+        ensures exists<storage_gas::StorageGas>(@aptos_framework);
+        ensures exists<gas_schedule::GasScheduleV2>(@aptos_framework);
+        ensures exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        ensures exists<coin::SupplyConfig>(@aptos_framework);
+        ensures exists<chain_id::ChainId>(@aptos_framework);
+        ensures exists<reconfiguration::Configuration>(@aptos_framework);
+        ensures exists<block::BlockResource>(@aptos_framework);
+        ensures exists<state_storage::StateStorageUsage>(@aptos_framework);
+        ensures exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        ensures exists<account::Account>(@aptos_framework);
+    }
+
+    spec initialize_aptos_coin {
+        requires !exists<stake::AptosCoinCapabilities>(@aptos_framework);
+        ensures exists<stake::AptosCoinCapabilities>(@aptos_framework);
+        requires exists<transaction_fee::AptosCoinCapabilities>(@aptos_framework);
+        ensures exists<transaction_fee::AptosCoinCapabilities>(@aptos_framework);
+    }
+
+    spec create_initialize_validators_with_commission {
+        include stake::ResourceRequirement;
+        include CompareTimeRequires;
+    }
+
+    spec create_initialize_validators {
+        include stake::ResourceRequirement;
+        include CompareTimeRequires;
+    }
+
+    spec create_initialize_validator {
+        include stake::ResourceRequirement;
     }
 
     spec initialize_for_verification {
-        pragma verify = true;
+        // We construct `initialize_for_verification` which is a "#[verify_only]" function that
+        // simulates the genesis encoding process in `vm-genesis` (written in Rust).
+        include InitalizeRequires;
+    }
+
+    spec schema InitalizeRequires {
+        execution_config: vector<u8>;
+        requires !exists<account::Account>(@aptos_framework);
+        requires chain_status::is_operating();
+        requires len(execution_config) > 0;
+        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework);
+        requires exists<stake::ValidatorFees>(@aptos_framework);
+        requires exists<coin::CoinInfo<AptosCoin>>(@aptos_framework);
+        include CompareTimeRequires;
+        include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+    }
+
+    spec schema CompareTimeRequires {
+        let staking_rewards_config = global<staking_config::StakingRewardsConfig>(@aptos_framework);
+        requires staking_rewards_config.last_rewards_rate_period_start_in_secs <= timestamp::spec_now_seconds();
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/guid.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/guid.spec.move
@@ -4,6 +4,30 @@ spec aptos_framework::guid {
         pragma aborts_if_is_strict;
     }
 
+    spec id(guid: &GUID): ID {
+        aborts_if false;
+    }
+
+    spec creator_address(guid: &GUID): address {
+        aborts_if false;
+    }
+
+    spec id_creator_address(id: &ID): address {
+        aborts_if false;
+    }
+
+    spec creation_num(guid: &GUID): u64 {
+        aborts_if false;
+    }
+
+    spec id_creation_num(id: &ID): u64 {
+        aborts_if false;
+    }
+
+    spec eq_id(guid: &GUID, id: &ID): bool {
+        aborts_if false;
+    }
+
     spec create(addr: address, creation_num_ref: &mut u64): GUID {
         aborts_if creation_num_ref + 1 > MAX_U64;
         ensures result.id.creation_num == old(creation_num_ref);


### PR DESCRIPTION
### Description

Add functional specification to the following framework modules: `chain_id`, `consensus_config`, `gas_schedule`, `genesis`, `guid`, `staking_config`, and `version`.