### PR TITLE
[Storage] Add block index support for leader reputation.

### DIFF
--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -16,13 +16,12 @@ use aptos_consensus_types::common::{Author, Round};
 use aptos_crypto::{bls12381, HashValue};
 use aptos_infallible::Mutex;
 use aptos_keygen::KeyGen;
-use aptos_storage_interface::{DbReader, Order};
+use aptos_storage_interface::DbReader;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{new_block_event_key, NewBlockEvent},
     contract_event::{ContractEvent, EventWithVersion},
     epoch_state::EpochState,
-    event::EventKey,
     transaction::Version,
     validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
 };
@@ -484,22 +483,13 @@ impl MockDbReader {
 }
 
 impl DbReader for MockDbReader {
-    fn get_events(
-        &self,
-        _event_key: &EventKey,
-        start: u64,
-        order: Order,
-        limit: u64,
-        _ledger_version: Version,
-    ) -> anyhow::Result<Vec<EventWithVersion>> {
+    fn get_latest_block_events(&self, num_events: usize) -> anyhow::Result<Vec<EventWithVersion>> {
         *self.fetched.lock() += 1;
-        assert_eq!(start, u64::max_value());
-        assert!(order == Order::Descending);
         let events = self.events.lock();
         // println!("Events {:?}", *events);
         Ok(events
             .iter()
-            .skip(events.len().saturating_sub(limit as usize))
+            .skip(events.len().saturating_sub(num_events))
             .rev()
             .cloned()
             .collect())

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -81,6 +81,7 @@ pub(super) fn write_set_db_column_families() -> Vec<ColumnFamilyName> {
 pub(super) fn ledger_metadata_db_column_families() -> Vec<ColumnFamilyName> {
     vec![
         /* empty cf */ DEFAULT_COLUMN_FAMILY_NAME,
+        BLOCK_INDEX_CF_NAME,
         DB_METADATA_CF_NAME,
         EPOCH_BY_VERSION_CF_NAME,
         LEDGER_INFO_CF_NAME,

--- a/storage/aptosdb/src/schema/block_index/mod.rs
+++ b/storage/aptosdb/src/schema/block_index/mod.rs
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines physical storage schema for a block index.
+//!
+//! ```text
+//! |<-----key----->|<---------value--------->|
+//! |  block_height |   block_start_version   |
+//! ```
+
+use crate::schema::{ensure_slice_len_eq, BLOCK_INDEX_CF_NAME};
+use anyhow::Result;
+use aptos_schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+use aptos_types::transaction::Version;
+use byteorder::{BigEndian, ReadBytesExt};
+use std::mem::size_of;
+
+type BlockHeight = u64;
+type Key = BlockHeight;
+type Value = Version;
+
+define_schema!(BlockIndexSchema, Key, Value, BLOCK_INDEX_CF_NAME);
+
+impl KeyCodec<BlockIndexSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+
+    fn decode_key(mut data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+        Ok(data.read_u64::<BigEndian>()?)
+    }
+}
+
+impl ValueCodec<BlockIndexSchema> for Value {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+
+    fn decode_value(mut data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+        Ok(data.read_u64::<BigEndian>()?)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/schema/block_index/test.rs
+++ b/storage/aptosdb/src/schema/block_index/test.rs
@@ -1,0 +1,18 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        block_height in any::<u64>(),
+        start_version in any::<u64>(),
+    ) {
+        assert_encode_decode::<BlockIndexSchema>(&block_height, &start_version);
+    }
+}
+
+test_no_panic_decoding!(BlockIndexSchema);

--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! All schemas are `pub(crate)` so not shown in rustdoc, refer to the source code to see details.
 
+pub(crate) mod block_index;
 pub(crate) mod db_metadata;
 pub(crate) mod epoch_by_version;
 pub(crate) mod event;
@@ -30,6 +31,7 @@ pub(crate) mod write_set;
 use anyhow::{ensure, Result};
 use aptos_schemadb::ColumnFamilyName;
 
+pub const BLOCK_INDEX_CF_NAME: ColumnFamilyName = "block_index";
 pub const DB_METADATA_CF_NAME: ColumnFamilyName = "db_metadata";
 pub const EPOCH_BY_VERSION_CF_NAME: ColumnFamilyName = "epoch_by_version";
 pub const EVENT_ACCUMULATOR_CF_NAME: ColumnFamilyName = "event_accumulator";
@@ -78,6 +80,7 @@ pub mod fuzzing {
     pub fn fuzz_decode(data: &[u8]) {
         #[allow(unused_must_use)]
         {
+            assert_no_panic_decoding::<super::block_index::BlockIndexSchema>(data);
             assert_no_panic_decoding::<super::epoch_by_version::EpochByVersionSchema>(data);
             assert_no_panic_decoding::<super::event::EventSchema>(data);
             assert_no_panic_decoding::<super::event_accumulator::EventAccumulatorSchema>(data);

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -239,6 +239,9 @@ pub trait DbReader: Send + Sync {
 
         fn get_next_block_event(&self, version: Version) -> Result<(Version, NewBlockEvent)>;
 
+        /// See [AptosDB::get_latest_block_events].
+        fn get_latest_block_events(&self, num_events: usize) -> Result<Vec<EventWithVersion>>;
+
         /// Returns the start_version, end_version and NewBlockEvent of the block containing the input
         /// transaction version.
         fn get_block_info_by_version(


### PR DESCRIPTION
### Description

First step to make block as first class concept at storage layer.
- Add a block index CF to store block_height -> version mapping.
- Add an api to return latest NewblockEvents, and change leader reputation to use the new API so it doesn't depend on event indices.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
