### PR TITLE
[Aptos Node] Use minor versions for aptos-node crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-node"
-version = "1.7.0"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "aptos-admin-service",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-node"
 description = "Aptos node"
-version = "1.7.0"
+version = "0.1.8" # We use minor versions on main. Only when a release is cut do we upgrade the major version.
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
This PR updates the `aptos-node` crate version from `1.7.0` to `0.1.8`. This reflects: (i) the latest active release (`1.8.0`); and (ii) the fact that running from `main` is unsupported -- folks who run from `main` should be discouraged from doing so, hence the minor release version of `0.1.8` instead of `1.8.0`. This was suggested by @perryjrandall ;)

### Test Plan
Manual verification.