### PR TITLE
[Doc] Added missing examples for CLI Args

### DIFF
--- a/aptos-move/move-examples/cli_args/entry_function_arguments.json
+++ b/aptos-move/move-examples/cli_args/entry_function_arguments.json
@@ -10,8 +10,21 @@
             "value": 123
         },
         {
+            "type": "hex",
+            "value": "0x1234"
+        },
+        {
+            "type": "string",
+            "value": "hello, world! ♥"
+        },
+        {
             "type": "bool",
-            "value": [false, true, false, false]
+            "value": [
+                false,
+                true,
+                false,
+                false
+            ]
         },
         {
             "type": "address",

--- a/aptos-move/move-examples/cli_args/script_function_arguments.json
+++ b/aptos-move/move-examples/cli_args/script_function_arguments.json
@@ -9,8 +9,21 @@
             "value": 123
         },
         {
+            "type": "hex",
+            "value": "0x1234"
+        },
+        {
+            "type": "string",
+            "value": "hello, world! ♥"
+        },
+        {
             "type": "u8",
-            "value": [122, 123, 124, 125]
+            "value": [
+                122,
+                123,
+                124,
+                125
+            ]
         },
         {
             "type": "address",

--- a/aptos-move/move-examples/cli_args/scripts/set_vals.move
+++ b/aptos-move/move-examples/cli_args/scripts/set_vals.move
@@ -2,6 +2,7 @@
 script {
     use test_account::cli_args;
     use std::vector;
+    use std::string::String;
 
     /// Get a `bool` vector where each element indicates `true` if the
     /// corresponding element in `u8_vec` is greater than `u8_solo`.
@@ -10,11 +11,13 @@ script {
     fun set_vals<T1, T2>(
         account: signer,
         u8_solo: u8,
+        bytes: vector<u8>,
+        utf8_string: String,
         u8_vec: vector<u8>,
         address_solo: address,
     ) {
         let bool_vec = vector::map_ref(&u8_vec, |e_ref| *e_ref > u8_solo);
         let addr_vec_vec = vector[vector[address_solo]];
-        cli_args::set_vals<T1, T2>(account, u8_solo, bool_vec, addr_vec_vec);
+        cli_args::set_vals<T1, T2>(account, u8_solo, bytes, utf8_string, bool_vec, addr_vec_vec);
     }
 } // <:!:script

--- a/aptos-move/move-examples/cli_args/sources/cli_args.move
+++ b/aptos-move/move-examples/cli_args/sources/cli_args.move
@@ -2,10 +2,12 @@
 module test_account::cli_args {
     use std::signer;
     use aptos_std::type_info::{Self, TypeInfo};
-
+    use std::string::String;
 
     struct Holder has key, drop {
         u8_solo: u8,
+        bytes: vector<u8>,
+        utf8_string: String,
         bool_vec: vector<bool>,
         address_vec_vec: vector<vector<address>>,
         type_info_1: TypeInfo,
@@ -18,6 +20,8 @@ module test_account::cli_args {
     public entry fun set_vals<T1, T2>(
         account: signer,
         u8_solo: u8,
+        bytes: vector<u8>,
+        utf8_string: String,
         bool_vec: vector<bool>,
         address_vec_vec: vector<vector<address>>,
     ) acquires Holder {
@@ -27,6 +31,8 @@ module test_account::cli_args {
         };
         move_to(&account, Holder {
             u8_solo,
+            bytes,
+            utf8_string,
             bool_vec,
             address_vec_vec,
             type_info_1: type_info::type_of<T1>(),
@@ -37,6 +43,8 @@ module test_account::cli_args {
     // :!:>view
     struct RevealResult has drop {
         u8_solo: u8,
+        bytes: vector<u8>,
+        utf8_string: String,
         bool_vec: vector<bool>,
         address_vec_vec: vector<vector<address>>,
         type_info_1_match: bool,
@@ -52,6 +60,8 @@ module test_account::cli_args {
         let holder_ref = borrow_global<Holder>(host);
         RevealResult {
             u8_solo: holder_ref.u8_solo,
+            bytes: holder_ref.bytes,
+            utf8_string: holder_ref.utf8_string,
             bool_vec: holder_ref.bool_vec,
             address_vec_vec: holder_ref.address_vec_vec,
             type_info_1_match:

--- a/developer-docs-site/docs/move/move-on-aptos/cli.md
+++ b/developer-docs-site/docs/move/move-on-aptos/cli.md
@@ -566,6 +566,8 @@ aptos move run \
         0x1::chain_id::ChainId \
     --args \
         u8:123 \
+        "hex:0x1234" \
+        "string:hello, world\! ♥" \
         "bool:[false, true, false, false]" \
         'address:[["0xace", "0xbee"], ["0xcad"], []]' \
     --private-key-file ace.key \
@@ -682,9 +684,11 @@ import view_json_file from '!!raw-loader!../../../../aptos-move/move-examples/cl
         false,
         false
       ],
+      "bytes": "0x1234",
       "type_info_1_match": true,
       "type_info_2_match": false,
-      "u8_solo": 123
+      "u8_solo": 123,
+      "utf8_string": "hello, world! ♥"
     }
   ]
 }
@@ -726,6 +730,8 @@ aptos move run-script \
         0x1::chain_id::ChainId \
     --args \
         u8:123 \
+        "hex:0x1234" \
+        "string:hello, world\! ♥" \
         "u8:[122, 123, 124, 125]" \
         address:"0xace" \
     --private-key-file ace.key \
@@ -810,9 +816,11 @@ aptos move view \
         true,
         true
       ],
+      "bytes": "0x1234",
       "type_info_1_match": true,
       "type_info_2_match": true,
-      "u8_solo": 123
+      "u8_solo": 123,
+      "utf8_string": "hello, world! ♥"
     }
   ]
 }


### PR DESCRIPTION
### Description

Added missing examples about CLI arguments, such as `hex` and `string`
