### PR TITLE
[cherry-pick devnet][quorum store][mempool] optimize pulling txns for when many txns are in progress (#10744)

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -43,10 +43,33 @@ impl fmt::Display for TransactionSummary {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone)]
 pub struct TransactionInProgress {
-    pub summary: TransactionSummary,
     pub gas_unit_price: u64,
+    pub count: u64,
+}
+
+impl TransactionInProgress {
+    pub fn new(gas_unit_price: u64) -> Self {
+        Self {
+            gas_unit_price,
+            count: 0,
+        }
+    }
+
+    pub fn gas_unit_price(&self) -> u64 {
+        self.gas_unit_price
+    }
+
+    pub fn decrement(&mut self) -> u64 {
+        self.count -= 1;
+        self.count
+    }
+
+    pub fn increment(&mut self) -> u64 {
+        self.count += 1;
+        self.count
+    }
 }
 
 #[derive(Clone)]

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -17,7 +17,10 @@ use futures::{
     },
     StreamExt,
 };
-use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 use tokio::time::timeout;
 
 pub struct DirectMempoolQuorumStore {
@@ -47,12 +50,9 @@ impl DirectMempoolQuorumStore {
         exclude_txns: Vec<TransactionSummary>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
-        let exclude_txns: Vec<_> = exclude_txns
-            .iter()
-            .map(|txn| TransactionInProgress {
-                summary: *txn,
-                gas_unit_price: 0,
-            })
+        let exclude_txns: BTreeMap<_, _> = exclude_txns
+            .into_iter()
+            .map(|txn| (txn, TransactionInProgress::new(0)))
             .collect();
         let msg = QuorumStoreRequest::GetBatchRequest(
             max_items,

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -11,7 +11,10 @@ use crate::quorum_store::{
     },
 };
 use aptos_config::config::QuorumStoreConfig;
-use aptos_consensus_types::{common::TransactionInProgress, proof_of_store::BatchId};
+use aptos_consensus_types::{
+    common::{TransactionInProgress, TransactionSummary},
+    proof_of_store::BatchId,
+};
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
 use aptos_types::transaction::SignedTransaction;
 use futures::{
@@ -19,7 +22,7 @@ use futures::{
     StreamExt,
 };
 use move_core_types::account_address::AccountAddress;
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel as TokioChannel, time::timeout};
 
 #[allow(clippy::needless_collect)]
@@ -27,7 +30,7 @@ async fn queue_mempool_batch_response(
     txns: Vec<SignedTransaction>,
     max_size: usize,
     quorum_store_to_mempool_receiver: &mut Receiver<QuorumStoreRequest>,
-) -> Vec<TransactionInProgress> {
+) -> BTreeMap<TransactionSummary, TransactionInProgress> {
     if let QuorumStoreRequest::GetBatchRequest(
         _max_batch_size,
         _max_bytes,
@@ -544,4 +547,59 @@ async fn test_sender_max_num_batches_multi_buckets() {
         .await
         .unwrap()
         .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batches_in_progress_same_txn_across_batches() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        QuorumStoreConfig::default(),
+        Arc::new(MockQuorumStoreDB::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    let join_handle = tokio::spawn(async move {
+        let signed_txns = create_vec_signed_transactions(3);
+        let first_one: Vec<_> = signed_txns.iter().take(1).cloned().collect();
+        let first_two: Vec<_> = signed_txns.iter().take(2).cloned().collect();
+        let first_three: Vec<_> = signed_txns.iter().take(3).cloned().collect();
+
+        // Add multiple of the same txns across batches (txn1: 3 times, txn2: 2 times, txn3: 1 time)
+        queue_mempool_batch_response(first_one, 100, &mut quorum_store_to_mempool_rx).await;
+        queue_mempool_batch_response(first_two, 100, &mut quorum_store_to_mempool_rx).await;
+        queue_mempool_batch_response(first_three, 100, &mut quorum_store_to_mempool_rx).await;
+    });
+
+    let first_one_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_one_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 1);
+
+    let first_two_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_two_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 2);
+
+    let first_three_result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(first_three_result.len(), 1);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 3);
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // After all batches are complete, txns_in_progress_sorted will be empty.
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_three_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 2);
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_two_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 1);
+    batch_generator
+        .remove_batch_in_progress_for_test(&first_one_result.first().unwrap().batch_id());
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 0);
 }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -15,7 +15,7 @@ use crate::{
     shared_mempool::types::MultiBucketTimelineIndexIds,
 };
 use aptos_config::config::NodeConfig;
