### PR TITLE
RestAPI: remove get_account_state

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -7538,6 +7538,74 @@
               }
             }
           },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
           "413": {
             "description": "",
             "content": {
@@ -9760,6 +9828,74 @@
               }
             }
           },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
           "413": {
             "description": "",
             "content": {
@@ -10261,6 +10397,74 @@
             }
           },
           "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "404": {
             "description": "",
             "content": {
               "application/json": {

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -5648,6 +5648,55 @@ paths:
               schema:
                 type: integer
                 format: uint64
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
         '413':
           description: ''
           content:
@@ -7311,6 +7360,55 @@ paths:
               schema:
                 type: integer
                 format: uint64
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
         '413':
           description: ''
           content:
@@ -7691,6 +7789,55 @@ paths:
                 type: integer
                 format: uint64
         '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '404':
           description: ''
           content:
             application/json:

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -10,7 +10,7 @@ use crate::{
         ForbiddenError, InternalError, NotFoundError, ServiceUnavailableError, StdApiError,
     },
 };
-use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
+use anyhow::{anyhow, bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_api_types::{
     AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo, ResourceGroup,
     TransactionOnChainData,
@@ -28,9 +28,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     access_path::{AccessPath, Path},
     account_address::AccountAddress,
-    account_config::NewBlockEvent,
-    account_state::AccountState,
-    account_view::AccountView,
+    account_config::{AccountResource, NewBlockEvent},
     chain_id::ChainId,
     contract_event::EventWithVersion,
     event::EventKey,
@@ -48,6 +46,7 @@ use aptos_vm::data_cache::AsMoveResolver;
 use futures::{channel::oneshot, SinkExt};
 use move_core_types::{
     language_storage::{ModuleId, StructTag},
+    move_resource::MoveResource,
     resolver::ModuleResolver,
 };
 use std::{
@@ -292,6 +291,52 @@ impl Context {
             .map_err(|e| E::internal_with_code(e, AptosErrorCode::InternalError, ledger_info))
     }
 
+    pub fn get_resource<T: MoveResource>(
+        &self,
+        address: AccountAddress,
+        version: Version,
+    ) -> Result<Option<T>> {
+        let access_path = AccessPath::resource_access_path(address, T::struct_tag())?;
+        let bytes_opt = self.get_state_value(&StateKey::access_path(access_path), version)?;
+        bytes_opt
+            .map(|bytes| bcs::from_bytes(&bytes))
+            .transpose()
+            .map_err(|err| anyhow!(format!("Failed to deserialize resource: {}", err)))
+    }
+
+    pub fn get_resource_poem<T: MoveResource, E: InternalError>(
+        &self,
+        address: AccountAddress,
+        version: Version,
+        latest_ledger_info: &LedgerInfo,
+    ) -> Result<Option<T>, E> {
+        self.get_resource(address, version)
+            .context("Failed to read account resource.")
+            .map_err(|err| {
+                E::internal_with_code(err, AptosErrorCode::InternalError, latest_ledger_info)
+            })
+    }
+
+    pub fn expect_resource_poem<T: MoveResource, E: InternalError + NotFoundError>(
+        &self,
+        address: AccountAddress,
+        version: Version,
+        latest_ledger_info: &LedgerInfo,
+    ) -> Result<T, E> {
+        self.get_resource_poem(address, version, latest_ledger_info)?
+            .ok_or_else(|| {
+                E::not_found_with_code(
+                    format!(
+                        "{} not found under address {}",
+                        T::struct_identifier(),
+                        address,
+                    ),
+                    AptosErrorCode::ResourceNotFound,
+                    latest_ledger_info,
+                )
+            })
+    }
+
     pub fn get_state_values(
         &self,
         address: AccountAddress,
@@ -451,26 +496,6 @@ impl Context {
             ))
         });
         Ok((kvs, next_key))
-    }
-
-    // This function should be deprecated. DO NOT USE it.
-    // Instead, call either `get_modules_by_pagination` or `get_modules_by_pagination`.
-    pub fn get_account_state<E: InternalError>(
-        &self,
-        address: AccountAddress,
-        version: u64,
-        latest_ledger_info: &LedgerInfo,
-    ) -> Result<Option<AccountState>, E> {
-        AccountState::from_access_paths_and_values(
-            address,
-            &self.get_state_values(address, version).map_err(|err| {
-                E::internal_with_code(err, AptosErrorCode::InternalError, latest_ledger_info)
-            })?,
-        )
-        .context("Failed to read account state at requested version")
-        .map_err(|err| {
-            E::internal_with_code(err, AptosErrorCode::InternalError, latest_ledger_info)
-        })
     }
 
     pub fn get_block_timestamp<E: InternalError>(
@@ -707,35 +732,13 @@ impl Context {
         let start_seq_number = if let Some(start_seq_number) = start_seq_number {
             start_seq_number
         } else {
-            // Get the current account state, and get the sequence number to get the limit most
-            // recent transactions
-            let account_state = self
-                .get_account_state(address, ledger_info.version(), ledger_info)?
-                .ok_or_else(|| {
-                    E::not_found_with_code(
-                        "Account not found",
-                        AptosErrorCode::AccountNotFound,
-                        ledger_info,
-                    )
-                })?;
-            let resource = account_state
-                .get_account_resource()
-                .map_err(|err| {
-                    E::internal_with_code(
-                        format!("Failed to get account resource {}", err),
-                        AptosErrorCode::InternalError,
-                        ledger_info,
-                    )
-                })?
-                .ok_or_else(|| {
-                    E::not_found_with_code(
-                        "Account not found",
-                        AptosErrorCode::AccountNotFound,
-                        ledger_info,
-                    )
-                })?;
-
-            resource.sequence_number().saturating_sub(limit as u64)
+            self.expect_resource_poem::<AccountResource, E>(
+                address,
+                ledger_info.version(),
+                ledger_info,
+            )?
+            .sequence_number()
+            .saturating_sub(limit as u64)
         };
 
         let txns = self

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -99,6 +99,7 @@ use aptos_types::{
     epoch_state::EpochState,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
+    on_chain_config::{CurrentTimeMicroseconds, OnChainConfig},
     proof::{
         accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProofExt,
         TransactionAccumulatorRangeProof, TransactionAccumulatorSummary,
@@ -1874,8 +1875,24 @@ impl DbReader for AptosDB {
             self.error_if_ledger_pruned("NewBlockEvent", version)?;
             ensure!(version <= self.get_latest_version()?);
 
-            let (_first_version, new_block_event) = self.event_store.get_block_metadata(version)?;
-            Ok(new_block_event.proposed_time())
+            match self.event_store.get_block_metadata(version) {
+                Ok((_first_version, new_block_event)) => Ok(new_block_event.proposed_time()),
+                Err(err) => {
+                    // when event index is disabled, we won't be able to search the NewBlock event stream.
+                    // TODO(grao): evaluate adding dedicated block_height_by_version index
+                    warn!(
+                        error = ?err,
+                        "Failed to fetch block timestamp, falling back to on-chain config.",
+                    );
+                    let ts = self
+                        .get_state_value_by_version(
+                            &StateKey::access_path(CurrentTimeMicroseconds::access_path()?),
+                            version,
+                        )?
+                        .ok_or_else(|| anyhow!("Timestamp not found at version {}", version))?;
+                    Ok(bcs::from_bytes::<CurrentTimeMicroseconds>(ts.bytes())?.microseconds)
+                },
+            }
         })
     }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1021,7 +1021,9 @@ impl AptosDB {
             &ledger_metadata_batch,
             &sharded_state_kv_batches,
             &state_kv_metadata_batch,
-            self.state_store.state_kv_db.enabled_sharding() && !skip_index_and_usage,
+            // Always put in state value index for now.
+            // TODO(grao): remove after APIs migrated off the DB to the indexer.
+            self.state_store.state_kv_db.enabled_sharding(),
             skip_index_and_usage,
         )?;
 


### PR DESCRIPTION
### Description
1. remove get_account_state: Simulation and get_account_txns API don't rely on the state kv index
2. always write to the state KV index
3. get around that get_block_timestamp breaks with event indices missing

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
unit tests and local fullnode simulation calls
