### PR TITLE
[Execution] Add support for configurable transaction filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_yaml 0.8.26",
  "strum_macros",
  "tempfile",
  "thiserror",

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, utils::RootPath, Error,
-    NodeConfig,
+    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType,
+    transaction_filter_type::Filter, utils::RootPath, Error, NodeConfig,
 };
-use aptos_crypto::HashValue;
-use aptos_types::{account_address::AccountAddress, chain_id::ChainId, transaction::Transaction};
+use aptos_types::{chain_id::ChainId, transaction::Transaction};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
     fs::File,
     io::{Read, Write},
     path::PathBuf,
@@ -37,29 +35,7 @@ pub struct ExecutionConfig {
     /// Enables enhanced metrics around processed transactions
     pub processed_transactions_detailed_counters: bool,
     /// Enables filtering of transactions before they are sent to execution
-    pub transaction_filter: TransactionFilterType,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub enum TransactionFilterType {
-    #[default]
-    NoFilter,
-    // Filters out all user transactions - only system transactions are allowed
-    AllTransactions,
-    // Filters out all user transactions for a set of block ids.
-    BlockListedBlockIdBased(HashSet<HashValue>),
-    // Filters out user transactions which correspond to a set of transaction hashes.
-    BlockListedTransactionHashBased(HashSet<HashValue>),
-    // Filters out user transactions which correspond to a set of senders.
-    BlockListedSenderBased(HashSet<AccountAddress>),
-    // Only allow user transactions which corresponds to a set of entry functions.
-    AllowListEntryFunctions(HashSet<(AccountAddress, String, String)>),
-    // Filters out all user transactions which corresponds to a set of entry functions.
-    BlockListEntryFunctions(HashSet<(AccountAddress, String, String)>),
-    // Only allow user transactions which corresponds to a set of module addresses.
-    AllowListModuleAddresses(HashSet<AccountAddress>),
-    // Filters out all user transactions which corresponds to a set of module addresses.
-    BlockListModuleAddresses(HashSet<AccountAddress>),
+    pub transaction_filter: Filter,
 }
 
 impl std::fmt::Debug for ExecutionConfig {
@@ -89,7 +65,7 @@ impl Default for ExecutionConfig {
             paranoid_type_verification: true,
             paranoid_hot_potato_verification: true,
             processed_transactions_detailed_counters: false,
-            transaction_filter: TransactionFilterType::default(),
+            transaction_filter: Filter::empty(),
         }
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -31,6 +31,7 @@ mod safety_rules_config;
 mod secure_backend_config;
 mod state_sync_config;
 mod storage_config;
+pub mod transaction_filter_type;
 mod utils;
 
 // All public usage statements should be declared below

--- a/config/src/config/transaction_filter_type.rs
+++ b/config/src/config/transaction_filter_type.rs
@@ -50,27 +50,27 @@ enum Rule {
     Deny(Matcher),
 }
 
-enum MatchResult {
+enum EvalResult {
     Allow,
     Deny,
     NoMatch,
 }
 
 impl Rule {
-    fn matches(&self, block_id: HashValue, txn: &SignedTransaction) -> MatchResult {
+    fn eval(&self, block_id: HashValue, txn: &SignedTransaction) -> EvalResult {
         match self {
             Rule::Allow(matcher) => {
                 if matcher.matches(block_id, txn) {
-                    MatchResult::Allow
+                    EvalResult::Allow
                 } else {
-                    MatchResult::NoMatch
+                    EvalResult::NoMatch
                 }
             },
             Rule::Deny(matcher) => {
                 if matcher.matches(block_id, txn) {
-                    MatchResult::Deny
+                    EvalResult::Deny
                 } else {
-                    MatchResult::NoMatch
+                    EvalResult::NoMatch
                 }
             },
         }
@@ -179,12 +179,12 @@ impl Filter {
         self
     }
 
-    pub fn matches(&self, block_id: HashValue, txn: &SignedTransaction) -> bool {
+    pub fn allows(&self, block_id: HashValue, txn: &SignedTransaction) -> bool {
         for rule in &self.rules {
-            match rule.matches(block_id, txn) {
-                MatchResult::Allow => return true,
-                MatchResult::Deny => return false,
-                MatchResult::NoMatch => continue,
+            match rule.eval(block_id, txn) {
+                EvalResult::Allow => return true,
+                EvalResult::Deny => return false,
+                EvalResult::NoMatch => continue,
             }
         }
         true

--- a/config/src/config/transaction_filter_type.rs
+++ b/config/src/config/transaction_filter_type.rs
@@ -1,0 +1,192 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{SignedTransaction, TransactionPayload},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+enum Matcher {
+    All,
+    BlockId(HashValue),
+    TransactionId(HashValue),
+    Sender(AccountAddress),
+    ModuleAddress(AccountAddress),
+    EntryFunction(AccountAddress, String, String),
+}
+
+impl Matcher {
+    fn matches(&self, block_id: HashValue, txn: &SignedTransaction) -> bool {
+        match self {
+            Matcher::All => true,
+            Matcher::BlockId(id) => block_id == *id,
+            Matcher::TransactionId(id) => txn.clone().committed_hash() == *id,
+            Matcher::Sender(sender) => txn.sender() == *sender,
+            Matcher::ModuleAddress(address) => match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => {
+                    *entry_function.module().address() == *address
+                },
+                _ => false,
+            },
+            Matcher::EntryFunction(address, module_name, function) => match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => {
+                    *entry_function.module().address() == *address
+                        && entry_function.module().name().to_string() == *module_name
+                        && entry_function.function().to_string() == *function
+                },
+                _ => false,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+enum Rule {
+    Allow(Matcher),
+    Deny(Matcher),
+}
+
+enum MatchResult {
+    Allow,
+    Deny,
+    NoMatch,
+}
+
+impl Rule {
+    fn matches(&self, block_id: HashValue, txn: &SignedTransaction) -> MatchResult {
+        match self {
+            Rule::Allow(matcher) => {
+                if matcher.matches(block_id, txn) {
+                    MatchResult::Allow
+                } else {
+                    MatchResult::NoMatch
+                }
+            },
+            Rule::Deny(matcher) => {
+                if matcher.matches(block_id, txn) {
+                    MatchResult::Deny
+                } else {
+                    MatchResult::NoMatch
+                }
+            },
+        }
+    }
+}
+
+/// A filter that can be used to allow or deny transactions from being executed. It contains a set
+/// of rules that are evaluated one by one in the order of declaration.
+/// If a rule matches, the transaction is either allowed or
+/// denied depending on the rule. If no rule matches, the transaction is allowed.
+/// For example a rules might look like this:
+///             rules:
+///                 - Allow:
+///                     Sender: f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a
+///                 - Allow:
+///                     ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000001"
+///                 - Allow:
+///                     EntryFunction:
+///                         - "0000000000000000000000000000000000000000000000000000000000000001"
+///                         - test
+///                         - check
+///                 - Allow:
+///                     EntryFunction:
+///                         - "0000000000000000000000000000000000000000000000000000000000000001"
+///                         - test
+///                         - new
+///                 - Deny: All
+/// This filter allows transactions from the sender with address f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a or
+/// from the module with address 0000000000000000000000000000000000000000000000000000000000000001 or entry functions
+/// test::check and test::new from the module 0000000000000000000000000000000000000000000000000000000000000001. All other transactions are denied.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Filter {
+    rules: Vec<Rule>,
+}
+
+impl Filter {
+    pub fn empty() -> Self {
+        Self { rules: vec![] }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    pub fn add_deny_all(mut self) -> Self {
+        self.rules.push(Rule::Deny(Matcher::All));
+        self
+    }
+
+    pub fn add_deny_block_id(mut self, block_id: HashValue) -> Self {
+        self.rules.push(Rule::Deny(Matcher::BlockId(block_id)));
+        self
+    }
+
+    pub fn add_deny_transaction_id(mut self, txn_id: HashValue) -> Self {
+        self.rules.push(Rule::Deny(Matcher::TransactionId(txn_id)));
+        self
+    }
+
+    pub fn add_allow_sender(mut self, sender: AccountAddress) -> Self {
+        self.rules.push(Rule::Allow(Matcher::Sender(sender)));
+        self
+    }
+
+    pub fn add_deny_sender(mut self, sender: AccountAddress) -> Self {
+        self.rules.push(Rule::Deny(Matcher::Sender(sender)));
+        self
+    }
+
+    pub fn add_allow_module_address(mut self, address: AccountAddress) -> Self {
+        self.rules
+            .push(Rule::Allow(Matcher::ModuleAddress(address)));
+        self
+    }
+
+    pub fn add_deny_module_address(mut self, address: AccountAddress) -> Self {
+        self.rules.push(Rule::Deny(Matcher::ModuleAddress(address)));
+        self
+    }
+
+    pub fn add_deny_entry_function(
+        mut self,
+        address: AccountAddress,
+        module_name: String,
+        function: String,
+    ) -> Self {
+        self.rules.push(Rule::Deny(Matcher::EntryFunction(
+            address,
+            module_name,
+            function,
+        )));
+        self
+    }
+
+    pub fn add_allow_entry_function(
+        mut self,
+        address: AccountAddress,
+        module_name: String,
+        function: String,
+    ) -> Self {
+        self.rules.push(Rule::Allow(Matcher::EntryFunction(
+            address,
+            module_name,
+            function,
+        )));
+        self
+    }
+
+    pub fn matches(&self, block_id: HashValue, txn: &SignedTransaction) -> bool {
+        for rule in &self.rules {
+            match rule.matches(block_id, txn) {
+                MatchResult::Allow => return true,
+                MatchResult::Deny => return false,
+                MatchResult::NoMatch => continue,
+            }
+        }
+        true
+    }
+}

--- a/config/src/config/transaction_filter_type.rs
+++ b/config/src/config/transaction_filter_type.rs
@@ -1,5 +1,4 @@
 // Copyright © Aptos Foundation
-// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::HashValue;
@@ -181,6 +180,8 @@ impl Filter {
 
     pub fn allows(&self, block_id: HashValue, txn: &SignedTransaction) -> bool {
         for rule in &self.rules {
+            // Rules are evaluated in the order and the first rule that matches is used. If no rule
+            // matches, the transaction is allowed.
             match rule.eval(block_id, txn) {
                 EvalResult::Allow => return true,
                 EvalResult::Deny => return false,

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -70,6 +70,7 @@ scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -10,7 +10,7 @@ use crate::{
     persistent_liveness_storage::StorageWriteProxy,
     quorum_store::quorum_store_db::QuorumStoreDB,
     state_computer::ExecutionProxy,
-    transaction_filter::create_transaction_filter,
+    transaction_filter::TransactionFilter,
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
 };
@@ -52,7 +52,7 @@ pub fn start_consensus(
         txn_notifier,
         state_sync_notifier,
         runtime.handle(),
-        create_transaction_filter(node_config.execution.transaction_filter.clone()),
+        TransactionFilter::new(node_config.execution.transaction_filter.clone()),
     ));
 
     let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -10,6 +10,7 @@ use crate::{
     persistent_liveness_storage::StorageWriteProxy,
     quorum_store::quorum_store_db::QuorumStoreDB,
     state_computer::ExecutionProxy,
+    transaction_filter::create_transaction_filter,
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
 };
@@ -51,6 +52,7 @@ pub fn start_consensus(
         txn_notifier,
         state_sync_notifier,
         runtime.handle(),
+        create_transaction_filter(node_config.execution.transaction_filter.clone()),
     ));
 
     let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -57,7 +57,8 @@ use anyhow::{bail, ensure, Context};
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{
-    ConsensusConfig, DagConsensusConfig, NodeConfig, QcAggregatorType, SecureBackend,
+    ConsensusConfig, DagConsensusConfig, ExecutionConfig, NodeConfig, QcAggregatorType,
+    SecureBackend,
 };
 use aptos_consensus_types::{
     common::{Author, Round},
@@ -120,6 +121,7 @@ pub enum LivenessStorageData {
 pub struct EpochManager<P: OnChainConfigProvider> {
     author: Author,
     config: ConsensusConfig,
+    execution_config: ExecutionConfig,
     time_service: Arc<dyn TimeService>,
     self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
@@ -174,12 +176,14 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
+        let execution_config = node_config.execution.clone();
         let dag_config = node_config.dag_consensus.clone();
         let sr_config = &node_config.consensus.safety_rules;
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
         Self {
             author,
             config,
+            execution_config,
             time_service,
             self_sender,
             network_sender,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -55,6 +55,7 @@ mod payload_manager;
 mod qc_aggregator;
 mod sender_aware_shuffler;
 mod transaction_deduper;
+mod transaction_filter;
 mod transaction_shuffler;
 mod txn_hash_and_authenticator_deduper;
 

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -11,6 +11,7 @@ use crate::{
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     transaction_deduper::TransactionDeduper,
+    transaction_filter::TransactionFilter,
     transaction_shuffler::TransactionShuffler,
     txn_notifier::TxnNotifier,
 };
@@ -63,6 +64,7 @@ pub struct ExecutionProxy {
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
     maybe_block_gas_limit: Mutex<Option<u64>>,
     transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
+    transaction_filter: Arc<dyn TransactionFilter>,
     execution_pipeline: ExecutionPipeline,
 }
 
@@ -72,6 +74,7 @@ impl ExecutionProxy {
         txn_notifier: Arc<dyn TxnNotifier>,
         state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
         handle: &tokio::runtime::Handle,
+        txn_filter: Arc<dyn TransactionFilter>,
     ) -> Self {
         let (tx, mut rx) =
             aptos_channels::new::<NotificationType>(10, &counters::PENDING_STATE_SYNC_NOTIFICATION);
@@ -100,6 +103,7 @@ impl ExecutionProxy {
             transaction_shuffler: Mutex::new(None),
             maybe_block_gas_limit: Mutex::new(None),
             transaction_deduper: Mutex::new(None),
+            transaction_filter: txn_filter,
             execution_pipeline,
         }
     }
@@ -131,7 +135,8 @@ impl StateComputer for ExecutionProxy {
             Err(err) => return Box::pin(async move { Err(err) }),
         };
 
-        let deduped_txns = txn_deduper.dedup(txns);
+        let filtered_txns = self.transaction_filter.filter(block_id, txns);
+        let deduped_txns = txn_deduper.dedup(filtered_txns);
         let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
 
         let maybe_block_gas_limit = *self.maybe_block_gas_limit.lock();
@@ -209,7 +214,8 @@ impl StateComputer for ExecutionProxy {
             }
 
             let signed_txns = payload_manager.get_transactions(block.block()).await?;
-            let deduped_txns = txn_deduper.dedup(signed_txns);
+            let filtered_txns = self.transaction_filter.filter(block.id(), signed_txns);
+            let deduped_txns = txn_deduper.dedup(filtered_txns);
             let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
 
             txns.extend(block.transactions_to_commit(
@@ -336,8 +342,10 @@ impl StateComputer for ExecutionProxy {
 async fn test_commit_sync_race() {
     use crate::{
         error::MempoolError, transaction_deduper::create_transaction_deduper,
+        transaction_filter::create_transaction_filter,
         transaction_shuffler::create_transaction_shuffler,
     };
+    use aptos_config::config::TransactionFilterType;
     use aptos_consensus_notifications::Error;
     use aptos_executor_types::state_checkpoint_output::StateCheckpointOutput;
     use aptos_types::{
@@ -460,6 +468,7 @@ async fn test_commit_sync_race() {
         recorded_commit.clone(),
         recorded_commit.clone(),
         &tokio::runtime::Handle::current(),
+        create_transaction_filter(TransactionFilterType::default()),
     );
     executor.new_epoch(
         &EpochState::empty(),

--- a/consensus/src/transaction_filter/mod.rs
+++ b/consensus/src/transaction_filter/mod.rs
@@ -1,0 +1,443 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_config::config::TransactionFilterType;
+use aptos_crypto::HashValue;
+use aptos_types::transaction::{SignedTransaction, TransactionPayload};
+use move_core_types::account_address::AccountAddress;
+use std::{collections::HashSet, sync::Arc};
+
+pub trait TransactionFilter: Send + Sync {
+    fn filter(&self, block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction>;
+}
+
+pub fn create_transaction_filter(
+    transaction_filter_type: TransactionFilterType,
+) -> Arc<dyn TransactionFilter> {
+    match transaction_filter_type {
+        TransactionFilterType::NoFilter => Arc::new(NoTransactionFilter {}),
+        TransactionFilterType::AllTransactions => Arc::new(AllTransactionsFilter {}),
+        TransactionFilterType::BlockListedBlockIdBased(block_id) => {
+            Arc::new(BlockListedBlockIdsFilter { block_id })
+        },
+        TransactionFilterType::BlockListedTransactionHashBased(transaction_hash) => {
+            Arc::new(BlockListedTransactionHashesFilter { transaction_hash })
+        },
+        TransactionFilterType::BlockListedSenderBased(blocked_senders) => {
+            Arc::new(BlockListedSendersFilter { blocked_senders })
+        },
+        TransactionFilterType::AllowListEntryFunctions(allowed_entry_functions) => {
+            Arc::new(AllowListEntryFunctionFilter {
+                allowed_entry_functions,
+            })
+        },
+        TransactionFilterType::BlockListEntryFunctions(blocked_entry_functions) => {
+            Arc::new(BlockListEntryFunctionFilter {
+                blocked_entry_functions,
+            })
+        },
+        TransactionFilterType::AllowListModuleAddresses(allowed_module_addresses) => {
+            Arc::new(AllowListModuleAddressFilter {
+                allowed_module_addresses,
+            })
+        },
+        TransactionFilterType::BlockListModuleAddresses(blocked_module_addresses) => {
+            Arc::new(BlockListModuleAddressFilter {
+                blocked_module_addresses,
+            })
+        },
+    }
+}
+
+struct NoTransactionFilter {}
+
+impl TransactionFilter for NoTransactionFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns
+    }
+}
+
+/// A filter that filters out all user transactions.
+struct AllTransactionsFilter {}
+
+impl TransactionFilter for AllTransactionsFilter {
+    fn filter(
+        &self,
+        _block_id: HashValue,
+        _txns: Vec<SignedTransaction>,
+    ) -> Vec<SignedTransaction> {
+        vec![]
+    }
+}
+
+struct BlockListedBlockIdsFilter {
+    block_id: HashSet<HashValue>,
+}
+
+impl TransactionFilter for BlockListedBlockIdsFilter {
+    fn filter(&self, block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        if self.block_id.contains(&block_id) {
+            vec![]
+        } else {
+            txns
+        }
+    }
+}
+
+struct BlockListedTransactionHashesFilter {
+    transaction_hash: HashSet<HashValue>,
+}
+
+impl TransactionFilter for BlockListedTransactionHashesFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| {
+                !self
+                    .transaction_hash
+                    .contains(&txn.clone().committed_hash())
+            })
+            .collect()
+    }
+}
+
+struct BlockListedSendersFilter {
+    blocked_senders: HashSet<AccountAddress>,
+}
+
+impl TransactionFilter for BlockListedSendersFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| !self.blocked_senders.contains(&txn.sender()))
+            .collect()
+    }
+}
+
+struct AllowListEntryFunctionFilter {
+    allowed_entry_functions: HashSet<(AccountAddress, String, String)>,
+}
+
+impl TransactionFilter for AllowListEntryFunctionFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => {
+                    self.allowed_entry_functions.contains(&(
+                        *entry_function.module().address(),
+                        entry_function.module().name().to_string(),
+                        entry_function.function().to_string(),
+                    ))
+                },
+                _ => false,
+            })
+            .collect()
+    }
+}
+
+struct BlockListEntryFunctionFilter {
+    blocked_entry_functions: HashSet<(AccountAddress, String, String)>,
+}
+
+impl TransactionFilter for BlockListEntryFunctionFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => {
+                    !self.blocked_entry_functions.contains(&(
+                        *entry_function.module().address(),
+                        entry_function.module().name().to_string(),
+                        entry_function.function().to_string(),
+                    ))
+                },
+                _ => true,
+            })
+            .collect()
+    }
+}
+
+struct AllowListModuleAddressFilter {
+    allowed_module_addresses: HashSet<AccountAddress>,
+}
+
+impl TransactionFilter for AllowListModuleAddressFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => self
+                    .allowed_module_addresses
+                    .contains(entry_function.module().address()),
+                _ => false,
+            })
+            .collect()
+    }
+}
+
+struct BlockListModuleAddressFilter {
+    blocked_module_addresses: HashSet<AccountAddress>,
+}
+
+impl TransactionFilter for BlockListModuleAddressFilter {
+    fn filter(&self, _block_id: HashValue, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns.into_iter()
+            .filter(|txn| match txn.payload() {
+                TransactionPayload::EntryFunction(entry_function) => !self
+                    .blocked_module_addresses
+                    .contains(entry_function.module().address()),
+                _ => true,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use aptos_config::config::TransactionFilterType;
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use aptos_types::{
+        chain_id::ChainId,
+        move_utils::MemberId,
+        transaction::{EntryFunction, RawTransaction, SignedTransaction, TransactionPayload},
+    };
+    use move_core_types::account_address::AccountAddress;
+    use std::collections::HashSet;
+
+    fn create_signed_transaction(function: MemberId) -> SignedTransaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let sender = AccountAddress::random();
+        let sequence_number = 0;
+        let MemberId {
+            module_id,
+            member_id: function_id,
+        } = function;
+
+        let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+            module_id,
+            function_id,
+            vec![],
+            vec![],
+        ));
+        let raw_transaction =
+            RawTransaction::new(sender, sequence_number, payload, 0, 0, 0, ChainId::new(10));
+
+        SignedTransaction::new(
+            raw_transaction.clone(),
+            public_key.clone(),
+            private_key.sign(&raw_transaction).unwrap(),
+        )
+    }
+
+    fn get_transactions() -> Vec<SignedTransaction> {
+        vec![
+            create_signed_transaction(str::parse("0x1::test::add").unwrap()),
+            create_signed_transaction(str::parse("0x1::test::check").unwrap()),
+            create_signed_transaction(str::parse("0x1::test::new").unwrap()),
+            create_signed_transaction(str::parse("0x1::test::sub").unwrap()),
+            create_signed_transaction(str::parse("0x2::test2::mul").unwrap()),
+            create_signed_transaction(str::parse("0x3::test2::div").unwrap()),
+            create_signed_transaction(str::parse("0x4::test2::mod").unwrap()),
+        ]
+    }
+
+    fn get_module_address(txn: &SignedTransaction) -> AccountAddress {
+        match txn.payload() {
+            TransactionPayload::EntryFunction(entry_func) => *entry_func.module().address(),
+            _ => panic!("Unexpected transaction payload"),
+        }
+    }
+
+    fn get_module_name(txn: &SignedTransaction) -> String {
+        match txn.payload() {
+            TransactionPayload::EntryFunction(entry_func) => entry_func.module().name().to_string(),
+            _ => panic!("Unexpected transaction payload"),
+        }
+    }
+
+    fn get_function_name(txn: &SignedTransaction) -> String {
+        match txn.payload() {
+            TransactionPayload::EntryFunction(entry_func) => entry_func.function().to_string(),
+            _ => panic!("Unexpected transaction payload"),
+        }
+    }
+
+    #[test]
+    fn test_no_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let no_filter = super::create_transaction_filter(TransactionFilterType::NoFilter);
+        let filtered_txns = no_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+
+    #[test]
+    fn test_all_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let all_filter = super::create_transaction_filter(TransactionFilterType::AllTransactions);
+        let filtered_txns = all_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+    }
+
+    #[test]
+    fn test_block_id_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut block_id_set = HashSet::new();
+        block_id_set.insert(block_id);
+        let block_id_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListedBlockIdBased(block_id_set),
+        );
+
+        let filtered_txns = block_id_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+
+        let block_id = HashValue::random();
+        let filtered_txns = block_id_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+
+    #[test]
+    fn test_transaction_hash_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut transaction_hash_set = HashSet::new();
+        transaction_hash_set.insert(txns[0].clone().committed_hash());
+        let transaction_hash_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListedTransactionHashBased(transaction_hash_set),
+        );
+        let filtered_txns = transaction_hash_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[1..].to_vec());
+
+        let mut transaction_hash_set = HashSet::new();
+        transaction_hash_set.insert(HashValue::random());
+        let transaction_hash_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListedTransactionHashBased(transaction_hash_set),
+        );
+        let filtered_txns = transaction_hash_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+
+    #[test]
+    fn test_sender_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut blocked_senders = HashSet::new();
+        blocked_senders.insert(txns[0].sender());
+        blocked_senders.insert(txns[1].sender());
+        let block_list_sender_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListedSenderBased(blocked_senders),
+        );
+        let filtered_txns = block_list_sender_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[2..].to_vec());
+
+        let blocked_senders = HashSet::new();
+        let block_list_sender_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListedSenderBased(blocked_senders),
+        );
+        let filtered_txns = block_list_sender_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+
+    #[test]
+    fn test_allow_list_entry_function_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut allowed_entry_functions = HashSet::new();
+
+        allowed_entry_functions.insert((
+            get_module_address(&txns[0]),
+            get_module_name(&txns[0]),
+            get_function_name(&txns[0]),
+        ));
+        allowed_entry_functions.insert((
+            get_module_address(&txns[1]),
+            get_module_name(&txns[1]),
+            get_function_name(&txns[1]),
+        ));
+
+        let allow_list_entry_function_filter = super::create_transaction_filter(
+            TransactionFilterType::AllowListEntryFunctions(allowed_entry_functions),
+        );
+        let filtered_txns = allow_list_entry_function_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[0..2].to_vec());
+
+        let allowed_entry_functions = HashSet::new();
+        let allow_list_entry_function_filter = super::create_transaction_filter(
+            TransactionFilterType::AllowListEntryFunctions(allowed_entry_functions),
+        );
+        let filtered_txns = allow_list_entry_function_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+    }
+
+    #[test]
+    fn test_block_list_entry_function_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut blocked_entry_functions = HashSet::new();
+        blocked_entry_functions.insert((
+            get_module_address(&txns[0]),
+            get_module_name(&txns[0]),
+            get_function_name(&txns[0]),
+        ));
+
+        blocked_entry_functions.insert((
+            get_module_address(&txns[1]),
+            get_module_name(&txns[1]),
+            get_function_name(&txns[1]),
+        ));
+
+        let block_list_entry_function_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListEntryFunctions(blocked_entry_functions),
+        );
+        let filtered_txns = block_list_entry_function_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[2..].to_vec());
+
+        let blocked_entry_functions = HashSet::new();
+        let block_list_entry_function_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListEntryFunctions(blocked_entry_functions),
+        );
+        let filtered_txns = block_list_entry_function_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+
+    #[test]
+    fn test_allow_list_module_address_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut allowed_module_addresses = HashSet::new();
+        allowed_module_addresses.insert(get_module_address(&txns[0])); // Only 0x1 is allowed
+        let allow_list_module_address_filter = super::create_transaction_filter(
+            TransactionFilterType::AllowListModuleAddresses(allowed_module_addresses),
+        );
+        let filtered_txns = allow_list_module_address_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[0..4].to_vec());
+
+        let allowed_module_addresses = HashSet::new();
+        let allow_list_module_address_filter = super::create_transaction_filter(
+            TransactionFilterType::AllowListModuleAddresses(allowed_module_addresses),
+        );
+        let filtered_txns = allow_list_module_address_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+    }
+
+    #[test]
+    fn test_block_list_module_address_filter() {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        let mut blocked_module_addresses = HashSet::new();
+        blocked_module_addresses.insert(get_module_address(&txns[0])); // 0x1 is blocked
+
+        let block_list_module_address_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListModuleAddresses(blocked_module_addresses),
+        );
+        let filtered_txns = block_list_module_address_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns[4..].to_vec());
+
+        let blocked_module_addresses = HashSet::new();
+        let block_list_module_address_filter = super::create_transaction_filter(
+            TransactionFilterType::BlockListModuleAddresses(blocked_module_addresses),
+        );
+        let filtered_txns = block_list_module_address_filter.filter(block_id, txns.clone());
+        assert_eq!(filtered_txns, txns);
+    }
+}

