### PR TITLE
Revert "[github CI] Remove Javascript from Rust CI"

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -18,7 +18,7 @@ runs:
 
     - name: install protoc and related tools
       shell: bash
-      run: scripts/dev_setup.sh -b -r -y -P -t
+      run: scripts/dev_setup.sh -b -r -y -P -J -t
 
     - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
       shell: bash


### PR DESCRIPTION


### Description
This reverts commit 82cb76c5ce066f4fc8928569cf989c6c5ab535e7.

Turns out prover needed javascript

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