-use aptos_consensus_types::common::TransactionInProgress;
+use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
 use aptos_types::{
@@ -25,8 +25,8 @@ use aptos_types::{
     vm_status::DiscardedVMStatus,
 };
 use std::{
-    collections::{HashMap, HashSet},
-    time::{Duration, SystemTime},
+    collections::{BTreeMap, HashMap, HashSet},
+    time::{Duration, Instant, SystemTime},
 };
 
 pub struct Mempool {
@@ -220,6 +220,16 @@ impl Mempool {
         status
     }
 
+    fn was_seen(
+        txn_pointer: &TransactionSummary,
+        seen: &HashMap<TransactionSummary, u64>,
+        upgraded: &HashSet<&TransactionSummary>,
+        exclude_transactions: &BTreeMap<TransactionSummary, TransactionInProgress>,
+    ) -> bool {
+        seen.contains_key(txn_pointer)
+            || (!upgraded.contains(txn_pointer) && exclude_transactions.get(txn_pointer).is_some())
+    }
+
     /// Fetches next block of transactions for consensus.
     /// `return_non_full` - if false, only return transactions when max_txns or max_bytes is reached
     ///                     Should always be true for Quorum Store.
@@ -234,30 +244,23 @@ impl Mempool {
         max_bytes: u64,
         return_non_full: bool,
         include_gas_upgraded: bool,
-        mut exclude_transactions: Vec<TransactionInProgress>,
+        exclude_transactions: BTreeMap<TransactionSummary, TransactionInProgress>,
     ) -> Vec<SignedTransaction> {
-        // Sort, so per TxnPointer the highest gas will be in the map
-        if include_gas_upgraded {
-            exclude_transactions.sort();
-        }
-        let mut seen: HashMap<TxnPointer, u64> = exclude_transactions
-            .iter()
-            .map(|txn| (txn.summary, txn.gas_unit_price))
-            .collect();
+        let start_time = Instant::now();
+        let exclude_size = exclude_transactions.len();
+        let mut seen = HashMap::new();
+        let mut upgraded = HashSet::new();
         // Do not exclude transactions that had a gas upgrade
         if include_gas_upgraded {
-            let mut seen_and_upgraded = vec![];
             for (txn_pointer, new_gas) in self.transactions.get_gas_upgraded_txns() {
-                if let Some(gas) = seen.get(txn_pointer) {
-                    if *new_gas > *gas {
-                        seen_and_upgraded.push(txn_pointer);
+                if let Some(txn_info) = exclude_transactions.get(txn_pointer) {
+                    if *new_gas > txn_info.gas_unit_price() {
+                        upgraded.insert(txn_pointer);
                     }
                 }
             }
-            for txn_pointer in seen_and_upgraded {
-                seen.remove(txn_pointer);
-            }
         }
+        let gas_end_time = start_time.elapsed();
 
         let mut result = vec![];
         // Helper DS. Helps to mitigate scenarios where account submits several transactions
@@ -268,21 +271,30 @@ impl Mempool {
         // `skipped` DS and rechecked once it's ancestor becomes available
         let mut skipped = HashSet::new();
         let mut total_bytes = 0;
-        let seen_size = seen.len();
         let mut txn_walked = 0usize;
         // iterate over the queue of transactions based on gas price
         'main: for txn in self.transactions.iter_queue() {
             txn_walked += 1;
-            if seen.contains_key(&TxnPointer::from(txn)) {
+            if Self::was_seen(
+                &TxnPointer::from(txn),
+                &seen,
+                &upgraded,
+                &exclude_transactions,
+            ) {
                 continue;
             }
             let tx_seq = txn.sequence_number.transaction_sequence_number;
             let account_sequence_number = self.transactions.get_sequence_number(&txn.address);
-            let seen_previous =
-                tx_seq > 0 && seen.contains_key(&TxnPointer::new(txn.address, tx_seq - 1));
+            let previous_txn_was_seen = tx_seq > 0
+                && Self::was_seen(
+                    &TxnPointer::new(txn.address, tx_seq - 1),
+                    &seen,
+                    &upgraded,
+                    &exclude_transactions,
+                );
             // include transaction if it's "next" for given account or
             // we've already sent its ancestor to Consensus.
-            if seen_previous || account_sequence_number == Some(&tx_seq) {
+            if previous_txn_was_seen || account_sequence_number == Some(&tx_seq) {
                 let ptr = TxnPointer::from(txn);
                 seen.insert(ptr, txn.gas_ranking_score);
                 result.push(ptr);
@@ -306,6 +318,9 @@ impl Mempool {
             }
         }
         let result_size = result.len();
+        let result_end_time = start_time.elapsed();
+        let result_time = result_end_time.saturating_sub(gas_end_time);
+
         let mut block = Vec::with_capacity(result_size);
         let mut full_bytes = false;
         for txn_pointer in result {
@@ -328,11 +343,13 @@ impl Mempool {
                 );
             }
         }
+        let block_end_time = start_time.elapsed();
+        let block_time = block_end_time.saturating_sub(result_end_time);
 
         if result_size > 0 {
             debug!(
                 LogSchema::new(LogEntry::GetBlock),
-                seen_consensus = seen_size,
+                seen_consensus = exclude_size,
                 walked = txn_walked,
                 seen_after = seen.len(),
                 // before size and non full check
@@ -341,19 +358,28 @@ impl Mempool {
                 byte_size = total_bytes,
                 block_size = block.len(),
                 return_non_full = return_non_full,
+                gas_time_ms = gas_end_time.as_millis(),
+                result_time_ms = result_time.as_millis(),
+                block_time_ms = block_time.as_millis(),
             );
         } else {
-            trace!(
-                LogSchema::new(LogEntry::GetBlock),
-                seen_consensus = seen_size,
-                walked = txn_walked,
-                seen_after = seen.len(),
-                // before size and non full check
-                result_size = result_size,
-                // before non full check
-                byte_size = total_bytes,
-                block_size = block.len(),
-                return_non_full = return_non_full,
+            sample!(
+                SampleRate::Duration(Duration::from_secs(60)),
+                debug!(
+                    LogSchema::new(LogEntry::GetBlock),
+                    seen_consensus = exclude_size,
+                    walked = txn_walked,
+                    seen_after = seen.len(),
+                    // before size and non full check
+                    result_size = result_size,
+                    // before non full check
+                    byte_size = total_bytes,
+                    block_size = block.len(),
+                    return_non_full = return_non_full,
+                    gas_time_ms = gas_end_time.as_millis(),
+                    result_time_ms = result_time.as_millis(),
+                    block_time_ms = block_time.as_millis(),
+                )
             );
         }
 

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -311,6 +311,10 @@ impl TransactionStore {
             self.hash_index.len(),
         );
         counters::core_mempool_index_size(counters::SIZE_BYTES_LABEL, self.size_bytes);
+        counters::core_mempool_index_size(
+            counters::GAS_UPGRADED_INDEX_LABEL,
+            self.gas_upgraded_index.len(),
+        );
     }
 
     /// Checks if Mempool is full.

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -20,6 +20,7 @@ pub const TIMELINE_INDEX_LABEL: &str = "timeline";
 pub const PARKING_LOT_INDEX_LABEL: &str = "parking_lot";
 pub const TRANSACTION_HASH_INDEX_LABEL: &str = "transaction_hash";
 pub const SIZE_BYTES_LABEL: &str = "size_bytes";
+pub const GAS_UPGRADED_INDEX_LABEL: &str = "gas_upgraded";
 
 // Core mempool stages labels
 pub const COMMIT_ACCEPTED_LABEL: &str = "commit_accepted";

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -12,7 +12,9 @@ use aptos_config::{
     config::{MempoolConfig, RoleType},
     network_id::PeerNetworkId,
 };
-use aptos_consensus_types::common::{RejectedTransactionSummary, TransactionInProgress};
+use aptos_consensus_types::common::{
+    RejectedTransactionSummary, TransactionInProgress, TransactionSummary,
+};
 use aptos_crypto::HashValue;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_network::{
@@ -170,7 +172,7 @@ pub enum QuorumStoreRequest {
         // include gas upgraded
         bool,
         // transactions to exclude from the requested batch
-        Vec<TransactionInProgress>,
+        BTreeMap<TransactionSummary, TransactionInProgress>,
         // callback to respond to
         oneshot::Sender<Result<QuorumStoreResponse>>,
     ),

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState, TxnPointer},
+    core_mempool::{CoreMempool, TimelineState},
     network::MempoolSyncMsg,
 };
 use anyhow::{format_err, Result};
 use aptos_compression::metrics::CompressionClient;
 use aptos_config::config::{NodeConfig, MAX_APPLICATION_MESSAGE_SIZE};
-use aptos_consensus_types::common::TransactionInProgress;
+use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_types::{
     account_address::AccountAddress,
@@ -20,7 +20,7 @@ use aptos_types::{
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::BTreeMap;
 
 pub(crate) fn setup_mempool() -> (CoreMempool, ConsensusMock) {
     let mut config = NodeConfig::generate_random_config();
@@ -160,11 +160,11 @@ pub(crate) fn batch_add_signed_txn(
 }
 
 // Helper struct that keeps state between `.get_block` calls. Imitates work of Consensus.
-pub struct ConsensusMock(HashSet<TxnPointer>);
+pub struct ConsensusMock(BTreeMap<TransactionSummary, TransactionInProgress>);
 
 impl ConsensusMock {
     pub(crate) fn new() -> Self {
-        Self(HashSet::new())
+        Self(BTreeMap::new())
     }
 
     pub(crate) fn get_block(
@@ -173,25 +173,12 @@ impl ConsensusMock {
         max_txns: u64,
         max_bytes: u64,
     ) -> Vec<SignedTransaction> {
-        let exclude_transactions: Vec<_> = self
-            .0
-            .iter()
-            .map(|txn| TransactionInProgress {
-                summary: *txn,
-                gas_unit_price: 0,
-            })
-            .collect();
-        let block = mempool.get_batch(max_txns, max_bytes, true, false, exclude_transactions);
-        self.0 = self
-            .0
-            .union(
-                &block
-                    .iter()
-                    .map(|t| TxnPointer::new(t.sender(), t.sequence_number()))
-                    .collect(),
-            )
-            .cloned()
-            .collect();
+        let block = mempool.get_batch(max_txns, max_bytes, true, true, self.0.clone());
+        block.iter().for_each(|t| {
+            let txn_summary = TransactionSummary::new(t.sender(), t.sequence_number());
+            let txn_info = TransactionInProgress::new(t.gas_unit_price());
+            self.0.insert(txn_summary, txn_info);
+        });
         block
     }
 }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -38,7 +38,10 @@ use aptos_vm_validator::{
 };
 use futures::channel::mpsc;
 use maplit::hashmap;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 use tokio::runtime::{Handle, Runtime};
 
 /// Mock of a running instance of shared mempool.
@@ -187,7 +190,7 @@ impl MockSharedMempool {
     pub fn get_txns(&self, size: u64) -> Vec<SignedTransaction> {
         let pool = self.mempool.lock();
         // assume txn size is less than 100kb
-        pool.get_batch(size, size * 102400, true, false, vec![])
+        pool.get_batch(size, size * 102400, true, false, BTreeMap::new())
     }
 
     pub fn remove_txn(&self, txn: &SignedTransaction) {

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -24,6 +24,7 @@ use aptos_network::{
     ProtocolId,
 };
 use aptos_types::{transaction::SignedTransaction, PeerId};
+use maplit::btreemap;
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashMap;
 use tokio::runtime::Runtime;
@@ -376,7 +377,7 @@ impl TestHarness {
                                 102400,
                                 true,
                                 false,
-                                vec![],
+                                btreemap![],
                             );
                             for txn in transactions.iter() {
                                 assert!(block.contains(txn));

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -50,6 +50,7 @@ use aptos_types::{
 };
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
 use futures::{channel::oneshot, SinkExt};
+use maplit::btreemap;
 use std::{collections::HashMap, hash::Hash, sync::Arc};
 use tokio::{runtime::Handle, time::Duration};
 use tokio_stream::StreamExt;
@@ -170,7 +171,7 @@ impl MempoolNode {
             let block = self
                 .mempool
                 .lock()
-                .get_batch(100, 102400, true, false, vec![]);
+                .get_batch(100, 102400, true, false, btreemap![]);
 
             if block_contains_all_transactions(&block, txns) {
                 break;
@@ -223,7 +224,7 @@ impl MempoolNode {
         let block = self
             .mempool
             .lock()
-            .get_batch(100, 102400, true, false, vec![]);
+            .get_batch(100, 102400, true, false, btreemap![]);
         if !condition(&block, txns) {
             let actual: Vec<_> = block
                 .iter()


### PR DESCRIPTION
cherry pick #10744 

### Description

In forge `realistic_network_tuned_for_throughput` it was found that:
* Calling pull takes > 25 ms.
* In an edge case where the pull returns 0 new txns, this could cause livelock because the pull call would be called every 25 ms.

Resolved by:
* Optimizing the pull; now on the same workload the pull takes ~8 ms.
  * Instead of using a hashmap, use a sorted vector + binary search for the excluded txns
  * And only re-sort the vector when batches in progress is updated (instead of every pull)
* Checking the time taken to pull, and pulling less frequently if the pull takes > 12.5 ms.

### Test Plan

Existing tests, ran `realistic_network_tuned_for_throughput` as ad-hoc job and observed results.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
