### PR TITLE
[NFT Metadata Crawler] Fix transparency bug

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
@@ -3,14 +3,14 @@
 /// Maximum retry time for exponential backoff (5 sec = 3-4 retries)
 pub const MAX_RETRY_TIME_SECONDS: u64 = 5;
 
-/// Allocate 5 seconds for a HEAD request
-pub const MAX_HEAD_REQUEST_RETRY_SECONDS: u64 = 5;
+/// Allocate 15 seconds for a HEAD request
+pub const MAX_HEAD_REQUEST_RETRY_SECONDS: u64 = 15;
 
 /// Allocate 30 seconds for downloading large JSON files
 pub const MAX_JSON_REQUEST_RETRY_SECONDS: u64 = 30;
 
-/// Allocate 180 seconds for downloading large image files
-pub const MAX_IMAGE_REQUEST_RETRY_SECONDS: u64 = 180;
+/// Allocate 90 seconds for downloading large image files
+pub const MAX_IMAGE_REQUEST_RETRY_SECONDS: u64 = 90;
 
 /// Skip URIs that contain the following strings
 pub const URI_SKIP_LIST: [&str; 5] = [

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
@@ -80,10 +80,10 @@ pub async fn write_image_to_gcs(
 ) -> anyhow::Result<String> {
     GCS_UPLOAD_INVOCATION_COUNT.inc();
     let extension = match img_format {
-        ImageFormat::Gif | ImageFormat::Avif => img_format
+        ImageFormat::Gif | ImageFormat::Avif | ImageFormat::Png => img_format
             .extensions_str()
             .last()
-            .unwrap_or(&"gif")
+            .expect("ImageFormat should have at least one extension")
             .to_string(),
         _ => "jpeg".to_string(),
     };

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -118,13 +118,12 @@ impl ImageOptimizer {
         }
     }
 
-    /// Checks if image has transparent pixels
+    /// Checks if an image has any transparent pixels
     fn has_transparent_pixels(img: &DynamicImage) -> bool {
         let (width, height) = img.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let pixel = img.get_pixel(x, y);
-                if pixel[3] < 255 {
+                if img.get_pixel(x, y)[3] < 255 {
                     return true;
                 }
             }

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -15,7 +15,7 @@ use backoff::{future::retry, ExponentialBackoff};
 use futures::FutureExt;
 use image::{
     imageops::{resize, FilterType},
-    DynamicImage, ImageBuffer, ImageFormat, ImageOutputFormat,
+    DynamicImage, GenericImageView, ImageBuffer, ImageFormat, ImageOutputFormat,
 };
 use reqwest::Client;
 use std::{io::Cursor, time::Duration};
@@ -74,8 +74,8 @@ impl ImageOptimizer {
                         let (nwidth, nheight) =
                             Self::calculate_dimensions_with_ration(512, img.width(), img.height());
                         let resized_image =
-                            resize(&img.to_rgb8(), nwidth, nheight, FilterType::Gaussian);
-                        Ok((Self::to_jpeg_bytes(resized_image, image_quality)?, format))
+                            resize(&img.to_rgba8(), nwidth, nheight, FilterType::Gaussian);
+                        Ok(Self::to_image_bytes(resized_image, image_quality)?)
                     },
                 }
             }
@@ -118,15 +118,36 @@ impl ImageOptimizer {
         }
     }
 
-    /// Converts image to JPEG bytes vector
-    fn to_jpeg_bytes(
-        image_buffer: ImageBuffer<image::Rgb<u8>, Vec<u8>>,
+    /// Checks if image has transparent pixels
+    fn has_transparent_pixels(img: &DynamicImage) -> bool {
+        let (width, height) = img.dimensions();
+        for x in 0..width {
+            for y in 0..height {
+                let pixel = img.get_pixel(x, y);
+                if pixel[3] < 255 {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Converts image to image bytes vector
+    fn to_image_bytes(
+        image_buffer: ImageBuffer<image::Rgba<u8>, Vec<u8>>,
         image_quality: u8,
-    ) -> anyhow::Result<Vec<u8>> {
-        let dynamic_image = DynamicImage::ImageRgb8(image_buffer);
+    ) -> anyhow::Result<(Vec<u8>, ImageFormat)> {
+        let dynamic_image = DynamicImage::ImageRgba8(image_buffer);
         let mut byte_store = Cursor::new(Vec::new());
-        match dynamic_image.write_to(&mut byte_store, ImageOutputFormat::Jpeg(image_quality)) {
-            Ok(_) => Ok(byte_store.into_inner()),
+        let mut encode_format = ImageOutputFormat::Jpeg(image_quality);
+        let mut output_format = ImageFormat::Jpeg;
+        if Self::has_transparent_pixels(&dynamic_image) {
+            encode_format = ImageOutputFormat::Png;
+            output_format = ImageFormat::Png;
+        }
+
+        match dynamic_image.write_to(&mut byte_store, encode_format) {
+            Ok(_) => Ok((byte_store.into_inner(), output_format)),
             Err(e) => {
                 warn!(error = ?e, "[NFT Metadata Crawler] Error converting image to bytes: {} bytes", dynamic_image.as_bytes().len());
                 Err(anyhow::anyhow!(e))


### PR DESCRIPTION
### Description
Previously, all images were being converted to JPEGs. As a result, any pixels containing alpha are changed into black pixels. This fixes that issue by only converting images to JPEGs if they don't have any pixels containing alpha. 

### Test Plan
Tested locally with PNGs containing transparency. 
