### PR TITLE
Distinguish between RawFromStorage and Exchanged in view.rs for resources

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -23,7 +23,7 @@ use aptos_aggregator::{
 };
 use aptos_logger::{debug, error, info};
 use aptos_mvhashmap::{
-    types::{Incarnation, MVDelayedFieldsError, TxnIndex, UnsetOrLayout, ValueWithLayout},
+    types::{Incarnation, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
     unsync_map::UnsyncMap,
     versioned_delayed_fields::CommitError,
     MVHashMap,
@@ -143,9 +143,7 @@ where
                     incarnation,
                     group_ops
                         .into_iter()
-                        .map(|(tag, (write_op, maybe_layout))| {
-                            (tag, (write_op, UnsetOrLayout::Set(maybe_layout)))
-                        }),
+                        .map(|(tag, (write_op, maybe_layout))| (tag, (write_op, maybe_layout))),
                 ) {
                     // Should return true if writes outside.
                     updates_outside = true;
@@ -298,7 +296,7 @@ where
             .read_set(idx_to_validate)
             .expect("[BlockSTM]: Prior read-set must be recorded");
 
-        if read_set.validate_incorrect_use() {
+        if read_set.is_incorrect_use() {
             return Err(code_invariant_error(
                 "Incorrect use detected in CapturedReads",
             ));
@@ -532,31 +530,30 @@ where
                 }
             }
 
-            let process_finalized_group = |finalized_group: anyhow::Result<
-                Vec<(T::Tag, (Arc<T::Value>, Option<Arc<MoveTypeLayout>>))>,
-            >,
-                                           metadata_is_deletion: bool|
-             -> Result<_, _> {
-                match finalized_group {
-                    Ok(finalized_group) => {
-                        // finalize_group already applies the deletions.
-                        if finalized_group.is_empty() != metadata_is_deletion {
-                            return Err(Error::FallbackToSequential(resource_group_error(
-                                format!(
+            let process_finalized_group =
+                |finalized_group: anyhow::Result<Vec<(T::Tag, ValueWithLayout<T::Value>)>>,
+                 metadata_is_deletion: bool|
+                 -> Result<_, _> {
+                    match finalized_group {
+                        Ok(finalized_group) => {
+                            // finalize_group already applies the deletions.
+                            if finalized_group.is_empty() != metadata_is_deletion {
+                                return Err(Error::FallbackToSequential(resource_group_error(
+                                    format!(
                                 "Group is empty = {} but op is deletion = {} in parallel execution",
                                 finalized_group.is_empty(),
                                 metadata_is_deletion
                             ),
-                            )));
-                        }
-                        Ok(finalized_group)
-                    },
-                    Err(e) => Err(Error::FallbackToSequential(resource_group_error(format!(
-                        "Error committing resource group {:?}",
-                        e
-                    )))),
-                }
-            };
+                                )));
+                            }
+                            Ok(finalized_group)
+                        },
+                        Err(e) => Err(Error::FallbackToSequential(resource_group_error(format!(
+                            "Error committing resource group {:?}",
+                            e
+                        )))),
+                    }
+                };
 
             let group_metadata_ops = last_input_output.group_metadata_ops(txn_idx);
             let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
@@ -686,30 +683,21 @@ where
     }
 
     fn map_id_to_values_in_group_writes(
-        finalized_groups: Vec<(
-            T::Key,
-            T::Value,
-            Vec<(T::Tag, (Arc<T::Value>, Option<Arc<MoveTypeLayout>>))>,
-        )>,
+        finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, ValueWithLayout<T::Value>)>)>,
         latest_view: &LatestView<T, S, X>,
     ) -> Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)> {
         let mut patched_finalized_groups = Vec::new();
         for (group_key, group_metadata_op, resource_vec) in finalized_groups.into_iter() {
             let mut patched_resource_vec = Vec::new();
-            for (tag, (value, maybe_layout)) in resource_vec.into_iter() {
-                // maybe_layout is Some(_) if it contains a delayed field
-                if let Some(layout) = maybe_layout {
-                    patched_resource_vec.push((
-                        tag,
-                        Arc::new(Self::replace_ids_with_values(
-                            &value,
-                            layout.as_ref(),
-                            latest_view,
-                        )),
-                    ));
-                } else {
-                    patched_resource_vec.push((tag, value.clone()));
-                }
+            for (tag, value_with_layout) in resource_vec.into_iter() {
+                let value = match value_with_layout {
+                    ValueWithLayout::RawFromStorage(value) => value,
+                    ValueWithLayout::Exchanged(value, None) => value,
+                    ValueWithLayout::Exchanged(value, Some(layout)) => Arc::new(
+                        Self::replace_ids_with_values(&value, layout.as_ref(), latest_view),
+                    ),
+                };
+                patched_resource_vec.push((tag, value));
             }
             patched_finalized_groups.push((group_key, group_metadata_op, patched_resource_vec));
         }
@@ -803,7 +791,9 @@ where
                         .expect("Aggregator base value deserialization error")
                         .expect("Aggregator base value must exist");
 
-                    versioned_cache.data().set_base_value(k.clone(), ValueWithLayout::RawFromStorage(Arc::new(w)));
+                    versioned_cache
+                        .data()
+                        .set_base_value(k.clone(), ValueWithLayout::RawFromStorage(Arc::new(w)));
                     op.apply_to(value_u128)
                         .expect("Materializing delta w. base value set must succeed")
                 });
