### PR TITLE
Add Move Linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-lint"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.3.21",
+ "codespan-reporting",
+ "move-abigen",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-model",
+ "move-package",
+ "move-symbol-pool",
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
     "crates/aptos-inspection-service",
     "crates/aptos-keygen",
     "crates/aptos-ledger",
+    "crates/aptos-lint",
     "crates/aptos-log-derive",
     "crates/aptos-logger",
     "crates/aptos-metrics-core",

--- a/crates/aptos-lint/Cargo.toml
+++ b/crates/aptos-lint/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "aptos-lint"
+version = "0.1.0"
+description = "Aptos linter for move projects"
+publish = true
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+move-compiler = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+move-ir-types = { workspace = true }
+anyhow = { workspace = true, features = [] }
+move-package = { workspace = true }
+move-core-types = { workspace = true }
+move-symbol-pool = { workspace = true }
+move-model = { workspace = true }
+move-abigen = { workspace = true }
+codespan-reporting = { workspace = true }
+move-command-line-common = { workspace = true }
+[dev-dependencies]
+regex = "1.1.8"

--- a/crates/aptos-lint/src/lib.rs
+++ b/crates/aptos-lint/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod lint;
+use std::path::PathBuf;
+use anyhow::{Result, Ok};
+use lint::context::VisitorContext;
+
+pub fn aptos_lint(path: PathBuf) -> Result<VisitorContext> {
+    lint::main(path).and_then(|c| Ok(c))
+}

--- a/crates/aptos-lint/src/lint/context.rs
+++ b/crates/aptos-lint/src/lint/context.rs
@@ -1,0 +1,52 @@
+
+use codespan_reporting::diagnostic::Label;
+use codespan_reporting::term::{Config, emit};
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::diagnostic::Diagnostic;
+use codespan_reporting::files::SimpleFiles;
+use move_compiler::FullyCompiledProgram;
+use move_compiler::diagnostics::FileId;
+
+pub struct VisitorContext {
+    pub ast: FullyCompiledProgram,
+    pub files: SimpleFiles<String, String>,
+    pub diagnostics: Vec<Diagnostic<usize>>,
+}
+impl VisitorContext {
+    pub fn new(ast: FullyCompiledProgram) -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            ast,
+            files: SimpleFiles::new(),
+        }
+    }
+
+    pub fn add_file(&mut self, filename: String, source: String) -> FileId {
+        self.files.add(filename, source)
+    }
+
+    pub fn add_diagnostic(&mut self, file_id: FileId, start: usize, end: usize, message: &str, severity: codespan_reporting::diagnostic::Severity) {
+        let label = Label::primary(file_id, start..end)
+            .with_message(message.to_string());
+        
+        let diagnostic = Diagnostic::new(severity)
+            .with_message(message)
+            .with_labels(vec![label]);
+
+        self.diagnostics.push(diagnostic);
+    }
+
+    pub fn emit_diagnostics(&self) {
+        let writer = StandardStream::stderr(ColorChoice::Always);
+        let config = Config::default();
+
+        for diagnostic in &self.diagnostics {
+            let _ = emit(
+                &mut writer.lock(),
+                &config,
+                &self.files,
+                &diagnostic,
+            );
+        }
+    }
+}

--- a/crates/aptos-lint/src/lint/core/build.rs
+++ b/crates/aptos-lint/src/lint/core/build.rs
@@ -1,0 +1,39 @@
+use std::{ path::PathBuf, collections::BTreeMap };
+use anyhow::Result;
+use move_command_line_common::address::NumericalAddress;
+use move_compiler::{
+    FullyCompiledProgram,
+    construct_pre_compiled_lib,
+    shared::{ known_attributes::KnownAttribute, PackagePaths },
+    Flags,
+    diagnostics,
+};
+
+pub fn build_ast(path: &PathBuf) -> Result<FullyCompiledProgram> {
+    let targets: Vec<String> = vec![path.as_path().to_str().unwrap().to_owned()];
+    let paths = vec![PackagePaths {
+        name: None,
+        paths: targets,
+        named_address_map: move_stdlib_named_addresses(),
+    }];
+    let fully_compiled_program = match
+        construct_pre_compiled_lib(paths, None, Flags::empty(), KnownAttribute::get_all_attribute_names())?
+    {
+        Ok(p) => p,
+        Err((files, diags)) => {
+            diagnostics::report_diagnostics(&files, diags);
+        }
+    };
+    Ok(fully_compiled_program)
+}
+
+fn move_stdlib_named_addresses() -> BTreeMap<String, NumericalAddress> {
+    let mapping = [
+        ("std", "0x1"),
+        ("NamedAddr", "0xCAFE"),
+    ];
+    mapping
+        .iter()
+        .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
+        .collect()
+}

