### PR TITLE
txn-emitter: query source account seq num

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -382,6 +382,11 @@ impl<'t> AccountMinter<'t> {
                     e, i
                 )
             } else {
+                new_source_account.set_sequence_number(
+                    txn_executor
+                        .query_sequence_number(new_source_account.address())
+                        .await?,
+                );
                 info!(
                     "New source account created {}",
                     new_source_account.address()


### PR DESCRIPTION
when account-minter-seed is used, the source account is reused as well

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
testing on previewnet
