### PR TITLE
[AdminService] Support thread dump.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +355,7 @@ dependencies = [
  "lazy_static",
  "mime",
  "pprof",
+ "rstack-self",
  "tokio",
  "tokio-scoped",
  "url",
@@ -2866,6 +2873,7 @@ dependencies = [
  "maplit",
  "rand 0.7.3",
  "rayon",
+ "rstack-self",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -6514,6 +6522,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dw"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0ed82b765c2ab79fb48e4bf2c95bd583202f4078a702bc714cc6e6f3ca80c3"
+dependencies = [
+ "dw-sys",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "dw-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14eb35c87ff6626cd1021bb32bc7d9a5372ea72547e1eaf0343a841d9d55a973"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "e2e-move-tests"
 version = "0.1.0"
 dependencies = [
@@ -7185,7 +7214,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -7193,6 +7243,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -10874,7 +10930,7 @@ checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -12697,6 +12753,34 @@ dependencies = [
  "smallvec",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstack"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7df9d3ebd4f17b52e6134efe2fa20021c80688cbe823d481a729a993b730493"
+dependencies = [
+ "cfg-if",
+ "dw",
+ "lazy_static",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "rstack-self"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
+dependencies = [
+ "antidote",
+ "backtrace",
+ "bincode",
+ "lazy_static",
+ "libc",
+ "rstack",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,6 +601,7 @@ reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
 rocksdb = { version = "0.21.0", features = ["lz4"] }
+rstack-self =  { version = "0.3.0", features = ["dw"], default_features = false }
 rstest = "0.15.0"
 rusty-fork = "0.3.0"
 scopeguard = "1.2.0"

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -79,6 +79,7 @@ url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }
+rstack-self = { workspace = true }
 
 [features]
 assert-private-keys-not-cloneable = ["aptos-crypto/assert-private-keys-not-cloneable"]

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -36,3 +36,4 @@ url = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 aptos-profiler = { workspace = true }
 pprof = { workspace = true }
+rstack-self = { workspace = true }

--- a/crates/aptos-admin-service/src/server/mod.rs
+++ b/crates/aptos-admin-service/src/server/mod.rs
@@ -23,6 +23,8 @@ use tokio::runtime::Runtime;
 mod consensus;
 #[cfg(target_os = "linux")]
 mod profiling;
+#[cfg(target_os = "linux")]
+mod thread_dump;
 mod utils;
 
 #[derive(Default)]
@@ -132,6 +134,8 @@ impl AdminService {
         match (req.method().clone(), req.uri().path()) {
             #[cfg(target_os = "linux")]
             (hyper::Method::GET, "/profilez") => profiling::handle_cpu_profiling_request(req).await,
+            #[cfg(target_os = "linux")]
+            (hyper::Method::GET, "/threadz") => thread_dump::handle_thread_dump_request(req).await,
             (hyper::Method::GET, "/debug/consensus/consensusdb") => {
                 let consensus_db = context.consensus_db.read().clone();
                 if let Some(consensus_db) = consensus_db {

--- a/crates/aptos-admin-service/src/server/thread_dump.rs
+++ b/crates/aptos-admin-service/src/server/thread_dump.rs
@@ -1,0 +1,111 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::server::utils::{reply_with, reply_with_status};
+use anyhow::{ensure, Error};
+use aptos_logger::info;
+use async_mutex::Mutex;
+use http::header::{HeaderValue, CONTENT_LENGTH};
+use hyper::{Body, Request, Response, StatusCode};
+use lazy_static::lazy_static;
+use rstack_self::TraceOptions;
+use std::{collections::HashMap, env, process::Command};
+
+lazy_static! {
+    static ref THREAD_DUMP_MUTEX: Mutex<()> = Mutex::new(());
+}
+
+pub async fn handle_thread_dump_request(req: Request<Body>) -> hyper::Result<Response<Body>> {
+    let query = req.uri().query().unwrap_or("");
+    let query_pairs: HashMap<_, _> = url::form_urlencoded::parse(query.as_bytes()).collect();
+
+    let snapshot: bool = match query_pairs.get("snapshot") {
+        Some(val) => match val.parse() {
+            Ok(val) => val,
+            Err(err) => return Ok(reply_with_status(StatusCode::BAD_REQUEST, err.to_string())),
+        },
+        None => false,
+    };
+
+    let location: bool = match query_pairs.get("location") {
+        Some(val) => match val.parse() {
+            Ok(val) => val,
+            Err(err) => return Ok(reply_with_status(StatusCode::BAD_REQUEST, err.to_string())),
+        },
+        None => true,
+    };
+
+    let frame_ip: bool = match query_pairs.get("frame_ip") {
+        Some(val) => match val.parse() {
+            Ok(val) => val,
+            Err(err) => return Ok(reply_with_status(StatusCode::BAD_REQUEST, err.to_string())),
+        },
+        None => false,
+    };
+
+    info!("Starting dumping stack trace for all threads.");
+    match start_thread_dump(snapshot, location, frame_ip).await {
+        Ok(body) => {
+            info!("Thread dumping is done.");
+            let headers: Vec<(_, HeaderValue)> =
+                vec![(CONTENT_LENGTH, HeaderValue::from(body.len()))];
+            Ok(reply_with(headers, body))
+        },
+        Err(e) => {
+            info!("Failed to dump threads: {e:?}");
+            Ok(reply_with_status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ))
+        },
+    }
+}
+
+async fn start_thread_dump(
+    snapshot: bool,
+    location: bool,
+    frame_ip: bool,
+) -> anyhow::Result<String> {
+    let lock = THREAD_DUMP_MUTEX.try_lock();
+    ensure!(lock.is_some(), "A thread dumping task is already running.");
+
+    let exe = env::current_exe().unwrap();
+    let trace = TraceOptions::new()
+        .snapshot(snapshot)
+        .trace(Command::new(exe).arg("--stacktrace"))
+        .map_err(Error::msg)?;
+
+    let mut body = String::new();
+    for thread in trace.threads() {
+        body.push_str(&format!("Thread {} ({}):\n", thread.id(), thread.name()));
+        for frame in thread.frames() {
+            if frame_ip {
+                body.push_str(&format!("Frame ip: {}\n", frame.ip()));
+            }
+            for symbol in frame.symbols() {
+                let name = if let Some(name) = symbol.name() {
+                    name
+                } else {
+                    "(unknown)"
+                };
+                if location {
+                    let location = if let Some(file) = symbol.file() {
+                        if let Some(line) = symbol.line() {
+                            format!("{}:{line}", file.display())
+                        } else {
+                            format!("{}", file.display())
+                        }
+                    } else {
+                        "".into()
+                    };
+                    body.push_str(&format!("{name}\t\t{location}\n"));
+                } else {
+                    body.push_str(&format!("{name}\n"));
+                }
+            }
+        }
+        body.push_str("\n\n");
+    }
+
+    Ok(body)
+}

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         pkg-config \
         libssl-dev \
         libpq-dev \
+        libdw-dev \
         binutils \
         lld \
         libudev-dev

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -713,6 +713,13 @@ function install_lld {
   fi
 }
 
+function install_libdw {
+  # Right now, only install libdw for linux
+  if [[ "$(uname)" == "Linux" ]]; then
+    install_pkg libdw-dev "$PACKAGE_MANAGER"
+  fi
+}
+
 # this is needed for hdpi crate from aptos-ledger
 function install_libudev-dev {
   # Need to install libudev-dev for linux
@@ -991,6 +998,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
   install_pkg_config "$PACKAGE_MANAGER"
 
   install_lld
+  install_libdw
 
   install_rustup "$BATCH_MODE"
   install_toolchain "$(grep channel ./rust-toolchain.toml | grep -o '"[^"]\+"' | sed 's/"//g')" # TODO: Fix me. This feels hacky.


### PR DESCRIPTION
### Description

Add `/threadz` endpoint to dump stack trace for all threads.
Default libunwind doesn't work well due to a compatibility issue with lld, using libdw instead.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