--- a/consensus/src/transaction_filter/mod.rs
+++ b/consensus/src/transaction_filter/mod.rs
@@ -17,7 +17,7 @@ impl TransactionFilter {
 
     pub fn filter(
         &self,
-        _block_id: HashValue,
+        block_id: HashValue,
         txns: Vec<SignedTransaction>,
     ) -> Vec<SignedTransaction> {
         // Special case for no filter to avoid unnecessary iteration through all transactions in the default case
@@ -25,7 +25,7 @@ impl TransactionFilter {
             return txns;
         }
         txns.into_iter()
-            .filter(|txn| self.filter.matches(_block_id, txn))
+            .filter(|txn| self.filter.allows(block_id, txn))
             .collect()
     }
 }

--- a/consensus/src/transaction_filter/mod.rs
+++ b/consensus/src/transaction_filter/mod.rs
@@ -1,5 +1,4 @@
 // Copyright © Aptos Foundation
-// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_config::config::transaction_filter_type::Filter;


### PR DESCRIPTION
### Description

A filter that can be used to allow or deny transactions from being executed. It contains a set
of rules that are evaluated one by one in the order of declaration. If a rule matches, the transaction is either allowed or
denied depending on the rule. If no rule matches, the transaction is allowed. For example a rules might look like this:
```
    rules:
        - Allow:
            Sender: f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a
        - Allow:
            ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000001"
        - Allow:
            EntryFunction:
                - "0000000000000000000000000000000000000000000000000000000000000001"
                - test
                - check
        - Allow:
            EntryFunction:
                - "0000000000000000000000000000000000000000000000000000000000000001"
                - test
                - new
        - Deny: All
 ```
This filter allows transactions from the sender with address f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a or
from the module with address 0000000000000000000000000000000000000000000000000000000000000001 or entry functions
test::check and test::new from the module 0000000000000000000000000000000000000000000000000000000000000001. All other transactions are denied.

Support for various types of rules have been added as below 

```
    All,
    BlockId(HashValue),
    TransactionId(HashValue),
    Sender(AccountAddress),
    ModuleAddress(AccountAddress),
    EntryFunction(AccountAddress, String, String),
 ```


### Test Plan

Added comprehensive UTs.
