### PR TITLE
Update version for processor and Hasura console, improve detection of Docker environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=bcba94c26c8a6372056d2b69ce411c5719f98965#bcba94c26c8a6372056d2b69ce411c5719f98965"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a12014686fcb6122ab787a54b1280ae305cbc193#a12014686fcb6122ab787a54b1280ae305cbc193"
 dependencies = [
  "chrono",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.1.2"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af4067b6606c0c4823dbb640e8f2db4cb2a1a7f9#af4067b6606c0c4823dbb640e8f2db4cb2a1a7f9"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=14c8813c9a0c31437a679c2601d1c828060c4a3c#14c8813c9a0c31437a679c2601d1c828060c4a3c"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -11909,11 +11909,11 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=bcba94c26c8a6372056d2b69ce411c5719f98965#bcba94c26c8a6372056d2b69ce411c5719f98965"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a12014686fcb6122ab787a54b1280ae305cbc193#a12014686fcb6122ab787a54b1280ae305cbc193"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=bcba94c26c8a6372056d2b69ce411c5719f98965)",
- "aptos-protos 1.1.2 (git+https://github.com/aptos-labs/aptos-core.git?rev=af4067b6606c0c4823dbb640e8f2db4cb2a1a7f9)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a12014686fcb6122ab787a54b1280ae305cbc193)",
+ "aptos-protos 1.1.2 (git+https://github.com/aptos-labs/aptos-core.git?rev=14c8813c9a0c31437a679c2601d1c828060c4a3c)",
  "async-trait",
  "base64 0.13.0",
  "bcs 0.1.4",
@@ -13421,7 +13421,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=bcba94c26c8a6372056d2b69ce411c5719f98965#bcba94c26c8a6372056d2b69ce411c5719f98965"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a12014686fcb6122ab787a54b1280ae305cbc193#a12014686fcb6122ab787a54b1280ae305cbc193"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "bcba94c26c8a6372056d2b69ce411c5719f98965" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "a12014686fcb6122ab787a54b1280ae305cbc193" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "bcba94c26c8a6372056d2b69ce411c5719f98965" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "a12014686fcb6122ab787a54b1280ae305cbc193" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -24,7 +24,7 @@ use std::{collections::HashSet, path::PathBuf};
 use tracing::{info, warn};
 
 const INDEXER_API_CONTAINER_NAME: &str = "indexer-api";
-const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.33.0";
+const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.35.0";
 
 /// This Hasura metadata originates from the aptos-indexer-processors repo.
 ///
@@ -156,11 +156,14 @@ impl ServiceManager for IndexerApiManager {
         // daemon but not when running in WSL configured to use Docker from within the
         // WSL environment. So instead of checking for OS we check the name of the
         // Docker daemon.
+        //
+        // This is the best method I could figure out for determining the Docker env,
+        // see more here: https://stackoverflow.com/q/77243960/3846032.
         let info = docker
             .info()
             .await
             .context("Failed to get info about Docker daemon")?;
-        let is_docker_desktop = info.name == Some("docker-desktop".to_string());
+        let is_docker_desktop = info.operating_system == Some("Docker Desktop".to_string());
         let postgres_connection_string = if is_docker_desktop {
             info!("Running with Docker Desktop, using host.docker.internal");
             self.postgres_connection_string


### PR DESCRIPTION
### Description
No particular reason for the version bumps, just trying to get the latest and greatest.

Previously I was using the name of the Docker context to figure out if the Docker engine was Docker Desktop or not. Turns out this is not reliable, so I'm using a different field now. 

### Test Plan
Works on Mac, if CI passes that means it works on Linux and Windows too.