### PR TITLE
Add CI to ensure MacOS build of CLI works

### DIFF
--- a/.github/workflows/mac-cli-build.yaml
+++ b/.github/workflows/mac-cli-build.yaml
@@ -1,0 +1,30 @@
+# This workflow tests that the Aptos CLI can be compiled and run on MacOS
+name: "MacOS CLI Build"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+  push:
+    branches:
+      - main
+
+jobs:
+  macos-cli-build:
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+
+      # This action will cache ~/.cargo and ./target. See more here:
+      # https://github.com/Swatinem/rust-cache#cache-details
+      - name: Run cargo cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+
+      - name: Build the Aptos CLI
+        run: cargo build -p aptos
+
+      - name: Run the Aptos CLI help command
+        run: cargo run -p aptos -- --help

--- a/.github/workflows/windows-cli-build.yaml
+++ b/.github/workflows/windows-cli-build.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  windows-build:
+  windows-cli-build:
     runs-on: windows-latest-8-core
     defaults:
       run:


### PR DESCRIPTION
### Description
As with the Windows build, our time is valuable. Better to test here rather than have it break later without our knowledge.

### Test Plan
See that the new step passes.