### PR TITLE
[storage] add print before the panic exit

### DIFF
--- a/crates/crash-handler/src/lib.rs
+++ b/crates/crash-handler/src/lib.rs
@@ -53,7 +53,7 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
     if state::get_state() == VMState::VERIFIER || state::get_state() == VMState::DESERIALIZER {
         return;
     }
-
+    eprintln!("The process panicked at:\n{}", panic_info);
     // Kill the process
     process::exit(12);
 }


### PR DESCRIPTION
### Description
Not clear if a sub replay-veriyf partition is deadlock or paniced 
Add the print to understand if the process exited or dead lock for replay-verify debugging
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
