### PR TITLE
[buffer manager] use reset flag for faster reset

### DIFF
--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -41,7 +41,7 @@ use futures::{
 };
 use once_cell::sync::OnceCell;
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
 };
 use tokio::time::{Duration, Instant};
@@ -118,9 +118,11 @@ pub struct BufferManager {
     // being updated on-chain.
     end_epoch_timestamp: OnceCell<u64>,
     previous_commit_time: Instant,
+    reset_flag: Arc<AtomicBool>,
 }
 
 impl BufferManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         author: Author,
         execution_schedule_phase_tx: Sender<CountedRequest<ExecutionRequest>>,
@@ -139,6 +141,7 @@ impl BufferManager {
         reset_rx: UnboundedReceiver<ResetRequest>,
         verifier: ValidatorVerifier,
         ongoing_tasks: Arc<AtomicU64>,
+        reset_flag: Arc<AtomicBool>,
     ) -> Self {
         let buffer = Buffer::<BufferItem>::new();
 
@@ -181,6 +184,7 @@ impl BufferManager {
             ongoing_tasks,
             end_epoch_timestamp: OnceCell::new(),
             previous_commit_time: Instant::now(),
+            reset_flag,
         }
     }
 
@@ -375,6 +379,7 @@ impl BufferManager {
         self.execution_root = None;
         self.signing_root = None;
         self.previous_commit_time = Instant::now();
+        self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
         while let Ok(Some(_)) = self.block_rx.try_next() {}
         // Wait for ongoing tasks to finish before sending back ack.
@@ -387,10 +392,12 @@ impl BufferManager {
     async fn process_reset_request(&mut self, request: ResetRequest) {
         let ResetRequest { tx, stop } = request;
         info!("Receive reset");
+        self.reset_flag.store(true, Ordering::SeqCst);
 
         self.stop = stop;
         self.reset().await;
         let _ = tx.send(ResetAck::default());
+        self.reset_flag.store(false, Ordering::SeqCst);
         info!("Reset finishes");
     }
 

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -23,7 +23,10 @@ use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorError, StateComputeResult};
 use aptos_types::{ledger_info::LedgerInfo, validator_verifier::random_validator_verifier};
 use async_trait::async_trait;
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64},
+    Arc,
+};
 
 // ExecutionSchedulePhase and ExecutionWaitPhase chained together.
 // In BufferManager they are chained through the main loop.
@@ -139,11 +142,13 @@ fn execution_phase_tests() {
     // e2e tests
     let (in_channel_tx, in_channel_rx) = create_channel::<CountedRequest<ExecutionRequest>>();
     let (out_channel_tx, out_channel_rx) = create_channel::<ExecutionResponse>();
+    let reset_flag = Arc::new(AtomicBool::new(false));
 
     let execution_phase_pipeline = PipelinePhase::new(
         in_channel_rx,
         Some(out_channel_tx),
         Box::new(execution_phase),
+        reset_flag,
     );
 
     runtime.spawn(execution_phase_pipeline.start());

--- a/consensus/src/experimental/tests/signing_phase_tests.rs
+++ b/consensus/src/experimental/tests/signing_phase_tests.rs
@@ -25,6 +25,7 @@ use aptos_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
 };
+use std::sync::{atomic::AtomicBool, Arc};
 
 pub fn prepare_signing_pipeline(
     signing_phase: SigningPhase,
@@ -36,9 +37,14 @@ pub fn prepare_signing_pipeline(
     // e2e tests
     let (in_channel_tx, in_channel_rx) = create_channel::<CountedRequest<SigningRequest>>();
     let (out_channel_tx, out_channel_rx) = create_channel::<SigningResponse>();
+    let reset_flag = Arc::new(AtomicBool::new(false));
 
-    let signing_phase_pipeline =
-        PipelinePhase::new(in_channel_rx, Some(out_channel_tx), Box::new(signing_phase));
+    let signing_phase_pipeline = PipelinePhase::new(
+        in_channel_rx,
+        Some(out_channel_tx),
+        Box::new(signing_phase),
+        reset_flag,
+    );
 
     (in_channel_tx, out_channel_rx, signing_phase_pipeline)
 }


### PR DESCRIPTION
We observe that in some cases, processing through all requests can take very long when we have to request for missing batches that are already garbage collected. This commit adds a flag to drop those pending requests.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
