### PR TITLE
Correct the feature number for `LIMIT_MAX_IDENTIFIER_LENGTH`

### DIFF
--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -302,7 +302,7 @@ Whether the fix to reduce the maximum identifer length is enabled.
 Lifetime: transient
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_LIMIT_MAX_IDENTIFIER_LENGTH">LIMIT_MAX_IDENTIFIER_LENGTH</a>: u64 = 33;
+<pre><code><b>const</b> <a href="features.md#0x1_features_LIMIT_MAX_IDENTIFIER_LENGTH">LIMIT_MAX_IDENTIFIER_LENGTH</a>: u64 = 38;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -253,7 +253,7 @@ module std::features {
 
     /// Whether the fix to reduce the maximum identifer length is enabled.
     /// Lifetime: transient
-    const LIMIT_MAX_IDENTIFIER_LENGTH: u64 = 33;
+    const LIMIT_MAX_IDENTIFIER_LENGTH: u64 = 38;
 
     // ============================================================================================
     // Feature Flag Implementation

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -40,7 +40,7 @@ pub enum FeatureFlag {
     AGGREGATOR_SNAPSHOTS = 30,
     SAFER_RESOURCE_GROUPS = 31,
     SAFER_METADATA = 32,
-    LIMIT_MAX_IDENTIFIER_LENGTH = 33,
+    LIMIT_MAX_IDENTIFIER_LENGTH = 38,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
### Description

Correct the feature number for `LIMIT_MAX_IDENTIFIER_LENGTH` to be consistent to that of the `main` branch