### PR TITLE
[State Sync] Disable subscription sync and optimize optimistic fetching

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -243,7 +243,7 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
-            enable_subscription_streaming: true,
+            enable_subscription_streaming: false,
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -183,15 +183,15 @@ impl AptosDataClient {
         Ok(())
     }
 
-    /// Chooses the peer with the lowest distance from the validator set
-    /// and measured latency (using the given set of serviceable peers).
-    fn choose_lowest_distance_and_latency_peer(
+    /// Chooses a peer randomly weighted by distance and
+    /// latency from the given set of serviceable peers.
+    fn choose_random_peer_by_distance_and_latency(
         &self,
         request: &StorageServiceRequest,
         serviceable_peers: HashSet<PeerNetworkId>,
     ) -> Result<PeerNetworkId, Error> {
-        // Choose the peer with the lowest distance and latency
-        if let Some(peer) = utils::choose_lowest_distance_and_latency_peer(
+        // Choose a peer weighted by distance and latency
+        if let Some(peer) = utils::choose_random_peer_by_distance_and_latency(
             serviceable_peers.clone(),
             self.get_peers_and_metadata(),
         ) {
@@ -223,8 +223,8 @@ impl AptosDataClient {
             // Choose a peer to handle the subscription request
             self.choose_peer_for_subscription_request(request, serviceable_peers)
         } else if request.data_request.is_optimistic_fetch() {
-            // Choose the peer with the lowest distance and latency for the optimistic fetch
-            self.choose_lowest_distance_and_latency_peer(request, serviceable_peers)
+            // Choose a peer to handle the optimistic fetch request
+            self.choose_random_peer_by_distance_and_latency(request, serviceable_peers)
         } else {
             // Choose the peer randomly weighted by latency
             self.choose_random_peer_by_latency(request, serviceable_peers)
@@ -283,7 +283,7 @@ impl AptosDataClient {
 
         // Otherwise, we need to choose a new peer and update the subscription state
         let peer_network_id =
-            self.choose_lowest_distance_and_latency_peer(request, serviceable_peers)?;
+            self.choose_random_peer_by_distance_and_latency(request, serviceable_peers)?;
         let subscription_state = SubscriptionState::new(peer_network_id, request_stream_id);
         *active_subscription_state = Some(subscription_state);
 

--- a/state-sync/aptos-data-client/src/tests/priority.rs
+++ b/state-sync/aptos-data-client/src/tests/priority.rs
@@ -24,7 +24,8 @@ use aptos_time_service::TimeServiceTrait;
 use claims::assert_matches;
 use maplit::hashset;
 use ordered_float::OrderedFloat;
-use std::collections::HashMap;
+use rand::Rng;
+use std::{cmp::Ordering, collections::HashMap};
 
 #[tokio::test]
 async fn all_peer_request_selection() {
@@ -549,19 +550,19 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
         update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
 
-        // Verify the lowest distance and latency regular peer is selected for the request
-        let lowest_latency_peer = verify_lowest_distance_and_latency_peer_selected(
+        // Verify the peer is selected by distance and latency
+        let selected_peer = verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
             &mut regular_peers,
         );
 
-        // Disconnect the lowest distance/latency peer and remove it from the list of regular peers
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, lowest_latency_peer);
+        // Disconnect the selected peer and remove it from the list of regular peers
+        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
 
-        // Verify the next lowest distance and latency regular peer is selected for the request
-        let lowest_latency_peer = verify_lowest_distance_and_latency_peer_selected(
+        // Verify the next peer is selected by distance and latency
+        let selected_peer = verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -576,7 +577,7 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
             priority_peers.push(priority_peer);
 
             // Verify the regular peer is still selected
-            verify_peer_selected_for_request(&client, lowest_latency_peer, &storage_request);
+            verify_peer_selected_for_request(&client, selected_peer, &storage_request);
         }
 
         // Advertise the data for the priority peers
@@ -587,8 +588,8 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
             timestamp_usecs,
         );
 
-        // Verify the lowest latency priority peer is selected for the request
-        verify_lowest_distance_and_latency_peer_selected(
+        // Verify the priority peers are selected by distance and latency
+        verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -610,8 +611,8 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
         // Disconnect the final priority peer and remove it from the list of priority peers
         disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, last_priority_peer);
 
-        // Verify the lowest distance and latency regular peer is selected for the request
-        verify_lowest_distance_and_latency_peer_selected(
+        // Verify a regular peer is selected by distance and latency
+        verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -623,6 +624,77 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
             mock_network.disconnect_peer(regular_peer);
         }
         verify_request_is_unserviceable(&client, &storage_request);
+    }
+}
+
+#[tokio::test]
+async fn prioritized_peer_optimistic_fetch_distance_latency_weights() {
+    // Create a data client with a max lag of 50
+    let max_optimistic_fetch_lag_secs = 50;
+    let data_client_config = AptosDataClientConfig {
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let min_validator_distance = 0;
+    let max_validator_distance = 2;
+
+    // Ensure the properties hold for both priority and non-priority peers
+    for priority_peers in [true, false] {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network, time service and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(None, Some(data_client_config), None);
+
+            // Add several peers and verify the peers cannot service the request
+            let mut peers = vec![];
+            for _ in 0..50 {
+                // Add a peer
+                let peer = mock_network.add_peer(priority_peers);
+                peers.push(peer);
+
+                // Verify the peer cannot service the request
+                verify_request_is_unserviceable(&client, &storage_request);
+
+                // Generate a random distance for the peer and update the peer's distance metadata
+                let distance_from_validator =
+                    rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
+                utils::update_distance_metadata(&client, peer, distance_from_validator as u64);
+            }
+
+            // Advertise the data for the peers
+            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+            update_storage_summaries_for_peers(&client, &peers, known_version, timestamp_usecs);
+
+            // Select a peer to service the request multiple times
+            let mut peers_and_selection_counts = HashMap::new();
+            for _ in 0..20_000 {
+                // Select a peer to service the request
+                let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+
+                // Update the peer selection counts
+                *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
+            }
+
+            // Verify all of the selected peers have the lowest distance
+            for peer in peers_and_selection_counts.keys() {
+                let distance_from_validator =
+                    utils::get_peer_distance_from_validators(&mut mock_network, *peer);
+                assert_eq!(distance_from_validator, min_validator_distance);
+            }
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+        }
     }
 }
 
@@ -943,8 +1015,8 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
         update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
 
-        // Verify the lowest distance and latency regular peer is selected
-        let lowest_latency_peer = verify_lowest_distance_and_latency_peer_selected(
+        // Verify the peer is selected by distance and latency
+        let selected_peer = verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -959,7 +1031,7 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
             priority_peers.push(priority_peer);
 
             // Verify the regular peer is still selected
-            verify_peer_selected_for_request(&client, lowest_latency_peer, &storage_request);
+            verify_peer_selected_for_request(&client, selected_peer, &storage_request);
         }
 
         // Advertise the data for the priority peers
@@ -973,10 +1045,10 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
         // Verify the request is unserviceable (the last request went to the regular peer)
         verify_request_is_unserviceable(&client, &storage_request);
 
-        // Update the request's subscription ID and verify the
-        // lowest distance and latency priority peer is selected.
+        // Update the request's subscription ID and verify
+        // the peer is selected by distance and latency.
         let storage_request = update_subscription_request_id(&storage_request);
-        verify_lowest_distance_and_latency_peer_selected(
+        verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -993,9 +1065,9 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
         priority_peers.retain(|peer| *peer == last_priority_peer);
 
         // Update the request's subscription ID and verify the
-        // lowest distance and latency priority peer is selected.
+        // peer is selected by distance and latency.
         let storage_request = update_subscription_request_id(&storage_request);
-        verify_lowest_distance_and_latency_peer_selected(
+        verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -1009,9 +1081,9 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
         verify_request_is_unserviceable(&client, &storage_request);
 
         // Update the request's subscription ID and verify the
-        // lowest distance and latency regular peer is selected.
+        // peer is selected by distance and latency.
         let storage_request = update_subscription_request_id(&storage_request);
-        verify_lowest_distance_and_latency_peer_selected(
+        verify_peer_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
@@ -1023,6 +1095,77 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
             mock_network.disconnect_peer(regular_peer);
         }
         verify_request_is_unserviceable(&client, &storage_request);
+    }
+}
+
+#[tokio::test]
+async fn prioritized_peer_subscription_distance_latency_weights() {
+    // Create a data client with a max lag of 500
+    let max_subscription_lag_secs = 500;
+    let data_client_config = AptosDataClientConfig {
+        max_subscription_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 1;
+    let known_epoch = 1;
+    let min_validator_distance = 1;
+    let max_validator_distance = 3;
+
+    // Ensure the properties hold for both priority and non-priority peers
+    for priority_peers in [true, false] {
+        // Ensure the properties hold for all subscription requests
+        for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network, time service and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(None, Some(data_client_config), None);
+
+            // Add several peers and verify the peers cannot service the request
+            let mut peers = vec![];
+            for _ in 0..50 {
+                // Add a peer
+                let peer = mock_network.add_peer(priority_peers);
+                peers.push(peer);
+
+                // Verify the peer cannot service the request
+                verify_request_is_unserviceable(&client, &storage_request);
+
+                // Generate a random distance for the peer and update the peer's distance metadata
+                let distance_from_validator =
+                    rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
+                utils::update_distance_metadata(&client, peer, distance_from_validator as u64);
+            }
+
+            // Advertise the data for the peers
+            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+            update_storage_summaries_for_peers(&client, &peers, known_version, timestamp_usecs);
+
+            // Select a peer to service the request multiple times
+            let mut peers_and_selection_counts = HashMap::new();
+            for _ in 0..20_000 {
+                // Select a peer to service the request
+                let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+
+                // Update the peer selection counts
+                *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
+            }
+
+            // Verify all of the selected peers have the lowest distance
+            for peer in peers_and_selection_counts.keys() {
+                let distance_from_validator =
+                    utils::get_peer_distance_from_validators(&mut mock_network, *peer);
+                assert_eq!(distance_from_validator, min_validator_distance);
+            }
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+        }
     }
 }
 
@@ -1513,31 +1656,37 @@ fn enumerate_subscription_requests(known_version: u64, known_epoch: u64) -> Vec<
     ]
 }
 
-/// Returns the peer with the lowest distance and latency from the given list of peers
-fn get_lowest_distance_and_latency_peer(
+/// Returns the peers with the lowest validator distance from the given list of peers
+fn get_lowest_distance_peers(
     peers: &[PeerNetworkId],
     mock_network: &mut MockNetwork,
-) -> PeerNetworkId {
-    let mut lowest_distance_and_latency_peer = peers[0];
+) -> Vec<PeerNetworkId> {
+    let mut lowest_distance_peers = vec![];
     let mut lowest_distance = u64::MAX;
-    let mut lowest_latency = f64::MAX;
 
-    // Identify the peer with the lowest distance and latency.
-    // Distance is prioritized over latency.
+    // Identify the peers with the lowest distance
     for peer in peers {
-        // Get the peer's distance and latency
+        // Get the peer's distance
         let distance = utils::get_peer_distance_from_validators(mock_network, *peer);
-        let latency = utils::get_peer_ping_latency(mock_network, *peer);
 
-        // Update the lowest distance and latency peer
-        if distance < lowest_distance || (distance == lowest_distance && latency < lowest_latency) {
-            lowest_distance = distance;
-            lowest_latency = latency;
-            lowest_distance_and_latency_peer = *peer;
+        // Update the lowest distance peers
+        match distance.cmp(&lowest_distance) {
+            Ordering::Equal => {
+                // Add the peer to the list of lowest distance peers
+                lowest_distance_peers.push(*peer)
+            },
+            Ordering::Less => {
+                // We found a new lowest distance!
+                lowest_distance = distance;
+                lowest_distance_peers = vec![*peer];
+            },
+            Ordering::Greater => {
+                // The peer is not a lowest distance peer
+            },
         }
     }
 
-    lowest_distance_and_latency_peer
+    lowest_distance_peers
 }
 
 /// Updates the storage summaries for the given peers using the specified
@@ -1583,22 +1732,26 @@ fn update_subscription_request_id(
     storage_service_request
 }
 
-/// Verifies that the lowest distance and latency peer is selected for
-/// the given request and returns the lowest calculated peer.
-fn verify_lowest_distance_and_latency_peer_selected(
+/// Verifies that a low distance and latency peer is selected for
+/// the given request (from the specified list of potential peers)
+/// and returns the select peer.
+fn verify_peer_selected_by_distance_and_latency(
     mock_network: &mut MockNetwork,
     client: &AptosDataClient,
     storage_request: &StorageServiceRequest,
-    regular_peers: &mut [PeerNetworkId],
+    potential_peers: &mut [PeerNetworkId],
 ) -> PeerNetworkId {
-    // Calculate the lowest distance and latency peer
-    let lowest_distance_and_latency_peer =
-        get_lowest_distance_and_latency_peer(regular_peers, mock_network);
+    // Select a peer for the given request
+    let selected_peer = client.choose_peer_for_request(storage_request).unwrap();
 
-    // Verify the lowest distance and latency peer is selected for the given request
-    verify_peer_selected_for_request(client, lowest_distance_and_latency_peer, storage_request);
+    // Verify the selected peer is in the list of potential peers
+    assert!(potential_peers.contains(&selected_peer));
 
-    lowest_distance_and_latency_peer
+    // Verify the selected peer has the lowest distance
+    let lowest_distance_peers = get_lowest_distance_peers(potential_peers, mock_network);
+    assert!(lowest_distance_peers.contains(&selected_peer));
+
+    selected_peer
 }
 
 /// Verifies that the peer is selected to service the given request

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -205,6 +205,30 @@ pub fn remove_latency_metadata(client: &AptosDataClient, peer: PeerNetworkId) {
         .unwrap();
 }
 
+/// Updates the distance metadata for the specified peer
+pub fn update_distance_metadata(
+    client: &AptosDataClient,
+    peer: PeerNetworkId,
+    distance_from_validators: u64,
+) {
+    // Get the peer monitoring metadata
+    let peers_and_metadata = client.get_peers_and_metadata();
+    let peer_metadata = peers_and_metadata.get_metadata_for_peer(peer).unwrap();
+    let mut peer_monitoring_metadata = peer_metadata.get_peer_monitoring_metadata().clone();
+
+    // Update the distance metadata
+    let mut latest_network_info_response = peer_monitoring_metadata
+        .latest_network_info_response
+        .unwrap();
+    latest_network_info_response.distance_from_validators = distance_from_validators;
+    peer_monitoring_metadata.latest_network_info_response = Some(latest_network_info_response);
+
+    // Update the peer monitoring metadata
+    peers_and_metadata
+        .update_peer_monitoring_metadata(peer, peer_monitoring_metadata)
+        .unwrap();
+}
+
 /// Verifies the top 10% of selected peers are the lowest latency peers
 pub fn verify_highest_peer_selection_latencies(
     mock_network: &mut MockNetwork,


### PR DESCRIPTION
### Description
This PR makes two modifications to state sync (each in their own commit):
1. Disable subscription syncing by default. For now, it makes sense to utilize optimistic fetching until we've fully stress tested the subscription syncing flows.
2. Improve the peer selection logic for optimistic fetches:
    - Currently, we're simply [choosing](https://github.com/aptos-labs/aptos-core/pull/10552) the peer with the lowest distance from the validator set and peer ping latency. While this is optimal for the happy path, it will struggle in the unhappy path (e.g., if the chosen peer is lagging, faulty or malicious).
    - To help combat this, we introduce some randomization into the selection logic and instead choose the peer weighted by distance and latency. Note: this is a temporary solution. Eventually, we'll want to improve the peer reputation and scoring logic to automatically identify and route around lagging/malicious peers. But for now, randomization should be sufficient.

### Test Plan
New and existing test infrastructure.