--- a/crates/aptos-lint/src/lint/core/mod.rs
+++ b/crates/aptos-lint/src/lint/core/mod.rs
@@ -1,0 +1,7 @@
+use move_compiler::FullyCompiledProgram;
+
+
+pub mod build;
+pub fn main(path: std::path::PathBuf) -> anyhow::Result<FullyCompiledProgram> {
+    build::build_ast(&path)
+}

--- a/crates/aptos-lint/src/lint/manager.rs
+++ b/crates/aptos-lint/src/lint/manager.rs
@@ -1,0 +1,25 @@
+use move_compiler::FullyCompiledProgram;
+
+use super::{visitor::LintVisitor, context::VisitorContext};
+
+pub struct VisitorManager<'a> {
+    linters: Vec<Box<dyn LintVisitor + 'a>>,
+}
+
+impl<'a> VisitorManager<'a> {
+    pub fn new(linters: Vec<Box<dyn LintVisitor + 'a>>) -> Self {
+        Self { linters }
+    }
+
+    pub fn run(&mut self, custom_ast: FullyCompiledProgram, context: &mut VisitorContext) {
+        for (_, _, module) in &custom_ast.typing.modules {
+            
+            for linter in &mut self.linters {
+                linter.visit_module(module, context);
+                for (_, _, function) in &module.functions {
+                    linter.visit_function(function, context);
+                }
+            }
+        }
+    }
+}

--- a/crates/aptos-lint/src/lint/mod.rs
+++ b/crates/aptos-lint/src/lint/mod.rs
@@ -1,0 +1,26 @@
+pub mod manager;
+pub mod visitor;
+pub mod context;
+pub mod rules;
+pub mod core;
+use std::path::PathBuf;
+
+use self::{manager::VisitorManager, rules::{ifs_same_cond::IfsSameCondVisitor, bool_comparison::BoolComparisonVisitor, double_bool_comparison::DoubleComparisonsVisitor, unnecessary_type_conversion::UnnecessaryTypeConversionVisitor, unused_private_function::UnusedFunctionVisitor, shift_overflow::ShiftOverflowVisitor, multiplication_before_division::MultiplicationBeforeDivisionVisitor}, context::VisitorContext};
+
+pub fn main(path: PathBuf) -> anyhow::Result<VisitorContext> {
+    let ast = core::main(path).unwrap();
+
+    let mut context: VisitorContext = VisitorContext::new(ast.clone());
+    let mut manager = VisitorManager::new(vec![
+        BoolComparisonVisitor::visitor(),
+        DoubleComparisonsVisitor::visitor(),
+        IfsSameCondVisitor::visitor(),
+        MultiplicationBeforeDivisionVisitor::visitor(),
+        ShiftOverflowVisitor::visitor(),
+        UnnecessaryTypeConversionVisitor::visitor(),
+        UnusedFunctionVisitor::visitor(),
+    ]);
+    
+    manager.run(ast, &mut context);
+    anyhow::Ok(context)
+}

