### PR TITLE
[State Sync Driver] Remove unnecessary advertised version check and add tests

### DIFF
--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -837,14 +837,7 @@ impl<
         };
 
         // Compare the highest local epoch end to the highest advertised epoch end
-        if highest_local_epoch_end > highest_advertised_epoch_end {
-            let error_message =
-                format!(
-                    "The highest local epoch end is higher than the advertised epoch end! Local: {:?}, advertised: {:?}",
-                    highest_local_epoch_end, highest_advertised_epoch_end
-                );
-            return Err(Error::AdvertisedDataError(error_message));
-        } else if highest_local_epoch_end < highest_advertised_epoch_end {
+        if highest_local_epoch_end < highest_advertised_epoch_end {
             info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
                 "Found higher epoch ending ledger infos in the network! Local: {:?}, advertised: {:?}",
                    highest_local_epoch_end, highest_advertised_epoch_end
@@ -890,17 +883,17 @@ impl<
             .advertised_data
             .highest_synced_ledger_info()
             .ok_or_else(|| {
-                Error::AdvertisedDataError(
-                    "No highest advertised ledger info found in the network!".into(),
+                Error::UnsatisfiableWaypoint(
+                    "Unable to check waypoint satisfiability! No highest advertised ledger info found in the network!".into(),
                 )
             })?;
         let highest_advertised_version = highest_advertised_ledger_info.ledger_info().version();
 
         // Compare the highest advertised version with our waypoint
         if highest_advertised_version < waypoint_version {
-            Err(Error::AdvertisedDataError(
+            Err(Error::UnsatisfiableWaypoint(
                 format!(
-                    "No advertised version higher than our waypoint! Highest version: {:?}, waypoint version: {:?}",
+                    "The waypoint is not satisfiable! No advertised version higher than our waypoint! Highest version: {:?}, waypoint version: {:?}.",
                     highest_advertised_version, waypoint_version
                 )
             ))

--- a/state-sync/state-sync-driver/src/error.rs
+++ b/state-sync/state-sync-driver/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     VerificationError(String),
     #[error("Unexpected error: {0}")]
     UnexpectedError(String),
+    #[error("Failed to verify waypoint satisfiability: {0}")]
+    UnsatisfiableWaypoint(String),
 }
 
 impl Error {
@@ -69,6 +71,7 @@ impl Error {
             Error::SyncedBeyondTarget(_, _) => "synced_beyond_target",
             Error::VerificationError(_) => "verification_error",
             Error::UnexpectedError(_) => "unexpected_error",
+            Error::UnsatisfiableWaypoint(_) => "unsatisfiable_waypoint",
         }
     }
 }

--- a/state-sync/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-driver/src/tests/utils.rs
@@ -56,6 +56,24 @@ pub fn create_epoch_ending_ledger_info() -> LedgerInfoWithSignatures {
     LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty())
 }
 
+/// Creates a test epoch ending ledger info for the specified epoch and version
+pub fn create_epoch_ending_ledger_info_for_epoch(
+    epoch: u64,
+    version: u64,
+) -> LedgerInfoWithSignatures {
+    let block_info = BlockInfo::new(
+        epoch,
+        0,
+        HashValue::zero(),
+        HashValue::zero(),
+        version,
+        0,
+        Some(EpochState::empty()),
+    );
+    let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
+    LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty())
+}
+
 /// Creates a single test event
 pub fn create_event(event_key: Option<EventKey>) -> ContractEvent {
     let event_key = event_key.unwrap_or_else(EventKey::random);
@@ -81,6 +99,26 @@ pub fn create_global_summary(highest_ended_epoch: Epoch) -> GlobalDataSummary {
     global_data_summary
         .advertised_data
         .epoch_ending_ledger_infos = vec![CompleteDataRange::new(0, highest_ended_epoch).unwrap()];
+    global_data_summary
+}
+
+/// Creates a global data summary with the highest ended epoch and specified version
+pub fn create_global_summary_with_version(
+    highest_ended_epoch: Epoch,
+    highest_synced_version: Version,
+) -> GlobalDataSummary {
+    // Create an empty global data summary
+    let mut global_data_summary = GlobalDataSummary::empty();
+
+    // Update the highest synced ledger info
+    global_data_summary.advertised_data.synced_ledger_infos =
+        vec![create_ledger_info_at_version(highest_synced_version)];
+
+    // Update the highest synced epoch
+    global_data_summary
+        .advertised_data
+        .epoch_ending_ledger_infos = vec![CompleteDataRange::new(0, highest_ended_epoch).unwrap()];
+
     global_data_summary
 }
 


### PR DESCRIPTION
Note: most of this PR is just new unit tests.

### Description
This PR makes two small modifications to the state sync driver (each in their own commit):
1. Wrap an `info!` log in `sample!` to prevent the log from spamming the output when nodes are unable to identify data in the network.
2. Remove an unnecessary advertised version check. If the local epoch end is higher than the advertised epoch end, and we've verified our waypoint, we should just mark bootstrapping as complete. This prevents us from blocking in the bootstrapping phase if we're ahead of all our peers.
    - We also add several simple tests for this logic.

### Test Plan
New and existing test infrastructure.
