### PR TITLE
[easy] Fix string length agg v2 native charges

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -208,6 +208,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [aggregator_v2_snapshot_base: InternalGas, {12.. => "aggregator_v2.snapshot.base"}, 6000],
 
         [aggregator_v2_create_snapshot_base: InternalGas, {11.. => "aggregator_v2.create_snapshot.base"}, 6000],
+        [aggregator_v2_create_snapshot_per_byte: InternalGasPerByte, { 12.. =>"aggregator_v2.create_snapshot.per_byte" }, 20],
         [aggregator_v2_copy_snapshot_base: InternalGas, {11.. => "aggregator_v2.copy_snapshot.base"}, 6000],
         [aggregator_v2_read_snapshot_base: InternalGas, {11.. => "aggregator_v2.read_snapshot.base"}, 12000],
         [aggregator_v2_string_concat_base: InternalGas, {11.. => "aggregator_v2.string_concat.base"}, 6000],

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -47,14 +47,15 @@ pub const EAGGREGATOR_API_NOT_ENABLED: u64 = 0x03_0006;
 /// The generic type supplied to the aggregators is not supported.
 pub const EUNSUPPORTED_AGGREGATOR_TYPE: u64 = 0x03_0007;
 
-/// Arguments passed to concat exceed max limit of 256 bytes (for prefix and suffix together).
-pub const ECONCAT_STRING_LENGTH_TOO_LARGE: u64 = 0x03_0008;
+/// Arguments passed to concat or create_snapshot exceed max limit of
+/// STRING_SNAPSHOT_INPUT_MAX_LENGTH bytes (for prefix and suffix together).
+pub const EINPUT_STRING_LENGTH_TOO_LARGE: u64 = 0x03_0008;
 
 /// The native aggregator function, that is in the move file, is not yet supported.
 /// and any calls will raise this error.
 pub const EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED: u64 = 0x03_0009;
 
-pub const CONCAT_PREFIX_AND_SUFFIX_MAX_LENGTH: usize = 256;
+pub const STRING_SNAPSHOT_INPUT_MAX_LENGTH: usize = 256;
 
 /// Checks if the type argument `type_arg` is a string type.
 fn is_string_type(context: &SafeNativeContext, type_arg: &Type) -> SafeNativeResult<bool> {
@@ -443,6 +444,15 @@ fn native_create_snapshot(
     let snapshot_type = SnapshotType::from_ty_arg(context, &ty_args[0])?;
     let input = snapshot_type.pop_snapshot_value_by_type(&mut args)?;
 
+    if let SnapshotValue::String(v) = &input {
+        context.charge(AGGREGATOR_V2_CREATE_SNAPSHOT_PER_BYTE * NumBytes::new(v.len() as u64))?;
+        if v.len() > STRING_SNAPSHOT_INPUT_MAX_LENGTH {
+            return Err(SafeNativeError::Abort {
+                abort_code: EINPUT_STRING_LENGTH_TOO_LARGE,
+            });
+        }
+    }
+
     let result_value = if let Some((resolver, mut delayed_field_data)) = get_context_data(context) {
         let snapshot_id = delayed_field_data.create_new_snapshot(input, resolver);
         SnapshotValue::Integer(snapshot_id.as_u64() as u128)
@@ -548,6 +558,8 @@ fn native_string_concat(
 
     // popping arguments from the end
     let suffix = string_to_bytes(safely_pop_arg!(args, Struct))?;
+    context.charge(AGGREGATOR_V2_STRING_CONCAT_PER_BYTE * NumBytes::new(suffix.len() as u64))?;
+
     let snapshot_value = match snapshot_input_type.pop_snapshot_field_by_type(&mut args)? {
         SnapshotValue::Integer(v) => v,
         SnapshotValue::String(_) => {
@@ -558,18 +570,17 @@ fn native_string_concat(
     };
 
     let prefix = string_to_bytes(safely_pop_arg!(args, Struct))?;
+    context.charge(AGGREGATOR_V2_STRING_CONCAT_PER_BYTE * NumBytes::new(prefix.len() as u64))?;
 
     if prefix
         .len()
         .checked_add(suffix.len())
-        .map_or(false, |v| v > CONCAT_PREFIX_AND_SUFFIX_MAX_LENGTH)
+        .map_or(false, |v| v > STRING_SNAPSHOT_INPUT_MAX_LENGTH)
     {
         return Err(SafeNativeError::Abort {
-            abort_code: ECONCAT_STRING_LENGTH_TOO_LARGE,
+            abort_code: EINPUT_STRING_LENGTH_TOO_LARGE,
         });
     }
-
-    context.charge(STRING_UTILS_PER_BYTE * NumBytes::new((prefix.len() + suffix.len()) as u64))?;
 
     let result_value = if let Some((resolver, mut delayed_field_data)) = get_context_data(context) {
         let base_id = aggregator_value_field_as_id(snapshot_value, resolver)?;


### PR DESCRIPTION
- forgot to have a limit on create_snapshot
- forgot to charge length in create_snapshot
- used incorrect gas param for concat call

Since these were never released, we can make these breaking changes

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
