### PR TITLE
[dag][rb][bugfix] handle error result on rb and drop RB handle properly

### DIFF
--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -353,7 +353,7 @@ impl RpcHandler for DagDriver {
 
 impl Drop for DagDriver {
     fn drop(&mut self) {
-        if let Some((handle, _)) = self.rb_abort_handle {
+        if let Some((handle, _)) = &self.rb_abort_handle {
             handle.abort()
         }
     }

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -5,7 +5,7 @@ use super::anchor_election::TChainHealthBackoff;
 use crate::{
     dag::{
         adapter::TLedgerInfoProvider,
-        dag_fetcher::{FetchRequester, TFetchRequester},
+        dag_fetcher::TFetchRequester,
         dag_store::Dag,
         errors::DagDriverError,
         observability::{
@@ -53,7 +53,7 @@ pub(crate) struct DagDriver {
     rb_abort_handle: Option<(AbortHandle, u64)>,
     storage: Arc<dyn DAGStorage>,
     order_rule: OrderRule,
-    fetch_requester: Arc<FetchRequester>,
+    fetch_requester: Arc<dyn TFetchRequester>,
     ledger_info_provider: Arc<dyn TLedgerInfoProvider>,
     round_state: RoundState,
     window_size_config: Round,
@@ -73,7 +73,7 @@ impl DagDriver {
         time_service: TimeService,
         storage: Arc<dyn DAGStorage>,
         order_rule: OrderRule,
-        fetch_requester: Arc<FetchRequester>,
+        fetch_requester: Arc<dyn TFetchRequester>,
         ledger_info_provider: Arc<dyn TLedgerInfoProvider>,
         round_state: RoundState,
         window_size_config: Round,

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -350,3 +350,11 @@ impl RpcHandler for DagDriver {
         Ok(CertifiedAck::new(epoch))
     }
 }
+
+impl Drop for DagDriver {
+    fn drop(&mut self) {
+        if let Some((handle, _)) = self.rb_abort_handle {
+            handle.abort()
+        }
+    }
+}

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -131,7 +131,7 @@ fn setup(
     });
 
     let mock_ledger_info = LedgerInfo::mock_genesis(None);
-    let mock_ledger_info = generate_ledger_info_with_sig(&signers, mock_ledger_info);
+    let mock_ledger_info = generate_ledger_info_with_sig(signers, mock_ledger_info);
     let storage = Arc::new(MockStorage::new_with_ledger_info(mock_ledger_info.clone()));
     let dag = Arc::new(RwLock::new(Dag::new(
         epoch_state.clone(),
@@ -171,7 +171,7 @@ fn setup(
         Box::new(OptimisticResponsive::new(round_tx)),
     );
 
-    let driver = DagDriver::new(
+    DagDriver::new(
         signers[0].author(),
         epoch_state,
         dag,
@@ -187,14 +187,15 @@ fn setup(
         TEST_DAG_WINDOW as Round,
         DagPayloadConfig::default(),
         Arc::new(MockChainHealthBackoff {}),
-    );
-    driver
+    )
 }
 
 #[tokio::test]
 async fn test_certified_node_handler() {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
-    let network_sender = Arc::new(MockNetworkSender { _drop_notifier: None });
+    let network_sender = Arc::new(MockNetworkSender {
+        _drop_notifier: None,
+    });
     let mut driver = setup(&signers, validator_verifier, network_sender);
 
     let first_round_node = new_certified_node(1, signers[0].author(), vec![]);
@@ -217,7 +218,9 @@ async fn test_dag_driver_drop() {
 
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let (tx, rx) = oneshot::channel();
-    let network_sender = Arc::new(MockNetworkSender { _drop_notifier: Some(tx) });
+    let network_sender = Arc::new(MockNetworkSender {
+        _drop_notifier: Some(tx),
+    });
     let mut driver = setup(&signers, validator_verifier, network_sender);
 
     driver.enter_new_round(1).await;

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -5,7 +5,7 @@ use crate::{
         adapter::TLedgerInfoProvider,
         anchor_election::{RoundRobinAnchorElection, TChainHealthBackoff},
         dag_driver::DagDriver,
-        dag_fetcher::DagFetcherService,
+        dag_fetcher::TFetchRequester,
         dag_network::{RpcWithFallback, TDAGNetworkSender},
         dag_store::Dag,
         errors::DagDriverError,
@@ -16,13 +16,13 @@ use crate::{
             helpers::{new_certified_node, TEST_DAG_WINDOW},
             order_rule_tests::TestNotifier,
         },
-        types::{CertifiedAck, DAGMessage},
+        types::{CertifiedAck, DAGMessage, TestAck},
         DAGRpcResult, RpcHandler,
     },
     payload_manager::PayloadManager,
     test_utils::MockPayloadManager,
 };
-use aptos_config::config::{DagFetcherConfig, DagPayloadConfig};
+use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Round};
 use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
@@ -30,15 +30,19 @@ use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_state::EpochState,
     ledger_info::{generate_ledger_info_with_sig, LedgerInfo, LedgerInfoWithSignatures},
-    validator_verifier::random_validator_verifier,
+    validator_signer::ValidatorSigner,
+    validator_verifier::{random_validator_verifier, ValidatorVerifier},
 };
 use async_trait::async_trait;
 use claims::{assert_ok, assert_ok_eq};
 use futures_channel::mpsc::unbounded;
 use std::{sync::Arc, time::Duration};
+use tokio::sync::oneshot;
 use tokio_retry::strategy::ExponentialBackoff;
 
-struct MockNetworkSender {}
+struct MockNetworkSender {
+    _drop_notifier: Option<oneshot::Sender<()>>,
+}
 
 #[async_trait]
 impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
@@ -48,7 +52,7 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
         _messagee: DAGMessage,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {
-        unimplemented!()
+        Ok(DAGRpcResult(Ok(DAGMessage::TestAck(TestAck(Vec::new())))))
     }
 }
 
@@ -104,9 +108,23 @@ impl TChainHealthBackoff for MockChainHealthBackoff {
     }
 }
 
-#[tokio::test]
-async fn test_certified_node_handler() {
-    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+struct MockFetchRequester {}
+
+impl TFetchRequester for MockFetchRequester {
+    fn request_for_node(&self, _node: crate::dag::Node) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+
+    fn request_for_certified_node(&self, _node: crate::dag::CertifiedNode) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn setup(
+    signers: &[ValidatorSigner],
+    validator_verifier: ValidatorVerifier,
+    network_sender: Arc<MockNetworkSender>,
+) -> DagDriver {
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
         verifier: validator_verifier,
@@ -122,7 +140,6 @@ async fn test_certified_node_handler() {
         TEST_DAG_WINDOW,
     )));
 
-    let network_sender = Arc::new(MockNetworkSender {});
     let rb = Arc::new(ReliableBroadcast::new(
         signers.iter().map(|s| s.author()).collect(),
         network_sender.clone(),
@@ -143,14 +160,7 @@ async fn test_certified_node_handler() {
         TEST_DAG_WINDOW as Round,
     );
 
-    let (_, fetch_requester, _, _) = DagFetcherService::new(
-        epoch_state.clone(),
-        network_sender,
-        dag.clone(),
-        aptos_time_service::TimeService::mock(),
-        DagFetcherConfig::default(),
-    );
-    let fetch_requester = Arc::new(fetch_requester);
+    let fetch_requester = Arc::new(MockFetchRequester {});
 
     let ledger_info_provider = Arc::new(MockLedgerInfoProvider {
         latest_ledger_info: mock_ledger_info,
@@ -161,7 +171,7 @@ async fn test_certified_node_handler() {
         Box::new(OptimisticResponsive::new(round_tx)),
     );
 
-    let mut driver = DagDriver::new(
+    let driver = DagDriver::new(
         signers[0].author(),
         epoch_state,
         dag,
@@ -178,6 +188,14 @@ async fn test_certified_node_handler() {
         DagPayloadConfig::default(),
         Arc::new(MockChainHealthBackoff {}),
     );
+    driver
+}
+
+#[tokio::test]
+async fn test_certified_node_handler() {
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let network_sender = Arc::new(MockNetworkSender { _drop_notifier: None });
+    let mut driver = setup(&signers, validator_verifier, network_sender);
 
     let first_round_node = new_certified_node(1, signers[0].author(), vec![]);
     // expect an ack for a valid message
@@ -191,4 +209,23 @@ async fn test_certified_node_handler() {
         driver.process(invalid_node).await.unwrap_err().to_string(),
         DagDriverError::MissingParents.to_string()
     );
+}
+
+#[tokio::test]
+async fn test_dag_driver_drop() {
+    aptos_logger::Logger::init_for_testing();
+
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let (tx, rx) = oneshot::channel();
+    let network_sender = Arc::new(MockNetworkSender { _drop_notifier: Some(tx) });
+    let mut driver = setup(&signers, validator_verifier, network_sender);
+
+    driver.enter_new_round(1).await;
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        drop(driver);
+    });
+
+    let _ = rx.await;
 }

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -5,7 +5,7 @@ use aptos_consensus_types::common::Author;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
 pub trait RBMessage: Send + Sync + Clone {}
 
@@ -61,7 +61,7 @@ where
         &self,
         message: S::Message,
         mut aggregating: S,
-    ) -> impl Future<Output = S::Aggregated> {
+    ) -> impl Future<Output = S::Aggregated>  where <<S as BroadcastStatus<Req, Res>>::Ack as TryFrom<Res>>::Error: Debug {
         let receivers: Vec<_> = self.validators.clone();
         let network_sender = self.network_sender.clone();
         let time_service = self.time_service.clone();
@@ -94,12 +94,11 @@ where
                 fut.push(send_message(receiver, message.clone(), None));
             }
             while let Some((receiver, result)) = fut.next().await {
-                match result {
-                    Ok(msg) => {
-                        if let Ok(ack) = msg.try_into() {
-                            if let Ok(Some(aggregated)) = aggregating.add(receiver, ack) {
-                                return aggregated;
-                            }
+                match result.and_then(|msg| msg.try_into().map_err(|e| anyhow::anyhow!("{:?}", e)))
+                {
+                    Ok(ack) => {
+                        if let Ok(Some(aggregated)) = aggregating.add(receiver, ack) {
+                            return aggregated;
                         }
                     },
                     Err(_) => {


### PR DESCRIPTION
### Description

This PR makes fixes some RB bugs.
- It handles any error returned by the remote. Otherwise, sometimes, the loop will exit and execute the `unreachable!` path.
- Abort reliable broadcast handle on DagDriver drop. Otherwise, it will orphan the reliable broadcast task and it will keep trying to broadcast its node.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
