### PR TITLE
[gha] update code coverage trigger

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,10 +6,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
-  push:
-    branches:
-      - main
+    types: [labeled]
   workflow_dispatch:
   workflow_call:
 
@@ -25,7 +22,9 @@ concurrency:
 
 jobs:
   rust-unit-coverage:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') || ${{ github.event_name }} == 'schedule'
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') ||
+      ${{ github.event_name == 'schedule' && github.ref_name == 'main' }}
     # Note the tests run slowly due to instrutmentation. It takes CI ~8 hrs
     timeout-minutes: 600
     runs-on: high-perf-docker
@@ -48,7 +47,9 @@ jobs:
           path: lcov_unit.info
 
   rust-smoke-coverage:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') || ${{ github.event_name }} == 'schedule'
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') ||
+      ${{ github.event_name == 'schedule' && github.ref_name == 'main' }}
     timeout-minutes: 240
     runs-on: high-perf-docker
     steps:


### PR DESCRIPTION
### Description
Update trigger condition to listen for label change in github pull_request event.  Disable the trigger on push event. 

### Test Plan
- Coverage job is not triggered in CI without label 
<img width="361" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/7528420/97e82b58-2864-4d86-89ea-ce91030a21a1">

- Coverage job is triggered in CI with label 
<img width="349" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/7528420/f71e2f61-f52d-4d90-8cbc-ec8e02ea791d">