--- a/crates/aptos-lint/src/lint/rules/bool_comparison.rs
+++ b/crates/aptos-lint/src/lint/rules/bool_comparison.rs
@@ -1,0 +1,64 @@
+// Detects comparisons where a variable is compared to 'true' or 'false' using
+// equality (==) or inequality (!=) operators and provides suggestions to simplify the comparisons.
+use move_compiler::expansion::ast::Value_;
+use move_compiler::parser::ast::BinOp_;
+use move_compiler::typing::ast::Exp;
+use move_compiler::typing::ast as AST;
+
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{LintVisitor, LintUtilities};
+
+pub struct BoolComparisonVisitor;
+impl BoolComparisonVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn check_boolean_comparison(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        if let AST::UnannotatedExp_::BinopExp(left, op, _, right) = &exp.exp.value {
+            if let AST::UnannotatedExp_::Value(val) = &right.exp.value {
+                if let Value_::Bool(b) = val.value {
+                    let variable = self.get_exp_string(left);
+                    match (op.value, b) {
+                        // Checking for comparisons where a variable is compared to 'true' using equality
+                        // or to 'false' using inequality. These can be simplified by using the variable directly.
+                        (BinOp_::Eq, true) | (BinOp_::Neq, false) => {
+                            self.add_warning(
+                                context,
+                                &exp.exp.loc,
+                                &format!("Use {} directly instead of comparing it to {}.", variable, b)
+                            );
+                        }
+                        // Checking for comparisons where a variable is compared to 'false' using equality
+                        // or to 'true' using inequality. These can be simplified by negating the variable.
+                        (BinOp_::Eq, false) | (BinOp_::Neq, true) => {
+                            self.add_warning(
+                                context,
+                                &exp.exp.loc,
+                                &format!("Use !{} instead of comparing it to {}.", variable, b)
+                            );
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl LintVisitor for BoolComparisonVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::IfElse(e1, _, _) | AST::UnannotatedExp_::While(e1, _) => {
+                self.check_boolean_comparison(e1, context);
+            }
+            _ => (),
+        }
+
+    }
+}
+
+impl LintUtilities for BoolComparisonVisitor {}

--- a/crates/aptos-lint/src/lint/rules/double_bool_comparison.rs
+++ b/crates/aptos-lint/src/lint/rules/double_bool_comparison.rs
@@ -1,0 +1,81 @@
+// Double comparisons occur when a value is compared twice with different relational operators
+// inside a logical OR operation. For example, expressions like `a == b || a < b` or `x != y || x > y`.
+// These patterns are potentially confusing and can be simplified for readability and maintainability.
+use move_compiler::parser::ast::BinOp_;
+use move_compiler::typing::ast::Exp;
+use move_compiler::typing::ast as AST;
+
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{LintVisitor, LintUtilities};
+
+pub struct DoubleComparisonsVisitor;
+
+impl DoubleComparisonsVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn check_double_comparison(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        if let AST::UnannotatedExp_::BinopExp(left, op1, _, right) = &exp.exp.value {
+            if op1.value == BinOp_::Or {
+                if let AST::UnannotatedExp_::BinopExp(left2, op2, _, right2) = &right.exp.value {
+                    if let AST::UnannotatedExp_::BinopExp(left3, op3, _, right3) = &left.exp.value {
+                        if left3 == left2 && right3 == right2 {
+                            match (op3.value, op2.value) {
+                                // Check for cases where a value is checked for equality and then for less than,
+                                (BinOp_::Eq, BinOp_::Lt) | (BinOp_::Lt, BinOp_::Eq) => {
+                                    self.add_warning(
+                                        context,
+                                        &exp.exp.loc,
+                                        &format!("Simplify double comparisons, use <= instead.")
+                                    );
+                                }
+                                // Check for cases where a value is checked for equality and then for greater than,
+                                (BinOp_::Eq, BinOp_::Gt) | (BinOp_::Gt, BinOp_::Eq) => {
+                                    self.add_warning(
+                                        context,
+                                        &exp.exp.loc,
+                                        &format!("Simplify double comparisons, use >= instead.")
+                                    );
+                                }
+                                // Check for cases where a value is checked for inequality and then for less than,
+                                (BinOp_::Neq, BinOp_::Lt) | (BinOp_::Lt, BinOp_::Neq) => {
+                                    self.add_warning(
+                                        context,
+                                        &exp.exp.loc,
+                                        &format!("Simplify double comparisons, use <= instead.")
+                                    );
+                                }
+                                // Check for cases where a value is checked for inequality and then for greater than,
+                                (BinOp_::Neq, BinOp_::Gt) | (BinOp_::Gt, BinOp_::Neq) => {
+                                    self.add_warning(
+                                        context,
+                                        &exp.exp.loc,
+                                        &format!("Simplify double comparisons, use >= instead.")
+                                    );
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl LintVisitor for DoubleComparisonsVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::IfElse(e1, _, _) | AST::UnannotatedExp_::While(e1, _) => {
+                self.check_double_comparison(e1, context);
+            }
+            _ => {}
+        }
+    }
+}
+impl LintUtilities for DoubleComparisonsVisitor {}

--- a/crates/aptos-lint/src/lint/rules/ifs_same_cond.rs
+++ b/crates/aptos-lint/src/lint/rules/ifs_same_cond.rs
@@ -1,0 +1,64 @@
+// Consecutive 'if' statements with identical conditions are usually redundant and can be refactored
+// to improve code readability and maintainability.
+use move_compiler::typing::ast::Exp;
+use move_compiler::typing::ast as AST;
+
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{LintVisitor, LintUtilities};
+
+pub struct IfsSameCondVisitor {
+    if_condition: Vec<String>,
+}
+
+impl IfsSameCondVisitor {
+    pub fn new() -> Self {
+        Self {
+            if_condition: Vec::new(),
+        }
+    }
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn check_and_set_condition(&mut self, exp: &Box<Exp>, context: &mut VisitorContext) {
+        let current_condition = self.get_condition_string(exp);
+
+        if self.if_condition.iter().any(|e| current_condition.contains(e)) {
+            self.add_warning(
+                context,
+                &exp.exp.loc,
+                "Detected consecutive if conditions with the same expression. Consider refactoring to avoid redundancy."
+            );
+        } else {
+            self.if_condition.push(current_condition);
+        }
+    }
+
+    fn clear_condition(&mut self) {
+        self.if_condition = Vec::new();
+    }
+}
+
+impl LintVisitor for IfsSameCondVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::IfElse(e1, _, e3) => {
+                self.check_and_set_condition(e1, context);
+                let mut next_exp = e3.as_ref();
+                loop {
+                    if let AST::UnannotatedExp_::IfElse(e1, _, e3) = &next_exp.exp.value {
+                        self.check_and_set_condition(e1, context);
+                        next_exp = e3.as_ref();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            _ => {
+                self.clear_condition();
+            }
+        }
+    }
+}
+
+impl LintUtilities for IfsSameCondVisitor {}

--- a/crates/aptos-lint/src/lint/rules/mod.rs
+++ b/crates/aptos-lint/src/lint/rules/mod.rs
@@ -1,0 +1,7 @@
+pub mod bool_comparison;
+pub mod double_bool_comparison;
+pub mod ifs_same_cond;
+pub mod multiplication_before_division;
+pub mod shift_overflow;
+pub mod unnecessary_type_conversion;
+pub mod unused_private_function;

--- a/crates/aptos-lint/src/lint/rules/multiplication_before_division.rs
+++ b/crates/aptos-lint/src/lint/rules/multiplication_before_division.rs
@@ -1,0 +1,54 @@
+// This linting rule detects expressions where multiplication appears before division.
+// Such patterns can potentially affect the precision of the result, and this lint warns
+// developers to ensure division operations precede multiplication in mathematical expressions.
+use move_compiler::typing::ast::{self as AST, Exp};
+use move_compiler::parser::ast as AST1;
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{LintVisitor, LintUtilities};
+
+pub struct MultiplicationBeforeDivisionVisitor;
+
+impl MultiplicationBeforeDivisionVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn check_multiplication_before_division(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::BinopExp(e1, op, _, _) => {
+                if let AST1::BinOp_::Mul = &op.value {
+                    if self.has_binop_div_in_exp(e1) {
+                        let message = &format!("Multiplication should come before division to avoid large rounding errors.");
+                        self.add_warning(context, &exp.exp.loc, message);
+
+                    }
+                }
+            },
+            _ => (),
+        }
+    }
+
+    fn has_binop_div_in_exp(&self, exp: &Exp) -> bool {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::BinopExp(e1, op, _, e2) => {
+                match &op.value {
+                    AST1::BinOp_::Div => true,
+                    _ => self.has_binop_div_in_exp(e1) || self.has_binop_div_in_exp(e2),
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+impl LintVisitor for MultiplicationBeforeDivisionVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        self.check_multiplication_before_division(exp, context);
+    }
+}
+
+impl LintUtilities for MultiplicationBeforeDivisionVisitor {}

--- a/crates/aptos-lint/src/lint/rules/shift_overflow.rs
+++ b/crates/aptos-lint/src/lint/rules/shift_overflow.rs
@@ -1,0 +1,88 @@
+// The visitor checks for potential overflow scenarios where the number of bits being shifted exceeds the bit width of
+// the variable being shifted, which could lead to unintended behavior or loss of data. If such a
+// potential overflow is detected, a warning is generated to alert the developer.
+use std::str::FromStr;
+
+use move_compiler::typing::ast::Exp;
+use move_compiler::parser::ast as AST1;
+use move_compiler::expansion::ast as AST2;
+use move_compiler::naming::ast as AST3;
+use move_compiler::typing::ast as AST4;
+use move_ir_types::sp;
+
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{ LintVisitor, LintUtilities };
+
+pub struct ShiftOverflowVisitor {}
+
+impl ShiftOverflowVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn check_shift_overflow(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        match &exp.exp.value {
+            AST4::UnannotatedExp_::BinopExp(e1, op, _, e2) => {
+                match &op.value {
+                    AST1::BinOp_::Shl | AST1::BinOp_::Shr => {
+                        // e1 << e2 | e1 >> e2
+                        if let AST3::Type_::Apply(_, sp!(_, AST3::TypeName_::Builtin(sp!(_, typ))), _) = &e1.ty.value {
+                            // bit of e1
+                            let v1_bit: Option<u128> = match &typ {
+                                AST3::BuiltinTypeName_::U8 => Some(8),
+                                AST3::BuiltinTypeName_::U16 => Some(16),
+                                AST3::BuiltinTypeName_::U32 => Some(32),
+                                AST3::BuiltinTypeName_::U64 => Some(64),
+                                AST3::BuiltinTypeName_::U128 => Some(128),
+                                AST3::BuiltinTypeName_::U256 => Some(256),
+                                _ => None,
+                            };
+                            if let Some(v1_bit) = v1_bit {
+                                // AST4::UnannotatedExp_::Value // constant node
+                                if let AST4::UnannotatedExp_::Value(v2) = &e2.exp.value {
+                                    let is_overflow = match &v2.value {
+                                        AST2::Value_::InferredNum(v) | AST2::Value_::U256(v) => {
+                                            if
+                                                let Ok(v1_bit_256) = move_core_types::u256::U256::from_str(
+                                                    v1_bit.to_string().as_str()
+                                                )
+                                            {
+                                                v >= &v1_bit_256
+                                            } else {
+                                                false
+                                            }
+                                        }
+                                        AST2::Value_::U8(v) => (*v as u128) >= v1_bit,
+                                        AST2::Value_::U16(v) => (*v as u128) >= v1_bit,
+                                        AST2::Value_::U32(v) => (*v as u128) >= v1_bit,
+                                        AST2::Value_::U64(v) => (*v as u128) >= v1_bit,
+                                        AST2::Value_::U128(v) => (*v as u128) >= v1_bit,
+                                        _ => false,
+                                    };
+                                    if is_overflow {
+                                        let message = "Potential overflow detected during a shift operation.";
+                                        self.add_warning(context, &exp.exp.loc, message);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+impl LintVisitor for ShiftOverflowVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        self.check_shift_overflow(exp, context);
+    }
+}
+
+impl LintUtilities for ShiftOverflowVisitor {}

--- a/crates/aptos-lint/src/lint/rules/unnecessary_type_conversion.rs
+++ b/crates/aptos-lint/src/lint/rules/unnecessary_type_conversion.rs
@@ -1,0 +1,57 @@
+// The visitor specifically targets cases where a variable is being cast to the same type it already has.
+// Such type conversions are redundant and can be omitted for cleaner and more readable code.
+use move_compiler::naming::ast::{ Type_, TypeName_, BuiltinTypeName };
+use move_compiler::typing::ast as AST;
+use move_compiler::typing::ast::Exp;
+
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{LintVisitor, LintUtilities};
+
+pub struct UnnecessaryTypeConversionVisitor;
+
+impl UnnecessaryTypeConversionVisitor {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn extract_builtin_type_name(ty: &Type_) -> Option<&BuiltinTypeName> {
+        if let Type_::Apply(_, type_name, _) = ty {
+            if let TypeName_::Builtin(builtin_name) = &type_name.value { Some(builtin_name) } else { None }
+        } else {
+            None
+        }
+    }
+
+    fn check_unnecessary_conversion(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        if let AST::UnannotatedExp_::Cast(e, typ) = &exp.exp.value {
+            // Checking if an expression is a type cast operation.
+            // If the original type and the target type of the cast operation are the same,
+            // a warning is generated because such a cast is redundant.
+            if &e.ty.value == &typ.value {
+                let var_name = self.get_exp_string(e);
+                let type_name = format!(
+                    "{:?}",
+                    UnnecessaryTypeConversionVisitor::extract_builtin_type_name(&typ.value).unwrap()
+                );
+                let message = &format!(
+                    "Unnecessary type conversion detected. '{}' is already of type '{}'. Avoid casting it to its own type.",
+                    var_name,
+                    type_name
+                );
+                self.add_warning(context, &exp.exp.loc, message);
+            }
+        }
+    }
+}
+
+impl LintVisitor for UnnecessaryTypeConversionVisitor {
+    fn visit_exp(&mut self, exp: &Exp, context: &mut VisitorContext) {
+        self.check_unnecessary_conversion(exp, context);
+    }
+}
+
+impl LintUtilities for UnnecessaryTypeConversionVisitor {}

--- a/crates/aptos-lint/src/lint/rules/unused_private_function.rs
+++ b/crates/aptos-lint/src/lint/rules/unused_private_function.rs
@@ -1,0 +1,90 @@
+// The visitor identifies functions that are declared but not used 
+// (i.e., functions that are defined but not called anywhere within the module).
+
+use std::collections::BTreeMap;
+
+use move_compiler::typing::ast::{ Function, ModuleDefinition };
+use move_compiler::typing::ast as AST;
+use move_compiler::expansion::ast as AST2;
+use move_ir_types::location::Loc;
+use crate::lint::context::VisitorContext;
+use crate::lint::visitor::{ LintVisitor, LintUtilities };
+
+pub struct UnusedFunctionVisitor {
+    declared_functions: BTreeMap<String, move_ir_types::location::Loc>,
+    called_functions: BTreeMap<String, move_ir_types::location::Loc>,
+}
+
+impl UnusedFunctionVisitor {
+    pub fn new() -> Self {
+        Self {
+            declared_functions: BTreeMap::new(),
+            called_functions: BTreeMap::new(),
+        }
+    }
+
+    pub fn visitor() -> Box<dyn LintVisitor> {
+        Box::new(Self::new())
+    }
+
+    fn register_function_declaration(&mut self, func_name: &str, loc: Loc) {
+        self.declared_functions.insert(func_name.to_string(), loc);
+    }
+
+    fn register_function_call(&mut self, func_name: &str, loc: Loc) {
+        self.called_functions.insert(func_name.to_string(), loc);
+    }
+
+    fn check_unused_functions(&mut self, context: &mut VisitorContext) {
+        let unused_function_names: Vec<_> = self.declared_functions
+            .iter()
+            .filter(|(fname, _)| !self.called_functions.contains_key(*fname))
+            .map(|(fname, loc)| (fname.clone(), loc.clone()))
+            .collect();
+        for (fname, loc) in unused_function_names {
+            let message = format!("Function '{}' is unused.", fname);
+            self.add_warning(context, &loc, &message);
+        }
+    }
+    fn check_function_calls(&mut self, function: &Function) {
+        match &function.body.value {
+            AST::FunctionBody_::Defined(block) => {
+                for seq in block {
+                    match &seq.value {
+                        AST::SequenceItem_::Seq(exp) => {
+                            if let AST::UnannotatedExp_::ModuleCall(call) = &exp.exp.value {
+                                let func_key = format!("{}", &call.name.0.value);
+                                self.register_function_call(&func_key, exp.exp.loc);
+                            }
+                        }
+                        AST::SequenceItem_::Bind(_, _, exp) => {
+                            if let AST::UnannotatedExp_::ModuleCall(call) = &exp.exp.value {
+                                let func_key = format!("{}", &call.name.0.value);
+                                self.register_function_call(&func_key, exp.exp.loc);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+impl LintVisitor for UnusedFunctionVisitor {
+    fn visit_module(&mut self, module: &ModuleDefinition, context: &mut VisitorContext) {
+        for (loc, fname, func) in &module.functions {
+            if func.visibility == AST2::Visibility::Internal && !func.entry.is_some() {
+                self.register_function_declaration(fname, loc);
+            }
+        }
+
+        for (_, _, func) in &module.functions {
+            self.check_function_calls(&func);
+        }
+        self.check_unused_functions(context);
+    }
+}
+
+impl LintUtilities for UnusedFunctionVisitor {}

--- a/crates/aptos-lint/src/lint/visitor.rs
+++ b/crates/aptos-lint/src/lint/visitor.rs
@@ -1,0 +1,92 @@
+use move_compiler::typing::ast::{ Function, Sequence, Exp, ModuleDefinition };
+use move_compiler::typing::ast as AST;
+
+use super::context::VisitorContext;
+
+pub trait LintVisitor {
+    fn visit_module(&mut self, _module: &ModuleDefinition, _context: &mut VisitorContext) {}
+
+    fn visit_function(&mut self, function: &Function, context: &mut VisitorContext) {
+        match &function.body.value {
+            AST::FunctionBody_::Defined(block) => {
+                self.visit_sequence(block, context);
+            }
+            _ => (),
+        }
+    }
+
+    fn visit_sequence(&mut self, block: &Sequence, context: &mut VisitorContext) {
+        for seq in block {
+            match &seq.value {
+                AST::SequenceItem_::Seq(exp) => {
+                    self.visit_exp(exp, context);
+                }
+                // AST::SequenceItem_::Declare(exp) => {
+                //     self.visit_exp(exp, context);
+                // }
+                AST::SequenceItem_::Bind(_, _, exp) => {
+                    self.visit_exp(exp, context);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_exp(&mut self, _function: &Exp, _context: &mut VisitorContext) {}
+}
+
+pub trait LintUtilities {
+    fn normalize_binary_op(&self, left: &str, op: &str, right: &str) -> String {
+        match op {
+            "Eq" | "Neq" => {
+                let (l, r) = if left <= right { (left, right) } else { (right, left) };
+                format!("{} {} {}", l, op, r)
+            }
+            "Gt" => { format!("{} Lt {}", right, left) }
+            "Ge" => { format!("{} Le {}", right, left) }
+            "Lt" => { format!("{} Gt {}", right, left) }
+            "Le" => { format!("{} Ge {}", right, left) }
+            _ => format!("{} {} {}", left, op, right),
+        }
+    }
+
+    fn get_condition_string(&self, exp: &Box<Exp>) -> String {
+        match &exp.exp.value {
+            AST::UnannotatedExp_::BinopExp(left, op, _, right) => {
+                let left_str = self.get_exp_string(left);
+                let op_str = format!("{:?}", op);
+                let right_str = self.get_exp_string(right);
+                self.normalize_binary_op(&left_str, &op_str, &right_str)
+            }
+            AST::UnannotatedExp_::Copy { var, .. } => var.to_string(),
+            AST::UnannotatedExp_::Value(val) => format!("{:?}", val),
+            _ => "".to_string(),
+        }
+    }
+
+    fn get_exp_string(&self, e: &Box<Exp>) -> String {
+        let condition_string = self.get_condition_string(e);
+        condition_string
+    }
+
+    fn add_diagnostic_with_severity(
+        &mut self,
+        context: &mut VisitorContext,
+        loc: &move_ir_types::location::Loc,
+        message: &str,
+        severity: codespan_reporting::diagnostic::Severity
+    ) {
+        if let Some(f) = context.ast.files.get(&loc.file_hash()) {
+            let file_id = context.add_file(f.0.to_string(), f.1.clone().into());
+            context.add_diagnostic(file_id, loc.start() as usize, loc.end() as usize, message, severity);
+        }
+    }
+
+    fn add_warning(&mut self, context: &mut VisitorContext, loc: &move_ir_types::location::Loc, message: &str) {
+        self.add_diagnostic_with_severity(context, loc, message, codespan_reporting::diagnostic::Severity::Warning);
+    }
+
+    fn add_error(&mut self, context: &mut VisitorContext, loc: &move_ir_types::location::Loc, message: &str) {
+        self.add_diagnostic_with_severity(context, loc, message, codespan_reporting::diagnostic::Severity::Error);
+    }
+}

--- a/crates/aptos-lint/tests/cases/bool_comparision/Move.toml
+++ b/crates/aptos-lint/tests/cases/bool_comparision/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/bool_comparision/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/bool_comparision/sources/Detector.move
@@ -1,0 +1,9 @@
+module NamedAddr::Detector {
+    const ERROR_NUM: u64 = 2;
+    public fun func1(x: bool) {
+        if (x == true) {};
+        if (x == false) {};
+        if (x) {};
+        if (!x) {};
+    }
+}

--- a/crates/aptos-lint/tests/cases/double_bool_comparison/Move.toml
+++ b/crates/aptos-lint/tests/cases/double_bool_comparison/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/double_bool_comparison/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/double_bool_comparison/sources/Detector.move
@@ -1,0 +1,18 @@
+module NamedAddr::Detector {
+    const ERROR_NUM: u64 = 2;
+    public fun func1(x: u64, y: u64) {
+        if (x == y || x < y) {}; // should be x <= y
+        if (x < y || x == y) {}; // should be x <= y
+        if (x == y || x > y) {}; // should be x >= y
+        if (x > y || x == y) {}; // should be x >= y
+        if (x != y || x < y) {}; // same as x < y
+        if (x < y || x != y) {}; // same as x < y
+        if (x != y || x > y) {}; // same as x > y
+        if (x > y || x != y) {}; // same as x > y
+
+        if (x <= y) {};
+        if (x >= y) {};
+        if (x > y) {};
+        if (x < y) {};
+    }
+}

--- a/crates/aptos-lint/tests/cases/ifs_same_cond/Move.toml
+++ b/crates/aptos-lint/tests/cases/ifs_same_cond/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/ifs_same_cond/sources/lint.move
+++ b/crates/aptos-lint/tests/cases/ifs_same_cond/sources/lint.move
@@ -1,0 +1,30 @@
+module NamedAddr::Detector {
+    const ERROR_NUM: u64 = 2;
+    public fun func1(x: u64) {
+        let x = 1;
+        let y = 2;
+        let z = 2;
+        if (x == y) {
+        } else if (x == y) {
+        } else if (x == y) {
+        }
+        else if (x == z) {
+        }
+        else if (x == y) {
+        };
+
+        if(x == y) {
+        };
+
+        if(y == x) {
+        };
+
+        if(y > x) {
+        } else if (y > x){
+
+        };
+        if(y > x) {};
+        if(x < y) {};
+    }
+
+}

--- a/crates/aptos-lint/tests/cases/multiplication_before_division/Move.toml
+++ b/crates/aptos-lint/tests/cases/multiplication_before_division/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/multiplication_before_division/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/multiplication_before_division/sources/Detector.move
@@ -1,0 +1,20 @@
+module NamedAddr::Detector {
+    public fun func1(x: u64, y: u64, z:u64) {
+        let a = x * y / z;
+        let b = x / z * y; // <Issue:7>
+        //Multiplication followed by Division (Expected Warnings)
+        let _c = x * (y / z); // <Issue:9>
+        let _d = x * y / (z * 2); // <Issue:10>
+        let _e = (x * 2) / y; // <Issue:11>
+
+        //Parentheses and Nested Expressions (Expected Warnings)
+        let _f = (x * y) / (z + 1); // <Issue:12>
+        let _g = (x * (y + 1)) / z; // <Issue:13>
+        let _h = x * (y / (z - 1)); // <Issue:14>
+
+        let _i = (x * y) / z * (a / b); // <Issue:15>
+        let _j = x * y * a / (z + b); // <Issue:16>
+        let _k = x * (y / (z + a)) / b; // <Issue:17>
+        let _l = x * (y / (z * a)) / (b + 1); // <Issue:18>
+    }
+}

--- a/crates/aptos-lint/tests/cases/shift_overflow/Move.toml
+++ b/crates/aptos-lint/tests/cases/shift_overflow/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/shift_overflow/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/shift_overflow/sources/Detector.move
@@ -1,0 +1,20 @@
+module NamedAddr::Detector {
+    public fun func1(x: u64) {
+        let _b = x << 24;
+        let _b = x << 64; // <Issue:5>
+        let _b = x << 65; // <Issue:5>
+        let _b = x >> 66; // <Issue:5>
+
+        let _u8 = (x as u8);
+        let _u16 = (x as u16);
+        let _u32 = (x as u32);
+        let _u128 = (x as u128);
+        let _u256 = (x as u256);
+        
+        let _b = _u8 << 8;
+        let _b = _u16 << 16;
+        let _b = _u32 << 32;
+        let _b = _u128 << 128;
+        let _b = _u256 << 128;
+    }
+}

--- a/crates/aptos-lint/tests/cases/unnecessary_type_conversion/Move.toml
+++ b/crates/aptos-lint/tests/cases/unnecessary_type_conversion/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/unnecessary_type_conversion/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/unnecessary_type_conversion/sources/Detector.move
@@ -1,0 +1,6 @@
+module NamedAddr::Detector {
+    public fun func1(x: u64) {
+        let _b = (x as u128);
+        let _b = (x as u64); // <Issue:3>
+    }
+}

--- a/crates/aptos-lint/tests/cases/unused_private_function/Move.toml
+++ b/crates/aptos-lint/tests/cases/unused_private_function/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Detector"
+version = "0.0.0"
+
+[addresses]
+NamedAddr = "0xCAFE"

--- a/crates/aptos-lint/tests/cases/unused_private_function/sources/Detector.move
+++ b/crates/aptos-lint/tests/cases/unused_private_function/sources/Detector.move
@@ -1,0 +1,7 @@
+module NamedAddr::Detector {
+    public fun func1(x: u64) { func2(x) }
+    fun func2(x: u64) {  }
+    fun func3(x: u64) {  } // <Issue:4>
+    inline fun func4(x: u64) {  } // <Issue:4>
+    entry fun func5(x: u64) {  } // <Issue:4>
+}

--- a/crates/aptos-lint/tests/test_detectors.rs
+++ b/crates/aptos-lint/tests/test_detectors.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+
+fn run_linter(path: PathBuf) {
+    let context = aptos_lint::aptos_lint(path).unwrap();
+    context.emit_diagnostics();
+}
+
+#[test]
+fn test_modules() {
+    run_linter(PathBuf::from("tests").join("cases").join("bool_comparision"));
+    run_linter(PathBuf::from("tests").join("cases").join("double_bool_comparison"));
+    run_linter(PathBuf::from("tests").join("cases").join("ifs_same_cond"));
+    run_linter(PathBuf::from("tests").join("cases").join("multiplication_before_division"));
+    run_linter(PathBuf::from("tests").join("cases").join("shift_overflow"));
+    run_linter(PathBuf::from("tests").join("cases").join("unnecessary_type_conversion"));
+    run_linter(PathBuf::from("tests").join("cases").join("unused_private_function"));
+}


### PR DESCRIPTION
### Description

This adds the core for the Move Linter and the first few rules. This also adds basic tests that generate Linter warnings. The linter core uses construct_pre_compiled_lib from the Move compiler CLI  to build the required ASTs and then run the rules on these ASTs.


### Future TODOs
1. More rules (50+ total)
2. Group similar rules into the same file (same for corresponding tests) to minimize number of files
3. Category of linter errors (error vs warning)
4. Automated tests that check expected warnings/errors instead of manually looking at the output of running the Linter on test Move modules like currently.


### Test Plan
Tests with linter errors