### PR TITLE
[AdminService] Add several debug APIs to dump consensus data.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-config",
+ "aptos-consensus",
+ "aptos-consensus-types",
+ "aptos-crypto",
+ "aptos-infallible",
  "aptos-logger",
  "aptos-profiler",
  "aptos-runtimes",
+ "aptos-storage-interface",
+ "aptos-types",
  "async-mutex",
  "futures",
  "http",
@@ -344,6 +350,7 @@ dependencies = [
  "mime",
  "pprof",
  "tokio",
+ "tokio-scoped",
  "url",
 ]
 
@@ -14467,6 +14474,16 @@ checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.7",
  "tokio",
+]
+
+[[package]]
+name = "tokio-scoped"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
+dependencies = [
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -646,6 +646,7 @@ tokio = { version = "1.21.0", features = ["full"] }
 tokio-io-timeout = "1.2.0"
 tokio-metrics = "0.1.0"
 tokio-retry = "0.3.0"
+tokio-scoped = { version = "0.2.0" }
 tokio-stream = { version = "0.1.14", features = ["fs"] }
 tokio-test = "0.4.1"
 tokio-util = { version = "0.7.2", features = ["compat", "codec"] }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -16,6 +16,7 @@ pub mod utils;
 mod tests;
 
 use anyhow::anyhow;
+use aptos_admin_service::AdminService;
 use aptos_api::bootstrap as bootstrap_api;
 use aptos_build_info::build_information;
 use aptos_config::config::{merge_node_config, NodeConfig, PersistableConfig};
@@ -163,6 +164,7 @@ pub fn load_seed(input: &str) -> Result<[u8; 32], FromHexError> {
 
 /// Runtime handle to ensure that all inner runtimes stay in scope
 pub struct AptosHandle {
+    _admin_service: AdminService,
     _api_runtime: Option<Runtime>,
     _backup_runtime: Option<Runtime>,
     _consensus_runtime: Option<Runtime>,
@@ -518,7 +520,10 @@ where
 
     aptos_config::config::sanitize_node_config(validators[0].config.override_config_mut())?;
 
-    let node_config = validators[0].config.override_config().clone();
+    let mut node_config = validators[0].config.override_config().clone();
+
+    // Enable the AdminService.
+    node_config.admin_service.enabled = Some(true);
 
     Ok(node_config)
 }
@@ -533,11 +538,13 @@ pub fn setup_environment_and_start_node(
     info!("Using node config {:?}", &node_config);
 
     // Starts the admin service
-    services::start_admin_service(&node_config);
+    let admin_service = services::start_admin_service(&node_config);
 
     // Set up the storage database and any RocksDB checkpoints
     let (aptos_db, db_rw, backup_service, genesis_waypoint) =
         storage::initialize_database_and_checkpoints(&mut node_config)?;
+
+    admin_service.set_aptos_db(db_rw.clone().into());
 
     // Set the Aptos VM configurations
     utils::set_aptos_vm_configurations(&node_config);
@@ -626,17 +633,20 @@ pub fn setup_environment_and_start_node(
         debug!("State sync initialization complete.");
 
         // Initialize and start consensus
-        services::start_consensus_runtime(
+        let (runtime, consensus_db, quorum_store_db) = services::start_consensus_runtime(
             &mut node_config,
             db_rw,
             consensus_reconfig_subscription,
             consensus_network_interfaces,
             consensus_notifier,
             consensus_to_mempool_sender,
-        )
+        );
+        admin_service.set_consensus_dbs(consensus_db, quorum_store_db);
+        runtime
     });
 
     Ok(AptosHandle {
+        _admin_service: admin_service,
         _api_runtime: api_runtime,
         _backup_runtime: backup_service,
         _consensus_runtime: consensus_runtime,

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{bootstrap_api, indexer, mpsc::Receiver, network::ApplicationNetworkInterfaces};
+use aptos_admin_service::AdminService;
 use aptos_build_info::build_information;
 use aptos_config::config::NodeConfig;
-use aptos_consensus::network_interface::ConsensusMsg;
+use aptos_consensus::{
+    network_interface::ConsensusMsg, persistent_liveness_storage::StorageWriteProxy,
+    quorum_store::quorum_store_db::QuorumStoreDB,
+};
 use aptos_consensus_notifications::ConsensusNotifier;
 use aptos_data_client::client::AptosDataClient;
 use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
@@ -85,9 +89,9 @@ pub fn start_consensus_runtime(
     consensus_network_interfaces: ApplicationNetworkInterfaces<ConsensusMsg>,
     consensus_notifier: ConsensusNotifier,
     consensus_to_mempool_sender: Sender<QuorumStoreRequest>,
-) -> Runtime {
+) -> (Runtime, Arc<StorageWriteProxy>, Arc<QuorumStoreDB>) {
     let instant = Instant::now();
-    let consensus_runtime = aptos_consensus::consensus_provider::start_consensus(
+    let consensus = aptos_consensus::consensus_provider::start_consensus(
         node_config,
         consensus_network_interfaces.network_client,
         consensus_network_interfaces.network_service_events,
@@ -98,7 +102,7 @@ pub fn start_consensus_runtime(
             .expect("Consensus requires a reconfiguration subscription!"),
     );
     debug!("Consensus started in {} ms", instant.elapsed().as_millis());
-    consensus_runtime
+    consensus
 }
 
 /// Create the mempool runtime and start mempool
@@ -134,8 +138,8 @@ pub fn start_mempool_runtime_and_get_consensus_sender(
 }
 
 /// Spawns a new thread for the admin service
-pub fn start_admin_service(node_config: &NodeConfig) {
-    aptos_admin_service::start_admin_service(node_config)
+pub fn start_admin_service(node_config: &NodeConfig) -> AdminService {
+    AdminService::new(node_config)
 }
 
 /// Spawns a new thread for the node inspection service

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -9,7 +9,6 @@
 //! The consensus protocol implemented is AptosBFT (based on
 //! [DiemBFT](https://developers.diem.com/papers/diem-consensus-state-machine-replication-in-the-diem-blockchain/2021-08-17.pdf)).
 
-#![cfg_attr(not(feature = "fuzzing"), deny(missing_docs))]
 #![cfg_attr(feature = "fuzzing", allow(dead_code))]
 #![recursion_limit = "512"]
 
@@ -32,8 +31,8 @@ mod network;
 mod network_tests;
 mod payload_client;
 mod pending_votes;
-mod persistent_liveness_storage;
-mod quorum_store;
+pub mod persistent_liveness_storage;
+pub mod quorum_store;
 mod recovery_manager;
 mod round_manager;
 mod state_computer;

--- a/consensus/src/quorum_store/mod.rs
+++ b/consensus/src/quorum_store/mod.rs
@@ -14,8 +14,8 @@ pub(crate) mod proof_coordinator;
 pub(crate) mod proof_manager;
 pub(crate) mod quorum_store_builder;
 pub(crate) mod quorum_store_coordinator;
-pub(crate) mod quorum_store_db;
-pub(crate) mod types;
+pub mod quorum_store_db;
+pub mod types;
 pub(crate) mod utils;
 
 mod schema;

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -15,7 +15,7 @@ use aptos_logger::prelude::*;
 use aptos_schemadb::{Options, ReadOptions, SchemaBatch, DB};
 use std::{collections::HashMap, path::Path, time::Instant};
 
-pub(crate) trait QuorumStoreStorage: Sync + Send {
+pub trait QuorumStoreStorage: Sync + Send {
     fn delete_batches(&self, digests: Vec<HashValue>) -> Result<(), DbError>;
 
     fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>>;

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -54,6 +54,10 @@ impl PersistedValue {
     pub fn batch_info(&self) -> &BatchInfo {
         &self.info
     }
+
+    pub fn payload(&self) -> &Option<Vec<SignedTransaction>> {
+        &self.maybe_payload
+    }
 }
 
 impl Deref for PersistedValue {

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -15,8 +15,14 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
+aptos-consensus = { workspace = true }
+aptos-consensus-types = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-runtimes = { workspace = true }
+aptos-storage-interface = { workspace = true }
+aptos-types = { workspace = true }
 async-mutex = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
@@ -24,6 +30,7 @@ hyper = { workspace = true }
 lazy_static = { workspace = true }
 mime = { workspace = true }
 tokio = { workspace = true }
+tokio-scoped = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/aptos-admin-service/src/server/consensus/mod.rs
+++ b/crates/aptos-admin-service/src/server/consensus/mod.rs
@@ -1,0 +1,239 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::server::utils::{reply_with, reply_with_status, spawn_blocking};
+use anyhow::{bail, Error};
+use aptos_consensus::{
+    persistent_liveness_storage::PersistentLivenessStorage,
+    quorum_store::{quorum_store_db::QuorumStoreStorage, types::PersistedValue},
+};
+use aptos_consensus_types::{block::Block, common::Payload};
+use aptos_crypto::HashValue;
+use aptos_logger::info;
+use aptos_types::transaction::SignedTransaction;
+use http::header::{HeaderValue, CONTENT_LENGTH};
+use hyper::{Body, Request, Response, StatusCode};
+use std::{collections::HashMap, sync::Arc};
+
+pub async fn handle_dump_consensus_db_request(
+    _req: Request<Body>,
+    consensus_db: Arc<dyn PersistentLivenessStorage>,
+) -> hyper::Result<Response<Body>> {
+    info!("Dumping consensus db.");
+
+    match spawn_blocking(move || dump_consensus_db(consensus_db.as_ref())).await {
+        Ok(result) => {
+            info!("Finished dumping consensus db.");
+            let headers: Vec<(_, HeaderValue)> =
+                vec![(CONTENT_LENGTH, HeaderValue::from(result.len()))];
+            Ok(reply_with(headers, result))
+        },
+        Err(e) => {
+            info!("Failed to dump consensus db: {e:?}");
+            Ok(reply_with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ))
+        },
+    }
+}
+
+pub async fn handle_dump_quorum_store_db_request(
+    req: Request<Body>,
+    quorum_store_db: Arc<dyn QuorumStoreStorage>,
+) -> hyper::Result<Response<Body>> {
+    let query = req.uri().query().unwrap_or("");
+    let query_pairs: HashMap<_, _> = url::form_urlencoded::parse(query.as_bytes()).collect();
+
+    let digest: Option<HashValue> = match query_pairs.get("digest") {
+        Some(val) => match val.parse() {
+            Ok(val) => Some(val),
+            Err(err) => return Ok(reply_with_status(StatusCode::BAD_REQUEST, err.to_string())),
+        },
+        None => None,
+    };
+
+    info!("Dumping quorum store db.");
+
+    match spawn_blocking(move || dump_quorum_store_db(quorum_store_db.as_ref(), digest)).await {
+        Ok(result) => {
+            info!("Finished dumping quorum store db.");
+            let headers: Vec<(_, HeaderValue)> =
+                vec![(CONTENT_LENGTH, HeaderValue::from(result.len()))];
+            Ok(reply_with(headers, result))
+        },
+        Err(e) => {
+            info!("Failed to dump quorum store db: {e:?}");
+            Ok(reply_with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ))
+        },
+    }
+}
+
+pub async fn handle_dump_block_request(
+    req: Request<Body>,
+    consensus_db: Arc<dyn PersistentLivenessStorage>,
+    quorum_store_db: Arc<dyn QuorumStoreStorage>,
+) -> hyper::Result<Response<Body>> {
+    // TODO(grao): Support bcs encoding.
+    let query = req.uri().query().unwrap_or("");
+    let query_pairs: HashMap<_, _> = url::form_urlencoded::parse(query.as_bytes()).collect();
+
+    let block_id: Option<HashValue> = match query_pairs.get("block_id") {
+        Some(val) => match val.parse() {
+            Ok(val) => Some(val),
+            Err(err) => return Ok(reply_with_status(StatusCode::BAD_REQUEST, err.to_string())),
+        },
+        None => None,
+    };
+
+    if let Some(block_id) = block_id {
+        info!("Dumping block ({block_id:?}).");
+    } else {
+        info!("Dumping all blocks.");
+    }
+
+    match spawn_blocking(move || {
+        dump_blocks(consensus_db.as_ref(), quorum_store_db.as_ref(), block_id)
+    })
+    .await
+    {
+        Ok(result) => {
+            info!("Finished dumping block(s).");
+            let headers: Vec<(_, HeaderValue)> =
+                vec![(CONTENT_LENGTH, HeaderValue::from(result.len()))];
+            Ok(reply_with(headers, result))
+        },
+        Err(e) => {
+            info!("Failed to dump block(s): {e:?}");
+            Ok(reply_with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ))
+        },
+    }
+}
+
+fn dump_consensus_db(consensus_db: &dyn PersistentLivenessStorage) -> anyhow::Result<String> {
+    let mut body = String::new();
+
+    let (last_vote, highest_tc, consensus_blocks, consensus_qcs) =
+        consensus_db.consensus_db().get_data()?;
+
+    body.push_str(&format!("Last vote: \n{last_vote:?}\n\n"));
+    body.push_str(&format!("Highest tc: \n{highest_tc:?}\n\n"));
+    body.push_str("Blocks: \n");
+    for block in consensus_blocks {
+        body.push_str(&format!(
+            "[id: {:?}, author: {:?}, epoch: {}, round: {:02}, parent_id: {:?}, timestamp: {}, payload: {:?}]\n\n",
+            block.id(),
+            block.author(),
+            block.epoch(),
+            block.round(),
+            block.parent_id(),
+            block.timestamp_usecs(),
+            block.payload(),
+        ));
+    }
+    body.push_str("QCs: \n");
+    for qc in consensus_qcs {
+        body.push_str(&format!("{qc:?}\n\n"));
+    }
+
+    Ok(body)
+}
+
+fn dump_quorum_store_db(
+    quorum_store_db: &dyn QuorumStoreStorage,
+    digest: Option<HashValue>,
+) -> anyhow::Result<String> {
+    let mut body = String::new();
+
+    if let Some(digest) = digest {
+        body.push_str(&format!("{digest:?}:\n"));
+        body.push_str(&format!(
+            "{:?}",
+            quorum_store_db.get_batch(&digest).map_err(Error::msg)?
+        ));
+    } else {
+        for (digest, _batch) in quorum_store_db.get_all_batches()? {
+            body.push_str(&format!("{digest:?}:\n"));
+        }
+    }
+
+    Ok(body)
+}
+
+fn dump_blocks(
+    consensus_db: &dyn PersistentLivenessStorage,
+    quorum_store_db: &dyn QuorumStoreStorage,
+    block_id: Option<HashValue>,
+) -> anyhow::Result<String> {
+    let mut body = String::new();
+
+    let all_batches = quorum_store_db.get_all_batches()?;
+
+    let (_, _, blocks, _) = consensus_db.consensus_db().get_data()?;
+
+    for block in blocks {
+        let id = block.id();
+        if block_id.is_none() || id == block_id.unwrap() {
+            body.push_str(&format!("Block ({id:?}): \n\n"));
+            match extract_txns_from_block(&block, &all_batches) {
+                Ok(txns) => {
+                    body.push_str(&format!("{txns:?}"));
+                },
+                Err(e) => {
+                    body.push_str(&format!("Not available: {e:?}"));
+                },
+            };
+            body.push_str("\n\n");
+        }
+    }
+
+    if body.is_empty() {
+        if let Some(block_id) = block_id {
+            body.push_str(&format!("Done, block ({block_id:?}) is not found."));
+        } else {
+            body.push_str("Done, no block is found.");
+        }
+    }
+
+    Ok(body)
+}
+
+fn extract_txns_from_block<'a>(
+    block: &'a Block,
+    all_batches: &'a HashMap<HashValue, PersistedValue>,
+) -> anyhow::Result<Vec<&'a SignedTransaction>> {
+    match block.payload().as_ref() {
+        Some(payload) => {
+            let mut block_txns = Vec::new();
+            match payload {
+                Payload::DirectMempool(_) => {
+                    bail!("DirectMempool is not supported.");
+                },
+                Payload::InQuorumStore(proof_with_data) => {
+                    for proof in &proof_with_data.proofs {
+                        let digest = proof.digest();
+                        if let Some(batch) = all_batches.get(digest) {
+                            if let Some(txns) = batch.payload() {
+                                block_txns.extend(txns);
+                            } else {
+                                bail!("Payload is not found for batch ({digest}).");
+                            }
+                        } else {
+                            bail!("Batch ({digest}) is not found.");
+                        }
+                    }
+                },
+            }
+            Ok(block_txns)
+        },
+        None => {
+            bail!("No payload in the block.")
+        },
+    }
+}

--- a/crates/aptos-admin-service/src/server/mod.rs
+++ b/crates/aptos-admin-service/src/server/mod.rs
@@ -3,7 +3,12 @@
 
 use crate::server::utils::reply_with_status;
 use aptos_config::config::NodeConfig;
+use aptos_consensus::{
+    persistent_liveness_storage::StorageWriteProxy, quorum_store::quorum_store_db::QuorumStoreDB,
+};
+use aptos_infallible::RwLock;
 use aptos_logger::info;
+use aptos_storage_interface::DbReaderWriter;
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
@@ -11,62 +16,162 @@ use hyper::{
 use std::{
     convert::Infallible,
     net::{SocketAddr, ToSocketAddrs},
-    thread,
+    sync::Arc,
 };
+use tokio::runtime::Runtime;
 
+mod consensus;
 #[cfg(target_os = "linux")]
 mod profiling;
 mod utils;
 
-/// Starts the admin service that listens on the configured address and handles various endpoint
-/// requests.
-pub fn start_admin_service(node_config: &NodeConfig) {
-    // Fetch the service port and address
-    let service_port = node_config.admin_service.port;
-    let service_address = node_config.admin_service.address.clone();
-
-    // Create the admin service socket address
-    let address: SocketAddr = (service_address.as_str(), service_port)
-        .to_socket_addrs()
-        .unwrap_or_else(|_| {
-            panic!(
-                "Failed to parse {}:{} as address",
-                service_address, service_port
-            )
-        })
-        .next()
-        .unwrap();
-
-    // Create a runtime for the admin service
-    let runtime = aptos_runtimes::spawn_named_runtime("admin".into(), None);
-
-    // TODO(grao): Consider support enabling the service through an authenticated request.
-    let enabled = node_config.admin_service.enabled.unwrap_or(false);
-    thread::spawn(move || {
-        let make_service = make_service_fn(move |_conn| async move {
-            Ok::<_, Infallible>(service_fn(move |req| serve_requests(req, enabled)))
-        });
-
-        runtime
-            .block_on(async move {
-                let server = Server::bind(&address).serve(make_service);
-                info!("Started AdminService at {address:?}, enabled: {enabled}.");
-                server.await
-            })
-            .unwrap();
-    });
+#[derive(Default)]
+pub struct Context {
+    aptos_db: RwLock<Option<Arc<DbReaderWriter>>>,
+    consensus_db: RwLock<Option<Arc<StorageWriteProxy>>>,
+    quorum_store_db: RwLock<Option<Arc<QuorumStoreDB>>>,
 }
 
-async fn serve_requests(req: Request<Body>, enabled: bool) -> hyper::Result<Response<Body>> {
-    if !enabled {
-        return Ok(reply_with_status(
-            StatusCode::NOT_FOUND,
-            "AdminService is not enabled.",
-        ));
+impl Context {
+    fn set_aptos_db(&self, aptos_db: Arc<DbReaderWriter>) {
+        *self.aptos_db.write() = Some(aptos_db);
     }
-    match (req.method().clone(), req.uri().path()) {
-        #[cfg(target_os = "linux")]
-        (hyper::Method::GET, "/profilez") => profiling::handle_cpu_profiling_request(req).await,
-        _ => Ok(reply_with_status(StatusCode::NOT_FOUND, "Not found.")),
+
+    fn set_consensus_dbs(
+        &self,
+        consensus_db: Arc<StorageWriteProxy>,
+        quorum_store_db: Arc<QuorumStoreDB>,
+    ) {
+        *self.consensus_db.write() = Some(consensus_db);
+        *self.quorum_store_db.write() = Some(quorum_store_db);
+    }
+}
+
+pub struct AdminService {
+    runtime: Runtime,
+    context: Arc<Context>,
+}
+
+impl AdminService {
+    /// Starts the admin service that listens on the configured address and handles various endpoint
+    /// requests.
+    pub fn new(node_config: &NodeConfig) -> Self {
+        // Fetch the service port and address
+        let service_port = node_config.admin_service.port;
+        let service_address = node_config.admin_service.address.clone();
+
+        // Create the admin service socket address
+        let address: SocketAddr = (service_address.as_str(), service_port)
+            .to_socket_addrs()
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to parse {}:{} as address",
+                    service_address, service_port
+                )
+            })
+            .next()
+            .unwrap();
+
+        // Create a runtime for the admin service
+        let runtime = aptos_runtimes::spawn_named_runtime("admin".into(), None);
+
+        let admin_service = Self {
+            runtime,
+            context: Default::default(),
+        };
+
+        // TODO(grao): Consider support enabling the service through an authenticated request.
+        let enabled = node_config.admin_service.enabled.unwrap_or(false);
+        admin_service.start(address, enabled);
+
+        admin_service
+    }
+
+    pub fn set_aptos_db(&self, aptos_db: Arc<DbReaderWriter>) {
+        self.context.set_aptos_db(aptos_db)
+    }
+
+    pub fn set_consensus_dbs(
+        &self,
+        consensus_db: Arc<StorageWriteProxy>,
+        quorum_store_db: Arc<QuorumStoreDB>,
+    ) {
+        self.context
+            .set_consensus_dbs(consensus_db, quorum_store_db)
+    }
+
+    fn start(&self, address: SocketAddr, enabled: bool) {
+        let context = self.context.clone();
+        self.runtime.spawn(async move {
+            let make_service = make_service_fn(move |_conn| {
+                let context = context.clone();
+                async move {
+                    Ok::<_, Infallible>(service_fn(move |req| {
+                        Self::serve_requests(context.clone(), req, enabled)
+                    }))
+                }
+            });
+
+            let server = Server::bind(&address).serve(make_service);
+            info!("Started AdminService at {address:?}, enabled: {enabled}.");
+            server.await
+        });
+    }
+
+    async fn serve_requests(
+        context: Arc<Context>,
+        req: Request<Body>,
+        enabled: bool,
+    ) -> hyper::Result<Response<Body>> {
+        if !enabled {
+            return Ok(reply_with_status(
+                StatusCode::NOT_FOUND,
+                "AdminService is not enabled.",
+            ));
+        }
+        match (req.method().clone(), req.uri().path()) {
+            #[cfg(target_os = "linux")]
+            (hyper::Method::GET, "/profilez") => profiling::handle_cpu_profiling_request(req).await,
+            (hyper::Method::GET, "/debug/consensus/consensusdb") => {
+                let consensus_db = context.consensus_db.read().clone();
+                if let Some(consensus_db) = consensus_db {
+                    consensus::handle_dump_consensus_db_request(req, consensus_db).await
+                } else {
+                    Ok(reply_with_status(
+                        StatusCode::NOT_FOUND,
+                        "Consensus db is not available.",
+                    ))
+                }
+            },
+            (hyper::Method::GET, "/debug/consensus/quorumstoredb") => {
+                let quorum_store_db = context.quorum_store_db.read().clone();
+                if let Some(quorum_store_db) = quorum_store_db {
+                    consensus::handle_dump_quorum_store_db_request(req, quorum_store_db).await
+                } else {
+                    Ok(reply_with_status(
+                        StatusCode::NOT_FOUND,
+                        "Quorum store db is not available.",
+                    ))
+                }
+            },
+            (hyper::Method::GET, "/debug/consensus/block") => {
+                let consensus_db = context.consensus_db.read().clone();
+                let quorum_store_db = context.quorum_store_db.read().clone();
+                if consensus_db.is_some() && quorum_store_db.is_some() {
+                    consensus::handle_dump_block_request(
+                        req,
+                        consensus_db.unwrap(),
+                        quorum_store_db.unwrap(),
+                    )
+                    .await
+                } else {
+                    Ok(reply_with_status(
+                        StatusCode::NOT_FOUND,
+                        "Consensus db and/or quorum store db is not available.",
+                    ))
+                }
+            },
+            _ => Ok(reply_with_status(StatusCode::NOT_FOUND, "Not found.")),
+        }
     }
 }

--- a/crates/aptos-admin-service/src/server/utils.rs
+++ b/crates/aptos-admin-service/src/server/utils.rs
@@ -3,12 +3,23 @@
 
 #![allow(unused)]
 
+use anyhow::{Error, Result};
 use aptos_logger::debug;
 use http::header::{HeaderName, HeaderValue};
 use hyper::{Body, Response, StatusCode};
 use std::{convert::Into, iter::IntoIterator};
 
 pub const UNEXPECTED_ERROR_MESSAGE: &str = "An unexpected error was encountered!";
+
+pub(crate) async fn spawn_blocking<F, T>(func: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(func)
+        .await
+        .map_err(Error::msg)?
+}
 
 pub(crate) fn reply_with_status<T>(status_code: StatusCode, message: T) -> Response<Body>
 where


### PR DESCRIPTION
### Description

Added 3 endpoints:

`/debug/consensus/consensusdb`: dump everything in consensus db.
`/debug/consensus/quorumstoredb`: dump all quorum store batchs, also a query param `digest` is supported for dumping a single batch.
`/debug/consensus/block`: dump all blocks in consensus, also a query param `block_id` is supported for dumping a single block.

### Test Plan
Manually tested on a local test node.
<!-- Please provide us with clear details for verifying that your changes work. -->
