### PR TITLE
Update first-transaction guide with relative cd paths

### DIFF
--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -32,7 +32,7 @@ git clone https://github.com/aptos-labs/aptos-core.git
 
   Navigate to the Typescript SDK examples directory:
   ```bash
-  cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript
+  cd aptos-core/ecosystem/typescript/sdk/examples/typescript
   ```
 
   Install the necessary dependencies:
@@ -50,7 +50,7 @@ git clone https://github.com/aptos-labs/aptos-core.git
 
   Navigate to the Python SDK directory:
   ```bash
-  cd ~/aptos-core/ecosystem/python/sdk
+  cd aptos-core/ecosystem/python/sdk
   ```
 
   Install the necessary dependencies:
@@ -68,7 +68,7 @@ git clone https://github.com/aptos-labs/aptos-core.git
 
   Navigate to the Rust SDK directory:
   ```bash
-  cd ~/aptos-core/sdk
+  cd aptos-core/sdk
   ```
 
   Run the [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/sdk/examples/transfer-coin.rs) example:


### PR DESCRIPTION
Replace `~` home related paths for `cd` command with relative to current directory. The user can execute the first command in the guide (`git clone https://github.com/aptos-labs/aptos-core.git`) from any directory, which will result in an error if this directory is not a home directory when the user will try to execute `cd` command, for example for Rust SDK `cd ~/aptos-core/sdk`.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
