### PR TITLE
[Smoke Tests] Add smoke tests for manual fullnode writesets.

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -430,16 +430,14 @@ impl LocalSwarm {
     }
 
     pub fn validators(&self) -> impl Iterator<Item = &LocalNode> {
-        // sort by id to keep the order consistent:
         let mut validators: Vec<&LocalNode> = self.validators.values().collect();
-        validators.sort_by_key(|v| v.index());
+        validators.sort_by_key(|v| v.index()); // Sort by index for consistent ordering
         validators.into_iter()
     }
 
     pub fn validators_mut(&mut self) -> impl Iterator<Item = &mut LocalNode> {
-        // sort by id to keep the order consistent:
         let mut validators: Vec<&mut LocalNode> = self.validators.values_mut().collect();
-        validators.sort_by_key(|v| v.index());
+        validators.sort_by_key(|v| v.index()); // Sort by index for consistent ordering
         validators.into_iter()
     }
 
@@ -449,6 +447,18 @@ impl LocalSwarm {
 
     pub fn fullnode_mut(&mut self, peer_id: PeerId) -> Option<&mut LocalNode> {
         self.fullnodes.get_mut(&peer_id)
+    }
+
+    pub fn fullnodes(&self) -> impl Iterator<Item = &LocalNode> {
+        let mut fullnodes: Vec<&LocalNode> = self.fullnodes.values().collect();
+        fullnodes.sort_by_key(|v| v.index()); // Sort by index for consistent ordering
+        fullnodes.into_iter()
+    }
+
+    pub fn fullnodes_mut(&mut self) -> impl Iterator<Item = &mut LocalNode> {
+        let mut fullnodes: Vec<&mut LocalNode> = self.fullnodes.values_mut().collect();
+        fullnodes.sort_by_key(|v| v.index()); // Sort by index for consistent ordering
+        fullnodes.into_iter()
     }
 
     pub fn dir(&self) -> &Path {

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -77,18 +77,27 @@ pub trait Node: Send + Sync {
 /// Trait used to represent a running Validator
 #[async_trait::async_trait]
 pub trait Validator: Node + Sync {
-    async fn check_connectivity(&self, expected_peers: usize) -> Result<bool> {
+    async fn check_connectivity(
+        &self,
+        network_id: NetworkId,
+        expected_peers: usize,
+    ) -> Result<bool> {
         if expected_peers == 0 {
             return Ok(true);
         }
 
-        self.get_connected_peers(NetworkId::Validator, None)
+        self.get_connected_peers(network_id, None)
             .await
             .map(|maybe_n| maybe_n.map(|n| n >= expected_peers as i64).unwrap_or(false))
     }
 
-    async fn wait_for_connectivity(&self, expected_peers: usize, deadline: Instant) -> Result<()> {
-        while !self.check_connectivity(expected_peers).await? {
+    async fn wait_for_connectivity(
+        &self,
+        network_id: NetworkId,
+        expected_peers: usize,
+        deadline: Instant,
+    ) -> Result<()> {
+        while !self.check_connectivity(network_id, expected_peers).await? {
             if Instant::now() > deadline {
                 return Err(anyhow!("waiting for connectivity timed out"));
             }

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -6,7 +6,10 @@ use crate::{
     AptosPublicInfo, ChainInfo, FullNode, NodeExt, Result, SwarmChaos, Validator, Version,
 };
 use anyhow::{anyhow, bail};
-use aptos_config::config::{NodeConfig, OverrideNodeConfig};
+use aptos_config::{
+    config::{NodeConfig, OverrideNodeConfig},
+    network_id::NetworkId,
+};
 use aptos_logger::info;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::types::PeerId;
@@ -157,7 +160,7 @@ pub trait SwarmExt: Swarm {
         while !try_join_all(
             validators
                 .iter()
-                .map(|node| node.check_connectivity(validators.len() - 1))
+                .map(|node| node.check_connectivity(NetworkId::Validator, validators.len() - 1))
                 .chain(full_nodes.iter().map(|node| node.check_connectivity())),
         )
         .await
@@ -492,7 +495,7 @@ pub async fn get_highest_synced_epoch(clients: &[(String, RestClient)]) -> Resul
 }
 
 /// Returns the highest synced version and epoch of the given clients
-async fn get_highest_synced_version_and_epoch(
+pub async fn get_highest_synced_version_and_epoch(
     clients: &[(String, RestClient)],
 ) -> Result<(u64, u64)> {
     let mut latest_version_and_epoch = (0, 0);

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -6,16 +6,21 @@ use crate::{
     smoke_test_environment::SwarmBuilder,
     storage::{db_backup, db_restore},
     test_utils::{
-        check_create_mint_transfer_node, swarm_utils::insert_waypoint, MAX_CATCH_UP_WAIT_SECS,
+        check_create_mint_transfer_node, create_test_accounts, execute_transactions,
+        execute_transactions_and_wait, swarm_utils::insert_waypoint, MAX_CATCH_UP_WAIT_SECS,
         MAX_CONNECTIVITY_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
     },
     workspace_builder,
     workspace_builder::workspace_root,
 };
 use anyhow::anyhow;
-use aptos_config::config::{AdminServiceConfig, InitialSafetyRulesConfig, NodeConfig};
+use aptos_config::{
+    config::{AdminServiceConfig, InitialSafetyRulesConfig, NodeConfig},
+    network_id::NetworkId,
+};
 use aptos_forge::{
-    get_highest_synced_version, LocalNode, LocalSwarm, Node, NodeExt, SwarmExt, Validator,
+    get_highest_synced_version, get_highest_synced_version_and_epoch,
+    wait_for_all_nodes_to_catchup, LocalNode, LocalSwarm, Node, NodeExt, SwarmExt, Validator,
 };
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
@@ -32,6 +37,150 @@ use std::{
 
 #[tokio::test]
 /// This test verifies:
+/// 1. The behaviour of the consensus sync_only mode (to emulate a network halt).
+/// 2. The flow of a genesis write-set transaction for fullnodes (after the validators have forked).
+///
+/// The test does the following:
+/// 1. Start a 4 node validator network, including 2 VFNs.
+/// 2. Use consensus `sync_only` mode to force all nodes to stop at the same version (i.e., emulate a halt).
+/// 3. Use the aptos CLI to generate a genesis transaction that removes the last validator from the set.
+/// 4. Use the aptos-debugger to manually apply the genesis transaction to all remaining validators.
+/// 5. Verify that the network is able to resume consensus and that the last validator is no longer in the set.
+/// 6. Use the aptos-debugger to manually apply the genesis transaction to all VFNs.
+/// 7. Verify that the VFNs are able to sync with the rest of the network.
+async fn test_fullnode_genesis_transaction_flow() {
+    println!("0. Building the Aptos CLI and debugger!");
+    let aptos_debugger = workspace_builder::get_bin("aptos-debugger");
+    let aptos_cli = workspace_builder::get_bin("aptos");
+
+    println!("1. Starting a 4 node validator network with 2 VFNs!");
+    let num_validators = 4;
+    let num_fullnodes = 2;
+    let (mut swarm, cli_test_framework, _) = SwarmBuilder::new_local(num_validators)
+        .with_num_fullnodes(num_fullnodes)
+        .with_aptos()
+        .build_with_cli(0)
+        .await;
+
+    println!("2. Executing a number of test transactions");
+    let validator = swarm.validators_mut().next().unwrap();
+    let validator_client = validator.rest_client();
+    let (mut account_0, account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions_and_wait(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        true,
+    )
+    .await;
+
+    println!("3. Enabling `sync_only` mode for every validator!");
+    for validator in swarm.validators_mut() {
+        enable_sync_only_mode(num_validators, validator).await;
+    }
+
+    println!("4. Fetching the halt version and epoch, and stopping all validators!");
+    let (halt_version, halt_epoch) =
+        get_highest_synced_version_and_epoch(&swarm.get_all_nodes_clients_with_names())
+            .await
+            .unwrap();
+    for node in swarm.validators_mut() {
+        node.stop();
+    }
+
+    println!("5. Generating a genesis transaction that removes the last validator from the set!");
+    let (genesis_blob_path, genesis_transaction) =
+        generate_genesis_transaction(&mut swarm, aptos_cli);
+
+    println!("6. Applying the genesis transaction to the first validator!");
+    let first_validator_config = swarm.validators_mut().next().unwrap().config().clone();
+    let first_validator_storage_dir = first_validator_config.storage.dir();
+    let output = Command::new(aptos_debugger.as_path())
+        .current_dir(workspace_root())
+        .args(&vec![
+            "aptos-db",
+            "bootstrap",
+            first_validator_storage_dir.to_str().unwrap(),
+            "--genesis-txn-file",
+            genesis_blob_path.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    println!("7. Parsing the output to get the waypoint: {:?}", output);
+    let output_string = std::str::from_utf8(&output.stdout).unwrap();
+    let waypoint = parse_waypoint(output_string);
+
+    println!(
+        "8. Applying the genesis transaction to validators 0, 1 and 2. Waypoint: {:?}",
+        waypoint
+    );
+    for (num_expected_peers, validator) in swarm.validators_mut().take(3).enumerate() {
+        apply_genesis_to_node(
+            validator,
+            genesis_transaction.clone(),
+            waypoint,
+            num_expected_peers,
+            false, // Don't test the admin service on the validators
+        )
+        .await;
+    }
+
+    println!("9. Verifying that we're able to resume consensus and execute transactions!");
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        true,
+    )
+    .await;
+
+    println!("10. Verifying that the last validator is no longer in the validator set!");
+    let validator_set = cli_test_framework.show_validator_set().await.unwrap();
+    assert_eq!(validator_set.active_validators.len(), num_validators - 1);
+
+    println!("11. Verifying that the VFNs are stuck at the network halt! Expected epoch: {}, version: {}", halt_epoch, halt_version);
+    for fullnode in swarm.fullnodes_mut() {
+        // Get the current epoch and version for the fullnode
+        let (current_epoch, current_version) = get_current_epoch_and_version(fullnode).await;
+
+        // Verify that the fullnode is stuck at the network halt
+        assert_eq!(current_epoch, halt_epoch);
+        assert_eq!(current_version, halt_version);
+    }
+
+    println!(
+        "12. Applying the genesis transaction to the VFNs. Waypoint: {:?}",
+        waypoint
+    );
+    for (fullnode_index, fullnode) in swarm.fullnodes_mut().enumerate() {
+        apply_genesis_to_node(
+            fullnode,
+            genesis_transaction.clone(),
+            waypoint,
+            1,                   // Number of expected peers
+            fullnode_index == 0, // Test admin service on the first fullnode
+        )
+        .await;
+    }
+
+    println!("13. Verifying that the VFNs are able to sync with the validators!");
+    let all_nodes = swarm.validators().take(3).chain(swarm.fullnodes());
+    let all_node_clients: Vec<_> = all_nodes
+        .map(|node| (node.name().to_string(), node.rest_client()))
+        .collect();
+    wait_for_all_nodes_to_catchup(
+        &all_node_clients,
+        Duration::from_secs(MAX_CATCH_UP_WAIT_SECS),
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+/// This test verifies:
 /// 1. The behaviour of the consensus sync_only mode.
 /// 2. The flow of a genesis write-set transaction after the chain has halted.
 /// 3. That db-restore is able to restore a failed validator node.
@@ -44,44 +193,45 @@ use std::{
 /// 5. Use the aptos-debugger to manually apply the genesis transaction to all remaining validators.
 /// 6. Verify that the network is able to resume consensus and that the last validator is no longer in the set.
 /// 7. Verify that a failed validator node is able to db-restore and rejoin the network.
-async fn test_genesis_transaction_and_db_restore_flow() {
+async fn test_validator_genesis_transaction_and_db_restore_flow() {
     println!("0. Building the Aptos CLI and debugger!");
     let aptos_debugger = workspace_builder::get_bin("aptos-debugger");
     let aptos_cli = workspace_builder::get_bin("aptos");
 
     println!("1. Starting a 5 node validator network!");
-    let num_nodes = 5;
-    let (mut env, cli_test_framework, _) = SwarmBuilder::new_local(num_nodes)
+    let num_validators = 5;
+    let (mut swarm, cli_test_framework, _) = SwarmBuilder::new_local(num_validators)
         .with_aptos()
         .build_with_cli(0)
         .await;
 
     println!("2. Enabling `sync_only` mode for the last validator and verifying that it can sync!");
-    let last_validator = env.validators_mut().last().unwrap();
-    enable_sync_only_mode(num_nodes, last_validator).await;
-    env.wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
+    let last_validator = swarm.validators_mut().last().unwrap();
+    enable_sync_only_mode(num_validators, last_validator).await;
+    swarm
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 
     println!("3. Enabling `sync_only` mode for every validator!");
-    for validator in env.validators_mut() {
-        enable_sync_only_mode(num_nodes, validator).await;
+    for validator in swarm.validators_mut() {
+        enable_sync_only_mode(num_validators, validator).await;
     }
 
     println!("4. Deleting one validator's DB and verifying that it can still catch up!");
-    delete_storage_and_wait_for_catchup(&mut env, 3).await;
+    delete_storage_and_wait_for_catchup(&mut swarm, 3).await;
 
     println!("5. Stopping three validator nodes!");
-    for node in env.validators_mut().take(3) {
+    for node in swarm.validators_mut().take(3) {
         node.stop();
     }
 
     println!("6. Generating a genesis transaction that removes the last validator from the set!");
     let (genesis_blob_path, genesis_transaction) =
-        generate_genesis_transaction(&mut env, aptos_cli);
+        generate_genesis_transaction(&mut swarm, aptos_cli);
 
     println!("7. Applying the genesis transaction to the first validator!");
-    let first_validator_config = env.validators_mut().next().unwrap().config().clone();
+    let first_validator_config = swarm.validators_mut().next().unwrap().config().clone();
     let first_validator_storage_dir = first_validator_config.storage.dir();
     let output = Command::new(aptos_debugger.as_path())
         .current_dir(workspace_root())
@@ -103,8 +253,8 @@ async fn test_genesis_transaction_and_db_restore_flow() {
         "9. Applying the genesis transaction to validators 0, 1 and 2. Waypoint: {:?}",
         waypoint
     );
-    for (num_expected_peers, validator) in env.validators_mut().take(3).enumerate() {
-        apply_genesis_to_validator(
+    for (num_expected_peers, validator) in swarm.validators_mut().take(3).enumerate() {
+        apply_genesis_to_node(
             validator,
             genesis_transaction.clone(),
             waypoint,
@@ -115,43 +265,46 @@ async fn test_genesis_transaction_and_db_restore_flow() {
     }
 
     println!("10. Verifying that we're able to resume consensus and execute transactions!");
-    env.wait_for_startup().await.unwrap();
-    check_create_mint_transfer_node(&mut env, 0).await;
+    swarm.wait_for_startup().await.unwrap();
+    check_create_mint_transfer_node(&mut swarm, 0).await;
 
     println!("11. Verifying that the last validator is no longer in the validator set!");
     let validator_set = cli_test_framework.show_validator_set().await.unwrap();
-    assert_eq!(validator_set.active_validators.len(), 4);
+    assert_eq!(validator_set.active_validators.len(), num_validators - 1);
 
     println!("12. Deleting the DB on validator 3 and verifying that it can still catch up via db-restore!");
-    delete_db_and_execute_restore(&mut env, 3, waypoint, num_nodes).await;
+    delete_db_and_execute_restore(&mut swarm, 3, waypoint, num_validators).await;
 
     println!("13. Verifying that we're able to execute transactions on validator 3!");
-    check_create_mint_transfer_node(&mut env, 3).await;
+    check_create_mint_transfer_node(&mut swarm, 3).await;
 }
 
-/// Applies the genesis transaction to the specified validator and waits for it to become healthy
-async fn apply_genesis_to_validator(
-    validator: &mut LocalNode,
+/// Applies the genesis transaction to the specified node and waits for it to become healthy
+async fn apply_genesis_to_node(
+    node: &mut LocalNode,
     genesis_transaction: Transaction,
     waypoint: Waypoint,
     num_expected_peers: usize,
     test_admin_service: bool,
 ) {
-    // Insert the waypoint into the validator's config
-    let mut node_config = validator.config().clone();
+    // Insert the waypoint into the node's config
+    let mut node_config = node.config().clone();
     insert_waypoint(&mut node_config, waypoint);
 
     // Update the genesis transaction
     node_config.execution.genesis = Some(genesis_transaction.clone());
 
-    // Reset the initial safety rules config
-    node_config
-        .consensus
-        .safety_rules
-        .initial_safety_rules_config = InitialSafetyRulesConfig::None;
+    // If the node is a validator, reset the initial safety rules config and the sync_only flag
+    if node_config.base.role.is_validator() {
+        // Reset the initial safety rules config
+        node_config
+            .consensus
+            .safety_rules
+            .initial_safety_rules_config = InitialSafetyRulesConfig::None;
 
-    // Reset the sync_only flag to false (so the validator can participate in consensus)
-    node_config.consensus.sync_only = false;
+        // Reset the sync_only flag to false (so the validator can participate in consensus)
+        node_config.consensus.sync_only = false;
+    }
 
     // Remove the admin service override (the config optimizer should run and set the config)
     if test_admin_service {
@@ -159,9 +312,16 @@ async fn apply_genesis_to_validator(
         node_config.admin_service = AdminServiceConfig::default();
     }
 
-    // Update the config, restart the validator and wait for it to become healthy
-    update_node_config_and_restart(validator, node_config);
-    wait_for_health_and_connectivity(validator, num_expected_peers).await;
+    // Update the config and restart the node
+    update_node_config_and_restart(node, node_config.clone());
+
+    // Wait for the node to become healthy
+    let network_id = if node_config.base.role.is_validator() {
+        NetworkId::Validator
+    } else {
+        NetworkId::Vfn
+    };
+    wait_for_health_and_connectivity(node, network_id, num_expected_peers).await;
 
     // Verify that the config optimizer ran and started the admin service at the default port
     if test_admin_service {
@@ -178,13 +338,7 @@ async fn delete_db_and_execute_restore(
 ) {
     // Get the current epoch and version from the first validator
     let first_validator = env.validators_mut().next().unwrap();
-    let current_ledger_info = first_validator
-        .rest_client()
-        .get_ledger_information()
-        .await
-        .unwrap();
-    let current_epoch = current_ledger_info.inner().epoch;
-    let current_version = current_ledger_info.inner().version;
+    let (current_epoch, current_version) = get_current_epoch_and_version(first_validator).await;
 
     // Perform a DB backup on the first validator
     let first_validator_backup_port = first_validator
@@ -233,7 +387,7 @@ async fn delete_db_and_execute_restore(
 
     // Restart the validator and wait for it to become healthy
     validator.start().unwrap();
-    wait_for_health_and_connectivity(validator, num_nodes - 2).await;
+    wait_for_health_and_connectivity(validator, NetworkId::Validator, num_nodes - 2).await;
 
     // Wait until the validator catches up to the current version
     let client = validator.rest_client();
@@ -273,7 +427,7 @@ async fn enable_sync_only_mode(num_nodes: usize, validator_node: &mut LocalNode)
     update_node_config_and_restart(validator_node, validator_config.clone());
 
     // Wait for the validator to become healthy
-    wait_for_health_and_connectivity(validator_node, num_nodes - 1).await;
+    wait_for_health_and_connectivity(validator_node, NetworkId::Validator, num_nodes - 1).await;
 }
 
 /// Generates a genesis write-set transaction that removes the last validator from the set
@@ -354,6 +508,19 @@ fn generate_genesis_transaction(
     (genesis_blob_path, genesis_transaction)
 }
 
+/// Returns the current epoch and version of the specified node
+/// by querying the node's REST API.
+async fn get_current_epoch_and_version(node: &mut LocalNode) -> (u64, u64) {
+    // Get current ledger info from the rest client
+    let rest_client = node.rest_client();
+    let current_ledger_info = rest_client.get_ledger_information().await.unwrap();
+
+    // Return the current epoch and version
+    let current_epoch = current_ledger_info.inner().epoch;
+    let current_version = current_ledger_info.inner().version;
+    (current_epoch, current_version)
+}
+
 /// Parses the waypoint from the output of the bootstrap command
 fn parse_waypoint(bootstrap_command_output: &str) -> Waypoint {
     let waypoint = Regex::new(r"Got waypoint: (\d+:\w+)")
@@ -396,18 +563,18 @@ async fn verify_admin_service_is_running() {
     assert_eq!(response_string, "AdminService is not enabled.");
 }
 
-/// Wait for the specified validator to become healthy and for the
-/// validator to connect to the specified number of peers.
+/// Wait for the specified node to become healthy and for the
+/// node to connect to the specified number of peers.
 async fn wait_for_health_and_connectivity(
-    validator: &mut dyn Validator,
+    node: &mut LocalNode,
+    network_id: NetworkId,
     num_expected_peers: usize,
 ) {
-    // Wait for the validator to become healthy
+    // Wait for the node to become healthy
     let healthy_deadline = Instant::now()
         .checked_add(Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .unwrap();
-    validator
-        .wait_until_healthy(healthy_deadline)
+    node.wait_until_healthy(healthy_deadline)
         .await
         .unwrap_or_else(|err| {
             let lsof_output = Command::new("lsof").arg("-i").output().unwrap();
@@ -417,12 +584,11 @@ async fn wait_for_health_and_connectivity(
             );
         });
 
-    // Wait for the validator to connect to the expected number of peers
+    // Wait for the node to connect to the expected number of peers
     let connectivity_deadline = Instant::now()
         .checked_add(Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
         .unwrap();
-    validator
-        .wait_for_connectivity(num_expected_peers, connectivity_deadline)
+    node.wait_for_connectivity(network_id, num_expected_peers, connectivity_deadline)
         .await
         .unwrap();
 }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -5,18 +5,17 @@
 use crate::{
     smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
     test_utils::{
-        create_and_fund_account, transfer_and_maybe_reconfig, transfer_coins,
-        MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
+        create_test_accounts, execute_transactions, execute_transactions_and_wait,
+        wait_for_all_nodes, MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
     },
 };
 use aptos_config::config::{
     BootstrappingMode, ContinuousSyncingMode, NodeConfig, OverrideNodeConfig,
 };
 use aptos_db::AptosDB;
-use aptos_forge::{LocalNode, LocalSwarm, Node, NodeExt, Swarm, SwarmExt};
+use aptos_forge::{LocalNode, LocalSwarm, Node, NodeExt, Swarm};
 use aptos_inspection_service::inspection_client::InspectionClient;
 use aptos_rest_client::Client as RestClient;
-use aptos_sdk::types::LocalAccount;
 use aptos_storage_interface::DbReader;
 use aptos_types::{
     account_address::AccountAddress,
@@ -916,75 +915,6 @@ pub async fn test_all_validator_failures(mut swarm: LocalSwarm) {
         true,
     )
     .await;
-}
-
-/// Executes transactions using the given transaction factory, client and
-/// accounts. If `execute_epoch_changes` is true, also execute transactions to
-/// force reconfigurations.
-async fn execute_transactions(
-    swarm: &mut LocalSwarm,
-    client: &RestClient,
-    sender: &mut LocalAccount,
-    receiver: &LocalAccount,
-    execute_epoch_changes: bool,
-) {
-    // Execute several transactions
-    let num_transfers = 10;
-    let transaction_factory = swarm.chain_info().transaction_factory();
-    if execute_epoch_changes {
-        transfer_and_maybe_reconfig(
-            client,
-            &transaction_factory,
-            swarm.chain_info().root_account,
-            sender,
-            receiver,
-            num_transfers,
-        )
-        .await;
-    } else {
-        for _ in 0..num_transfers {
-            // Execute simple transfer transactions
-            transfer_coins(client, &transaction_factory, sender, receiver, 1).await;
-        }
-    }
-
-    // Always ensure that at least one reconfiguration transaction is executed
-    if !execute_epoch_changes {
-        aptos_forge::reconfig(
-            client,
-            &transaction_factory,
-            swarm.chain_info().root_account,
-        )
-        .await;
-    }
-}
-
-/// Executes transactions and waits for all nodes to catch up
-async fn execute_transactions_and_wait(
-    swarm: &mut LocalSwarm,
-    client: &RestClient,
-    sender: &mut LocalAccount,
-    receiver: &LocalAccount,
-    epoch_changes: bool,
-) {
-    execute_transactions(swarm, client, sender, receiver, epoch_changes).await;
-    wait_for_all_nodes(swarm).await;
-}
-
-/// Waits for all nodes to catch up
-async fn wait_for_all_nodes(swarm: &mut LocalSwarm) {
-    swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
-        .await
-        .unwrap();
-}
-
-/// Creates and funds two test accounts
-async fn create_test_accounts(swarm: &mut LocalSwarm) -> (LocalAccount, LocalAccount) {
-    let token_amount = 1000;
-    let account_0 = create_and_fund_account(swarm, token_amount).await;
-    let account_1 = create_and_fund_account(swarm, token_amount).await;
-    (account_0, account_1)
 }
 
 /// Stops the specified fullnode and deletes storage

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_cached_packages::aptos_stdlib;
-use aptos_forge::{reconfig, LocalSwarm, NodeExt, Swarm};
+use aptos_forge::{reconfig, LocalSwarm, NodeExt, Swarm, SwarmExt};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use rand::random;
+use std::time::Duration;
 
 pub const MAX_CATCH_UP_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to catch up
 pub const MAX_CONNECTIVITY_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to gain connectivity
@@ -18,6 +19,67 @@ pub const MAX_HEALTHY_WAIT_SECS: u64 = 120; // The max time we'll wait for nodes
 pub async fn create_and_fund_account(swarm: &'_ mut dyn Swarm, amount: u64) -> LocalAccount {
     let mut info = swarm.aptos_public_info();
     info.create_and_fund_user_account(amount).await.unwrap()
+}
+
+/// Creates and funds two test accounts
+pub async fn create_test_accounts(swarm: &mut LocalSwarm) -> (LocalAccount, LocalAccount) {
+    let token_amount = 1000;
+    let account_0 = create_and_fund_account(swarm, token_amount).await;
+    let account_1 = create_and_fund_account(swarm, token_amount).await;
+    (account_0, account_1)
+}
+
+/// Executes transactions using the given transaction factory, client and
+/// accounts. If `execute_epoch_changes` is true, also execute transactions to
+/// force reconfigurations.
+pub async fn execute_transactions(
+    swarm: &mut LocalSwarm,
+    client: &RestClient,
+    sender: &mut LocalAccount,
+    receiver: &LocalAccount,
+    execute_epoch_changes: bool,
+) {
+    // Execute several transactions
+    let num_transfers = 10;
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    if execute_epoch_changes {
+        transfer_and_maybe_reconfig(
+            client,
+            &transaction_factory,
+            swarm.chain_info().root_account,
+            sender,
+            receiver,
+            num_transfers,
+        )
+        .await;
+    } else {
+        for _ in 0..num_transfers {
+            // Execute simple transfer transactions
+            transfer_coins(client, &transaction_factory, sender, receiver, 1).await;
+        }
+    }
+
+    // Always ensure that at least one reconfiguration transaction is executed
+    if !execute_epoch_changes {
+        aptos_forge::reconfig(
+            client,
+            &transaction_factory,
+            swarm.chain_info().root_account,
+        )
+        .await;
+    }
+}
+
+/// Executes transactions and waits for all nodes to catch up
+pub async fn execute_transactions_and_wait(
+    swarm: &mut LocalSwarm,
+    client: &RestClient,
+    sender: &mut LocalAccount,
+    receiver: &LocalAccount,
+    epoch_changes: bool,
+) {
+    execute_transactions(swarm, client, sender, receiver, epoch_changes).await;
+    wait_for_all_nodes(swarm).await;
 }
 
 pub async fn transfer_coins_non_blocking(
@@ -133,4 +195,12 @@ pub async fn check_create_mint_transfer_node(swarm: &mut LocalSwarm, idx: usize)
     // Create account 2, mint 15 coins and check balance
     let account_2 = info.create_and_fund_user_account(15).await.unwrap();
     assert_balance(&client, &account_2, 15).await;
+}
+
+/// Waits for all nodes to catch up
+pub async fn wait_for_all_nodes(swarm: &mut LocalSwarm) {
+    swarm
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
### Description
This PR adds a new smoke test to verify that fullnodes are also able to bypass a network halt using the same flow as the validators (i.e., manually apply a genesis writeset transaction to the DB to bypass the halt and continue syncing).

Once this lands, I'll work on updating state sync to be able to bypass network halts using only a trusted waypoint, but this test is important because it helps to verify that we always have a manual "working" solution.

### Test Plan
New and existing test infrastructure.