### PR TITLE
AsyncConcurrentDropper: use dedicated pool

### DIFF
--- a/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
+++ b/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::TIMER;
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use std::sync::mpsc::{channel, Receiver, Sender};
+use threadpool::ThreadPool;
 
 /// A helper to send things to a thread pool for asynchronous dropping.
 ///
@@ -17,20 +17,24 @@ pub struct AsyncConcurrentDropper {
     name: &'static str,
     token_tx: Sender<()>,
     token_rx: Mutex<Receiver<()>>,
+    /// use dedicated threadpool to minimize the possibility of dead lock
+    thread_pool: ThreadPool,
 }
 
 impl AsyncConcurrentDropper {
-    pub fn new(name: &'static str, max_concurrent_drops: usize) -> Self {
+    pub fn new(name: &'static str, max_async_drops: usize, num_threads: usize) -> Self {
         let (token_tx, token_rx) = channel();
-        for _ in 0..max_concurrent_drops {
+        for _ in 0..max_async_drops {
             token_tx
                 .send(())
                 .expect("DropHelper: Failed to buffer initial tokens.");
         }
+        let thread_pool = ThreadPool::new(num_threads);
         Self {
             name,
             token_tx,
             token_rx: Mutex::new(token_rx),
+            thread_pool,
         }
     }
 
@@ -51,7 +55,7 @@ impl AsyncConcurrentDropper {
 
         let token_tx = self.token_tx.clone();
         let name = self.name;
-        THREAD_MANAGER.get_non_exe_cpu_pool().spawn(move || {
+        self.thread_pool.execute(move || {
             let _timer = TIMER.timer_with(&[name, "real_drop"]);
 
             drop(v);
@@ -74,32 +78,43 @@ mod tests {
 
     impl Drop for SlowDropper {
         fn drop(&mut self) {
-            sleep(Duration::from_secs(1));
+            sleep(Duration::from_millis(200));
         }
-    }
-
-    #[test]
-    fn test_concurrency_limit_hit() {
-        let s = AsyncConcurrentDropper::new("test", 8);
-        let now = std::time::Instant::now();
-        let rx = s.schedule_drop_with_waiter(SlowDropper);
-        for _ in 1..8 {
-            s.schedule_drop(SlowDropper);
-        }
-        assert!(now.elapsed() < Duration::from_millis(500));
-        rx.recv().unwrap();
-        assert!(now.elapsed() > Duration::from_secs(1));
     }
 
     #[test]
     fn test_within_concurrency_limit() {
-        let s = AsyncConcurrentDropper::new("test", 8);
+        let s = AsyncConcurrentDropper::new("test", 8, 4);
+        let now = std::time::Instant::now();
+        let rx1 = s.schedule_drop_with_waiter(SlowDropper); // first round
+        for _ in 0..3 {
+            s.schedule_drop(SlowDropper);
+        }
+        let rx2 = s.schedule_drop_with_waiter(SlowDropper); // second round
+        for _ in 0..3 {
+            s.schedule_drop(SlowDropper);
+        }
+        assert!(now.elapsed() < Duration::from_millis(200));
+        rx1.recv().unwrap();
+        assert!(now.elapsed() > Duration::from_millis(200));
+        assert!(now.elapsed() < Duration::from_millis(400));
+        rx2.recv().unwrap();
+        assert!(now.elapsed() > Duration::from_millis(400));
+        assert!(now.elapsed() < Duration::from_millis(600));
+    }
+
+    #[test]
+    fn test_concurrency_limit_hit() {
+        let s = AsyncConcurrentDropper::new("test", 8, 4);
         let now = std::time::Instant::now();
         for _ in 0..8 {
             s.schedule_drop(SlowDropper);
         }
-        assert!(now.elapsed() < Duration::from_millis(500));
+        assert!(now.elapsed() < Duration::from_millis(200));
         s.schedule_drop(SlowDropper);
-        assert!(now.elapsed() > Duration::from_secs(1));
+        assert!(now.elapsed() > Duration::from_millis(200));
+        assert!(now.elapsed() < Duration::from_millis(400));
+        s.schedule_drop(SlowDropper);
+        assert!(now.elapsed() < Duration::from_millis(400));
     }
 }

--- a/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
+++ b/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
@@ -28,7 +28,7 @@ impl AsyncConcurrentDropper {
         Self {
             name,
             num_tasks_tracker: Arc::new(NumTasksTracker::new(max_tasks)),
-            thread_pool: ThreadPool::new(num_threads),
+            thread_pool: ThreadPool::with_name(format!("{}_conc_dropper", name), num_threads),
         }
     }
 

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -9,4 +9,4 @@ pub mod async_drop_queue;
 mod metrics;
 
 pub static DEFAULT_DROPPER: Lazy<AsyncConcurrentDropper> =
-    Lazy::new(|| AsyncConcurrentDropper::new("default", 32));
+    Lazy::new(|| AsyncConcurrentDropper::new("default", 32, 8));

--- a/crates/aptos-drop-helper/src/metrics.rs
+++ b/crates/aptos-drop-helper/src/metrics.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_metrics_core::{exponential_buckets, register_histogram_vec, HistogramVec};
+use aptos_metrics_core::{
+    exponential_buckets, register_histogram_vec, register_int_gauge_vec, HistogramVec, IntGaugeVec,
+};
 use once_cell::sync::Lazy;
 
 pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
@@ -10,6 +12,15 @@ pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
         "Various timers for performance analysis.",
         &["helper_name", "name"],
         exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
+    )
+    .unwrap()
+});
+
+pub static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_drop_helper_gauges",
+        "Various gauges to help debugging.",
+        &["helper_name", "name"],
     )
     .unwrap()
 });

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -227,7 +227,7 @@ impl StateDb {
 
 impl DbReader for StateStore {
     fn get_buffered_state_base(&self) -> Result<SparseMerkleTree<StateValue>> {
-        Ok(self.smt_ancestors.lock().get_youngest()?)
+        Ok(self.smt_ancestors.lock().get_youngest())
     }
 
     /// Returns the latest state snapshot strictly before `next_version` if any.

--- a/storage/scratchpad/src/sparse_merkle/ancestors.rs
+++ b/storage/scratchpad/src/sparse_merkle/ancestors.rs
@@ -3,96 +3,44 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{sparse_merkle::metrics::TIMER, SparseMerkleTree};
-use aptos_crypto::hash::CryptoHash;
-use aptos_drop_helper::async_drop_queue::AsyncDropQueue;
-use aptos_infallible::Mutex;
-use aptos_logger::prelude::*;
-use aptos_metrics_core::TimerHelper;
-use std::{
-    collections::VecDeque,
-    sync::{Arc, MutexGuard},
-    time::Duration,
+use crate::{
+    sparse_merkle::{dropper::SUBTREE_DROPPER, metrics::TIMER},
+    SparseMerkleTree,
 };
+use aptos_crypto::hash::CryptoHash;
+use aptos_infallible::Mutex;
+use aptos_metrics_core::TimerHelper;
+use std::sync::Arc;
 
-type Result<V> = std::result::Result<V, Error>;
-
-/// Keep the oldest SMTs in a central place so that:
-/// 1. elsewhere, dropping the SMT will be fast since this indirectly holds a ref to every tree in
-///    the entire forest.
-/// 2. this must be invoked somewhere in the critical path so that it can provide some
-///    back pressure to slow things down to prevent from leaking memory
+/// A container to track the ancestor of the SMTs that represent a committed state (older state is
+/// guaranteed to be found in persisted storage.
+/// When being queried, back pressure (a slow down) is provided in order to make sure not too many
+/// SMTs are being kept in memory.
 #[derive(Clone, Debug)]
 pub struct SmtAncestors<V: Clone + Send + Sync + 'static> {
-    /// Keep a queue of ancestors, in hope that the when the oldest is being evicted, it's the
-    /// the last ref of it, which means the drop latency doesn't impact other code paths.
-    ancestors: Arc<Mutex<VecDeque<SparseMerkleTree<V>>>>,
-    /// Drop the oldest ancestor asynchronously in good cases, with limited backlog, providing
-    /// back pressure when the drops are slow in order to avoid memory leak.
-    drop_queue: Arc<AsyncDropQueue>,
+    youngest: Arc<Mutex<SparseMerkleTree<V>>>,
 }
 
 impl<V: CryptoHash + Clone + Send + Sync + 'static> SmtAncestors<V> {
-    const MAX_PENDING_DROPS: usize = 4;
-    const NUM_ANCESTORS: usize = 8;
+    const MAX_PENDING_DROPS: usize = 8;
 
     pub fn new(ancestor: SparseMerkleTree<V>) -> Self {
         Self {
-            ancestors: Arc::new(Mutex::new(VecDeque::from(vec![ancestor]))),
-            drop_queue: Arc::new(AsyncDropQueue::new(
-                "smt_ancestors",
-                Self::MAX_PENDING_DROPS,
-            )),
+            youngest: Arc::new(Mutex::new(ancestor)),
         }
     }
 
-    fn ancestors(&self) -> MutexGuard<VecDeque<SparseMerkleTree<V>>> {
-        self.ancestors.lock()
-    }
+    pub fn get_youngest(&self) -> SparseMerkleTree<V> {
+        let _timer = TIMER.timer_with(&["get_youngest_ancestor"]);
 
-    pub fn get_youngest(&self) -> Result<SparseMerkleTree<V>> {
-        self.ancestors()
-            .back()
-            .map(SparseMerkleTree::clone)
-            .ok_or(Error::NotFound)
+        // The back pressure is on the getting side (which is the execution side) so that it's less
+        // likely for a lot of blocks locking the same old base SMT.
+        SUBTREE_DROPPER.wait_for_backlog_drop(Self::MAX_PENDING_DROPS);
+
+        self.youngest.lock().clone()
     }
 
     pub fn add(&self, youngest: SparseMerkleTree<V>) {
-        let _timer = TIMER.timer_with(&["add_smt_ancestor"]);
-
-        let mut ancestors = self.ancestors();
-        ancestors.push_back(youngest);
-
-        if ancestors.len() > Self::NUM_ANCESTORS {
-            let oldest = ancestors.pop_front().unwrap();
-            oldest.log_generation("evict_ancestor");
-            if !oldest.is_the_only_ref() {
-                sample!(
-                    SampleRate::Duration(Duration::from_secs(1)),
-                    error!(
-                        "Oldest SMT being tracked by SmtAncestors is still referenced elsewhere. Potential memory leak.",
-                    )
-                );
-            } else {
-                self.drop_queue.enqueue_drop(oldest);
-            }
-        }
+        *self.youngest.lock() = youngest;
     }
-
-    pub fn replace_with(&self, other: SmtAncestors<V>) {
-        let Self {
-            ancestors,
-            drop_queue: _drop_queue,
-        } = other;
-
-        *self.ancestors.lock() = Arc::into_inner(ancestors)
-            .expect("Not the only ref.")
-            .into_inner();
-    }
-}
-
-#[derive(Debug, thiserror::Error, Eq, PartialEq)]
-pub enum Error {
-    #[error("Ancestor SMT not found.")]
-    NotFound,
 }

--- a/storage/scratchpad/src/sparse_merkle/dropper.rs
+++ b/storage/scratchpad/src/sparse_merkle/dropper.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use aptos_drop_helper::async_concurrent_dropper::AsyncConcurrentDropper;
+use once_cell::sync::Lazy;
+
+pub(crate) static SUBTREE_DROPPER: Lazy<AsyncConcurrentDropper> =
+    Lazy::new(|| AsyncConcurrentDropper::new("smt_subtree", 32, 8));

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -598,10 +598,6 @@ where
             None
         }
     }
-
-    pub(crate) fn is_the_only_ref(&self) -> bool {
-        Arc::strong_count(&self.inner) == 1
-    }
 }
 
 /// In tests and benchmark, reference to ancestors are manually managed

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -400,6 +400,7 @@ fn test_update() {
 
     // Now prune smt1.
     drop(smt1);
+    SUBTREE_DROPPER.wait_for_backlog_drop(0);
 
     // Verify oldest ancestor
     assert_eq_pointee(&smt2.get_oldest_ancestor(), &smt2);

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -130,7 +130,7 @@ trait AssertNoExternalStrongRef {
 
 impl<V: Send + Sync + 'static> AssertNoExternalStrongRef for SparseMerkleTree<V> {
     fn assert_no_external_strong_ref(&self) {
-        assert_subtree_sole_strong_ref(&self.inner.root);
+        assert_subtree_sole_strong_ref(self.inner.root());
     }
 }
 


### PR DESCRIPTION
### Description

Making these changes based on the following observations:

1. it's a dead lock harzard to put nested drops onto a bounded concurrency pool
2. in the current mechanism, trees are actually dropped sequentially, because every ref on the chain are held
3. the back pressure being on the committing side is wrong -- more blocks will lock the current base, making it impossible to be really dropped.

In this change:
1. drop the root asynchronously in a different pool (instead of children Inner's). Inner will be blazing fast to drop, and there's no deadlock.
2. back pressure is on the execution side (when trying to ref the base). the committing side is free to move forweard and switch to a newer base as soon as possible.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit tests
Artificially increase SubTree drop latency and observe back pressure kicking in.