### PR TITLE
[Draft] fallback to combine group ops but charge AsSum

### DIFF
--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -125,17 +125,12 @@ pub trait TResourceGroupView {
             .map(|maybe_bytes| maybe_bytes.is_some())
     }
 
-    /// Executor view may internally implement a naive resource group cache when:
-    /// - ExecutorView is not based on block executor, such as ExecutorViewBase
-    /// - providing backwards compatibility (older gas versions) in storage adapter.
-    ///
-    /// The trait allows releasing the cache in such cases. Otherwise (default behavior),
-    /// if naive cache is not implemeneted (e.g. in block executor), None is returned.
     fn release_group_cache(
         &self,
-    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
-        None
-    }
+    ) -> (
+        Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>>,
+        bool,
+    );
 }
 
 /// Allows to query modules from the state.

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -569,6 +569,8 @@ impl AptosVM {
             storage_refund = 0.into();
         }
 
+        change_set.maybe_combine_group_ops();
+
         // TODO(Gas): Charge for aggregator writes
         let session_id = SessionId::epilogue_meta(txn_data);
         RespawnedSession::spawn(self, session_id, resolver, change_set, storage_refund)

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -193,7 +193,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
 impl<'e, E: ExecutorView> ResourceGroupResolver for StorageAdapter<'e, E> {
     fn release_resource_group_cache(
         &self,
-    ) -> Option<HashMap<StateKey, BTreeMap<StructTag, Bytes>>> {
+    ) -> (Option<HashMap<StateKey, BTreeMap<StructTag, Bytes>>>, bool) {
         self.resource_group_view.release_group_cache()
     }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
@@ -29,8 +29,17 @@ pub trait AptosMoveResolver:
 }
 
 pub trait ResourceGroupResolver {
-    fn release_resource_group_cache(&self)
-        -> Option<HashMap<StateKey, BTreeMap<StructTag, Bytes>>>;
+    /// If the option is Some, then it contains contents of the resource group
+    /// cache with all resources in it, and the VM must use this to prepare the
+    /// output as a combined group write as a part of normal resource writes (V0
+    /// behavior). When None is returned, the V1 resource group behavior must be
+    /// triggered, preparing more granular GroupWrite output (with individual
+    /// writes to affected resources within the group). If the bool is true, then
+    /// the gas should be charged in the V1 / granular fashion (AsSum), even if
+    /// the output is being prepared in the V0 way (i.e. Option is set / Some).
+    fn release_resource_group_cache(
+        &self,
+    ) -> (Option<HashMap<StateKey, BTreeMap<StructTag, Bytes>>>, bool);
 
     fn resource_group_size(&self, group_key: &StateKey) -> anyhow::Result<u64>;
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -38,6 +38,7 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::{err_msg, StatusCode, VMStatus},
 };
+use std::collections::{BTreeMap, HashMap};
 
 /// We finish the session after the user transaction is done running to get the change set and
 /// charge gas and storage fee based on it before running storage refunds and the transaction
@@ -286,6 +287,15 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
                 maybe_layout,
             )
         }
+    }
+
+    fn release_group_cache(
+        &self,
+    ) -> (
+        Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>>,
+        bool,
+    ) {
+        unreachable!("Must not be called by RespawnedSession finish");
     }
 }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -94,6 +94,7 @@ impl<'r> WriteOpConverter<'r> {
         &self,
         state_key: &StateKey,
         group_changes: BTreeMap<StructTag, MoveStorageOp<BytesWithResourceLayout>>,
+        maybe_combined_op: Option<WriteOp>,
     ) -> Result<GroupWrite, VMStatus> {
         // Resource group metadata is stored at the group StateKey, and can be obtained via the
         // same interfaces at for a resource at a given StateKey.
@@ -191,6 +192,7 @@ impl<'r> WriteOpConverter<'r> {
             self.convert(state_value_metadata_result, metadata_op, false)?,
             post_group_size,
             inner_ops,
+            maybe_combined_op,
         ))
     }
 
@@ -516,9 +518,10 @@ mod tests {
 
         // Deletion should still contain the metadata - for storage refunds.
         assert_eq!(group_write.metadata_op().metadata(), Some(&metadata));
-        assert_eq!(group_write.metadata_op(), &WriteOp::DeletionWithMetadata {
-            metadata
-        });
+        assert_eq!(
+            group_write.metadata_op(),
+            &WriteOp::DeletionWithMetadata { metadata }
+        );
         assert_none!(group_write.metadata_op().bytes());
     }
 }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -197,11 +197,14 @@ fn compute_delayed_field_try_add_delta_outcome_from_history(
         true
     };
 
-    Ok((result, DelayedFieldRead::HistoryBounded {
-        restriction: history,
-        max_value,
-        inner_aggregator_value: base_aggregator_value,
-    }))
+    Ok((
+        result,
+        DelayedFieldRead::HistoryBounded {
+            restriction: history,
+            max_value,
+            inner_aggregator_value: base_aggregator_value,
+        },
+    ))
 }
 
 fn compute_delayed_field_try_add_delta_outcome_first_time(
@@ -229,11 +232,14 @@ fn compute_delayed_field_try_add_delta_outcome_first_time(
         true
     };
 
-    Ok((result, DelayedFieldRead::HistoryBounded {
-        restriction: history,
-        max_value,
-        inner_aggregator_value: base_aggregator_value,
-    }))
+    Ok((
+        result,
+        DelayedFieldRead::HistoryBounded {
+            restriction: history,
+            max_value,
+            inner_aggregator_value: base_aggregator_value,
+        },
+    ))
 }
 // TODO[agg_v2](cleanup): see about the split with CapturedReads,
 // and whether anything should be moved there.
@@ -1032,7 +1038,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceGr
 
     fn release_group_cache(
         &self,
-    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
+    ) -> (
+        Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>>,
+        bool,
+    ) {
         unimplemented!("Currently resolved by ResourceGroupAdapter");
     }
 }


### PR DESCRIPTION
For additional safety if block executor observes group invariant violations, to be able to fallback to essentially gating off the granular write set preparation, but stay consistent with AsSum size/gas computation, once that feature is enabled.

TODO: good testing.