### PR TITLE
[dag] state sync mode rewrite

### DIFF
--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -19,7 +19,7 @@ use crate::{
     dag::{
         adapter::{compute_initial_block_and_ledger_info, LedgerInfoProvider},
         anchor_election::{LeaderReputationAdapter, MetadataBackendAdapter},
-        dag_state_sync::{StateSyncStatus, SyncModeMessageHandler},
+        dag_state_sync::{SyncModeMessageHandler, SyncOutcome},
         observability::logging::{LogEvent, LogSchema},
         round_state::{AdaptiveResponsive, RoundState},
     },
@@ -39,7 +39,7 @@ use aptos_channels::{
 use aptos_config::config::DagConsensusConfig;
 use aptos_consensus_types::common::{Author, Round};
 use aptos_infallible::RwLock;
-use aptos_logger::{debug, info};
+use aptos_logger::info;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
 use aptos_types::{
     epoch_state::EpochState, on_chain_config::DagConsensusConfigV1,
@@ -52,7 +52,7 @@ use futures_channel::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 use tokio::{select, task::JoinHandle};
 use tokio_retry::strategy::ExponentialBackoff;
 
@@ -68,6 +68,15 @@ struct BootstrapBaseState {
 enum Mode {
     Active(ActiveMode),
     Sync(SyncMode),
+}
+
+impl fmt::Display for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Mode::Active(_) => write!(f, "Active"),
+            Mode::Sync(_) => write!(f, "Sync"),
+        }
+    }
 }
 
 #[async_trait]
@@ -94,6 +103,17 @@ impl TDagMode for ActiveMode {
         dag_rpc_rx: &mut Receiver<Author, IncomingDAGRequest>,
         _bootstrapper: &DagBootstrapper,
     ) -> Option<Mode> {
+        info!(
+            LogSchema::new(LogEvent::ActiveMode)
+                .round(self.base_state.dag_store.read().highest_round()),
+            highest_committed_round = self
+                .base_state
+                .ledger_info_provider
+                .get_latest_ledger_info()
+                .commit_info()
+                .round()
+        );
+
         // Spawn the fetch service
         let handle = tokio::spawn(self.fetch_service.start());
         defer!({
@@ -103,14 +123,19 @@ impl TDagMode for ActiveMode {
         });
 
         // Run the network handler until it returns with state sync status.
-        let sync_status = self.handler.run(dag_rpc_rx, self.buffer).await;
+        let sync_outcome = self.handler.run(dag_rpc_rx, self.buffer).await;
 
-        match sync_status {
-            StateSyncStatus::NeedsSync(certified_node_msg) => Some(Mode::Sync(SyncMode {
+        info!(
+            LogSchema::new(LogEvent::SyncOutcome),
+            sync_outcome = %sync_outcome,
+        );
+
+        match sync_outcome {
+            SyncOutcome::NeedsSync(certified_node_msg) => Some(Mode::Sync(SyncMode {
                 certified_node_msg,
                 base_state: self.base_state,
             })),
-            StateSyncStatus::EpochEnds => None,
+            SyncOutcome::EpochEnds => None,
             _ => unreachable!(),
         }
     }
@@ -142,8 +167,9 @@ impl TDagMode for SyncMode {
             .base_state
             .ledger_info_provider
             .get_highest_committed_anchor_round();
-        debug!(
-            LogSchema::new(LogEvent::StateSync)
+
+        info!(
+            LogSchema::new(LogEvent::SyncMode)
                 .round(self.base_state.dag_store.read().highest_round()),
             target_round = self.certified_node_msg.round(),
             local_ordered_round = self
@@ -160,7 +186,7 @@ impl TDagMode for SyncMode {
             bootstrapper.config.fetcher_config.clone(),
         );
 
-        let (request, responders, sync_dag_store) = sync_manager.build_sync_to_request(
+        let (request, responders, sync_dag_store) = sync_manager.build_request(
             &self.certified_node_msg,
             self.base_state.dag_store.clone(),
             highest_committed_anchor_round,
@@ -176,20 +202,16 @@ impl TDagMode for SyncMode {
 
         let (res_tx, res_rx) = oneshot::channel();
         let handle = tokio::spawn(async move {
-            let success = match sync_manager
-                .sync_dag_to(dag_fetcher, request, responders, sync_dag_store, commit_li)
-                .await
-            {
-                Ok(_) => {
-                    info!("sync success. going to rebootstrap.");
-                    true
-                },
-                Err(_) => {
-                    info!("sync failed. continuing without advancing.");
-                    false
-                },
-            };
-            let _ = res_tx.send(success);
+            let result = sync_manager
+                .sync_dag_to(
+                    dag_fetcher,
+                    request,
+                    responders,
+                    sync_dag_store,
+                    commit_li,
+                )
+                .await;
+            let _ = res_tx.send(result);
         });
         defer!({
             handle.abort();
@@ -199,6 +221,37 @@ impl TDagMode for SyncMode {
         let mut buffer = Vec::new();
 
         select! {
+            biased;
+            res = res_rx => {
+                match res {
+                    Ok(sync_result) => {
+                        if let Ok(_) = sync_result {
+                            info!("sync succeeded. running full bootstrap.");
+                            // If the sync task finishes successfully, we can transition to Active mode by
+                            // rebootstrapping all components starting from the DAG store.
+                            let (new_state, new_handler, new_fetch_service) = bootstrapper.full_bootstrap();
+                            return Some(Mode::Active(ActiveMode {
+                                handler: new_handler,
+                                fetch_service: new_fetch_service,
+                                base_state: new_state,
+                                buffer,
+                            }))
+                        } else {
+                            info!("sync failed. resuming with current DAG state.");
+                            // If the sync task fails, then continue the DAG in Active Mode with existing state.
+                            let (new_handler, new_fetch_service) =
+                                bootstrapper.bootstrap_components(&self.base_state);
+                            return Some(Mode::Active(ActiveMode {
+                                handler: new_handler,
+                                fetch_service: new_fetch_service,
+                                base_state: self.base_state,
+                                buffer,
+                            }))
+                        }
+                    },
+                    Err(_) => unreachable!("sender won't be dropped without sending"),
+                }
+            },
             res = network_handle.run(dag_rpc_rx, &mut buffer) => {
                 // The network handle returns if the sender side of dag_rpc_rx closes,
                 // or network handle found a future CertifiedNodeMessage to cancel the
@@ -210,29 +263,6 @@ impl TDagMode for SyncMode {
                     }));
                 } else {
                     unreachable!("remote mustn't drop the network message sender until bootstrapper returns");
-                }
-            },
-            res = res_rx => {
-                if let Ok(true) = res {
-                    // If the sync task finishes successfully, we can transition to Active mode by
-                    // rebootstrapping all components starting from the DAG store.
-                    let (new_state, new_handler, new_fetch_service) = bootstrapper.full_bootstrap();
-                    return Some(Mode::Active(ActiveMode {
-                        handler: new_handler,
-                        fetch_service: new_fetch_service,
-                        base_state: new_state,
-                        buffer,
-                    }))
-                } else {
-                    // If the sync task fails, then continue the DAG in Active Mode with existing state.
-                    let (new_handler, new_fetch_service) =
-                        bootstrapper.bootstrap_components(&self.base_state);
-                    return Some(Mode::Active(ActiveMode {
-                        handler: new_handler,
-                        fetch_service: new_fetch_service,
-                        base_state: self.base_state,
-                        buffer,
-                    }))
                 }
             }
         }
@@ -512,7 +542,13 @@ impl DagBootstrapper {
         mut dag_rpc_rx: Receiver<Author, IncomingDAGRequest>,
         mut shutdown_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
+        info!(
+            LogSchema::new(LogEvent::Start),
+            epoch = self.epoch_state.epoch,
+        );
+
         let (base_state, handler, fetch_service) = self.full_bootstrap();
+
         let mut mode = Mode::Active(ActiveMode {
             handler,
             fetch_service,
@@ -524,10 +560,12 @@ impl DagBootstrapper {
                 biased;
                 Ok(ack_tx) = &mut shutdown_rx => {
                     let _ = ack_tx.send(());
+                    info!(LogSchema::new(LogEvent::Shutdown), "shutdown complete");
                     return;
                 },
                 Some(next_mode) = mode.run(&mut dag_rpc_rx, &self) => {
-                    mode = next_mode
+                    info!(LogSchema::new(LogEvent::ModeTransition), next_mode = %next_mode);
+                    mode = next_mode;
                 }
             }
         }
@@ -547,7 +585,7 @@ pub(super) fn bootstrap_dag_for_test(
     payload_client: Arc<dyn PayloadClient>,
     state_computer: Arc<dyn StateComputer>,
 ) -> (
-    JoinHandle<StateSyncStatus>,
+    JoinHandle<SyncOutcome>,
     JoinHandle<()>,
     aptos_channel::Sender<Author, IncomingDAGRequest>,
     UnboundedReceiver<OrderedBlocks>,

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -224,7 +224,7 @@ impl TDagMode for SyncMode {
             res = res_rx => {
                 match res {
                     Ok(sync_result) => {
-                        if let Ok(_) = sync_result {
+                        if sync_result.is_ok() {
                             info!("sync succeeded. running full bootstrap.");
                             // If the sync task finishes successfully, we can transition to Active mode by
                             // rebootstrapping all components starting from the DAG store.

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -5,7 +5,7 @@ use crate::{
         dag_driver::DagDriver,
         dag_fetcher::{FetchRequestHandler, FetchWaiter},
         dag_network::RpcHandler,
-        dag_state_sync::{SyncOutcome, StateSyncTrigger},
+        dag_state_sync::{StateSyncTrigger, SyncOutcome},
         errors::{
             DAGError, DAGRpcError, DagDriverError, FetchRequestHandleError,
             NodeBroadcastHandleError,
@@ -147,8 +147,9 @@ impl NetworkHandler {
                                             DAGError::DagDriverError(err)
                                         })
                                 }),
-                            status @ (SyncOutcome::NeedsSync(_)
-                            | SyncOutcome::EpochEnds) => return Ok(status),
+                            status @ (SyncOutcome::NeedsSync(_) | SyncOutcome::EpochEnds) => {
+                                return Ok(status)
+                            },
                             _ => unreachable!(),
                         }
                     },

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -63,7 +63,9 @@ impl NetworkHandler {
     pub async fn run(
         mut self,
         dag_rpc_rx: &mut aptos_channel::Receiver<Author, IncomingDAGRequest>,
+        _buffer: Vec<DAGMessage>,
     ) -> StateSyncStatus {
+        // TODO: process buffer
         loop {
             select! {
                 msg = dag_rpc_rx.select_next_some() => {

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -290,7 +290,7 @@ impl SyncModeMessageHandler {
                 },
             }
         }
-        return None;
+        None
     }
 
     fn process_rpc(
@@ -331,6 +331,6 @@ impl SyncModeMessageHandler {
                 return Err(err);
             },
         };
-        return Ok(None);
+        Ok(None)
     }
 }

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -236,7 +236,7 @@ impl DagStateSynchronizer {
         responders: Vec<Author>,
         sync_dag_store: Arc<RwLock<Dag>>,
         commit_li: LedgerInfoWithSignatures,
-    ) -> anyhow::Result<Option<Dag>> {
+    ) -> anyhow::Result<Dag> {
         match dag_fetcher
             .fetch(request, responders, sync_dag_store.clone())
             .await
@@ -250,7 +250,7 @@ impl DagStateSynchronizer {
 
         self.state_computer.sync_to(commit_li).await?;
 
-        Ok(Arc::into_inner(sync_dag_store).map(|r| r.into_inner()))
+        Ok(Arc::into_inner(sync_dag_store).unwrap().into_inner())
     }
 }
 

--- a/consensus/src/dag/observability/logging.rs
+++ b/consensus/src/dag/observability/logging.rs
@@ -14,7 +14,7 @@ pub struct LogSchema {
 
 #[derive(Serialize)]
 pub enum LogEvent {
-    Start,
+    EpochStart,
     ModeTransition,
     BroadcastNode,
     ReceiveNode,

--- a/consensus/src/dag/observability/logging.rs
+++ b/consensus/src/dag/observability/logging.rs
@@ -15,6 +15,7 @@ pub struct LogSchema {
 #[derive(Serialize)]
 pub enum LogEvent {
     Start,
+    ModeTransition,
     BroadcastNode,
     ReceiveNode,
     Vote,
@@ -26,7 +27,10 @@ pub enum LogEvent {
     NewRound,
     FetchNodes,
     ReceiveFetchNodes,
-    StateSync,
+    ActiveMode,
+    SyncMode,
+    SyncOutcome,
+    Shutdown,
 }
 
 impl LogSchema {

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -197,8 +197,17 @@ async fn test_dag_state_sync() {
         epoch_state: epoch_state.clone(),
     };
 
+    let (request, responders, sync_dag_store) =
+        state_sync.build_sync_to_request(&sync_node_li, slow_dag.clone(), 0);
+
     let sync_result = state_sync
-        .sync_dag_to(&sync_node_li, dag_fetcher, slow_dag.clone(), 0)
+        .sync_dag_to(
+            dag_fetcher,
+            request,
+            responders,
+            sync_dag_store,
+            sync_node_li.ledger_info().clone(),
+        )
         .await;
     let new_dag = sync_result.unwrap().unwrap();
 

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -209,7 +209,7 @@ async fn test_dag_state_sync() {
             sync_node_li.ledger_info().clone(),
         )
         .await;
-    let new_dag = sync_result.unwrap().unwrap();
+    let new_dag = sync_result.unwrap();
 
     assert_eq!(
         new_dag.lowest_round(),

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -198,7 +198,7 @@ async fn test_dag_state_sync() {
     };
 
     let (request, responders, sync_dag_store) =
-        state_sync.build_sync_to_request(&sync_node_li, slow_dag.clone(), 0);
+        state_sync.build_request(&sync_node_li, slow_dag.clone(), 0);
 
     let sync_result = state_sync
         .sync_dag_to(

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -2,7 +2,10 @@
 
 use super::dag_test;
 use crate::{
-    dag::{bootstrap::bootstrap_dag_for_test, dag_state_sync::StateSyncStatus},
+    dag::{
+        bootstrap::bootstrap_dag_for_test,
+        dag_state_sync::SyncOutcome,
+    },
     experimental::buffer_manager::OrderedBlocks,
     network::{IncomingDAGRequest, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
@@ -42,7 +45,7 @@ use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 struct DagBootstrapUnit {
-    nh_task_handle: JoinHandle<StateSyncStatus>,
+    nh_task_handle: JoinHandle<SyncOutcome>,
     df_task_handle: JoinHandle<()>,
     dag_rpc_tx: aptos_channel::Sender<Author, IncomingDAGRequest>,
     network_events:

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -2,10 +2,7 @@
 
 use super::dag_test;
 use crate::{
-    dag::{
-        bootstrap::bootstrap_dag_for_test,
-        dag_state_sync::SyncOutcome,
-    },
+    dag::{bootstrap::bootstrap_dag_for_test, dag_state_sync::SyncOutcome},
     experimental::buffer_manager::OrderedBlocks,
     network::{IncomingDAGRequest, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},


### PR DESCRIPTION
### Description

This PR rewrites the DAG state sync mode to making catching up more effective
- It now processes incoming network messages. Fetch and Node messages are ignored. CertifiedNodeMessages are buffered. Also, if we get a CertifiedNodeMsg with 2*window higher round than the current synching target, then we abort the current sync and sync to this new CertifiedNodeMsg.
- If sync is unsuccessful, we keep using the current DAG store and order rule.
- If sync is successful, we rebootstrap all the components including a new DAG store reading from latest storage.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
