### PR TITLE
[tests] fix the flaky tests for indexer grpc.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-access/src/in_memory_storage/storage.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-access/src/in_memory_storage/storage.rs
@@ -270,7 +270,7 @@ mod tests {
             .unwrap();
         // Wait for the fetch task to finish.
         tokio::time::sleep(std::time::Duration::from_millis(
-            REDIS_FETCH_TASK_INTERVAL_IN_MILLIS * 2,
+            REDIS_FETCH_TASK_INTERVAL_IN_MILLIS * 10,
         ))
         .await;
         {
@@ -321,7 +321,7 @@ mod tests {
                 .unwrap();
         // Wait for the fetch task to finish.
         tokio::time::sleep(std::time::Duration::from_millis(
-            REDIS_FETCH_TASK_INTERVAL_IN_MILLIS * 3,
+            REDIS_FETCH_TASK_INTERVAL_IN_MILLIS * 10,
         ))
         .await;
         {


### PR DESCRIPTION
### Description
^ 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Tested locally and it passed. Root cause is the other thread is not yielding in time, which delays the update operation. Extend the waiting time to allow more time for yielding. 

![image](https://github.com/aptos-labs/aptos-core/assets/112209412/81436f9b-a887-482a-afd0-d55e38fa9901)

