### PR TITLE
[CLI] Make inter container networking more reliable in local testnet

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to 2d5cb211a89a8705674e9e1e741c841dd899c558.
+- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to 2d5cb211a89a8705674e9e1e741c841dd899c558. 
+- Improved reliability of inter-container networking with local testnet.
 
 ## [2.3.0] - 2023/10/25
 ### Added

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -4,7 +4,7 @@
 use super::{
     docker::{
         delete_container, get_docker, pull_docker_image, setup_docker_logging,
-        StopContainerShutdownStep,
+        StopContainerShutdownStep, CONTAINER_NETWORK_NAME,
     },
     health_checker::HealthChecker,
     traits::{PostHealthyStep, ServiceManager, ShutdownStep},
@@ -23,7 +23,7 @@ use reqwest::Url;
 use std::{collections::HashSet, path::PathBuf};
 use tracing::{info, warn};
 
-const INDEXER_API_CONTAINER_NAME: &str = "indexer-api";
+const INDEXER_API_CONTAINER_NAME: &str = "local-testnet-indexer-api";
 const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.35.0";
 
 /// This Hasura metadata originates from the aptos-indexer-processors repo.
@@ -135,8 +135,36 @@ impl ServiceManager for IndexerApiManager {
     async fn run_service(self: Box<Self>) -> Result<()> {
         setup_docker_logging(&self.test_dir, "indexer-api", INDEXER_API_CONTAINER_NAME)?;
 
+        // This is somewhat hard to maintain. If it requires any further maintenance we
+        // should just delete support for using Postgres on the host system.
+        let (postgres_connection_string, network_mode) =
+            // When connecting to postgres on the host via an IP from inside a
+            // container, we need to instead connect to host.docker.internal.
+            // There is no need to bind to a Docker network in this case.
+            if self.postgres_connection_string.contains("127.0.0.1") {
+                (
+                    self.postgres_connection_string
+                        .replace("127.0.0.1", "host.docker.internal"),
+                    None,
+                )
+            } else {
+                // Otherwise we use the standard connection string (containing the name
+                // of the container) and bind to the Docker network we created earlier
+                // in the Postgres pre_run steps.
+                (
+                    self.postgres_connection_string,
+                    Some(CONTAINER_NETWORK_NAME.to_string()),
+                )
+            };
+
         let exposed_ports = Some(hashmap! {self.indexer_api_port.to_string() => hashmap!{}});
-        let mut host_config = HostConfig {
+        let host_config = HostConfig {
+            // Connect the container to the network we made in the postgres pre_run.
+            // This allows the indexer API to access the postgres container without
+            // routing through the host network.
+            network_mode,
+            // This is necessary so connecting to the host postgres works on Linux.
+            extra_hosts: Some(vec!["host.docker.internal:host-gateway".to_string()]),
             port_bindings: Some(hashmap! {
                 self.indexer_api_port.to_string() => Some(vec![PortBinding {
                     host_ip: Some("127.0.0.1".to_string()),
@@ -147,39 +175,6 @@ impl ServiceManager for IndexerApiManager {
         };
 
         let docker = get_docker().await?;
-
-        // When using Docker Desktop you can and indeed must use the magic hostname
-        // host.docker.internal in order to access localhost on the host system from
-        // within the container. This also theoretically works without Docker Desktop,
-        // but you have to manually add the name to /etc/hosts in the container, and in
-        // my experience even that doesn't work sometimes. So when in a Docker Desktop
-        // environment we replace 127.0.0.1 with host.docker.internal, whereas in other
-        // environments we still use 127.0.0.1 and use host networking mode.
-        //
-        // In practice, this means we do the replacement when on MacOS or Windows, both
-        // standard (NT) and WSL and we don't do it on Linux / when running from within
-        // a container. But checking for OS is not accurate, since for example we must
-        // do the replacement when running in WSL configured to use the host Docker
-        // daemon but not when running in WSL configured to use Docker from within the
-        // WSL environment. So instead of checking for OS we check the name of the
-        // Docker daemon.
-        //
-        // This is the best method I could figure out for determining the Docker env,
-        // see more here: https://stackoverflow.com/q/77243960/3846032.
-        let info = docker
-            .info()
-            .await
-            .context("Failed to get info about Docker daemon")?;
-        let is_docker_desktop = info.operating_system == Some("Docker Desktop".to_string());
-        let postgres_connection_string = if is_docker_desktop {
-            info!("Running with Docker Desktop, using host.docker.internal");
-            self.postgres_connection_string
-                .replace("127.0.0.1", "host.docker.internal")
-        } else {
-            info!("Not running with Docker Desktop, using host networking mode");
-            host_config.network_mode = Some("host".to_string());
-            self.postgres_connection_string
-        };
 
         info!(
             "Using postgres connection string: {}",
@@ -200,6 +195,8 @@ impl ServiceManager for IndexerApiManager {
                 format!("INDEXER_V2_POSTGRES_URL={}", postgres_connection_string),
                 "HASURA_GRAPHQL_DEV_MODE=true".to_string(),
                 "HASURA_GRAPHQL_ENABLE_CONSOLE=true".to_string(),
+                // See the docs for the image, this is a magic path inside the
+                // container where they have already bundled in the UI assets.
                 "HASURA_GRAPHQL_CONSOLE_ASSETS_DIR=/srv/console-assets".to_string(),
                 format!("HASURA_GRAPHQL_SERVER_PORT={}", self.indexer_api_port),
             ]),

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -256,7 +256,7 @@ impl CliCommand<()> for RunLocalTestnet {
                 &self,
                 processor_preqrequisite_healthcheckers,
                 node_manager.get_data_service_url(),
-                self.postgres_args.get_connection_string(None),
+                self.postgres_args.get_connection_string(None, true),
             )
             .context("Failed to build processor service managers")?;
 
@@ -275,7 +275,7 @@ impl CliCommand<()> for RunLocalTestnet {
                 &self,
                 processor_health_checkers,
                 test_dir.clone(),
-                self.postgres_args.get_connection_string(None),
+                self.postgres_args.get_connection_string(None, false),
             )
             .context("Failed to build indexer API service manager")?;
             managers.push(Box::new(indexer_api_manager));


### PR DESCRIPTION
### Description
I finally figured out a way to run the containers such that I don't need to detect the Docker environment (Docker Desktop or not) and change the invocation accordingly. This should make it much more reliable.

### Test Plan
Tested manually on MacOS, Linux, Windows (WSL) with this command:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-indexer-api
```

I also confirmed that running the local testnet from inside a container (with the tools image) still works.

Windows (NT) doesn't seem to be working, but the release version of the CLI is also not working, even without `--with-indexer-api`, so I suspect it has to do with my machine rather than the CLI. Still investigating.

All the failing CI seems unrelated, it has been broken for a while it turns out.