### PR TITLE
[CLI][move-unit-test] Enable compiler-version for aptos move test

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -459,6 +459,7 @@ impl CliCommand<&'static str> for TestPackage {
             compiler_config: CompilerConfig {
                 known_attributes: known_attributes.clone(),
                 skip_attribute_checks: self.move_options.skip_attribute_checks,
+                compiler_version: self.move_options.compiler_version,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
### Description

This PR enables the option `--compiler-version` for the command `aptos move test`.

### Test Plan

run `aptos move test --compiler-version=v2`
