### PR TITLE
[compiler v2] Fixing bug in spec block analysis

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
@@ -4,12 +4,12 @@ module 0x42::inline_specs {
         {
           let x: u64 = 0;
           spec {
-            assert Eq<u256>(x, 0);
+            assert Eq<u64>(x, 0);
           }
           ;
           x: u64 = inline_specs::succ(x);
           spec {
-            assert Eq<u256>(x, 1);
+            assert Eq<u64>(x, 1);
           }
           ;
           x
@@ -34,10 +34,10 @@ fun inline_specs::specs(): u64 {
      var $t3: u64
   0: $t2 := 0
   1: $t1 := move($t2)
-  2: assert Eq<u256>(x, 0)
+  2: assert Eq<u64>(x, 0)
   3: $t3 := inline_specs::succ($t1)
   4: $t1 := move($t3)
-  5: assert Eq<u256>(x, 1)
+  5: assert Eq<u64>(x, 1)
   6: $t0 := move($t1)
   7: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference.exp
@@ -1,0 +1,14 @@
+// ---- Model Dump
+module 0x42::m {
+    private fun foo() {
+        {
+          let i: u64 = 10;
+          spec {
+            assert forall j: num: Range(0, i): Lt(j, i);
+          }
+          ;
+          i: u64 = Add<u64>(i, 1)
+        }
+    }
+    spec fun $foo();
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+  fun foo() {
+    let i = 10;
+    spec {
+      assert forall j in 0..i: j < i;
+    };
+    i = i + 1
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_bitvector.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_bitvector.exp
@@ -1,0 +1,25 @@
+// ---- Model Dump
+module 0x42::bit_vector_infer {
+    use std::vector;
+    public fun new(length: u64) {
+        {
+          let counter: u64 = 1;
+          if Gt<u64>(counter, 0) {
+            counter: u64 = Sub<u64>(counter, 1);
+            Tuple()
+          } else {
+            Tuple()
+          };
+          {
+            let bit_field: vector<bool> = vector::empty<bool>();
+            vector::push_back<bool>(Borrow(Mutable)(bit_field), false);
+            spec {
+              assert Eq<num>(Len<bool>(bit_field), 0);
+            }
+            ;
+            Tuple()
+          }
+        }
+    }
+    spec fun $new(length: u64);
+} // end 0x42::bit_vector_infer

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_bitvector.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_bitvector.move
@@ -1,0 +1,14 @@
+module 0x42::bit_vector_infer {
+  use std::vector;
+  public fun new(length: u64) {
+    let counter = 1;
+    if (counter > 0) {
+      counter = counter - 1;
+    };
+    let bit_field = vector::empty();
+    vector::push_back(&mut bit_field, false);
+    spec {
+      assert len(bit_field) == 0;
+    };
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_vector.exp
@@ -1,0 +1,16 @@
+// ---- Model Dump
+module 0x42::bit_vector {
+    use std::vector;
+    public fun new(length: u64) {
+        {
+          let bit_field: vector<bool> = vector::empty<bool>();
+          spec {
+            assert Eq<num>(Len<bool>(bit_field), 0);
+          }
+          ;
+          vector::push_back<bool>(Borrow(Mutable)(bit_field), false);
+          Tuple()
+        }
+    }
+    spec fun $new(length: u64);
+} // end 0x42::bit_vector

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_vector.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_spec_inference_vector.move
@@ -1,0 +1,10 @@
+module 0x42::bit_vector {
+  use std::vector;
+  public fun new(length: u64) {
+    let bit_field = vector::empty();
+    spec {
+      assert len(bit_field) == 0;
+    };
+    vector::push_back(&mut bit_field, false);
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
@@ -1,11 +1,5 @@
 
 Diagnostics:
-bug: unresolved spec anchor
-   ┌─ tests/checking/typing/constant_unsupported_exps.move:17:9
-   │
-17 │         spec { };
-   │         ^^^^^^^^
-
 error: no function named `f_script` found
    ┌─ tests/checking/typing/constant_unsupported_exps.move:21:9
    │

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -299,8 +299,6 @@ pub struct Spec {
     pub update_map: BTreeMap<NodeId, Condition>,
 }
 
-pub enum ImplSpecId {}
-
 impl Spec {
     pub fn has_conditions(&self) -> bool {
         !self.conditions.is_empty()

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1259,8 +1259,11 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 } else {
                     None
                 };
-                let result = et.translate_seq(&loc, seq, &result_type);
+                let mut result = et.translate_seq(&loc, seq, &result_type);
                 et.finalize_types();
+                if !as_spec_fun {
+                    result = et.post_process_spec_blocks(result.into_exp()).into();
+                }
                 (result, access_specifiers)
             };
 


### PR DESCRIPTION
This closes #10885 and closes #10875 and closes #10874. The fix is a bit more involved as thought because the way how inlined spec blocks are type checked needed to be changed:

- Inlined spec blocks _cannot_ be checked as they appear in the code, since they are not supposed to influence type inference, and since they are designed to work in their own inference context.
- Rather the entire function body needs to be checked first, and then subsequently the spec blocks, each with the context of locals in which they are defined, at a point where the types of the locals have been inferred.

This PR implements this new scheme by collecting spec blocks and only at the end of a function body, post-processes them.

Adds the test from the bug report.
