### PR TITLE
Fix events.md typo

### DIFF
--- a/developer-docs-site/docs/concepts/events.md
+++ b/developer-docs-site/docs/concepts/events.md
@@ -18,7 +18,7 @@ example,
 /// 0xcafe::my_module_name
 /// An example module event struct denotes a coin transfer.
 #[event]
-struct TransferEvent has store, drop {
+struct TransferEvent has drop, store {
     sender: address,
     receiver: address,
     amount: u64


### PR DESCRIPTION
### Description

Fix docs. Should be `store, drop`. Not `copy, drop`

### Test Plan
No tests. Just doc changes
