### PR TITLE
[forge] increase TPS thresholds for realistic_env_max_load_test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1773,7 +1773,15 @@ fn realistic_env_max_load_test(
                     mempool_backlog: 40000,
                 })
                 .init_gas_price_multiplier(20),
-            inner_success_criteria: SuccessCriteria::new(if ha_proxy { 4600 } else { 6800 }),
+            inner_success_criteria: SuccessCriteria::new(
+                if ha_proxy {
+                    4600
+                } else if long_running {
+                    7500
+                } else {
+                    7000
+                },
+            ),
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             // Have single epoch change in land blocking, and a few on long-running


### PR DESCRIPTION
### Description

We have been consistently hitting these marks for awhile, so we need to update to avoid silent regressions. Even these are pretty conservative, for now erring on the side of loose thresholds to prevent flakiness.