### PR TITLE
[NFT Metadata Crawler] Increase URI Parser coverage for redirected IPFS public gateway URIs

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
@@ -22,16 +22,18 @@ impl URIParser {
             uri
         };
 
+        // Expects the following format for provided URIs `ipfs/{CID}/{path}`
         let re = Regex::new(r"^(ipfs/)(?P<cid>[a-zA-Z0-9]+)(?P<path>/.*)?$")?;
+
+        // Expects the following format for provided URIs `https://{CID}.ipfs.com/{path}`
         let redir_re = Regex::new(r"https:\/\/(?P<cid>[^\.]+)\.ipfs\.[^\/]+(?P<path>\/.+)?")?;
 
         let path = Url::parse(&modified_uri)?
             .path_segments()
-            .map(|segments| segments.collect::<Vec<_>>().join("/"))
-            .unwrap_or_default();
+            .map(|segments| segments.collect::<Vec<_>>().join("/"));
 
         if let Some(captures) = re
-            .captures(&path)
+            .captures(&path.unwrap_or_default())
             .or_else(|| redir_re.captures(&modified_uri))
         {
             return Self::format_capture(captures, ipfs_prefix);


### PR DESCRIPTION
### Description
Most submitted IPFS asset URIs that use a public gateway are in this format: 
- `https://public.gateway.com/ipfs/<cid>/<path>`
- e.g. https://dweb.link/ipfs/bafybeifdkldssgfrlt4iukpniuq24fugpw53crt5jkchmo3wjypocwzi7y/101

When visited, the previous URI will redirect to this format:
- `https://<cid>.ipfs.public.gateway.com/<path>`
- e.g. https://bafybeifdkldssgfrlt4iukpniuq24fugpw53crt5jkchmo3wjypocwzi7y.ipfs.dweb.link/101

These changes add coverage to the URI Parser for the redirected version and increase the success rate for the parser. 

### Test Plan
Added said case to unit tests for URI Parser. 
