### PR TITLE
Enables `LIMIT_MAX_IDENTIFIER_LENGTH` in devnet by default

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -434,6 +434,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SINGLE_SENDER_AUTHENTICATOR,
         FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
         FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
+        FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
     ]
 }
 


### PR DESCRIPTION
### Description
This PR enables `LIMIT_MAX_IDENTIFIER_LENGTH` in devnet by default.
