### PR TITLE
[move_vm] Split out module cache from loader

### DIFF
--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Loader;
+use crate::loader::{Loader, ModuleAdapter};
 use bytes::Bytes;
 use move_binary_format::errors::*;
 use move_core_types::{
@@ -162,6 +162,7 @@ impl<'r> TransactionDataCache<'r> {
         loader: &Loader,
         addr: AccountAddress,
         ty: &Type,
+        module_store: &ModuleAdapter,
     ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
         let account_cache = Self::get_mut_or_insert_with(&mut self.account_map, &addr, || {
             (addr, AccountDataCache::new())
@@ -179,9 +180,9 @@ impl<'r> TransactionDataCache<'r> {
             };
             // TODO(Gas): Shall we charge for this?
             let (ty_layout, has_aggregator_lifting) =
-                loader.type_to_type_layout_with_identifier_mappings(ty)?;
+                loader.type_to_type_layout_with_identifier_mappings(ty, module_store)?;
 
-            let module = loader.get_module(&ty_tag.module_id());
+            let module = module_store.module_at(&ty_tag.module_id());
             let metadata: &[Metadata] = match &module {
                 Some(module) => &module.module().metadata,
                 None => &[],

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::{Loader, ModuleAdapter};
+use crate::loader::{Loader, ModuleStorageAdapter};
 use bytes::Bytes;
 use move_binary_format::errors::*;
 use move_core_types::{
@@ -162,7 +162,7 @@ impl<'r> TransactionDataCache<'r> {
         loader: &Loader,
         addr: AccountAddress,
         ty: &Type,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
     ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
         let account_cache = Self::get_mut_or_insert_with(&mut self.account_map, &addr, || {
             (addr, AccountDataCache::new())

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     data_cache::TransactionDataCache,
-    loader::{Function, Loader, ModuleAdapter, Resolver},
+    loader::{Function, Loader, ModuleStorageAdapter, Resolver},
     native_extensions::NativeContextExtensions,
     native_functions::NativeContext,
     trace,
@@ -89,7 +89,7 @@ impl Interpreter {
         ty_args: Vec<Type>,
         args: Vec<Value>,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
         loader: &Loader,
@@ -121,7 +121,7 @@ impl Interpreter {
         mut self,
         loader: &Loader,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
         function: Arc<Function>,
@@ -287,7 +287,7 @@ impl Interpreter {
     fn make_call_frame(
         &mut self,
         loader: &Loader,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         func: Arc<Function>,
         ty_args: Vec<Type>,
     ) -> PartialVMResult<Frame> {
@@ -325,7 +325,7 @@ impl Interpreter {
     fn make_new_frame(
         &self,
         loader: &Loader,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         function: Arc<Function>,
         ty_args: Vec<Type>,
         locals: Locals,
@@ -559,7 +559,7 @@ impl Interpreter {
     fn load_resource<'c>(
         loader: &Loader,
         data_store: &'c mut TransactionDataCache,
-        module_store: &'c ModuleAdapter,
+        module_store: &'c ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
@@ -587,7 +587,7 @@ impl Interpreter {
         is_generic: bool,
         loader: &Loader,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
@@ -612,7 +612,7 @@ impl Interpreter {
         is_generic: bool,
         loader: &Loader,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
@@ -630,7 +630,7 @@ impl Interpreter {
         is_generic: bool,
         loader: &Loader,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
@@ -665,7 +665,7 @@ impl Interpreter {
         is_generic: bool,
         loader: &Loader,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
@@ -1147,7 +1147,7 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<ExitCode> {
         self.execute_code_impl(resolver, interpreter, data_store, module_store, gas_meter)
@@ -1763,7 +1763,7 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleAdapter,
+        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
     ) -> PartialVMResult<ExitCode> {
         use SimpleInstruction as S;
@@ -2417,7 +2417,7 @@ impl Frame {
         &self.ty_args
     }
 
-    fn resolver<'a>(&self, loader: &'a Loader, module_store: &'a ModuleAdapter) -> Resolver<'a> {
+    fn resolver<'a>(&self, loader: &'a Loader, module_store: &'a ModuleStorageAdapter) -> Resolver<'a> {
         self.function.get_resolver(loader, module_store)
     }
 

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2417,7 +2417,11 @@ impl Frame {
         &self.ty_args
     }
 
-    fn resolver<'a>(&self, loader: &'a Loader, module_store: &'a ModuleStorageAdapter) -> Resolver<'a> {
+    fn resolver<'a>(
+        &self,
+        loader: &'a Loader,
+        module_store: &'a ModuleStorageAdapter,
+    ) -> Resolver<'a> {
         self.function.get_resolver(loader, module_store)
     }
 

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::ModuleAdapter;
 use crate::{
     loader::{Loader, Module, Resolver, ScriptHash},
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
@@ -135,17 +136,21 @@ impl Function {
         self.index
     }
 
-    pub(crate) fn get_resolver<'a>(&self, loader: &'a Loader) -> Resolver<'a> {
+    pub(crate) fn get_resolver<'a>(
+        &self,
+        loader: &'a Loader,
+        module_store: &'a ModuleAdapter,
+    ) -> Resolver<'a> {
         match &self.scope {
             Scope::Module(module_id) => {
-                let module = loader
-                    .get_module(module_id)
+                let module = module_store
+                    .module_at(module_id)
                     .expect("ModuleId on Function must exist");
-                Resolver::for_module(loader, module)
+                Resolver::for_module(loader, module_store, module)
             },
             Scope::Script(script_hash) => {
                 let script = loader.get_script(script_hash);
-                Resolver::for_script(loader, script)
+                Resolver::for_script(loader, module_store, script)
             },
         }
     }

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::ModuleAdapter;
+use super::ModuleStorageAdapter;
 use crate::{
     loader::{Loader, Module, Resolver, ScriptHash},
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
@@ -139,7 +139,7 @@ impl Function {
     pub(crate) fn get_resolver<'a>(
         &self,
         loader: &'a Loader,
-        module_store: &'a ModuleAdapter,
+        module_store: &'a ModuleStorageAdapter,
     ) -> Resolver<'a> {
         match &self.scope {
             Scope::Module(module_id) => {

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMConfig, data_cache::TransactionDataCache, logging::expect_no_verification_errors,
-    native_functions::NativeFunctions, session::LoadedFunctionInstantiation,
+    config::VMConfig, data_cache::TransactionDataCache, loader::modules::ModuleCache,
+    logging::expect_no_verification_errors, native_functions::NativeFunctions,
+    session::LoadedFunctionInstantiation,
 };
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
@@ -43,7 +44,7 @@ mod script;
 mod type_loader;
 
 pub(crate) use function::{Function, FunctionHandle, FunctionInstantiation, LoadedFunction, Scope};
-pub(crate) use modules::{Module, ModuleCache};
+pub(crate) use modules::{Module, ModuleAdapter, ModuleStorage};
 pub(crate) use script::{Script, ScriptCache};
 use type_loader::intern_type;
 
@@ -136,10 +137,10 @@ impl StructNameCache {
 // The `pub(crate)` API is what a Loader offers to the runtime.
 pub(crate) struct Loader {
     scripts: RwLock<ScriptCache>,
-    module_cache: RwLock<ModuleCache>,
+    pub(crate) module_cache: ModuleCache,
     type_cache: RwLock<TypeCache>,
     natives: NativeFunctions,
-    name_cache: StructNameCache,
+    pub(crate) name_cache: StructNameCache,
 
     // The below field supports a hack to workaround well-known issues with the
     // loader cache. This cache is not designed to support module upgrade or deletion.
@@ -178,7 +179,7 @@ impl Clone for Loader {
     fn clone(&self) -> Self {
         Self {
             scripts: RwLock::new(self.scripts.read().clone()),
-            module_cache: RwLock::new(self.module_cache.read().clone()),
+            module_cache: ModuleCache::clone(&self.module_cache),
             type_cache: RwLock::new(self.type_cache.read().clone()),
             natives: self.natives.clone(),
             name_cache: self.name_cache.clone(),
@@ -193,7 +194,7 @@ impl Loader {
     pub(crate) fn new(natives: NativeFunctions, vm_config: VMConfig) -> Self {
         Self {
             scripts: RwLock::new(ScriptCache::new()),
-            module_cache: RwLock::new(ModuleCache::new()),
+            module_cache: ModuleCache::new(),
             type_cache: RwLock::new(TypeCache::new()),
             name_cache: StructNameCache::new(),
             natives,
@@ -212,7 +213,7 @@ impl Loader {
         let mut invalidated = self.invalidated.write();
         if *invalidated {
             *self.scripts.write() = ScriptCache::new();
-            *self.module_cache.write() = ModuleCache::new();
+            self.module_cache.flush();
             *self.type_cache.write() = TypeCache::new();
             *invalidated = false;
         }
@@ -245,6 +246,7 @@ impl Loader {
         script_blob: &[u8],
         ty_args: &[TypeTag],
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<(Arc<Function>, LoadedFunctionInstantiation)> {
         // retrieve or load the script
         let mut sha3_256 = Sha3_256::new();
@@ -255,13 +257,9 @@ impl Loader {
         let (main, parameters, return_) = match scripts.get(&hash_value) {
             Some(cached) => cached,
             None => {
-                let ver_script = self.deserialize_and_verify_script(script_blob, data_store)?;
-                let script = Script::new(
-                    ver_script,
-                    &hash_value,
-                    &self.module_cache.read(),
-                    &self.name_cache,
-                )?;
+                let ver_script =
+                    self.deserialize_and_verify_script(script_blob, data_store, module_store)?;
+                let script = Script::new(ver_script, &hash_value, module_store, &self.name_cache)?;
                 scripts.insert(hash_value, script)
             },
         };
@@ -269,7 +267,7 @@ impl Loader {
         // verify type arguments
         let mut type_arguments = vec![];
         for ty in ty_args {
-            type_arguments.push(self.load_type(ty, data_store)?);
+            type_arguments.push(self.load_type(ty, data_store, module_store)?);
         }
 
         if self.vm_config.type_size_limit
@@ -302,6 +300,7 @@ impl Loader {
         &self,
         script: &[u8],
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<CompiledScript> {
         let script = match CompiledScript::deserialize_with_config(
             script,
@@ -322,7 +321,7 @@ impl Loader {
                 let loaded_deps = script
                     .immediate_dependencies()
                     .into_iter()
-                    .map(|module_id| self.load_module(&module_id, data_store))
+                    .map(|module_id| self.load_module(&module_id, data_store, module_store))
                     .collect::<VMResult<_>>()?;
                 self.verify_script_dependencies(&script, loaded_deps)?;
                 Ok(script)
@@ -361,11 +360,10 @@ impl Loader {
         module_id: &ModuleId,
         function_name: &IdentStr,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<(Arc<Module>, Arc<Function>, Vec<Type>, Vec<Type>)> {
-        let module = self.load_module(module_id, data_store)?;
-        let func = self
-            .module_cache
-            .read()
+        let module = self.load_module(module_id, data_store, module_store)?;
+        let func = module_store
             .resolve_function_by_name(function_name, module_id)
             .map_err(|err| err.finish(Location::Undefined))?;
 
@@ -469,9 +467,14 @@ impl Loader {
         function_name: &IdentStr,
         expected_return_type: &Type,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<(LoadedFunction, LoadedFunctionInstantiation)> {
-        let (module, func, parameters, return_vec) =
-            self.load_function_without_type_args(module_id, function_name, data_store)?;
+        let (module, func, parameters, return_vec) = self.load_function_without_type_args(
+            module_id,
+            function_name,
+            data_store,
+            module_store,
+        )?;
 
         if return_vec.len() != 1 {
             // For functions that are marked constructor this should not happen.
@@ -531,13 +534,18 @@ impl Loader {
         function_name: &IdentStr,
         ty_args: &[TypeTag],
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<(Arc<Module>, Arc<Function>, LoadedFunctionInstantiation)> {
-        let (module, func, parameters, return_) =
-            self.load_function_without_type_args(module_id, function_name, data_store)?;
+        let (module, func, parameters, return_) = self.load_function_without_type_args(
+            module_id,
+            function_name,
+            data_store,
+            module_store,
+        )?;
 
         let type_arguments = ty_args
             .iter()
-            .map(|ty| self.load_type(ty, data_store))
+            .map(|ty| self.load_type(ty, data_store, module_store))
             .collect::<VMResult<Vec<_>>>()
             .map_err(|mut err| {
                 // User provided type arguement failed to load. Set extra sub status to distinguish from internal type loading error.
@@ -567,6 +575,7 @@ impl Loader {
         &self,
         modules: &[CompiledModule],
         data_store: &mut TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<()> {
         fail::fail_point!("verifier-failpoint-1", |_| { Ok(()) });
 
@@ -581,6 +590,7 @@ impl Loader {
                 &bundle_verified,
                 &bundle_unverified,
                 data_store,
+                module_store,
             )?;
             bundle_verified.insert(module_id.clone(), module.clone());
         }
@@ -604,6 +614,7 @@ impl Loader {
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<()> {
         // Performs all verification steps to load the module without loading it, i.e., the new
         // module will NOT show up in `module_cache`. In the module republishing case, it means
@@ -624,6 +635,7 @@ impl Loader {
             module,
             bundle_verified,
             data_store,
+            module_store,
             &mut visited,
             &mut friends_discovered,
             /* allow_dependency_loading_failure */ true,
@@ -638,12 +650,18 @@ impl Loader {
             bundle_verified,
             bundle_unverified,
             data_store,
+            module_store,
             /* allow_friend_loading_failure */ true,
             /* dependencies_depth */ 0,
         )?;
 
         // make sure there is no cyclic dependency
-        self.verify_module_cyclic_relations(module, bundle_verified, bundle_unverified)
+        self.verify_module_cyclic_relations(
+            module,
+            bundle_verified,
+            bundle_unverified,
+            module_store,
+        )
     }
 
     fn verify_module_cyclic_relations(
@@ -651,15 +669,20 @@ impl Loader {
         module: &CompiledModule,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
+        module_store: &ModuleAdapter,
     ) -> VMResult<()> {
-        let module_cache = self.module_cache.read();
+        // let module_cache = self.module_cache.read();
         cyclic_dependencies::verify_module(
             module,
             |module_id| {
                 bundle_verified
                     .get(module_id)
-                    .or_else(|| module_cache.modules.get(module_id).map(|m| m.module()))
-                    .map(|m| m.immediate_dependencies())
+                    .map(|module| module.immediate_dependencies())
+                    .or_else(|| {
+                        module_store
+                            .module_at(module_id)
+                            .map(|m| m.module.immediate_dependencies())
+                    })
                     .ok_or_else(|| PartialVMError::new(StatusCode::MISSING_DEPENDENCY))
             },
             |module_id| {
@@ -673,8 +696,12 @@ impl Loader {
                     // creates a cyclic relation.
                     bundle_verified
                         .get(module_id)
-                        .or_else(|| module_cache.modules.get(module_id).map(|m| m.module()))
-                        .map(|m| m.immediate_friends())
+                        .map(|module| module.immediate_friends())
+                        .or_else(|| {
+                            module_store
+                                .module_at(module_id)
+                                .map(|m| m.module.immediate_friends())
+                        })
                         .ok_or_else(|| PartialVMError::new(StatusCode::MISSING_DEPENDENCY))
                 }
             },
@@ -707,6 +734,7 @@ impl Loader {
         &self,
         type_tag: &TypeTag,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<Type> {
         Ok(match type_tag {
             TypeTag::Bool => Type::Bool,
@@ -718,15 +746,15 @@ impl Loader {
             TypeTag::U256 => Type::U256,
             TypeTag::Address => Type::Address,
             TypeTag::Signer => Type::Signer,
-            TypeTag::Vector(tt) => {
-                Type::Vector(triomphe::Arc::new(self.load_type(tt, data_store)?))
-            },
+            TypeTag::Vector(tt) => Type::Vector(triomphe::Arc::new(self.load_type(
+                tt,
+                data_store,
+                module_store,
+            )?)),
             TypeTag::Struct(struct_tag) => {
                 let module_id = ModuleId::new(struct_tag.address, struct_tag.module.clone());
-                self.load_module(&module_id, data_store)?;
-                let struct_type = self
-                    .module_cache
-                    .read()
+                self.load_module(&module_id, data_store, module_store)?;
+                let struct_type = module_store
                     // GOOD module was loaded above
                     .get_struct_type_by_identifier(&struct_tag.name, &module_id)
                     .map_err(|e| e.finish(Location::Undefined))?;
@@ -738,7 +766,7 @@ impl Loader {
                 } else {
                     let mut type_params = vec![];
                     for ty_param in &struct_tag.type_params {
-                        type_params.push(self.load_type(ty_param, data_store)?);
+                        type_params.push(self.load_type(ty_param, data_store, module_store)?);
                     }
                     self.verify_ty_args(struct_type.type_param_constraints(), &type_params)
                         .map_err(|e| e.finish(Location::Undefined))?;
@@ -761,8 +789,9 @@ impl Loader {
         &self,
         id: &ModuleId,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<Arc<Module>> {
-        self.load_module_internal(id, data_store)
+        self.load_module_internal(id, data_store, module_store)
     }
 
     // Load the transitive closure of the target module first, and then verify that the modules in
@@ -771,9 +800,10 @@ impl Loader {
         &self,
         id: &ModuleId,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
     ) -> VMResult<Arc<Module>> {
         // if the module is already in the code cache, load the cached version
-        if let Some(cached) = self.module_cache.read().module_at(id) {
+        if let Some(cached) = module_store.module_at(id) {
             self.module_cache_hits.write().insert(id.clone());
             return Ok(cached);
         }
@@ -784,6 +814,7 @@ impl Loader {
             &BTreeMap::new(),
             &BTreeSet::new(),
             data_store,
+            module_store,
             /* allow_module_loading_failure */ true,
             /* dependencies_depth */ 0,
         )?;
@@ -793,6 +824,7 @@ impl Loader {
             module_ref.module(),
             &BTreeMap::new(),
             &BTreeSet::new(),
+            module_store,
         )
         .map_err(expect_no_verification_errors)?;
         Ok(module_ref)
@@ -851,6 +883,7 @@ impl Loader {
         id: &ModuleId,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
         visited: &mut BTreeSet<ModuleId>,
         friends_discovered: &mut BTreeSet<ModuleId>,
         allow_module_loading_failure: bool,
@@ -873,6 +906,7 @@ impl Loader {
             &module,
             bundle_verified,
             data_store,
+            module_store,
             visited,
             friends_discovered,
             /* allow_dependency_loading_failure */ false,
@@ -880,10 +914,8 @@ impl Loader {
         )?;
 
         // if linking goes well, insert the module to the code cache
-        let mut locked_cache = self.module_cache.write();
         let module_ref =
-            locked_cache.insert(&self.natives, id.clone(), module, &self.name_cache)?;
-        drop(locked_cache); // explicit unlock
+            module_store.insert(&self.natives, id.clone(), module, &self.name_cache)?;
 
         Ok(module_ref)
     }
@@ -894,6 +926,7 @@ impl Loader {
         module: &CompiledModule,
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
         visited: &mut BTreeSet<ModuleId>,
         friends_discovered: &mut BTreeSet<ModuleId>,
         allow_dependency_loading_failure: bool,
@@ -917,20 +950,17 @@ impl Loader {
             if let Some(cached) = bundle_verified.get(&module_id) {
                 bundle_deps.push(cached);
             } else {
-                let locked_cache = self.module_cache.read();
-                let loaded = match locked_cache.module_at(&module_id) {
-                    None => {
-                        drop(locked_cache); // explicit unlock
-                        self.load_and_verify_module_and_dependencies(
-                            &module_id,
-                            bundle_verified,
-                            data_store,
-                            visited,
-                            friends_discovered,
-                            allow_dependency_loading_failure,
-                            dependencies_depth + 1,
-                        )?
-                    },
+                let loaded = match module_store.module_at(&module_id) {
+                    None => self.load_and_verify_module_and_dependencies(
+                        &module_id,
+                        bundle_verified,
+                        data_store,
+                        module_store,
+                        visited,
+                        friends_discovered,
+                        allow_dependency_loading_failure,
+                        dependencies_depth + 1,
+                    )?,
                     Some(cached) => cached,
                 };
                 cached_deps.push(loaded);
@@ -963,6 +993,7 @@ impl Loader {
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
         allow_module_loading_failure: bool,
         dependencies_depth: usize,
     ) -> VMResult<Arc<Module>> {
@@ -973,6 +1004,7 @@ impl Loader {
             id,
             bundle_verified,
             data_store,
+            module_store,
             &mut visited,
             &mut friends_discovered,
             allow_module_loading_failure,
@@ -987,6 +1019,7 @@ impl Loader {
             bundle_verified,
             bundle_unverified,
             data_store,
+            module_store,
             /* allow_friend_loading_failure */ false,
             dependencies_depth,
         )?;
@@ -1000,6 +1033,7 @@ impl Loader {
         bundle_verified: &BTreeMap<ModuleId, CompiledModule>,
         bundle_unverified: &BTreeSet<ModuleId>,
         data_store: &TransactionDataCache,
+        module_store: &ModuleAdapter,
         allow_friend_loading_failure: bool,
         dependencies_depth: usize,
     ) -> VMResult<()> {
@@ -1025,16 +1059,16 @@ impl Loader {
         //   If the module under verification declares a friend which is also in the bundle (and
         //   positioned after this module in the bundle), we defer the loading of that module when
         //   it is the module's turn in the bundle.
-        let locked_cache = self.module_cache.read();
+
+        // FIXME: Is there concurrency issue?
         let new_imm_friends: Vec<_> = friends_discovered
             .into_iter()
             .filter(|mid| {
-                !locked_cache.has_module(mid)
+                !module_store.has_module(mid)
                     && !bundle_verified.contains_key(mid)
                     && !bundle_unverified.contains(mid)
             })
             .collect();
-        drop(locked_cache); // explicit unlock
 
         for module_id in new_imm_friends {
             self.load_and_verify_module_and_dependencies_and_friends(
@@ -1042,6 +1076,7 @@ impl Loader {
                 bundle_verified,
                 bundle_unverified,
                 data_store,
+                module_store,
                 allow_friend_loading_failure,
                 dependencies_depth + 1,
             )?;
@@ -1118,26 +1153,8 @@ impl Loader {
     // Internal helpers
     //
 
-    fn function_at(&self, handle: &FunctionHandle) -> PartialVMResult<Arc<Function>> {
-        match handle {
-            FunctionHandle::Local(func) => Ok(func.clone()),
-            FunctionHandle::Remote { module, name } => {
-                self.get_module(module)
-                    .and_then(|module| {
-                        let idx = module.function_map.get(name)?;
-                        module.function_defs.get(*idx).cloned()
-                    })
-                    .ok_or_else(|| {
-                        PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(
-                            format!("Failed to resolve function: {:?}::{:?}", module, name),
-                        )
-                    })
-            },
-        }
-    }
-
     pub(crate) fn get_module(&self, idx: &ModuleId) -> Option<Arc<Module>> {
-        self.module_cache.read().modules.get(idx).cloned()
+        self.module_cache.fetch_module(idx)
     }
 
     fn get_script(&self, hash: &ScriptHash) -> Arc<Script> {
@@ -1148,25 +1165,6 @@ impl Loader {
                 .get(hash)
                 .expect("Script hash on Function must exist"),
         )
-    }
-
-    pub(crate) fn get_struct_type_by_identifier(
-        &self,
-        name: &StructIdentifier,
-    ) -> PartialVMResult<Arc<StructType>> {
-        self.module_cache
-            .read()
-            .get_struct_type_by_identifier(&name.name, &name.module)
-    }
-
-    pub(crate) fn get_struct_type_by_idx(
-        &self,
-        idx: StructNameIndex,
-    ) -> PartialVMResult<Arc<StructType>> {
-        let name = self.name_cache.idx_to_identifier(idx);
-        self.module_cache
-            .read()
-            .get_struct_type_by_identifier(&name.name, &name.module)
     }
 }
 
@@ -1185,18 +1183,35 @@ enum BinaryType {
 // needs.
 pub(crate) struct Resolver<'a> {
     loader: &'a Loader,
+    module_store: &'a ModuleAdapter<'a>,
     binary: BinaryType,
 }
 
 impl<'a> Resolver<'a> {
-    fn for_module(loader: &'a Loader, module: Arc<Module>) -> Self {
+    fn for_module(
+        loader: &'a Loader,
+        module_store: &'a ModuleAdapter,
+        module: Arc<Module>,
+    ) -> Self {
         let binary = BinaryType::Module(module);
-        Self { loader, binary }
+        Self {
+            loader,
+            binary,
+            module_store,
+        }
     }
 
-    fn for_script(loader: &'a Loader, script: Arc<Script>) -> Self {
+    fn for_script(
+        loader: &'a Loader,
+        module_store: &'a ModuleAdapter,
+        script: Arc<Script>,
+    ) -> Self {
         let binary = BinaryType::Script(script);
-        Self { loader, binary }
+        Self {
+            loader,
+            binary,
+            module_store,
+        }
     }
 
     //
@@ -1222,7 +1237,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.function_at(idx.0),
             BinaryType::Script(script) => script.function_at(idx.0),
         };
-        self.loader.function_at(idx)
+        self.module_store.function_at(idx)
     }
 
     pub(crate) fn function_from_instantiation(
@@ -1233,7 +1248,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.function_instantiation_at(idx.0),
             BinaryType::Script(script) => script.function_instantiation_at(idx.0),
         };
-        self.loader.function_at(&func_inst.handle)
+        self.module_store.function_at(&func_inst.handle)
     }
 
     pub(crate) fn instantiate_generic_function(
@@ -1484,26 +1499,33 @@ impl<'a> Resolver<'a> {
     }
 
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
-        self.loader.type_to_type_layout(ty)
+        self.loader.type_to_type_layout(ty, &self.module_store)
     }
 
     pub(crate) fn type_to_type_layout_with_identifier_mappings(
         &self,
         ty: &Type,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
-        self.loader.type_to_type_layout_with_identifier_mappings(ty)
+        self.loader
+            .type_to_type_layout_with_identifier_mappings(ty, &self.module_store)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
         &self,
         ty: &Type,
     ) -> PartialVMResult<MoveTypeLayout> {
-        self.loader.type_to_fully_annotated_layout(ty)
+        self.loader
+            .type_to_fully_annotated_layout(ty, &self.module_store)
     }
 
     // get the loader
     pub(crate) fn loader(&self) -> &Loader {
         self.loader
+    }
+
+    // get the loader
+    pub(crate) fn module_store(&self) -> &ModuleAdapter {
+        &self.module_store
     }
 }
 
@@ -1687,6 +1709,7 @@ impl Loader {
 
     fn struct_name_to_type_layout(
         &self,
+        module_store: &ModuleAdapter,
         struct_idx: StructNameIndex,
         ty_args: &[Type],
         count: &mut u64,
@@ -1706,7 +1729,7 @@ impl Loader {
         }
 
         let count_before = *count;
-        let struct_type = self.get_struct_type_by_identifier(name)?;
+        let struct_type = module_store.get_struct_type_by_identifier(&name.name, &name.module)?;
 
         // Some types can have fields which are lifted at serialization or deserialization
         // times. Right now these are Aggregator and AggregatorSnapshot.
@@ -1720,7 +1743,7 @@ impl Loader {
         let (mut field_layouts, field_has_identifier_mappings): (Vec<MoveTypeLayout>, Vec<bool>) =
             field_tys
                 .iter()
-                .map(|ty| self.type_to_type_layout_impl(ty, count, depth + 1))
+                .map(|ty| self.type_to_type_layout_impl(ty, module_store, count, depth + 1))
                 .collect::<PartialVMResult<Vec<_>>>()?
                 .into_iter()
                 .unzip();
@@ -1789,6 +1812,7 @@ impl Loader {
     fn type_to_type_layout_impl(
         &self,
         ty: &Type,
+        module_store: &ModuleAdapter,
         count: &mut u64,
         depth: u64,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
@@ -1838,7 +1862,7 @@ impl Loader {
             Type::Vector(ty) => {
                 *count += 1;
                 let (layout, has_identifier_mappings) =
-                    self.type_to_type_layout_impl(ty, count, depth + 1)?;
+                    self.type_to_type_layout_impl(ty, module_store, count, depth + 1)?;
                 (
                     MoveTypeLayout::Vector(Box::new(layout)),
                     has_identifier_mappings,
@@ -1848,14 +1872,14 @@ impl Loader {
                 *count += 1;
                 // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
-                    self.struct_name_to_type_layout(*idx, &[], count, depth)?;
+                    self.struct_name_to_type_layout(module_store, *idx, &[], count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)
             },
             Type::StructInstantiation { idx, ty_args, .. } => {
                 *count += 1;
                 // Note depth is incread inside struct_name_to_type_layout instead.
                 let (layout, has_identifier_mappings) =
-                    self.struct_name_to_type_layout(*idx, ty_args, count, depth)?;
+                    self.struct_name_to_type_layout(module_store, *idx, ty_args, count, depth)?;
                 (MoveTypeLayout::Struct(layout), has_identifier_mappings)
             },
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
@@ -1870,6 +1894,7 @@ impl Loader {
     fn struct_name_to_fully_annotated_layout(
         &self,
         struct_idx: StructNameIndex,
+        module_store: &ModuleAdapter,
         ty_args: &[Type],
         count: &mut u64,
         depth: u64,
@@ -1886,7 +1911,7 @@ impl Loader {
             }
         }
 
-        let struct_type = self.get_struct_type_by_identifier(name)?;
+        let struct_type = module_store.get_struct_type_by_identifier(&name.name, &name.module)?;
         if struct_type.fields.len() != struct_type.field_names.len() {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
@@ -1910,7 +1935,8 @@ impl Loader {
             .zip(&struct_type.fields)
             .map(|(n, ty)| {
                 let ty = self.subst(ty, ty_args)?;
-                let l = self.type_to_fully_annotated_layout_impl(&ty, count, depth + 1)?;
+                let l =
+                    self.type_to_fully_annotated_layout_impl(&ty, module_store, count, depth + 1)?;
                 Ok(MoveFieldLayout::new(n.clone(), l))
             })
             .collect::<PartialVMResult<Vec<_>>>()?;
@@ -1933,6 +1959,7 @@ impl Loader {
     fn type_to_fully_annotated_layout_impl(
         &self,
         ty: &Type,
+        module_store: &ModuleAdapter,
         count: &mut u64,
         depth: u64,
     ) -> PartialVMResult<MoveTypeLayout> {
@@ -1953,16 +1980,20 @@ impl Loader {
             Type::Address => MoveTypeLayout::Address,
             Type::Signer => MoveTypeLayout::Signer,
             Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
-                self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
+                self.type_to_fully_annotated_layout_impl(ty, module_store, count, depth + 1)?,
             )),
             Type::Struct { idx, .. } => MoveTypeLayout::Struct(
-                self.struct_name_to_fully_annotated_layout(*idx, &[], count, depth)?,
+                self.struct_name_to_fully_annotated_layout(*idx, module_store, &[], count, depth)?,
             ),
             Type::StructInstantiation {
                 idx: name, ty_args, ..
-            } => MoveTypeLayout::Struct(
-                self.struct_name_to_fully_annotated_layout(*name, ty_args, count, depth)?,
-            ),
+            } => MoveTypeLayout::Struct(self.struct_name_to_fully_annotated_layout(
+                *name,
+                module_store,
+                ty_args,
+                count,
+                depth,
+            )?),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -1975,18 +2006,19 @@ impl Loader {
     pub(crate) fn calculate_depth_of_struct(
         &self,
         struct_idx: StructNameIndex,
+        module_store: &ModuleAdapter,
     ) -> PartialVMResult<DepthFormula> {
         let name = &*self.name_cache.idx_to_identifier(struct_idx);
         if let Some(depth_formula) = self.type_cache.read().depth_formula.get(name) {
             return Ok(depth_formula.clone());
         }
 
-        let struct_type = self.get_struct_type_by_identifier(name)?;
+        let struct_type = module_store.get_struct_type_by_identifier(&name.name, &name.module)?;
 
         let formulas = struct_type
             .fields
             .iter()
-            .map(|field_type| self.calculate_depth_of_type(field_type))
+            .map(|field_type| self.calculate_depth_of_type(field_type, module_store))
             .collect::<PartialVMResult<Vec<_>>>()?;
         let formula = DepthFormula::normalize(formulas);
         let prev = self
@@ -2003,7 +2035,11 @@ impl Loader {
         Ok(formula)
     }
 
-    fn calculate_depth_of_type(&self, ty: &Type) -> PartialVMResult<DepthFormula> {
+    fn calculate_depth_of_type(
+        &self,
+        ty: &Type,
+        module_store: &ModuleAdapter,
+    ) -> PartialVMResult<DepthFormula> {
         Ok(match ty {
             Type::Bool
             | Type::U8
@@ -2015,18 +2051,18 @@ impl Loader {
             | Type::U32
             | Type::U256 => DepthFormula::constant(1),
             Type::Vector(ty) => {
-                let mut inner = self.calculate_depth_of_type(ty)?;
+                let mut inner = self.calculate_depth_of_type(ty, module_store)?;
                 inner.scale(1);
                 inner
             },
             Type::Reference(ty) | Type::MutableReference(ty) => {
-                let mut inner = self.calculate_depth_of_type(ty)?;
+                let mut inner = self.calculate_depth_of_type(ty, module_store)?;
                 inner.scale(1);
                 inner
             },
             Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
             Type::Struct { idx, .. } => {
-                let mut struct_formula = self.calculate_depth_of_struct(*idx)?;
+                let mut struct_formula = self.calculate_depth_of_struct(*idx, module_store)?;
                 debug_assert!(struct_formula.terms.is_empty());
                 struct_formula.scale(1);
                 struct_formula
@@ -2037,10 +2073,10 @@ impl Loader {
                     .enumerate()
                     .map(|(idx, ty)| {
                         let var = idx as TypeParameterIndex;
-                        Ok((var, self.calculate_depth_of_type(ty)?))
+                        Ok((var, self.calculate_depth_of_type(ty, module_store)?))
                     })
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
-                let struct_formula = self.calculate_depth_of_struct(*idx)?;
+                let struct_formula = self.calculate_depth_of_struct(*idx, module_store)?;
                 let mut subst_struct_formula = struct_formula.subst(ty_arg_map)?;
                 subst_struct_formula.scale(1);
                 subst_struct_formula
@@ -2061,24 +2097,30 @@ impl Loader {
     pub(crate) fn type_to_type_layout_with_identifier_mappings(
         &self,
         ty: &Type,
+        module_store: &ModuleAdapter,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
         let mut count = 0;
-        self.type_to_type_layout_impl(ty, &mut count, 1)
+        self.type_to_type_layout_impl(ty, module_store, &mut count, 1)
     }
 
-    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    pub(crate) fn type_to_type_layout(
+        &self,
+        ty: &Type,
+        module_store: &ModuleAdapter,
+    ) -> PartialVMResult<MoveTypeLayout> {
         let mut count = 0;
         let (layout, _has_identifier_mappings) =
-            self.type_to_type_layout_impl(ty, &mut count, 1)?;
+            self.type_to_type_layout_impl(ty, module_store, &mut count, 1)?;
         Ok(layout)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
         &self,
         ty: &Type,
+        module_store: &ModuleAdapter,
     ) -> PartialVMResult<MoveTypeLayout> {
         let mut count = 0;
-        self.type_to_fully_annotated_layout_impl(ty, &mut count, 1)
+        self.type_to_fully_annotated_layout_impl(ty, module_store, &mut count, 1)
     }
 }
 
@@ -2088,9 +2130,10 @@ impl Loader {
         &self,
         type_tag: &TypeTag,
         move_storage: &TransactionDataCache,
+        module_storage: &ModuleAdapter,
     ) -> VMResult<MoveTypeLayout> {
-        let ty = self.load_type(type_tag, move_storage)?;
-        self.type_to_type_layout(&ty)
+        let ty = self.load_type(type_tag, move_storage, module_storage)?;
+        self.type_to_type_layout(&ty, module_storage)
             .map_err(|e| e.finish(Location::Undefined))
     }
 
@@ -2098,9 +2141,10 @@ impl Loader {
         &self,
         type_tag: &TypeTag,
         move_storage: &TransactionDataCache,
+        module_storage: &ModuleAdapter,
     ) -> VMResult<MoveTypeLayout> {
-        let ty = self.load_type(type_tag, move_storage)?;
-        self.type_to_fully_annotated_layout(&ty)
+        let ty = self.load_type(type_tag, move_storage, module_storage)?;
+        self.type_to_fully_annotated_layout(&ty, module_storage)
             .map_err(|e| e.finish(Location::Undefined))
     }
 }

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -8,13 +8,12 @@ use crate::{
 };
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
-    binary_views::BinaryIndexedView,
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        AbilitySet, Bytecode, CompiledModule, CompiledScript, Constant, ConstantPoolIndex,
-        FieldHandleIndex, FieldInstantiationIndex, FunctionDefinitionIndex, FunctionHandleIndex,
-        FunctionInstantiationIndex, Signature, SignatureIndex, StructDefInstantiationIndex,
-        StructDefinitionIndex, StructFieldInformation, TableIndex, TypeParameterIndex,
+        AbilitySet, CompiledModule, CompiledScript, Constant, ConstantPoolIndex, FieldHandleIndex,
+        FieldInstantiationIndex, FunctionHandleIndex, FunctionInstantiationIndex, SignatureIndex,
+        StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation, TableIndex,
+        TypeParameterIndex,
     },
     IndexKind,
 };
@@ -22,7 +21,7 @@ use move_bytecode_verifier::{self, cyclic_dependencies, dependencies};
 use move_core_types::{
     account_address::AccountAddress,
     ident_str,
-    identifier::{IdentStr, Identifier},
+    identifier::IdentStr,
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{IdentifierMappingKind, LayoutTag, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
@@ -40,10 +39,12 @@ use std::{
 
 mod function;
 mod modules;
+mod script;
 mod type_loader;
 
 pub(crate) use function::{Function, FunctionHandle, FunctionInstantiation, LoadedFunction, Scope};
 pub(crate) use modules::{Module, ModuleCache};
+pub(crate) use script::{Script, ScriptCache};
 use type_loader::intern_type;
 
 type ScriptHash = [u8; 32];
@@ -80,50 +81,6 @@ where
     fn get(&self, key: &K) -> Option<&Arc<V>> {
         let index = self.id_map.get(key)?;
         self.binaries.get(*index)
-    }
-}
-
-// A script cache is a map from the hash value of a script and the `Script` itself.
-// Script are added in the cache once verified and so getting a script out the cache
-// does not require further verification (except for parameters and type parameters)
-#[derive(Clone)]
-struct ScriptCache {
-    scripts: BinaryCache<ScriptHash, Script>,
-}
-
-impl ScriptCache {
-    fn new() -> Self {
-        Self {
-            scripts: BinaryCache::new(),
-        }
-    }
-
-    fn get(&self, hash: &ScriptHash) -> Option<(Arc<Function>, Vec<Type>, Vec<Type>)> {
-        self.scripts.get(hash).map(|script| {
-            (
-                script.entry_point(),
-                script.parameter_tys.clone(),
-                script.return_tys.clone(),
-            )
-        })
-    }
-
-    fn insert(
-        &mut self,
-        hash: ScriptHash,
-        script: Script,
-    ) -> (Arc<Function>, Vec<Type>, Vec<Type>) {
-        match self.get(&hash) {
-            Some(cached) => cached,
-            None => {
-                let script = self.scripts.insert(hash, script);
-                (
-                    script.entry_point(),
-                    script.parameter_tys.clone(),
-                    script.return_tys.clone(),
-                )
-            },
-        }
     }
 }
 
@@ -202,8 +159,6 @@ pub(crate) struct Loader {
     // the adapter must explicitly call a function to flush the invalidated loader.
     //
     // This code (the loader) needs a complete refactoring. The new loader should
-    //
-    // - support upgrade and deletion of modules, while still preserving max cache lookup
     //   performance. This is essential for a cache like this in a multi-tenant execution
     //   environment.
     // - should delegate lifetime ownership to the adapter. Code loading (including verification)
@@ -1549,204 +1504,6 @@ impl<'a> Resolver<'a> {
     // get the loader
     pub(crate) fn loader(&self) -> &Loader {
         self.loader
-    }
-}
-
-// A Script is very similar to a `CompiledScript` but data is "transformed" to a representation
-// more appropriate to execution.
-// When code executes, indexes in instructions are resolved against runtime structures
-// (rather then "compiled") to make available data needed for execution
-// #[derive(Debug)]
-#[derive(Clone)]
-struct Script {
-    // primitive pools
-    script: CompiledScript,
-
-    // functions as indexes into the Loader function list
-    function_refs: Vec<FunctionHandle>,
-    // materialized instantiations, whether partial or not
-    function_instantiations: Vec<FunctionInstantiation>,
-
-    // entry point
-    main: Arc<Function>,
-
-    // parameters of main
-    parameter_tys: Vec<Type>,
-
-    // return values
-    return_tys: Vec<Type>,
-
-    // a map of single-token signature indices to type
-    single_signature_token_map: BTreeMap<SignatureIndex, Type>,
-}
-
-impl Script {
-    fn new(
-        script: CompiledScript,
-        script_hash: &ScriptHash,
-        cache: &ModuleCache,
-        name_cache: &StructNameCache,
-    ) -> VMResult<Self> {
-        let mut struct_names = vec![];
-        for struct_handle in script.struct_handles() {
-            let struct_name = script.identifier_at(struct_handle.name);
-            let module_handle = script.module_handle_at(struct_handle.module);
-            let module_id = script.module_id_for_handle(module_handle);
-            cache
-                .get_struct_type_by_identifier(struct_name, &module_id)
-                .map_err(|err| err.finish(Location::Script))?
-                .check_compatibility(struct_handle)
-                .map_err(|err| err.finish(Location::Script))?;
-
-            struct_names.push(name_cache.insert_or_get(StructIdentifier {
-                module: module_id,
-                name: struct_name.to_owned(),
-            }));
-        }
-
-        let mut function_refs = vec![];
-        for func_handle in script.function_handles().iter() {
-            let func_name = script.identifier_at(func_handle.name);
-            let module_handle = script.module_handle_at(func_handle.module);
-            let module_id = ModuleId::new(
-                *script.address_identifier_at(module_handle.address),
-                script.identifier_at(module_handle.name).to_owned(),
-            );
-            function_refs.push(FunctionHandle::Remote {
-                module: module_id,
-                name: func_name.to_owned(),
-            });
-        }
-
-        let mut function_instantiations = vec![];
-        for func_inst in script.function_instantiations() {
-            let handle = function_refs[func_inst.handle.0 as usize].clone();
-            let mut instantiation = vec![];
-            for ty in &script.signature_at(func_inst.type_parameters).0 {
-                instantiation.push(
-                    intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
-                        .map_err(|e| e.finish(Location::Script))?,
-                );
-            }
-            function_instantiations.push(FunctionInstantiation {
-                handle,
-                instantiation,
-            });
-        }
-
-        let scope = Scope::Script(*script_hash);
-
-        let code: Vec<Bytecode> = script.code.code.clone();
-        let parameters = script.signature_at(script.parameters).clone();
-
-        let parameter_tys = parameters
-            .0
-            .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-        let locals = Signature(
-            parameters
-                .0
-                .iter()
-                .chain(script.signature_at(script.code.locals).0.iter())
-                .cloned()
-                .collect(),
-        );
-        let local_tys = locals
-            .0
-            .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-        let return_ = Signature(vec![]);
-        let return_tys = return_
-            .0
-            .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
-        let type_parameters = script.type_parameters.clone();
-        // TODO: main does not have a name. Revisit.
-        let name = Identifier::new("main").unwrap();
-        let (native, def_is_native) = (None, false); // Script entries cannot be native
-        let main: Arc<Function> = Arc::new(Function {
-            file_format_version: script.version(),
-            index: FunctionDefinitionIndex(0),
-            code,
-            type_parameters,
-            native,
-            def_is_native,
-            def_is_friend_or_private: false,
-            scope,
-            name,
-            return_types: return_tys.clone(),
-            local_types: local_tys,
-            parameter_types: parameter_tys.clone(),
-        });
-
-        let mut single_signature_token_map = BTreeMap::new();
-        for bc in &script.code.code {
-            match bc {
-                Bytecode::VecPack(si, _)
-                | Bytecode::VecLen(si)
-                | Bytecode::VecImmBorrow(si)
-                | Bytecode::VecMutBorrow(si)
-                | Bytecode::VecPushBack(si)
-                | Bytecode::VecPopBack(si)
-                | Bytecode::VecUnpack(si, _)
-                | Bytecode::VecSwap(si) => {
-                    if !single_signature_token_map.contains_key(si) {
-                        let ty = match script.signature_at(*si).0.get(0) {
-                            None => {
-                                return Err(PartialVMError::new(
-                                    StatusCode::VERIFIER_INVARIANT_VIOLATION,
-                                )
-                                .with_message(
-                                    "the type argument for vector-related bytecode \
-                                                expects one and only one signature token"
-                                        .to_owned(),
-                                )
-                                .finish(Location::Script));
-                            },
-                            Some(sig_token) => sig_token,
-                        };
-                        single_signature_token_map.insert(
-                            *si,
-                            intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
-                                .map_err(|e| e.finish(Location::Script))?,
-                        );
-                    }
-                },
-                _ => {},
-            }
-        }
-
-        Ok(Self {
-            script,
-            function_refs,
-            function_instantiations,
-            main,
-            parameter_tys,
-            return_tys,
-            single_signature_token_map,
-        })
-    }
-
-    fn entry_point(&self) -> Arc<Function> {
-        self.main.clone()
-    }
-
-    fn function_at(&self, idx: u16) -> &FunctionHandle {
-        &self.function_refs[idx as usize]
-    }
-
-    fn function_instantiation_at(&self, idx: u16) -> &FunctionInstantiation {
-        &self.function_instantiations[idx as usize]
-    }
-
-    fn single_type_at(&self, idx: SignatureIndex) -> &Type {
-        self.single_signature_token_map.get(&idx).unwrap()
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -43,7 +43,7 @@ mod script;
 mod type_loader;
 
 pub(crate) use function::{Function, FunctionHandle, FunctionInstantiation, LoadedFunction, Scope};
-pub(crate) use modules::{Module, ModuleStorageAdapter, ModuleCache, ModuleStorage};
+pub(crate) use modules::{Module, ModuleCache, ModuleStorage, ModuleStorageAdapter};
 pub(crate) use script::{Script, ScriptCache};
 use type_loader::intern_type;
 
@@ -1490,7 +1490,7 @@ impl<'a> Resolver<'a> {
     }
 
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
-        self.loader.type_to_type_layout(ty, &self.module_store)
+        self.loader.type_to_type_layout(ty, self.module_store)
     }
 
     pub(crate) fn type_to_type_layout_with_identifier_mappings(
@@ -1498,7 +1498,7 @@ impl<'a> Resolver<'a> {
         ty: &Type,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
         self.loader
-            .type_to_type_layout_with_identifier_mappings(ty, &self.module_store)
+            .type_to_type_layout_with_identifier_mappings(ty, self.module_store)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
@@ -1506,7 +1506,7 @@ impl<'a> Resolver<'a> {
         ty: &Type,
     ) -> PartialVMResult<MoveTypeLayout> {
         self.loader
-            .type_to_fully_annotated_layout(ty, &self.module_store)
+            .type_to_fully_annotated_layout(ty, self.module_store)
     }
 
     // get the loader
@@ -1516,7 +1516,7 @@ impl<'a> Resolver<'a> {
 
     // get the loader
     pub(crate) fn module_store(&self) -> &ModuleStorageAdapter {
-        &self.module_store
+        self.module_store
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -41,11 +41,11 @@ pub trait ModuleStorage {
     fn fetch_module(&self, module_id: &ModuleId) -> Option<Arc<Module>>;
 }
 
-pub(crate) struct ModuleCache(Arc<RwLock<BinaryCache<ModuleId, Module>>>);
+pub(crate) struct ModuleCache(RwLock<BinaryCache<ModuleId, Module>>);
 
 impl ModuleCache {
     pub fn new() -> Self {
-        ModuleCache(Arc::new(RwLock::new(BinaryCache::new())))
+        ModuleCache(RwLock::new(BinaryCache::new()))
     }
 
     pub fn flush(&self) {
@@ -55,7 +55,7 @@ impl ModuleCache {
 
 impl Clone for ModuleCache {
     fn clone(&self) -> Self {
-        ModuleCache(Arc::new(RwLock::new(self.0.read().clone())))
+        ModuleCache(RwLock::new(self.0.read().clone()))
     }
 }
 
@@ -72,12 +72,12 @@ impl ModuleStorage for ModuleCache {
     }
 }
 
-pub(crate) struct ModuleAdapter<'a> {
-    modules: &'a dyn ModuleStorage,
+pub(crate) struct ModuleStorageAdapter {
+    modules: Arc<dyn ModuleStorage>,
 }
 
-impl<'a> ModuleAdapter<'a> {
-    pub(crate) fn new(modules: &'a dyn ModuleStorage) -> Self {
+impl ModuleStorageAdapter {
+    pub(crate) fn new(modules: Arc<dyn ModuleStorage>) -> Self {
         Self { modules }
     }
 
@@ -251,7 +251,7 @@ impl Module {
     pub(crate) fn new(
         natives: &NativeFunctions,
         module: CompiledModule,
-        cache: &ModuleAdapter,
+        cache: &ModuleStorageAdapter,
         name_cache: &StructNameCache,
     ) -> Result<Self, (PartialVMError, CompiledModule)> {
         let id = module.self_id();

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -29,36 +29,66 @@ use move_core_types::{
 use move_vm_types::loaded_data::runtime_types::{
     StructIdentifier, StructNameIndex, StructType, Type,
 };
+use parking_lot::RwLock;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     sync::Arc,
 };
 
-// A ModuleCache is the core structure in the Loader.
-// It holds all Modules, Types and Functions loaded.
-// Types and Functions are pushed globally to the ModuleCache.
-// All accesses to the ModuleCache are under lock (exclusive).
-#[derive(Clone)]
-pub(crate) struct ModuleCache {
-    pub(crate) modules: BinaryCache<ModuleId, Module>,
+pub trait ModuleStorage {
+    fn store_module(&self, module_id: &ModuleId, binary: Module) -> Arc<Module>;
+    fn fetch_module(&self, module_id: &ModuleId) -> Option<Arc<Module>>;
 }
 
+pub(crate) struct ModuleCache(Arc<RwLock<BinaryCache<ModuleId, Module>>>);
+
 impl ModuleCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            modules: BinaryCache::new(),
-        }
+    pub fn new() -> Self {
+        ModuleCache(Arc::new(RwLock::new(BinaryCache::new())))
+    }
+
+    pub fn flush(&self) {
+        *self.0.write() = BinaryCache::new();
+    }
+}
+
+impl Clone for ModuleCache {
+    fn clone(&self) -> Self {
+        ModuleCache(Arc::new(RwLock::new(self.0.read().clone())))
+    }
+}
+
+impl ModuleStorage for ModuleCache {
+    fn store_module(&self, module_id: &ModuleId, binary: Module) -> Arc<Module> {
+        self.0.write().insert(module_id.clone(), binary).clone()
+    }
+
+    fn fetch_module(&self, module_id: &ModuleId) -> Option<Arc<Module>> {
+        self.0
+            .read()
+            .get(module_id)
+            .map(|module| Arc::clone(module))
+    }
+}
+
+pub(crate) struct ModuleAdapter<'a> {
+    modules: &'a dyn ModuleStorage,
+}
+
+impl<'a> ModuleAdapter<'a> {
+    pub(crate) fn new(modules: &'a dyn ModuleStorage) -> Self {
+        Self { modules }
     }
 
     // Retrieve a module by `ModuleId`. The module may have not been loaded yet in which
     // case `None` is returned
     pub(crate) fn module_at(&self, id: &ModuleId) -> Option<Arc<Module>> {
-        self.modules.get(id).map(Arc::clone)
+        self.modules.fetch_module(id)
     }
 
     pub(crate) fn insert(
-        &mut self,
+        &self,
         natives: &NativeFunctions,
         id: ModuleId,
         module: CompiledModule,
@@ -69,62 +99,13 @@ impl ModuleCache {
         }
 
         match Module::new(natives, module, self, name_cache) {
-            Ok(module) => Ok(Arc::clone(self.modules.insert(id, module))),
+            Ok(module) => Ok(self.modules.store_module(&id, module)),
             Err((err, _)) => Err(err.finish(Location::Undefined)),
         }
     }
 
-    fn make_struct_type(
-        &self,
-        module: &CompiledModule,
-        struct_def: &StructDefinition,
-        struct_name_table: &[StructNameIndex],
-    ) -> PartialVMResult<StructType> {
-        let struct_handle = module.struct_handle_at(struct_def.struct_handle);
-        let field_names = match &struct_def.field_information {
-            StructFieldInformation::Native => vec![],
-            StructFieldInformation::Declared(field_info) => field_info
-                .iter()
-                .map(|f| module.identifier_at(f.name).to_owned())
-                .collect(),
-        };
-        let abilities = struct_handle.abilities;
-        let name = module.identifier_at(struct_handle.name).to_owned();
-        let type_parameters = struct_handle.type_parameters.clone();
-        let fields = match &struct_def.field_information {
-            StructFieldInformation::Native => unreachable!("native structs have been removed"),
-            StructFieldInformation::Declared(fields) => fields,
-        };
-
-        let mut field_tys = vec![];
-        for field in fields {
-            let ty = intern_type(
-                BinaryIndexedView::Module(module),
-                &field.signature.0,
-                struct_name_table,
-            )?;
-            debug_assert!(field_tys.len() < usize::max_value());
-            field_tys.push(ty);
-        }
-
-        Ok(StructType {
-            fields: field_tys,
-            phantom_ty_args_mask: struct_handle
-                .type_parameters
-                .iter()
-                .map(|ty| ty.is_phantom)
-                .collect(),
-            field_names,
-            abilities,
-            type_parameters,
-            idx: struct_name_table[struct_def.struct_handle.0 as usize],
-            module: module.self_id(),
-            name,
-        })
-    }
-
     pub(crate) fn has_module(&self, module_id: &ModuleId) -> bool {
-        self.modules.id_map.contains_key(module_id)
+        self.modules.fetch_module(module_id).is_some()
     }
 
     // Given a ModuleId::struct_name, retrieve the `StructType` and the index associated.
@@ -135,7 +116,7 @@ impl ModuleCache {
         module_id: &ModuleId,
     ) -> PartialVMResult<Arc<StructType>> {
         self.modules
-            .get(module_id)
+            .fetch_module(module_id)
             .and_then(|module| {
                 let idx = module.struct_map.get(struct_name)?;
                 Some(module.structs.get(*idx)?.definition_struct_type.clone())
@@ -155,17 +136,36 @@ impl ModuleCache {
         func_name: &IdentStr,
         module_id: &ModuleId,
     ) -> PartialVMResult<Arc<Function>> {
-        match self.modules.get(module_id).and_then(|module| {
+        match self.modules.fetch_module(module_id).and_then(|module| {
             let idx = module.function_map.get(func_name)?;
-            module.function_defs.get(*idx)
+            module.function_defs.get(*idx).map(|func| Arc::clone(func))
         }) {
-            Some(func) => Ok(func.clone()),
+            Some(func) => Ok(func),
             None => Err(
                 PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE).with_message(format!(
                     "Cannot find {:?}::{:?} in cache",
                     module_id, func_name
                 )),
             ),
+        }
+    }
+
+    pub(crate) fn function_at(&self, handle: &FunctionHandle) -> PartialVMResult<Arc<Function>> {
+        match handle {
+            FunctionHandle::Local(func) => Ok(func.clone()),
+            FunctionHandle::Remote { module, name } => {
+                self.modules
+                    .fetch_module(module)
+                    .and_then(|module| {
+                        let idx = module.function_map.get(name)?;
+                        module.function_defs.get(*idx).cloned()
+                    })
+                    .ok_or_else(|| {
+                        PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(
+                            format!("Failed to resolve function: {:?}::{:?}", module, name),
+                        )
+                    })
+            },
         }
     }
 }
@@ -175,7 +175,7 @@ impl ModuleCache {
 // When code executes indexes in instructions are resolved against those runtime structure
 // so that any data needed for execution is immediately available
 #[derive(Clone, Debug)]
-pub(crate) struct Module {
+pub struct Module {
     #[allow(dead_code)]
     id: ModuleId,
     // primitive pools
@@ -251,7 +251,7 @@ impl Module {
     pub(crate) fn new(
         natives: &NativeFunctions,
         module: CompiledModule,
-        cache: &ModuleCache,
+        cache: &ModuleAdapter,
         name_cache: &StructNameCache,
     ) -> Result<Self, (PartialVMError, CompiledModule)> {
         let id = module.self_id();
@@ -302,7 +302,7 @@ impl Module {
 
             for (idx, struct_def) in module.struct_defs().iter().enumerate() {
                 let definition_struct_type =
-                    Arc::new(cache.make_struct_type(&module, struct_def, &struct_idxs)?);
+                    Arc::new(Self::make_struct_type(&module, struct_def, &struct_idxs)?);
                 structs.push(StructDef {
                     field_count: definition_struct_type.fields.len() as u16,
                     definition_struct_type,
@@ -443,6 +443,54 @@ impl Module {
             }),
             Err(err) => Err((err, module)),
         }
+    }
+
+    fn make_struct_type(
+        module: &CompiledModule,
+        struct_def: &StructDefinition,
+        struct_name_table: &[StructNameIndex],
+    ) -> PartialVMResult<StructType> {
+        let struct_handle = module.struct_handle_at(struct_def.struct_handle);
+        let field_names = match &struct_def.field_information {
+            StructFieldInformation::Native => vec![],
+            StructFieldInformation::Declared(field_info) => field_info
+                .iter()
+                .map(|f| module.identifier_at(f.name).to_owned())
+                .collect(),
+        };
+        let abilities = struct_handle.abilities;
+        let name = module.identifier_at(struct_handle.name).to_owned();
+        let type_parameters = struct_handle.type_parameters.clone();
+        let fields = match &struct_def.field_information {
+            StructFieldInformation::Native => unreachable!("native structs have been removed"),
+            StructFieldInformation::Declared(fields) => fields,
+        };
+
+        let mut field_tys = vec![];
+        for field in fields {
+            let ty = intern_type(
+                BinaryIndexedView::Module(module),
+                &field.signature.0,
+                struct_name_table,
+            )?;
+            debug_assert!(field_tys.len() < usize::max_value());
+            field_tys.push(ty);
+        }
+
+        Ok(StructType {
+            fields: field_tys,
+            phantom_ty_args_mask: struct_handle
+                .type_parameters
+                .iter()
+                .map(|ty| ty.is_phantom)
+                .collect(),
+            field_names,
+            abilities,
+            type_parameters,
+            idx: struct_name_table[struct_def.struct_handle.0 as usize],
+            module: module.self_id(),
+            name,
+        })
     }
 
     pub(crate) fn struct_at(&self, idx: StructDefinitionIndex) -> Arc<StructType> {

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleAdapter,
+    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleStorageAdapter,
     Scope, ScriptHash, StructNameCache,
 };
 use move_binary_format::{
@@ -48,7 +48,7 @@ impl Script {
     pub(crate) fn new(
         script: CompiledScript,
         script_hash: &ScriptHash,
-        cache: &ModuleAdapter,
+        cache: &ModuleStorageAdapter,
         name_cache: &StructNameCache,
     ) -> VMResult<Self> {
         let mut struct_names = vec![];

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -1,0 +1,259 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleCache, Scope,
+    ScriptHash, StructNameCache,
+};
+use move_binary_format::{
+    access::ScriptAccess,
+    binary_views::BinaryIndexedView,
+    errors::{Location, PartialVMError, PartialVMResult, VMResult},
+    file_format::{Bytecode, CompiledScript, FunctionDefinitionIndex, Signature, SignatureIndex},
+};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
+use move_vm_types::loaded_data::runtime_types::{StructIdentifier, Type};
+use std::{collections::BTreeMap, sync::Arc};
+
+// A Script is very similar to a `CompiledScript` but data is "transformed" to a representation
+// more appropriate to execution.
+// When code executes, indexes in instructions are resolved against runtime structures
+// (rather then "compiled") to make available data needed for execution
+// #[derive(Debug)]
+#[derive(Clone)]
+pub(crate) struct Script {
+    // primitive pools
+    pub(crate) script: CompiledScript,
+
+    // functions as indexes into the Loader function list
+    pub(crate) function_refs: Vec<FunctionHandle>,
+    // materialized instantiations, whether partial or not
+    pub(crate) function_instantiations: Vec<FunctionInstantiation>,
+
+    // entry point
+    pub(crate) main: Arc<Function>,
+
+    // parameters of main
+    pub(crate) parameter_tys: Vec<Type>,
+
+    // return values
+    pub(crate) return_tys: Vec<Type>,
+
+    // a map of single-token signature indices to type
+    pub(crate) single_signature_token_map: BTreeMap<SignatureIndex, Type>,
+}
+
+impl Script {
+    pub(crate) fn new(
+        script: CompiledScript,
+        script_hash: &ScriptHash,
+        cache: &ModuleCache,
+        name_cache: &StructNameCache,
+    ) -> VMResult<Self> {
+        let mut struct_names = vec![];
+        for struct_handle in script.struct_handles() {
+            let struct_name = script.identifier_at(struct_handle.name);
+            let module_handle = script.module_handle_at(struct_handle.module);
+            let module_id = script.module_id_for_handle(module_handle);
+            cache
+                .get_struct_type_by_identifier(struct_name, &module_id)
+                .map_err(|err| err.finish(Location::Script))?
+                .check_compatibility(struct_handle)
+                .map_err(|err| err.finish(Location::Script))?;
+
+            struct_names.push(name_cache.insert_or_get(StructIdentifier {
+                module: module_id,
+                name: struct_name.to_owned(),
+            }));
+        }
+
+        let mut function_refs = vec![];
+        for func_handle in script.function_handles().iter() {
+            let func_name = script.identifier_at(func_handle.name);
+            let module_handle = script.module_handle_at(func_handle.module);
+            let module_id = ModuleId::new(
+                *script.address_identifier_at(module_handle.address),
+                script.identifier_at(module_handle.name).to_owned(),
+            );
+            function_refs.push(FunctionHandle::Remote {
+                module: module_id,
+                name: func_name.to_owned(),
+            });
+        }
+
+        let mut function_instantiations = vec![];
+        for func_inst in script.function_instantiations() {
+            let handle = function_refs[func_inst.handle.0 as usize].clone();
+            let mut instantiation = vec![];
+            for ty in &script.signature_at(func_inst.type_parameters).0 {
+                instantiation.push(
+                    intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
+                        .map_err(|e| e.finish(Location::Script))?,
+                );
+            }
+            function_instantiations.push(FunctionInstantiation {
+                handle,
+                instantiation,
+            });
+        }
+
+        let scope = Scope::Script(*script_hash);
+
+        let code: Vec<Bytecode> = script.code.code.clone();
+        let parameters = script.signature_at(script.parameters).clone();
+
+        let parameter_tys = parameters
+            .0
+            .iter()
+            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        let locals = Signature(
+            parameters
+                .0
+                .iter()
+                .chain(script.signature_at(script.code.locals).0.iter())
+                .cloned()
+                .collect(),
+        );
+        let local_tys = locals
+            .0
+            .iter()
+            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        let return_ = Signature(vec![]);
+        let return_tys = return_
+            .0
+            .iter()
+            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Undefined))?;
+        let type_parameters = script.type_parameters.clone();
+        // TODO: main does not have a name. Revisit.
+        let name = Identifier::new("main").unwrap();
+        let (native, def_is_native) = (None, false); // Script entries cannot be native
+        let main: Arc<Function> = Arc::new(Function {
+            file_format_version: script.version(),
+            index: FunctionDefinitionIndex(0),
+            code,
+            type_parameters,
+            native,
+            def_is_native,
+            def_is_friend_or_private: false,
+            scope,
+            name,
+            return_types: return_tys.clone(),
+            local_types: local_tys,
+            parameter_types: parameter_tys.clone(),
+        });
+
+        let mut single_signature_token_map = BTreeMap::new();
+        for bc in &script.code.code {
+            match bc {
+                Bytecode::VecPack(si, _)
+                | Bytecode::VecLen(si)
+                | Bytecode::VecImmBorrow(si)
+                | Bytecode::VecMutBorrow(si)
+                | Bytecode::VecPushBack(si)
+                | Bytecode::VecPopBack(si)
+                | Bytecode::VecUnpack(si, _)
+                | Bytecode::VecSwap(si) => {
+                    if !single_signature_token_map.contains_key(si) {
+                        let ty = match script.signature_at(*si).0.get(0) {
+                            None => {
+                                return Err(PartialVMError::new(
+                                    StatusCode::VERIFIER_INVARIANT_VIOLATION,
+                                )
+                                .with_message(
+                                    "the type argument for vector-related bytecode \
+                                                expects one and only one signature token"
+                                        .to_owned(),
+                                )
+                                .finish(Location::Script));
+                            },
+                            Some(sig_token) => sig_token,
+                        };
+                        single_signature_token_map.insert(
+                            *si,
+                            intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
+                                .map_err(|e| e.finish(Location::Script))?,
+                        );
+                    }
+                },
+                _ => {},
+            }
+        }
+
+        Ok(Self {
+            script,
+            function_refs,
+            function_instantiations,
+            main,
+            parameter_tys,
+            return_tys,
+            single_signature_token_map,
+        })
+    }
+
+    pub(crate) fn entry_point(&self) -> Arc<Function> {
+        self.main.clone()
+    }
+
+    pub(crate) fn function_at(&self, idx: u16) -> &FunctionHandle {
+        &self.function_refs[idx as usize]
+    }
+
+    pub(crate) fn function_instantiation_at(&self, idx: u16) -> &FunctionInstantiation {
+        &self.function_instantiations[idx as usize]
+    }
+
+    pub(crate) fn single_type_at(&self, idx: SignatureIndex) -> &Type {
+        self.single_signature_token_map.get(&idx).unwrap()
+    }
+}
+
+// A script cache is a map from the hash value of a script and the `Script` itself.
+// Script are added in the cache once verified and so getting a script out the cache
+// does not require further verification (except for parameters and type parameters)
+#[derive(Clone)]
+pub(crate) struct ScriptCache {
+    pub(crate) scripts: BinaryCache<ScriptHash, Script>,
+}
+
+impl ScriptCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            scripts: BinaryCache::new(),
+        }
+    }
+
+    pub(crate) fn get(&self, hash: &ScriptHash) -> Option<(Arc<Function>, Vec<Type>, Vec<Type>)> {
+        self.scripts.get(hash).map(|script| {
+            (
+                script.entry_point(),
+                script.parameter_tys.clone(),
+                script.return_tys.clone(),
+            )
+        })
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        hash: ScriptHash,
+        script: Script,
+    ) -> (Arc<Function>, Vec<Type>, Vec<Type>) {
+        match self.get(&hash) {
+            Some(cached) => cached,
+            None => {
+                let script = self.scripts.insert(hash, script);
+                (
+                    script.entry_point(),
+                    script.parameter_tys.clone(),
+                    script.return_tys.clone(),
+                )
+            },
+        }
+    }
+}

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleCache, Scope,
-    ScriptHash, StructNameCache,
+    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleAdapter,
+    Scope, ScriptHash, StructNameCache,
 };
 use move_binary_format::{
     access::ScriptAccess,
@@ -48,7 +48,7 @@ impl Script {
     pub(crate) fn new(
         script: CompiledScript,
         script_hash: &ScriptHash,
-        cache: &ModuleCache,
+        cache: &ModuleAdapter,
         name_cache: &StructNameCache,
     ) -> VMResult<Self> {
         let mut struct_names = vec![];

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -1,4 +1,3 @@
-// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,10 +17,9 @@ use std::{collections::BTreeMap, sync::Arc};
 
 // A Script is very similar to a `CompiledScript` but data is "transformed" to a representation
 // more appropriate to execution.
-// When code executes, indexes in instructions are resolved against runtime structures
+// When code executes, indices in instructions are resolved against runtime structures
 // (rather then "compiled") to make available data needed for execution
-// #[derive(Debug)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Script {
     // primitive pools
     pub(crate) script: CompiledScript,

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation, ModuleStorageAdapter,
-    Scope, ScriptHash, StructNameCache,
+    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation,
+    ModuleStorageAdapter, Scope, ScriptHash, StructNameCache,
 };
 use move_binary_format::{
     access::ScriptAccess,

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -14,7 +14,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     metadata::Metadata, resolver::MoveResolver,
 };
-use std::{collections::BTreeSet, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct MoveVM {
@@ -102,14 +102,6 @@ impl MoveVM {
     /// TODO: new loader architecture
     pub fn flush_loader_cache_if_invalidated(&self) {
         self.runtime.loader().flush_if_invalidated()
-    }
-
-    /// Gets and clears module cache hits. This is hack which allows the adapter to see module
-    /// reads if executing multiple transactions in a VM. Without this, the adapter only sees
-    /// the first load of a module.
-    /// TODO: new loader architecture
-    pub fn get_and_clear_module_cache_hits(&self) -> BTreeSet<ModuleId> {
-        self.runtime.loader().get_and_clear_module_cache_hits()
     }
 
     /// Attempts to discover metadata in a given module with given key. Availability

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -124,8 +124,12 @@ impl MoveVM {
     /// If the loader cache has been invalidated (either by the above call or by internal logic)
     /// flush it so it is valid again. Notice that should only be called if there are no
     /// outstanding sessions created from this VM.
-    /// TODO: new loader architecture
     pub fn flush_loader_cache_if_invalidated(&self) {
+        // Flush the module cache inside the VMRuntime. This code is there for a legacy reason:
+        // - In the old session api that we provide, MoveVM will hold a cache for loaded module and the session will be created against that cache.
+        //   Thus if an module invalidation event happens (e.g, by upgrade request), we will need to flush this internal cache as well.
+        // - If we can deprecate this session api, we will be able to get rid of this internal loaded cache and make the MoveVM "stateless" and
+        //   invulnerable to module invalidation.
         if self.runtime.loader().is_invalidated() {
             self.runtime.module_cache.flush();
         };

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -3,8 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMConfig, data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
-    native_functions::NativeFunction, runtime::VMRuntime, session::Session,
+    config::VMConfig,
+    data_cache::TransactionDataCache,
+    loader::ModuleAdapter,
+    native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction,
+    runtime::VMRuntime,
+    session::Session,
 };
 use move_binary_format::{
     errors::{Location, VMResult},
@@ -65,6 +70,9 @@ impl MoveVM {
         Session {
             move_vm: self,
             data_cache: TransactionDataCache::new(remote),
+            module_store: ModuleAdapter::new(
+                &self.runtime.loader().module_cache,
+            ),
             native_extensions,
         }
     }
@@ -77,7 +85,13 @@ impl MoveVM {
     ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
-            .load_module(module_id, &TransactionDataCache::new(remote))
+            .load_module(
+                module_id,
+                &TransactionDataCache::new(remote),
+                &ModuleAdapter::new(
+                    &self.runtime.loader().module_cache
+                ),
+            )
             .map(|arc_module| arc_module.arc_module())
     }
 

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -5,7 +5,7 @@
 use crate::{
     config::VMConfig,
     data_cache::TransactionDataCache,
-    loader::{ModuleStorageAdapter, ModuleStorage},
+    loader::{ModuleStorage, ModuleStorageAdapter},
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunction,
     runtime::VMRuntime,

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -136,7 +136,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
                 self.resolver.loader(),
                 address,
                 type_,
-                &self.resolver.module_store(),
+                self.resolver.module_store(),
             )
             .map_err(|err| err.finish(Location::Undefined))?;
         let exists = value

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -132,7 +132,12 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     ) -> VMResult<(bool, Option<NumBytes>)> {
         let (value, num_bytes) = self
             .data_store
-            .load_resource(self.resolver.loader(), address, type_)
+            .load_resource(
+                self.resolver.loader(),
+                address,
+                type_,
+                &self.resolver.module_store(),
+            )
             .map_err(|err| err.finish(Location::Undefined))?;
         let exists = value
             .exists()

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::{
     config::VMConfig,
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
-    loader::{Function, LoadedFunction, Loader, ModuleStorageAdapter, ModuleCache, ModuleStorage},
+    loader::{Function, LoadedFunction, Loader, ModuleCache, ModuleStorage, ModuleStorageAdapter},
     native_extensions::NativeContextExtensions,
     native_functions::{NativeFunction, NativeFunctions},
     session::{LoadedFunctionInstantiation, SerializedReturnValues},

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -5,7 +5,7 @@
 use crate::{
     config::VMConfig,
     data_cache::TransactionDataCache,
-    loader::{LoadedFunction, ModuleAdapter},
+    loader::{LoadedFunction, ModuleStorageAdapter},
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
 };
@@ -33,7 +33,7 @@ use std::{borrow::Borrow, sync::Arc};
 pub struct Session<'r, 'l> {
     pub(crate) move_vm: &'l MoveVM,
     pub(crate) data_cache: TransactionDataCache<'r>,
-    pub(crate) module_store: ModuleAdapter<'l>,
+    pub(crate) module_store: ModuleStorageAdapter,
     pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 


### PR DESCRIPTION
### Description

The idea is the session should pass in which loader cache to use. The default API remains the same but created a new API for passing a custom module cache instead. This would make MoveVM itself stateless if such API is used.

### Test Plan

Rebased on the testing PR #11126

