### PR TITLE
Continue ignoring STORAGE_ERROR until full cleanup

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1852,6 +1852,9 @@ impl VMAdapter for AptosVM {
                         },
                         // Ignore DelayedFields speculative errors as it can be intentionally triggered by parallel execution.
                         StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR => (),
+                        // Ignore Storage Error as currently it sometimes wraps speculative errors
+                        // TODO[agg_v2](fix) propagate SPECULATIVE_EXECUTION_ABORT_ERROR correctly, and remove storage from valid errors here.
+                        StatusCode::STORAGE_ERROR => (),
                         // We will log the rest of invariant violation directly with regular logger as they shouldn't happen.
                         //
                         // TODO: Add different counters for the error categories here.

--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -210,7 +210,9 @@ pub fn expect_only_successful_execution(
         e @ VMStatus::Error {
             status_code:
                 StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR
-                | StatusCode::DELAYED_FIELDS_CODE_INVARIANT_ERROR,
+                | StatusCode::DELAYED_FIELDS_CODE_INVARIANT_ERROR
+                // TODO[agg_v2](fix) remove special handling of storage errors here
+                | StatusCode::STORAGE_ERROR,
             ..
         } => e,
         status => {

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -201,6 +201,8 @@ impl<'r> TransactionDataCache<'r> {
                 },
             );
 
+            // TODO[agg_v2](fix) We need to propagate errors better, and handle them differently based on:
+            // - DELAYED_FIELDS_CODE_INVARIANT_ERROR, SPECULATIVE_EXECUTION_ABORT_ERROR or other.
             let (data, bytes_loaded) = resolved_result.map_err(|err| {
                 let msg = format!("Unexpected storage error: {:?}", err);
                 PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(msg)


### PR DESCRIPTION
Previously we (over)used STORAGE_ERROR for speculation failures, and so we needed to ignore all STORAGE_ERRORs

We created special errors - SPECULATIVE_EXECUTION_ABORT_ERROR, to disambiguate from other STORAGE_ERRORs, and stopped ignoring STORAGE_ERRORs

Unfortunately get_resource_bytes_with_metadata_and_layout wraps the inner error, and the caller cannot distinguish, and just throws STORAGE_ERROR instead, making STORAGE_ERROR still being created for speculative errors, causing alert to fire.

Reverting to ignore STORAGE_ERRORs for now, but we need to propagate inner errors better in get_resource_bytes_with_metadata_and_layout longterm


### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
