### PR TITLE
[aptos-node] add --performance mode for --test

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -70,6 +70,10 @@ pub struct AptosNodeArgs {
     #[clap(long)]
     test: bool,
 
+    /// Optimize the single validator node testnet for higher performance
+    #[clap(long, requires("test"))]
+    performance: bool,
+
     /// Random number generator seed for starting a single validator testnet.
     #[clap(long, value_parser = load_seed, requires("test"))]
     seed: Option<[u8; 32]>,
@@ -125,6 +129,9 @@ impl AptosNodeArgs {
 
         if self.test {
             println!("WARNING: Entering test mode! This should never be used in production!");
+            if self.performance {
+                println!("WARNING: Entering performance mode! System utilization may be high!");
+            }
 
             // Set the genesis framework
             let genesis_framework = if let Some(path) = self.genesis_framework {
@@ -145,6 +152,7 @@ impl AptosNodeArgs {
                 self.test_dir,
                 self.random_ports,
                 self.lazy,
+                self.performance,
                 &genesis_framework,
                 rng,
             )
@@ -256,6 +264,7 @@ pub fn load_node_config<R>(
     test_dir: &Path,
     random_ports: bool,
     enable_lazy_mode: bool,
+    enable_performance_mode: bool,
     framework: &ReleaseBundle,
     rng: R,
 ) -> anyhow::Result<NodeConfig>
@@ -276,6 +285,7 @@ where
             test_dir,
             random_ports,
             enable_lazy_mode,
+            enable_performance_mode,
             framework,
             rng,
         )?;
@@ -356,6 +366,7 @@ pub fn setup_test_environment_and_start_node<R>(
     test_dir: Option<PathBuf>,
     random_ports: bool,
     enable_lazy_mode: bool,
+    enable_performance_mode: bool,
     framework: &ReleaseBundle,
     rng: R,
 ) -> anyhow::Result<()>
@@ -378,6 +389,7 @@ where
             &test_dir,
             random_ports,
             enable_lazy_mode,
+            enable_performance_mode,
             framework,
             rng,
         )?,
@@ -395,6 +407,7 @@ pub fn create_single_node_test_config<R>(
     test_dir: &Path,
     random_ports: bool,
     enable_lazy_mode: bool,
+    enable_performance_mode: bool,
     framework: &ReleaseBundle,
     rng: R,
 ) -> anyhow::Result<NodeConfig>
@@ -425,14 +438,17 @@ where
 
     // Adjust some fields in the default template to lower the overhead of
     // running on a local machine.
+    // Some are further overridden to give us higher performance when enable_performance_mode is true
     node_config
         .consensus
         .quorum_store
         .num_workers_for_remote_batches = 1;
     node_config.consensus.quorum_store_poll_time_ms = 1000;
 
-    node_config.execution.concurrency_level = 1;
-    node_config.execution.num_proof_reading_threads = 1;
+    if !enable_performance_mode {
+        node_config.execution.concurrency_level = 1;
+        node_config.execution.num_proof_reading_threads = 1;
+    }
     node_config.execution.paranoid_hot_potato_verification = false;
     node_config.execution.paranoid_type_verification = false;
     node_config
@@ -444,11 +460,19 @@ where
         .peer_monitoring_service
         .enable_peer_monitoring_client = false;
 
-    node_config
-        .mempool
-        .shared_mempool_max_concurrent_inbound_syncs = 1;
-    node_config.mempool.default_failovers = 1;
-    node_config.mempool.max_broadcasts_per_peer = 1;
+    if enable_performance_mode {
+        node_config
+            .mempool
+            .shared_mempool_max_concurrent_inbound_syncs = 16;
+        node_config.mempool.shared_mempool_tick_interval_ms = 10;
+        node_config.mempool.default_failovers = 0;
+    } else {
+        node_config
+            .mempool
+            .shared_mempool_max_concurrent_inbound_syncs = 1;
+        node_config.mempool.default_failovers = 1;
+        node_config.mempool.max_broadcasts_per_peer = 1;
+    }
 
     node_config
         .state_sync


### PR DESCRIPTION
### Description

Add a new single-node `--test --performance` mode which we can use as a basis for Forge-like E2E performance tests for downstream services like Indexer (gRPC + Processors), DB benchmarking, etc

Specifically, it removes the config optimization for running idle on a local machine, which is what the CLI does by default, since it's optimized for lightweight local dev.
* Execution
  * use default concurrency level
  * use default num proof reading threads
* Mempool
  * shared mempool max concurrent inbound syncs bump to 16 (default for VFNs) per https://github.com/aptos-labs/aptos-core/pull/2390

### Test Plan

CI + Some basic benchmarking on my local machine (M1 Mac):

Run txn emitter against `cargo run -p aptos-node --release -- --test --performance`

```
$ cargo run -p aptos-transaction-emitter --release -- emit-tx -t http://0.0.0.0:8080 -t http://0.0.0.0:8080 -t http://0.0.0.0:8080 -t http://0.0.0.0:8080 -t http://0.0.0.0:8080 -t http://0.0.0.0:8080 --mint-file $MINT_FILE --chain-id testing --duration 240 --txn-expiration-time-secs 60 --mempool-backlog=4000 --max-transactions-per-account 10
...
~1858 TPS
```

Compared to non-performance mode: `cargo run -p aptos-node --release -- --test`
Currently non-conclusive ;/ 

```
~1864 TPS
```

The difference is not crazy. Not sure what numbers to expect though. I may try again on t2d-standard on GCP

<!-- Please provide us with clear details for verifying that your changes work. -->
