### PR TITLE
Add indexer-grpc test back unbroken

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -75,7 +75,7 @@ permissions:
 # This workflow is designed such that:
 # 1. Run ALL jobs when a 'push', 'workflow_dispatch' triggered the workflow or on 'pull_request's which have set auto_merge=true or have the label "CICD:run-e2e-tests".
 # 2. Run ONLY the docker image building jobs on PRs with the "CICD:build[-<PROFILE/FEATURE>]-images" label.
-# 3. Run ONLY the forge-e2e-test job on PRs with the "CICD:run-forge-e2e-perf" label.
+# 3. Run ONLY the forge-e2e-test job on PRs with the "CICD:run-forge-e2e-perf" label. 
 # 4. Run NOTHING when neither 1. or 2. or 3. conditions are satisfied.
 jobs:
   permission-check:
@@ -230,6 +230,17 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
+
+  indexer-grpc-e2e-tests:
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      contains(github.event.pull_request.body, '#e2e')
+    uses: aptos-labs/aptos-core/.github/workflows/docker-indexer-grpc-test.yaml@main
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   # This is a PR required job.
   forge-e2e-test:

--- a/docker/compose/indexer-grpc/data-service-config.yaml
+++ b/docker/compose/indexer-grpc/data-service-config.yaml
@@ -7,6 +7,7 @@ server_config:
       data_service_grpc_listen_address: 0.0.0.0:50053
       cert_path: /opt/aptos/certs/data-service-grpc-server.crt
       key_path: /opt/aptos/certs/data-service-grpc-server.key
+  disable_auth_check: true
   whitelisted_auth_tokens: []
   file_store_config:
     file_store_type: LocalFileStore

--- a/testsuite/indexer_grpc_local.py
+++ b/testsuite/indexer_grpc_local.py
@@ -38,9 +38,9 @@ GRPC_DATA_SERVICE_TLS_URL = "localhost:50053"
 GRPC_IS_READY_MESSAGE = f"""
     ======================================
     Transaction Stream Service(indexer grpc) is ready to serve!
-    
+
     You can use grpcurl to test it out:
-    
+
     - For non-TLS:
         grpcurl -plaintext -d '{{ "starting_version": 0 }}' \\
             -H "x-aptos-data-authorization:dummy_token" \\
@@ -244,7 +244,7 @@ def wait_for_indexer_grpc_progress(context: SystemContext) -> None:
                     "-H",
                     "x-aptos-data-authorization:dummy_token",
                     "-import-path",
-                    "crates/aptos-protos/proto",
+                    "protos/proto",
                     "-proto",
                     "aptos/indexer/v1/raw_data.proto",
                     "-plaintext",


### PR DESCRIPTION
### Description
From the logs of a failed run (from https://github.com/aptos-labs/aptos-core/actions/runs/6642204051/job/18047211693?pr=10602) I saw this:
```
indexer-grpc-indexer-grpc-data-service-1 | Caused by:
indexer-grpc-indexer-grpc-data-service-1 |     disable_auth_check is not set but whitelisted_auth_tokens is empty
indexer-grpc-indexer-grpc-data-service-1 | Error: Config did not pass validation
```

The script was also using the wrong proto path.

After fixing those the test passes.

### Test Plan
See that it passes in CI.