### PR TITLE
[agg_v2] Proper gas charging for writing to resources with aggregators

### DIFF
--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -223,8 +223,15 @@ mod test {
         write_set::WriteOp,
     };
     use claims::{assert_err, assert_matches, assert_ok, assert_ok_eq};
-    use move_core_types::vm_status::{StatusCode, VMStatus};
+    use move_core_types::{
+        value::MoveTypeLayout,
+        vm_status::{StatusCode, VMStatus},
+    };
     use once_cell::sync::Lazy;
+    use std::{
+        collections::{BTreeMap, HashSet},
+        sync::Arc,
+    };
 
     fn delta_add_with_history(v: u128, max_value: u128, max: u128, min: u128) -> DeltaOp {
         let mut delta = delta_add(v, max_value);
@@ -501,6 +508,9 @@ mod test {
 
     impl TDelayedFieldView for BadStorage {
         type Identifier = ();
+        type ResourceGroupTag = ();
+        type ResourceKey = ();
+        type ResourceValue = ();
 
         fn is_delayed_field_optimization_capable(&self) -> bool {
             unimplemented!("Irrelevant for the test")
@@ -524,6 +534,14 @@ mod test {
         }
 
         fn generate_delayed_field_id(&self) -> Self::Identifier {
+            unimplemented!("Irrelevant for the test")
+        }
+
+        fn get_reads_needing_exchange(
+            &self,
+            _delayed_write_set_keys: &HashSet<Self::Identifier>,
+            _skip: &HashSet<Self::ResourceKey>,
+        ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
             unimplemented!("Irrelevant for the test")
         }
     }

--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -219,6 +219,7 @@ mod test {
         FakeAggregatorView,
     };
     use aptos_types::{
+        aggregator::PanicError,
         state_store::{state_key::StateKey, state_value::StateValue},
         write_set::WriteOp,
     };
@@ -541,7 +542,10 @@ mod test {
             &self,
             _delayed_write_set_keys: &HashSet<Self::Identifier>,
             _skip: &HashSet<Self::ResourceKey>,
-        ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+        ) -> Result<
+            BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>,
+            PanicError,
+        > {
             unimplemented!("Irrelevant for the test")
         }
     }

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use aptos_state_view::StateView;
 use aptos_types::{
+    aggregator::PanicError,
     state_store::{
         state_key::StateKey,
         state_value::{StateValue, StateValueMetadataKind},
@@ -187,7 +188,7 @@ pub trait TDelayedFieldView {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>;
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>;
 }
 
 pub trait DelayedFieldResolver:
@@ -251,7 +252,8 @@ where
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
+    {
         unimplemented!("get_reads_needing_exchange not implemented")
     }
 }

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -8,8 +8,16 @@ use crate::{
     resolver::{TAggregatorV1View, TDelayedFieldView},
     types::{expect_ok, DelayedFieldID, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
-use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
-use std::{cell::RefCell, collections::HashMap};
+use aptos_types::{
+    state_store::{state_key::StateKey, state_value::StateValue},
+    write_set::WriteOp,
+};
+use move_core_types::{language_storage::StructTag, value::MoveTypeLayout};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
 
 pub fn aggregator_v1_id_for_test(key: u128) -> AggregatorID {
     AggregatorID(aggregator_v1_state_key_for_test(key))
@@ -66,6 +74,9 @@ impl TAggregatorV1View for FakeAggregatorView {
 
 impl TDelayedFieldView for FakeAggregatorView {
     type Identifier = DelayedFieldID;
+    type ResourceGroupTag = StructTag;
+    type ResourceKey = StateKey;
+    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         true
@@ -99,5 +110,13 @@ impl TDelayedFieldView for FakeAggregatorView {
         let id = Self::Identifier::new(*counter as u64);
         *counter += 1;
         id
+    }
+
+    fn get_reads_needing_exchange(
+        &self,
+        _delayed_write_set_keys: &HashSet<Self::Identifier>,
+        _skip: &HashSet<Self::ResourceKey>,
+    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+        unimplemented!();
     }
 }

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -9,6 +9,7 @@ use crate::{
     types::{expect_ok, DelayedFieldID, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
 use aptos_types::{
+    aggregator::PanicError,
     state_store::{state_key::StateKey, state_value::StateValue},
     write_set::WriteOp,
 };
@@ -116,7 +117,8 @@ impl TDelayedFieldView for FakeAggregatorView {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
+    {
         unimplemented!();
     }
 }

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -169,6 +169,7 @@ impl VMOutput {
         self.change_set.set_events(patched_events.into_iter());
         // TODO[agg_v2](cleanup) move drain to happen when getting what to materialize.
         let _ = self.change_set.drain_delayed_field_change_set();
+        let _ = self.change_set.drain_reads_needing_delayed_field_exchange();
 
         let (vm_change_set, gas_used, status) = self.unpack();
         let (write_set, events) = vm_change_set

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -156,6 +156,8 @@ pub(crate) fn build_change_set(
         BTreeMap::from_iter(aggregator_v1_write_set),
         BTreeMap::from_iter(aggregator_v1_delta_set),
         BTreeMap::from_iter(delayed_field_change_set),
+        // TODO[agg_v2](fix) add to the caller.
+        BTreeMap::new(),
         vec![],
         &MockChangeSetChecker,
     )

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -539,6 +539,12 @@ impl AptosVM {
         for (key, op) in change_set.write_set_iter() {
             gas_meter.charge_io_gas_for_write(key, op)?;
         }
+        // TODO[agg_v2](fix): Charge SnapshotDerived (string concat) based on lenght,
+        // as charge below charges based on non-exchanged writes (i.e. identifier being in the read_op)
+        // Do we want to charge delayed field changes also?
+        for (key, (read_op, _)) in change_set.reads_needing_delayed_field_exchange().iter() {
+            gas_meter.charge_io_gas_for_write(key, read_op)?;
+        }
         for (key, group_write) in change_set.resource_group_write_set().iter() {
             gas_meter.charge_io_gas_for_group_write(key, group_write)?;
         }
@@ -552,7 +558,7 @@ impl AptosVM {
             storage_refund = 0.into();
         }
 
-        // TODO(Gas): Charge for aggregator writes
+        // TODO[agg_v1](fix): Charge for aggregator writes
         let session_id = SessionId::epilogue_meta(txn_data);
         RespawnedSession::spawn(self, session_id, resolver, change_set, storage_refund)
     }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -181,6 +181,24 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> BTreeMap<
+        <Self::Txn as BlockExecutableTransaction>::Key,
+        (
+            <Self::Txn as BlockExecutableTransaction>::Value,
+            Arc<MoveTypeLayout>,
+        ),
+    > {
+        self.vm_output
+            .lock()
+            .as_ref()
+            .expect("Output to be set to get reads")
+            .change_set()
+            .reads_needing_delayed_field_exchange()
+            .clone()
+    }
+
     /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
         self.vm_output

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -27,6 +27,7 @@ use aptos_types::{
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueMetadataKind},
     },
+    write_set::WriteOp,
 };
 use aptos_vm_types::{
     resolver::{
@@ -48,6 +49,7 @@ use move_core_types::{
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
 };
 
 pub(crate) fn get_resource_group_from_metadata(
@@ -287,6 +289,9 @@ impl<'e, E: ExecutorView> TAggregatorV1View for StorageAdapter<'e, E> {
 
 impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
     type Identifier = DelayedFieldID;
+    type ResourceGroupTag = StructTag;
+    type ResourceKey = StateKey;
+    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         self.executor_view.is_delayed_field_optimization_capable()
@@ -312,6 +317,15 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
 
     fn generate_delayed_field_id(&self) -> Self::Identifier {
         self.executor_view.generate_delayed_field_id()
+    }
+
+    fn get_reads_needing_exchange(
+        &self,
+        delayed_write_set_keys: &HashSet<Self::Identifier>,
+        skip: &HashSet<Self::ResourceKey>,
+    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+        self.executor_view
+            .get_reads_needing_exchange(delayed_write_set_keys, skip)
     }
 }
 

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -21,6 +21,7 @@ use aptos_state_view::{StateView, StateViewId};
 use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     access_path::AccessPath,
+    aggregator::PanicError,
     on_chain_config::{ConfigStorage, Features, OnChainConfig},
     state_store::{
         state_key::StateKey,
@@ -323,7 +324,8 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
+    {
         self.executor_view
             .get_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -19,6 +19,7 @@ use aptos_aggregator::{
 use aptos_gas_algebra::Fee;
 use aptos_state_view::StateViewId;
 use aptos_types::{
+    aggregator::PanicError,
     state_store::{
         state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
     },
@@ -247,7 +248,8 @@ impl<'r> TDelayedFieldView for ExecutorViewWithChangeSet<'r> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
+    {
         self.base_executor_view
             .get_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -188,7 +188,9 @@ impl<'r, 'l> SessionExt<'r, 'l> {
             .map_err(|e| e.finish(Location::Undefined))?;
 
         let aggregator_context: NativeAggregatorContext = extensions.remove();
-        let aggregator_change_set = aggregator_context.into_change_set();
+        let aggregator_change_set = aggregator_context
+            .into_change_set()
+            .map_err(|e| PartialVMError::from(e).finish(Location::Undefined))?;
 
         let event_context: NativeEventContext = extensions.remove();
         let events = event_context.into_events();

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -24,6 +24,7 @@ use aptos_native_interface::SafeNativeBuilder;
 use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
+    aggregator::PanicError,
     on_chain_config::{Features, TimedFeatures, TimedFeaturesBuilder},
     write_set::WriteOp,
 };
@@ -34,6 +35,7 @@ use aptos_types::{
 };
 #[cfg(feature = "testing")]
 use bytes::Bytes;
+#[cfg(feature = "testing")]
 use move_core_types::language_storage::StructTag;
 #[cfg(feature = "testing")]
 use move_core_types::value::MoveTypeLayout;
@@ -117,7 +119,8 @@ impl TDelayedFieldView for AptosBlankStorage {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
+    {
         unimplemented!()
     }
 }

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -25,6 +25,7 @@ use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     on_chain_config::{Features, TimedFeatures, TimedFeaturesBuilder},
+    write_set::WriteOp,
 };
 #[cfg(feature = "testing")]
 use aptos_types::{
@@ -33,9 +34,14 @@ use aptos_types::{
 };
 #[cfg(feature = "testing")]
 use bytes::Bytes;
+use move_core_types::language_storage::StructTag;
 #[cfg(feature = "testing")]
 use move_core_types::value::MoveTypeLayout;
 use move_vm_runtime::native_functions::NativeFunctionTable;
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 #[cfg(feature = "testing")]
 use {
     aptos_framework::natives::{
@@ -78,6 +84,9 @@ impl TAggregatorV1View for AptosBlankStorage {
 #[cfg(feature = "testing")]
 impl TDelayedFieldView for AptosBlankStorage {
     type Identifier = DelayedFieldID;
+    type ResourceGroupTag = StructTag;
+    type ResourceKey = StateKey;
+    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         false
@@ -102,6 +111,14 @@ impl TDelayedFieldView for AptosBlankStorage {
 
     fn generate_delayed_field_id(&self) -> Self::Identifier {
         (self.counter.fetch_add(1, Ordering::SeqCst) as u64).into()
+    }
+
+    fn get_reads_needing_exchange(
+        &self,
+        _delayed_write_set_keys: &HashSet<Self::Identifier>,
+        _skip: &HashSet<Self::ResourceKey>,
+    ) -> BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)> {
+        unimplemented!()
     }
 }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    captured_reads::DataRead,
     counters,
     counters::{
         PARALLEL_EXECUTION_SECONDS, RAYON_EXECUTION_SECONDS, TASK_EXECUTE_SECONDS,
@@ -614,15 +613,13 @@ where
     fn map_id_to_values_in_write_set(
         resource_write_set: Option<BTreeMap<T::Key, (T::Value, Option<Arc<MoveTypeLayout>>)>>,
         latest_view: &LatestView<T, S, X>,
-    ) -> (BTreeMap<T::Key, T::Value>, HashSet<T::Key>) {
-        let mut write_set_keys = HashSet::new();
+    ) -> BTreeMap<T::Key, T::Value> {
         let mut patched_resource_write_set = BTreeMap::new();
         if let Some(resource_write_set) = resource_write_set {
             for (key, (write_op, layout)) in resource_write_set.iter() {
                 // layout is Some(_) if it contains a delayed field
                 if let Some(layout) = layout {
                     if !write_op.is_deletion() {
-                        write_set_keys.insert(key.clone());
                         let patched_bytes = match latest_view
                             .replace_identifiers_with_values(write_op.bytes().unwrap(), layout)
                         {
@@ -636,103 +633,32 @@ where
                 }
             }
         }
-        (patched_resource_write_set, write_set_keys)
+        patched_resource_write_set
     }
 
     // Parse the input `value` and replace delayed field identifiers with
     // corresponding values
     fn replace_ids_with_values(
-        value: Arc<T::Value>,
+        value: &T::Value,
         layout: &MoveTypeLayout,
         latest_view: &LatestView<T, S, X>,
-        delayed_field_keys: &HashSet<T::Identifier>,
-    ) -> Option<T::Value> {
-        if let Some(value_bytes) = value.bytes() {
-            match latest_view.replace_identifiers_with_values(value_bytes, layout) {
-                Ok((patched_bytes, delayed_field_keys_in_resource)) => {
-                    if !delayed_field_keys.is_disjoint(&delayed_field_keys_in_resource) {
-                        let mut patched_value = value.as_ref().clone();
-                        patched_value.set_bytes(patched_bytes);
-                        Some(patched_value)
-                    } else {
-                        None
-                    }
-                },
-                Err(_) => unreachable!("Failed to replace identifiers with values in read set"),
+    ) -> T::Value {
+        if let Some(mut value) = value.from_read_to_modification() {
+            if let Some(value_bytes) = value.bytes() {
+                let (patched_bytes, _) = latest_view
+                    .replace_identifiers_with_values(value_bytes, layout)
+                    .unwrap();
+                value.set_bytes(patched_bytes);
+                value
+            } else {
+                unreachable!("Value to be exchanged doesn't have bytes: {:?}", value)
             }
         } else {
-            // TODO[agg_v2](fix): Is this unreachable?
-            unreachable!("Data read value must exist");
+            unreachable!(
+                "Value to be exchanged cannot be transformed to modification: {:?}",
+                value
+            );
         }
-    }
-
-    // For each resource that satisfies the following conditions,
-    //     1. Resource is in read set
-    //     2. Resource is not in write set
-    // replace the delayed field identifiers in the resource with corresponding values.
-    // If any of the delayed field identifiers in the resource are part of delayed_field_write_set,
-    // then include the resource in the write set.
-    fn map_id_to_values_in_read_set_parallel(
-        txn_idx: TxnIndex,
-        delayed_field_keys: Option<impl Iterator<Item = T::Identifier>>,
-        write_set_keys: HashSet<T::Key>,
-        last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
-        latest_view: &LatestView<T, S, X>,
-    ) -> BTreeMap<T::Key, T::Value> {
-        let mut patched_resource_write_set = BTreeMap::new();
-        if let Some(delayed_field_keys) = delayed_field_keys {
-            let delayed_field_keys = delayed_field_keys.collect::<HashSet<_>>();
-            let read_set = last_input_output.read_set(txn_idx);
-            if let Some(read_set) = read_set {
-                for (key, data_read) in read_set.get_read_values_with_delayed_fields() {
-                    if write_set_keys.contains(key) {
-                        continue;
-                    }
-                    // layout is Some(_) if it contains an delayed field
-                    if let DataRead::Versioned(_version, value, Some(layout)) = data_read {
-                        if let Some(patched_value) = Self::replace_ids_with_values(
-                            value.clone(),
-                            layout,
-                            latest_view,
-                            &delayed_field_keys,
-                        ) {
-                            patched_resource_write_set.insert(key.clone(), patched_value);
-                        }
-                    }
-                }
-            }
-        }
-        patched_resource_write_set
-    }
-
-    fn map_id_to_values_in_read_set_sequential(
-        delayed_field_keys: Option<impl Iterator<Item = T::Identifier>>,
-        write_set_keys: HashSet<T::Key>,
-        read_set: RefCell<HashSet<T::Key>>,
-        unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
-        latest_view: &LatestView<T, S, X>,
-    ) -> HashMap<T::Key, T::Value> {
-        let mut patched_resource_write_set = HashMap::new();
-        if let Some(delayed_field_keys) = delayed_field_keys {
-            let delayed_field_keys = delayed_field_keys.collect::<HashSet<_>>();
-            for key in read_set.borrow().iter() {
-                if write_set_keys.contains(key) {
-                    continue;
-                }
-                // layout is Some(_) if it contains an delayed field
-                if let Some((value, Some(layout))) = unsync_map.fetch_data(key) {
-                    if let Some(patched_value) = Self::replace_ids_with_values(
-                        value.clone(),
-                        &layout,
-                        latest_view,
-                        &delayed_field_keys,
-                    ) {
-                        patched_resource_write_set.insert(key.clone(), patched_value);
-                    }
-                }
-            }
-        }
-        patched_resource_write_set
     }
 
     // For each delayed field in the event, replace delayed field identifier with value.
@@ -849,18 +775,21 @@ where
         let parallel_state = ParallelState::<T, X>::new(versioned_cache, scheduler, shared_counter);
         let latest_view = LatestView::new(base_view, ViewState::Sync(parallel_state), txn_idx);
         let resource_write_set = last_input_output.resource_write_set(txn_idx);
-        let delayed_field_keys = last_input_output.delayed_field_keys(txn_idx);
         let finalized_groups = last_input_output.take_finalized_group(txn_idx);
 
-        let (mut patched_resource_write_set, write_set_keys) =
+        let mut patched_resource_write_set =
             Self::map_id_to_values_in_write_set(resource_write_set, &latest_view);
-        patched_resource_write_set.extend(Self::map_id_to_values_in_read_set_parallel(
-            txn_idx,
-            delayed_field_keys,
-            write_set_keys,
-            last_input_output,
-            &latest_view,
-        ));
+
+        if let Some(reads_needing_delayed_field_exchange) =
+            last_input_output.reads_needing_delayed_field_exchange(txn_idx)
+        {
+            for (key, (value, layout)) in reads_needing_delayed_field_exchange.into_iter() {
+                patched_resource_write_set.insert(
+                    key,
+                    Self::replace_ids_with_values(&value, layout.as_ref(), &latest_view),
+                );
+            }
+        }
 
         let events = last_input_output.events(txn_idx);
         let patched_events = Self::map_id_to_values_events(events, &latest_view);
@@ -1262,22 +1191,29 @@ where
 
                     if dynamic_change_set_optimizations_enabled {
                         // Replace delayed field id with values in resource write set and read set.
-                        let delayed_field_keys =
-                            Some(output.delayed_field_change_set().into_keys());
                         let resource_change_set = Some(output.resource_write_set());
-                        let (mut patched_resource_write_set, write_set_keys) =
+                        let mut patched_resource_write_set =
                             Self::map_id_to_values_in_write_set(resource_change_set, &latest_view);
 
-                        let read_set = latest_view.read_set_sequential_execution();
-                        patched_resource_write_set.extend(
-                            Self::map_id_to_values_in_read_set_sequential(
-                                delayed_field_keys,
-                                write_set_keys,
-                                read_set,
-                                &unsync_map,
-                                &latest_view,
-                            ),
-                        );
+                        for (key, (value, layout)) in
+                            output.reads_needing_delayed_field_exchange().into_iter()
+                        {
+                            if patched_resource_write_set
+                                .insert(
+                                    key,
+                                    Self::replace_ids_with_values(
+                                        &value,
+                                        layout.as_ref(),
+                                        &latest_view,
+                                    ),
+                                )
+                                .is_some()
+                            {
+                                return Err(Error::FallbackToSequential(code_invariant_error(
+                                    "reads_needing_delayed_field_exchange already in the write set for key",
+                                ).into()));
+                            }
+                        }
 
                         // Replace delayed field id with values in events
                         let patched_events = Self::map_id_to_values_events(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -643,7 +643,7 @@ where
         layout: &MoveTypeLayout,
         latest_view: &LatestView<T, S, X>,
     ) -> T::Value {
-        if let Some(mut value) = value.from_read_to_modification() {
+        if let Some(mut value) = value.convert_read_to_modification() {
             if let Some(value_bytes) = value.bytes() {
                 let (patched_bytes, _) = latest_view
                     .replace_identifiers_with_values(value_bytes, layout)

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -297,6 +297,13 @@ impl TransactionWrite for ValueType {
     fn set_bytes(&mut self, bytes: Bytes) {
         self.bytes = bytes.into();
     }
+
+    fn from_read_to_modification(&self) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        Some(self.clone())
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -827,7 +834,7 @@ where
 
     fn execute_transaction(
         &self,
-        view: &(impl TExecutorView<K, u32, MoveTypeLayout, DelayedFieldID>
+        view: &(impl TExecutorView<K, u32, MoveTypeLayout, DelayedFieldID, ValueType>
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         txn: &Self::Txn,
         txn_idx: TxnIndex,
@@ -1018,6 +1025,16 @@ where
     ) -> BTreeMap<
         <Self::Txn as Transaction>::Identifier,
         DelayedChange<<Self::Txn as Transaction>::Identifier>,
+    > {
+        // TODO[agg_v2](tests): add aggregators V2 to the proptest?
+        BTreeMap::new()
+    }
+
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> BTreeMap<
+        <Self::Txn as Transaction>::Key,
+        (<Self::Txn as Transaction>::Value, Arc<MoveTypeLayout>),
     > {
         // TODO[agg_v2](tests): add aggregators V2 to the proptest?
         BTreeMap::new()

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -298,7 +298,7 @@ impl TransactionWrite for ValueType {
         self.bytes = bytes.into();
     }
 
-    fn from_read_to_modification(&self) -> Option<Self>
+    fn convert_read_to_modification(&self) -> Option<Self>
     where
         Self: Sized,
     {

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -66,6 +66,7 @@ pub trait ExecutorTask: Sync {
             <Self::Txn as Transaction>::Tag,
             MoveTypeLayout,
             <Self::Txn as Transaction>::Identifier,
+            <Self::Txn as Transaction>::Value,
         > + TResourceGroupView<
             GroupKey = <Self::Txn as Transaction>::Key,
             ResourceTag = <Self::Txn as Transaction>::Tag,
@@ -111,6 +112,13 @@ pub trait TransactionOutput: Send + Sync + Debug {
     ) -> BTreeMap<
         <Self::Txn as Transaction>::Identifier,
         DelayedChange<<Self::Txn as Transaction>::Identifier>,
+    >;
+
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> BTreeMap<
+        <Self::Txn as Transaction>::Key,
+        (<Self::Txn as Transaction>::Value, Arc<MoveTypeLayout>),
     >;
 
     /// Get the events of a transaction from its output.

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -10,9 +10,14 @@ use aptos_aggregator::{
     resolver::{AggregatorV1Resolver, DelayedFieldResolver},
     types::DelayedFieldID,
 };
-use aptos_types::state_store::state_key::StateKey;
+use aptos_types::{state_store::state_key::StateKey, write_set::WriteOp};
 use better_any::{Tid, TidAble};
-use std::{cell::RefCell, collections::HashMap};
+use move_core_types::value::MoveTypeLayout;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 /// Represents a single aggregator change.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -29,8 +34,9 @@ pub enum AggregatorChangeV1 {
 /// set can be converted into appropriate `WriteSet` and `DeltaChangeSet` by the
 /// user, e.g. VM session.
 pub struct AggregatorChangeSet {
-    pub aggregator_v1_changes: HashMap<StateKey, AggregatorChangeV1>,
-    pub delayed_field_changes: HashMap<DelayedFieldID, DelayedChange<DelayedFieldID>>,
+    pub aggregator_v1_changes: BTreeMap<StateKey, AggregatorChangeV1>,
+    pub delayed_field_changes: BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>,
+    pub reads_needing_exchange: BTreeMap<StateKey, (WriteOp, Arc<MoveTypeLayout>)>,
 }
 
 /// Native context that can be attached to VM `NativeContextExtensions`.
@@ -77,7 +83,7 @@ impl<'a> NativeAggregatorContext<'a> {
         } = self;
         let (_, destroyed_aggregators, aggregators) = aggregator_v1_data.into_inner().into();
 
-        let mut aggregator_v1_changes = HashMap::new();
+        let mut aggregator_v1_changes = BTreeMap::new();
 
         // First, process all writes and deltas.
         for (id, aggregator) in aggregators {
@@ -107,10 +113,22 @@ impl<'a> NativeAggregatorContext<'a> {
         }
 
         let delayed_field_changes = delayed_field_data.into_inner().into();
-
+        let delayed_write_set_keys = delayed_field_changes
+            .keys()
+            .cloned()
+            .collect::<HashSet<_>>();
         AggregatorChangeSet {
             aggregator_v1_changes,
-            delayed_field_changes: HashMap::from_iter(delayed_field_changes),
+            delayed_field_changes,
+            // is_empty check covers both whether delayed fields are enabled or not, as well as whether there
+            // are any changes that would require computing reads needing exchange.
+            // TODO[agg_v2](optimize) we only later compute the the write set, so cannot pass the correct skip values here.
+            reads_needing_exchange: if delayed_write_set_keys.is_empty() {
+                BTreeMap::new()
+            } else {
+                self.delayed_field_resolver
+                    .get_reads_needing_exchange(&delayed_write_set_keys, &HashSet::new())
+            },
         }
     }
 }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -218,7 +218,7 @@ pub(crate) mod test {
     // group base values (used in some tests), and most tests do not care about
     // the kind. Otherwise, there are specific constructors that initialize kind
     // for the tests that care (testing group commit logic in parallel).
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) struct TestValue {
         bytes: Bytes,
         kind: WriteOpKind,
@@ -291,6 +291,13 @@ pub(crate) mod test {
 
         fn set_bytes(&mut self, bytes: Bytes) {
             self.bytes = bytes;
+        }
+
+        fn from_read_to_modification(&self) -> Option<Self>
+        where
+            Self: Sized,
+        {
+            Some(self.clone())
         }
     }
 

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -293,7 +293,7 @@ pub(crate) mod test {
             self.bytes = bytes;
         }
 
-        fn from_read_to_modification(&self) -> Option<Self>
+        fn convert_read_to_modification(&self) -> Option<Self>
         where
             Self: Sized,
         {

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -85,6 +85,14 @@ impl<V: Into<Vec<u8>> + Clone + Debug> TransactionWrite for Value<V> {
     fn set_bytes(&mut self, bytes: Bytes) {
         self.maybe_bytes = Some(bytes);
     }
+
+    fn from_read_to_modification(&self) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        // If we have no bytes, no modification can be created.
+        maybe_bytes.map(|_| self.clone())
+    }
 }
 
 enum Data<V> {

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -86,12 +86,12 @@ impl<V: Into<Vec<u8>> + Clone + Debug> TransactionWrite for Value<V> {
         self.maybe_bytes = Some(bytes);
     }
 
-    fn from_read_to_modification(&self) -> Option<Self>
+    fn convert_read_to_modification(&self) -> Option<Self>
     where
         Self: Sized,
     {
         // If we have no bytes, no modification can be created.
-        maybe_bytes.map(|_| self.clone())
+        self.maybe_bytes.as_ref().map(|_| self.clone())
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1872,6 +1872,6 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
         + From<u64>
         + TryIntoMoveValue
         + TryFromMoveValue<Hint = ()>;
-    type Value: Send + Sync + Clone + TransactionWrite;
+    type Value: Send + Sync + Debug + Clone + TransactionWrite;
     type Event: Send + Sync + Debug + Clone + ReadWriteEvent;
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -192,6 +192,13 @@ pub trait TransactionWrite: Debug {
     }
 
     fn set_bytes(&mut self, bytes: Bytes);
+
+    /// Convert a `self`, which was read (containing DelayedField exchanges) in a current
+    /// transaction, to a modification write, in which we can then exchange DelayedField
+    /// identifiers into their final values, to produce a write operation.
+    fn from_read_to_modification(&self) -> Option<Self>
+    where
+        Self: Sized;
 }
 
 impl TransactionWrite for WriteOp {
@@ -240,6 +247,21 @@ impl TransactionWrite for WriteOp {
             Creation(data) | CreationWithMetadata { data, .. } => *data = bytes,
             Modification(data) | ModificationWithMetadata { data, .. } => *data = bytes,
             Deletion | DeletionWithMetadata { .. } => (),
+        }
+    }
+
+    fn from_read_to_modification(&self) -> Option<Self> {
+        use WriteOp::*;
+
+        match self {
+            Creation(data) | Modification(data) => Some(Modification(data.clone())),
+            CreationWithMetadata { data, metadata }
+            | ModificationWithMetadata { data, metadata } => Some(ModificationWithMetadata {
+                data: data.clone(),
+                metadata: metadata.clone(),
+            }),
+            // Deletion don't have data to become modification.
+            Deletion | DeletionWithMetadata { .. } => None,
         }
     }
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -196,7 +196,7 @@ pub trait TransactionWrite: Debug {
     /// Convert a `self`, which was read (containing DelayedField exchanges) in a current
     /// transaction, to a modification write, in which we can then exchange DelayedField
     /// identifiers into their final values, to produce a write operation.
-    fn from_read_to_modification(&self) -> Option<Self>
+    fn convert_read_to_modification(&self) -> Option<Self>
     where
         Self: Sized;
 }
@@ -250,7 +250,7 @@ impl TransactionWrite for WriteOp {
         }
     }
 
-    fn from_read_to_modification(&self) -> Option<Self> {
+    fn convert_read_to_modification(&self) -> Option<Self> {
         use WriteOp::*;
 
         match self {


### PR DESCRIPTION
### Description

Previously, for resources that have aggregators, if only aggregator is modified, they were not being charged, even though they do show up in the transaction output.

So we move figuring out which read-set keys need exchanges from materialization to VMChangeSet creation, so it can be charged appropriately.

### Test Plan
e2e aggregator unit tests.

In follow-up, that handles PayloadWriteSet::Direct appropriately, will add comparison tests between aggregators enabled and disabled.
