### PR TITLE
[Smoke Tests] Clean up the genesis flow test.

### DIFF
--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -157,6 +157,10 @@ impl LocalNode {
             self.name, self.config.inspection_service.port
         );
         info!(
+            "Node {}: Admin service is listening at http://127.0.0.1:{}",
+            self.name, self.config.admin_service.port
+        );
+        info!(
             "Node {}: Backup service is listening at http://127.0.0.1:{}",
             self.name,
             self.config.storage.backup_service_address.port()

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -72,4 +72,5 @@ num_cpus = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true }
 serde_yaml = { workspace = true }

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -13,13 +13,15 @@ use crate::{
     workspace_builder::workspace_root,
 };
 use anyhow::anyhow;
-use aptos_config::config::{InitialSafetyRulesConfig, NodeConfig};
-use aptos_forge::{get_highest_synced_version, LocalNode, Node, NodeExt, SwarmExt, Validator};
-use aptos_logger::prelude::*;
+use aptos_config::config::{AdminServiceConfig, InitialSafetyRulesConfig, NodeConfig};
+use aptos_forge::{
+    get_highest_synced_version, LocalNode, LocalSwarm, Node, NodeExt, SwarmExt, Validator,
+};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use regex::Regex;
+use reqwest::Client;
 use std::{
     fs,
     path::PathBuf,
@@ -28,100 +30,267 @@ use std::{
     time::{Duration, Instant},
 };
 
-fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
-    validator.stop();
-    let node_path = validator.config_path();
-    config.save_to_path(node_path).unwrap();
-    validator.start().unwrap();
-}
-
-async fn wait_for_node(validator: &mut dyn Validator, expected_to_connect: usize) {
-    let healthy_deadline = Instant::now()
-        .checked_add(Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
-        .unwrap();
-    validator
-        .wait_until_healthy(healthy_deadline)
-        .await
-        .unwrap_or_else(|err| {
-            let lsof_output = Command::new("lsof").arg("-i").output().unwrap();
-            panic!(
-                "wait_until_healthy failed. lsof -i: {:?}: {}",
-                lsof_output, err
-            );
-        });
-    info!("Validator restart health check passed");
-
-    let connectivity_deadline = Instant::now()
-        .checked_add(Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
-        .unwrap();
-    validator
-        .wait_for_connectivity(expected_to_connect, connectivity_deadline)
-        .await
-        .unwrap();
-    info!("Validator restart connectivity check passed");
-}
-
 #[tokio::test]
-/// This test verifies the flow of a genesis transaction after the chain starts.
-/// 1. Test the consensus sync_only mode, every node should stop at the same version.
-/// 2. Test the db-bootstrapper applying a manual genesis transaction (remove validator 0) on diemdb directly
-/// 3. Test the nodes and clients resume working after updating waypoint
-/// 4. Test a node lagging behind can sync to the waypoint
-async fn test_genesis_transaction_flow() {
+/// This test verifies:
+/// 1. The behaviour of the consensus sync_only mode.
+/// 2. The flow of a genesis write-set transaction after the chain has halted.
+/// 3. That db-restore is able to restore a failed validator node.
+///
+/// The test does the following:
+/// 1. Start a 5 node validator network.
+/// 2. Enable consensus `sync_only` mode for the last validator and verify that it can sync.
+/// 3. Use consensus `sync_only` mode to force all nodes to stop at the same version (i.e., emulate a halt).
+/// 4. Use the aptos CLI to generate a genesis transaction that removes the last validator from the set.
+/// 5. Use the aptos-debugger to manually apply the genesis transaction to all remaining validators.
+/// 6. Verify that the network is able to resume consensus and that the last validator is no longer in the set.
+/// 7. Verify that a failed validator node is able to db-restore and rejoin the network.
+async fn test_genesis_transaction_and_db_restore_flow() {
+    println!("0. Building the Aptos CLI and debugger!");
     let aptos_debugger = workspace_builder::get_bin("aptos-debugger");
     let aptos_cli = workspace_builder::get_bin("aptos");
 
-    println!("0. pre-building finished.");
-
+    println!("1. Starting a 5 node validator network!");
     let num_nodes = 5;
-    let (mut env, cli, _) = SwarmBuilder::new_local(num_nodes)
+    let (mut env, cli_test_framework, _) = SwarmBuilder::new_local(num_nodes)
         .with_aptos()
         .build_with_cli(0)
         .await;
 
-    println!("1. Set sync_only = true for the last node and check it can sync to others");
-    let node = env.validators_mut().nth(4).unwrap();
-    let mut new_config = node.config().clone();
-    new_config.consensus.sync_only = true;
-    update_node_config_restart(node, new_config.clone());
-    wait_for_node(node, num_nodes - 1).await;
-    // wait for some versions
-    env.wait_for_all_nodes_to_catchup_to_version(10, Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
-        .await
-        .unwrap();
-
-    println!("2. Set sync_only = true for all nodes and restart");
-    for node in env.validators_mut() {
-        let mut node_config = node.config().clone();
-        node_config.consensus.sync_only = true;
-        update_node_config_restart(node, node_config);
-        wait_for_node(node, num_nodes - 1).await;
-    }
-
-    println!("3. delete one node's db and test they can still sync when sync_only is true for every nodes");
-    let node = env.validators_mut().nth(3).unwrap();
-    node.stop();
-    node.clear_storage().await.unwrap();
-    node.start().unwrap();
-
-    println!("4. verify all nodes are at the same round and no progress being made");
+    println!("2. Enabling `sync_only` mode for the last validator and verifying that it can sync!");
+    let last_validator = env.validators_mut().last().unwrap();
+    enable_sync_only_mode(num_nodes, last_validator).await;
     env.wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 
-    println!("5. kill nodes and prepare a genesis txn to remove the last validator");
+    println!("3. Enabling `sync_only` mode for every validator!");
+    for validator in env.validators_mut() {
+        enable_sync_only_mode(num_nodes, validator).await;
+    }
+
+    println!("4. Deleting one validator's DB and verifying that it can still catch up!");
+    delete_storage_and_wait_for_catchup(&mut env, 3).await;
+
+    println!("5. Stopping three validator nodes!");
     for node in env.validators_mut().take(3) {
         node.stop();
     }
 
-    let first_validator_address = env
+    println!("6. Generating a genesis transaction that removes the last validator from the set!");
+    let (genesis_blob_path, genesis_transaction) =
+        generate_genesis_transaction(&mut env, aptos_cli);
+
+    println!("7. Applying the genesis transaction to the first validator!");
+    let first_validator_config = env.validators_mut().next().unwrap().config().clone();
+    let first_validator_storage_dir = first_validator_config.storage.dir();
+    let output = Command::new(aptos_debugger.as_path())
+        .current_dir(workspace_root())
+        .args(&vec![
+            "aptos-db",
+            "bootstrap",
+            first_validator_storage_dir.to_str().unwrap(),
+            "--genesis-txn-file",
+            genesis_blob_path.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    println!("8. Parsing the output to get the waypoint: {:?}", output);
+    let output_string = std::str::from_utf8(&output.stdout).unwrap();
+    let waypoint = parse_waypoint(output_string);
+
+    println!(
+        "9. Applying the genesis transaction to validators 0, 1 and 2. Waypoint: {:?}",
+        waypoint
+    );
+    for (num_expected_peers, validator) in env.validators_mut().take(3).enumerate() {
+        apply_genesis_to_validator(
+            validator,
+            genesis_transaction.clone(),
+            waypoint,
+            num_expected_peers,
+            num_expected_peers == 0, // Test admin service on the first validator
+        )
+        .await;
+    }
+
+    println!("10. Verifying that we're able to resume consensus and execute transactions!");
+    env.wait_for_startup().await.unwrap();
+    check_create_mint_transfer_node(&mut env, 0).await;
+
+    println!("11. Verifying that the last validator is no longer in the validator set!");
+    let validator_set = cli_test_framework.show_validator_set().await.unwrap();
+    assert_eq!(validator_set.active_validators.len(), 4);
+
+    println!("12. Deleting the DB on validator 3 and verifying that it can still catch up via db-restore!");
+    delete_db_and_execute_restore(&mut env, 3, waypoint, num_nodes).await;
+
+    println!("13. Verifying that we're able to execute transactions on validator 3!");
+    check_create_mint_transfer_node(&mut env, 3).await;
+}
+
+/// Applies the genesis transaction to the specified validator and waits for it to become healthy
+async fn apply_genesis_to_validator(
+    validator: &mut LocalNode,
+    genesis_transaction: Transaction,
+    waypoint: Waypoint,
+    num_expected_peers: usize,
+    test_admin_service: bool,
+) {
+    // Insert the waypoint into the validator's config
+    let mut node_config = validator.config().clone();
+    insert_waypoint(&mut node_config, waypoint);
+
+    // Update the genesis transaction
+    node_config.execution.genesis = Some(genesis_transaction.clone());
+
+    // Reset the initial safety rules config
+    node_config
+        .consensus
+        .safety_rules
+        .initial_safety_rules_config = InitialSafetyRulesConfig::None;
+
+    // Reset the sync_only flag to false (so the validator can participate in consensus)
+    node_config.consensus.sync_only = false;
+
+    // Remove the admin service override (the config optimizer should run and set the config)
+    if test_admin_service {
+        // TODO: is there a way we can verify the config optimizer without doing this?
+        node_config.admin_service = AdminServiceConfig::default();
+    }
+
+    // Update the config, restart the validator and wait for it to become healthy
+    update_node_config_and_restart(validator, node_config);
+    wait_for_health_and_connectivity(validator, num_expected_peers).await;
+
+    // Verify that the config optimizer ran and started the admin service at the default port
+    if test_admin_service {
+        verify_admin_service_is_running().await;
+    }
+}
+
+/// Deletes the DB on the specified validator and verifies that it can still catch up via db-restore
+async fn delete_db_and_execute_restore(
+    env: &mut LocalSwarm,
+    validator_index: usize,
+    waypoint: Waypoint,
+    num_nodes: usize,
+) {
+    // Get the current epoch and version from the first validator
+    let first_validator = env.validators_mut().next().unwrap();
+    let current_ledger_info = first_validator
+        .rest_client()
+        .get_ledger_information()
+        .await
+        .unwrap();
+    let current_epoch = current_ledger_info.inner().epoch;
+    let current_version = current_ledger_info.inner().version;
+
+    // Perform a DB backup on the first validator
+    let first_validator_backup_port = first_validator
+        .config()
+        .storage
+        .backup_service_address
+        .port();
+    let previous_epoch = current_epoch.checked_sub(1).unwrap();
+    let (backup_path, _) = db_backup(
+        first_validator_backup_port,
+        previous_epoch,           // target epoch: most recently closed epoch
+        current_version,          // target version
+        current_version as usize, // txn batch size (version 0 is in its own batch)
+        previous_epoch as usize,  // state snapshot interval
+        &[waypoint],
+    );
+
+    // Stop the specified validator
+    let validator = env.validators_mut().nth(validator_index).unwrap();
+    validator.stop();
+
+    // Disable sync_only mode on the specified validator
+    let mut validator_config = validator.config().clone();
+    validator_config.consensus.sync_only = false;
+    validator_config
+        .save_to_path(validator.config_path())
+        .unwrap();
+
+    // Delete the DB on the specified validator
+    let db_dir = validator.config().storage.dir();
+    fs::remove_dir_all(&db_dir).unwrap();
+
+    // Perform a DB restore on the specified validator
+    let enable_storage_sharding = validator
+        .config()
+        .storage
+        .rocksdb_configs
+        .enable_storage_sharding;
+    db_restore(
+        backup_path.path(),
+        db_dir.as_path(),
+        &[waypoint],
+        enable_storage_sharding,
+        None,
+    );
+
+    // Restart the validator and wait for it to become healthy
+    validator.start().unwrap();
+    wait_for_health_and_connectivity(validator, num_nodes - 2).await;
+
+    // Wait until the validator catches up to the current version
+    let client = validator.rest_client();
+    let version = get_highest_synced_version(&env.get_all_nodes_clients_with_names())
+        .await
+        .unwrap();
+    loop {
+        if let Ok(resp) = client.get_ledger_information().await {
+            if resp.into_inner().version > version {
+                println!("Node 3 catches up on {}", version);
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Deletes the DB of the specified validator and waits for it to catch up
+async fn delete_storage_and_wait_for_catchup(env: &mut LocalSwarm, validator_index: usize) {
+    // Stop the validator and delete the DB
+    let validator = env.validators_mut().nth(validator_index).unwrap();
+    validator.stop();
+    validator.clear_storage().await.unwrap();
+
+    // Restart the validator and wait for it to catch up
+    validator.start().unwrap();
+    env.wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
+        .await
+        .unwrap();
+}
+
+/// Enables sync_only mode for the specified validator and wait for it to become healthy
+async fn enable_sync_only_mode(num_nodes: usize, validator_node: &mut LocalNode) {
+    // Update the validator's config to enable sync_only mode
+    let mut validator_config = validator_node.config().clone();
+    validator_config.consensus.sync_only = true;
+    update_node_config_and_restart(validator_node, validator_config.clone());
+
+    // Wait for the validator to become healthy
+    wait_for_health_and_connectivity(validator_node, num_nodes - 1).await;
+}
+
+/// Generates a genesis write-set transaction that removes the last validator from the set
+fn generate_genesis_transaction(
+    env: &mut LocalSwarm,
+    aptos_cli: PathBuf,
+) -> (TempPath, Transaction) {
+    // Get the address of the last validator
+    let last_validator_address = env
         .validators()
-        .nth(4)
+        .last()
         .unwrap()
         .config()
         .get_peer_id()
         .unwrap();
 
+    // Create a write-set transaction that removes the last validator from the set
     let script = format!(
         r#"
         script {{
@@ -136,18 +305,16 @@ async fn test_genesis_transaction_flow() {
             }}
     }}
     "#,
-        first_validator_address.to_hex()
+        last_validator_address.to_hex()
     );
 
+    // Write the transaction to a temporary file
     let temp_script_path = TempPath::new();
     let mut move_script_path = temp_script_path.path().to_path_buf();
     move_script_path.set_extension("move");
-
     fs::write(move_script_path.as_path(), script).unwrap();
 
-    let genesis_blob_path = TempPath::new();
-    genesis_blob_path.create_as_file().unwrap();
-
+    // Determine the framework path
     let framework_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
@@ -155,6 +322,11 @@ async fn test_genesis_transaction_flow() {
         .join("framework")
         .join("aptos-framework");
 
+    // Create a temporary file to hold the genesis blob
+    let genesis_blob_path = TempPath::new();
+    genesis_blob_path.create_as_file().unwrap();
+
+    // Generate the genesis write-set transaction
     Command::new(aptos_cli.as_path())
         .current_dir(workspace_root())
         .args(&vec![
@@ -173,136 +345,84 @@ async fn test_genesis_transaction_flow() {
         .output()
         .unwrap();
 
+    // Read the genesis transaction from the temporary file
     let genesis_transaction = {
         let buf = fs::read(genesis_blob_path.as_ref()).unwrap();
         bcs::from_bytes::<Transaction>(&buf).unwrap()
     };
 
-    println!("6. prepare the waypoint with the transaction");
-    let waypoint_command = Command::new(aptos_debugger.as_path())
-        .current_dir(workspace_root())
-        .args(&vec![
-            "aptos-db",
-            "bootstrap",
-            env.validators()
-                .next()
-                .unwrap()
-                .config()
-                .storage
-                .dir()
-                .to_str()
-                .unwrap(),
-            "--genesis-txn-file",
-            genesis_blob_path.path().to_str().unwrap(),
-        ])
-        .output()
-        .unwrap();
-    println!("Db bootstrapper output: {:?}", waypoint_command);
-    let output = std::str::from_utf8(&waypoint_command.stdout).unwrap();
-    let waypoint = parse_waypoint(output);
-
-    println!("7. apply genesis transaction for nodes 0, 1, 2");
-    for (expected_to_connect, node) in env.validators_mut().take(3).enumerate() {
-        let mut node_config = node.config().clone();
-        insert_waypoint(&mut node_config, waypoint);
-        node_config
-            .consensus
-            .safety_rules
-            .initial_safety_rules_config = InitialSafetyRulesConfig::None;
-        node_config.execution.genesis = Some(genesis_transaction.clone());
-        // reset the sync_only flag to false
-        node_config.consensus.sync_only = false;
-        update_node_config_restart(node, node_config);
-        wait_for_node(node, expected_to_connect).await;
-    }
-
-    println!("8. verify it's able to mint after the waypoint");
-    env.wait_for_startup().await.unwrap();
-    check_create_mint_transfer_node(&mut env, 0).await;
-
-    let (epoch, version) = {
-        let response = env
-            .validators()
-            .next()
-            .unwrap()
-            .rest_client()
-            .get_ledger_information()
-            .await
-            .unwrap();
-        (response.inner().epoch, response.inner().version)
-    };
-
-    let (backup_path, _) = db_backup(
-        env.validators()
-            .next()
-            .unwrap()
-            .config()
-            .storage
-            .backup_service_address
-            .port(),
-        epoch.checked_sub(1).unwrap(), // target epoch: most recently closed epoch
-        version,                       // target version
-        version as usize,              // txn batch size (version 0 is in its own batch)
-        epoch.checked_sub(1).unwrap() as usize, // state snapshot interval
-        &[waypoint],
-    );
-
-    println!("9. verify node 4 is out from the validator set");
-    assert_eq!(
-        cli.show_validator_set()
-            .await
-            .unwrap()
-            .active_validators
-            .len(),
-        4
-    );
-
-    println!("10. nuke DB on node 3, and run db restore, test if it rejoins the network okay.");
-    let node = env.validators_mut().nth(3).unwrap();
-    node.stop();
-    let mut node_config = node.config().clone();
-    node_config.consensus.sync_only = false;
-    node_config.save_to_path(node.config_path()).unwrap();
-
-    let db_dir = node.config().storage.dir();
-    fs::remove_dir_all(&db_dir).unwrap();
-    db_restore(
-        backup_path.path(),
-        db_dir.as_path(),
-        &[waypoint],
-        node.config()
-            .storage
-            .rocksdb_configs
-            .enable_storage_sharding,
-        None,
-    );
-
-    node.start().unwrap();
-    wait_for_node(node, num_nodes - 2).await;
-    let client = node.rest_client();
-    // wait for it to catch up
-    {
-        let version = get_highest_synced_version(&env.get_all_nodes_clients_with_names())
-            .await
-            .unwrap();
-        loop {
-            if let Ok(resp) = client.get_ledger_information().await {
-                if resp.into_inner().version > version {
-                    println!("Node 3 catches up on {}", version);
-                    break;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    }
-
-    check_create_mint_transfer_node(&mut env, 3).await;
+    (genesis_blob_path, genesis_transaction)
 }
 
-fn parse_waypoint(db_bootstrapper_output: &str) -> Waypoint {
+/// Parses the waypoint from the output of the bootstrap command
+fn parse_waypoint(bootstrap_command_output: &str) -> Waypoint {
     let waypoint = Regex::new(r"Got waypoint: (\d+:\w+)")
         .unwrap()
-        .captures(db_bootstrapper_output)
-        .ok_or_else(|| anyhow!("Failed to parse aptos-db-bootstrapper output."));
+        .captures(bootstrap_command_output)
+        .ok_or_else(|| {
+            anyhow!("Failed to parse `aptos-debugger aptos-db bootstrap` waypoint output!")
+        });
     Waypoint::from_str(waypoint.unwrap()[1].into()).unwrap()
+}
+
+/// Update the specified node's config and restart the node
+fn update_node_config_and_restart(node: &mut LocalNode, mut config: NodeConfig) {
+    // Stop the node
+    node.stop();
+
+    // Update the node's config
+    let node_path = node.config_path();
+    config.save_to_path(node_path).unwrap();
+
+    // Restart the node
+    node.start().unwrap();
+}
+
+/// Verifies that the admin service is running on the default port
+/// and that it returns the expected response when the endpoints are disabled.
+async fn verify_admin_service_is_running() {
+    // Create a simple REST client
+    let rest_client = Client::new();
+
+    // Send a request to the admin service
+    let default_admin_service_port = AdminServiceConfig::default().port;
+    let admin_service_url = format!("http://127.0.0.1:{}", default_admin_service_port);
+    let request = rest_client.get(admin_service_url.clone());
+
+    // Verify that the admin service receives the request, and responds
+    // with a message indicating that the endpoint is disabled.
+    let response = request.send().await.unwrap();
+    let response_string = response.text().await.unwrap();
+    assert_eq!(response_string, "AdminService is not enabled.");
+}
+
+/// Wait for the specified validator to become healthy and for the
+/// validator to connect to the specified number of peers.
+async fn wait_for_health_and_connectivity(
+    validator: &mut dyn Validator,
+    num_expected_peers: usize,
+) {
+    // Wait for the validator to become healthy
+    let healthy_deadline = Instant::now()
+        .checked_add(Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
+        .unwrap();
+    validator
+        .wait_until_healthy(healthy_deadline)
+        .await
+        .unwrap_or_else(|err| {
+            let lsof_output = Command::new("lsof").arg("-i").output().unwrap();
+            panic!(
+                "wait_until_healthy failed. lsof -i: {:?}: {}",
+                lsof_output, err
+            );
+        });
+
+    // Wait for the validator to connect to the expected number of peers
+    let connectivity_deadline = Instant::now()
+        .checked_add(Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
+        .unwrap();
+    validator
+        .wait_for_connectivity(num_expected_peers, connectivity_deadline)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
### Description
This PR updates the genesis write-set smoke test to: (i) ensure that the config optimizer doesn't block the recovery flow after a genesis write-set transaction is applied to the network and the node restarts; and (ii) verify that the config optimizer does indeed run.

The PR also makes several small readability refactors and comment updates, but nothing should logically change.

### Test Plan
Existing test infrastructure.