### PR TITLE
Update first-coin guide

### DIFF
--- a/developer-docs-site/docs/tutorials/first-coin.md
+++ b/developer-docs-site/docs/tutorials/first-coin.md
@@ -72,10 +72,10 @@ curl -sSL https://install.python-poetry.org | python3
 poetry install
 ```
 
-Run the Python [`your-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/your-coin.py) example:
+Run the Python [`your_coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/your_coin.py) example:
 
 ```bash
-poetry run python -m examples.your-coin ~/aptos-core/aptos-move/move-examples/moon_coin
+poetry run python -m examples.your_coin ~/aptos-core/aptos-move/move-examples/moon_coin
 ```
 
   </TabItem>


### PR DESCRIPTION
### Description

Fix typo in a Your First Coin example for python, instead of `your-coin` python module should be named as it is defined in `examples` directory: `your_coin.py`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
