### PR TITLE
set mint to root for txn emitter

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -274,6 +274,11 @@ impl EmitJobRequest {
         self
     }
 
+    pub fn set_mint_to_root(mut self) -> Self {
+        self.mint_to_root = true;
+        self
+    }
+
     pub fn calculate_mode_params(&self) -> EmitModeParams {
         let clients_count = self.rest_clients.len();
 

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -120,7 +120,9 @@ pub async fn emit_transactions_with_cluster(
     if let Some(expected_gas_per_txn) = args.expected_gas_per_txn {
         emit_job_request = emit_job_request.expected_gas_per_txn(expected_gas_per_txn);
     }
-    if !cluster.coin_source_is_root {
+    if cluster.coin_source_is_root {
+        emit_job_request = emit_job_request.set_mint_to_root();
+    } else {
         emit_job_request = emit_job_request.prompt_before_spending();
     }
 


### PR DESCRIPTION
### Description

When using txn emitter on a test network (which has root account), we already have mint_to_root flag to not require user to fund root account manually
enable it for txn emitter, and make it not fail if root account has too much resources to make minting overflow

### Test Plan
forge tests use mint_to_root to test the non-failing behavior. 
