### PR TITLE
[api] Add BCS inputs for View Functions

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -18,7 +18,7 @@ runs:
 
     - name: install protoc and related tools
       shell: bash
-      run: scripts/dev_setup.sh -b -r -y -P -J -t
+      run: scripts/dev_setup.sh -b -r -y -P -t
 
     - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "anyhow",
  "aptos-api-test-context",
  "aptos-api-types",
+ "aptos-bcs-utils",
  "aptos-build-info",
  "aptos-cached-packages",
  "aptos-config",
@@ -599,6 +600,14 @@ dependencies = [
  "serde",
  "tokio",
  "warp",
+]
+
+[[package]]
+name = "aptos-bcs-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "crates/aptos",
     "crates/aptos-admin-service",
     "crates/aptos-api-tester",
+    "crates/aptos-bcs-utils",
     "crates/aptos-bitvec",
     "crates/aptos-build-info",
     "crates/aptos-compression",
@@ -276,6 +277,7 @@ aptos-api-test-context = { path = "api/test-context" }
 aptos-api-types = { path = "api/types" }
 aptos-backup-cli = { path = "storage/backup/backup-cli" }
 aptos-backup-service = { path = "storage/backup/backup-service" }
+aptos-bcs-utils = { path = "crates/aptos-bcs-utils" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }
 aptos-block-executor = { path = "aptos-move/block-executor" }
 aptos-bitvec = { path = "crates/aptos-bitvec" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
+aptos-bcs-utils = { workspace = true }
 aptos-build-info = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -11594,6 +11594,15 @@
               "schema": {
                 "$ref": "#/components/schemas/ViewRequest"
               }
+            },
+            "application/x.aptos.view_function+bcs": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              }
             }
           },
           "required": true

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -8691,6 +8691,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ViewRequest'
+          application/x.aptos.view_function+bcs:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: uint8
         required: true
       responses:
         '200':

--- a/api/src/view_function.rs
+++ b/api/src/view_function.rs
@@ -3,23 +3,40 @@
 
 use crate::{
     accept_type::AcceptType,
+    bcs_payload::Bcs,
     context::api_spawn_blocking,
     failpoint::fail_point_poem,
     response::{
         BadRequestError, BasicErrorWith404, BasicResponse, BasicResponseStatus, BasicResultWith404,
+        InternalError,
     },
     ApiTags, Context,
 };
-use aptos_api_types::{AptosErrorCode, AsConverter, MoveValue, ViewRequest, U64};
+use anyhow::Context as anyhowContext;
+use aptos_api_types::{
+    AptosErrorCode, AsConverter, MoveValue, ViewFunction, ViewRequest, MAX_RECURSIVE_TYPES_ALLOWED,
+    U64,
+};
+use aptos_bcs_utils::serialize_uleb128;
 use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
+use itertools::Itertools;
 use move_core_types::language_storage::TypeTag;
-use poem_openapi::{param::Query, payload::Json, OpenApi};
+use poem_openapi::{param::Query, payload::Json, ApiRequest, OpenApi};
 use std::sync::Arc;
 
 /// API for executing Move view function.
 #[derive(Clone)]
 pub struct ViewFunctionApi {
     pub context: Arc<Context>,
+}
+
+#[derive(ApiRequest, Debug)]
+pub enum ViewFunctionRequest {
+    #[oai(content_type = "application/json")]
+    Json(Json<ViewRequest>),
+
+    #[oai(content_type = "application/x.aptos.view_function+bcs")]
+    Bcs(Bcs),
 }
 
 #[OpenApi]
