### PR TITLE
[Smoke Test] Add smoke tests to ensure validators can participate in consensus after syncing

### DIFF
--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -11,6 +11,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
+// The default file name for the secure storage file
+pub const SECURE_STORAGE_FILENAME: &str = "secure_storage.json";
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum SecureBackend {
@@ -128,7 +131,7 @@ impl Default for OnDiskStorageConfig {
     fn default() -> Self {
         Self {
             namespace: None,
-            path: PathBuf::from("secure_storage.json"),
+            path: PathBuf::from(SECURE_STORAGE_FILENAME),
             data_dir: PathBuf::from("/opt/aptos/data"),
         }
     }

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -4,7 +4,10 @@
 
 use crate::{FullNode, HealthCheckError, LocalVersion, Node, NodeExt, Validator, Version};
 use anyhow::{anyhow, ensure, Context, Result};
-use aptos_config::{config::NodeConfig, keys::ConfigKey};
+use aptos_config::{
+    config::{NodeConfig, SECURE_STORAGE_FILENAME},
+    keys::ConfigKey,
+};
 use aptos_db::{fast_sync_storage_wrapper::SECONDARY_DB_DIR, LEDGER_DB_NAME, STATE_MERKLE_DB_NAME};
 use aptos_logger::{debug, info};
 use aptos_sdk::{
@@ -297,7 +300,7 @@ impl Node for LocalNode {
         let node_config = self.config();
         let ledger_db_path = node_config.storage.dir().join(LEDGER_DB_NAME);
         let state_db_path = node_config.storage.dir().join(STATE_MERKLE_DB_NAME);
-        let secure_storage_path = node_config.get_working_dir().join("secure_storage.json");
+        let secure_storage_path = node_config.get_working_dir().join(SECURE_STORAGE_FILENAME);
         let state_sync_db_path = node_config.storage.dir().join(STATE_SYNC_DB_NAME);
         let secondary_db_path = node_config.storage.dir().join(SECONDARY_DB_DIR);
 
@@ -315,10 +318,10 @@ impl Node for LocalNode {
         assert!(ledger_db_path.as_path().exists() && state_db_path.as_path().exists());
         assert!(state_sync_db_path.as_path().exists());
         if self.config.base.role.is_validator() {
-            assert!(secure_storage_path.as_path().exists(),);
+            assert!(secure_storage_path.as_path().exists());
         }
 
-        // Remove the files
+        // Remove the primary DB files
         fs::remove_dir_all(ledger_db_path)
             .map_err(anyhow::Error::from)
             .context("Failed to delete ledger_db_path")?;
@@ -329,12 +332,14 @@ impl Node for LocalNode {
             .map_err(anyhow::Error::from)
             .context("Failed to delete state_sync_db_path")?;
 
-        // remove secondary db if the path exists
+        // Remove the secondary DB files
         if secondary_db_path.as_path().exists() {
             fs::remove_dir_all(secondary_db_path)
                 .map_err(anyhow::Error::from)
                 .context("Failed to delete secondary_db_path")?;
         }
+
+        // Remove the secure storage file
         if self.config.base.role.is_validator() {
             fs::remove_file(secure_storage_path)
                 .map_err(anyhow::Error::from)

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -411,15 +411,14 @@ async fn wait_for_all_nodes_to_catchup_to_target_version_or_epoch(
                 ))
             }))
             .await;
-        let node_versions_and_epochs = version_and_epoch_results
-            .map(|results| results.into_iter().collect::<Vec<_>>())
-            .ok();
+        let node_versions_and_epochs =
+            version_and_epoch_results.map(|results| results.into_iter().collect::<Vec<_>>());
 
         // Check if all nodes are caught up to the target version
         let all_caught_up_to_version = target_version
             .map(|target_version| {
                 node_versions_and_epochs
-                    .clone()
+                    .as_ref()
                     .map(|responses| {
                         responses
                             .iter()
@@ -433,7 +432,7 @@ async fn wait_for_all_nodes_to_catchup_to_target_version_or_epoch(
         let all_caught_up_to_epoch = target_epoch
             .map(|target_epoch| {
                 node_versions_and_epochs
-                    .clone()
+                    .as_ref()
                     .map(|responses| responses.iter().all(|(_, _, epoch)| *epoch >= target_epoch))
                     .unwrap_or(false) // No epoch found
             })
@@ -457,7 +456,7 @@ async fn wait_for_all_nodes_to_catchup_to_target_version_or_epoch(
                 target_version,
                 target_epoch,
                 start_time.elapsed().as_secs(),
-                node_versions_and_epochs.unwrap_or_default()
+                node_versions_and_epochs
             ));
         }
 


### PR DESCRIPTION
Note: this PR is built on: https://github.com/aptos-labs/aptos-core/pull/10763

### Description
This PR adds a set of smoke tests to ensure that validator nodes are able to participate in consensus after syncing. This property was temporarily broken for fast syncing validators, so we want to ensure it doesn't happen again.

The PR offers several commits:
1. Some small cleanups to the state sync smoke tests. Nothing should change logically -- I've just moved some things around and grouped some logic into functions.
2. Add 4 smoke tests to ensure that validators can participate in consensus after having their DB's wiped and synced. These tests check this property for: (i) fast syncing with epoch changes; (ii) fast syncing without epoch changes; (iii) default syncing with epoch changes; and (iv) default syncing without epoch changes.
3. Rename the state sync smoke tests (and other methods) to clarify exactly what is being tested. Most of these tests were named when nomenclature was different 😄 

### Test Plan
New and existing test infrastructure.