### PR TITLE
[State Sync] Reduce pipeline depth and use execution for validators.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -141,7 +141,7 @@ impl Default for StateSyncDriverConfig {
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 100,
             max_num_stream_timeouts: 30, // 30 * 5 seconds = 180 seconds before stream times out
-            max_pending_data_chunks: 500,
+            max_pending_data_chunks: 50,
             max_stream_wait_time_ms: 5000,
             mempool_commit_ack_timeout_ms: 5000, // 5 seconds
             num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.


### PR DESCRIPTION
### Description
This PR:
- Reduces the max state sync pipeline depth from 500 to 50 (to mitigate the OOMing nodes).
- Update validators to use execution mode for syncing (seems like they struggle with networking much more than VFNs).
- Keep VFNs using output syncing (we need the extra CPU for the REST API).

### Test Plan
Manual verification.