### PR TITLE
[gha] release network-specific grpc images

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-release.yaml
@@ -2,12 +2,16 @@ name: Copy images to dockerhub on release
 on:
   push:
     branches:
-      # release branches
+      # aptos-node network-specific release branches
       - devnet
       - testnet
       - mainnet
       # preview branches
       - preview
+      # aptos-indexer-grpc network-specific release branches
+      - aptos-indexer-grpc-devnet
+      - aptos-indexer-grpc-testnet
+      - aptos-indexer-grpc-mainnet
     tags:
       - aptos-node-v*
       - aptos-indexer-grpc-v*

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -38,6 +38,11 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - performance_benchmark
       - quorum-store
       - preview
+      # grpc release branches
+      - aptos-indexer-grpc-devnet
+      - aptos-indexer-grpc-testnet
+      - aptos-indexer-grpc-mainnet
+      - aptos-indexer-grpc-v*
 
 # cancel redundant builds
 concurrency:
@@ -75,7 +80,7 @@ permissions:
 # This workflow is designed such that:
 # 1. Run ALL jobs when a 'push', 'workflow_dispatch' triggered the workflow or on 'pull_request's which have set auto_merge=true or have the label "CICD:run-e2e-tests".
 # 2. Run ONLY the docker image building jobs on PRs with the "CICD:build[-<PROFILE/FEATURE>]-images" label.
-# 3. Run ONLY the forge-e2e-test job on PRs with the "CICD:run-forge-e2e-perf" label. 
+# 3. Run ONLY the forge-e2e-test job on PRs with the "CICD:run-forge-e2e-perf" label.
 # 4. Run NOTHING when neither 1. or 2. or 3. conditions are satisfied.
 jobs:
   permission-check:


### PR DESCRIPTION
### Description

Similar to aptos-node, for grpc images:
* release network-specific images when `aptos-indexer-grpc-{devnet,testnet,mainnet}` branch is cut. These images are no longer released on `{devnet,testnet,mainnet}` branch cut
* release versioned X.Y.Z images when `aptos-indexer-grpc-vX.Y.Z` git tag is created

### Test Plan

CI

<!-- Please provide us with clear details for verifying that your changes work. -->
