### PR TITLE
[compiler v2] Reference safety analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9815,6 +9815,7 @@ dependencies = [
  "codespan-reporting",
  "datatest-stable",
  "ethnum",
+ "im",
  "itertools 0.10.5",
  "move-binary-format",
  "move-bytecode-source-map",

--- a/third_party/move/move-compiler-v2/Cargo.toml
+++ b/third_party/move/move-compiler-v2/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.3.9", features = ["derive", "env"] }
 codespan = "0.11.1"
 codespan-reporting = { version = "0.11.1", features = ["serde", "serialization"] }
 ethnum = "1.0.4"
-#im = "15.0.0"
+im = "15.0.0"
 itertools = "0.10.0"
 #log = "0.4.14"
 num = "0.4.0"
@@ -44,6 +44,9 @@ move-disassembler = { path = "../tools/move-disassembler" }
 move-ir-types = { path = "../move-ir/types" }
 move-prover-test-utils = { path = "../move-prover/test-utils" }
 move-stdlib = { path = "../move-stdlib" }
+
+[features]
+verbose-debug-print = ["move-stackless-bytecode/verbose-debug-print"]
 
 [lib]
 doctest = false

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -278,7 +278,13 @@ impl<'env> Generator<'env> {
                 return *idx;
             }
         }
