### PR TITLE
Resource group follow-up fix-ups

### DIFF
--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -188,7 +188,8 @@ pub trait AptosGasMeter: MoveGasMeter {
             Self::maybe_record_storage_deposit(group_metadata_op, slot_fee);
             total_refund += refund;
 
-            let bytes_fee = self.storage_fee_for_state_bytes(key, group_write.encoded_group_size());
+            let bytes_fee =
+                self.storage_fee_for_state_bytes(key, group_write.maybe_group_op_size());
 
             write_fee += slot_fee + bytes_fee;
         }

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -585,7 +585,8 @@ where
             Self::maybe_record_storage_deposit(group_metadata_op, slot_fee);
             total_refund += refund;
 
-            let bytes_fee = self.storage_fee_for_state_bytes(key, group_write.encoded_group_size());
+            let bytes_fee =
+                self.storage_fee_for_state_bytes(key, group_write.maybe_group_op_size());
 
             let fee = slot_fee + bytes_fee;
             // TODO: should we distringuish group writes.

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -125,17 +125,9 @@ pub trait TResourceGroupView {
             .map(|maybe_bytes| maybe_bytes.is_some())
     }
 
-    /// Executor view may internally implement a naive resource group cache when:
-    /// - ExecutorView is not based on block executor, such as ExecutorViewBase
-    /// - providing backwards compatibility (older gas versions) in storage adapter.
-    ///
-    /// The trait allows releasing the cache in such cases. Otherwise (default behavior),
-    /// if naive cache is not implemeneted (e.g. in block executor), None is returned.
     fn release_group_cache(
         &self,
-    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
-        None
-    }
+    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>>;
 }
 
 /// Allows to query modules from the state.
@@ -279,12 +271,8 @@ pub trait StateValueMetadataResolver {
         state_key: &StateKey,
     ) -> anyhow::Result<Option<StateValueMetadataKind>>;
 
+    /// Can also be used to get the metadata of a resource group at a provided group key.
     fn get_resource_state_value_metadata(
-        &self,
-        state_key: &StateKey,
-    ) -> anyhow::Result<Option<StateValueMetadataKind>>;
-
-    fn get_resource_group_state_value_metadata(
         &self,
         state_key: &StateKey,
     ) -> anyhow::Result<Option<StateValueMetadataKind>>;

--- a/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
@@ -98,9 +98,8 @@ impl<'r> ResourceGroupAdapter<'r> {
         );
 
         Self {
-            maybe_resource_group_view: (group_size_kind == GroupSizeKind::AsSum)
-                .then_some(maybe_resource_group_view)
-                .flatten(),
+            maybe_resource_group_view: maybe_resource_group_view
+                .filter(|_| group_size_kind == GroupSizeKind::AsSum),
             resource_view,
             group_size_kind,
             group_cache: RefCell::new(HashMap::new()),

--- a/aptos-move/aptos-vm-types/src/storage.rs
+++ b/aptos-move/aptos-vm-types/src/storage.rs
@@ -215,7 +215,7 @@ impl StoragePricingV3 {
         key: &StateKey,
         group_write: &GroupWrite,
     ) -> impl GasExpression<VMGasParameters, Unit = InternalGasUnit> {
-        match group_write.encoded_group_size() {
+        match group_write.maybe_group_op_size() {
             Some(group_op_size) => Either::Left(
                 STORAGE_IO_PER_STATE_SLOT_WRITE * NumArgs::new(1)
                     + STORAGE_IO_PER_STATE_BYTE_WRITE * self.write_op_size(key, group_op_size),

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -88,8 +88,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 
     // TODO: get rid of the cloning data-structures in the following APIs.
 
-    /// Should never be called after incorporate_additional_writes, as it
-    /// will consume vm_output to prepare an output with deltas.
+    /// Should never be called after incorporating materialized output, as that consumes vm_output.
     fn resource_group_write_set(&self) -> Vec<(StateKey, WriteOp, BTreeMap<StructTag, WriteOp>)> {
         self.vm_output
             .lock()
@@ -200,7 +199,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             <Self::Txn as BlockExecutableTransaction>::Value,
         >,
         patched_events: Vec<<Self::Txn as BlockExecutableTransaction>::Event>,
-        combined_groups: Vec<(
+        serialized_groups: Vec<(
             <Self::Txn as BlockExecutableTransaction>::Key,
             <Self::Txn as BlockExecutableTransaction>::Value,
         )>,
@@ -216,7 +215,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
                             aggregator_v1_writes,
                             patched_resource_write_set,
                             patched_events,
-                            combined_groups,
+                            serialized_groups,
                         ),
                 )
                 .is_ok(),

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -377,14 +377,6 @@ impl<'e, E: ExecutorView> StateValueMetadataResolver for StorageAdapter<'e, E> {
         self.executor_view
             .get_resource_state_value_metadata(state_key)
     }
-
-    fn get_resource_group_state_value_metadata(
-        &self,
-        _state_key: &StateKey,
-    ) -> anyhow::Result<Option<StateValueMetadataKind>> {
-        // TODO[agg_v2](fix): forward to self.executor_view.
-        unimplemented!("Resource group metadata handling not yet implemented");
-    }
 }
 
 // Allows to extract the view from `StorageAdapter`.

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -38,6 +38,7 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::{err_msg, StatusCode, VMStatus},
 };
+use std::collections::{BTreeMap, HashMap};
 
 /// We finish the session after the user transaction is done running to get the change set and
 /// charge gas and storage fee based on it before running storage refunds and the transaction
@@ -287,6 +288,12 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
             )
         }
     }