@@ -1162,18 +1152,13 @@ where
             unsync_map.write(group_key, metadata_op, None);
         }
 
-        for (key, write_op) in output
-            .aggregator_v1_write_set()
-            .into_iter()
-        {
+        for (key, write_op) in output.aggregator_v1_write_set().into_iter() {
             unsync_map.write(key, write_op, None);
         }
 
-        for (key, write_op) in output.module_write_set().into_iter()
-        {
+        for (key, write_op) in output.module_write_set().into_iter() {
             unsync_map.write_module(key, write_op);
         }
-
 
         let mut second_phase = Vec::new();
         let mut updates = HashMap::new();
@@ -1355,6 +1340,10 @@ where
                         );
                     } else {
                         output.set_txn_output_for_non_dynamic_change_set();
+                    }
+
+                    if latest_view.is_incorrect_use() {
+                        panic!("Incorrect use in sequential execution")
                     }
 
                     if let Some(commit_hook) = &self.transaction_commit_hook {

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -21,7 +21,7 @@ use aptos_aggregator::delta_change_set::serialize;
 use aptos_types::{contract_event::ReadWriteEvent, write_set::TransactionWrite};
 use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use bytes::Bytes;
-use claims::{assert_matches, assert_none, assert_some, assert_some_eq};
+use claims::{assert_matches, assert_none, assert_ok_eq, assert_some, assert_some_eq};
 use itertools::izip;
 use std::{collections::HashMap, fmt::Debug, hash::Hash, result::Result, sync::atomic::Ordering};
 
@@ -270,7 +270,10 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                     for (group_key, size) in output.read_group_sizes.iter() {
                         let group_map = group_world.entry(group_key).or_insert(base_map.clone());
 
-                        assert_eq!(*size, group_size_as_sum(group_map.iter()).unwrap());
+                        assert_ok_eq!(
+                            group_size_as_sum(group_map.iter().map(|(t, v)| (t, v.len()))),
+                            *size
+                        );
                     }
 
                     // Test normal reads.

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -305,8 +305,8 @@ proptest! {
         // Cases are expensive, few cases is enough.
         // We will test a few more comprehensive tests more times, and the rest even fewer.
         // when trying to stress-test, increase (to 200 or more), and disable result cache.
-        cases: 10,
-        result_cache: prop::test_runner::basic_result_cache,
+        cases: 200,
+        // result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 
@@ -406,8 +406,8 @@ proptest! {
     #![proptest_config(ProptestConfig {
         // Cases are expensive, few cases is enough for these
         // when trying to stress-test, increase (to 200 or more), and disable result cache.
-        cases: 5,
-        result_cache: prop::test_runner::basic_result_cache,
+        cases: 200,
+        // result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]
 

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -6,7 +6,7 @@ use super::{
     types::{test::KeyType, MVDataError, MVDataOutput, MVGroupError, TxnIndex},
     MVHashMap,
 };
-use crate::types::UnsetOrLayout;
+use crate::types::ValueWithLayout;
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, DeltaOp};
 use aptos_types::{
     executable::ExecutableTestType,
@@ -20,10 +20,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     hash::Hash,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 const DEFAULT_TIMEOUT: u64 = 30;
@@ -248,10 +245,8 @@ where
         let value = Value::new(None);
         let idx = idx as TxnIndex;
         if test_group {
-            map.group_data().write(key.clone(), idx, 0, vec![(
-                5,
-                (value, UnsetOrLayout::Set(None)),
-            )]);
+            map.group_data()
+                .write(key.clone(), idx, 0, vec![(5, (value, None))]);
             map.group_data().mark_estimate(&key, idx);
         } else {
             map.data().write(key.clone(), idx, 0, (value, None));
@@ -278,7 +273,11 @@ where
                         use MVDataOutput::*;
 
                         let baseline = baseline.get(key, idx as TxnIndex);
-                        let assert_value = |v: Arc<Value<V>>| match v.maybe_value.as_ref() {
+                        let assert_value = |v: ValueWithLayout<Value<V>>| match v
+                            .extract_value_no_layout()
+                            .maybe_value
+                            .as_ref()
+                        {
                             Some(w) => {
                                 assert_eq!(baseline, ExpectedOutput::Value(w.clone()), "{:?}", idx);
                             },
@@ -290,13 +289,12 @@ where
                         let mut retry_attempts = 0;
                         loop {
                             if test_group {
-                                match map.group_data.read_from_group(
+                                match map.group_data.fetch_tagged_data(
                                     &KeyType(key.clone()),
                                     &5,
                                     idx as TxnIndex,
-                                    UnsetOrLayout::Set(None),
                                 ) {
-                                    Ok((_, v, _)) => {
+                                    Ok((_, v)) => {
                                         assert_value(v);
                                         break;
                                     },
@@ -312,7 +310,7 @@ where
                                     .data()
                                     .fetch_data(&KeyType(key.clone()), idx as TxnIndex)
                                 {
-                                    Ok(Versioned(_, v, _)) => {
+                                    Ok(Versioned(_, v)) => {
                                         assert_value(v);
                                         break;
                                     },
@@ -356,10 +354,8 @@ where
                         let key = KeyType(key.clone());
                         let value = Value::new(None);
                         if test_group {
-                            map.group_data().write(key, idx as TxnIndex, 1, vec![(
-                                5,
-                                (value, UnsetOrLayout::Set(None)),
-                            )]);
+                            map.group_data()
+                                .write(key, idx as TxnIndex, 1, vec![(5, (value, None))]);
                         } else {
                             map.data().write(key, idx as TxnIndex, 1, (value, None));
                         }
@@ -368,10 +364,8 @@ where
                         let key = KeyType(key.clone());
                         let value = Value::new(Some(v.clone()));
                         if test_group {
-                            map.group_data().write(key, idx as TxnIndex, 1, vec![(
-                                5,
-                                (value, UnsetOrLayout::Set(None)),
-                            )]);
+                            map.group_data()
+                                .write(key, idx as TxnIndex, 1, vec![(5, (value, None))]);
                         } else {
                             map.data().write(key, idx as TxnIndex, 1, (value, None));
                         }

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -2,7 +2,9 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{Flag, Incarnation, MVDataError, MVDataOutput, ShiftedTxnIndex, TxnIndex, ValueWithLayout};
+use crate::types::{
+    Flag, Incarnation, MVDataError, MVDataOutput, ShiftedTxnIndex, TxnIndex, ValueWithLayout,
+};
 use anyhow::Result;
 use aptos_aggregator::delta_change_set::DeltaOp;
 use aptos_types::write_set::TransactionWrite;
@@ -53,10 +55,7 @@ pub struct VersionedData<K, V> {
 }
 
 impl<V> Entry<V> {
-    fn new_write_from(
-        incarnation: Incarnation,
-        value: ValueWithLayout<V>,
-    ) -> Entry<V> {
+    fn new_write_from(incarnation: Incarnation, value: ValueWithLayout<V>) -> Entry<V> {
         Entry {
             cell: EntryCell::Write(incarnation, value),
             flag: Flag::Done,
@@ -276,7 +275,7 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
                             // Assert the length of bytes for efficiency (instead of full equality)
                             assert!(
                                 *i == 0
-                                && v.bytes().map(|b| b.len()) == ev.bytes().map(|b| b.len())
+                                    && v.bytes().map(|b| b.len()) == ev.bytes().map(|b| b.len())
                             )
                         },
                         (Exchanged(_, _), RawFromStorage(_)) => {
@@ -295,8 +294,12 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
                             // If maybe_layout is None, they are required to be identical
                             // If maybe_layout is Some, there might have been an exchange
                             // Assert the length of bytes for efficiency (instead of full equality)
-                            assert!(e_layout.is_some() == layout.is_some()
-                                && (layout.is_some() || v.bytes().map(|b| b.len()) == ev.bytes().map(|b| b.len())));
+                            assert!(
+                                e_layout.is_some() == layout.is_some()
+                                    && (layout.is_some()
+                                        || v.bytes().map(|b| b.len())
+                                            == ev.bytes().map(|b| b.len()))
+                            );
                         },
                         // (DoesntExist, DoesntExist) => {
                         // },
@@ -320,7 +323,10 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
         let mut v = self.values.entry(key).or_default();
         let prev_entry = v.versioned_map.insert(
             ShiftedTxnIndex::new(txn_idx),
-            CachePadded::new(Entry::new_write_from(incarnation, ValueWithLayout::Exchanged(Arc::new(data.0), data.1))),
+            CachePadded::new(Entry::new_write_from(
+                incarnation,
+                ValueWithLayout::Exchanged(Arc::new(data.0), data.1),
+            )),
         );
 
         // Assert that the previous entry for txn_idx, if present, had lower incarnation.


### PR DESCRIPTION
### Description

If we call resource_exists/get_metadata, we pass None layout, and that gets stored in storage - which is incorrect.
added unit tests to test those, and they were failing.

Adding ValueWithLayout to distinguish whether Layout was known or unknown, and used it for resources. to modify resource groups as well.

Additionally - consolidated logic between sequential and parallel via ResourceState

### Test Plan
unit tests that were added.
