### PR TITLE
Automatically create PR to bump homebrew version of CLI, don't build MacOS binary

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -53,21 +53,6 @@ jobs:
           name: cli-builds
           path: aptos-cli-*.zip
 
-  build-os-x-binary:
-    name: "Build OS X binary"
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.source_git_ref_override }}
-      - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "MacOSX"
-      - name: Upload Binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: cli-builds
-          path: aptos-cli-*.zip
-
   build-windows-binary:
     name: "Build Windows binary"
     runs-on: windows-latest
@@ -88,7 +73,6 @@ jobs:
     needs:
       - build-ubuntu20-binary
       - build-ubuntu22-binary
-      - build-os-x-binary
       - build-windows-binary
     runs-on: ubuntu-latest
     permissions:
@@ -109,3 +93,24 @@ jobs:
           title: "${{ format('Aptos CLI Release v{0}', inputs.release_version) }}"
           files: |
             aptos-cli-*.zip
+
+  bump-homebrew-version-pr:
+    name: "Make PR to bump version in Homebrew"
+    needs:
+      - release-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: aptos
+          tag-name: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
+          base-branch: master
+          create-pullrequest: true
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+
+            From CLI release run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -1,4 +1,5 @@
 # Aptos Command Line Interface (CLI) Tool
 
 The `aptos` tool is a command line interface (CLI) for debugging, development, and node operation.
+
 See [Aptos CLI Documentation](https://aptos.dev/cli-tools/aptos-cli/use-cli/install-aptos-cli) for how to install the `aptos` CLI tool and how to use it.

--- a/developer-docs-site/docs/tools/aptos-cli/install-cli/download-cli-binaries.md
+++ b/developer-docs-site/docs/tools/aptos-cli/install-cli/download-cli-binaries.md
@@ -6,7 +6,7 @@ title: "Download CLI Binaries"
 
 The `aptos` tool is a command line interface (CLI) for developing on the Aptos blockchain, debugging Move contracts, and conducting node operations. This document describes how to install the `aptos` CLI tool using precompiled binaries that reduce variables in setting up your environment. Also see:
 
-- [Installing the Aptos CLI](./index.md) for an alternative to using the precompiled binaries.
+- [Installing the Aptos CLI](./index.md) for alternatives to using the precompiled binaries.
 - [Installing the Move Prover](./install-move-prover.md) for an optional tool to validate your Move code.
 - [Using Aptos CLI](../use-cli/use-aptos-cli.md) for detailed instructions on employing the Aptos CLI.
 
@@ -15,47 +15,8 @@ Binary releases are recommended for most users, otherwise see [Building Aptos Fr
 <details>
 <summary>macOS</summary>
 
-## macOS
-
-:::tip
-These instructions have been tested on macOS Monterey (12.6)
-:::
-
-1. Go to the [Aptos CLI Release](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true) list.
-1. Click the **Assets** expandable menu for the latest release.
-1. You will see the zip files with the filename of the format: `aptos-cli-<version>-<platform>`. These are the platform-specific pre-compiled binaries of the CLI. Download the zip file for your platform, dismissing any warnings.
-1. Unzip the downloaded file. This will extract the `aptos` CLI binary file into your default downloads folder. For example, on macOS it is the `~/Downloads` folder.
-1. Move this extracted `aptos` binary file into your preferred local folder. For example, place it in the `~/bin/aptos` folder on macOS to make it accessible from the command line.
-
-   :::tip Upgrading? Remember to look in the default download folder
-   When you update the CLI binary with the latest version, note that the newer version binary will be downloaded to your default Downloads folder. Remember to move this newer version binary from the Downloads folder to the `~/bin/aptos` folder to update and overwrite the older version.
-   :::
-
-1. Make the `~/bin/aptos` directory executable by running this command: `chmod +x ~/bin/aptos`
-1. Follow the simple steps recommended by the Apple support in [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to remove the "unknown developer" blocker.
-1. Type `~/bin/aptos help` to read help instructions.
-1. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
-1. Run `aptos help` to see the list of commands and verify that the CLI is working.
-
-Note: You will need to manually install `openssl3` if you encounter an error message like the following:
-```
-dyld[81095]: Library not loaded: /usr/local/opt/openssl@3/lib/libssl.3.dylib
-  Referenced from: <56FDDCBF-43F4-381E-9ECA-ACEBC556EAB7> /Users/jinhou/.local/bin/aptos
-  Reason: tried: '/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/usr/local/lib/libssl.3.dylib' (no such file), '/usr/lib/libssl.3.dylib' (no such file, not in dyld cache)
-[1]    81095 abort      aptos
-```
-
-Take the following steps to install `openssl3`:
-1. Download the latest version from [OpenSSL](https://www.openssl.org/source).
-2. Unzip the downloaded file.
-3. `cd` into the unzipped folder, for example: `cd openssl-3.1.2`
-4. Run `./config --prefix /usr/local darwin64-x86_64-cc` to configure openssl3.
-5. Run `make` to build openssl3.
-6. Run `sudo make install` to install openssl3. Notice that `sudo` is required to install openssl3 to the `/usr/local` folder.
-7. Run `openssl version` to verify the installation. You should see something similar to the following output:
-```
-OpenSSL 3.1.2 1 Aug 2023
-```
+## MacOS
+We do not release binaries for MacOS, you must use [brew](https://brew.sh/).
 
 </details>
 

--- a/developer-docs-site/docs/tools/aptos-cli/install-cli/index.md
+++ b/developer-docs-site/docs/tools/aptos-cli/install-cli/index.md
@@ -8,7 +8,7 @@ You can install the Aptos CLI as a pre-compiled binary:
 
 - [Install the Aptos CLI with Homebrew](./install-from-brew.md) - Recommended for MacOS.
 - [Install the Aptos CLI by script](./automated-install.md) - Recommended for Linux and Windows.
-- [Download the prebuilt Aptos CLI binaries](./download-cli-binaries.md) - Ensures you get a stable version of the Aptos CLI built on a regular cadence from the `main` upstream development branch.
+- [Download the prebuilt Aptos CLI binaries](./download-cli-binaries.md) - Generally not recommended, but useful if you prefer not to use an automated installation method.
 
 You can also [build the Aptos CLI from source code](./build-from-source.md). This allows you to build from any of the Aptos branches, including `devnet`, `testnet`, `mainnet`, and the latest code in `main`, the development branch.
 


### PR DESCRIPTION
### Description
We've learned in the last few months that brew isn't as magic as I thought and every time we release a CLI, someone actually creates a PR to bump the version in homebrew-core manually. This means sometimes it can take a while.

To make this process faster, this PR adds a step to the CLI release that submits that version bump PR automatically.

### Test Plan
This PR was opened thanks to the new job added here: https://github.com/Homebrew/homebrew-core/pull/153591.