### PR TITLE
[quorum store][mempool] optimize pulling txns for when many txns are in progress

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -43,20 +43,13 @@ impl fmt::Display for TransactionSummary {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct TransactionInProgress {
-    pub summary: TransactionSummary,
-    pub gas_unit_price: u64,
-}
-
 #[derive(Clone)]
-pub struct TransactionInfo {
-    // TODO: scope?
+pub struct TransactionInProgress {
     pub gas_unit_price: u64,
     pub count: u64,
 }
 
-impl TransactionInfo {
+impl TransactionInProgress {
     pub fn new(gas_unit_price: u64) -> Self {
         Self {
             gas_unit_price,
@@ -68,7 +61,6 @@ impl TransactionInfo {
         self.gas_unit_price
     }
 
-    // TODO: scope?
     pub fn decrement(&mut self) -> u64 {
         self.count -= 1;
         self.count

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -43,7 +43,7 @@ impl fmt::Display for TransactionSummary {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TransactionInProgress {
     pub summary: TransactionSummary,
     pub gas_unit_price: u64,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -50,6 +50,37 @@ pub struct TransactionInProgress {
 }
 
 #[derive(Clone)]
+pub struct TransactionInfo {
+    // TODO: scope?
+    pub gas_unit_price: u64,
+    pub count: u64,
+}
+
+impl TransactionInfo {
+    pub fn new(gas_unit_price: u64) -> Self {
+        Self {
+            gas_unit_price,
+            count: 0,
+        }
+    }
+
+    pub fn gas_unit_price(&self) -> u64 {
+        self.gas_unit_price
+    }
+
+    // TODO: scope?
+    pub fn decrement(&mut self) -> u64 {
+        self.count -= 1;
+        self.count
+    }
+
+    pub fn increment(&mut self) -> u64 {
+        self.count += 1;
+        self.count
+    }
+}
+
+#[derive(Clone)]
 pub struct RejectedTransactionSummary {
     pub sender: AccountAddress,
     pub sequence_number: u64,

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -310,7 +310,6 @@ impl BatchGenerator {
             let _timer = counters::BATCH_GENERATOR_MAIN_LOOP.start_timer();
 
             tokio::select! {
-                biased;
                 Some(updated_back_pressure) = back_pressure_rx.recv() => {
                     self.back_pressure = updated_back_pressure;
                 },

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -254,6 +254,16 @@ impl BatchGenerator {
         }
     }
 
+    #[cfg(test)]
+    pub fn remove_batch_in_progress_for_test(&mut self, batch_id: &BatchId) -> bool {
+        self.remove_batch_in_progress(batch_id)
+    }
+
+    #[cfg(test)]
+    pub fn txns_in_progress_sorted_len(&self) -> usize {
+        self.txns_in_progress_sorted.len()
+    }
+
     pub(crate) async fn handle_scheduled_pull(&mut self, max_count: u64) -> Vec<Batch> {
         counters::BATCH_PULL_EXCLUDED_TXNS.observe(self.txns_in_progress_sorted.len() as f64);
         trace!(

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -19,6 +19,7 @@ use aptos_logger::prelude::*;
 use aptos_mempool::QuorumStoreRequest;
 use aptos_types::{transaction::SignedTransaction, PeerId};
 use futures_channel::mpsc::Sender;
+use itertools::Itertools;
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -118,6 +119,7 @@ impl BatchGenerator {
                 },
                 gas_unit_price: txn.gas_unit_price(),
             })
+            .sorted()
             .collect();
         self.batches_in_progress.insert(batch_id, txns_in_progress);
         self.batch_expirations.add_item(batch_id, expiry_time);

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -271,13 +271,7 @@ impl BatchGenerator {
                 max_count,
                 self.config.mempool_txn_pull_max_bytes,
                 // TODO: pass the actual BTreeMap
-                self.txns_in_progress_sorted
-                    .iter()
-                    .map(|(summary, info)| TransactionInProgress {
-                        summary: *summary,
-                        gas_unit_price: info.gas_unit_price(),
-                    })
-                    .collect(),
+                self.txns_in_progress_sorted.clone(),
             )
             .await
             .unwrap_or_default();

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -4,7 +4,7 @@
 use crate::{monitor, quorum_store::counters};
 use anyhow::Result;
 use aptos_consensus_types::{
-    common::{Payload, PayloadFilter, TransactionInProgress, TransactionSummary},
+    common::{Payload, PayloadFilter, TransactionInfo, TransactionSummary},
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_logger::prelude::*;
@@ -17,7 +17,10 @@ use futures::{
     },
     StreamExt,
 };
-use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 use tokio::time::timeout;
 
 pub struct DirectMempoolQuorumStore {
@@ -47,12 +50,9 @@ impl DirectMempoolQuorumStore {
         exclude_txns: Vec<TransactionSummary>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
-        let exclude_txns: Vec<_> = exclude_txns
-            .iter()
-            .map(|txn| TransactionInProgress {
-                summary: *txn,
-                gas_unit_price: 0,
-            })
+        let exclude_txns: BTreeMap<_, _> = exclude_txns
+            .into_iter()
+            .map(|txn| (txn, TransactionInfo::new(0)))
             .collect();
         let msg = QuorumStoreRequest::GetBatchRequest(
             max_items,

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -4,7 +4,7 @@
 use crate::{monitor, quorum_store::counters};
 use anyhow::Result;
 use aptos_consensus_types::{
-    common::{Payload, PayloadFilter, TransactionInfo, TransactionSummary},
+    common::{Payload, PayloadFilter, TransactionInProgress, TransactionSummary},
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_logger::prelude::*;
@@ -52,7 +52,7 @@ impl DirectMempoolQuorumStore {
         let (callback, callback_rcv) = oneshot::channel();
         let exclude_txns: BTreeMap<_, _> = exclude_txns
             .into_iter()
-            .map(|txn| (txn, TransactionInfo::new(0)))
+            .map(|txn| (txn, TransactionInProgress::new(0)))
             .collect();
         let msg = QuorumStoreRequest::GetBatchRequest(
             max_items,

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -548,3 +548,58 @@ async fn test_sender_max_num_batches_multi_buckets() {
         .unwrap()
         .unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batches_in_progress_same_txn_across_batches() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        QuorumStoreConfig::default(),
+        Arc::new(MockQuorumStoreDB::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    let join_handle = tokio::spawn(async move {
+        let signed_txns = create_vec_signed_transactions(3);
+        let first_one: Vec<_> = signed_txns.iter().take(1).cloned().collect();
+        let first_two: Vec<_> = signed_txns.iter().take(2).cloned().collect();
+        let first_three: Vec<_> = signed_txns.iter().take(3).cloned().collect();
+
+        // Add multiple of the same txns across batches (txn1: 3 times, txn2: 2 times, txn3: 1 time)
+        queue_mempool_batch_response(first_one, 100, &mut quorum_store_to_mempool_rx).await;
+        queue_mempool_batch_response(first_two, 100, &mut quorum_store_to_mempool_rx).await;
+        queue_mempool_batch_response(first_three, 100, &mut quorum_store_to_mempool_rx).await;
+    });
+
+    let first_one_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_one_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 1);
+
+    let first_two_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_two_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 2);
+
+    let first_three_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_three_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 3);
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // After all batches are complete, txns_in_progress_sorted will be empty.
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_three_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 2);
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_two_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 1);
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_one_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 0);
+}

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -11,7 +11,10 @@ use crate::quorum_store::{
     },
 };
 use aptos_config::config::QuorumStoreConfig;
-use aptos_consensus_types::{common::TransactionInProgress, proof_of_store::BatchId};
+use aptos_consensus_types::{
+    common::{TransactionInfo, TransactionSummary},
+    proof_of_store::BatchId,
+};
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
 use aptos_types::transaction::SignedTransaction;
 use futures::{
@@ -19,7 +22,7 @@ use futures::{
     StreamExt,
 };
 use move_core_types::account_address::AccountAddress;
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel as TokioChannel, time::timeout};
 
 #[allow(clippy::needless_collect)]
@@ -27,7 +30,7 @@ async fn queue_mempool_batch_response(
     txns: Vec<SignedTransaction>,
     max_size: usize,
     quorum_store_to_mempool_receiver: &mut Receiver<QuorumStoreRequest>,
-) -> Vec<TransactionInProgress> {
+) -> BTreeMap<TransactionSummary, TransactionInfo> {
     if let QuorumStoreRequest::GetBatchRequest(
         _max_batch_size,
         _max_bytes,

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -12,7 +12,7 @@ use crate::quorum_store::{
 };
 use aptos_config::config::QuorumStoreConfig;
 use aptos_consensus_types::{
-    common::{TransactionInfo, TransactionSummary},
+    common::{TransactionInProgress, TransactionSummary},
     proof_of_store::BatchId,
 };
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
@@ -30,7 +30,7 @@ async fn queue_mempool_batch_response(
     txns: Vec<SignedTransaction>,
     max_size: usize,
     quorum_store_to_mempool_receiver: &mut Receiver<QuorumStoreRequest>,
-) -> BTreeMap<TransactionSummary, TransactionInfo> {
+) -> BTreeMap<TransactionSummary, TransactionInProgress> {
     if let QuorumStoreRequest::GetBatchRequest(
         _max_batch_size,
         _max_bytes,

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -3,7 +3,7 @@
 
 use crate::{monitor, quorum_store::counters};
 use aptos_consensus_types::{
-    common::{TransactionInfo, TransactionSummary},
+    common::{TransactionInProgress, TransactionSummary},
     proof_of_store::{BatchId, BatchInfo, ProofOfStore},
 };
 use aptos_logger::prelude::*;
@@ -104,7 +104,7 @@ impl MempoolProxy {
         &self,
         max_items: u64,
         max_bytes: u64,
-        exclude_transactions: BTreeMap<TransactionSummary, TransactionInfo>,
+        exclude_transactions: BTreeMap<TransactionSummary, TransactionInProgress>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
         let msg = QuorumStoreRequest::GetBatchRequest(

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -3,7 +3,7 @@
 
 use crate::{monitor, quorum_store::counters};
 use aptos_consensus_types::{
-    common::TransactionInProgress,
+    common::{TransactionInfo, TransactionSummary},
     proof_of_store::{BatchId, BatchInfo, ProofOfStore},
 };
 use aptos_logger::prelude::*;
@@ -104,7 +104,7 @@ impl MempoolProxy {
         &self,
         max_items: u64,
         max_bytes: u64,
-        exclude_transactions_sorted: Vec<TransactionInProgress>,
+        exclude_transactions: BTreeMap<TransactionSummary, TransactionInfo>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
         let msg = QuorumStoreRequest::GetBatchRequest(
@@ -112,7 +112,7 @@ impl MempoolProxy {
             max_bytes,
             true,
             true,
-            exclude_transactions_sorted,
+            exclude_transactions,
             callback,
         );
         self.mempool_tx

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -104,7 +104,7 @@ impl MempoolProxy {
         &self,
         max_items: u64,
         max_bytes: u64,
-        exclude_txns: Vec<TransactionInProgress>,
+        exclude_transactions_sorted: Vec<TransactionInProgress>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
         let msg = QuorumStoreRequest::GetBatchRequest(
@@ -112,7 +112,7 @@ impl MempoolProxy {
             max_bytes,
             true,
             true,
-            exclude_txns,
+            exclude_transactions_sorted,
             callback,
         );
         self.mempool_tx
@@ -129,12 +129,12 @@ impl MempoolProxy {
             .await
         ) {
             Err(_) => Err(anyhow::anyhow!(
-                "[direct_mempool_quorum_store] did not receive GetBatchResponse on time"
+                "[quorum_store] did not receive GetBatchResponse on time"
             )),
             Ok(resp) => match resp.map_err(anyhow::Error::from)?? {
                 QuorumStoreResponse::GetBatchResponse(txns) => Ok(txns),
                 _ => Err(anyhow::anyhow!(
-                    "[direct_mempool_quorum_store] did not receive expected GetBatchResponse"
+                    "[quorum_store] did not receive expected GetBatchResponse"
                 )),
             },
         }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -251,7 +251,6 @@ impl Mempool {
             }
         }
         let gas_end_time = start_time.elapsed();
-        let gas_time = gas_end_time;
 
         let mut result = vec![];
         // Helper DS. Helps to mitigate scenarios where account submits several transactions
@@ -351,7 +350,7 @@ impl Mempool {
                 byte_size = total_bytes,
                 block_size = block.len(),
                 return_non_full = return_non_full,
-                gas_time_ms = gas_time.as_millis(),
+                gas_time_ms = gas_end_time.as_millis(),
                 result_time_ms = result_time.as_millis(),
                 block_time_ms = block_time.as_millis(),
             );
@@ -369,7 +368,7 @@ impl Mempool {
                     byte_size = total_bytes,
                     block_size = block.len(),
                     return_non_full = return_non_full,
-                    gas_time_ms = gas_time.as_millis(),
+                    gas_time_ms = gas_end_time.as_millis(),
                     result_time_ms = result_time.as_millis(),
                     block_time_ms = block_time.as_millis(),
                 )

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -367,7 +367,7 @@ impl Mempool {
             );
         } else {
             sample!(
-                SampleRate::Duration(Duration::from_secs(1)),
+                SampleRate::Duration(Duration::from_secs(60)),
                 debug!(
                     LogSchema::new(LogEntry::GetBlock),
                     seen_consensus = exclude_size,

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -15,7 +15,7 @@ use crate::{
     shared_mempool::types::MultiBucketTimelineIndexIds,
 };
 use aptos_config::config::NodeConfig;
-use aptos_consensus_types::common::{TransactionInfo, TransactionSummary};
+use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
 use aptos_types::{
@@ -234,7 +234,7 @@ impl Mempool {
         max_bytes: u64,
         return_non_full: bool,
         include_gas_upgraded: bool,
-        exclude_transactions: BTreeMap<TransactionSummary, TransactionInfo>,
+        exclude_transactions: BTreeMap<TransactionSummary, TransactionInProgress>,
     ) -> Vec<SignedTransaction> {
         let start_time = Instant::now();
         let exclude_size = exclude_transactions.len();

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -238,11 +238,7 @@ impl Mempool {
     ) -> Vec<SignedTransaction> {
         let start_time = Instant::now();
         let exclude_size = exclude_transactions_sorted.len();
-        let sort_end_time = start_time.elapsed();
-        let sort_time = sort_end_time;
         let mut seen = HashMap::new();
-        let map_end_time = start_time.elapsed();
-        let map_time = map_end_time.saturating_sub(sort_end_time);
         let mut upgraded = HashSet::new();
         // Do not exclude transactions that had a gas upgrade
         if include_gas_upgraded {
@@ -257,7 +253,7 @@ impl Mempool {
             }
         }
         let gas_end_time = start_time.elapsed();
-        let gas_time = gas_end_time.saturating_sub(map_end_time);
+        let gas_time = gas_end_time;
 
         let mut result = vec![];
         // Helper DS. Helps to mitigate scenarios where account submits several transactions
@@ -365,8 +361,6 @@ impl Mempool {
                 byte_size = total_bytes,
                 block_size = block.len(),
                 return_non_full = return_non_full,
-                sort_time_ms = sort_time.as_millis(),
-                map_time_ms = map_time.as_millis(),
                 gas_time_ms = gas_time.as_millis(),
                 result_time_ms = result_time.as_millis(),
                 block_time_ms = block_time.as_millis(),
@@ -385,8 +379,6 @@ impl Mempool {
                     byte_size = total_bytes,
                     block_size = block.len(),
                     return_non_full = return_non_full,
-                    sort_time_ms = sort_time.as_millis(),
-                    map_time_ms = map_time.as_millis(),
                     gas_time_ms = gas_time.as_millis(),
                     result_time_ms = result_time.as_millis(),
                     block_time_ms = block_time.as_millis(),

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -241,14 +241,14 @@ impl Mempool {
         if include_gas_upgraded {
             exclude_transactions.sort();
         }
-        let sort_start_time = start_time.elapsed();
-        let sort_time = sort_start_time;
+        let sort_end_time = start_time.elapsed();
+        let sort_time = sort_end_time;
         let mut seen: HashMap<TxnPointer, u64> = exclude_transactions
             .iter()
             .map(|txn| (txn.summary, txn.gas_unit_price))
             .collect();
-        let map_start_time = start_time.elapsed();
-        let map_time = map_start_time.saturating_sub(sort_start_time);
+        let map_end_time = start_time.elapsed();
+        let map_time = map_end_time.saturating_sub(sort_end_time);
         // Do not exclude transactions that had a gas upgrade
         if include_gas_upgraded {
             let mut seen_and_upgraded = vec![];
@@ -263,8 +263,8 @@ impl Mempool {
                 seen.remove(txn_pointer);
             }
         }
-        let gas_start_time = start_time.elapsed();
-        let gas_time = gas_start_time.saturating_sub(map_start_time);
+        let gas_end_time = start_time.elapsed();
+        let gas_time = gas_end_time.saturating_sub(map_end_time);
 
         let mut result = vec![];
         // Helper DS. Helps to mitigate scenarios where account submits several transactions
@@ -313,8 +313,8 @@ impl Mempool {
             }
         }
         let result_size = result.len();
-        let result_start_time = start_time.elapsed();
-        let result_time = result_start_time.saturating_sub(gas_start_time);
+        let result_end_time = start_time.elapsed();
+        let result_time = result_end_time.saturating_sub(gas_end_time);
 
         let mut block = Vec::with_capacity(result_size);
         let mut full_bytes = false;
@@ -338,8 +338,8 @@ impl Mempool {
                 );
             }
         }
-        let block_start_time = start_time.elapsed();
-        let block_time = block_start_time.saturating_sub(result_time);
+        let block_end_time = start_time.elapsed();
+        let block_time = block_end_time.saturating_sub(result_end_time);
 
         if result_size > 0 {
             debug!(

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -234,14 +234,11 @@ impl Mempool {
         max_bytes: u64,
         return_non_full: bool,
         include_gas_upgraded: bool,
-        mut exclude_transactions: Vec<TransactionInProgress>,
+        // TODO: how to put in the API that this is sorted?
+        exclude_transactions: Vec<TransactionInProgress>,
     ) -> Vec<SignedTransaction> {
         let start_time = Instant::now();
         let exclude_size = exclude_transactions.len();
-        // Sort, so per TxnPointer the highest gas will be in the map
-        if include_gas_upgraded {
-            exclude_transactions.sort();
-        }
         let sort_end_time = start_time.elapsed();
         let sort_time = sort_end_time;
         let mut seen = HashMap::new();

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -311,6 +311,10 @@ impl TransactionStore {
             self.hash_index.len(),
         );
         counters::core_mempool_index_size(counters::SIZE_BYTES_LABEL, self.size_bytes);
+        counters::core_mempool_index_size(
+            counters::GAS_UPGRADED_INDEX_LABEL,
+            self.gas_upgraded_index.len(),
+        );
     }
 
     /// Checks if Mempool is full.

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -20,6 +20,7 @@ pub const TIMELINE_INDEX_LABEL: &str = "timeline";
 pub const PARKING_LOT_INDEX_LABEL: &str = "parking_lot";
 pub const TRANSACTION_HASH_INDEX_LABEL: &str = "transaction_hash";
 pub const SIZE_BYTES_LABEL: &str = "size_bytes";
+pub const GAS_UPGRADED_INDEX_LABEL: &str = "gas_upgraded";
 
 // Core mempool stages labels
 pub const COMMIT_ACCEPTED_LABEL: &str = "commit_accepted";

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -475,7 +475,7 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
             max_bytes,
             return_non_full,
             include_gas_upgraded,
-            exclude_transactions_sorted,
+            exclude_transactions,
             callback,
         ) => {
             let txns;
@@ -508,7 +508,7 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
                     max_bytes,
                     return_non_full,
                     include_gas_upgraded,
-                    exclude_transactions_sorted,
+                    exclude_transactions,
                 );
             }
 

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -475,7 +475,7 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
             max_bytes,
             return_non_full,
             include_gas_upgraded,
-            exclude_transactions,
+            exclude_transactions_sorted,
             callback,
         ) => {
             let txns;
@@ -508,7 +508,7 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
                     max_bytes,
                     return_non_full,
                     include_gas_upgraded,
-                    exclude_transactions,
+                    exclude_transactions_sorted,
                 );
             }
 

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -12,7 +12,9 @@ use aptos_config::{
     config::{MempoolConfig, RoleType},
     network_id::PeerNetworkId,
 };
-use aptos_consensus_types::common::{RejectedTransactionSummary, TransactionInProgress};
+use aptos_consensus_types::common::{
+    RejectedTransactionSummary, TransactionInfo, TransactionSummary,
+};
 use aptos_crypto::HashValue;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_network::{
@@ -170,7 +172,7 @@ pub enum QuorumStoreRequest {
         // include gas upgraded
         bool,
         // transactions to exclude from the requested batch
-        Vec<TransactionInProgress>,
+        BTreeMap<TransactionSummary, TransactionInfo>,
         // callback to respond to
         oneshot::Sender<Result<QuorumStoreResponse>>,
     ),

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -13,7 +13,7 @@ use aptos_config::{
     network_id::PeerNetworkId,
 };
 use aptos_consensus_types::common::{
-    RejectedTransactionSummary, TransactionInfo, TransactionSummary,
+    RejectedTransactionSummary, TransactionInProgress, TransactionSummary,
 };
 use aptos_crypto::HashValue;
 use aptos_infallible::{Mutex, RwLock};
@@ -172,7 +172,7 @@ pub enum QuorumStoreRequest {
         // include gas upgraded
         bool,
         // transactions to exclude from the requested batch
-        BTreeMap<TransactionSummary, TransactionInfo>,
+        BTreeMap<TransactionSummary, TransactionInProgress>,
         // callback to respond to
         oneshot::Sender<Result<QuorumStoreResponse>>,
     ),

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::{format_err, Result};
 use aptos_compression::metrics::CompressionClient;
 use aptos_config::config::{NodeConfig, MAX_APPLICATION_MESSAGE_SIZE};
-use aptos_consensus_types::common::{TransactionInfo, TransactionSummary};
+use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_types::{
     account_address::AccountAddress,
@@ -160,7 +160,7 @@ pub(crate) fn batch_add_signed_txn(
 }
 
 // Helper struct that keeps state between `.get_block` calls. Imitates work of Consensus.
-pub struct ConsensusMock(BTreeMap<TransactionSummary, TransactionInfo>);
+pub struct ConsensusMock(BTreeMap<TransactionSummary, TransactionInProgress>);
 
 impl ConsensusMock {
     pub(crate) fn new() -> Self {
@@ -176,7 +176,7 @@ impl ConsensusMock {
         let block = mempool.get_batch(max_txns, max_bytes, true, true, self.0.clone());
         block.iter().for_each(|t| {
             let txn_summary = TransactionSummary::new(t.sender(), t.sequence_number());
-            let txn_info = TransactionInfo::new(t.gas_unit_price());
+            let txn_info = TransactionInProgress::new(t.gas_unit_price());
             self.0.insert(txn_summary, txn_info);
         });
         block

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -10,12 +10,13 @@ use crate::{
     },
 };
 use aptos_config::config::NodeConfig;
-use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
+use aptos_consensus_types::common::{TransactionInProgress, TransactionInfo, TransactionSummary};
 use aptos_crypto::HashValue;
 use aptos_types::{
     mempool_status::MempoolStatusCode, transaction::SignedTransaction, vm_status::DiscardedVMStatus,
 };
 use itertools::Itertools;
+use maplit::btreemap;
 use std::time::{Duration, SystemTime};
 
 #[test]
@@ -294,7 +295,7 @@ fn test_system_ttl() {
 
     // GC routine should clear transaction from first insert but keep last one.
     mempool.gc();
-    let batch = mempool.get_batch(1, 1024, true, false, vec![]);
+    let batch = mempool.get_batch(1, 1024, true, false, btreemap![]);
     assert_eq!(vec![transaction.make_signed_transaction()], batch);
 }
 
@@ -306,11 +307,14 @@ fn test_commit_callback() {
     let txns = add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 6, 1)]);
 
     // Check that pool is empty.
-    assert!(pool.get_batch(1, 1024, true, false, vec![]).is_empty());
+    assert!(pool.get_batch(1, 1024, true, false, btreemap![]).is_empty());
     // Transaction 5 got back from consensus.
     pool.commit_transaction(&TestTransaction::get_address(1), 5);
     // Verify that we can execute transaction 6.
-    assert_eq!(pool.get_batch(1, 1024, true, false, vec![])[0], txns[0]);
+    assert_eq!(
+        pool.get_batch(1, 1024, true, false, btreemap![])[0],
+        txns[0]
+    );
 }
 
 #[test]
@@ -612,7 +616,7 @@ fn test_parking_lot_eviction() {
     }
     // Make sure that we have correct txns in Mempool.
     let mut txns: Vec<_> = pool
-        .get_batch(5, 5120, true, false, vec![])
+        .get_batch(5, 5120, true, false, btreemap![])
         .iter()
         .map(SignedTransaction::sequence_number)
         .collect();
@@ -641,7 +645,7 @@ fn test_parking_lot_evict_only_for_ready_txn_insertion() {
 
     // Make sure that we have correct txns in Mempool.
     let mut txns: Vec<_> = pool
-        .get_batch(5, 5120, true, false, vec![])
+        .get_batch(5, 5120, true, false, btreemap![])
         .iter()
         .map(SignedTransaction::sequence_number)
         .collect();
@@ -677,7 +681,7 @@ fn test_gc_ready_transaction() {
     pool.gc_by_expiration_time(Duration::from_secs(1));
 
     // Make sure txns 2 and 3 became not ready and we can't read them from any API.
-    let block = pool.get_batch(1, 1024, true, false, vec![]);
+    let block = pool.get_batch(1, 1024, true, false, btreemap![]);
     assert_eq!(block.len(), 1);
     assert_eq!(block[0].sequence_number(), 0);
 
@@ -702,7 +706,7 @@ fn test_clean_stuck_transactions() {
     let db_sequence_number = 10;
     let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
     pool.add_txn(txn, 1, db_sequence_number, TimelineState::NotReady, false);
-    let block = pool.get_batch(1, 1024, true, false, vec![]);
+    let block = pool.get_batch(1, 1024, true, false, btreemap![]);
     assert_eq!(block.len(), 1);
     assert_eq!(block[0].sequence_number(), 10);
 }
@@ -768,11 +772,11 @@ fn test_bytes_limit() {
     for seq in 0..100 {
         add_txn(&mut pool, TestTransaction::new(1, seq, 1)).unwrap();
     }
-    let get_all = pool.get_batch(100, 100 * 1024, true, false, vec![]);
+    let get_all = pool.get_batch(100, 100 * 1024, true, false, btreemap![]);
     assert_eq!(get_all.len(), 100);
     let txn_size = get_all[0].raw_txn_bytes_len() as u64;
     let limit = 10;
-    let hit_limit = pool.get_batch(100, txn_size * limit, true, false, vec![]);
+    let hit_limit = pool.get_batch(100, txn_size * limit, true, false, btreemap![]);
     assert_eq!(hit_limit.len(), limit as usize);
 }
 
@@ -820,7 +824,7 @@ fn test_sequence_number_behavior_at_capacity() {
     add_txn(&mut pool, TestTransaction::new(2, 0, 1)).unwrap();
     pool.commit_transaction(&TestTransaction::get_address(2), 0);
 
-    let batch = pool.get_batch(10, 10240, true, false, vec![]);
+    let batch = pool.get_batch(10, 10240, true, false, btreemap![]);
     assert_eq!(batch.len(), 1);
 }
 
@@ -831,13 +835,13 @@ fn test_not_return_non_full() {
     let mut pool = CoreMempool::new(&config);
     add_txn(&mut pool, TestTransaction::new(0, 0, 1)).unwrap();
 
-    let batch = pool.get_batch(10, 10240, true, false, vec![]);
+    let batch = pool.get_batch(10, 10240, true, false, btreemap![]);
     assert_eq!(batch.len(), 1);
 
-    let batch = pool.get_batch(10, 10240, false, false, vec![]);
+    let batch = pool.get_batch(10, 10240, false, false, btreemap![]);
     assert_eq!(batch.len(), 0);
 
-    let batch = pool.get_batch(1, 10240, false, false, vec![]);
+    let batch = pool.get_batch(1, 10240, false, false, btreemap![]);
     assert_eq!(batch.len(), 1);
 }
 
@@ -863,7 +867,9 @@ fn test_include_gas_upgraded() {
         ),
         gas_unit_price: low_gas_price,
     };
-    let batch = pool.get_batch(10, 10240, true, true, vec![low_gas_txn.clone()]);
+    let batch = pool.get_batch(10, 10240, true, true, btreemap! {
+        low_gas_txn.summary => TransactionInfo::new(low_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
 
     let high_gas_price = 100;
@@ -881,7 +887,9 @@ fn test_include_gas_upgraded() {
     };
 
     // When gas upgraded is allowed and the low gas txn (but not the high gas txn) is excluded, will the high gas txn be included.
-    let batch = pool.get_batch(10, 10240, true, true, vec![low_gas_txn.clone()]);
+    let batch = pool.get_batch(10, 10240, true, true, btreemap! {
+        low_gas_txn.summary => TransactionInfo::new(low_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 1);
     assert_eq!(
         batch[0].sender(),
@@ -890,19 +898,28 @@ fn test_include_gas_upgraded() {
     assert_eq!(batch[0].sequence_number(), sequence_number);
     assert_eq!(batch[0].gas_unit_price(), high_gas_price);
     // In all other cases, the transaction will be excluded.
-    let batch = pool.get_batch(10, 10240, true, false, vec![low_gas_txn.clone()]);
+    let batch = pool.get_batch(10, 10240, true, false, btreemap! {
+        low_gas_txn.summary => TransactionInfo::new(low_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
 
-    let batch = pool.get_batch(10, 10240, true, true, vec![high_gas_txn.clone()]);
+    let batch = pool.get_batch(10, 10240, true, true, btreemap! {
+        high_gas_txn.summary => TransactionInfo::new(high_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
-    let batch = pool.get_batch(10, 10240, true, false, vec![high_gas_txn.clone()]);
+    let batch = pool.get_batch(10, 10240, true, false, btreemap! {
+        high_gas_txn.summary => TransactionInfo::new(high_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
 
-    let mut exclude_transactions_sorted = vec![low_gas_txn.clone(), high_gas_txn.clone()];
-    exclude_transactions_sorted.sort();
-
-    let batch = pool.get_batch(10, 10240, true, true, exclude_transactions_sorted.clone());
+    let batch = pool.get_batch(10, 10240, true, true, btreemap! {
+        low_gas_txn.summary => TransactionInfo::new(low_gas_txn.gas_unit_price),
+        high_gas_txn.summary => TransactionInfo::new(high_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
-    let batch = pool.get_batch(10, 10240, true, false, exclude_transactions_sorted.clone());
+    let batch = pool.get_batch(10, 10240, true, false, btreemap! {
+        low_gas_txn.summary => TransactionInfo::new(low_gas_txn.gas_unit_price),
+        high_gas_txn.summary => TransactionInfo::new(high_gas_txn.gas_unit_price)
+    });
     assert_eq!(batch.len(), 0);
 }

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -898,22 +898,11 @@ fn test_include_gas_upgraded() {
     let batch = pool.get_batch(10, 10240, true, false, vec![high_gas_txn.clone()]);
     assert_eq!(batch.len(), 0);
 
-    let batch = pool.get_batch(10, 10240, true, true, vec![
-        low_gas_txn.clone(),
-        high_gas_txn.clone(),
-    ]);
-    assert_eq!(batch.len(), 0);
-    let batch = pool.get_batch(10, 10240, true, false, vec![
-        low_gas_txn.clone(),
-        high_gas_txn.clone(),
-    ]);
-    assert_eq!(batch.len(), 0);
+    let mut exclude_transactions_sorted = vec![low_gas_txn.clone(), high_gas_txn.clone()];
+    exclude_transactions_sorted.sort();
 
-    let batch = pool.get_batch(10, 10240, true, false, vec![
-        high_gas_txn.clone(),
-        low_gas_txn.clone(),
-    ]);
+    let batch = pool.get_batch(10, 10240, true, true, exclude_transactions_sorted.clone());
     assert_eq!(batch.len(), 0);
-    let batch = pool.get_batch(10, 10240, true, true, vec![high_gas_txn, low_gas_txn]);
+    let batch = pool.get_batch(10, 10240, true, false, exclude_transactions_sorted.clone());
     assert_eq!(batch.len(), 0);
 }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -38,7 +38,10 @@ use aptos_vm_validator::{
 };
 use futures::channel::mpsc;
 use maplit::hashmap;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 use tokio::runtime::{Handle, Runtime};
 
 /// Mock of a running instance of shared mempool.
@@ -187,7 +190,7 @@ impl MockSharedMempool {
     pub fn get_txns(&self, size: u64) -> Vec<SignedTransaction> {
         let pool = self.mempool.lock();
         // assume txn size is less than 100kb
-        pool.get_batch(size, size * 102400, true, false, vec![])
+        pool.get_batch(size, size * 102400, true, false, BTreeMap::new())
     }
 
     pub fn remove_txn(&self, txn: &SignedTransaction) {

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -24,6 +24,7 @@ use aptos_network::{
     ProtocolId,
 };
 use aptos_types::{transaction::SignedTransaction, PeerId};
+use maplit::btreemap;
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashMap;
 use tokio::runtime::Runtime;
@@ -376,7 +377,7 @@ impl TestHarness {
                                 102400,
                                 true,
                                 false,
-                                vec![],
+                                btreemap![],
                             );
                             for txn in transactions.iter() {
                                 assert!(block.contains(txn));

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -50,6 +50,7 @@ use aptos_types::{
 };
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
 use futures::{channel::oneshot, SinkExt};
+use maplit::btreemap;
 use std::{collections::HashMap, hash::Hash, sync::Arc};
 use tokio::{runtime::Handle, time::Duration};
 use tokio_stream::StreamExt;
@@ -170,7 +171,7 @@ impl MempoolNode {
             let block = self
                 .mempool
                 .lock()
-                .get_batch(100, 102400, true, false, vec![]);
+                .get_batch(100, 102400, true, false, btreemap![]);
 
             if block_contains_all_transactions(&block, txns) {
                 break;
@@ -223,7 +224,7 @@ impl MempoolNode {
         let block = self
             .mempool
             .lock()
-            .get_batch(100, 102400, true, false, vec![]);
+            .get_batch(100, 102400, true, false, btreemap![]);
         if !condition(&block, txns) {
             let actual: Vec<_> = block
                 .iter()


### PR DESCRIPTION
### Description

In forge `realistic_network_tuned_for_throughput` it was found that:
* Calling pull takes > 25 ms.
* In an edge case where the pull returns 0 new txns, this could cause livelock because the pull call would be called every 25 ms.

Resolved by:
* Optimizing the pull; now on the same workload the pull takes ~8 ms.
  * Instead of using a hashmap, use a sorted vector + binary search for the excluded txns
  * And only re-sort the vector when batches in progress is updated (instead of every pull)
* Checking the time taken to pull, and pulling less frequently if the pull takes > 12.5 ms.

### Test Plan

Existing tests, ran `realistic_network_tuned_for_throughput` as ad-hoc job and observed results.
