### PR TITLE
[vm] Ensure fee payer transactions are verified correctly

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1722,17 +1722,13 @@ impl VMAdapter for AptosVM {
     }
 
     fn check_signature(&self, txn: SignedTransaction) -> Result<SignatureCheckedTransaction> {
-        if let aptos_types::transaction::authenticator::TransactionAuthenticator::FeePayer {
-            ..
-        } = &txn.authenticator_ref()
-        {
-            if self
+        if txn.is_fee_payer()
+            && self
                 .0
                 .get_features()
                 .is_enabled(FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL)
-            {
-                return txn.check_fee_payer_signature();
-            }
+        {
+            return txn.check_fee_payer_signature();
         }
         txn.check_signature()
     }


### PR DESCRIPTION
### Description
The VM was blocking fee payer with optional arguments because the transaction wasn't being verified correctly.  Now it should handle it correctly.

### Test Plan

Verified manually with the typescript SDK, that it is possible to do.

The API test does not check for the transaction to be committed, that is next to fix.