@@ -40,7 +57,7 @@ impl ViewFunctionApi {
         &self,
         accept_type: AcceptType,
         /// View function request with type and position arguments
-        request: Json<ViewRequest>,
+        request: ViewFunctionRequest,
         /// Ledger version to get state of account
         ///
         /// If not provided, it will be the latest version
@@ -51,27 +68,101 @@ impl ViewFunctionApi {
             .check_api_output_enabled("View function", &accept_type)?;
 
         let context = self.context.clone();
-        api_spawn_blocking(move || {
-            let (ledger_info, requested_version) = context
-                .get_latest_ledger_info_and_verify_lookup_version(
-                    ledger_version.map(|inner| inner.0),
-                )?;
+        api_spawn_blocking(move || view_request(context, accept_type, request, ledger_version))
+            .await
+    }
+}
 
-            let state_view = context.latest_state_view_poem(&ledger_info)?;
+fn view_request(
+    context: Arc<Context>,
+    accept_type: AcceptType,
+    request: ViewFunctionRequest,
+    ledger_version: Query<Option<U64>>,
+) -> BasicResultWith404<Vec<MoveValue>> {
+    // Retrieve the current state of the chain
+    let (ledger_info, requested_version) = context
+        .get_latest_ledger_info_and_verify_lookup_version(ledger_version.map(|inner| inner.0))?;
+
+    let state_view = context
+        .state_view_at_version(requested_version)
+        .map_err(|err| {
+            BasicErrorWith404::bad_request_with_code(
+                err,
+                AptosErrorCode::InternalError,
+                &ledger_info,
+            )
+        })?;
+
+    let view_function: ViewFunction = match request {
+        ViewFunctionRequest::Json(data) => {
             let resolver = state_view.as_move_resolver();
-
-            let entry_func = resolver
+            resolver
                 .as_converter(context.db.clone())
-                .convert_view_function(request.0)
+                .convert_view_function(data.0)
                 .map_err(|err| {
                     BasicErrorWith404::bad_request_with_code(
                         err,
                         AptosErrorCode::InvalidInput,
                         &ledger_info,
                     )
-                })?;
-            let state_view = context
-                .state_view_at_version(requested_version)
+                })?
+        },
+        ViewFunctionRequest::Bcs(data) => {
+            bcs::from_bytes_with_limit(data.0.as_slice(), MAX_RECURSIVE_TYPES_ALLOWED as usize)
+                .context("Failed to deserialize input into ViewRequest")
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InvalidInput,
+                        &ledger_info,
+                    )
+                })?
+        },
+    };
+
+    let return_vals = AptosVM::execute_view_function(
+        &state_view,
+        view_function.module.clone(),
+        view_function.function.clone(),
+        view_function.ty_args.clone(),
+        view_function.args.clone(),
+        context.node_config.api.max_gas_view_function,
+    )
+    .map_err(|err| {
+        BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
+    })?;
+    match accept_type {
+        AcceptType::Bcs => {
+            // The return values are already BCS encoded, but we still need to encode the outside
+            // vector without re-encoding the inside values
+            let num_vals = return_vals.len();
+
+            // Push the length of the return values
+            let mut length = vec![];
+            serialize_uleb128(&mut length, num_vals as u64).map_err(|err| {
+                BasicErrorWith404::internal_with_code(
+                    err,
+                    AptosErrorCode::InternalError,
+                    &ledger_info,
+                )
+            })?;
+
+            // Combine all of the return values
+            let values = return_vals.into_iter().concat();
+            let ret = [length, values].concat();
+
+            BasicResponse::try_from_encoded((ret, &ledger_info, BasicResponseStatus::Ok))
+        },
+        AcceptType::Json => {
+            let resolver = state_view.as_move_resolver();
+            let return_types = resolver
+                .as_converter(context.db.clone())
+                .function_return_types(&view_function)
+                .and_then(|tys| {
+                    tys.into_iter()
+                        .map(TypeTag::try_from)
+                        .collect::<anyhow::Result<Vec<_>>>()
+                })
                 .map_err(|err| {
                     BasicErrorWith404::bad_request_with_code(
                         err,
@@ -80,61 +171,24 @@ impl ViewFunctionApi {
                     )
                 })?;
 
-            let return_vals = AptosVM::execute_view_function(
-                &state_view,
-                entry_func.module().clone(),
-                entry_func.function().to_owned(),
-                entry_func.ty_args().to_owned(),
-                entry_func.args().to_owned(),
-                context.node_config.api.max_gas_view_function,
-            )
-            .map_err(|err| {
-                BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
-            })?;
-            match accept_type {
-                AcceptType::Bcs => BasicResponse::try_from_bcs((
-                    return_vals,
-                    &ledger_info,
-                    BasicResponseStatus::Ok,
-                )),
-                AcceptType::Json => {
-                    let return_types = resolver
+            let move_vals = return_vals
+                .into_iter()
+                .zip(return_types.into_iter())
+                .map(|(v, ty)| {
+                    resolver
                         .as_converter(context.db.clone())
-                        .function_return_types(&entry_func)
-                        .and_then(|tys| {
-                            tys.into_iter()
-                                .map(TypeTag::try_from)
-                                .collect::<anyhow::Result<Vec<_>>>()
-                        })
-                        .map_err(|err| {
-                            BasicErrorWith404::bad_request_with_code(
-                                err,
-                                AptosErrorCode::InternalError,
-                                &ledger_info,
-                            )
-                        })?;
+                        .try_into_move_value(&ty, &v)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InternalError,
+                        &ledger_info,
+                    )
+                })?;
 
-                    let move_vals = return_vals
-                        .into_iter()
-                        .zip(return_types.into_iter())
-                        .map(|(v, ty)| {
-                            resolver
-                                .as_converter(context.db.clone())
-                                .try_into_move_value(&ty, &v)
-                        })
-                        .collect::<anyhow::Result<Vec<_>>>()
-                        .map_err(|err| {
-                            BasicErrorWith404::bad_request_with_code(
-                                err,
-                                AptosErrorCode::InternalError,
-                                &ledger_info,
-                            )
-                        })?;
-
-                    BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
-                },
-            }
-        })
-        .await
+            BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
+        },
     }
 }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -9,7 +9,7 @@ use crate::{
         StateCheckpointTransaction, UserTransactionRequestInner, WriteModule, WriteResource,
         WriteTableItem,
     },