-        self.internal_error(id, "local not defined");
+        self.internal_error(
+            id,
+            format!(
+                "local `{}` not defined",
+                sym.display(self.env().symbol_pool())
+            ),
+        );
         0
     }
 

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -883,10 +883,10 @@ impl<'env> Generator<'env> {
 impl<'env> Generator<'env> {
     fn gen_borrow(&mut self, target: TempIndex, id: NodeId, kind: ReferenceKind, arg: &Exp) {
         match arg.as_ref() {
-            ExpData::Call(arg_id, Operation::Select(mid, sid, fid), args) => {
+            ExpData::Call(_arg_id, Operation::Select(mid, sid, fid), args) => {
                 return self.gen_borrow_field(
                     target,
-                    *arg_id,
+                    id,
                     kind,
                     mid.qualified(*sid),
                     *fid,

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -916,7 +916,7 @@ impl<'env> Generator<'env> {
         &mut self,
         target: TempIndex,
         id: NodeId,
-        _kind: ReferenceKind,
+        kind: ReferenceKind,
         struct_id: QualifiedId<StructId>,
         field_id: FieldId,
         oper: &Exp,

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -2,9 +2,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::file_format_generator::{
-    module_generator::{ModuleContext, ModuleGenerator},
-    MAX_FUNCTION_DEF_COUNT, MAX_LOCAL_COUNT,
+use crate::{
+    file_format_generator::{
+        module_generator::{ModuleContext, ModuleGenerator},
+        MAX_FUNCTION_DEF_COUNT, MAX_LOCAL_COUNT,
+    },
+    pipeline::livevar_analysis_processor::LiveVarAnnotation,
 };
 use move_binary_format::file_format as FF;
 use move_model::{
@@ -15,7 +18,6 @@ use move_model::{
 use move_stackless_bytecode::{
     function_target::FunctionTarget,
     function_target_pipeline::FunctionVariant,
-    livevar_analysis::LiveVarAnnotation,
     stackless_bytecode::{Bytecode, Constant, Label, Operation},
 };
 use std::collections::{BTreeMap, BTreeSet};
@@ -824,7 +826,7 @@ impl<'env> BytecodeContext<'env> {
             .get::<LiveVarAnnotation>()
             .expect("livevar analysis result");
         an.get_live_var_info_at(self.code_offset)
-            .map(|a| a.after.contains(&temp))
+            .map(|a| a.after.contains_key(&temp))
             .unwrap_or(false)
     }
 
@@ -838,7 +840,7 @@ impl<'env> BytecodeContext<'env> {
             .get::<LiveVarAnnotation>()
             .expect("livevar analysis result");
         an.get_live_var_info_at(self.code_offset)
-            .map(|a| a.before.contains(&temp))
+            .map(|a| a.before.contains_key(&temp))
             .unwrap_or(false)
     }
 }

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -4,13 +4,63 @@
 
 //! Implements a live-variable analysis processor, annotating lifetime information about locals.
 //! See also https://en.wikipedia.org/wiki/Live-variable_analysis
+//!
+//! After transformation, this also also runs copy inference transformation, which inserts
+//! copies as needed, and reports errors for invalid copies.
 
-use move_model::model::FunctionEnv;
+use codespan_reporting::diagnostic::Severity;
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    ast::TempIndex,
+    model::{FunctionEnv, Loc},
+    ty::Type,
+};
 use move_stackless_bytecode::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult, MapDomain},
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    livevar_analysis,
+    stackless_bytecode::{AssignKind, AttrId, Bytecode, Operation},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
 };
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter::{empty, once},
+};
+
+/// Annotation which is attached to function data.
+#[derive(Default, Clone)]
+pub struct LiveVarAnnotation(BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>);
+
+impl LiveVarAnnotation {
+    /// Get the live var info at the given code offset
+    pub fn get_live_var_info_at(
+        &self,
+        code_offset: CodeOffset,
+    ) -> Option<&LiveVarInfoAtCodeOffset> {
+        self.0.get(&code_offset)
+    }
+}
+
+/// The annotation for live variable analysis per code offset.
+#[derive(Debug, Default, Clone)]
+pub struct LiveVarInfoAtCodeOffset {
+    /// Usage before this program point.
+    pub before: BTreeMap<TempIndex, LiveVarInfo>,
+    /// Usage after this program point.
+    pub after: BTreeMap<TempIndex, LiveVarInfo>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub struct LiveVarInfo {
+    /// The usage of a given temporary after this program point, inclusive of locations where
+    /// the usage happens.
+    pub usages: BTreeSet<Loc>,
+}
+
+// =================================================================================================
+// Processor
 
 pub struct LiveVarAnalysisProcessor();
 
@@ -19,20 +69,22 @@ impl FunctionTargetProcessor for LiveVarAnalysisProcessor {
         &self,
         _targets: &mut FunctionTargetsHolder,
         fun_env: &FunctionEnv,
-        mut data: FunctionData,
+        data: FunctionData,
         _scc_opt: Option<&[FunctionEnv]>,
     ) -> FunctionData {
         if fun_env.is_native() {
             return data;
         }
-        // Call the existing live-var analysis from the move-prover.
         let target = FunctionTarget::new(fun_env, &data);
-        let offset_to_live_refs = livevar_analysis::LiveVarAnnotation::from_map(
-            livevar_analysis::run_livevar_analysis(&target, &data.code),
-        );
+        let offset_to_live_refs = LiveVarAnnotation(self.analyze(&target));
+        let mut transformer = CopyTransformation { fun_env, data };
+        transformer.transform(&offset_to_live_refs);
+        // Now run the analyze a 2nd time, as we modified the code
+        let target = FunctionTarget::new(fun_env, &transformer.data);
+        let offset_to_live_refs = LiveVarAnnotation(self.analyze(&target));
         // Annotate the result on the function data.
-        data.annotations.set(offset_to_live_refs, true);
-        data
+        transformer.data.annotations.set(offset_to_live_refs, true);
+        transformer.data
     }
 
     fn name(&self) -> String {
@@ -41,9 +93,378 @@ impl FunctionTargetProcessor for LiveVarAnalysisProcessor {
 }
 
 impl LiveVarAnalysisProcessor {
+    /// Run the live var analysis.
+    fn analyze(
+        &self,
+        func_target: &FunctionTarget,
+    ) -> BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset> {
+        let code = func_target.get_bytecode();
+        // Perform backward analysis from all blocks just in case some block
+        // cannot reach an exit block
+        let cfg = StacklessControlFlowGraph::new_backward(code, /*from_all_blocks*/ true);
+        let analyzer = LiveVarAnalysis { func_target };
+        let state_map = analyzer.analyze_function(
+            LiveVarState {
+                livevars: MapDomain::default(),
+            },
+            code,
+            &cfg,
+        );
+        analyzer.state_per_instruction(state_map, code, &cfg, |before, after| {
+            LiveVarInfoAtCodeOffset {
+                before: before.livevars.clone().into_iter().collect(),
+                after: after.livevars.clone().into_iter().collect(),
+            }
+        })
+    }
+
     /// Registers annotation formatter at the given function target. This is for debugging and
     /// testing.
     pub fn register_formatters(target: &FunctionTarget) {
-        target.register_annotation_formatter(Box::new(livevar_analysis::format_livevar_annotation))
+        target.register_annotation_formatter(Box::new(format_livevar_annotation))
     }
+}
+
+// =================================================================================================
+// Dataflow Analysis
+
+/// State of the livevar analysis,
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+struct LiveVarState {
+    livevars: MapDomain<TempIndex, LiveVarInfo>,
+}
+
+impl AbstractDomain for LiveVarState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        self.livevars.join(&other.livevars)
+    }
+}
+
+impl AbstractDomain for LiveVarInfo {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let count = self.usages.len();
+        self.usages.extend(other.usages.iter().cloned());
+        if self.usages.len() != count {
+            JoinResult::Changed
+        } else {
+            JoinResult::Unchanged
+        }
+    }
+}
+
+struct LiveVarAnalysis<'a> {
+    func_target: &'a FunctionTarget<'a>,
+}
+
+/// Implements the necessary transfer function to instantiate the data flow framework
+impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
+    type State = LiveVarState;
+
+    const BACKWARD: bool = true;
+
+    fn execute(&self, state: &mut LiveVarState, instr: &Bytecode, _idx: CodeOffset) {
+        use Bytecode::*;
+        match instr {
+            Assign(id, dst, src, _) => {
+                // Only if dst is used afterwards account for usage. Otherwise this is dead
+                // code.
+                if state.livevars.contains_key(dst) {
+                    state.livevars.remove(dst);
+                    state.livevars.insert(*src, self.livevar_info(id));
+                }
+            },
+            Load(_, dst, _) => {
+                state.livevars.remove(dst);
+            },
+            Call(id, dsts, _, srcs, _) => {
+                for dst in dsts {
+                    state.livevars.remove(dst);
+                }
+                for src in srcs {
+                    state.livevars.insert(*src, self.livevar_info(id));
+                }
+            },
+            Ret(id, srcs) => {
+                for src in srcs {
+                    state.livevars.insert(*src, self.livevar_info(id));
+                }
+            },
+            Abort(id, src) | Branch(id, _, _, src) => {
+                state.livevars.insert(*src, self.livevar_info(id));
+            },
+            Prop(id, _, exp) => {
+                for (idx, _) in exp.used_temporaries(self.func_target.global_env()) {
+                    state.livevars.insert(idx, self.livevar_info(id));
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Implements various entry points to the framework based on the transfer function.
+impl<'a> DataflowAnalysis for LiveVarAnalysis<'a> {}
+
+impl<'a> LiveVarAnalysis<'a> {
+    fn livevar_info(&self, id: &AttrId) -> LiveVarInfo {
+        LiveVarInfo {
+            usages: once(self.func_target.get_bytecode_loc(*id)).collect(),
+        }
+    }
+}
+
+// =================================================================================================
+// Bytecode Transformation
+
+/// State for copy inference transformation.
+struct CopyTransformation<'a> {
+    fun_env: &'a FunctionEnv<'a>,
+    data: FunctionData,
+}
+
+impl<'a> CopyTransformation<'a> {
+    /// Runs copy inference transformation. This transformation inserts implicit copies. It also
+    /// checks correctness of copies, whether explicit or implicit.
+    fn transform(&mut self, alive: &LiveVarAnnotation) {
+        let code = std::mem::take(&mut self.data.code);
+        for (i, bc) in code.into_iter().enumerate() {
+            self.transform_bytecode(
+                alive
+                    .get_live_var_info_at(i as CodeOffset)
+                    .expect("live var info"),
+                bc,
+            )
+        }
+    }
+
+    /// Transforms a bytecode. This handles `Assign` and `Call` instructions.
+    /// For the former, it infers the `AssignKind` (copy or move) and for the later,
+    /// it implicitly copies arguments if needed. Implicit copy is needed
+    /// if a non-primitive value is used after the given program point.
+    fn transform_bytecode(&mut self, alive: &LiveVarInfoAtCodeOffset, bc: Bytecode) {
+        use Bytecode::*;
+        match bc {
+            Assign(id, dst, src, kind) => match kind {
+                AssignKind::Inferred => {
+                    if self.check_implicit_copy(alive, id, false, src) {
+                        self.data.code.push(Assign(id, dst, src, AssignKind::Copy))
+                    } else {
+                        self.data.code.push(Assign(id, dst, src, AssignKind::Move))
+                    }
+                },
+                AssignKind::Copy | AssignKind::Store => {
+                    self.check_explicit_copy(id, src);
+                    self.data.code.push(Assign(id, dst, src, AssignKind::Copy))
+                },
+                AssignKind::Move => {
+                    self.check_explicit_move(alive, id, src);
+                    self.data.code.push(Assign(id, dst, src, AssignKind::Move))
+                },
+            },
+            Call(_, _, Operation::BorrowLoc, _, _) => {
+                // Borrow does not consume its operand and need no copy
+                self.data.code.push(bc)
+            },
+            Call(id, dsts, oper, srcs, ai) => {
+                let srcs = self.copy_arg_if_needed(alive, id, srcs);
+                self.data.code.push(Call(id, dsts, oper, srcs, ai))
+            },
+            _ => self.data.code.push(bc),
+        }
+    }
+
+    /// Walks over the argument list and inserts copies if needed.
+    fn copy_arg_if_needed(
+        &mut self,
+        alive: &LiveVarInfoAtCodeOffset,
+        id: AttrId,
+        srcs: Vec<TempIndex>,
+    ) -> Vec<TempIndex> {
+        use Bytecode::*;
+        let mut new_srcs = vec![];
+        for (i, src) in srcs.iter().enumerate() {
+            let is_prim = matches!(self.target().get_local_type(*src), Type::Primitive(_));
+            if !is_prim
+                && (self.check_implicit_copy(alive, id, true, *src)
+                    || self.check_implicit_copy_in_arglist(id, *src, &srcs[i + 1..srcs.len()]))
+            {
+                let temp = self.clone_local(*src);
+                self.data
+                    .code
+                    .push(Assign(id, temp, *src, AssignKind::Copy));
+                new_srcs.push(temp)
+            } else {
+                new_srcs.push(*src)
+            }
+        }
+        new_srcs
+    }
+
+    /// Checks whether an implicit copy is needed because the value is used afterwards.
+    /// This produces an error if copie is not allowed.
+    fn check_implicit_copy(
+        &self,
+        alive: &LiveVarInfoAtCodeOffset,
+        id: AttrId,
+        is_updated: bool,
+        temp: TempIndex,
+    ) -> bool {
+        if let Some(info) = alive.after.get(&temp) {
+            let target = self.target();
+            if target.get_local_type(temp).is_mutable_reference() {
+                if !is_updated {
+                    // If this is a &mut which is not updated (e.g. a function call argument)
+                    // produce an error. &mut arguments play a special role, they are used
+                    // and updated at the same time. Therefore subsequent usage without copy is
+                    // fine, as it conceptually refers to a new instance for the same variable.
+                    self.error_with_hints(
+                        &target.get_bytecode_loc(id),
+                        format!(
+                            "implicit copy of mutable reference in {} which is used later",
+                            target.get_local_name_for_error_message(temp)
+                        ),
+                        "implicitly copied here",
+                        self.make_hints_from_usage(info),
+                    );
+                }
+                // Don't copy &mut
+                false
+            } else {
+                // TODO(#10723): insert ability check here
+                true
+            }
+        } else {
+            false
+        }
+    }
+
+    fn make_hints_from_usage(
+        &self,
+        info: &'a LiveVarInfo,
+    ) -> impl Iterator<Item = (Loc, String)> + 'a {
+        info.usages
+            .iter()
+            .map(|loc| (loc.clone(), "used here".to_owned()))
+    }
+
+    /// Checks whether an implicit copy is needed because the value is used again in
+    /// an argument list. This cannot be determined from the livevar analysis result
+    /// because the 2nd usage appears at the same program point.
+    fn check_implicit_copy_in_arglist(
+        &self,
+        id: AttrId,
+        temp: TempIndex,
+        args: &[TempIndex],
+    ) -> bool {
+        if args.contains(&temp) {
+            // If this is a &mut, produce an error
+            let target = self.target();
+            if target.get_local_type(temp).is_mutable_reference() {
+                self.error_with_hints(
+                    &target.get_bytecode_loc(id),
+                    format!(
+                        "implicit copy of mutable reference in {} which \
+                    is used later in argument list",
+                        target.get_local_name_for_error_message(temp)
+                    ),
+                    "implicitly copied here",
+                    empty(),
+                );
+                false
+            } else {
+                // TODO(#10723): insert ability check here
+                true
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Checks whether an explicit copy is allowed.
+    fn check_explicit_copy(&self, id: AttrId, temp: TempIndex) {
+        let target = self.target();
+        if target.get_local_type(temp).is_mutable_reference() {
+            self.error_with_hints(
+                &target.get_bytecode_loc(id),
+                format!(
+                    "cannot copy mutable reference in {}",
+                    target.get_local_name_for_error_message(temp)
+                ),
+                "copied here",
+                empty(),
+            );
+        }
+        // TODO(#10723): insert ability check here
+    }
+
+    /// Checks whether an explicit move is allowed.
+    fn check_explicit_move(&self, alive: &LiveVarInfoAtCodeOffset, id: AttrId, temp: TempIndex) {
+        if let Some(info) = alive.after.get(&temp) {
+            let target = self.target();
+            self.error_with_hints(
+                &target.get_bytecode_loc(id),
+                format!(
+                    "cannot move {} since it is used later",
+                    target.get_local_name_for_error_message(temp)
+                ),
+                "attempted to move here",
+                self.make_hints_from_usage(info),
+            );
+        }
+    }
+
+    /// Makes a new temporary with the same type as the given one.
+    fn clone_local(&mut self, temp: TempIndex) -> TempIndex {
+        let ty = self.target().get_local_type(temp).clone();
+        self.data.local_types.push(ty);
+        self.data.local_types.len() - 1
+    }
+
+    /// Produces an error with primary message and secondary hints.
+    fn error_with_hints(
+        &self,
+        loc: &Loc,
+        msg: impl AsRef<str>,
+        primary: impl AsRef<str>,
+        hints: impl Iterator<Item = (Loc, String)>,
+    ) {
+        self.fun_env.module_env.env.diag_with_primary_and_labels(
+            Severity::Error,
+            loc,
+            msg.as_ref(),
+            primary.as_ref(),
+            hints.collect(),
+        )
+    }
+
+    /// Constructs a function target for temporary use. Since we need to mutate `self.data`
+    /// we cannot store the target in `self`, so construct it as needed.
+    fn target(&self) -> FunctionTarget<'_> {
+        FunctionTarget::new(self.fun_env, &self.data)
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a live variable annotation.
+pub fn format_livevar_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(LiveVarAnnotation(map)) = target.get_annotations().get::<LiveVarAnnotation>() {
+        if let Some(map_at) = map.get(&code_offset) {
+            let mut res = map_at
+                .before
+                .keys()
+                .map(|idx| {
+                    let name = target.get_local_raw_name(*idx);
+                    format!("{}", name.display(target.symbol_pool()))
+                })
+                .join(", ");
+            res.insert_str(0, "live vars: ");
+            return Some(res);
+        }
+    }
+    None
 }

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -5,7 +5,7 @@
 //! Implements a live-variable analysis processor, annotating lifetime information about locals.
 //! See also https://en.wikipedia.org/wiki/Live-variable_analysis
 //!
-//! After transformation, this also also runs copy inference transformation, which inserts
+//! After transformation, this also runs copy inference transformation, which inserts
 //! copies as needed, and reports errors for invalid copies.
 
 use codespan_reporting::diagnostic::Severity;
@@ -301,7 +301,7 @@ impl<'a> CopyTransformation<'a> {
     }
 
     /// Checks whether an implicit copy is needed because the value is used afterwards.
-    /// This produces an error if copie is not allowed.
+    /// This produces an error if copy is not allowed.
     fn check_implicit_copy(
         &self,
         alive: &LiveVarInfoAtCodeOffset,

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -2,4 +2,5 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 pub mod livevar_analysis_processor;
+pub mod reference_safety_processor;
 pub mod visibility_checker;

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -1,0 +1,1407 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements memory safety analysis
+
+use crate::pipeline::livevar_analysis_processor::{LiveVarAnnotation, LiveVarInfoAtCodeOffset};
+use codespan_reporting::diagnostic::Severity;
+use im::ordmap::Entry;
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    ast::TempIndex,
+    model::{FieldId, FunctionEnv, Loc, QualifiedInstId, StructId},
+    ty::Type,
+};
+use move_stackless_bytecode::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult, MapDomain, SetDomain},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{AssignKind, AttrId, Bytecode, Operation},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::{
+    collections::{btree_map, BTreeMap, BTreeSet},
+    fmt::{Display, Formatter},
+};
+
+// ===============================================================================
+// Memory Safety Analysis
+
+// -------------------------------------------------------------------------------------------------
+// Program Analysis Domain
+
+/// Lifetime graph nodes represent information about memory locations, as well as nodes derived
+/// from that locations. For example, if `s` is the memory location of a struct, then
+/// `&s.f` is represented by a node which is derived fromm `s`. The lifetime graph is
+/// a DAG (acyclic).
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LifetimeNode {
+    location: MemoryLocation,
+    descendants: SetDomain<BorrowEdge>,
+    ancestors: SetDomain<LifetimeLabel>,
+}
+
+/// A label for a lifetime node.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug)]
+struct LifetimeLabel(usize);
+
+/// A memory location, either a global in storage or a local on the stack.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+enum MemoryLocation {
+    Global(QualifiedInstId<StructId>),
+    Local(TempIndex),
+    Replaced,
+}
+
+/// Represents an edge in the lifetime graph.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+struct BorrowEdge {
+    kind: BorrowEdgeKind,
+    is_mut: bool,
+    loc: Option<Loc>,
+    target: LifetimeLabel,
+}
+
+/// The different type of edges.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+enum BorrowEdgeKind {
+    BorrowLocal,
+    BorrowGlobal,
+    BorrowField(FieldId),
+    #[allow(unused)]
+    BorrowIndex,
+    Call(Operation),
+    /// The `Skip` edge is used for graph composition and glues two graph nodes together via
+    /// connecting them. For more details see the implementation of the `LifetimeDomain`
+    /// join operator.
+    Skip,
+}
+
+impl LifetimeLabel {
+    /// Creates a new, unique and stable, life time label based on a code offset and
+    /// a qualifier to distinguish multiple labels at the same code point.
+    fn new(code_offset: CodeOffset, qualifier: u8) -> LifetimeLabel {
+        LifetimeLabel(((code_offset as usize) << 8) | (qualifier as usize))
+    }
+
+    /// Creates a new, unique and stable, lifetime label from two other labels.
+    /// This exploits the fact that code offsets are 16 bits, so we can shift
+    /// the one lifetime label and bitor it with the other.
+    fn derive(label1: LifetimeLabel, label2: LifetimeLabel) -> LifetimeLabel {
+        LifetimeLabel(label1.0 << 24 | label2.0)
+    }
+}
+
+impl BorrowEdge {
+    fn new(kind: BorrowEdgeKind, is_mut: bool, loc: Option<Loc>, target: LifetimeLabel) -> Self {
+        Self {
+            kind,
+            is_mut,
+            loc,
+            target,
+        }
+    }
+}
+
+impl BorrowEdgeKind {
+    /// Determines whether the region derived from this edge as overlap with the region
+    /// of the other edge. Overlap can only be excluded for field edges.
+    fn overlaps(&self, other: &BorrowEdgeKind) -> bool {
+        use BorrowEdgeKind::*;
+        match (self, other) {
+            (BorrowField(field1), BorrowField(field2)) => field1 == field2,
+            _ => true,
+        }
+    }
+}
+
+/// The program analysis domain used with the data flow analysis framework.
+#[derive(Clone, Default, Debug)]
+struct LifetimeState {
+    /// Contains the lifetime graph at the current program point.
+    graph: MapDomain<LifetimeLabel, LifetimeNode>,
+    /// A map from locals to labels. Represents root states of the active graph.
+    local_to_label_map: BTreeMap<TempIndex, LifetimeLabel>,
+    /// A map from globals to labels. Represents root states of the active graph.
+    global_to_label_map: BTreeMap<QualifiedInstId<StructId>, LifetimeLabel>,
+}
+
+impl AbstractDomain for LifetimeNode {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        self.descendants
+            .join(&other.descendants)
+            .combine(self.ancestors.join(&other.ancestors))
+    }
+}
+
+impl AbstractDomain for LifetimeState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut change = self.graph.join(&other.graph);
+
+        let mut new_local_to_label_map = std::mem::take(&mut self.local_to_label_map);
+        change = change.combine(self.join_label_map(
+            &mut new_local_to_label_map,
+            &other.local_to_label_map,
+            |temp| MemoryLocation::Local(*temp),
+        ));
+        let mut new_global_to_label_map = std::mem::take(&mut self.global_to_label_map);
+        change = change.combine(self.join_label_map(
+            &mut new_global_to_label_map,
+            &other.global_to_label_map,
+            |id| MemoryLocation::Global(id.clone()),
+        ));
+        self.local_to_label_map = new_local_to_label_map;
+        self.global_to_label_map = new_global_to_label_map;
+        change
+    }
+}
+
+impl LifetimeState {
+    /// Joins two maps with labels in their range. For overlapping keys, a new `Skip`
+    /// node is created and configured as a descendant of both label nodes.
+    fn join_label_map<A: Clone + Ord>(
+        &mut self,
+        map: &mut BTreeMap<A, LifetimeLabel>,
+        other_map: &BTreeMap<A, LifetimeLabel>,
+        mk_location: impl Fn(&A) -> MemoryLocation,
+    ) -> JoinResult {
+        let mut change = JoinResult::Unchanged;
+        for (k, other_label) in other_map {
+            match map.entry(k.clone()) {
+                btree_map::Entry::Vacant(entry) => {
+                    entry.insert(*other_label);
+                    change = JoinResult::Changed;
+                },
+                btree_map::Entry::Occupied(mut entry) => {
+                    let label = *entry.get();
+                    if &label != other_label && self.node(label) != self.node(*other_label) {
+                        // Create a new intermediate node and make it descendant of the other ones.
+                        let new_label = LifetimeLabel::derive(label, *other_label);
+                        self.new_node(new_label, mk_location(entry.key()));
+                        entry.insert(new_label);
+                        // Determine mutability from the other nodes and add a `Skip` edge
+                        let is_mut = self
+                            .node(label)
+                            .descendants
+                            .iter()
+                            .chain(self.node(*other_label).descendants.iter())
+                            .any(|e| e.is_mut);
+                        let skip_edge =
+                            BorrowEdge::new(BorrowEdgeKind::Skip, is_mut, None, new_label);
+                        self.add_edge(label, skip_edge.clone());
+                        self.add_edge(*other_label, skip_edge);
+                        change = JoinResult::Changed;
+                    }
+                },
+            }
+        }
+        change
+    }
+}
+
+impl LifetimeState {
+    /// Creates a new node with the given label and location information.
+    fn new_node(&mut self, assigned_label: LifetimeLabel, location: MemoryLocation) {
+        self.graph.insert(assigned_label, LifetimeNode {
+            location,
+            descendants: Default::default(),
+            ancestors: Default::default(),
+        });
+    }
+
+    /// Returns reference to node.
+    fn node(&self, label: LifetimeLabel) -> &LifetimeNode {
+        &self.graph[&label]
+    }
+
+    /// Returns mutable reference to node.
+    fn node_mut(&mut self, label: LifetimeLabel) -> &mut LifetimeNode {
+        &mut self.graph[&label]
+    }
+
+    /// Returns an iteration of descendant edges of given node.
+    fn descendants(&self, label: LifetimeLabel) -> impl Iterator<Item = &BorrowEdge> {
+        self.node(label).descendants.iter()
+    }
+
+    /// Returns true if given node has no descendants
+    fn is_leaf(&self, label: LifetimeLabel) -> bool {
+        self.node(label).descendants.is_empty()
+    }
+
+    /// Iterates the effective descendant edges of a node. For incoming or outgoing Skip edges,
+    /// ancestor and target descendants are also included. This reflects that Skip edges represent
+    /// aliases, like when one local is assigned to another.
+    fn effective_descendants(&self, label: LifetimeLabel) -> Vec<(LifetimeLabel, &BorrowEdge)> {
+        // The walk upwards and downwards the graph can run into cycles, henceforth a
+        // `visited` set is needed.
+        self.effective_descendants_walk(label, &mut BTreeSet::new())
+    }
+
+    /// Implementation of `effective_descendants` with visited set.
+    fn effective_descendants_walk(
+        &self,
+        label: LifetimeLabel,
+        visited: &mut BTreeSet<LifetimeLabel>,
+    ) -> Vec<(LifetimeLabel, &BorrowEdge)> {
+        if !visited.insert(label) {
+            return vec![];
+        }
+        let mut result = vec![];
+        for e in self.descendants(label) {
+            if e.kind == BorrowEdgeKind::Skip {
+                result.append(&mut self.effective_descendants_walk(e.target, visited));
+            } else {
+                result.push((label, e))
+            }
+        }
+        for (ancestor, e) in self.ancestor_edges(label) {
+            if e.kind == BorrowEdgeKind::Skip {
+                result.append(&mut self.effective_descendants_walk(ancestor, visited))
+            } // else: the ancestor edge is not a descendant
+        }
+        result
+    }
+
+    /// Returns true if there are any effective descendants.
+    fn is_effective_leaf(&self, label: LifetimeLabel) -> bool {
+        self.effective_descendants(label).is_empty()
+    }
+
+    /// Gets the label associated with a local, if it has effective descendants.
+    fn label_for_local_with_descendants(&self, temp: TempIndex) -> Option<LifetimeLabel> {
+        self.label_for_local(temp)
+            .filter(|l| !self.is_effective_leaf(*l))
+    }
+
+    /// Gets the label associated with a global, if it has effective descendants.
+    fn label_for_global_with_descendants(
+        &self,
+        resource: &QualifiedInstId<StructId>,
+    ) -> Option<LifetimeLabel> {
+        self.label_for_global(resource)
+            .filter(|l| !self.is_effective_leaf(*l))
+    }
+
+    /// Returns true if the node has outgoing (effective) mut edges.
+    fn has_mut_edges(&self, label: LifetimeLabel) -> bool {
+        self.effective_descendants(label)
+            .iter()
+            .any(|(_, e)| e.is_mut)
+    }
+
+    /// Gets the label associated with a local.
+    fn label_for_local(&self, temp: TempIndex) -> Option<LifetimeLabel> {
+        self.local_to_label_map.get(&temp).cloned()
+    }
+
+    /// If label for local exists, return it, otherwise create a new node.
+    fn make_local(
+        &mut self,
+        temp: TempIndex,
+        code_offset: CodeOffset,
+        qualifier: u8,
+    ) -> LifetimeLabel {
+        if let Some(label) = self.local_to_label_map.get(&temp) {
+            *label
+        } else {
+            let label = LifetimeLabel::new(code_offset, qualifier);
+            self.new_node(label, MemoryLocation::Local(temp));
+            self.local_to_label_map.insert(temp, label);
+            label
+        }
+    }
+
+    /// Gets the label associated with a global.
+    #[allow(unused)]
+    fn label_for_global(&self, global: &QualifiedInstId<StructId>) -> Option<LifetimeLabel> {
+        self.global_to_label_map.get(global).cloned()
+    }
+
+    /// If label for global exists, return it, otherwise create a new one.
+    fn make_global(
+        &mut self,
+        struct_id: QualifiedInstId<StructId>,
+        code_offset: CodeOffset,
+        qualifier: u8,
+    ) -> LifetimeLabel {
+        if let Some(label) = self.global_to_label_map.get(&struct_id) {
+            *label
+        } else {
+            let label = LifetimeLabel::new(code_offset, qualifier);
+            self.new_node(label, MemoryLocation::Global(struct_id.clone()));
+            self.global_to_label_map.insert(struct_id, label);
+            label
+        }
+    }
+
+    /// Adds an edge to the graph.
+    fn add_edge(&mut self, label: LifetimeLabel, edge: BorrowEdge) {
+        let descendant = edge.target;
+        self.node_mut(label).descendants.insert(edge);
+        self.node_mut(descendant).ancestors.insert(label);
+    }
+
+    /// Drops a node. The ancestors are recursively dropped if their descendants go down to
+    /// zero. Collects the locations of the removed nodes.
+    fn drop_node(&mut self, label: LifetimeLabel, removed: &mut BTreeSet<MemoryLocation>) {
+        match self.graph.entry(label) {
+            Entry::Occupied(entry) => {
+                let current: LifetimeNode = entry.remove();
+                debug_assert!(current.descendants.is_empty());
+                removed.insert(current.location);
+                for ancestor in current.ancestors {
+                    let node = self.node_mut(ancestor);
+                    let descendants = std::mem::take(&mut node.descendants);
+                    node.descendants = descendants
+                        .into_iter()
+                        .filter(|e| e.target != label)
+                        .collect();
+                    if node.descendants.is_empty() {
+                        self.drop_node(ancestor, removed)
+                    }
+                }
+            },
+            Entry::Vacant(_) => {
+                panic!("inconsistent lifetime graph")
+            },
+        }
+    }
+
+    /// Releases graph resources related to the local, for example, since the local
+    /// is overwritem or not longer used.
+    fn release_local(&mut self, temp: TempIndex) {
+        if let Some(label) = self.label_for_local(temp) {
+            if self.is_leaf(label) {
+                let mut removed = BTreeSet::new();
+                self.drop_node(label, &mut removed);
+                for location in removed {
+                    use MemoryLocation::*;
+                    match location {
+                        Local(temp) => {
+                            self.local_to_label_map.remove(&temp);
+                        },
+                        Global(qid) => {
+                            self.global_to_label_map.remove(&qid);
+                        },
+                        Replaced => {},
+                    }
+                }
+            }
+        }
+    }
+
+    /// Replaces a local, as result of an assignment. The current
+    /// node associated with the local is released and then
+    /// a new node for the local is created.
+    fn replace_local(
+        &mut self,
+        temp: TempIndex,
+        code_offset: CodeOffset,
+        qualifier: u8,
+    ) -> LifetimeLabel {
+        self.release_local(temp);
+        if let Some(label) = self.label_for_local(temp) {
+            // Set the location to be 'replaced'. That means while the node logically still
+            // exists, it is not longer associated with a specific temporary.
+            self.node_mut(label).location = MemoryLocation::Replaced;
+            self.local_to_label_map.remove(&temp);
+        }
+        self.make_local(temp, code_offset, qualifier)
+    }
+
+    /// Returns an iterator of the edges which are leading into this node.
+    fn ancestor_edges(
+        &self,
+        label: LifetimeLabel,
+    ) -> impl Iterator<Item = (LifetimeLabel, &BorrowEdge)> + '_ {
+        self.node(label).ancestors.iter().flat_map(move |ancestor| {
+            self.descendants(*ancestor)
+                .filter(move |edge| edge.target == label)
+                .map(|e| (*ancestor, e))
+        })
+    }
+
+    /// Returns the roots of this node, that is those nodes which have no ancestors.
+    fn roots(&self, label: LifetimeLabel) -> BTreeSet<LifetimeLabel> {
+        let mut roots = BTreeSet::new();
+        let mut todo = self
+            .node(label)
+            .ancestors
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        while let Some(l) = todo.pop() {
+            let mut ancestors = self.node(l).ancestors.iter().cloned().collect::<Vec<_>>();
+            if ancestors.is_empty() {
+                // Found a root
+                roots.insert(l);
+            } else {
+                // Explore ancestors
+                todo.append(&mut ancestors)
+            }
+        }
+        roots
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Lifetime Analysis
+
+/// Used to distinguish how a local is read
+#[derive(Clone, Copy)]
+enum ReadMode {
+    /// The local is moved
+    Move,
+    /// The local is copied
+    Copy,
+    /// The local is transferred as an argument to another function
+    Argument,
+}
+
+/// A structure providing context information for operations during lifetime analysis.
+/// This encapsulates the function target which is analyzed, giving also access to
+/// the global model. Live var annotations are attached which are evaluated during
+/// analysis.
+struct LifeTimeAnalysis<'env> {
+    target: &'env FunctionTarget<'env>,
+    live_var_annotation: &'env LiveVarAnnotation,
+}
+
+impl<'env> LifeTimeAnalysis<'env> {
+    // ---------------------------------------------------------------------------------------------
+    // Diagnosis
+
+    fn check_mut_edge(
+        &self,
+        state: &LifetimeState,
+        label: LifetimeLabel,
+        edge: &BorrowEdge,
+    ) -> Vec<(Loc, String)> {
+        let mut diags = vec![];
+        // There must be no overlapping descendant.
+        for (_, e) in state.effective_descendants(label) {
+            if e.kind.overlaps(&edge.kind) {
+                if let Some(diag) = self.borrow_edge_info("previous ", state, false, e) {
+                    diags.push(diag)
+                } else {
+                    debug_assert!(false, "unexpect Skip edge")
+                }
+            }
+        }
+        diags
+    }
+
+    fn check_imut_edge(
+        &self,
+        state: &LifetimeState,
+        label: LifetimeLabel,
+        edge: &BorrowEdge,
+    ) -> Vec<(Loc, String)> {
+        let mut diags = vec![];
+        // There must be no overlapping mutable descendant.
+        for (_, e) in state.effective_descendants(label) {
+            if e.is_mut && e.kind.overlaps(&edge.kind) {
+                if let Some(diag) = self.borrow_edge_info("previous ", state, true, e) {
+                    diags.push(diag)
+                } else {
+                    debug_assert!(false, "unYexpect Skip edge")
+                }
+            }
+        }
+        diags
+    }
+
+    fn check_and_add_edge(
+        &self,
+        state: &mut LifetimeState,
+        label: LifetimeLabel,
+        edge: BorrowEdge,
+        _alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        debug_assert_ne!(edge.kind, BorrowEdgeKind::Skip);
+        let msg_for_source = || {
+            match &state.node(label).location {
+                MemoryLocation::Global(resource) => {
+                    format!("global `{}`", self.target.global_env().display(resource))
+                },
+                MemoryLocation::Local(temp) => self.display(*temp),
+                MemoryLocation::Replaced => {
+                    // We do not create a new edge starting from a replace location.
+                    panic!("unexpected location for new edge")
+                },
+            }
+        };
+        if edge.is_mut {
+            let diags = self.check_mut_edge(state, label, &edge);
+            if !diags.is_empty() {
+                self.error_with_hints(
+                    edge.loc.as_ref().expect("only Skip edge has no location"),
+                    format!(
+                        "cannot mutable borrow {} since other references exists",
+                        msg_for_source()
+                    ),
+                    "mutable borrow attempted here",
+                    diags.into_iter(),
+                )
+            }
+        } else {
+            let diags = self.check_imut_edge(state, label, &edge);
+            if !diags.is_empty() {
+                self.error_with_hints(
+                    edge.loc.as_ref().expect("only Skip edge has no location"),
+                    format!(
+                        "cannot immutable borrow {} since other mutable references exist",
+                        msg_for_source()
+                    ),
+                    "immutable borrow attempted here",
+                    diags.into_iter(),
+                )
+            }
+        }
+        state.add_edge(label, edge)
+    }
+
+    fn error_with_hints(
+        &self,
+        loc: &Loc,
+        msg: impl AsRef<str>,
+        primary: impl AsRef<str>,
+        hints: impl Iterator<Item = (Loc, String)>,
+    ) {
+        self.target.global_env().diag_with_primary_and_labels(
+            Severity::Error,
+            loc,
+            msg.as_ref(),
+            primary.as_ref(),
+            hints.collect(),
+        )
+    }
+
+    fn borrow_info(
+        &self,
+        state: &LifetimeState,
+        label: LifetimeLabel,
+        only_mut: bool,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) -> Vec<(Loc, String)> {
+        let primary_edges = state
+            .effective_descendants(label)
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut secondary_edges = BTreeSet::new();
+        for (_, edge) in primary_edges.iter() {
+            if let MemoryLocation::Local(temp) = &state.graph[&edge.target].location {
+                // Include secondary edge only if it is a local which has gone out of
+                // scope. In this case, the user may wonder why they get the error
+                // message, and showing derived references helps. Otherwise derived
+                // references may be noisy.
+                if !alive.before.contains_key(temp) {
+                    secondary_edges.extend(state.effective_descendants(edge.target))
+                }
+            }
+        }
+        primary_edges
+            .into_iter()
+            .filter_map(|(_, e)| self.borrow_edge_info("previous ", state, only_mut, e))
+            .chain(
+                secondary_edges
+                    .into_iter()
+                    .filter_map(|(_, e)| self.borrow_edge_info("used by ", state, only_mut, e)),
+            )
+            .collect()
+    }
+
+    fn borrow_edge_info(
+        &self,
+        prefix: &str,
+        _state: &LifetimeState,
+        only_mut: bool,
+        e: &BorrowEdge,
+    ) -> Option<(Loc, String)> {
+        if e.is_mut || !only_mut {
+            if let Some(loc) = &e.loc {
+                use BorrowEdgeKind::*;
+                let mut_prefix = if e.is_mut { "mutable " } else { "" };
+                return Some((
+                    loc.clone(),
+                    format!("{}{}{}", prefix, mut_prefix, match e.kind {
+                        BorrowLocal => "local borrow",
+                        BorrowGlobal => "global borrow",
+                        BorrowField(..) => "field borrow",
+                        BorrowIndex => "index borrow",
+                        Call(..) => "call result",
+                        Skip => return None,
+                    },),
+                ));
+            }
+        }
+        None
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Program Steps
+
+    /// Process an assign operation. This checks whether the source is currently borrowed and
+    /// rejects a move if so. Constructs a `Skip` edge in the lifetime graph if references
+    /// are assigned.
+    fn assign(
+        &self,
+        state: &mut LifetimeState,
+        code_offset: CodeOffset,
+        id: AttrId,
+        dest: TempIndex,
+        src: TempIndex,
+        kind: AssignKind,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        // Check validness
+        let mode = if kind == AssignKind::Move {
+            ReadMode::Move
+        } else {
+            ReadMode::Copy
+        };
+        self.check_read_local(state, id, src, mode, alive);
+        self.check_write_local(state, id, dest, alive);
+        let ty = self.ty(src);
+        if ty.is_reference() {
+            // Track reference in the graph as a Skip edge.
+            let loc = self.loc(id);
+            let label = state.make_local(src, code_offset, 0);
+            let descendant = state.replace_local(dest, code_offset, 1);
+            state.add_edge(
+                label,
+                BorrowEdge::new(
+                    BorrowEdgeKind::Skip,
+                    ty.is_mutable_reference(),
+                    Some(loc),
+                    descendant,
+                ),
+            );
+        }
+    }
+
+    /// Check validness of reading a local. The read is not allowed if the local is borrowed,
+    /// depending on whether it is read or written. Returns true if valid.
+    fn check_read_local(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        local: TempIndex,
+        read_mode: ReadMode,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) -> bool {
+        if let Some(label) = state.label_for_local_with_descendants(local) {
+            let ty = self.ty(local);
+            let loc = self.loc(id);
+            if ty.is_reference() {
+                if ty.is_mutable_reference() {
+                    match read_mode {
+                        ReadMode::Move => {
+                            self.error_with_hints(
+                                &loc,
+                                format!(
+                                    "cannot move mutable reference in {} which is still borrowed",
+                                    self.display(local)
+                                ),
+                                "moved here",
+                                self.borrow_info(state, label, false, alive).into_iter(),
+                            );
+                            false
+                        },
+                        ReadMode::Argument => {
+                            self.error_with_hints(
+                                &loc,
+                                format!(
+                                    "cannot pass mutable reference in {}, which is still borrowed, as function argument",
+                                    self.display(local)
+                                ),
+                                "passed here",
+                                self.borrow_info(state, label, false, alive).into_iter(),
+                            );
+                            false
+                        },
+                        ReadMode::Copy => {
+                            // This has been checked in live-var analysis
+                            true
+                        },
+                    }
+                } else {
+                    // immutable reference always ok
+                    true
+                }
+            } else {
+                match read_mode {
+                    ReadMode::Copy => {
+                        // Mutable borrow is not allowed
+                        if state.has_mut_edges(label) {
+                            self.error_with_hints(
+                                &loc,
+                                format!(
+                                    "cannot copy {} which is still mutable borrowed",
+                                    self.display(local)
+                                ),
+                                "copied here",
+                                self.borrow_info(state, label, true, alive).into_iter(),
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    },
+                    ReadMode::Move => {
+                        // Any borrow not allowed
+                        self.error_with_hints(
+                            &loc,
+                            format!(
+                                "cannot move {} which is still borrowed",
+                                self.display(local)
+                            ),
+                            "moved here",
+                            self.borrow_info(state, label, false, alive).into_iter(),
+                        );
+                        false
+                    },
+                    ReadMode::Argument => {
+                        // Mutable borrow not allowed
+                        if state.has_mut_edges(label) {
+                            self.error_with_hints(
+                                &loc,
+                                format!(
+                                    "cannot pass {} which is still borrowed as function argument",
+                                    self.display(local)
+                                ),
+                                "passed here",
+                                self.borrow_info(state, label, false, alive).into_iter(),
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    },
+                }
+            }
+        } else {
+            true
+        }
+    }
+
+    /// Check whether a local can be written. This is not allowed if its non-reference which
+    /// is borrowed.
+    fn check_write_local(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        local: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        if let Some(label) = state.label_for_local_with_descendants(local) {
+            let ty = self.ty(local);
+            if !ty.is_reference() {
+                // The destination is currently borrowed and cannot be assigned
+                let loc = self.loc(id);
+                self.error_with_hints(
+                    &loc,
+                    format!("cannot assign to borrowed {}", self.display(local)),
+                    "attempted to assign here",
+                    self.borrow_info(state, label, false, alive).into_iter(),
+                )
+            }
+        }
+    }
+
+    /// Process a borrow local. This checks whether the borrow is allowed and constructs a
+    /// borrow edge.
+    fn borrow_local(
+        &self,
+        state: &mut LifetimeState,
+        code_offset: CodeOffset,
+        id: AttrId,
+        dest: TempIndex,
+        src: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        let label = state.make_local(src, code_offset, 0);
+        let descendant = state.replace_local(dest, code_offset, 1);
+        let loc = self.loc(id);
+        let is_mut = self.ty(dest).is_mutable_reference();
+        self.check_and_add_edge(
+            state,
+            label,
+            BorrowEdge::new(BorrowEdgeKind::BorrowLocal, is_mut, Some(loc), descendant),
+            alive,
+        )
+    }
+
+    /// Process a borrow global. This checks whether the borrow is allowed and constructs a
+    /// borrow edge.
+    fn borrow_global(
+        &self,
+        state: &mut LifetimeState,
+        code_offset: CodeOffset,
+        id: AttrId,
+        struct_: QualifiedInstId<StructId>,
+        dest: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        let label = state.make_global(struct_.clone(), code_offset, 0);
+        let descendant = state.replace_local(dest, code_offset, 1);
+        let loc = self.loc(id);
+        let is_mut = self.ty(dest).is_mutable_reference();
+        self.check_and_add_edge(
+            state,
+            label,
+            BorrowEdge::new(BorrowEdgeKind::BorrowGlobal, is_mut, Some(loc), descendant),
+            alive,
+        )
+    }
+
+    /// Process a borrow field. This checks whether the borrow is allowed and constructs a
+    /// borrow edge.
+    fn borrow_field(
+        &self,
+        state: &mut LifetimeState,
+        code_offset: CodeOffset,
+        id: AttrId,
+        struct_: QualifiedInstId<StructId>,
+        field_offs: &usize,
+        dest: TempIndex,
+        src: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        let label = state.make_local(src, code_offset, 0);
+        let descendant = state.replace_local(dest, code_offset, 1);
+        let loc = self.loc(id);
+        let is_mut = self.ty(dest).is_mutable_reference();
+        let struct_env = self
+            .target
+            .global_env()
+            .get_struct(struct_.to_qualified_id());
+        let field_id = struct_env.get_field_by_offset(*field_offs).get_id();
+        self.check_and_add_edge(
+            state,
+            label,
+            BorrowEdge::new(
+                BorrowEdgeKind::BorrowField(field_id),
+                is_mut,
+                Some(loc),
+                descendant,
+            ),
+            alive,
+        )
+    }
+
+    /// Process a function call. For now we implement standard Move semantics, where every
+    /// output reference is a descendant of all input references. Here would be the point where to
+    //  evaluate lifetime modifiers in future language versions.
+    fn call_operation(
+        &self,
+        state: &mut LifetimeState,
+        code_offset: CodeOffset,
+        id: AttrId,
+        oper: Operation,
+        dests: &[TempIndex],
+        srcs: &[TempIndex],
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        // Check validness of transferring arguments into function.
+        let mut src_check_failed = BTreeSet::new();
+        for src in srcs {
+            if !self.check_read_local(state, id, *src, ReadMode::Argument, alive) {
+                src_check_failed.insert(*src);
+            }
+        }
+        // Next check whether we can assign to the destinations.
+        for dest in dests {
+            self.check_write_local(state, id, *dest, alive)
+        }
+        // Now draw edges from all reference destinations to all reference sources
+        let dest_labels = dests
+            .iter()
+            .filter(|d| self.ty(**d).is_reference())
+            .enumerate()
+            .map(|(i, t)| (*t, state.replace_local(*t, code_offset, i as u8)))
+            .collect::<BTreeMap<_, _>>();
+        let src_qualifier_offset = dest_labels.len();
+        let loc = self.loc(id);
+        for dest in dests {
+            let dest_ty = self.ty(*dest);
+            if dest_ty.is_reference() {
+                for (i, src) in srcs.iter().enumerate() {
+                    // Only check the edge if src check succeeded, otherwise we get confusing
+                    // double errors on the same location.
+                    if src_check_failed.contains(src) {
+                        continue;
+                    }
+                    let src_ty = self.ty(*src);
+                    if src_ty.is_reference() {
+                        let label =
+                            state.make_local(*src, code_offset, (src_qualifier_offset + i) as u8);
+                        let descendant = dest_labels[dest];
+                        self.check_and_add_edge(
+                            state,
+                            label,
+                            BorrowEdge::new(
+                                BorrowEdgeKind::Call(oper.clone()),
+                                dest_ty.is_mutable_reference(),
+                                Some(loc.clone()),
+                                descendant,
+                            ),
+                            alive,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Move resource out of storage. It must not be borrowed.
+    fn move_from(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        dest: TempIndex,
+        resource: &QualifiedInstId<StructId>,
+        src: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        self.check_read_local(state, id, src, ReadMode::Argument, alive);
+        self.check_write_local(state, id, dest, alive);
+        if let Some(label) = state.label_for_global_with_descendants(resource) {
+            self.error_with_hints(
+                &self.loc(id),
+                format!(
+                    "cannot extract resource `{}` which is still borrowed",
+                    self.target.global_env().display(resource)
+                ),
+                "extracted here",
+                self.borrow_info(state, label, false, alive).into_iter(),
+            )
+        }
+    }
+
+    fn return_(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        srcs: &[TempIndex],
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        for src in srcs {
+            if self.ty(*src).is_reference() {
+                // Need to check whether this reference is derived from a local which is not a
+                // a parameter
+                if let Some(label) = state.label_for_local(*src) {
+                    for root in state.roots(label) {
+                        match &state.node(root).location {
+                            MemoryLocation::Global(resource) => self.error_with_hints(
+                                &self.loc(id),
+                                format!(
+                                    "cannot return a reference derived from global `{}`",
+                                    self.target.global_env().display(resource)
+                                ),
+                                "returned here",
+                                self.borrow_info(state, root, false, alive).into_iter(),
+                            ),
+                            MemoryLocation::Local(local) => {
+                                if *local >= self.target.get_parameter_count() {
+                                    self.error_with_hints(
+                                        &self.loc(id),
+                                        format!(
+                                            "cannot return a reference derived from {} since it is not a parameter",
+                                            self.display(*local)
+                                        ),
+                                        "returned here",
+                                        self.borrow_info(state, root, false, alive).into_iter(),
+                                    )
+                                }
+                            },
+                            MemoryLocation::Replaced => {},
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read from a reference. In difference to `self.check_read_local`, this needs
+    /// to check the value behind the reference.
+    fn read_ref(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        dest: TempIndex,
+        src: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        self.check_write_local(state, id, dest, alive);
+        if let Some(label) = state.label_for_local_with_descendants(src) {
+            if state.has_mut_edges(label) {
+                self.error_with_hints(
+                    &self.loc(id),
+                    format!(
+                        "cannot dereference {} which is still mutable borrowed",
+                        self.display(src)
+                    ),
+                    "dereferenced here",
+                    self.borrow_info(state, label, true, alive).into_iter(),
+                )
+            }
+        }
+    }
+
+    /// Write to a reference. In difference to `self.check_write_local`, this needs
+    /// to check the value behind the reference.
+    fn write_ref(
+        &self,
+        state: &LifetimeState,
+        id: AttrId,
+        dest: TempIndex,
+        src: TempIndex,
+        alive: &LiveVarInfoAtCodeOffset,
+    ) {
+        self.check_read_local(state, id, src, ReadMode::Argument, alive);
+        if let Some(label) = state.label_for_local_with_descendants(dest) {
+            self.error_with_hints(
+                &self.loc(id),
+                format!(
+                    "cannot write to reference in {} which is still borrowed",
+                    self.display(dest)
+                ),
+                "written here",
+                self.borrow_info(state, label, false, alive).into_iter(),
+            )
+        }
+    }
+
+    /// Get the location associated with bytecode attribute.
+    fn loc(&self, id: AttrId) -> Loc {
+        self.target.get_bytecode_loc(id)
+    }
+
+    /// Gets a string for a local to be displayed in error messages
+    fn display(&self, local: TempIndex) -> String {
+        self.target.get_local_name_for_error_message(local)
+    }
+
+    /// Get the type associated with local.
+    fn ty(&self, local: TempIndex) -> &Type {
+        self.target.get_local_type(local)
+    }
+}
+
+impl<'env> TransferFunctions for LifeTimeAnalysis<'env> {
+    type State = LifetimeState;
+
+    const BACKWARD: bool = false;
+
+    /// Transfer function for given bytecode.
+    fn execute(&self, state: &mut Self::State, instr: &Bytecode, code_offset: CodeOffset) {
+        use Bytecode::*;
+        let alive = self
+            .live_var_annotation
+            .get_live_var_info_at(code_offset)
+            .expect("livevar annotation");
+        // Before processing the instruction, release all temps in the label map
+        // which are not longer alive at this point.
+        for temp in state.local_to_label_map.keys().cloned().collect::<Vec<_>>() {
+            if !alive.before.contains_key(&temp) {
+                state.release_local(temp)
+            }
+        }
+        match instr {
+            Assign(id, dest, src, kind) => {
+                self.assign(state, code_offset, *id, *dest, *src, *kind, alive);
+            },
+            Ret(id, srcs) => self.return_(state, *id, srcs, alive),
+            Call(id, dests, oper, srcs, _) => {
+                use Operation::*;
+                match oper {
+                    BorrowLoc => {
+                        self.borrow_local(state, code_offset, *id, dests[0], srcs[0], alive);
+                    },
+                    BorrowGlobal(mid, sid, inst) => {
+                        self.borrow_global(
+                            state,
+                            code_offset,
+                            *id,
+                            mid.qualified_inst(*sid, inst.clone()),
+                            dests[0],
+                            alive,
+                        );
+                    },
+                    BorrowField(mid, sid, inst, field_offs) => {
+                        let (dest, src) = (dests[0], srcs[0]);
+                        self.borrow_field(
+                            state,
+                            code_offset,
+                            *id,
+                            mid.qualified_inst(*sid, inst.clone()),
+                            field_offs,
+                            dest,
+                            src,
+                            alive,
+                        );
+                    },
+                    ReadRef => self.read_ref(state, *id, dests[0], srcs[0], alive),
+                    WriteRef => self.write_ref(state, *id, srcs[0], srcs[1], alive),
+                    MoveFrom(mid, sid, inst) => self.move_from(
+                        state,
+                        *id,
+                        dests[0],
+                        &mid.qualified_inst(*sid, inst.clone()),
+                        srcs[0],
+                        alive,
+                    ),
+                    _ => self.call_operation(
+                        state,
+                        code_offset,
+                        *id,
+                        oper.clone(),
+                        dests,
+                        srcs,
+                        alive,
+                    ),
+                }
+            },
+            _ => {},
+        }
+        // After processing, release any locals which are dying at this program point.
+        for released in alive.before.keys() {
+            if !alive.after.contains_key(released) {
+                state.release_local(*released)
+            }
+        }
+    }
+}
+
+/// Instantiate the data flow analysis framework based on the transfer function
+impl<'env> DataflowAnalysis for LifeTimeAnalysis<'env> {}
+
+// ===============================================================================
+// Processor
+
+pub struct ReferenceSafetyProcessor {}
+
+/// Annotation produced by this processor
+#[derive(Clone, Debug)]
+pub struct LifetimeAnnotation(BTreeMap<CodeOffset, LifetimeInfoAtCodeOffset>);
+
+impl LifetimeAnnotation {
+    /// Returns information for code offset.
+    pub fn get_info_at(&self, code_offset: CodeOffset) -> &LifetimeInfoAtCodeOffset {
+        self.0.get(&code_offset).expect("lifetime info")
+    }
+}
+
+/// Annotation present at each code offset
+#[derive(Debug, Clone)]
+pub struct LifetimeInfoAtCodeOffset {
+    before: LifetimeState,
+    after: LifetimeState,
+}
+
+/// Public functions on lifetime info
+impl LifetimeInfoAtCodeOffset {
+    /// Returns the locals which are released at the give code offset since they are not borrowed
+    /// any longer. Notice that this is only for locals which are actually borrowed, other
+    /// locals being released need to be determined from livevar analysis results.
+    pub fn released_temps(&self) -> impl Iterator<Item = TempIndex> + '_ {
+        self.before
+            .local_to_label_map
+            .keys()
+            .filter(|t| self.after.local_to_label_map.contains_key(t))
+            .cloned()
+    }
+}
+
+impl FunctionTargetProcessor for ReferenceSafetyProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if fun_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(fun_env, &data);
+        let live_var_annotation = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("livevar annotation");
+        let analyzer = LifeTimeAnalysis {
+            target: &target,
+            live_var_annotation,
+        };
+        let cfg = StacklessControlFlowGraph::new_forward(target.get_bytecode());
+        let state_map =
+            analyzer.analyze_function(LifetimeState::default(), target.get_bytecode(), &cfg);
+        let annotation = LifetimeAnnotation(analyzer.state_per_instruction(
+            state_map,
+            target.get_bytecode(),
+            &cfg,
+            |before, after| LifetimeInfoAtCodeOffset {
+                before: before.clone(),
+                after: after.clone(),
+            },
+        ));
+        data.annotations.set(annotation, true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "MemorySafetyProcessor".to_owned()
+    }
+}
+
+// ===============================================================================================
+// Display
+
+impl ReferenceSafetyProcessor {
+    /// Registers annotation formatter at the given function target. This is for debugging and
+    /// testing.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_lifetime_annotation))
+    }
+}
+
+struct BorrowEdgeDisplay<'a>(&'a FunctionTarget<'a>, &'a BorrowEdge, bool);
+impl<'a> Display for BorrowEdgeDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let edge = &self.1;
+        let display_descendant = self.2;
+        use BorrowEdgeKind::*;
+        (match &edge.kind {
+            BorrowLocal => write!(f, "borrow({}", edge.is_mut),
+            BorrowGlobal => write!(f, "borrow_global({})", edge.is_mut),
+            BorrowField(_) => write!(f, "borrow_field({})", edge.is_mut),
+            BorrowIndex => write!(f, "index({})", edge.is_mut),
+            Call(_) => write!(f, "call({})", edge.is_mut),
+            Skip => f.write_str("skip"),
+        })?;
+        if display_descendant {
+            write!(f, " -> {}", edge.target)
+        } else {
+            Ok(())
+        }
+    }
+}
+impl BorrowEdge {
+    fn display<'a>(
+        &'a self,
+        target: &'a FunctionTarget,
+        display_decendant: bool,
+    ) -> BorrowEdgeDisplay<'a> {
+        BorrowEdgeDisplay(target, self, display_decendant)
+    }
+}
+
+impl Display for LifetimeLabel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+struct MemoryLocationDisplay<'a>(&'a FunctionTarget<'a>, &'a MemoryLocation);
+impl<'a> Display for MemoryLocationDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use MemoryLocation::*;
+        let env = self.0.global_env();
+        match self.1 {
+            Global(qid) => write!(f, "global<{}>", env.display(qid)),
+            Local(temp) => write!(
+                f,
+                "local({})",
+                env.display(&self.0.get_local_raw_name(*temp))
+            ),
+            Replaced => write!(f, "replaced"),
+        }
+    }
+}
+impl MemoryLocation {
+    fn display<'a>(&'a self, fun: &'a FunctionTarget) -> MemoryLocationDisplay<'a> {
+        MemoryLocationDisplay(fun, self)
+    }
+}
+
+struct LifetimeNodeDisplay<'a>(&'a FunctionTarget<'a>, &'a LifetimeNode);
+impl<'a> Display for LifetimeNodeDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}[", self.1.location.display(self.0))?;
+        f.write_str(
+            &self
+                .1
+                .descendants
+                .iter()
+                .map(|e| e.display(self.0, true).to_string())
+                .join(","),
+        )?;
+        f.write_str("]")
+    }
+}
+impl LifetimeNode {
+    fn display<'a>(&'a self, fun: &'a FunctionTarget) -> LifetimeNodeDisplay<'a> {
+        LifetimeNodeDisplay(fun, self)
+    }
+}
+
+struct LifetimeDomainDisplay<'a>(&'a FunctionTarget<'a>, &'a LifetimeState);
+impl<'a> Display for LifetimeDomainDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let LifetimeState {
+            graph,
+            local_to_label_map,
+            global_to_label_map,
+        } = &self.1;
+        writeln!(
+            f,
+            "graph: {}",
+            graph.to_string(|k| k.to_string(), |v| v.display(self.0).to_string())
+        )?;
+        writeln!(
+            f,
+            "local_to_label: {{{}}}",
+            local_to_label_map
+                .iter()
+                .map(|(temp, label)| format!(
+                    "{}={}",
+                    self.0
+                        .get_local_raw_name(*temp)
+                        .display(self.0.global_env().symbol_pool()),
+                    label
+                ))
+                .join(",")
+        )?;
+        writeln!(
+            f,
+            "global_to_label: {{{}}}",
+            global_to_label_map
+                .iter()
+                .map(|(str, label)| format!("{}={}", self.0.global_env().display(str), label))
+                .join(",")
+        )
+    }
+}
+impl LifetimeState {
+    fn display<'a>(&'a self, fun: &'a FunctionTarget) -> LifetimeDomainDisplay<'a> {
+        LifetimeDomainDisplay(fun, self)
+    }
+}
+
+fn format_lifetime_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(LifetimeAnnotation(map)) = target.get_annotations().get::<LifetimeAnnotation>() {
+        if let Some(at) = map.get(&code_offset) {
+            return Some(at.before.display(target).to_string());
+        }
+    }
+    None
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/assign_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/assign_inline.exp
@@ -31,10 +31,10 @@ public fun assign::main(): (u64, u64) {
      var $t4: u64
      var $t5: u64
   0: $t5 := 3
-  1: $t4 := move($t5)
+  1: $t4 := infer($t5)
   2: $t2 := 1
-  3: $t3 := move($t4)
-  4: $t0 := move($t2)
-  5: $t1 := move($t3)
+  3: $t3 := infer($t4)
+  4: $t0 := infer($t2)
+  5: $t1 := infer($t3)
   6: return ($t0, $t1)
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
@@ -82,7 +82,7 @@ fun borrow::field($t0: &borrow::S): u64 {
      var $t2: &u64
      var $t3: &u64
   0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t1 := read_ref($t2)
   3: return $t1
 }
@@ -96,9 +96,9 @@ fun borrow::local($t0: u64): u64 {
      var $t4: &u64
      var $t5: &u64
   0: $t3 := 33
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t5 := borrow_local($t2)
-  3: $t4 := move($t5)
+  3: $t4 := infer($t5)
   4: $t1 := read_ref($t4)
   5: return $t1
 }
@@ -110,7 +110,7 @@ fun borrow::param($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
   0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t1 := read_ref($t2)
   3: return $t1
 }
@@ -123,7 +123,7 @@ fun borrow::mut_field($t0: &mut borrow::S): u64 {
      var $t3: &mut u64
      var $t4: u64
   0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := 22
   3: write_ref($t2, $t4)
   4: $t1 := read_ref($t2)
@@ -140,9 +140,9 @@ fun borrow::mut_local($t0: u64): u64 {
      var $t5: &mut u64
      var $t6: u64
   0: $t3 := 33
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t5 := borrow_local($t2)
-  3: $t4 := move($t5)
+  3: $t4 := infer($t5)
   4: $t6 := 22
   5: write_ref($t4, $t6)
   6: $t1 := read_ref($t4)
@@ -157,7 +157,7 @@ fun borrow::mut_param($t0: u64): u64 {
      var $t3: &mut u64
      var $t4: u64
   0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := 22
   3: write_ref($t2, $t4)
   4: $t1 := read_ref($t2)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow_invalid.exp
@@ -34,7 +34,7 @@ fun borrow::mut_expr($t0: u64): u64 {
   0: $t5 := 1
   1: $t4 := +($t0, $t5)
   2: $t3 := borrow_local($t4)
-  3: $t2 := move($t3)
+  3: $t2 := infer($t3)
   4: $t6 := 22
   5: write_ref($t2, $t6)
   6: $t1 := read_ref($t2)
@@ -49,7 +49,7 @@ fun borrow::mut_field($t0: &borrow::S): u64 {
      var $t3: &mut u64
      var $t4: u64
   0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := 22
   3: write_ref($t2, $t4)
   4: $t1 := read_ref($t2)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -141,13 +141,13 @@ fun fields::write_local_direct(): fields::S {
   1: $t5 := 0
   2: $t4 := pack fields::T($t5)
   3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := move($t2)
+  4: $t1 := infer($t2)
   5: $t6 := 42
   6: $t9 := borrow_local($t1)
   7: $t8 := borrow_field<fields::S>.g($t9)
   8: $t7 := borrow_field<fields::T>.h($t8)
   9: write_ref($t7, $t6)
- 10: $t0 := move($t1)
+ 10: $t0 := infer($t1)
  11: return $t0
 }
 
@@ -169,14 +169,14 @@ fun fields::write_local_via_ref(): fields::S {
   1: $t5 := 0
   2: $t4 := pack fields::T($t5)
   3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := move($t2)
+  4: $t1 := infer($t2)
   5: $t7 := borrow_local($t1)
-  6: $t6 := move($t7)
+  6: $t6 := infer($t7)
   7: $t8 := 42
   8: $t10 := borrow_field<fields::S>.g($t6)
   9: $t9 := borrow_field<fields::T>.h($t10)
  10: write_ref($t9, $t8)
- 11: $t0 := move($t1)
+ 11: $t0 := infer($t1)
  12: return $t0
 }
 
@@ -237,6 +237,6 @@ fun fields::write_val($t0: fields::S): fields::S {
   2: $t4 := borrow_field<fields::S>.g($t5)
   3: $t3 := borrow_field<fields::T>.h($t4)
   4: write_ref($t3, $t2)
-  5: $t1 := move($t0)
+  5: $t1 := infer($t0)
   6: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -191,24 +191,22 @@ fun fields::write_local_via_ref_2(): fields::S {
      var $t5: u64
      var $t6: &mut u64
      var $t7: &mut u64
-     var $t8: fields::T
-     var $t9: &fields::S
-     var $t10: &fields::T
-     var $t11: u64
+     var $t8: &mut fields::T
+     var $t9: &mut fields::S
+     var $t10: u64
   0: $t3 := 0
   1: $t5 := 0
   2: $t4 := pack fields::T($t5)
   3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := move($t2)
+  4: $t1 := infer($t2)
   5: $t9 := borrow_local($t1)
-  6: $t10 := borrow_field<fields::S>.g($t9)
-  7: $t8 := read_ref($t10)
-  8: $t7 := borrow_field<fields::T>.h($t8)
-  9: $t6 := move($t7)
- 10: $t11 := 42
- 11: write_ref($t6, $t11)
- 12: $t0 := move($t1)
- 13: return $t0
+  6: $t8 := borrow_field<fields::S>.g($t9)
+  7: $t7 := borrow_field<fields::T>.h($t8)
+  8: $t6 := infer($t7)
+  9: $t10 := 42
+ 10: write_ref($t6, $t10)
+ 11: $t0 := infer($t1)
+ 12: return $t0
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
@@ -64,7 +64,7 @@ fun globals::read($t0: address): u64 {
      var $t3: &globals::R
      var $t4: &u64
   0: $t3 := borrow_global<globals::R>($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := borrow_field<globals::R>.f($t2)
   3: $t1 := read_ref($t4)
   4: return $t1
@@ -79,7 +79,7 @@ fun globals::write($t0: address, $t1: u64): u64 {
      var $t5: u64
      var $t6: &mut u64
   0: $t4 := borrow_global<globals::R>($t0)
-  1: $t3 := move($t4)
+  1: $t3 := infer($t4)
   2: $t5 := 2
   3: $t6 := borrow_field<globals::R>.f($t3)
   4: write_ref($t6, $t5)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
@@ -33,12 +33,12 @@ fun inline_specs::specs(): u64 {
      var $t2: u64
      var $t3: u64
   0: $t2 := 0
-  1: $t1 := move($t2)
+  1: $t1 := infer($t2)
   2: assert Eq<u64>(x, 0)
   3: $t3 := inline_specs::succ($t1)
-  4: $t1 := move($t3)
+  4: $t1 := infer($t3)
   5: assert Eq<u64>(x, 1)
-  6: $t0 := move($t1)
+  6: $t0 := infer($t1)
   7: return $t0
 }
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/loop.exp
@@ -83,7 +83,7 @@ fun loops::nested_loop($t0: u64): u64 {
   9: label L7
  10: $t7 := 1
  11: $t6 := -($t0, $t7)
- 12: $t0 := move($t6)
+ 12: $t0 := infer($t6)
  13: goto 19
  14: goto 17
  15: label L8
@@ -93,7 +93,7 @@ fun loops::nested_loop($t0: u64): u64 {
  19: label L6
  20: $t9 := 1
  21: $t8 := -($t0, $t9)
- 22: $t0 := move($t8)
+ 22: $t0 := infer($t8)
  23: goto 0
  24: goto 27
  25: label L3
@@ -101,7 +101,7 @@ fun loops::nested_loop($t0: u64): u64 {
  27: label L4
  28: goto 0
  29: label L1
- 30: $t1 := move($t0)
+ 30: $t1 := infer($t0)
  31: return $t1
 }
 
@@ -120,14 +120,14 @@ fun loops::while_loop($t0: u64): u64 {
   4: label L2
   5: $t5 := 1
   6: $t4 := -($t0, $t5)
-  7: $t0 := move($t4)
+  7: $t0 := infer($t4)
   8: goto 11
   9: label L3
  10: goto 13
  11: label L4
  12: goto 0
  13: label L1
- 14: $t1 := move($t0)
+ 14: $t1 := infer($t0)
  15: return $t1
 }
 
@@ -166,13 +166,13 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
  20: label L10
  21: $t9 := 1
  22: $t8 := -($t0, $t9)
- 23: $t0 := move($t8)
+ 23: $t0 := infer($t8)
  24: goto 27
  25: label L3
  26: goto 29
  27: label L4
  28: goto 0
  29: label L1
- 30: $t1 := move($t0)
+ 30: $t1 := infer($t0)
  31: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/operators.exp
@@ -76,7 +76,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
      var $t7: bool
   0: if ($t0) goto 1 else goto 4
   1: label L0
-  2: $t5 := move($t1)
+  2: $t5 := infer($t1)
   3: goto 6
   4: label L1
   5: $t5 := false
@@ -102,7 +102,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
  25: $t6 := !($t0)
  26: if ($t6) goto 27 else goto 30
  27: label L12
- 28: $t3 := move($t1)
+ 28: $t3 := infer($t1)
  29: goto 32
  30: label L13
  31: $t3 := false

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_order.exp
@@ -106,8 +106,8 @@ fun pack_unpack::pack2($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t4, $t2, $t5)
   3: return $t3
 }
@@ -117,7 +117,7 @@ fun pack_unpack::pack2($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
 fun pack_unpack::pack3($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
-  0: $t4 := move($t0)
+  0: $t4 := infer($t0)
   1: $t3 := pack pack_unpack::S($t1, $t4, $t2)
   2: return $t3
 }
@@ -128,8 +128,8 @@ fun pack_unpack::pack4($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t2, $t4, $t5)
   3: return $t3
 }
@@ -139,7 +139,7 @@ fun pack_unpack::pack4($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
 fun pack_unpack::pack5($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
-  0: $t4 := move($t0)
+  0: $t4 := infer($t0)
   1: $t3 := pack pack_unpack::S($t1, $t2, $t4)
   2: return $t3
 }
@@ -150,8 +150,8 @@ fun pack_unpack::pack6($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t2, $t5, $t4)
   3: return $t3
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_unpack.exp
@@ -48,7 +48,7 @@ fun pack_unpack::unpack($t0: pack_unpack::S): (u64, u64) {
      var $t5: pack_unpack::T
   0: ($t3, $t5) := unpack pack_unpack::S($t0)
   1: $t4 := unpack pack_unpack::T($t5)
-  2: $t1 := move($t3)
-  3: $t2 := move($t4)
+  2: $t1 := infer($t3)
+  3: $t2 := infer($t4)
   4: return ($t1, $t2)
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -39,9 +39,9 @@ fun reference_conversion::use_it(): u64 {
      var $t5: u64
      var $t6: &u64
   0: $t2 := 42
-  1: $t1 := move($t2)
+  1: $t1 := infer($t2)
   2: $t4 := borrow_local($t1)
-  3: $t3 := move($t4)
+  3: $t3 := infer($t4)
   4: $t5 := 43
   5: write_ref($t3, $t5)
   6: $t6 := freeze_ref($t3)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/tuple.exp
@@ -31,7 +31,7 @@ fun tuple::tuple($t0: u64): (u64, tuple::S) {
      var $t2: tuple::S
      var $t3: u64
      var $t4: u64
-  0: $t1 := move($t0)
+  0: $t1 := infer($t0)
   1: $t4 := 1
   2: $t3 := +($t0, $t4)
   3: $t2 := pack tuple::S($t3)

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_add.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_add.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Add<u128>(0, 1);
         Add<u128>(0, 1);
         Add<u64>(0, 1);
-        Add<u64>(x, x);
+        Add<u64>(Copy(x), Move(x));
         Add<u64>(select M::R.f(r), select M::R.f(r));
         Add<u64>(Add<u64>(Add<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_and.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_and.exp
@@ -8,7 +8,7 @@ module 0x8675309::M {
         And(false, true);
         And(true, false);
         And(true, true);
-        And(x, x);
+        And(Copy(x), Move(x));
         And(select M::R.f(r), select M::R.f(r));
         And(And(true, false), And(true, false));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         BitAnd<u128>(0, 1);
         BitAnd<u128>(0, 1);
         BitAnd<u64>(0, 1);
-        BitAnd<u64>(x, x);
+        BitAnd<u64>(Copy(x), Move(x));
         BitAnd<u64>(select M::R.f(r), select M::R.f(r));
         BitAnd<u64>(BitAnd<u64>(BitAnd<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         BitOr<u128>(0, 1);
         BitOr<u128>(0, 1);
         BitOr<u64>(0, 1);
-        BitOr<u64>(x, x);
+        BitOr<u64>(Copy(x), Move(x));
         BitOr<u64>(select M::R.f(r), select M::R.f(r));
         BitOr<u64>(BitOr<u64>(BitOr<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_div.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_div.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Div<u128>(0, 1);
         Div<u128>(0, 1);
         Div<u64>(0, 1);
-        Div<u64>(x, x);
+        Div<u64>(Copy(x), Move(x));
         Div<u64>(select M::R.f(r), select M::R.f(r));
         Div<u64>(Div<u64>(Div<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Ge<u128>(0, 1);
         Ge<u128>(0, 1);
         Ge<u64>(0, 1);
-        Ge<u64>(x, x);
+        Ge<u64>(Copy(x), Move(x));
         Ge<u64>(select M::R.f(r), select M::R.f(r));
         And(Ge<u64>(1, select M::R.f(r)), Ge<u64>(select M::R.f(r), 0));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Gt<u128>(0, 1);
         Gt<u128>(0, 1);
         Gt<u64>(0, 1);
-        Gt<u64>(x, x);
+        Gt<u64>(Copy(x), Move(x));
         Gt<u64>(select M::R.f(r), select M::R.f(r));
         And(Gt<u64>(1, select M::R.f(r)), Gt<u64>(select M::R.f(r), 0));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Le<u128>(0, 1);
         Le<u128>(0, 1);
         Le<u64>(0, 1);
-        Le<u64>(x, x);
+        Le<u64>(Copy(x), Move(x));
         Le<u64>(select M::R.f(r), select M::R.f(r));
         And(Le<u64>(1, select M::R.f(r)), Le<u64>(select M::R.f(r), 0));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Lt<u128>(0, 1);
         Lt<u128>(0, 1);
         Lt<u64>(0, 1);
-        Lt<u64>(x, x);
+        Lt<u64>(Copy(x), Move(x));
         Lt<u64>(select M::R.f(r), select M::R.f(r));
         And(Lt<u64>(1, select M::R.f(r)), Lt<u64>(select M::R.f(r), 0));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Mod<u128>(0, 1);
         Mod<u128>(0, 1);
         Mod<u64>(0, 1);
-        Mod<u64>(x, x);
+        Mod<u64>(Copy(x), Move(x));
         Mod<u64>(select M::R.f(r), select M::R.f(r));
         Mod<u64>(Mod<u64>(Mod<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Mul<u128>(0, 1);
         Mul<u128>(0, 1);
         Mul<u64>(0, 1);
-        Mul<u64>(x, x);
+        Mul<u64>(Copy(x), Move(x));
         Mul<u64>(select M::R.f(r), select M::R.f(r));
         Mul<u64>(Mul<u64>(Mul<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_or.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_or.exp
@@ -8,7 +8,7 @@ module 0x8675309::M {
         Or(false, true);
         Or(true, false);
         Or(true, true);
-        Or(x, x);
+        Or(Copy(x), Move(x));
         Or(select M::R.f(r), select M::R.f(r));
         Or(Or(true, false), Or(true, false));
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Add<u8>(0, 1);
         Shl<u128>(0, 1);
         Shl<u64>(0, 1);
-        Shl<u64>(x, b);
+        Shl<u64>(Copy(x), Copy(b));
         Shl<u64>(select M::R.f(r), select M::R.b(r));
         Shl<u64>(Shl<u64>(Shl<u64>(1, select M::R.b(r)), select M::R.b(r)), 0);
         M::R{ f: _, b: _ } = r

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Add<u8>(0, 1);
         Shr<u128>(0, 1);
         Shr<u64>(0, 1);
-        Shr<u64>(x, b);
+        Shr<u64>(Copy(x), Copy(b));
         Shr<u64>(select M::R.f(r), select M::R.b(r));
         Shr<u64>(Shr<u64>(Shr<u64>(1, select M::R.b(r)), select M::R.b(r)), 0);
         M::R{ f: _, b: _ } = r

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Sub<u128>(0, 1);
         Sub<u128>(0, 1);
         Sub<u64>(0, 1);
-        Sub<u64>(x, x);
+        Sub<u64>(Copy(x), Move(x));
         Sub<u64>(select M::R.f(r), select M::R.f(r));
         Sub<u64>(Sub<u64>(Sub<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_xor.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_xor.exp
@@ -12,7 +12,7 @@ module 0x8675309::M {
         Xor<u128>(0, 1);
         Xor<u128>(0, 1);
         Xor<u64>(0, 1);
-        Xor<u64>(x, x);
+        Xor<u64>(Copy(x), Move(x));
         Xor<u64>(select M::R.f(r), select M::R.f(r));
         Xor<u64>(Xor<u64>(Xor<u64>(1, select M::R.f(r)), select M::R.f(r)), 0);
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_allowed_but_not_supported.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_allowed_but_not_supported.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: constant expression must be a literal
+error: not a valid constant expression
    ┌─ tests/checking/typing/constant_allowed_but_not_supported.move:6:20
    │
  6 │       const C: u64 = {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/explicit_copy.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/explicit_copy.exp
@@ -11,8 +11,8 @@ module 0x8675309::M {
           let u: u64 = 0;
           {
             let s: M::S = pack M::S(false);
-            u;
-            s;
+            Copy(u);
+            Copy(s);
             s;
             u;
             Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/explicit_move.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/explicit_move.exp
@@ -13,9 +13,9 @@ module 0x8675309::M {
             let s: M::S = pack M::S(false);
             {
               let r: M::R = pack M::R(false);
-              u;
-              s;
-              M::R{ dummy_field: _ } = r;
+              Move(u);
+              Move(s);
+              M::R{ dummy_field: _ } = Move(r);
               Tuple()
             }
           }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/unary_not.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/unary_not.exp
@@ -7,8 +7,8 @@ module 0x8675309::M {
         Not(true);
         Not(false);
         Not(x);
-        Not(x);
-        Not(x);
+        Not(Copy(x));
+        Not(Move(x));
         Not(select M::R.f(r));
         {
           let M::R{ f: _ } = r;

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -6,7 +6,7 @@ fun borrow::field($t0: &borrow::S): u64 {
      var $t2: &u64
      var $t3: &u64
   0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t1 := read_ref($t2)
   3: return $t1
 }
@@ -20,9 +20,9 @@ fun borrow::local($t0: u64): u64 {
      var $t4: &u64
      var $t5: &u64
   0: $t3 := 33
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t5 := borrow_local($t2)
-  3: $t4 := move($t5)
+  3: $t4 := infer($t5)
   4: $t1 := read_ref($t4)
   5: return $t1
 }
@@ -34,7 +34,7 @@ fun borrow::param($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
   0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t1 := read_ref($t2)
   3: return $t1
 }
@@ -47,7 +47,7 @@ fun borrow::mut_field($t0: &mut borrow::S): u64 {
      var $t3: &mut u64
      var $t4: u64
   0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := 22
   3: write_ref($t2, $t4)
   4: $t1 := read_ref($t2)
@@ -64,9 +64,9 @@ fun borrow::mut_local($t0: u64): u64 {
      var $t5: &mut u64
      var $t6: u64
   0: $t3 := 33
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t5 := borrow_local($t2)
-  3: $t4 := move($t5)
+  3: $t4 := infer($t5)
   4: $t6 := 22
   5: write_ref($t4, $t6)
   6: $t1 := read_ref($t4)
@@ -81,7 +81,7 @@ fun borrow::mut_param($t0: u64): u64 {
      var $t3: &mut u64
      var $t4: u64
   0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := 22
   3: write_ref($t2, $t4)
   4: $t1 := read_ref($t2)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -28,30 +28,30 @@ fun constant::test_constans() {
      var $t23: vector<u8>
      var $t24: vector<u8>
   0: $t1 := true
-  1: $t0 := move($t1)
+  1: $t0 := infer($t1)
   2: $t3 := false
-  3: $t2 := move($t3)
+  3: $t2 := infer($t3)
   4: $t5 := 1
-  5: $t4 := move($t5)
+  5: $t4 := infer($t5)
   6: $t7 := 7086
-  7: $t6 := move($t7)
+  7: $t6 := infer($t7)
   8: $t9 := 14593408
-  9: $t8 := move($t9)
+  9: $t8 := infer($t9)
  10: $t11 := 51966
- 11: $t10 := move($t11)
+ 11: $t10 := infer($t11)
  12: $t13 := 3735928559
- 13: $t12 := move($t13)
+ 13: $t12 := infer($t13)
  14: $t15 := 301490978409967
- 15: $t14 := move($t15)
+ 15: $t14 := infer($t15)
  16: $t17 := 0x42
- 17: $t16 := move($t17)
+ 17: $t16 := infer($t17)
  18: $t20 := 1
  19: $t21 := 2
  20: $t22 := 3
  21: $t19 := vector($t20, $t21, $t22)
- 22: $t18 := move($t19)
+ 22: $t18 := infer($t19)
  23: $t24 := [72, 101, 108, 108, 111, 33, 10]
- 24: $t23 := move($t24)
+ 24: $t23 := infer($t24)
  25: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -42,13 +42,13 @@ fun fields::write_local_direct(): fields::S {
   1: $t5 := 0
   2: $t4 := pack fields::T($t5)
   3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := move($t2)
+  4: $t1 := infer($t2)
   5: $t6 := 42
   6: $t9 := borrow_local($t1)
   7: $t8 := borrow_field<fields::S>.g($t9)
   8: $t7 := borrow_field<fields::T>.h($t8)
   9: write_ref($t7, $t6)
- 10: $t0 := move($t1)
+ 10: $t0 := infer($t1)
  11: return $t0
 }
 
@@ -70,14 +70,14 @@ fun fields::write_local_via_ref(): fields::S {
   1: $t5 := 0
   2: $t4 := pack fields::T($t5)
   3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := move($t2)
+  4: $t1 := infer($t2)
   5: $t7 := borrow_local($t1)
-  6: $t6 := move($t7)
+  6: $t6 := infer($t7)
   7: $t8 := 42
   8: $t10 := borrow_field<fields::S>.g($t6)
   9: $t9 := borrow_field<fields::T>.h($t10)
  10: write_ref($t9, $t8)
- 11: $t0 := move($t1)
+ 11: $t0 := infer($t1)
  12: return $t0
 }
 
@@ -107,7 +107,7 @@ fun fields::write_val($t0: fields::S): fields::S {
   2: $t4 := borrow_field<fields::S>.g($t5)
   3: $t3 := borrow_field<fields::T>.h($t4)
   4: write_ref($t3, $t2)
-  5: $t1 := move($t0)
+  5: $t1 := infer($t0)
   6: return $t1
 }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -11,7 +11,7 @@ fun Test::foo($t0: u64): u64 {
 [variant baseline]
 fun Test::identity<#0>($t0: #0): #0 {
      var $t1: #0
-  0: $t1 := move($t0)
+  0: $t1 := infer($t0)
   1: return $t1
 }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -26,7 +26,7 @@ fun globals::read($t0: address): u64 {
      var $t3: &globals::R
      var $t4: &u64
   0: $t3 := borrow_global<globals::R>($t0)
-  1: $t2 := move($t3)
+  1: $t2 := infer($t3)
   2: $t4 := borrow_field<globals::R>.f($t2)
   3: $t1 := read_ref($t4)
   4: return $t1
@@ -41,7 +41,7 @@ fun globals::write($t0: address, $t1: u64): u64 {
      var $t5: u64
      var $t6: &mut u64
   0: $t4 := borrow_global<globals::R>($t0)
-  1: $t3 := move($t4)
+  1: $t3 := infer($t4)
   2: $t5 := 2
   3: $t6 := borrow_field<globals::R>.f($t3)
   4: write_ref($t6, $t5)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -23,7 +23,7 @@ fun loops::nested_loop($t0: u64): u64 {
   9: label L7
  10: $t7 := 1
  11: $t6 := -($t0, $t7)
- 12: $t0 := move($t6)
+ 12: $t0 := infer($t6)
  13: goto 19
  14: goto 17
  15: label L8
@@ -33,7 +33,7 @@ fun loops::nested_loop($t0: u64): u64 {
  19: label L6
  20: $t9 := 1
  21: $t8 := -($t0, $t9)
- 22: $t0 := move($t8)
+ 22: $t0 := infer($t8)
  23: goto 0
  24: goto 27
  25: label L3
@@ -41,7 +41,7 @@ fun loops::nested_loop($t0: u64): u64 {
  27: label L4
  28: goto 0
  29: label L1
- 30: $t1 := move($t0)
+ 30: $t1 := infer($t0)
  31: return $t1
 }
 
@@ -60,14 +60,14 @@ fun loops::while_loop($t0: u64): u64 {
   4: label L2
   5: $t5 := 1
   6: $t4 := -($t0, $t5)
-  7: $t0 := move($t4)
+  7: $t0 := infer($t4)
   8: goto 11
   9: label L3
  10: goto 13
  11: label L4
  12: goto 0
  13: label L1
- 14: $t1 := move($t0)
+ 14: $t1 := infer($t0)
  15: return $t1
 }
 
@@ -106,14 +106,14 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
  20: label L10
  21: $t9 := 1
  22: $t8 := -($t0, $t9)
- 23: $t0 := move($t8)
+ 23: $t0 := infer($t8)
  24: goto 27
  25: label L3
  26: goto 29
  27: label L4
  28: goto 0
  29: label L1
- 30: $t1 := move($t0)
+ 30: $t1 := infer($t0)
  31: return $t1
 }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -42,7 +42,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
      var $t7: bool
   0: if ($t0) goto 1 else goto 4
   1: label L0
-  2: $t5 := move($t1)
+  2: $t5 := infer($t1)
   3: goto 6
   4: label L1
   5: $t5 := false
@@ -68,7 +68,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
  25: $t6 := !($t0)
  26: if ($t6) goto 27 else goto 30
  27: label L12
- 28: $t3 := move($t1)
+ 28: $t3 := infer($t1)
  29: goto 32
  30: label L13
  31: $t3 := false
@@ -202,7 +202,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
      # live vars: $t0, $t1
   1: label L0
      # live vars: $t0, $t1
-  2: $t5 := move($t1)
+  2: $t5 := copy($t1)
      # live vars: $t0, $t1, $t5
   3: goto 6
      # live vars: $t0, $t1
@@ -254,7 +254,7 @@ fun operators::bools($t0: bool, $t1: bool): bool {
      # live vars: $t0, $t1
  27: label L12
      # live vars: $t0, $t1
- 28: $t3 := move($t1)
+ 28: $t3 := copy($t1)
      # live vars: $t0, $t1, $t3
  29: goto 32
      # live vars: $t0, $t1

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
@@ -13,8 +13,8 @@ fun pack_unpack::pack2($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t4, $t2, $t5)
   3: return $t3
 }
@@ -24,7 +24,7 @@ fun pack_unpack::pack2($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
 fun pack_unpack::pack3($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
-  0: $t4 := move($t0)
+  0: $t4 := infer($t0)
   1: $t3 := pack pack_unpack::S($t1, $t4, $t2)
   2: return $t3
 }
@@ -35,8 +35,8 @@ fun pack_unpack::pack4($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t2, $t4, $t5)
   3: return $t3
 }
@@ -46,7 +46,7 @@ fun pack_unpack::pack4($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
 fun pack_unpack::pack5($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
-  0: $t4 := move($t0)
+  0: $t4 := infer($t0)
   1: $t3 := pack pack_unpack::S($t1, $t2, $t4)
   2: return $t3
 }
@@ -57,8 +57,8 @@ fun pack_unpack::pack6($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      var $t5: u8
-  0: $t4 := move($t0)
-  1: $t5 := move($t1)
+  0: $t4 := infer($t0)
+  1: $t5 := infer($t1)
   2: $t3 := pack pack_unpack::S($t2, $t5, $t4)
   3: return $t3
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -19,8 +19,8 @@ fun pack_unpack::unpack($t0: pack_unpack::S): (u64, u64) {
      var $t5: pack_unpack::T
   0: ($t3, $t5) := unpack pack_unpack::S($t0)
   1: $t4 := unpack pack_unpack::T($t5)
-  2: $t1 := move($t3)
-  3: $t2 := move($t4)
+  2: $t1 := infer($t3)
+  3: $t2 := infer($t4)
   4: return ($t1, $t2)
 }
 

--- a/third_party/move/move-compiler-v2/tests/live-var/explicit_move.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/explicit_move.exp
@@ -1,0 +1,116 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::f1_fail() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := move($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t3)
+  6: m::some($t0)
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := move($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t3)
+  6: m::some($t3)
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::some($t0: m::R) {
+  0: return ()
+}
+
+
+Diagnostics:
+error: cannot move local `r` since it is used later
+   ┌─ tests/live-var/explicit_move.move:18:17
+   │
+18 │         let x = move r; // expected to fail
+   │                 ^^^^^^ attempted to move here
+19 │         some(x);
+20 │         some(r);
+   │         ------- used here
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::f1_fail() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := move($t0)
+     # live vars: $t0, $t4
+  4: $t3 := move($t4)
+     # live vars: $t0, $t3
+  5: m::some($t3)
+     # live vars: $t0
+  6: m::some($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+     var $t5: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := move($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: $t5 := copy($t3)
+     # live vars: $t3, $t5
+  6: m::some($t5)
+     # live vars: $t3
+  7: m::some($t3)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::some($t0: m::R) {
+     # live vars:
+  0: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/explicit_move.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/explicit_move.move
@@ -1,0 +1,22 @@
+module 0x42::m {
+
+    struct R has key {
+        v: u64
+    }
+
+    fun some(_r: R) {}
+
+    fun f1_ok() {
+        let r = R { v: 0 };
+        let x = move r;
+        some(x);
+        some(x);
+    }
+
+    fun f1_fail() {
+        let r = R { v: 0 };
+        let x = move r; // expected to fail
+        some(x);
+        some(r);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
@@ -1,0 +1,209 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: m::some($t0)
+  4: m::some($t0)
+  5: return ()
+}
+
+
+[variant baseline]
+fun m::f2_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: m::some2($t0, $t0)
+  4: return ()
+}
+
+
+[variant baseline]
+fun m::f3_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t3 := infer($t0)
+  4: m::some($t0)
+  5: m::some($t3)
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f4_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := move($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t0)
+  6: m::some($t3)
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: m::R): m::R {
+     var $t1: m::R
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::some($t0: m::R) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::some2($t0: m::R, $t1: m::R) {
+  0: return ()
+}
+
+
+Diagnostics:
+error: cannot move local `r` since it is used later
+   ┌─ tests/live-var/inferred_copy.move:33:17
+   │
+33 │         let y = move r;
+   │                 ^^^^^^ attempted to move here
+34 │         some(r);
+   │         ------- used here
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t3 := copy($t0)
+     # live vars: $t0, $t3
+  4: m::some($t3)
+     # live vars: $t0
+  5: m::some($t0)
+     # live vars:
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f2_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t3 := copy($t0)
+     # live vars: $t0, $t3
+  4: m::some2($t3, $t0)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun m::f3_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t3 := copy($t0)
+     # live vars: $t0, $t3
+  4: m::some($t0)
+     # live vars: $t3
+  5: m::some($t3)
+     # live vars:
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f4_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: m::R
+     var $t4: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := move($t0)
+     # live vars: $t0, $t4
+  4: $t3 := move($t4)
+     # live vars: $t0, $t3
+  5: m::some($t0)
+     # live vars: $t3
+  6: m::some($t3)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: m::R): m::R {
+     var $t1: m::R
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::some($t0: m::R) {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::some2($t0: m::R, $t1: m::R) {
+     # live vars:
+  0: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
@@ -44,7 +44,7 @@ fun m::f3_ok() {
 
 
 [variant baseline]
-fun m::f4_ok() {
+fun m::f4_fail() {
      var $t0: m::R
      var $t1: m::R
      var $t2: u64
@@ -160,7 +160,7 @@ fun m::f3_ok() {
 
 
 [variant baseline]
-fun m::f4_ok() {
+fun m::f4_fail() {
      var $t0: m::R
      var $t1: m::R
      var $t2: u64

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.move
@@ -28,7 +28,7 @@ module 0x42::m {
         some(y);
     }
 
-    fun f4_ok() {
+    fun f4_fail() {
         let r = R { v: 0 };
         let y = move r;
         some(r);

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.move
@@ -1,0 +1,37 @@
+module 0x42::m {
+
+    struct R has key, copy {
+        v: u64
+    }
+
+    fun some(_r: R) {}
+
+    fun some2(_r: R, _r1: R) {}
+
+    fun id(r: R): R { r }
+
+    fun f1_ok() {
+        let r = R { v: 0 };
+        some(r);
+        some(r);
+    }
+
+    fun f2_ok() {
+        let r = R { v: 0 };
+        some2(r, r);
+    }
+
+    fun f3_ok() {
+        let r = R { v: 0 };
+        let y = r;
+        some(r);
+        some(y);
+    }
+
+    fun f4_ok() {
+        let r = R { v: 0 };
+        let y = move r;
+        some(r);
+        some(y);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
@@ -1,0 +1,419 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t3)
+  6: m::some($t3)
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::f1a_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: $t5 := read_ref($t3)
+  6: m::some($t3)
+  7: m::some($t3)
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f1b_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t3)
+  6: $t5 := read_ref($t3)
+  7: m::some($t3)
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f2_fail() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: m::some2($t3, $t3)
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f3_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: m::some($t3)
+  6: $t5 := borrow_local($t0)
+  7: $t3 := infer($t5)
+  8: m::some($t3)
+  9: return ()
+}
+
+
+[variant baseline]
+fun m::f4_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t0 := infer($t1)
+  3: $t4 := borrow_local($t0)
+  4: $t3 := infer($t4)
+  5: $t5 := m::id($t3)
+  6: $t3 := infer($t5)
+  7: m::some($t3)
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f5_fail($t0: bool) {
+     var $t1: m::R
+     var $t2: m::R
+     var $t3: u64
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+     var $t6: &mut m::R
+  0: $t3 := 0
+  1: $t2 := pack m::R($t3)
+  2: $t1 := infer($t2)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := infer($t5)
+  5: $t6 := infer($t4)
+  6: if ($t0) goto 7 else goto 11
+  7: label L0
+  8: m::some($t4)
+  9: m::some($t6)
+ 10: goto 14
+ 11: label L1
+ 12: m::some($t6)
+ 13: m::some($t4)
+ 14: label L2
+ 15: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: &mut m::R): &mut m::R {
+     var $t1: &mut m::R
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::some($t0: &mut m::R) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::some2($t0: &mut m::R, $t1: &mut m::R) {
+  0: return ()
+}
+
+
+Diagnostics:
+error: implicit copy of mutable reference in local `x` which is used later in argument list
+   ┌─ tests/live-var/mut_ref.move:41:9
+   │
+41 │         some2(x, x); // expected error because multiple use
+   │         ^^^^^^^^^^^ implicitly copied here
+
+error: implicit copy of mutable reference in local `x` which is used later
+   ┌─ tests/live-var/mut_ref.move:62:13
+   │
+62 │         let y = x; // expected error because of implicit copy
+   │             ^ implicitly copied here
+63 │         if (cond) {
+64 │             some(x);
+   │             ------- used here
+   ·
+68 │             some(x);
+   │             ------- used here
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::f1_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: m::some($t3)
+     # live vars: $t3
+  6: m::some($t3)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::f1a_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: $t5 := read_ref($t3)
+     # live vars: $t3
+  6: m::some($t3)
+     # live vars: $t3
+  7: m::some($t3)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f1b_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: m::some($t3)
+     # live vars: $t3
+  6: $t5 := read_ref($t3)
+     # live vars: $t3
+  7: m::some($t3)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f2_fail() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: m::some2($t3, $t3)
+     # live vars:
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f3_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t0, $t4
+  4: $t3 := move($t4)
+     # live vars: $t0, $t3
+  5: m::some($t3)
+     # live vars: $t0
+  6: $t5 := borrow_local($t0)
+     # live vars: $t5
+  7: $t3 := move($t5)
+     # live vars: $t3
+  8: m::some($t3)
+     # live vars:
+  9: return ()
+}
+
+
+[variant baseline]
+fun m::f4_ok() {
+     var $t0: m::R
+     var $t1: m::R
+     var $t2: u64
+     var $t3: &mut m::R
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t1 := pack m::R($t2)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t4 := borrow_local($t0)
+     # live vars: $t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: $t5 := m::id($t3)
+     # live vars: $t5
+  6: $t3 := move($t5)
+     # live vars: $t3
+  7: m::some($t3)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::f5_fail($t0: bool) {
+     var $t1: m::R
+     var $t2: m::R
+     var $t3: u64
+     var $t4: &mut m::R
+     var $t5: &mut m::R
+     var $t6: &mut m::R
+     # live vars: $t0
+  0: $t3 := 0
+     # live vars: $t0, $t3
+  1: $t2 := pack m::R($t3)
+     # live vars: $t0, $t2
+  2: $t1 := move($t2)
+     # live vars: $t0, $t1
+  3: $t5 := borrow_local($t1)
+     # live vars: $t0, $t5
+  4: $t4 := move($t5)
+     # live vars: $t0, $t4
+  5: $t6 := move($t4)
+     # live vars: $t0, $t4, $t6
+  6: if ($t0) goto 7 else goto 11
+     # live vars: $t4, $t6
+  7: label L0
+     # live vars: $t4, $t6
+  8: m::some($t4)
+     # live vars: $t6
+  9: m::some($t6)
+     # live vars:
+ 10: goto 14
+     # live vars: $t4, $t6
+ 11: label L1
+     # live vars: $t4, $t6
+ 12: m::some($t6)
+     # live vars: $t4
+ 13: m::some($t4)
+     # live vars:
+ 14: label L2
+     # live vars:
+ 15: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: &mut m::R): &mut m::R {
+     var $t1: &mut m::R
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::some($t0: &mut m::R) {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::some2($t0: &mut m::R, $t1: &mut m::R) {
+     # live vars:
+  0: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.move
@@ -1,0 +1,71 @@
+module 0x42::m {
+
+    struct R has key {
+        v: u64
+    }
+
+    fun some(_r: &mut R) {}
+
+    fun some2(_r: &mut R, _t: &mut R) {}
+
+    fun id(r: &mut R): &mut R { r }
+
+    fun f1_ok() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        // expected ok since x is used and assigned again
+        some(x);
+        some(x);
+    }
+
+    fun f1a_ok() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        *x; // Expected ok because x is only read; ability analysis will check whether read is ok
+        some(x);
+        some(x);
+    }
+
+    fun f1b_ok() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        some(x);
+        *x; // Same as f1aok
+        some(x);
+    }
+
+
+    fun f2_fail() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        some2(x, x); // expected error because multiple use
+    }
+
+    fun f3_ok() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        some(x); // expected ok
+        x = &mut r;
+        some(x);
+    }
+
+    fun f4_ok() {
+        let r = R { v: 0 };
+        let x = &mut r;
+        x = id(x); // expected ok
+        some(x);
+    }
+
+    fun f5_fail(cond: bool) {
+        let r = R { v: 0 };
+        let x = &mut r;
+        let y = x; // expected error because of implicit copy
+        if (cond) {
+            some(x);
+            some(y)
+        } else {
+            some(y);
+            some(x);
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.move
@@ -1,0 +1,53 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t4(cond: bool) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) s = S { f: 0, g: 0 } else { *f; };
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
@@ -1,0 +1,42 @@
+
+Diagnostics:
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:49:19
+   │
+48 │         let f = &s.f;
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
+49 │         if (cond) s = S { f: 0, g: 0 };
+   │                   ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:32:9
+   │
+31 │         if (cond) f = &mut s else f = other;
+   │                       ------ previous mutable local borrow
+32 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:23:9
+   │
+22 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
+23 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:41:9
+   │
+40 │         if (cond) f = id_mut(&mut s) else f = other;
+   │                       --------------
+   │                       │      │
+   │                       │      previous mutable local borrow
+   │                       used by mutable call result
+41 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:49:19
    │
 48 │         let f = &s.f;
-   │                  ---
-   │                  │
-   │                  used by field borrow
-   │                  previous local borrow
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
 49 │         if (cond) s = S { f: 0, g: 0 };
    │                   ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -23,10 +23,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:23:9
    │
 22 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            ---
-   │                            │
-   │                            used by mutable field borrow
-   │                            previous mutable local borrow
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
 23 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:49:19
    │
 48 │         let f = &s.f;
-   │                 ----
-   │                 ││
-   │                 │previous local borrow
-   │                 used by field borrow
+   │                  ---
+   │                  │
+   │                  used by field borrow
+   │                  previous local borrow
 49 │         if (cond) s = S { f: 0, g: 0 };
    │                   ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -23,10 +23,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_combo_invalid.move:23:9
    │
 22 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       --------
-   │                       │    │
-   │                       │    previous mutable local borrow
-   │                       used by mutable field borrow
+   │                            ---
+   │                            │
+   │                            used by mutable field borrow
+   │                            previous mutable local borrow
 23 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo_invalid.move
@@ -1,0 +1,54 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t4(cond: bool) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.move
@@ -1,0 +1,56 @@
+module 0x8675309::M {
+    struct S has drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id(&s.f);
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        *f;
+        s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        s = &mut S { f: 0, g: 0 };
+        *f;
+
+        let f = &mut s.f;
+        s = &mut S { f: 0, g: 0 };
+        *f;
+
+        let f = id(&s.f);
+        s = &mut S { f: 0, g: 0 };
+        *f;
+
+        let f = id_mut(&mut s.f);
+        s = &mut S { f: 0, g: 0 };
+        *f;
+
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
@@ -1,0 +1,45 @@
+
+Diagnostics:
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:13:9
+   │
+12 │         let f = &s.f;
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
+13 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:19:9
+   │
+18 │         let f = &mut s.f;
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
+19 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:25:9
+   │
+24 │         let f = id(&s.f);
+   │                    ----
+   │                    ││
+   │                    │previous local borrow
+   │                    used by field borrow
+25 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `s`
+   ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:31:9
+   │
+30 │         let f = id_mut(&mut s.f);
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
+31 │         s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:13:9
    │
 12 │         let f = &s.f;
-   │                 ----
-   │                 ││
-   │                 │previous local borrow
-   │                 used by field borrow
+   │                  ---
+   │                  │
+   │                  used by field borrow
+   │                  previous local borrow
 13 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -15,10 +15,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:19:9
    │
 18 │         let f = &mut s.f;
-   │                 --------
-   │                 │    │
-   │                 │    previous mutable local borrow
-   │                 used by mutable field borrow
+   │                      ---
+   │                      │
+   │                      used by mutable field borrow
+   │                      previous mutable local borrow
 19 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -26,10 +26,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:25:9
    │
 24 │         let f = id(&s.f);
-   │                    ----
-   │                    ││
-   │                    │previous local borrow
-   │                    used by field borrow
+   │                     ---
+   │                     │
+   │                     used by field borrow
+   │                     previous local borrow
 25 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -37,9 +37,9 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:31:9
    │
 30 │         let f = id_mut(&mut s.f);
-   │                        --------
-   │                        │    │
-   │                        │    previous mutable local borrow
-   │                        used by mutable field borrow
+   │                             ---
+   │                             │
+   │                             used by mutable field borrow
+   │                             previous mutable local borrow
 31 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:13:9
    │
 12 │         let f = &s.f;
-   │                  ---
-   │                  │
-   │                  used by field borrow
-   │                  previous local borrow
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
 13 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -15,10 +15,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:19:9
    │
 18 │         let f = &mut s.f;
-   │                      ---
-   │                      │
-   │                      used by mutable field borrow
-   │                      previous mutable local borrow
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
 19 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -26,10 +26,10 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:25:9
    │
 24 │         let f = id(&s.f);
-   │                     ---
-   │                     │
-   │                     used by field borrow
-   │                     previous local borrow
+   │                    ----
+   │                    ││
+   │                    │previous local borrow
+   │                    used by field borrow
 25 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here
 
@@ -37,9 +37,9 @@ error: cannot assign to borrowed local `s`
    ┌─ tests/reference-safety/v1-tests/assign_local_field_invalid.move:31:9
    │
 30 │         let f = id_mut(&mut s.f);
-   │                             ---
-   │                             │
-   │                             used by mutable field borrow
-   │                             previous mutable local borrow
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
 31 │         s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^ attempted to assign here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field_invalid.move
@@ -1,0 +1,36 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id(&s.f);
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.move
@@ -1,0 +1,36 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &x;
+        *f;
+        x = 0;
+        x;
+
+        let x = 0;
+        let f = &mut x;
+        *f;
+        x = 0;
+        x;
+
+        let x = 0;
+        let f = id(&x);
+        *f;
+        x = 0;
+        x;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        *f;
+        x = 0;
+        x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full_invalid.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot assign to borrowed local `x`
+   ┌─ tests/reference-safety/v1-tests/assign_local_full_invalid.move:13:9
+   │
+12 │         let f = &x;
+   │                 -- previous local borrow
+13 │         x = 0;
+   │         ^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `x`
+   ┌─ tests/reference-safety/v1-tests/assign_local_full_invalid.move:19:9
+   │
+18 │         let f = &mut x;
+   │                 ------ previous mutable local borrow
+19 │         x = 0;
+   │         ^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `x`
+   ┌─ tests/reference-safety/v1-tests/assign_local_full_invalid.move:25:9
+   │
+24 │         let f = id(&x);
+   │                 ------
+   │                 │  │
+   │                 │  previous local borrow
+   │                 used by call result
+25 │         x = 0;
+   │         ^^^^^ attempted to assign here
+
+error: cannot assign to borrowed local `x`
+   ┌─ tests/reference-safety/v1-tests/assign_local_full_invalid.move:31:9
+   │
+30 │         let f = id_mut(&mut x);
+   │                 --------------
+   │                 │      │
+   │                 │      previous mutable local borrow
+   │                 used by mutable call result
+31 │         x = 0;
+   │         ^^^^^ attempted to assign here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full_invalid.move
@@ -1,0 +1,36 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &x;
+        x = 0;
+        *f;
+        x;
+
+        let x = 0;
+        let f = &mut x;
+        x = 0;
+        *f;
+        x;
+
+        let x = 0;
+        let f = id(&x);
+        x = 0;
+        *f;
+        x;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        x = 0;
+        *f;
+        x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -1,0 +1,43 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:31:37
+   │
+31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
+   │                                     ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:40:40
+   │
+40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
+   │                                        ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:49:30
+   │
+49 │         let c; if (cond) c = copy inner else c = &mut outer.s2; // error in v2
+   │                              ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:56:37
+   │
+56 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s2; // error in v2
+   │                                     ^^^^^^^^^^ copied here
+
+
+Diagnostics:
+error: cannot mutable borrow local `inner` since other references exists
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:104:18
+    │
+103 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
+    │                              ------------- previous mutable field borrow
+104 │         let f1 = &mut inner.f1; // no error in v1, but should error.
+    │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `inner` since other references exists
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:113:18
+    │
+112 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f2;
+    │                                     ------------- previous mutable field borrow
+113 │         let f1 = &mut inner.f1; // no error in v1, but should error
+    │                  ^^^^^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -27,17 +27,17 @@ error: cannot copy mutable reference in local `inner`
 
 Diagnostics:
 error: cannot mutable borrow local `inner` since other references exists
-    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:104:18
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:104:23
     │
 103 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
-    │                              ------------- previous mutable field borrow
+    │                                   -------- previous mutable field borrow
 104 │         let f1 = &mut inner.f1; // no error in v1, but should error.
-    │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+    │                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:113:18
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:113:23
     │
 112 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f2;
-    │                                     ------------- previous mutable field borrow
+    │                                          -------- previous mutable field borrow
 113 │         let f1 = &mut inner.f1; // no error in v1, but should error
-    │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+    │                       ^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -27,17 +27,17 @@ error: cannot copy mutable reference in local `inner`
 
 Diagnostics:
 error: cannot mutable borrow local `inner` since other references exists
-    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:104:23
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:104:18
     │
 103 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
-    │                                   -------- previous mutable field borrow
+    │                              ------------- previous mutable field borrow
 104 │         let f1 = &mut inner.f1; // no error in v1, but should error.
-    │                       ^^^^^^^^ mutable borrow attempted here
+    │                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:113:23
+    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:113:18
     │
 112 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f2;
-    │                                          -------- previous mutable field borrow
+    │                                     ------------- previous mutable field borrow
 113 │         let f1 = &mut inner.f1; // no error in v1, but should error
-    │                       ^^^^^^^^ mutable borrow attempted here
+    │                  ^^^^^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.move
@@ -1,0 +1,119 @@
+module 0x8675309::M {
+    struct Outer has copy, drop { s1: Inner, s2: Inner }
+    struct Inner has copy, drop { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, outer: &mut Outer, other: &mut Outer) {
+        let inner = &outer.s1;
+        let c; if (cond) c = copy inner else c = &outer.s1; // error in v2
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &outer.s1;
+        let c; if (cond) c = id(copy inner) else c = id(&outer.s1);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = freeze(copy inner) else c = &other.s1;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = copy inner else c = &mut outer.s2; // error in v2
+        let f1 = &mut c.f1;
+        *f1;
+        *c;
+        *inner;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s2; // error in v2
+        let f1 = &mut c.f1;
+        *f1;
+        *c;
+        *inner;
+    }
+
+    fun t1(cond: bool, outer: &mut Outer, other: &mut Outer) {
+        let inner = &outer.s1;
+        let c; if (cond) c = &inner.f1 else c = &inner.f2;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &outer.s1;
+        let c; if (cond) c = id(&inner.f1) else c = &other.s1.f2;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = &inner.f1 else c = &other.s1.f2;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id(&inner.f1) else c = &other.s1.f2;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        // The next case flags no error in the v1 compiler, though appears to be wrong,
+        // since `c` can hold a reference to either `inner.f1` or `inner.f2`.
+        let inner = &mut outer.s1;
+        let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
+        let f1 = &mut inner.f1; // no error in v1, but should error.
+        *c;
+        *f1;
+        *inner;
+
+        // The next case flags no error in the v1 compiler, though appears to be wrong,
+        // since `c` can hold a reference to either `inner.f1` or `inner.f2`.
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f2;
+        let f1 = &mut inner.f1; // no error in v1, but should error
+        *c;
+        *f1;
+        *inner;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
@@ -27,26 +27,26 @@ error: cannot copy mutable reference in local `inner`
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:58:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:58:18
    │
 57 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
-   │                                   -------- previous mutable field borrow
+   │                              ------------- previous mutable field borrow
 58 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:55
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:50
    │
 34 │         let inner = &mut outer.s1;
-   │                          -------- previous mutable field borrow
+   │                     ------------- previous mutable field borrow
 35 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
-   │                                                       ^^^^^^^^ mutable borrow attempted here
+   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `c` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:37:9
    │
 36 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 37 │         *c;
    │         ^^ dereferenced here
 
@@ -54,44 +54,44 @@ error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:38:9
    │
 36 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 37 │         *c;
 38 │         *inner;
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:55
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:50
    │
 12 │         let inner = &mut outer.s1;
-   │                          -------- previous mutable field borrow
+   │                     ------------- previous mutable field borrow
 13 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
-   │                                                       ^^^^^^^^ mutable borrow attempted here
+   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:67:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:67:18
    │
 66 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
-   │                                          --------                -------- previous mutable field borrow
-   │                                          │
-   │                                          previous mutable field borrow
+   │                                     -------------           ------------- previous mutable field borrow
+   │                                     │
+   │                                     previous mutable field borrow
 67 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:63
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:58
    │
 45 │         let inner = &mut outer.s1;
-   │                          -------- previous mutable field borrow
+   │                     ------------- previous mutable field borrow
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
-   │                                                               ^^^^^^^^ mutable borrow attempted here
+   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:23
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:18
    │
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
-   │                       ^^^^^^^^ mutable borrow attempted here
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:49:9
@@ -99,7 +99,7 @@ error: cannot dereference local `inner` which is still mutable borrowed
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 48 │         *c;
 49 │         *inner;
    │         ^^^^^^ dereferenced here
@@ -114,20 +114,20 @@ error: cannot dereference local `inner` which is still mutable borrowed
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:63
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:58
    │
 23 │         let inner = &mut outer.s1;
-   │                          -------- previous mutable field borrow
+   │                     ------------- previous mutable field borrow
 24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
-   │                                                               ^^^^^^^^ mutable borrow attempted here
+   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:18
    │
 24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 25 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:27:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
@@ -27,26 +27,26 @@ error: cannot copy mutable reference in local `inner`
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:58:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:58:19
    │
 57 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
-   │                              ------------- previous mutable field borrow
+   │                                   -------- previous mutable field borrow
 58 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:50
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:55
    │
 34 │         let inner = &mut outer.s1;
-   │                     ------------- previous mutable field borrow
+   │                          -------- previous mutable field borrow
 35 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
-   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                                                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `c` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:37:9
    │
 36 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 37 │         *c;
    │         ^^ dereferenced here
 
@@ -54,44 +54,44 @@ error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:38:9
    │
 36 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 37 │         *c;
 38 │         *inner;
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:50
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:55
    │
 12 │         let inner = &mut outer.s1;
-   │                     ------------- previous mutable field borrow
+   │                          -------- previous mutable field borrow
 13 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
-   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                                                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:67:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:67:19
    │
 66 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
-   │                                     -------------           ------------- previous mutable field borrow
-   │                                     │
-   │                                     previous mutable field borrow
+   │                                          --------                -------- previous mutable field borrow
+   │                                          │
+   │                                          previous mutable field borrow
 67 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:58
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:63
    │
 45 │         let inner = &mut outer.s1;
-   │                     ------------- previous mutable field borrow
+   │                          -------- previous mutable field borrow
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
-   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                                                               ^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:23
    │
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
-   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:49:9
@@ -99,7 +99,7 @@ error: cannot dereference local `inner` which is still mutable borrowed
 46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 48 │         *c;
 49 │         *inner;
    │         ^^^^^^ dereferenced here
@@ -114,20 +114,20 @@ error: cannot dereference local `inner` which is still mutable borrowed
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `outer` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:58
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:63
    │
 23 │         let inner = &mut outer.s1;
-   │                     ------------- previous mutable field borrow
+   │                          -------- previous mutable field borrow
 24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
-   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                                                               ^^^^^^^^ mutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:19
    │
 24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
    │                              ------------------ previous mutable call result
 25 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:27:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
@@ -1,0 +1,148 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:30
+   │
+35 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
+   │                              ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:30
+   │
+13 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
+   │                              ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:37
+   │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                                     ^^^^^^^^^^ copied here
+
+error: cannot copy mutable reference in local `inner`
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:37
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                                     ^^^^^^^^^^ copied here
+
+
+Diagnostics:
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:58:18
+   │
+57 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
+   │                              ------------- previous mutable field borrow
+58 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here
+
+error: cannot mutable borrow local `outer` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:35:50
+   │
+34 │         let inner = &mut outer.s1;
+   │                     ------------- previous mutable field borrow
+35 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
+   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot dereference local `c` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:37:9
+   │
+36 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+37 │         *c;
+   │         ^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:38:9
+   │
+36 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+37 │         *c;
+38 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot mutable borrow local `outer` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:13:50
+   │
+12 │         let inner = &mut outer.s1;
+   │                     ------------- previous mutable field borrow
+13 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
+   │                                                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:67:18
+   │
+66 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
+   │                                     -------------           ------------- previous mutable field borrow
+   │                                     │
+   │                                     previous mutable field borrow
+67 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here
+
+error: cannot mutable borrow local `outer` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:46:58
+   │
+45 │         let inner = &mut outer.s1;
+   │                     ------------- previous mutable field borrow
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `inner` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:18
+   │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+47 │         let f1 = &mut inner.f1;
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:49:9
+   │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+47 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+48 │         *c;
+49 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:51:9
+   │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+51 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot mutable borrow local `outer` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:24:58
+   │
+23 │         let inner = &mut outer.s1;
+   │                     ------------- previous mutable field borrow
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                                                          ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:18
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+25 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:27:9
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+27 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:29:9
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+29 │         *inner;
+   │         ^^^^^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.move
@@ -1,0 +1,73 @@
+module 0x8675309::M {
+    struct Outer { s1: Inner, s2: Inner }
+    struct Inner { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = copy inner else c = &mut outer.s1;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+    }
+
+    fun t1(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+    }
+
+    fun t2(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = copy inner else c = &mut outer.s1;
+        let f1 = &mut inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+    }
+
+    fun t3(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+        let f1 = &mut inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+    }
+
+    fun t4(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
+        let f1 = &inner.f1;
+        *f1;
+        *c;
+        *inner;
+    }
+
+    fun t5(cond: bool, outer: &mut Outer, _other: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
+        let f1 = &inner.f1;
+        *f1;
+        *c;
+        *inner;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: cannot mutable borrow local `inner` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:50:18
+   │
+49 │         let c = &mut inner.f1;
+   │                 ------------- previous mutable field borrow
+50 │         let f1 = &mut inner.f1; // error in v2
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `inner` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:57:18
+   │
+56 │         let c = id_mut(&mut inner.f1);
+   │                        ------------- previous mutable field borrow
+57 │         let f1 = &mut inner.f1; // error in v2
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
@@ -1,17 +1,17 @@
 
 Diagnostics:
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:50:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:50:23
    │
 49 │         let c = &mut inner.f1;
-   │                 ------------- previous mutable field borrow
+   │                      -------- previous mutable field borrow
 50 │         let f1 = &mut inner.f1; // error in v2
-   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:57:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:57:23
    │
 56 │         let c = id_mut(&mut inner.f1);
-   │                        ------------- previous mutable field borrow
+   │                             -------- previous mutable field borrow
 57 │         let f1 = &mut inner.f1; // error in v2
-   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                       ^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
@@ -1,17 +1,17 @@
 
 Diagnostics:
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:50:23
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:50:18
    │
 49 │         let c = &mut inner.f1;
-   │                      -------- previous mutable field borrow
+   │                 ------------- previous mutable field borrow
 50 │         let f1 = &mut inner.f1; // error in v2
-   │                       ^^^^^^^^ mutable borrow attempted here
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:57:23
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:57:18
    │
 56 │         let c = id_mut(&mut inner.f1);
-   │                             -------- previous mutable field borrow
+   │                        ------------- previous mutable field borrow
 57 │         let f1 = &mut inner.f1; // error in v2
-   │                       ^^^^^^^^ mutable borrow attempted here
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.move
@@ -1,0 +1,63 @@
+module 0x8675309::M {
+    struct Outer has copy, drop { s1: Inner, s2: Inner }
+    struct Inner has copy, drop { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(outer: &mut Outer) {
+        let inner = &outer.s1;
+        let c = &inner.f1;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &outer.s1;
+        let c = id(&inner.f1);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = &inner.f1;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = id(&inner.f1);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = &mut inner.f1;
+        let f1 = &mut inner.f1; // error in v2
+        *c;
+        *f1;
+        *inner;
+
+        let inner = &mut outer.s1;
+        let c = id_mut(&mut inner.f1);
+        let f1 = &mut inner.f1; // error in v2
+        *c;
+        *f1;
+        *inner;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:14:18
+   │
+13 │         let c = &mut inner.f1;
+   │                 ------------- previous mutable field borrow
+14 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here
+
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:21:18
+   │
+20 │         let c = id_mut(&mut inner.f1);
+   │                        ------------- previous mutable field borrow
+21 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
@@ -1,17 +1,17 @@
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:14:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:14:19
    │
 13 │         let c = &mut inner.f1;
-   │                 ------------- previous mutable field borrow
+   │                      -------- previous mutable field borrow
 14 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:21:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:21:19
    │
 20 │         let c = id_mut(&mut inner.f1);
-   │                        ------------- previous mutable field borrow
+   │                             -------- previous mutable field borrow
 21 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.exp
@@ -1,17 +1,17 @@
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:14:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:14:18
    │
 13 │         let c = &mut inner.f1;
-   │                      -------- previous mutable field borrow
+   │                 ------------- previous mutable field borrow
 14 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here
 
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:21:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_field_invalid.move:21:18
    │
 20 │         let c = id_mut(&mut inner.f1);
-   │                             -------- previous mutable field borrow
+   │                        ------------- previous mutable field borrow
 21 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.move
@@ -1,0 +1,27 @@
+module 0x8675309::M {
+    struct Outer { s1: Inner, s2: Inner }
+    struct Inner { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(outer: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c = &mut inner.f1;
+        let f1 = &inner.f1;
+        *f1;
+        *c;
+        *inner;
+
+        let inner = &mut outer.s1;
+        let c = id_mut(&mut inner.f1);
+        let f1 = &inner.f1;
+        *f1;
+        *c;
+        *inner;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `inner` which is used later
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full.move:49:13
+   │
+49 │         let c = inner; // error in v2
+   │             ^ implicitly copied here
+   ·
+53 │         *inner;
+   │         ------ used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.move
@@ -1,0 +1,63 @@
+module 0x8675309::M {
+    struct Outer has copy, drop { s1: Inner, s2: Inner }
+    struct Inner has copy, drop { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(outer: &mut Outer) {
+        let inner = &outer.s1;
+        let c = copy inner;
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &outer.s1;
+        let c = id(copy inner);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = freeze(inner);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = id(freeze(inner));
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = inner; // error in v2
+        let f1 = &mut c.f1;
+        *f1;
+        *c;
+        *inner;
+
+        let inner = &mut outer.s1;
+        let c = id_mut(inner);
+        let f1 = &mut c.f1;
+        *f1;
+        *c;
+        *inner;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
@@ -6,7 +6,7 @@ error: implicit copy of mutable reference in local `inner` which is used later
 13 │         let c = inner; // error in v2
    │             ^ implicitly copied here
 14 │         let f1 = &inner.f1;
-   │                   -------- used here
+   │                  --------- used here
 
 error: implicit copy of mutable reference in local `inner` which is used later
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:31:13
@@ -14,17 +14,17 @@ error: implicit copy of mutable reference in local `inner` which is used later
 31 │         let c = inner; // error in v2
    │             ^ implicitly copied here
 32 │         let f1 = &mut inner.f1;
-   │                       -------- used here
+   │                  ------------- used here
 
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:19
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:18
    │
 22 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 23 │         let f1 = &inner.f1;
-   │                   ^^^^^^^^ immutable borrow attempted here
+   │                  ^^^^^^^^^ immutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:25:9
@@ -48,7 +48,7 @@ error: cannot dereference local `c` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:33:9
    │
 32 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 33 │         *c;
    │         ^^ dereferenced here
 
@@ -56,18 +56,18 @@ error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:34:9
    │
 32 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 33 │         *c;
 34 │         *inner;
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:23
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:18
    │
 40 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
-   │                       ^^^^^^^^ mutable borrow attempted here
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:43:9
@@ -75,7 +75,7 @@ error: cannot dereference local `inner` which is still mutable borrowed
 40 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
-   │                       -------- previous mutable field borrow
+   │                  ------------- previous mutable field borrow
 42 │         *c;
 43 │         *inner;
    │         ^^^^^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
@@ -1,0 +1,90 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `inner` which is used later
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:13:13
+   │
+13 │         let c = inner; // error in v2
+   │             ^ implicitly copied here
+14 │         let f1 = &inner.f1;
+   │                  --------- used here
+
+error: implicit copy of mutable reference in local `inner` which is used later
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:31:13
+   │
+31 │         let c = inner; // error in v2
+   │             ^ implicitly copied here
+32 │         let f1 = &mut inner.f1;
+   │                  ------------- used here
+
+
+Diagnostics:
+error: cannot immutable borrow local `inner` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:18
+   │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+23 │         let f1 = &inner.f1;
+   │                  ^^^^^^^^^ immutable borrow attempted here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:25:9
+   │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+25 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:27:9
+   │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+27 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `c` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:33:9
+   │
+32 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+33 │         *c;
+   │         ^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:34:9
+   │
+32 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+33 │         *c;
+34 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot mutable borrow local `inner` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:18
+   │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+41 │         let f1 = &mut inner.f1;
+   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:43:9
+   │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+41 │         let f1 = &mut inner.f1;
+   │                  ------------- previous mutable field borrow
+42 │         *c;
+43 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:45:9
+   │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+45 │         *inner;
+   │         ^^^^^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
@@ -6,7 +6,7 @@ error: implicit copy of mutable reference in local `inner` which is used later
 13 │         let c = inner; // error in v2
    │             ^ implicitly copied here
 14 │         let f1 = &inner.f1;
-   │                  --------- used here
+   │                   -------- used here
 
 error: implicit copy of mutable reference in local `inner` which is used later
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:31:13
@@ -14,17 +14,17 @@ error: implicit copy of mutable reference in local `inner` which is used later
 31 │         let c = inner; // error in v2
    │             ^ implicitly copied here
 32 │         let f1 = &mut inner.f1;
-   │                  ------------- used here
+   │                       -------- used here
 
 
 Diagnostics:
 error: cannot immutable borrow local `inner` since other mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:19
    │
 22 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 23 │         let f1 = &inner.f1;
-   │                  ^^^^^^^^^ immutable borrow attempted here
+   │                   ^^^^^^^^ immutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:25:9
@@ -48,7 +48,7 @@ error: cannot dereference local `c` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:33:9
    │
 32 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 33 │         *c;
    │         ^^ dereferenced here
 
@@ -56,18 +56,18 @@ error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:34:9
    │
 32 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 33 │         *c;
 34 │         *inner;
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `inner` since other references exists
-   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:18
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:23
    │
 40 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
-   │                  ^^^^^^^^^^^^^ mutable borrow attempted here
+   │                       ^^^^^^^^ mutable borrow attempted here
 
 error: cannot dereference local `inner` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:43:9
@@ -75,7 +75,7 @@ error: cannot dereference local `inner` which is still mutable borrowed
 40 │         let c = id_mut(inner);
    │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
-   │                  ------------- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 42 │         *c;
 43 │         *inner;
    │         ^^^^^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.move
@@ -1,0 +1,49 @@
+module 0x8675309::M {
+    struct Outer { s1: Inner, s2: Inner }
+    struct Inner { f1: u64, f2: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(outer: &mut Outer) {
+        let inner = &mut outer.s1;
+        let c = inner; // error in v2
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = id_mut(inner);
+        let f1 = &inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = inner; // error in v2
+        let f1 = &mut inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+
+        let inner = &mut outer.s1;
+        let c = id_mut(inner);
+        let f1 = &mut inner.f1;
+        *c;
+        *inner;
+        *f1;
+        *inner;
+        *c;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot immutable borrow global `M::R` since other mutable references exist
+  ┌─ tests/reference-safety/v1-tests/borrow_global.move:6:18
+  │
+5 │         let f = &borrow_global_mut<R>(addr).f;
+  │                  -------------------------- previous mutable global borrow
+6 │         let r1 = borrow_global<R>(addr); // error in v2
+  │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global.move
@@ -1,0 +1,34 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+
+    fun t0(addr: address): bool acquires R {
+        let f = &borrow_global_mut<R>(addr).f;
+        let r1 = borrow_global<R>(addr); // error in v2
+        f == &r1.f
+    }
+
+    fun t1(addr: address): bool acquires R {
+        let f = borrow_global<R>(addr).f;
+        let r1 = borrow_global<R>(addr);
+        f == r1.f
+    }
+
+    fun t2(addr: address):bool acquires R {
+        borrow_global<R>(addr).f == borrow_global<R>(addr).f
+    }
+
+    fun t3(addr: address): bool acquires R {
+        let R { f } = move_from<R>(addr);
+        let r1 = borrow_global<R>(addr);
+        r1.f == f
+    }
+
+    fun t4(cond: bool, addr: address): bool acquires R {
+        let r = R { f: 0 };
+        let f = &borrow_global<R>(addr).f;
+        let r1; if (cond) r1 = borrow_global<R>(addr) else r1 = &mut r;
+        let res = f == &r1.f;
+        R { f: _ } = r;
+        res
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_invalid.exp
@@ -1,0 +1,57 @@
+
+Diagnostics:
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:43:18
+   │
+42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+43 │         let f = &borrow_global<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:36:18
+   │
+35 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+36 │         let f = &borrow_global<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:30:18
+   │
+29 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      -------------------------- previous mutable global borrow
+30 │         let r2 = borrow_global<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:24:18
+   │
+23 │         let r2 = borrow_global<R>(addr);
+   │                  ---------------------- previous global borrow
+24 │         let r1 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:18:18
+   │
+17 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+18 │         let f = &borrow_global<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:12:18
+   │
+11 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      -------------------------- previous mutable global borrow
+12 │         let r2 = borrow_global<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+  ┌─ tests/reference-safety/v1-tests/borrow_global_invalid.move:6:18
+  │
+5 │         let r1 = borrow_global_mut<R>(addr);
+  │                  -------------------------- previous mutable global borrow
+6 │         let r2 = borrow_global<R>(addr);
+  │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_invalid.move
@@ -1,0 +1,48 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+
+    fun t0(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let r2 = borrow_global<R>(addr);
+        r1.f = r2.f
+    }
+
+    fun t1(addr: address) acquires R {
+        let f = &mut borrow_global_mut<R>(addr).f;
+        let r2 = borrow_global<R>(addr);
+        *f = r2.f
+    }
+
+    fun t2(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let f = &borrow_global<R>(addr).f;
+        r1.f = *f
+    }
+
+    fun t3(addr: address) acquires R {
+        let r2 = borrow_global<R>(addr);
+        let r1 = borrow_global_mut<R>(addr);
+        r1.f = r2.f
+    }
+
+    fun t4(addr: address) acquires R {
+        let f = &mut borrow_global_mut<R>(addr).f;
+        let r2 = borrow_global<R>(addr);
+        *f = r2.f
+    }
+
+    fun t5(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let f = &borrow_global<R>(addr).f;
+        r1.f = *f
+    }
+
+    fun t6(cond: bool, addr: address) acquires R {
+        let r = R { f: 0 };
+        let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+        let f = &borrow_global<R>(addr).f;
+        r1.f = *f;
+
+        R { f: _ } = r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.move
@@ -1,0 +1,34 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+
+    fun t0(addr: address) acquires R {
+        let f = borrow_global_mut<R>(addr).f;
+        let r1 = borrow_global_mut<R>(addr);
+        r1.f = f
+    }
+
+    fun t1(addr: address) acquires R {
+        let f = borrow_global<R>(addr).f;
+        let r1 = borrow_global_mut<R>(addr);
+        r1.f = f
+    }
+
+    fun t2(addr: address) acquires R {
+        borrow_global_mut<R>(addr).f = borrow_global_mut<R>(addr).f
+    }
+
+    fun t3(addr: address) acquires R {
+        let R { f } = move_from<R>(addr);
+        let r1 = borrow_global_mut<R>(addr);
+        r1.f = f
+    }
+
+    fun t4(cond: bool, addr: address) acquires R {
+        let r = R { f: 0 };
+        let f = borrow_global<R>(addr).f;
+        let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+        r1.f = f;
+
+        R { f: _ } = r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.exp
@@ -1,0 +1,57 @@
+
+Diagnostics:
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:43:18
+   │
+42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+43 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:36:18
+   │
+35 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+36 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:30:18
+   │
+29 │         let f = &borrow_global<R>(addr).f;
+   │                  ---------------------- previous global borrow
+30 │         let r2 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow global `M::R` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:24:18
+   │
+23 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+24 │         let r2 = borrow_global<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:18:22
+   │
+17 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+18 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:12:18
+   │
+11 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      -------------------------- previous mutable global borrow
+12 │         let r2 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow global `M::R` since other references exists
+  ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:6:18
+  │
+5 │         let r1 = borrow_global_mut<R>(addr);
+  │                  -------------------------- previous mutable global borrow
+6 │         let r2 = borrow_global_mut<R>(addr);
+  │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.move
@@ -1,0 +1,48 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+
+    fun t0(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let r2 = borrow_global_mut<R>(addr);
+        r1.f = r2.f
+    }
+
+    fun t1(addr: address) acquires R {
+        let f = &mut borrow_global_mut<R>(addr).f;
+        let r2 = borrow_global_mut<R>(addr);
+        *f = r2.f
+    }
+
+    fun t2(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let f = &mut borrow_global_mut<R>(addr).f;
+        r1.f = *f
+    }
+
+    fun t3(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let r2 = borrow_global<R>(addr);
+        r1.f = r2.f
+    }
+
+    fun t4(addr: address) acquires R {
+        let f = &borrow_global<R>(addr).f;
+        let r2 = borrow_global_mut<R>(addr);
+        r2.f = *f
+    }
+
+    fun t5(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let f = &borrow_global_mut<R>(addr).f;
+        r1.f = *f
+    }
+
+    fun t6(cond: bool, addr: address) acquires R {
+        let r = R { f: 0 };
+        let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+        let f = &borrow_global_mut<R>(addr).f;
+        r1.f = *f;
+
+        R { f: _ } = r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo.exp
@@ -1,0 +1,35 @@
+
+Diagnostics:
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo.move:45:17
+   │
+44 │         if (cond) x = &mut s else x = other;
+   │                       ------ previous mutable local borrow
+45 │         let y = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo.move:29:17
+   │
+28 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                            - previous mutable local borrow
+29 │         let x = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo.move:21:17
+   │
+20 │         if (cond) f = &s.f else f = &s.g;
+   │                        -             - previous local borrow
+   │                        │
+   │                        previous local borrow
+21 │         let x = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo.move:13:17
+   │
+12 │         if (cond) f = &s.f else f = &other.f;
+   │                        - previous local borrow
+13 │         let x = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo.move
@@ -1,0 +1,49 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: S, other: &S) {
+        let f;
+        if (cond) f = &s.f else f = &other.f;
+        let x = &mut s;
+        *f;
+        *x;
+    }
+
+    fun t1(cond: bool, s: S) {
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        let x = &mut s;
+        *f;
+        *x;
+    }
+
+    fun t2(cond: bool, s: S, other: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        let x = &mut s;
+        *f;
+        *x;
+    }
+
+    fun t3(cond: bool, s: S, other: &S) {
+        let x;
+        if (cond) x = &s else x = other;
+        let y = &s;
+        *x;
+        *y;
+    }
+
+    fun t4(cond: bool, s: S, other: &mut S) {
+        let x;
+        if (cond) x = &mut s else x = other;
+        let y = &mut s;
+        *x;
+        *y;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo_invalid.exp
@@ -1,0 +1,43 @@
+
+Diagnostics:
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo_invalid.move:47:17
+   │
+46 │         if (cond) x = &mut s else x = other;
+   │                       ------ previous mutable local borrow
+47 │         let y = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow local `s` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo_invalid.move:38:17
+   │
+37 │         if (cond) x = &mut s else x = other;
+   │                       ------ previous mutable local borrow
+38 │         let y = &s;
+   │                 ^^ immutable borrow attempted here
+
+error: cannot immutable borrow local `s` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo_invalid.move:30:17
+   │
+29 │         if (cond) f = &mut s.f else f = &mut s.g;
+   │                            -                 - previous mutable local borrow
+   │                            │
+   │                            previous mutable local borrow
+30 │         let x = &s;
+   │                 ^^ immutable borrow attempted here
+
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo_invalid.move:21:17
+   │
+20 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                            - previous mutable local borrow
+21 │         let x = &mut s;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow local `s` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_local_combo_invalid.move:13:17
+   │
+12 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                            - previous mutable local borrow
+13 │         let x = &s;
+   │                 ^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_combo_invalid.move
@@ -1,0 +1,52 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: S, other: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        let x = &s;
+        *f;
+        *x;
+    }
+
+    fun t1(cond: bool, s: S, other: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        let x = &mut s;
+        *f;
+        *x;
+        *f;
+    }
+
+    fun t2(cond: bool, s: S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut s.g;
+        let x = &s;
+        *f;
+        *x;
+    }
+
+    fun t3(cond: bool, s: S, other: &mut S) {
+        let x;
+        if (cond) x = &mut s else x = other;
+        let y = &s;
+        *y;
+        *x;
+        *y;
+    }
+
+    fun t4(cond: bool, s: S, other: &mut S) {
+        let x;
+        if (cond) x = &mut s else x = other;
+        let y = &mut s;
+        *y;
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_field.move:27:17
+   │
+26 │         let f = &v.f;
+   │                  - previous local borrow
+27 │         let s = &mut v; // error in v2
+   │                 ^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field.move
@@ -1,0 +1,33 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let v = S { f: 0, g: 0 };
+        let f = &v.f;
+        let s = &v;
+        *f;
+        *s;
+        *f;
+
+        let v = S { f: 0, g: 0 };
+        let f = id(&v.f);
+        let s = &v;
+        *f;
+        *s;
+        *f;
+
+        let v = S { f: 0, g: 0 };
+        let f = &v.f;
+        let s = &mut v; // error in v2
+        *f;
+        *s;
+        *f;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field_invalid.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_field_invalid.move:13:17
+   │
+12 │         let f = &v.f;
+   │                  - previous local borrow
+13 │         let s = &mut v;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot immutable borrow local `v` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_local_field_invalid.move:19:17
+   │
+18 │         let f = &mut v.f;
+   │                      - previous mutable local borrow
+19 │         let s = &v;
+   │                 ^^ immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_field_invalid.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let v = S { f: 0, g: 0 };
+        let f = &v.f;
+        let s = &mut v;
+        *s = S { f: 0, g: 0 };
+        *f;
+
+        let v = S { f: 0, g: 0 };
+        let f = &mut v.f;
+        let s = &v;
+        *s;
+        *f;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full.move:13:17
+   │
+12 │         let x = &mut v;
+   │                 ------ previous mutable local borrow
+13 │         let y = &mut v; // error in v2
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full.move:18:17
+   │
+17 │         let x = id_mut(&mut v);
+   │                        ------ previous mutable local borrow
+18 │         let y = &mut v; // error in v2
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full.move:23:17
+   │
+22 │         let x = &v;
+   │                 -- previous local borrow
+23 │         let y = &mut v;
+   │                 ^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full.move
@@ -1,0 +1,41 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let v = 0;
+        let x = &mut v;
+        let y = &mut v; // error in v2
+        *x;
+        *y;
+
+        let x = id_mut(&mut v);
+        let y = &mut v; // error in v2
+        *x;
+        *y;
+
+        let x = &v;
+        let y = &mut v;
+        *y;
+        *x;
+        *y;
+
+        let x = &v;
+        let y = &v;
+        *x;
+        *y;
+        *x;
+
+        let x = id(&v);
+        let y = &v;
+        *x;
+        *y;
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full_invalid.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+error: cannot immutable borrow local `v` since other mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full_invalid.move:33:17
+   │
+32 │         let x = &mut v;
+   │                 ------ previous mutable local borrow
+33 │         let y = &v;
+   │                 ^^ immutable borrow attempted here
+
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full_invalid.move:13:17
+   │
+12 │         let x = &mut v;
+   │                 ------ previous mutable local borrow
+13 │         let y = &mut v;
+   │                 ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full_invalid.move:18:24
+   │
+17 │         let x = &mut v;
+   │                 ------ previous mutable local borrow
+18 │         let y = id_mut(&mut v);
+   │                        ^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `v` since other references exists
+   ┌─ tests/reference-safety/v1-tests/borrow_local_full_invalid.move:23:17
+   │
+22 │         let x = &v;
+   │                 -- previous local borrow
+23 │         let y = &mut v;
+   │                 ^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_local_full_invalid.move
@@ -1,0 +1,38 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let v = 0;
+        let x = &mut v;
+        let y = &mut v;
+        *y;
+        *x;
+
+        let x = &mut v;
+        let y = id_mut(&mut v);
+        *y;
+        *x;
+
+        let x = &v;
+        let y = &mut v;
+        *y = 0;
+        *x;
+
+    }
+
+    fun t1() {
+        let v = 0;
+
+        let x = &mut v;
+        let y = &v;
+        *x;
+        *y;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot move local `x` which is still borrowed
+  ┌─ tests/reference-safety/v1-tests/borrowed_before_last_usage.move:5:9
+  │
+4 │     let r = &x;
+  │             -- previous local borrow
+5 │     let y = x;
+  │         ^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.move
@@ -1,0 +1,8 @@
+script {
+fun main() {
+    let x = 0;
+    let r = &x;
+    let y = x;
+    assert!(*r == y, 0);
+}
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows.move:14:29
+   │
+14 │         imm_imm(freeze(s1), freeze(s1));
+   │                 ----------  ^^^^^^^^^^ passed here
+   │                 │
+   │                 previous call result

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.move
@@ -1,0 +1,26 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun imm_imm<T1, T2>(_x: &T1, _y: &T2) { }
+    fun mut_imm<T1, T2>(_x: &mut T1, _y: &T2) { }
+    fun mut_mut<T1, T2>(_x: &mut T1, _y: &mut T2) { }
+
+    fun t0(s1: &mut S, s2: &mut S) {
+        imm_imm(freeze(s1), freeze(s1));
+        imm_imm(freeze(s1), &s1.f);
+        imm_imm(&s1.f, &s1.f);
+        imm_imm(id(s1), s2);
+
+        mut_imm(&mut s1.f, &s1.g);
+        mut_imm(id_mut(&mut s1.f), id(&s1.g));
+
+        mut_mut(&mut s1.f, &mut s2.g);
+        mut_mut(id_mut(&mut s1.f), &mut s2.g);
+        mut_mut(s1, s2);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
@@ -1,0 +1,87 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `s1` which is used later in argument list
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:23:9
+   │
+23 │         mut_mut(s1, s1);
+   │         ^^^^^^^^^^^^^^^ implicitly copied here
+
+
+Diagnostics:
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:15:9
+   │
+14 │         let f = freeze(s1);
+   │                 ---------- previous call result
+15 │         mut_imm(s1, f);
+   │         ^^^^^^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
+   │
+16 │         let f = &s1.f;
+   │                 ----- previous field borrow
+17 │         mut_imm(s1, f);
+   │         ^^^^^^^^^^^^^^ passed here
+
+error: cannot mutable borrow local `s1` since other references exists
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:19:17
+   │
+18 │         let f = &s1.f;
+   │                 ----- previous field borrow
+19 │         mut_imm(&mut s1.f, f);
+   │                 ^^^^^^^^^ mutable borrow attempted here
+
+error: cannot mutable borrow local `s1` since other references exists
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:21:16
+   │
+20 │         let f = id(&s1.f);
+   │                    ----- previous field borrow
+21 │         id_mut(&mut s1.f); *f;
+   │                ^^^^^^^^^ mutable borrow attempted here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
+   │
+24 │         let f = &mut s1.f;
+   │                 --------- previous mutable field borrow
+25 │         mut_mut(s1, f);
+   │         ^^^^^^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:26:9
+   │
+26 │         mut_mut(&mut s1.f, s1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │
+   │         │       previous mutable field borrow
+   │         passed here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:28:9
+   │
+27 │         let s = id_mut(s1);
+   │                 ---------- previous mutable call result
+28 │         id_mut(s1);
+   │         ^^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:31:9
+   │
+30 │         let f = id_mut(&mut s1.f);
+   │                 -----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+31 │         mut_mut(s1, f);
+   │         ^^^^^^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:32:9
+   │
+32 │         mut_mut(id_mut(&mut s1.f), s1);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │       │      │
+   │         │       │      previous mutable field borrow
+   │         │       used by mutable call result
+   │         passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
@@ -20,31 +20,31 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
    │
 16 │         let f = &s1.f;
-   │                  ---- previous field borrow
+   │                 ----- previous field borrow
 17 │         mut_imm(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:19:22
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:19:17
    │
 18 │         let f = &s1.f;
-   │                  ---- previous field borrow
+   │                 ----- previous field borrow
 19 │         mut_imm(&mut s1.f, f);
-   │                      ^^^^ mutable borrow attempted here
+   │                 ^^^^^^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:21:21
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:21:16
    │
 20 │         let f = id(&s1.f);
-   │                     ---- previous field borrow
+   │                    ----- previous field borrow
 21 │         id_mut(&mut s1.f); *f;
-   │                     ^^^^ mutable borrow attempted here
+   │                ^^^^^^^^^ mutable borrow attempted here
 
 error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
    │
 24 │         let f = &mut s1.f;
-   │                      ---- previous mutable field borrow
+   │                 --------- previous mutable field borrow
 25 │         mut_mut(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
 
@@ -53,8 +53,8 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 26 │         mut_mut(&mut s1.f, s1);
    │         ^^^^^^^^^^^^^^^^^^^^^^
-   │         │            │
-   │         │            previous mutable field borrow
+   │         │       │
+   │         │       previous mutable field borrow
    │         passed here
 
 error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
@@ -70,8 +70,8 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 30 │         let f = id_mut(&mut s1.f);
    │                 -----------------
-   │                 │           │
-   │                 │           previous mutable field borrow
+   │                 │      │
+   │                 │      previous mutable field borrow
    │                 used by mutable call result
 31 │         mut_mut(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
@@ -81,7 +81,7 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 32 │         mut_mut(id_mut(&mut s1.f), s1);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │       │           │
-   │         │       │           previous mutable field borrow
+   │         │       │      │
+   │         │       │      previous mutable field borrow
    │         │       used by mutable call result
    │         passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
@@ -20,31 +20,31 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
    │
 16 │         let f = &s1.f;
-   │                 ----- previous field borrow
+   │                  ---- previous field borrow
 17 │         mut_imm(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:19:17
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:19:22
    │
 18 │         let f = &s1.f;
-   │                 ----- previous field borrow
+   │                  ---- previous field borrow
 19 │         mut_imm(&mut s1.f, f);
-   │                 ^^^^^^^^^ mutable borrow attempted here
+   │                      ^^^^ mutable borrow attempted here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:21:16
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:21:21
    │
 20 │         let f = id(&s1.f);
-   │                    ----- previous field borrow
+   │                     ---- previous field borrow
 21 │         id_mut(&mut s1.f); *f;
-   │                ^^^^^^^^^ mutable borrow attempted here
+   │                     ^^^^ mutable borrow attempted here
 
 error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
    │
 24 │         let f = &mut s1.f;
-   │                 --------- previous mutable field borrow
+   │                      ---- previous mutable field borrow
 25 │         mut_mut(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
 
@@ -53,8 +53,8 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 26 │         mut_mut(&mut s1.f, s1);
    │         ^^^^^^^^^^^^^^^^^^^^^^
-   │         │       │
-   │         │       previous mutable field borrow
+   │         │            │
+   │         │            previous mutable field borrow
    │         passed here
 
 error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
@@ -70,8 +70,8 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 30 │         let f = id_mut(&mut s1.f);
    │                 -----------------
-   │                 │      │
-   │                 │      previous mutable field borrow
+   │                 │           │
+   │                 │           previous mutable field borrow
    │                 used by mutable call result
 31 │         mut_mut(s1, f);
    │         ^^^^^^^^^^^^^^ passed here
@@ -81,7 +81,7 @@ error: cannot pass mutable reference in local `s1`, which is still borrowed, as 
    │
 32 │         mut_mut(id_mut(&mut s1.f), s1);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │       │      │
-   │         │       │      previous mutable field borrow
+   │         │       │           │
+   │         │       │           previous mutable field borrow
    │         │       used by mutable call result
    │         passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move
@@ -1,0 +1,34 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun imm_imm<T1, T2>(_x: &T1, _y: &T2) { }
+    fun mut_imm<T1, T2>(_x: &mut T1, _y: &T2) { }
+    fun mut_mut<T1, T2>(_x: &mut T1, _y: &mut T2) { }
+
+    fun t0(s1: &mut S, _s2: &mut S) {
+        let f = freeze(s1);
+        mut_imm(s1, f);
+        let f = &s1.f;
+        mut_imm(s1, f);
+        let f = &s1.f;
+        mut_imm(&mut s1.f, f);
+        let f = id(&s1.f);
+        id_mut(&mut s1.f); *f;
+
+        mut_mut(s1, s1);
+        let f = &mut s1.f;
+        mut_mut(s1, f);
+        mut_mut(&mut s1.f, s1);
+        let s = id_mut(s1);
+        id_mut(s1);
+        *s;
+        let f = id_mut(&mut s1.f);
+        mut_mut(s1, f);
+        mut_mut(id_mut(&mut s1.f), s1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
@@ -4,7 +4,7 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
   ┌─ tests/reference-safety/v1-tests/call_ordering.move:7:13
   │
 6 │         let f = &mut s.f;
-  │                 -------- previous mutable field borrow
+  │                      --- previous mutable field borrow
 7 │         foo(freeze(s), { *f = 0; 1 })
   │             ^^^^^^^^^ passed here
 
@@ -12,6 +12,6 @@ error: cannot mutable borrow local `s` since other references exists
    ┌─ tests/reference-safety/v1-tests/call_ordering.move:12:25
    │
 12 │         bar(&mut s.f, { s.f = 0; 1 })
-   │             --------    ^^^ mutable borrow attempted here
-   │             │
-   │             previous mutable field borrow
+   │                  ---    ^^^ mutable borrow attempted here
+   │                  │
+   │                  previous mutable field borrow

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
@@ -4,7 +4,7 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
   ┌─ tests/reference-safety/v1-tests/call_ordering.move:7:13
   │
 6 │         let f = &mut s.f;
-  │                      --- previous mutable field borrow
+  │                 -------- previous mutable field borrow
 7 │         foo(freeze(s), { *f = 0; 1 })
   │             ^^^^^^^^^ passed here
 
@@ -12,6 +12,6 @@ error: cannot mutable borrow local `s` since other references exists
    ┌─ tests/reference-safety/v1-tests/call_ordering.move:12:25
    │
 12 │         bar(&mut s.f, { s.f = 0; 1 })
-   │                  ---    ^^^ mutable borrow attempted here
-   │                  │
-   │                  previous mutable field borrow
+   │             --------    ^^^ mutable borrow attempted here
+   │             │
+   │             previous mutable field borrow

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+  ┌─ tests/reference-safety/v1-tests/call_ordering.move:7:13
+  │
+6 │         let f = &mut s.f;
+  │                 -------- previous mutable field borrow
+7 │         foo(freeze(s), { *f = 0; 1 })
+  │             ^^^^^^^^^ passed here
+
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/call_ordering.move:12:25
+   │
+12 │         bar(&mut s.f, { s.f = 0; 1 })
+   │             --------    ^^^ mutable borrow attempted here
+   │             │
+   │             previous mutable field borrow

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_ordering.move
@@ -1,0 +1,14 @@
+module 0x8675309::M {
+    struct S { f: u64 }
+
+    fun foo(_s: &S, _u: u64) {}
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        foo(freeze(s), { *f = 0; 1 })
+    }
+
+    fun bar(_s: &mut u64, _u: u64) {}
+    fun t1(s: &mut S) {
+        bar(&mut s.f, { s.f = 0; 1 })
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.exp
@@ -1,0 +1,21 @@
+
+Diagnostics:
+error: cannot dereference local `x_ref` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:16:9
+   │
+15 │         let r = take_imm_mut_give_mut(x_ref, y_ref);
+   │                 ----------------------------------- previous mutable call result
+16 │         *x_ref;
+   │         ^^^^^^ dereferenced here
+
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:17:9
+   │
+13 │         let x_ref = &x;
+   │                     -- previous local borrow
+14 │         let y_ref = &mut y;
+15 │         let r = take_imm_mut_give_mut(x_ref, y_ref);
+   │                 ----------------------------------- used by mutable call result
+16 │         *x_ref;
+17 │         move x; // error in v2 (bug in v1)?
+   │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.move
@@ -1,0 +1,34 @@
+module 0x8675309::M {
+    fun take_imm_mut_give_mut(_x: &u64, y: &mut u64): &mut u64 {
+        y
+    }
+
+    fun take_imm_mut_give_imm(_x: &u64, y: &mut u64): &u64 {
+        y
+    }
+
+    fun t0() {
+        let x = 0;
+        let y = 0;
+        let x_ref = &x;
+        let y_ref = &mut y;
+        let r = take_imm_mut_give_mut(x_ref, y_ref);
+        *x_ref;
+        move x; // error in v2 (bug in v1)?
+        *r = 1;
+    }
+
+    fun t1() {
+        let x = 0;
+        let y = 0;
+        let x_ref = &x;
+        let y_ref = &mut y;
+        let r = take_imm_mut_give_imm(x_ref, y_ref);
+        *r;
+        *x_ref;
+        *y_ref;
+        *x_ref;
+        *r;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows_invalid.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+error: cannot move local `y` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows_invalid.move:16:9
+   │
+14 │         let y_ref = &mut y;
+   │                     ------ previous mutable local borrow
+15 │         let r = take_imm_mut_give_mut(move x_ref, move y_ref);
+   │                 --------------------------------------------- used by mutable call result
+16 │         move y;
+   │         ^^^^^^ moved here
+
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows_invalid.move:26:9
+   │
+23 │         let x_ref = &x;
+   │                     -- previous local borrow
+24 │         let y_ref = &mut y;
+25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
+   │                 --------------------------------------------- used by call result
+26 │         move x;
+   │         ^^^^^^ moved here
+
+error: cannot move local `y` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows_invalid.move:27:9
+   │
+24 │         let y_ref = &mut y;
+   │                     ------ previous mutable local borrow
+25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
+   │                 --------------------------------------------- used by call result
+26 │         move x;
+27 │         move y;
+   │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows_invalid.move
@@ -1,0 +1,30 @@
+module 0x8675309::M {
+    fun take_imm_mut_give_mut(_x: &u64, y: &mut u64): &mut u64 {
+        y
+    }
+
+    fun take_imm_mut_give_imm(_x: &u64, y: &mut u64): &u64 {
+        y
+    }
+
+    fun t0() {
+        let x = 0;
+        let y = 0;
+        let x_ref = &x;
+        let y_ref = &mut y;
+        let r = take_imm_mut_give_mut(move x_ref, move y_ref);
+        move y;
+        *r = 1;
+    }
+
+    fun t1() {
+        let x = 0;
+        let y = 0;
+        let x_ref = &x;
+        let y_ref = &mut y;
+        let r = take_imm_mut_give_imm(move x_ref, move y_ref);
+        move x;
+        move y;
+        *r;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.move
@@ -1,0 +1,60 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        copy s;
+        *f;
+        s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *f;
+        copy s;
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        *f;
+        copy s;
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        *f;
+        copy s;
+        s;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) { copy s; s; } else { *f; }
+    }
+
+    fun t5(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) { copy s; };
+        *f;
+    }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
@@ -1,0 +1,42 @@
+
+Diagnostics:
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:40:21
+   │
+39 │         let f = &mut s.f;
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
+40 │         if (cond) { copy s; };
+   │                     ^^^^^^ copied here
+
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:23:9
+   │
+22 │         if (cond) f = &mut s else f = other;
+   │                       ------ previous mutable local borrow
+23 │         copy s;
+   │         ^^^^^^ copied here
+
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:14:9
+   │
+13 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
+14 │         copy s;
+   │         ^^^^^^ copied here
+
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:32:9
+   │
+31 │         if (cond) f = id_mut(&mut s) else f = other;
+   │                       --------------
+   │                       │      │
+   │                       │      previous mutable local borrow
+   │                       used by mutable call result
+32 │         copy s;
+   │         ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:40:21
    │
 39 │         let f = &mut s.f;
-   │                      ---
-   │                      │
-   │                      used by mutable field borrow
-   │                      previous mutable local borrow
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
 40 │         if (cond) { copy s; };
    │                     ^^^^^^ copied here
 
@@ -23,10 +23,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:14:9
    │
 13 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            ---
-   │                            │
-   │                            used by mutable field borrow
-   │                            previous mutable local borrow
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
 14 │         copy s;
    │         ^^^^^^ copied here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:40:21
    │
 39 │         let f = &mut s.f;
-   │                 --------
-   │                 │    │
-   │                 │    previous mutable local borrow
-   │                 used by mutable field borrow
+   │                      ---
+   │                      │
+   │                      used by mutable field borrow
+   │                      previous mutable local borrow
 40 │         if (cond) { copy s; };
    │                     ^^^^^^ copied here
 
@@ -23,10 +23,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_combo_invalid.move:14:9
    │
 13 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       --------
-   │                       │    │
-   │                       │    previous mutable local borrow
-   │                       used by mutable field borrow
+   │                            ---
+   │                            │
+   │                            used by mutable field borrow
+   │                            previous mutable local borrow
 14 │         copy s;
    │         ^^^^^^ copied here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo_invalid.move
@@ -1,0 +1,45 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        copy s;
+        *f;
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        copy s;
+        *f;
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        copy s;
+        *f;
+        s;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        if (cond) { copy s; };
+        *f;
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.move
@@ -1,0 +1,35 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        copy s;
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        *f;
+        copy s;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id(&s.f);
+        copy s;
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        *f;
+        copy s;
+        s;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
@@ -1,0 +1,23 @@
+
+Diagnostics:
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:13:9
+   │
+12 │         let f = &mut s.f;
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
+13 │         copy s;
+   │         ^^^^^^ copied here
+
+error: cannot copy local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:19:9
+   │
+18 │         let f = id_mut(&mut s.f);
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
+19 │         copy s;
+   │         ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:13:9
    │
 12 │         let f = &mut s.f;
-   │                      ---
-   │                      │
-   │                      used by mutable field borrow
-   │                      previous mutable local borrow
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
 13 │         copy s;
    │         ^^^^^^ copied here
 
@@ -15,9 +15,9 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:19:9
    │
 18 │         let f = id_mut(&mut s.f);
-   │                             ---
-   │                             │
-   │                             used by mutable field borrow
-   │                             previous mutable local borrow
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
 19 │         copy s;
    │         ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:13:9
    │
 12 │         let f = &mut s.f;
-   │                 --------
-   │                 │    │
-   │                 │    previous mutable local borrow
-   │                 used by mutable field borrow
+   │                      ---
+   │                      │
+   │                      used by mutable field borrow
+   │                      previous mutable local borrow
 13 │         copy s;
    │         ^^^^^^ copied here
 
@@ -15,9 +15,9 @@ error: cannot copy local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/copy_field_invalid.move:19:9
    │
 18 │         let f = id_mut(&mut s.f);
-   │                        --------
-   │                        │    │
-   │                        │    previous mutable local borrow
-   │                        used by mutable field borrow
+   │                             ---
+   │                             │
+   │                             used by mutable field borrow
+   │                             previous mutable local borrow
 19 │         copy s;
    │         ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field_invalid.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        copy s;
+        *f;
+        s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        copy s;
+        *f;
+        s;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.move
@@ -1,0 +1,36 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &x;
+        *f;
+        copy x;
+        x;
+
+        let x = 0;
+        let f = &mut x;
+        *f;
+        copy x;
+        x;
+
+        let x = 0;
+        let f = id(&x);
+        *f;
+        copy x;
+        x;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        *f;
+        copy x;
+        x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.exp
@@ -1,0 +1,20 @@
+
+Diagnostics:
+error: cannot pass local `x` which is still borrowed as function argument
+   ┌─ tests/reference-safety/v1-tests/copy_full_invalid.move:13:9
+   │
+12 │         let f = &mut x;
+   │                 ------ previous mutable local borrow
+13 │         x + 0;
+   │         ^^^^^ passed here
+
+error: cannot pass local `x` which is still borrowed as function argument
+   ┌─ tests/reference-safety/v1-tests/copy_full_invalid.move:19:9
+   │
+18 │         let f = id_mut(&mut x);
+   │                 --------------
+   │                 │      │
+   │                 │      previous mutable local borrow
+   │                 used by mutable call result
+19 │         x + 0;
+   │         ^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot pass local `x` which is still borrowed as function argument
+error: cannot pass local `x` which is still mutably borrowed as function argument
    ┌─ tests/reference-safety/v1-tests/copy_full_invalid.move:13:9
    │
 12 │         let f = &mut x;
@@ -8,7 +8,7 @@ error: cannot pass local `x` which is still borrowed as function argument
 13 │         x + 0;
    │         ^^^^^ passed here
 
-error: cannot pass local `x` which is still borrowed as function argument
+error: cannot pass local `x` which is still mutably borrowed as function argument
    ┌─ tests/reference-safety/v1-tests/copy_full_invalid.move:19:9
    │
 18 │         let f = id_mut(&mut x);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.move
@@ -1,0 +1,24 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &mut x;
+        x + 0;
+        *f;
+        x + 0;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        x + 0;
+        *f;
+        x + 0;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `s`
+   ┌─ tests/reference-safety/v1-tests/dereference_combo.move:28:23
+   │
+28 │         if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
+   │                       ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.move
@@ -1,0 +1,33 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &S,) {
+        let f;
+        if (cond) f = &s.f else f = &other.f;
+        *s;
+        *f;
+        *s;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        *s;
+        *f;
+        *s;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &S) {
+        let x: &S;
+        if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
+        *s;
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
@@ -1,0 +1,27 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `s`
+   ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:26:23
+   │
+26 │         if (cond) x = copy s else x = other; // different error in v2 because copy of &mut
+   │                       ^^^^^^ copied here
+
+
+Diagnostics:
+error: cannot dereference local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:20:9
+   │
+19 │         if (cond) f = &mut s.f else f = &mut s.g;
+   │                       --------          -------- previous mutable field borrow
+   │                       │
+   │                       previous mutable field borrow
+20 │         *s;
+   │         ^^ dereferenced here
+
+error: cannot dereference local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:13:9
+   │
+12 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       -------- previous mutable field borrow
+13 │         *s;
+   │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
@@ -12,9 +12,9 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:20:9
    │
 19 │         if (cond) f = &mut s.f else f = &mut s.g;
-   │                       --------          -------- previous mutable field borrow
-   │                       │
-   │                       previous mutable field borrow
+   │                            ---               --- previous mutable field borrow
+   │                            │
+   │                            previous mutable field borrow
 20 │         *s;
    │         ^^ dereferenced here
 
@@ -22,6 +22,6 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:13:9
    │
 12 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       -------- previous mutable field borrow
+   │                            --- previous mutable field borrow
 13 │         *s;
    │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
@@ -12,9 +12,9 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:20:9
    │
 19 │         if (cond) f = &mut s.f else f = &mut s.g;
-   │                            ---               --- previous mutable field borrow
-   │                            │
-   │                            previous mutable field borrow
+   │                       --------          -------- previous mutable field borrow
+   │                       │
+   │                       previous mutable field borrow
 20 │         *s;
    │         ^^ dereferenced here
 
@@ -22,6 +22,6 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:13:9
    │
 12 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            --- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 13 │         *s;
    │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *s;
+        *f;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut s.g;
+        *s;
+        *f;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &mut S) {
+        let x;
+        if (cond) x = copy s else x = other; // different error in v2 because copy of &mut
+        *s;
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        *f;
+        *s;
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        *s;
+        *f;
+        *s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
@@ -1,0 +1,20 @@
+
+Diagnostics:
+error: cannot dereference local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_field_invalid.move:12:9
+   │
+11 │         let f = &mut s.f;
+   │                 -------- previous mutable field borrow
+12 │         *s;
+   │         ^^ dereferenced here
+
+error: cannot dereference local `s` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_field_invalid.move:16:9
+   │
+15 │         let f = id_mut(&mut s.f);
+   │                 ----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+16 │         *s;
+   │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
@@ -4,7 +4,7 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_field_invalid.move:12:9
    │
 11 │         let f = &mut s.f;
-   │                 -------- previous mutable field borrow
+   │                      --- previous mutable field borrow
 12 │         *s;
    │         ^^ dereferenced here
 
@@ -13,8 +13,8 @@ error: cannot dereference local `s` which is still mutable borrowed
    │
 15 │         let f = id_mut(&mut s.f);
    │                 ----------------
-   │                 │      │
-   │                 │      previous mutable field borrow
+   │                 │           │
+   │                 │           previous mutable field borrow
    │                 used by mutable call result
 16 │         *s;
    │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.exp
@@ -4,7 +4,7 @@ error: cannot dereference local `s` which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_field_invalid.move:12:9
    │
 11 │         let f = &mut s.f;
-   │                      --- previous mutable field borrow
+   │                 -------- previous mutable field borrow
 12 │         *s;
    │         ^^ dereferenced here
 
@@ -13,8 +13,8 @@ error: cannot dereference local `s` which is still mutable borrowed
    │
 15 │         let f = id_mut(&mut s.f);
    │                 ----------------
-   │                 │           │
-   │                 │           previous mutable field borrow
+   │                 │      │
+   │                 │      previous mutable field borrow
    │                 used by mutable call result
 16 │         *s;
    │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_field_invalid.move
@@ -1,0 +1,19 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        *s;
+        *f;
+
+        let f = id_mut(&mut s.f);
+        *s;
+        *f;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `x`
+   ┌─ tests/reference-safety/v1-tests/dereference_full.move:12:17
+   │
+12 │         let y = copy x; // error in v2
+   │                 ^^^^^^ copied here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.move
@@ -1,0 +1,33 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        let y = copy x; // error in v2
+        *y;
+        *x;
+
+        let x = &mut 0;
+        let y = id_mut(x);
+        *y;
+        *x;
+
+        let x = &0;
+        let y = copy x;
+        *y;
+        *x;
+
+
+        let x = &0;
+        let y = id(x);
+        *y;
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: cannot copy mutable reference in local `x`
+   ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:12:17
+   │
+12 │         let y = copy x; // error in v2
+   │                 ^^^^^^ copied here
+
+
+Diagnostics:
+error: cannot dereference local `x` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:18:9
+   │
+17 │         let y = id_mut(x);
+   │                 --------- previous mutable call result
+18 │         *x;
+   │         ^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.move
@@ -1,0 +1,21 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        let y = copy x; // error in v2
+        *x;
+        *y;
+
+        let x = &mut 0;
+        let y = id_mut(x);
+        *x;
+        *y;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
@@ -1,0 +1,27 @@
+
+Diagnostics:
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_combo.move:27:9
+   │
+26 │         if (cond) x = freeze(s) else x = other;
+   │                       --------- previous call result
+27 │         freeze(s); // error in v2 even though s is not read
+   │         ^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_combo.move:20:9
+   │
+19 │         if (cond) f = &s.f else f = &s.g;
+   │                       ----          ---- previous field borrow
+   │                       │
+   │                       previous field borrow
+20 │         freeze(s); // error in v2 even though s is not read
+   │         ^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_combo.move:13:9
+   │
+12 │         if (cond) f = &s.f else f = &other.f;
+   │                       ---- previous field borrow
+13 │         freeze(s); // error in v2 even though s is not read
+   │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
@@ -12,9 +12,9 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo.move:20:9
    │
 19 │         if (cond) f = &s.f else f = &s.g;
-   │                       ----          ---- previous field borrow
-   │                       │
-   │                       previous field borrow
+   │                        ---           --- previous field borrow
+   │                        │
+   │                        previous field borrow
 20 │         freeze(s); // error in v2 even though s is not read
    │         ^^^^^^^^^ passed here
 
@@ -22,6 +22,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo.move:13:9
    │
 12 │         if (cond) f = &s.f else f = &other.f;
-   │                       ---- previous field borrow
+   │                        --- previous field borrow
 13 │         freeze(s); // error in v2 even though s is not read
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
@@ -12,9 +12,9 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo.move:20:9
    │
 19 │         if (cond) f = &s.f else f = &s.g;
-   │                        ---           --- previous field borrow
-   │                        │
-   │                        previous field borrow
+   │                       ----          ---- previous field borrow
+   │                       │
+   │                       previous field borrow
 20 │         freeze(s); // error in v2 even though s is not read
    │         ^^^^^^^^^ passed here
 
@@ -22,6 +22,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo.move:13:9
    │
 12 │         if (cond) f = &s.f else f = &other.f;
-   │                        --- previous field borrow
+   │                       ---- previous field borrow
 13 │         freeze(s); // error in v2 even though s is not read
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &S) {
+        let f;
+        if (cond) f = &s.f else f = &other.f;
+        freeze(s); // error in v2 even though s is not read
+        *f;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        freeze(s); // error in v2 even though s is not read
+        *f;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &S) {
+        let x;
+        if (cond) x = freeze(s) else x = other;
+        freeze(s); // error in v2 even though s is not read
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
@@ -1,0 +1,29 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `s` which is used later
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:26:19
+   │
+26 │         if (cond) x = s else x = other; // error in v2
+   │                   ^^^^^ implicitly copied here
+27 │         freeze(s);
+   │         --------- used here
+
+
+Diagnostics:
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:20:9
+   │
+19 │         if (cond) f = &mut s.f else f = &mut s.g;
+   │                       --------          -------- previous mutable field borrow
+   │                       │
+   │                       previous mutable field borrow
+20 │         freeze(s);
+   │         ^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
+   │
+12 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       -------- previous mutable field borrow
+13 │         freeze(s);
+   │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
@@ -14,9 +14,9 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:20:9
    │
 19 │         if (cond) f = &mut s.f else f = &mut s.g;
-   │                            ---               --- previous mutable field borrow
-   │                            │
-   │                            previous mutable field borrow
+   │                       --------          -------- previous mutable field borrow
+   │                       │
+   │                       previous mutable field borrow
 20 │         freeze(s);
    │         ^^^^^^^^^ passed here
 
@@ -24,6 +24,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
    │
 12 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            --- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 13 │         freeze(s);
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
@@ -14,9 +14,9 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:20:9
    │
 19 │         if (cond) f = &mut s.f else f = &mut s.g;
-   │                       --------          -------- previous mutable field borrow
-   │                       │
-   │                       previous mutable field borrow
+   │                            ---               --- previous mutable field borrow
+   │                            │
+   │                            previous mutable field borrow
 20 │         freeze(s);
    │         ^^^^^^^^^ passed here
 
@@ -24,6 +24,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
    │
 12 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       -------- previous mutable field borrow
+   │                            --- previous mutable field borrow
 13 │         freeze(s);
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, s: &mut S, other: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        freeze(s);
+        *f;
+    }
+
+    fun t1(cond: bool, s: &mut S) {
+        let f;
+        if (cond) f = &mut s.f else f = &mut s.g;
+        freeze(s);
+        *f;
+    }
+
+    fun t2(cond: bool, s: &mut S, other: &mut S) {
+        let x;
+        if (cond) x = s else x = other; // error in v2
+        freeze(s);
+        *x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_field.move:18:9
+   │
+17 │         let f = &s.f;
+   │                 ---- previous field borrow
+18 │         freeze(s); // error in v2 since it doesn't matter whether s is read
+   │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
@@ -4,6 +4,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_field.move:18:9
    │
 17 │         let f = &s.f;
-   │                  --- previous field borrow
+   │                 ---- previous field borrow
 18 │         freeze(s); // error in v2 since it doesn't matter whether s is read
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
@@ -4,6 +4,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_field.move:18:9
    │
 17 │         let f = &s.f;
-   │                 ---- previous field borrow
+   │                  --- previous field borrow
 18 │         freeze(s); // error in v2 since it doesn't matter whether s is read
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.move
@@ -1,0 +1,22 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        *f;
+        freeze(s);
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        freeze(s); // error in v2 since it doesn't matter whether s is read
+        *f;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
@@ -1,20 +1,20 @@
 
 Diagnostics:
 error: cannot mutable borrow local `s` since other references exists
-   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:18:17
+   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:18:22
    │
 17 │         let f = &s.f;
-   │                 ---- previous field borrow
+   │                  --- previous field borrow
 18 │         let g = &mut s.f; // error in v2
-   │                 ^^^^^^^^ mutable borrow attempted here
+   │                      ^^^ mutable borrow attempted here
 
 error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:19:9
    │
 17 │         let f = &s.f;
-   │                 ---- previous field borrow
+   │                  --- previous field borrow
 18 │         let g = &mut s.f; // error in v2
-   │                 -------- previous mutable field borrow
+   │                      --- previous mutable field borrow
 19 │         freeze(s);
    │         ^^^^^^^^^ passed here
 
@@ -22,6 +22,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:12:9
    │
 11 │         let f = &mut s.f;
-   │                 -------- previous mutable field borrow
+   │                      --- previous mutable field borrow
 12 │         freeze(s);
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
@@ -1,0 +1,27 @@
+
+Diagnostics:
+error: cannot mutable borrow local `s` since other references exists
+   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:18:17
+   │
+17 │         let f = &s.f;
+   │                 ---- previous field borrow
+18 │         let g = &mut s.f; // error in v2
+   │                 ^^^^^^^^ mutable borrow attempted here
+
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:19:9
+   │
+17 │         let f = &s.f;
+   │                 ---- previous field borrow
+18 │         let g = &mut s.f; // error in v2
+   │                 -------- previous mutable field borrow
+19 │         freeze(s);
+   │         ^^^^^^^^^ passed here
+
+error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:12:9
+   │
+11 │         let f = &mut s.f;
+   │                 -------- previous mutable field borrow
+12 │         freeze(s);
+   │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.exp
@@ -1,20 +1,20 @@
 
 Diagnostics:
 error: cannot mutable borrow local `s` since other references exists
-   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:18:22
+   ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:18:17
    │
 17 │         let f = &s.f;
-   │                  --- previous field borrow
+   │                 ---- previous field borrow
 18 │         let g = &mut s.f; // error in v2
-   │                      ^^^ mutable borrow attempted here
+   │                 ^^^^^^^^ mutable borrow attempted here
 
 error: cannot pass mutable reference in local `s`, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:19:9
    │
 17 │         let f = &s.f;
-   │                  --- previous field borrow
+   │                 ---- previous field borrow
 18 │         let g = &mut s.f; // error in v2
-   │                      --- previous mutable field borrow
+   │                 -------- previous mutable field borrow
 19 │         freeze(s);
    │         ^^^^^^^^^ passed here
 
@@ -22,6 +22,6 @@ error: cannot pass mutable reference in local `s`, which is still borrowed, as f
    ┌─ tests/reference-safety/v1-tests/freeze_field_invalid.move:12:9
    │
 11 │         let f = &mut s.f;
-   │                      --- previous mutable field borrow
+   │                 -------- previous mutable field borrow
 12 │         freeze(s);
    │         ^^^^^^^^^ passed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field_invalid.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        freeze(s);
+        *f;
+    }
+
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        let g = &mut s.f; // error in v2
+        freeze(s);
+        *f;
+        *g;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.move
@@ -1,0 +1,18 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        freeze(x);
+
+        let x = id_mut(&mut 0);
+        freeze(x);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.move
@@ -1,0 +1,21 @@
+// Not actually invalid both in v1 and v2
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        freeze(x);
+        *x = 0;
+
+        let x = id_mut(&mut 0);
+        freeze(x);
+        *x = 0;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.move
@@ -1,0 +1,48 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        *f;
+        move s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *f;
+        move s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        *f;
+        move s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        *f;
+        move s;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) { move s; } else { *f; }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:45:21
    │
 44 │         let f = &s.f;
-   │                  ---
-   │                  │
-   │                  used by field borrow
-   │                  previous local borrow
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
 45 │         if (cond) { move s; };
    │                     ^^^^^^ moved here
 
@@ -23,10 +23,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:22:9
    │
 21 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            ---
-   │                            │
-   │                            used by mutable field borrow
-   │                            previous mutable local borrow
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
 22 │         move s;
    │         ^^^^^^ moved here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
@@ -4,10 +4,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:45:21
    │
 44 │         let f = &s.f;
-   │                 ----
-   │                 ││
-   │                 │previous local borrow
-   │                 used by field borrow
+   │                  ---
+   │                  │
+   │                  used by field borrow
+   │                  previous local borrow
 45 │         if (cond) { move s; };
    │                     ^^^^^^ moved here
 
@@ -23,10 +23,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:22:9
    │
 21 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       --------
-   │                       │    │
-   │                       │    previous mutable local borrow
-   │                       used by mutable field borrow
+   │                            ---
+   │                            │
+   │                            used by mutable field borrow
+   │                            previous mutable local borrow
 22 │         move s;
    │         ^^^^^^ moved here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.exp
@@ -1,0 +1,42 @@
+
+Diagnostics:
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:45:21
+   │
+44 │         let f = &s.f;
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
+45 │         if (cond) { move s; };
+   │                     ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:30:9
+   │
+29 │         if (cond) f = &mut s else f = other;
+   │                       ------ previous mutable local borrow
+30 │         move s;
+   │         ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:22:9
+   │
+21 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       --------
+   │                       │    │
+   │                       │    previous mutable local borrow
+   │                       used by mutable field borrow
+22 │         move s;
+   │         ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_combo_invalid.move:38:9
+   │
+37 │         if (cond) f = id_mut(&mut s) else f = other;
+   │                       --------------
+   │                       │      │
+   │                       │      previous mutable local borrow
+   │                       used by mutable call result
+38 │         move s;
+   │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo_invalid.move
@@ -1,0 +1,49 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        move s;
+        *f;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        move s;
+        *f;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s else f = other;
+        move s;
+        *f;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(&mut s) else f = other;
+        move s;
+        *f;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) { move s; };
+        *f;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.move
@@ -1,0 +1,32 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        *f;
+        move s;
+
+
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        *f;
+        move s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id(&s.f);
+        *f;
+        move s;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        *f;
+        move s;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
@@ -1,0 +1,45 @@
+
+Diagnostics:
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:13:9
+   │
+12 │         let f = &s.f;
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
+13 │         move s;
+   │         ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:18:9
+   │
+17 │         let f = &mut s.f;
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
+18 │         move s;
+   │         ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:23:9
+   │
+22 │         let f = id(&s.f);
+   │                    ----
+   │                    ││
+   │                    │previous local borrow
+   │                    used by field borrow
+23 │         move s;
+   │         ^^^^^^ moved here
+
+error: cannot move local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:28:9
+   │
+27 │         let f = id_mut(&mut s.f);
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
+28 │         move s;
+   │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:13:9
    │
 12 │         let f = &s.f;
-   │                 ----
-   │                 ││
-   │                 │previous local borrow
-   │                 used by field borrow
+   │                  ---
+   │                  │
+   │                  used by field borrow
+   │                  previous local borrow
 13 │         move s;
    │         ^^^^^^ moved here
 
@@ -15,10 +15,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:18:9
    │
 17 │         let f = &mut s.f;
-   │                 --------
-   │                 │    │
-   │                 │    previous mutable local borrow
-   │                 used by mutable field borrow
+   │                      ---
+   │                      │
+   │                      used by mutable field borrow
+   │                      previous mutable local borrow
 18 │         move s;
    │         ^^^^^^ moved here
 
@@ -26,10 +26,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:23:9
    │
 22 │         let f = id(&s.f);
-   │                    ----
-   │                    ││
-   │                    │previous local borrow
-   │                    used by field borrow
+   │                     ---
+   │                     │
+   │                     used by field borrow
+   │                     previous local borrow
 23 │         move s;
    │         ^^^^^^ moved here
 
@@ -37,9 +37,9 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:28:9
    │
 27 │         let f = id_mut(&mut s.f);
-   │                        --------
-   │                        │    │
-   │                        │    previous mutable local borrow
-   │                        used by mutable field borrow
+   │                             ---
+   │                             │
+   │                             used by mutable field borrow
+   │                             previous mutable local borrow
 28 │         move s;
    │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.exp
@@ -4,10 +4,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:13:9
    │
 12 │         let f = &s.f;
-   │                  ---
-   │                  │
-   │                  used by field borrow
-   │                  previous local borrow
+   │                 ----
+   │                 ││
+   │                 │previous local borrow
+   │                 used by field borrow
 13 │         move s;
    │         ^^^^^^ moved here
 
@@ -15,10 +15,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:18:9
    │
 17 │         let f = &mut s.f;
-   │                      ---
-   │                      │
-   │                      used by mutable field borrow
-   │                      previous mutable local borrow
+   │                 --------
+   │                 │    │
+   │                 │    previous mutable local borrow
+   │                 used by mutable field borrow
 18 │         move s;
    │         ^^^^^^ moved here
 
@@ -26,10 +26,10 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:23:9
    │
 22 │         let f = id(&s.f);
-   │                     ---
-   │                     │
-   │                     used by field borrow
-   │                     previous local borrow
+   │                    ----
+   │                    ││
+   │                    │previous local borrow
+   │                    used by field borrow
 23 │         move s;
    │         ^^^^^^ moved here
 
@@ -37,9 +37,9 @@ error: cannot move local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_field_invalid.move:28:9
    │
 27 │         let f = id_mut(&mut s.f);
-   │                             ---
-   │                             │
-   │                             used by mutable field borrow
-   │                             previous mutable local borrow
+   │                        --------
+   │                        │    │
+   │                        │    previous mutable local borrow
+   │                        used by mutable field borrow
 28 │         move s;
    │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field_invalid.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let s = S { f: 0, g: 0 };
+        let f = &s.f;
+        move s;
+        *f;
+
+        let s = S { f: 0, g: 0 };
+        let f = &mut s.f;
+        move s;
+        *f;
+
+        let s = S { f: 0, g: 0 };
+        let f = id(&s.f);
+        move s;
+        *f;
+
+        let s = S { f: 0, g: 0 };
+        let f = id_mut(&mut s.f);
+        move s;
+        *f;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.move
@@ -1,0 +1,26 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+
+    fun t0(addr: address) acquires R {
+        R { f: _ } = move_from<R>(addr);
+        R { f: _ } = move_from<R>(addr);
+    }
+
+    fun t1(addr: address) acquires R {
+        R { f: _ } = move_from<R>(addr);
+        borrow_global_mut<R>(addr);
+    }
+
+    fun t2(addr: address) acquires R {
+        R { f: _ } = move_from<R>(addr);
+        borrow_global<R>(addr);
+    }
+
+    fun t3(cond: bool, addr: address) acquires R {
+        let r = R { f: 0 };
+        R { f: _ } = move_from<R>(addr);
+        let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+        r1.f = 0;
+        R { f: _ } = r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
@@ -1,0 +1,91 @@
+
+Diagnostics:
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:62:23
+   │
+61 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+62 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:42:23
+   │
+41 │         let f_ref = &borrow_global<R>(addr).f;
+   │                     -------------------------
+   │                     ││
+   │                     │previous global borrow
+   │                     used by field borrow
+42 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:36:23
+   │
+35 │         let r1 = borrow_global<R>(addr);
+   │                  ---------------------- previous global borrow
+36 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:18:23
+   │
+17 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
+   │                     ---------------------------------
+   │                     │    │
+   │                     │    previous mutable global borrow
+   │                     used by mutable field borrow
+18 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:12:23
+   │
+11 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+12 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:30:23
+   │
+29 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
+   │                            ---------------------------------
+   │                            │    │
+   │                            │    previous mutable global borrow
+   │                            used by mutable field borrow
+30 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:24:23
+   │
+23 │         let r1 = id_mut(borrow_global_mut<R>(addr));
+   │                  ----------------------------------
+   │                  │      │
+   │                  │      previous mutable global borrow
+   │                  used by mutable call result
+24 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:54:23
+   │
+53 │         let f_ref = id(&borrow_global<R>(addr).f);
+   │                        -------------------------
+   │                        ││
+   │                        │previous global borrow
+   │                        used by field borrow
+54 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here
+
+error: cannot extract resource `M::R` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:48:23
+   │
+47 │         let r1 = id(borrow_global<R>(addr));
+   │                  --------------------------
+   │                  │  │
+   │                  │  previous global borrow
+   │                  used by call result
+48 │         let R { f } = move_from<R>(addr);
+   │                       ^^^^^^^^^^^^^^^^^^ extracted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
@@ -12,10 +12,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:42:23
    │
 41 │         let f_ref = &borrow_global<R>(addr).f;
-   │                      ------------------------
-   │                      │
-   │                      used by field borrow
-   │                      previous global borrow
+   │                     -------------------------
+   │                     ││
+   │                     │previous global borrow
+   │                     used by field borrow
 42 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -31,10 +31,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:18:23
    │
 17 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
-   │                          ----------------------------
-   │                          │
-   │                          used by mutable field borrow
-   │                          previous mutable global borrow
+   │                     ---------------------------------
+   │                     │    │
+   │                     │    previous mutable global borrow
+   │                     used by mutable field borrow
 18 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -50,10 +50,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:30:23
    │
 29 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
-   │                                 ----------------------------
-   │                                 │
-   │                                 used by mutable field borrow
-   │                                 previous mutable global borrow
+   │                            ---------------------------------
+   │                            │    │
+   │                            │    previous mutable global borrow
+   │                            used by mutable field borrow
 30 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -72,10 +72,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:54:23
    │
 53 │         let f_ref = id(&borrow_global<R>(addr).f);
-   │                         ------------------------
-   │                         │
-   │                         used by field borrow
-   │                         previous global borrow
+   │                        -------------------------
+   │                        ││
+   │                        │previous global borrow
+   │                        used by field borrow
 54 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.exp
@@ -12,10 +12,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:42:23
    │
 41 │         let f_ref = &borrow_global<R>(addr).f;
-   │                     -------------------------
-   │                     ││
-   │                     │previous global borrow
-   │                     used by field borrow
+   │                      ------------------------
+   │                      │
+   │                      used by field borrow
+   │                      previous global borrow
 42 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -31,10 +31,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:18:23
    │
 17 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
-   │                     ---------------------------------
-   │                     │    │
-   │                     │    previous mutable global borrow
-   │                     used by mutable field borrow
+   │                          ----------------------------
+   │                          │
+   │                          used by mutable field borrow
+   │                          previous mutable global borrow
 18 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -50,10 +50,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:30:23
    │
 29 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
-   │                            ---------------------------------
-   │                            │    │
-   │                            │    previous mutable global borrow
-   │                            used by mutable field borrow
+   │                                 ----------------------------
+   │                                 │
+   │                                 used by mutable field borrow
+   │                                 previous mutable global borrow
 30 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 
@@ -72,10 +72,10 @@ error: cannot extract resource `M::R` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/move_from_invalid.move:54:23
    │
 53 │         let f_ref = id(&borrow_global<R>(addr).f);
-   │                        -------------------------
-   │                        ││
-   │                        │previous global borrow
-   │                        used by field borrow
+   │                         ------------------------
+   │                         │
+   │                         used by field borrow
+   │                         previous global borrow
 54 │         let R { f } = move_from<R>(addr);
    │                       ^^^^^^^^^^^^^^^^^^ extracted here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from_invalid.move
@@ -1,0 +1,67 @@
+module 0x8675309::M {
+    struct R has key { f: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(addr: address) acquires R {
+        let r1 = borrow_global_mut<R>(addr);
+        let R { f } = move_from<R>(addr);
+        r1.f = f
+    }
+
+    fun t1(addr: address) acquires R {
+        let f_ref = &mut borrow_global_mut<R>(addr).f;
+        let R { f } = move_from<R>(addr);
+        *f_ref = f
+    }
+
+    fun t2(addr: address) acquires R {
+        let r1 = id_mut(borrow_global_mut<R>(addr));
+        let R { f } = move_from<R>(addr);
+        r1.f = f
+    }
+
+    fun t3(addr: address) acquires R {
+        let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
+        let R { f } = move_from<R>(addr);
+        *f_ref = f
+    }
+
+    fun t4(addr: address): u64 acquires R {
+        let r1 = borrow_global<R>(addr);
+        let R { f } = move_from<R>(addr);
+        r1.f + f
+    }
+
+    fun t5(addr: address): u64 acquires R {
+        let f_ref = &borrow_global<R>(addr).f;
+        let R { f } = move_from<R>(addr);
+        *f_ref + f
+    }
+
+    fun t6(addr: address): u64 acquires R {
+        let r1 = id(borrow_global<R>(addr));
+        let R { f } = move_from<R>(addr);
+        r1.f + f
+    }
+
+    fun t7(addr: address): u64 acquires R {
+        let f_ref = id(&borrow_global<R>(addr).f);
+        let R { f } = move_from<R>(addr);
+        *f_ref + f
+    }
+
+
+    fun t8(cond: bool, addr: address) acquires R {
+        let r = R { f: 0 };
+        let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+        let R { f } = move_from<R>(addr);
+        r1.f = f;
+
+        R { f: _ } = r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.move
@@ -1,0 +1,32 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &x;
+        *f;
+        move x;
+
+        let x = 0;
+        let f = &mut x;
+        *f;
+        move x;
+
+        let x = 0;
+        let f = id(&x);
+        *f;
+        move x;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        *f;
+        move x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full_invalid.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_full_invalid.move:13:9
+   │
+12 │         let f = &x;
+   │                 -- previous local borrow
+13 │         move x;
+   │         ^^^^^^ moved here
+
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_full_invalid.move:18:9
+   │
+17 │         let f = &mut x;
+   │                 ------ previous mutable local borrow
+18 │         move x;
+   │         ^^^^^^ moved here
+
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_full_invalid.move:23:9
+   │
+22 │         let f = id(&x);
+   │                 ------
+   │                 │  │
+   │                 │  previous local borrow
+   │                 used by call result
+23 │         move x;
+   │         ^^^^^^ moved here
+
+error: cannot move local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/move_full_invalid.move:28:9
+   │
+27 │         let f = id_mut(&mut x);
+   │                 --------------
+   │                 │      │
+   │                 │      previous mutable local borrow
+   │                 used by mutable call result
+28 │         move x;
+   │         ^^^^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full_invalid.move
@@ -1,0 +1,32 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = 0;
+        let f = &x;
+        move x;
+        *f;
+
+        let x = 0;
+        let f = &mut x;
+        move x;
+        *f;
+
+        let x = 0;
+        let f = id(&x);
+        move x;
+        *f;
+
+        let x = 0;
+        let f = id_mut(&mut x);
+        move x;
+        *f;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `s` which is used later
+   ┌─ tests/reference-safety/v1-tests/mutate_combo.move:31:19
+   │
+31 │         if (cond) f = s else f = other; // error in v2 because s is copied
+   │                   ^^^^^ implicitly copied here
+32 │         *f;
+33 │         *s = S { f: 0, g: 0 };
+   │         --------------------- used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.move
@@ -1,0 +1,54 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, _other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        *f;
+        *s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *f;
+        *s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = s else f = other; // error in v2 because s is copied
+        *f;
+        *s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(s) else f = other;
+        *f;
+        *s = S { f: 0, g: 0 };
+        s;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f = &s.f;
+        *f;
+        if (cond) *s = S { f: 0, g: 0 };
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -14,7 +14,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:49:19
    │
 48 │         let f = &s.f;
-   │                  --- previous field borrow
+   │                 ---- previous field borrow
 49 │         if (cond) *s = S { f: 0, g: 0 };
    │                   ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -22,7 +22,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:23:9
    │
 22 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                            --- previous mutable field borrow
+   │                       -------- previous mutable field borrow
 23 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -30,9 +30,9 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:14:9
    │
 13 │         if (cond) f = &s.f else f = &s.g;
-   │                        ---           --- previous field borrow
-   │                        │
-   │                        previous field borrow
+   │                       ----          ---- previous field borrow
+   │                       │
+   │                       previous field borrow
 14 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -14,7 +14,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:49:19
    │
 48 │         let f = &s.f;
-   │                 ---- previous field borrow
+   │                  --- previous field borrow
 49 │         if (cond) *s = S { f: 0, g: 0 };
    │                   ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -22,7 +22,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:23:9
    │
 22 │         if (cond) f = &mut s.f else f = &mut other.f;
-   │                       -------- previous mutable field borrow
+   │                            --- previous mutable field borrow
 23 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -30,9 +30,9 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:14:9
    │
 13 │         if (cond) f = &s.f else f = &s.g;
-   │                       ----          ---- previous field borrow
-   │                       │
-   │                       previous field borrow
+   │                        ---           --- previous field borrow
+   │                        │
+   │                        previous field borrow
 14 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -1,0 +1,45 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `s` which is used later
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:31:19
+   │
+31 │         if (cond) f = s else f = other; // error in v2 because s is copied
+   │                   ^^^^^ implicitly copied here
+32 │         *s = S { f: 0, g: 0 };
+   │         --------------------- used here
+
+
+Diagnostics:
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:49:19
+   │
+48 │         let f = &s.f;
+   │                 ---- previous field borrow
+49 │         if (cond) *s = S { f: 0, g: 0 };
+   │                   ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:23:9
+   │
+22 │         if (cond) f = &mut s.f else f = &mut other.f;
+   │                       -------- previous mutable field borrow
+23 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:14:9
+   │
+13 │         if (cond) f = &s.f else f = &s.g;
+   │                       ----          ---- previous field borrow
+   │                       │
+   │                       previous field borrow
+14 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9
+   │
+40 │         if (cond) f = id_mut(s) else f = other;
+   │                       --------- previous mutable call result
+41 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.move
@@ -1,0 +1,54 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0(cond: bool, _other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &s.f else f = &s.g;
+        *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t1(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = &mut s.f else f = &mut other.f;
+        *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t2(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = s else f = other; // error in v2 because s is copied
+        *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t3(cond: bool, other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f;
+        if (cond) f = id_mut(s) else f = other;
+        *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+    fun t4(cond: bool, _other: &mut S) {
+        let s = &mut S { f: 0, g: 0 };
+        let f = &s.f;
+        if (cond) *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.move
@@ -1,0 +1,31 @@
+module 0x8675309::M {
+    struct S has drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        *f;
+        s.g = 0;
+        *s = S { f: 0, g: 0 };
+
+        let f = &mut s.f;
+        *f;
+        s.g = 0;
+        *s = S { f: 0, g: 0 };
+
+        let f = id(&s.f);
+        *f;
+        s.g = 0;
+        *s = S { f: 0, g: 0 };
+
+        let f = id_mut(&mut s.f);
+        *f;
+        s.g = 0;
+        *s = S { f: 0, g: 0 };
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:11:9
+   │
+10 │         let f = &s.f;
+   │                 ---- previous field borrow
+11 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:15:9
+   │
+14 │         let f = &mut s.f;
+   │                 -------- previous mutable field borrow
+15 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:19:9
+   │
+18 │         let f = id(&s.f);
+   │                 --------
+   │                 │  │
+   │                 │  previous field borrow
+   │                 used by call result
+19 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+
+error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:23:9
+   │
+22 │         let f = id_mut(&mut s.f);
+   │                 ----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+23 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
@@ -4,7 +4,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:11:9
    │
 10 │         let f = &s.f;
-   │                  --- previous field borrow
+   │                 ---- previous field borrow
 11 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -12,7 +12,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:15:9
    │
 14 │         let f = &mut s.f;
-   │                      --- previous mutable field borrow
+   │                 -------- previous mutable field borrow
 15 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -21,8 +21,8 @@ error: cannot write to reference in local `s` which is still borrowed
    │
 18 │         let f = id(&s.f);
    │                 --------
-   │                 │   │
-   │                 │   previous field borrow
+   │                 │  │
+   │                 │  previous field borrow
    │                 used by call result
 19 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
@@ -32,8 +32,8 @@ error: cannot write to reference in local `s` which is still borrowed
    │
 22 │         let f = id_mut(&mut s.f);
    │                 ----------------
-   │                 │           │
-   │                 │           previous mutable field borrow
+   │                 │      │
+   │                 │      previous mutable field borrow
    │                 used by mutable call result
 23 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.exp
@@ -4,7 +4,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:11:9
    │
 10 │         let f = &s.f;
-   │                 ---- previous field borrow
+   │                  --- previous field borrow
 11 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -12,7 +12,7 @@ error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_field_invalid.move:15:9
    │
 14 │         let f = &mut s.f;
-   │                 -------- previous mutable field borrow
+   │                      --- previous mutable field borrow
 15 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 
@@ -21,8 +21,8 @@ error: cannot write to reference in local `s` which is still borrowed
    │
 18 │         let f = id(&s.f);
    │                 --------
-   │                 │  │
-   │                 │  previous field borrow
+   │                 │   │
+   │                 │   previous field borrow
    │                 used by call result
 19 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
@@ -32,8 +32,8 @@ error: cannot write to reference in local `s` which is still borrowed
    │
 22 │         let f = id_mut(&mut s.f);
    │                 ----------------
-   │                 │      │
-   │                 │      previous mutable field borrow
+   │                 │           │
+   │                 │           previous mutable field borrow
    │                 used by mutable call result
 23 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field_invalid.move
@@ -1,0 +1,28 @@
+module 0x8675309::M {
+    struct S has drop { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun t1(s: &mut S) {
+        let f = &s.f;
+        *s = S { f: 0, g: 0 };
+        *f;
+
+        let f = &mut s.f;
+        *s = S { f: 0, g: 0 };
+        *f;
+
+        let f = id(&s.f);
+        *s = S { f: 0, g: 0 };
+        *f;
+
+        let f = id_mut(&mut s.f);
+        *s = S { f: 0, g: 0 };
+        *f;
+        s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `x` which is used later
+   ┌─ tests/reference-safety/v1-tests/mutate_full.move:12:13
+   │
+12 │         let f = x; // error in v2 because of copy
+   │             ^ implicitly copied here
+13 │         *f;
+14 │         *x = 0;
+   │         ------ used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.move
@@ -1,0 +1,33 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        let f = x; // error in v2 because of copy
+        *f;
+        *x = 0;
+
+
+        let x = &mut 0;
+        let f = freeze(x);
+        *f;
+        *x = 0;
+
+        let x = &mut 0;
+        let f = id(x);
+        *f;
+        *x = 0;
+
+        let x = &mut 0;
+        let f = id_mut(x);
+        *f;
+        *x = 0;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
@@ -1,0 +1,38 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `x` which is used later
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:12:13
+   │
+12 │         let f = x; // error in v2 because of copy
+   │             ^ implicitly copied here
+13 │         *x = 0;
+   │         ------ used here
+
+
+Diagnostics:
+error: cannot write to reference in local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9
+   │
+17 │         let f = freeze(x);
+   │                 --------- previous call result
+18 │         *x = 0;
+   │         ^^^^^^ written here
+
+error: cannot write to reference in local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:23:9
+   │
+22 │         let f = id(x);
+   │                 -----
+   │                 │  │
+   │                 │  previous call result
+   │                 used by call result
+23 │         *x = 0;
+   │         ^^^^^^ written here
+
+error: cannot write to reference in local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:28:9
+   │
+27 │         let f = id_mut(x);
+   │                 --------- previous mutable call result
+28 │         *x = 0;
+   │         ^^^^^^ written here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.move
@@ -1,0 +1,32 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        let f = x; // error in v2 because of copy
+        *x = 0;
+        *f;
+
+        let x = &mut 0;
+        let f = freeze(x);
+        *x = 0;
+        *f;
+
+        let x = &mut 0;
+        let f = id(x);
+        *x = 0;
+        *f;
+
+        let x = &mut 0;
+        let f = id_mut(x);
+        *x = 0;
+        *f;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.move
@@ -1,0 +1,15 @@
+module 0x8675309::M {
+    fun t0(cond: bool) {
+        let v = 0;
+        let (x, y);
+        if (cond) {
+            x = &v;
+            y = copy x;
+        } else {
+            y = &v;
+            x = copy y;
+        };
+        move x;
+        move y;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.move
@@ -1,0 +1,28 @@
+module 0x8675309::M {
+    struct S has copy, drop { f: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun t0() {
+        let v1 = 0;
+        let v2 = 0;
+        let v3 = 0;
+        let v4 = 0;
+        let s1 = S { f: 0 };
+        let s2 = S { f: 0 };
+        let s3 = S { f: 0 };
+        let s4 = S { f: 0 };
+
+        &mut v1;
+        &v2;
+        id_mut(&mut v3);
+        id(&v4);
+        &mut s1.f;
+        &s2.f;
+        id_mut(&mut s3.f);
+        id(&s4.f);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
@@ -1,0 +1,125 @@
+
+Diagnostics:
+error: cannot return a reference derived from local `v1` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+   │            ------- previous mutable local borrow
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v2` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+   │ │         --- previous local borrow
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v3` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+   │ │         ---------------
+   │ │         │      │
+   │ │         │      previous mutable local borrow
+   │ │         used by mutable call result
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v4` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   │ │         -------
+   │ │         │  │
+   │ │         │  previous local borrow
+   │ │         used by call result
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `s1` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+23 │ │         &mut s1.f,
+   │ │         ---------
+   │ │         │    │
+   │ │         │    previous mutable local borrow
+   │ │         used by mutable field borrow
+24 │ │         &s2.f,
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `s2` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+23 │ │         &mut s1.f,
+24 │ │         &s2.f,
+   │ │         -----
+   │ │         ││
+   │ │         │previous local borrow
+   │ │         used by field borrow
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `s3` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+   │ │                ---------
+   │ │                │    │
+   │ │                │    previous mutable local borrow
+   │ │                used by mutable field borrow
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `s4` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ │            -----
+   │ │            ││
+   │ │            │previous local borrow
+   │ │            used by field borrow
+   │ ╰──────────────────^ returned here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
@@ -66,10 +66,10 @@ error: cannot return a reference derived from local `s1` since it is not a param
 21 │ │         id_mut(&mut v3),
 22 │ │         id(&v4),
 23 │ │         &mut s1.f,
-   │ │              ----
-   │ │              │
-   │ │              used by mutable field borrow
-   │ │              previous mutable local borrow
+   │ │         ---------
+   │ │         │    │
+   │ │         │    previous mutable local borrow
+   │ │         used by mutable field borrow
 24 │ │         &s2.f,
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
@@ -84,10 +84,10 @@ error: cannot return a reference derived from local `s2` since it is not a param
 22 │ │         id(&v4),
 23 │ │         &mut s1.f,
 24 │ │         &s2.f,
-   │ │          ----
-   │ │          │
-   │ │          used by field borrow
-   │ │          previous local borrow
+   │ │         -----
+   │ │         ││
+   │ │         │previous local borrow
+   │ │         used by field borrow
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
    │ ╰──────────────────^ returned here
@@ -101,10 +101,10 @@ error: cannot return a reference derived from local `s3` since it is not a param
 22 │ │         id(&v4),
    · │
 25 │ │         id_mut(&mut s3.f),
-   │ │                     ----
-   │ │                     │
-   │ │                     used by mutable field borrow
-   │ │                     previous mutable local borrow
+   │ │                ---------
+   │ │                │    │
+   │ │                │    previous mutable local borrow
+   │ │                used by mutable field borrow
 26 │ │         id(&s4.f))
    │ ╰──────────────────^ returned here
 
@@ -118,8 +118,8 @@ error: cannot return a reference derived from local `s4` since it is not a param
    · │
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
-   │ │             ----
-   │ │             │
-   │ │             used by field borrow
-   │ │             previous local borrow
+   │ │            -----
+   │ │            ││
+   │ │            │previous local borrow
+   │ │            used by field borrow
    │ ╰──────────────────^ returned here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
@@ -66,10 +66,10 @@ error: cannot return a reference derived from local `s1` since it is not a param
 21 │ │         id_mut(&mut v3),
 22 │ │         id(&v4),
 23 │ │         &mut s1.f,
-   │ │         ---------
-   │ │         │    │
-   │ │         │    previous mutable local borrow
-   │ │         used by mutable field borrow
+   │ │              ----
+   │ │              │
+   │ │              used by mutable field borrow
+   │ │              previous mutable local borrow
 24 │ │         &s2.f,
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
@@ -84,10 +84,10 @@ error: cannot return a reference derived from local `s2` since it is not a param
 22 │ │         id(&v4),
 23 │ │         &mut s1.f,
 24 │ │         &s2.f,
-   │ │         -----
-   │ │         ││
-   │ │         │previous local borrow
-   │ │         used by field borrow
+   │ │          ----
+   │ │          │
+   │ │          used by field borrow
+   │ │          previous local borrow
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
    │ ╰──────────────────^ returned here
@@ -101,10 +101,10 @@ error: cannot return a reference derived from local `s3` since it is not a param
 22 │ │         id(&v4),
    · │
 25 │ │         id_mut(&mut s3.f),
-   │ │                ---------
-   │ │                │    │
-   │ │                │    previous mutable local borrow
-   │ │                used by mutable field borrow
+   │ │                     ----
+   │ │                     │
+   │ │                     used by mutable field borrow
+   │ │                     previous mutable local borrow
 26 │ │         id(&s4.f))
    │ ╰──────────────────^ returned here
 
@@ -118,8 +118,8 @@ error: cannot return a reference derived from local `s4` since it is not a param
    · │
 25 │ │         id_mut(&mut s3.f),
 26 │ │         id(&s4.f))
-   │ │            -----
-   │ │            ││
-   │ │            │previous local borrow
-   │ │            used by field borrow
+   │ │             ----
+   │ │             │
+   │ │             used by field borrow
+   │ │             previous local borrow
    │ ╰──────────────────^ returned here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.move
@@ -1,0 +1,28 @@
+module 0x8675309::M {
+    struct S has drop { f: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun t0(): (&mut u64, &u64, &mut u64, &u64, &mut u64, &u64, &mut u64, &u64) {
+        let v1 = 0;
+        let v2 = 0;
+        let v3 = 0;
+        let v4 = 0;
+        let s1 = S { f: 0 };
+        let s2 = S { f: 0 };
+        let s3 = S { f: 0 };
+        let s4 = S { f: 0 };
+
+        (&mut v1,
+        &v2,
+        id_mut(&mut v3),
+        id(&v4),
+        &mut s1.f,
+        &s2.f,
+        id_mut(&mut s3.f),
+        id(&s4.f))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: cannot pass mutable reference in local `s1`, which is still borrowed, as function argument
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows.move:11:22
+   │
+11 │         (freeze(s1), freeze(s1)) // error in v2 since &mut cannot be copied
+   │          ----------  ^^^^^^^^^^ passed here
+   │          │
+   │          previous call result

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.move
@@ -1,0 +1,39 @@
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun imm_imm_0(s1: &mut S): (&S, &S) {
+        (freeze(s1), freeze(s1)) // error in v2 since &mut cannot be copied
+    }
+    fun imm_imm_1(s1: &mut S): (&S, &u64) {
+        (freeze(s1), &s1.f)
+    }
+    fun imm_imm_2(s1: &mut S): (&u64, &u64) {
+        (&s1.f, &s1.f)
+    }
+    fun imm_imm_3(s1: &mut S, s2: &mut S): (&S, &S) {
+        (id(s1), s2)
+    }
+
+    fun mut_imm_0(s1: &mut S): (&mut u64, &u64) {
+        (&mut s1.f, &s1.g)
+    }
+    fun mut_imm_1(s1: &mut S): (&mut u64, &u64) {
+        (id_mut(&mut s1.f), id(&s1.g))
+    }
+
+    fun mut_mut_0(s1: &mut S, s2: &mut S): (&mut u64, &mut u64) {
+        (&mut s1.f, &mut s2.g)
+    }
+    fun mut_mut_1(s1: &mut S, s2: &mut S): (&mut u64, &mut u64) {
+        (id_mut(&mut s1.f), &mut s2.g)
+    }
+    fun mut_mut_2(s1: &mut S, s2: &mut S): (&mut S, &mut S) {
+        (s1, s2)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
@@ -14,31 +14,31 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:21
    │
 39 │         (&mut s1.f, s1)
-   │          ---------  ^^ moved here
-   │          │
-   │          previous mutable field borrow
+   │               ----  ^^ moved here
+   │               │
+   │               previous mutable field borrow
 
 error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:10
    │
 35 │         let f =  &mut s1.f;
-   │                  --------- previous mutable field borrow
+   │                       ---- previous mutable field borrow
 36 │         (s1, f)
    │          ^^ moved here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:24:10
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:24:15
    │
 23 │         let f = &s1.f;
-   │                 ----- previous field borrow
+   │                  ---- previous field borrow
 24 │         (&mut s1.f, f)
-   │          ^^^^^^^^^ mutable borrow attempted here
+   │               ^^^^ mutable borrow attempted here
 
 error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:10
    │
 19 │         let f = &s1.f;
-   │                 ----- previous field borrow
+   │                  ---- previous field borrow
 20 │         (s1, f)
    │          ^^ moved here
 
@@ -55,8 +55,8 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │
 49 │         (id_mut(&mut s1.f), s1)
    │          -----------------  ^^ moved here
-   │          │      │
-   │          │      previous mutable field borrow
+   │          │           │
+   │          │           previous mutable field borrow
    │          used by mutable call result
 
 error: cannot move mutable reference in local `s1` which is still borrowed
@@ -64,8 +64,8 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │
 45 │         let f = id_mut(&mut s1.f);
    │                 -----------------
-   │                 │      │
-   │                 │      previous mutable field borrow
+   │                 │           │
+   │                 │           previous mutable field borrow
    │                 used by mutable call result
 46 │         (s1, f)
    │          ^^ moved here
@@ -79,9 +79,9 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │          previous mutable call result
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:28:10
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:28:15
    │
 27 │         let f = id(&s1.f);
-   │                    ----- previous field borrow
+   │                     ---- previous field borrow
 28 │         (&mut s1.f, f)
-   │          ^^^^^^^^^ mutable borrow attempted here
+   │               ^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
@@ -1,0 +1,87 @@
+
+Diagnostics:
+error: implicit copy of mutable reference in local `s1` which is used later
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:32:10
+   │
+32 │         (s1, s1) // error in v1 since &mut cannot be copied
+   │          ^^  -- used here
+   │          │
+   │          implicitly copied here
+
+
+Diagnostics:
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:21
+   │
+39 │         (&mut s1.f, s1)
+   │          ---------  ^^ moved here
+   │          │
+   │          previous mutable field borrow
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:10
+   │
+35 │         let f =  &mut s1.f;
+   │                  --------- previous mutable field borrow
+36 │         (s1, f)
+   │          ^^ moved here
+
+error: cannot mutable borrow local `s1` since other references exists
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:24:10
+   │
+23 │         let f = &s1.f;
+   │                 ----- previous field borrow
+24 │         (&mut s1.f, f)
+   │          ^^^^^^^^^ mutable borrow attempted here
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:10
+   │
+19 │         let f = &s1.f;
+   │                 ----- previous field borrow
+20 │         (s1, f)
+   │          ^^ moved here
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:16:10
+   │
+15 │         let f = freeze(s1);
+   │                 ---------- previous call result
+16 │         (s1, f)
+   │          ^^ moved here
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:49:29
+   │
+49 │         (id_mut(&mut s1.f), s1)
+   │          -----------------  ^^ moved here
+   │          │      │
+   │          │      previous mutable field borrow
+   │          used by mutable call result
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:10
+   │
+45 │         let f = id_mut(&mut s1.f);
+   │                 -----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+46 │         (s1, f)
+   │          ^^ moved here
+
+error: cannot move mutable reference in local `s1` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:42:22
+   │
+42 │         (id_mut(s1), s1)
+   │          ----------  ^^ moved here
+   │          │
+   │          previous mutable call result
+
+error: cannot mutable borrow local `s1` since other references exists
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:28:10
+   │
+27 │         let f = id(&s1.f);
+   │                    ----- previous field borrow
+28 │         (&mut s1.f, f)
+   │          ^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
@@ -14,31 +14,31 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:21
    │
 39 │         (&mut s1.f, s1)
-   │               ----  ^^ moved here
-   │               │
-   │               previous mutable field borrow
+   │          ---------  ^^ moved here
+   │          │
+   │          previous mutable field borrow
 
 error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:10
    │
 35 │         let f =  &mut s1.f;
-   │                       ---- previous mutable field borrow
+   │                  --------- previous mutable field borrow
 36 │         (s1, f)
    │          ^^ moved here
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:24:15
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:24:10
    │
 23 │         let f = &s1.f;
-   │                  ---- previous field borrow
+   │                 ----- previous field borrow
 24 │         (&mut s1.f, f)
-   │               ^^^^ mutable borrow attempted here
+   │          ^^^^^^^^^ mutable borrow attempted here
 
 error: cannot move mutable reference in local `s1` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:10
    │
 19 │         let f = &s1.f;
-   │                  ---- previous field borrow
+   │                 ----- previous field borrow
 20 │         (s1, f)
    │          ^^ moved here
 
@@ -55,8 +55,8 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │
 49 │         (id_mut(&mut s1.f), s1)
    │          -----------------  ^^ moved here
-   │          │           │
-   │          │           previous mutable field borrow
+   │          │      │
+   │          │      previous mutable field borrow
    │          used by mutable call result
 
 error: cannot move mutable reference in local `s1` which is still borrowed
@@ -64,8 +64,8 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │
 45 │         let f = id_mut(&mut s1.f);
    │                 -----------------
-   │                 │           │
-   │                 │           previous mutable field borrow
+   │                 │      │
+   │                 │      previous mutable field borrow
    │                 used by mutable call result
 46 │         (s1, f)
    │          ^^ moved here
@@ -79,9 +79,9 @@ error: cannot move mutable reference in local `s1` which is still borrowed
    │          previous mutable call result
 
 error: cannot mutable borrow local `s1` since other references exists
-   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:28:15
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:28:10
    │
 27 │         let f = id(&s1.f);
-   │                     ---- previous field borrow
+   │                    ----- previous field borrow
 28 │         (&mut s1.f, f)
-   │               ^^^^ mutable borrow attempted here
+   │          ^^^^^^^^^ mutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move
@@ -1,0 +1,51 @@
+// This produces different errors than v1 because all use cases copy &mut
+module 0x8675309::M {
+    struct S { f: u64, g: u64 }
+    fun id<T>(r: &T): &T {
+        r
+    }
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+    fun imm_imm<T1, T2>(_x: &T1, _xy: &T2) { }
+    fun mut_imm<T1, T2>(_x: &mut T1, _y: &T2) { }
+    fun mut_mut<T1, T2>(_x: &mut T1, _y: &mut T2) { }
+
+    fun mut_imm_0(s1: &mut S): (&mut S, &S) {
+        let f = freeze(s1);
+        (s1, f)
+    }
+    fun mut_imm_1(s1: &mut S): (&mut S, &u64) {
+        let f = &s1.f;
+        (s1, f)
+    }
+    fun mut_imm_2(s1: &mut S): (&mut u64, &u64) {
+        let f = &s1.f;
+        (&mut s1.f, f)
+    }
+    fun mut_imm_3(s1: &mut S): (&mut u64, &u64) {
+        let f = id(&s1.f);
+        (&mut s1.f, f)
+    }
+
+    fun mut_mut_0(s1: &mut S): (&mut S, &mut S) {
+        (s1, s1) // error in v1 since &mut cannot be copied
+    }
+    fun mut_mut_1(s1: &mut S): (&mut S, &mut u64) {
+        let f =  &mut s1.f;
+        (s1, f)
+    }
+    fun mut_mut_2(s1: &mut S): (&mut u64, &mut S) {
+        (&mut s1.f, s1)
+    }
+    fun mut_mut_3(s1: &mut S): (&mut S, &mut S) {
+        (id_mut(s1), s1)
+    }
+    fun mut_mut_4(s1: &mut S): (&mut S, &mut u64) {
+        let f = id_mut(&mut s1.f);
+        (s1, f)
+    }
+    fun mut_mut_5(s1: &mut S): (&mut u64, &mut S) {
+        (id_mut(&mut s1.f), s1)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.move
@@ -1,0 +1,32 @@
+module 0x42::m {
+
+struct Txn { sender: address }
+struct X {}
+
+fun begin(sender: address): Txn {
+    Txn { sender }
+}
+
+fun new(_: &mut Txn): X {
+    X {}
+}
+
+fun add<K: copy + drop + store, V: store>(_x: &mut X, _k: K, _v: V) {
+    abort 0
+}
+
+
+fun borrow<K: copy + drop + store, V: store>(_x: &X, _k: K): &V {
+    abort 0
+}
+
+fun borrow_wrong_type() {
+    let sender = @0x0;
+    let scenario = begin(sender);
+    let x = new(&mut scenario);
+    add(&mut x, 0, 0);
+    borrow<u64, u64>(&mut x, 0);
+    abort 42
+}
+
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -9,7 +9,9 @@ use move_compiler::compiled_unit::CompiledUnit;
 use move_compiler_v2::{
     inliner,
     pipeline::{
-        livevar_analysis_processor::LiveVarAnalysisProcessor, visibility_checker::VisibilityChecker,
+        livevar_analysis_processor::LiveVarAnalysisProcessor,
+        reference_safety_processor::ReferenceSafetyProcessor,
+        visibility_checker::VisibilityChecker,
     },
     run_file_format_gen, Options,
 };
@@ -77,6 +79,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 impl TestConfig {
     fn get_config_from_path(path: &Path) -> TestConfig {
         let path = path.to_string_lossy();
+        let verbose = cfg!(feature = "verbose-debug-print");
         let mut pipeline = FunctionTargetPipeline::default();
         if path.contains("/checking/inlining/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
@@ -121,6 +124,25 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: false,
+            }
+        } else if path.contains("/live-var/") {
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            Self {
+                type_check_only: false,
+                dump_ast: false,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: true,
+            }
+        } else if path.contains("/reference-safety/") {
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
+            Self {
+                type_check_only: false,
+                dump_ast: verbose,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: verbose,
             }
         } else {
             panic!(
@@ -234,7 +256,8 @@ impl TestConfig {
 
     /// Callback from the framework to register formatters for annotations.
     fn register_formatters(target: &FunctionTarget) {
-        LiveVarAnalysisProcessor::register_formatters(target)
+        LiveVarAnalysisProcessor::register_formatters(target);
+        ReferenceSafetyProcessor::register_formatters(target)
     }
 
     fn check_diags(baseline: &mut String, env: &GlobalEnv) -> bool {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -291,63 +291,75 @@ module 42.heap {
 
 
 array_equals(Arg0: &vector<u64>, Arg1: &vector<u64>): bool {
-L0:	loc2: u64
+L0:	loc2: &vector<u64>
 L1:	loc3: u64
+L2:	loc4: u64
+L3:	loc5: &vector<u64>
+L4:	loc6: &vector<u64>
+L5:	loc7: u64
 B0:
 	0: CopyLoc[0](Arg0: &vector<u64>)
-	1: VecLen(2)
-	2: StLoc[2](loc0: u64)
-	3: CopyLoc[1](Arg1: &vector<u64>)
-	4: VecLen(2)
-	5: StLoc[3](loc1: u64)
-	6: CopyLoc[2](loc0: u64)
-	7: MoveLoc[3](loc1: u64)
-	8: Neq
-	9: BrFalse(13)
+	1: StLoc[2](loc0: &vector<u64>)
+	2: MoveLoc[2](loc0: &vector<u64>)
+	3: VecLen(2)
+	4: StLoc[3](loc1: u64)
+	5: CopyLoc[1](Arg1: &vector<u64>)
+	6: StLoc[4](loc2: &vector<u64>)
+	7: MoveLoc[4](loc2: &vector<u64>)
+	8: VecLen(2)
+	9: StLoc[5](loc3: u64)
+	10: CopyLoc[3](loc1: u64)
+	11: MoveLoc[5](loc3: u64)
+	12: Neq
+	13: BrFalse(17)
 B1:
-	10: LdFalse
-	11: Ret
+	14: LdFalse
+	15: Ret
 B2:
-	12: Branch(13)
+	16: Branch(17)
 B3:
-	13: LdU64(0)
-	14: StLoc[4](loc2: u64)
+	17: LdU64(0)
+	18: StLoc[6](loc4: u64)
 B4:
-	15: CopyLoc[4](loc2: u64)
-	16: CopyLoc[2](loc0: u64)
-	17: Lt
-	18: BrFalse(39)
+	19: CopyLoc[6](loc4: u64)
+	20: CopyLoc[3](loc1: u64)
+	21: Lt
+	22: BrFalse(47)
 B5:
-	19: CopyLoc[0](Arg0: &vector<u64>)
-	20: CopyLoc[4](loc2: u64)
-	21: VecImmBorrow(2)
-	22: ReadRef
-	23: CopyLoc[1](Arg1: &vector<u64>)
-	24: CopyLoc[4](loc2: u64)
-	25: VecImmBorrow(2)
-	26: ReadRef
-	27: Neq
-	28: BrFalse(32)
+	23: CopyLoc[0](Arg0: &vector<u64>)
+	24: StLoc[7](loc5: &vector<u64>)
+	25: MoveLoc[7](loc5: &vector<u64>)
+	26: CopyLoc[6](loc4: u64)
+	27: VecImmBorrow(2)
+	28: ReadRef
+	29: CopyLoc[1](Arg1: &vector<u64>)
+	30: StLoc[8](loc6: &vector<u64>)
+	31: MoveLoc[8](loc6: &vector<u64>)
+	32: CopyLoc[6](loc4: u64)
+	33: VecImmBorrow(2)
+	34: ReadRef
+	35: Neq
+	36: BrFalse(40)
 B6:
-	29: LdFalse
-	30: Ret
+	37: LdFalse
+	38: Ret
 B7:
-	31: Branch(32)
+	39: Branch(40)
 B8:
-	32: LdU64(1)
-	33: StLoc[5](loc3: u64)
-	34: MoveLoc[4](loc2: u64)
-	35: MoveLoc[5](loc3: u64)
-	36: Add
-	37: StLoc[4](loc2: u64)
-	38: Branch(40)
+	40: LdU64(1)
+	41: StLoc[9](loc7: u64)
+	42: MoveLoc[6](loc4: u64)
+	43: MoveLoc[9](loc7: u64)
+	44: Add
+	45: StLoc[6](loc4: u64)
+	46: Branch(48)
 B9:
-	39: Branch(41)
+	47: Branch(49)
 B10:
-	40: Branch(15)
+	48: Branch(19)
 B11:
-	41: LdTrue
-	42: Ret
+	49: LdTrue
+	50: Ret
 }
 create1(): vector<u64> {
 B0:
@@ -521,45 +533,51 @@ B12:
 }
 vcopy(Arg0: &vector<u64>): vector<u64> {
 L0:	loc1: u64
-L1:	loc2: u64
+L1:	loc2: &vector<u64>
 L2:	loc3: u64
-L3:	loc4: vector<u64>
+L3:	loc4: &vector<u64>
+L4:	loc5: u64
+L5:	loc6: vector<u64>
 B0:
 	0: VecPack(2, 0)
 	1: StLoc[1](loc0: vector<u64>)
 	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 	4: CopyLoc[0](Arg0: &vector<u64>)
-	5: VecLen(2)
-	6: StLoc[3](loc2: u64)
+	5: StLoc[3](loc2: &vector<u64>)
+	6: MoveLoc[3](loc2: &vector<u64>)
+	7: VecLen(2)
+	8: StLoc[4](loc3: u64)
 B1:
-	7: CopyLoc[2](loc1: u64)
-	8: CopyLoc[3](loc2: u64)
-	9: Lt
-	10: BrFalse(24)
+	9: CopyLoc[2](loc1: u64)
+	10: CopyLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(28)
 B2:
-	11: MutBorrowLoc[1](loc0: vector<u64>)
-	12: CopyLoc[0](Arg0: &vector<u64>)
-	13: CopyLoc[2](loc1: u64)
-	14: VecImmBorrow(2)
-	15: ReadRef
-	16: VecPushBack(2)
-	17: LdU64(1)
-	18: StLoc[4](loc3: u64)
-	19: MoveLoc[2](loc1: u64)
-	20: MoveLoc[4](loc3: u64)
-	21: Add
-	22: StLoc[2](loc1: u64)
-	23: Branch(25)
+	13: MutBorrowLoc[1](loc0: vector<u64>)
+	14: CopyLoc[0](Arg0: &vector<u64>)
+	15: StLoc[5](loc4: &vector<u64>)
+	16: MoveLoc[5](loc4: &vector<u64>)
+	17: CopyLoc[2](loc1: u64)
+	18: VecImmBorrow(2)
+	19: ReadRef
+	20: VecPushBack(2)
+	21: LdU64(1)
+	22: StLoc[6](loc5: u64)
+	23: MoveLoc[2](loc1: u64)
+	24: MoveLoc[6](loc5: u64)
+	25: Add
+	26: StLoc[2](loc1: u64)
+	27: Branch(29)
 B3:
-	24: Branch(26)
+	28: Branch(30)
 B4:
-	25: Branch(7)
+	29: Branch(9)
 B5:
-	26: MoveLoc[1](loc0: vector<u64>)
-	27: StLoc[5](loc4: vector<u64>)
-	28: MoveLoc[5](loc4: vector<u64>)
-	29: Ret
+	30: MoveLoc[1](loc0: vector<u64>)
+	31: StLoc[7](loc6: vector<u64>)
+	32: MoveLoc[7](loc6: vector<u64>)
+	33: Ret
 }
 }
 == END Bytecode ==

--- a/third_party/move/move-model/bytecode/Cargo.toml
+++ b/third_party/move/move-model/bytecode/Cargo.toml
@@ -36,6 +36,12 @@ anyhow = "1.0.52"
 datatest-stable = "0.1.1"
 move-stackless-bytecode-test-utils = { path = "../bytecode-test-utils" }
 
+
+[features]
+default = []
+# If set, more information is printed when debug printing, e.g. for baseline files
+verbose-debug-print = []
+
 [[test]]
 name = "testsuite"
 harness = false

--- a/third_party/move/move-model/bytecode/Cargo.toml
+++ b/third_party/move/move-model/bytecode/Cargo.toml
@@ -36,7 +36,6 @@ anyhow = "1.0.52"
 datatest-stable = "0.1.1"
 move-stackless-bytecode-test-utils = { path = "../bytecode-test-utils" }
 
-
 [features]
 default = []
 # If set, more information is printed when debug printing, e.g. for baseline files

--- a/third_party/move/move-model/bytecode/src/borrow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/borrow_analysis.rs
@@ -617,7 +617,7 @@ impl<'a> TransferFunctions for BorrowAnalysis<'a> {
 
                 let src_node = self.borrow_node(*src);
                 match kind {
-                    AssignKind::Move => {
+                    AssignKind::Move | AssignKind::Inferred => {
                         assert!(!self.func_target.get_local_type(*src).is_reference());
                         assert!(!self.func_target.get_local_type(*dest).is_reference());
                         state.del_node(&src_node);

--- a/third_party/move/move-model/bytecode/src/dataflow_domains.rs
+++ b/third_party/move/move-model/bytecode/src/dataflow_domains.rs
@@ -154,6 +154,12 @@ impl<E: Ord + Clone> SetDomain<E> {
     pub fn is_disjoint(&self, other: &Self) -> bool {
         self.iter().all(move |e| !other.contains(e))
     }
+
+    /// Implements string formatting. Not using Display because of context dependent element
+    /// display.
+    pub fn to_string(&self, to_str: impl Fn(&E) -> String) -> String {
+        format!("{{{}}}", self.0.iter().map(to_str).join(","))
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -262,6 +268,22 @@ impl<K: Ord + Clone, V: AbstractDomain + Clone> MapDomain<K, V> {
                 v
             });
         change
+    }
+
+    /// Implements string formatting. Not using Display because of context dependent element
+    /// display.
+    pub fn to_string(
+        &self,
+        k_to_str: impl Fn(&K) -> String,
+        v_to_str: impl Fn(&V) -> String,
+    ) -> String {
+        format!(
+            "{{{}}}",
+            self.0
+                .iter()
+                .map(|(k, v)| format!("{}={}", k_to_str(k), v_to_str(v)))
+                .join(",")
+        )
     }
 }
 

--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -260,7 +260,7 @@ impl<'env> FunctionTarget<'env> {
 
     /// Returns a printable name for a local. If the local is a temporary which has
     /// no name, returns `local`, otherwise `local <name>`. The returned value
-    /// should be equally produce correct English whether a name is available or not.
+    /// should produce correct English whether a name is available or not.
     pub fn get_local_name_for_error_message(&self, temp: TempIndex) -> String {
         if let Some(sym) = self.data.local_names.get(&temp) {
             format!("local `{}`", sym.display(self.global_env().symbol_pool()))

--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -212,9 +212,7 @@ impl<'env> FunctionTarget<'env> {
         if let Some(name) = self.data.local_names.get(&idx) {
             *name
         } else {
-            self.func_env
-                .get_local_name(idx)
-                .expect("should never happen")
+            self.func_env.get_local_name(idx)
         }
     }
 

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -71,6 +71,8 @@ pub enum AssignKind {
     // currently makes a difference of this case. It originates from stack code where Copy
     // and Move push on the stack and Store pops.
     Store,
+    /// The assign kind should be inferred based on livevar analysis
+    Inferred,
 }
 
 /// The type of variable that is being havoc-ed
@@ -136,7 +138,7 @@ impl Constant {
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and
 /// operators.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Operation {
     // ==============================================================
     // Core Bytecodes (part of the programming language)
@@ -834,6 +836,9 @@ impl<'env> fmt::Display for BytecodeDisplay<'env> {
             },
             Assign(_, dst, src, AssignKind::Store) => {
                 write!(f, "{} := {}", self.lstr(*dst), self.lstr(*src))?
+            },
+            Assign(_, dst, src, AssignKind::Inferred) => {
+                write!(f, "{} := infer({})", self.lstr(*dst), self.lstr(*src))?
             },
             Call(_, dsts, oper, args, aa) => {
                 if !dsts.is_empty() {

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -178,6 +178,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                 .expect(COMPILED_MODULE_AVAILABLE),
             loop_unrolling,
             loop_invariants,
+            BTreeMap::new(),
         )
     }
 

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -156,14 +156,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
         let name_to_index = (0..func_env
             .get_local_count()
             .expect("compiled module available"))
-            .map(|idx| {
-                (
-                    func_env
-                        .get_local_name(idx)
-                        .expect("compiled module available"),
-                    idx,
-                )
-            })
+            .map(|idx| (func_env.get_local_name(idx), idx))
             .collect();
 
         FunctionData::new(

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1096,6 +1096,16 @@ impl ExpData {
             }
         });
     }
+
+    /// Returns the node id of the inner expression which delivers the result. For blocks,
+    /// this traverses into the body.
+    pub fn result_node_id(&self) -> NodeId {
+        if let ExpData::Block(_, _, _, body) = self {
+            body.result_node_id()
+        } else {
+            self.node_id()
+        }
+    }
 }
 
 struct ExpRewriter<'a> {
@@ -1153,6 +1163,10 @@ pub enum Operation {
     Gt,
     Le,
     Ge,
+
+    // Copy and Move
+    Copy,
+    Move,
 
     // Unary operators
     Not,
@@ -1270,7 +1284,7 @@ impl Pattern {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum TraceKind {
     /// A user level TRACE(..) in the source.
     User,

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -815,6 +815,9 @@ impl<'env> SpecTranslator<'env> {
             Operation::Slice => self.translate_primitive_call("$SliceVecByRange", args),
             Operation::Range => self.translate_primitive_call("$Range", args),
 
+            // Copy and Move treated as identity for Boogie
+            Operation::Copy | Operation::Move => self.translate_exp(&args[0]),
+
             // Binary operators
             Operation::Add => self.translate_op("+", "Add", args),
             Operation::Sub => self.translate_op("-", "Sub", args),

--- a/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/loop_analysis.rs
@@ -240,11 +240,7 @@ impl LoopAnalysisProcessor {
                                     .map(|&idx| {
                                         func_env
                                             .symbol_pool()
-                                            .string(
-                                                func_env
-                                                    .get_local_name(*idx)
-                                                    .expect("compiled module available"),
-                                            )
+                                            .string(func_env.get_local_name(*idx))
                                             .to_string()
                                     })
                                     .collect();


### PR DESCRIPTION
This implements a first cut of reference safety analysis (aka borrow analysis):

- This implements the variation of the semantics which also the Move prover uses and which is aligned with Rust. See also the discussion on Discord about this subject.
- There is also a new version of the live var analysis (forked from the previous generic one) which does a few things differently: it computes locations for used variables (closes #10718), as well as infers copies and moves in the bytecode assign instruction, which is essential for the reference safety.
- `copy x` and `move x` which had been more or less ignored until now, this PR implements it up to refererence safety analysis.
- There are a few fixes around the codebase required to make this PR work. For instance, scoping of names in expression was wrong during bytecode generation,
- The implementation is fairly complete and passes all v1 compiler tests as verified by comparing the outputs. This is module the variation in semantics.
