### PR TITLE
[Consensus] Label metrics with address in `to_hex` format

### DIFF
--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -619,14 +619,14 @@ impl LeaderReputation {
 
                 if counter_index == max(CHAIN_HEALTH_WINDOW_SIZES.len() - 2, 0) {
                     // Only emit this for one window value. Currently defaults to 100
-                    candidates.iter().for_each(|x| {
-                        if participants.contains(x) {
+                    candidates.iter().for_each(|author| {
+                        if participants.contains(author) {
                             CONSENSUS_PARTICIPATION_STATUS
-                                .with_label_values(&[&x.to_string()])
+                                .with_label_values(&[&author.to_hex()])
                                 .set(1_i64)
                         } else {
                             CONSENSUS_PARTICIPATION_STATUS
-                                .with_label_values(&[&x.to_string()])
+                                .with_label_values(&[&author.to_hex()])
                                 .set(0_i64)
                         }
                     });


### PR DESCRIPTION
### Description
In https://github.com/aptos-labs/aptos-core/pull/9919 I made the `Display` impl of `AccountAddress` AIP-40 compliant so new users of `AccountAddress` would get compliant behavior by default. In that PR I endeavored to make sure everything that already used `AccountAddress` kept the old behavior. It seems like I missed a spot.

This PR switches the labelling here to use `to_hex` instead of `to_string`. `to_hex` behaves how `to_string` worked before #9919.

### Test Plan
CI