-    view::ViewRequest,
+    view::{ViewFunction, ViewRequest},
     Bytecode, DirectWriteSet, EntryFunctionId, EntryFunctionPayload, Event, HexEncodedBytes,
     MoveFunction, MoveModuleBytecode, MoveResource, MoveScriptBytecode, MoveType, MoveValue,
     PendingTransaction, ResourceGroup, ScriptPayload, ScriptWriteSet, SubmitTransactionRequest,
@@ -877,17 +877,17 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         self.inner.view_value(typ, bytes)?.try_into()
     }
 
-    pub fn function_return_types(&self, function: &EntryFunction) -> Result<Vec<MoveType>> {
-        let module = function.module().clone();
+    pub fn function_return_types(&self, function: &ViewFunction) -> Result<Vec<MoveType>> {
+        let module = function.module.clone();
         let code = self.inner.get_module(&module)? as Rc<dyn Bytecode>;
         let func = code
-            .find_function(function.function())
+            .find_function(function.function.as_ident_str())
             .ok_or_else(|| format_err!("could not find entry function by {:?}", function))?;
 
         Ok(func.return_)
     }
 
-    pub fn convert_view_function(&self, view_request: ViewRequest) -> Result<EntryFunction> {
+    pub fn convert_view_function(&self, view_request: ViewRequest) -> Result<ViewFunction> {
         let ViewRequest {
             function,
             type_arguments,
@@ -912,15 +912,15 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
             .map(bcs::to_bytes)
             .collect::<Result<_, bcs::Error>>()?;
 
-        Ok(EntryFunction::new(
-            module.into(),
-            function.name.into(),
-            type_arguments
+        Ok(ViewFunction {
+            module: module.into(),
+            function: function.name.into(),
+            ty_args: type_arguments
                 .into_iter()
                 .map(|v| v.try_into())
                 .collect::<Result<_>>()?,
             args,
-        ))
+        })
     }
 }
 

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -57,7 +57,7 @@ pub use transaction::{
     UserTransactionRequest, VersionedEvent, WriteModule, WriteResource, WriteSet, WriteSetChange,
     WriteSetPayload, WriteTableItem,
 };
-pub use view::ViewRequest;
+pub use view::{ViewFunction, ViewRequest};
 pub use wrappers::{EventGuid, IdentifierWrapper, StateKeyWrapper};
 
 pub fn deserialize_from_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>

--- a/api/types/src/mime_types.rs
+++ b/api/types/src/mime_types.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// MIME type to submit BCS transactions
+pub const BCS_VIEW_FUNCTION: &str = "application/x.aptos.view_function+bcs";
+
 pub const BCS_SIGNED_TRANSACTION: &str = "application/x.aptos.signed_transaction+bcs";
 
 /// MIME type to submit JSON transactions and get JSON output

--- a/api/types/src/view.rs
+++ b/api/types/src/view.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{EntryFunctionId, MoveType};
+use aptos_types::serde_helper::vec_bytes;
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+};
 use poem_openapi::Object;
 use serde::{Deserialize, Serialize};
 
@@ -13,4 +18,13 @@ pub struct ViewRequest {
     pub type_arguments: Vec<MoveType>,
     /// Arguments of the function
     pub arguments: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ViewFunction {
+    pub module: ModuleId,
+    pub function: Identifier,
+    pub ty_args: Vec<TypeTag>,
+    #[serde(with = "vec_bytes")]
+    pub args: Vec<Vec<u8>>,
 }

--- a/crates/aptos-bcs-utils/Cargo.toml
+++ b/crates/aptos-bcs-utils/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "aptos-bcs-utils"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+hex = { workspace = true }

--- a/crates/aptos-bcs-utils/src/lib.rs
+++ b/crates/aptos-bcs-utils/src/lib.rs
@@ -1,0 +1,100 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::bail;
+
+pub fn serialize_uleb128(buffer: &mut Vec<u8>, mut val: u64) -> anyhow::Result<()> {
+    loop {
+        let cur = val & 0x7F;
+        if cur != val {
+            buffer.push((cur | 0x80) as u8);
+            val >>= 7;
+        } else {
+            buffer.push(cur as u8);
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Returns Uleb128 value, followed by bytes read
+pub fn deserialize_uleb128(buffer: &[u8]) -> anyhow::Result<(u64, usize)> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    let mut i = 0;
+
+    // Go through values until the full number is found
+    loop {
+        let byte = buffer[i];
+        let cur = (byte & 0x7F) as u64;
+        if (cur << shift) >> shift != cur {
+            bail!("invalid ULEB128 repr for usize");
+        }
+        value |= cur << shift;
+
+        if (byte & 0x80) == 0 {
+            if shift > 0 && cur == 0 {
+                bail!("invalid ULEB128 repr for usize");
+            }
+            return Ok((value, i + 1));
+        }
+
+        shift += 7;
+        if shift > u64::BITS {
+            break;
+        }
+        i += 1;
+    }
+    Err(anyhow::Error::msg("invalid ULEB128 repr for usize"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        test_serialize_case(0, "00");
+        test_serialize_case(1, "01");
+        test_serialize_case(2, "02");
+        test_serialize_case(3, "03");
+        test_serialize_case(4, "04");
+        test_serialize_case(5, "05");
+        test_serialize_case(6, "06");
+        test_serialize_case(7, "07");
+        test_serialize_case(8, "08");
+        test_serialize_case(9, "09");
+        test_serialize_case(10, "0A");
+        test_serialize_case(11, "0B");
+        test_serialize_case(12, "0C");
+        test_serialize_case(13, "0D");
+        test_serialize_case(14, "0E");
+        test_serialize_case(15, "0F");
+        test_serialize_case(16, "10");
+        test_serialize_case(17, "11");
+        test_serialize_case(624485, "E58E26");
+        test_serialize_case(u64::MAX, "FFFFFFFFFFFFFFFFFF01");
+    }
+
+    #[test]
+    fn test_deserialize() {
+        test_deserialize_case("00", 0, 1);
+        test_deserialize_case("01", 1, 1);
+        test_deserialize_case("E58E26", 624485, 3);
+        test_deserialize_case("FFFFFFFFFFFFFFFFFF01", u64::MAX, 10);
+    }
+
+    fn test_serialize_case(value: u64, expected: &str) {
+        let mut buffer = vec![];
+        serialize_uleb128(&mut buffer, value).expect("Should not fail");
+        assert_eq!(buffer, hex::decode(expected).unwrap())
+    }
+
+    fn test_deserialize_case(bytes: &str, expected: u64, expected_num_bytes: usize) {
+        let buffer = hex::decode(bytes).unwrap();
+        let (value, num_bytes) = deserialize_uleb128(&buffer).unwrap();
+
+        assert_eq!(num_bytes, expected_num_bytes);
+        assert_eq!(value, expected);
+    }
+}

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -25,10 +25,10 @@ pub use aptos_api_types::{
 };
 use aptos_api_types::{
     deserialize_from_string,
-    mime_types::{BCS, BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, JSON},
+    mime_types::{BCS, BCS_SIGNED_TRANSACTION, BCS_VIEW_FUNCTION, JSON},
     AptosError, BcsBlock, Block, GasEstimation, HexEncodedBytes, IndexResponse, MoveModuleId,
     TransactionData, TransactionOnChainData, TransactionsBatchSubmissionResult, UserTransaction,
-    VersionedEvent, ViewRequest,
+    VersionedEvent, ViewFunction, ViewRequest,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, info, sample, sample::SampleRate};
@@ -307,6 +307,30 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn view_bcs<T: DeserializeOwned>(
+        &self,
+        request: &ViewFunction,
+        version: Option<u64>,
+    ) -> AptosResult<Response<T>> {
+        let txn_payload = bcs::to_bytes(request)?;
+        let mut url = self.build_path("view")?;
+        if let Some(version) = version {
+            url.set_query(Some(format!("ledger_version={}", version).as_str()));
+        }
+
+        let response = self
+            .inner
+            .post(url)
+            .header(CONTENT_TYPE, BCS_VIEW_FUNCTION)
+            .header(ACCEPT, BCS)
+            .body(txn_payload)
+            .send()
+            .await?;
+
+        let response = self.check_and_parse_bcs_response(response).await?;
+        Ok(response.and_then(|bytes| bcs::from_bytes(&bytes))?)
+    }
+
     pub async fn simulate(
         &self,
         txn: &SignedTransaction,
@@ -317,7 +341,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .body(txn_payload)
             .send()
             .await?;
@@ -341,7 +365,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .body(txn_payload)
             .send()
             .await?;
@@ -359,7 +383,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .header(ACCEPT, BCS)
             .body(txn_payload)
             .send()
@@ -384,7 +408,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .header(ACCEPT, BCS)
             .body(txn_payload)
             .send()
@@ -404,7 +428,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .body(txn_payload)
             .send()
             .await?;
@@ -419,7 +443,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .header(ACCEPT, BCS)
             .body(txn_payload)
             .send()
@@ -439,7 +463,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .body(txn_payload)
             .send()
             .await?;
@@ -456,7 +480,7 @@ impl Client {
         let response = self
             .inner
             .post(url)
-            .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+            .header(CONTENT_TYPE, BCS_SIGNED_TRANSACTION)
             .header(ACCEPT, BCS)
             .body(txn_payload)
             .send()

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -12,7 +12,7 @@ use aptos_crypto::ed25519::Ed25519Signature;
 use aptos_forge::{LocalSwarm, NodeExt, Swarm, TransactionType};
 use aptos_global_constants::{DEFAULT_BUCKETS, GAS_UNIT_PRICE};
 use aptos_rest_client::{
-    aptos_api_types::{MoveModuleId, TransactionData},
+    aptos_api_types::{MoveModuleId, TransactionData, ViewFunction, ViewRequest},
     Client,
 };
 use aptos_sdk::move_types::language_storage::StructTag;
@@ -21,6 +21,10 @@ use aptos_types::{
     account_config::{AccountResource, CORE_CODE_ADDRESS},
     on_chain_config::{ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType},
     transaction::{authenticator::AuthenticationKey, SignedTransaction, Transaction},
+};
+use move_core_types::{
+    ident_str,
+    language_storage::{ModuleId, TypeTag},
 };
 use std::{convert::TryFrom, str::FromStr, sync::Arc, time::Duration};
 
@@ -540,4 +544,44 @@ async fn test_bcs() {
         .into_inner();
     assert_eq!(json_txns.len(), 30);
     assert_eq!(json_txns.len(), bcs_txns.len());
+}
+
+#[tokio::test]
+async fn test_view_function() {
+    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let info = swarm.aptos_public_info();
+    let client: &Client = info.client();
+
+    let address = AccountAddress::ONE;
+
+    // Non-BCS
+    let view_request = ViewRequest {
+        function: "0x1::coin::is_account_registered".parse().unwrap(),
+        type_arguments: vec!["0x1::aptos_coin::AptosCoin".parse().unwrap()],
+        arguments: vec![serde_json::Value::String(address.to_hex_literal())],
+    };
+
+    // Balance should be 0 and there should only be one return value
+    let json_ret_values = client.view(&view_request, None).await.unwrap().into_inner();
+    assert_eq!(json_ret_values.len(), 1);
+    assert!(!json_ret_values[0].as_bool().unwrap());
+
+    // BCS
+    let bcs_view_request = ViewFunction {
+        module: ModuleId::new(address, ident_str!("coin").into()),
+        function: ident_str!("is_account_registered").into(),
+        ty_args: vec![TypeTag::Struct(Box::new(
+            StructTag::from_str("0x1::aptos_coin::AptosCoin").unwrap(),
+        ))],
+        args: vec![bcs::to_bytes(&address).unwrap()],
+    };
+
+    // Balance should be 0 and there should only be one return value
+    let bcs_ret_values: Vec<bool> = client
+        .view_bcs(&bcs_view_request, None)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(bcs_ret_values.len(), 1);
+    assert!(!bcs_ret_values[0]);
 }


### PR DESCRIPTION
### Description
This should let users provide any BCS encoded input into the view function. This cleaner interface will make it easier for things like options and other complex inputs.

This is part of a discovery on making changes to the SDK interfacing.  The view functions work differently than transaction submission since they only accept JSON inputs, which make the API a huge mess to work with via the SDK

I added a special function to ensure that outputs were encoded only once in BCS and are easy to decode rather than being wrapped twice.


### Test Plan
I added a smoke test to ensure that the encoding is right.