+
+    fn release_group_cache(
+        &self,
+    ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
+        unreachable!("Must not be called by RespawnedSession finish");
+    }
 }
 
 impl<'r> TModuleView for ExecutorViewWithChangeSet<'r> {
@@ -441,7 +448,6 @@ mod test {
                 key("resource_group_both"),
                 GroupWrite::new(
                     WriteOp::Deletion,
-                    0,
                     BTreeMap::from([
                         (
                             mock_tag_0(),
@@ -452,17 +458,18 @@ mod test {
                             (WriteOp::Modification(serialize(&300).into()), None),
                         ),
                     ]),
+                    0,
                 ),
             ),
             (
                 key("resource_group_write_set"),
                 GroupWrite::new(
                     WriteOp::Deletion,
-                    0,
                     BTreeMap::from([(
                         mock_tag_1(),
                         (WriteOp::Modification(serialize(&5000).into()), None),
                     )]),
+                    0,
                 ),
             ),
         ]);

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -189,8 +189,8 @@ impl<'r> WriteOpConverter<'r> {
         };
         Ok(GroupWrite::new(
             self.convert(state_value_metadata_result, metadata_op, false)?,
-            post_group_size,
             inner_ops,
+            post_group_size,
         ))
     }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1123,15 +1123,16 @@ where
             unsync_map.write(key, write_op, layout);
         }
 
-        // TODO[agg_v2](fix): provide layouts
-        for (group_key, _, group_ops) in output.resource_group_write_set().into_iter() {
+        for (group_key, metadata_op, group_ops) in output.resource_group_write_set().into_iter() {
             for (value_tag, group_op) in group_ops.into_iter() {
+                // TODO[agg_v2](fix): provide layouts
                 unsync_map
                     .insert_group_op(&group_key, value_tag, group_op)
                     .map_err(|_| {
                         PanicOr::Or(IntentionalFallbackToSequential::ResourceGroupError)
                     })?;
             }
+            unsync_map.write(group_key, metadata_op, None);
         }
 
         for (key, write_op) in output

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -110,7 +110,7 @@ impl WriteOp {
             (Deletion, Creation(data) | CreationWithMetadata {data, ..}) => {
                 *op = Modification(data)
             },
-            (DeletionWithMetadata {metadata, ..}, Creation(data)| CreationWithMetadata {data, ..}) => {
+            (DeletionWithMetadata {metadata, ..}, Creation(data) | CreationWithMetadata {data, ..}) => {
                 *op = ModificationWithMetadata{data, metadata: metadata.clone()}
             },
             (Creation(_) | CreationWithMetadata {..}, Deletion | DeletionWithMetadata {..}) => {


### PR DESCRIPTION
- Remove default implementation for release group cache and implement manually ("unimplemented") for RespawnedSession
- Provide base metadata op for MVHashMap/UnsyncMap when reading group from storage
- Process metadata op in sequential execution
- Address @zekun000's final comments from https://github.com/aptos-labs/aptos-core/pull/10514
- Delete unnecessary resource group metadata resolver API
- Add a member for group size in GroupWrite instead of encoding in fake metadata op bytes 