### PR TITLE
[Consensus] Notify state sync of all transaction events.

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -154,12 +154,12 @@ impl ExecutedBlock {
         .collect()
     }
 
-    pub fn reconfig_event(&self) -> Vec<ContractEvent> {
+    pub fn events_to_commit(&self) -> Vec<ContractEvent> {
         // reconfiguration suffix don't count, the state compute result is carried over from parents
         if self.is_reconfiguration_suffix() {
             return vec![];
         }
-        self.state_compute_result.reconfig_events().to_vec()
+        self.state_compute_result.events().to_vec()
     }
 
     /// The block is suffix of a reconfiguration block if the state result carries over the epoch state

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -171,7 +171,7 @@ impl BlockStore {
             None,                     /* epoch_state */
             vec![],                   /* compute_status */
             vec![],                   /* txn_infos */
-            vec![],                   /* reconfig_events */
+            vec![],                   /* events */
         );
 
         let executed_root_block = ExecutedBlock::new(

--- a/execution/executor-types/src/ledger_update_output.rs
+++ b/execution/executor-types/src/ledger_update_output.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 pub struct LedgerUpdateOutput {
     pub status: Vec<TransactionStatus>,
     pub to_commit: Vec<TransactionToCommit>,
-    pub reconfig_events: Vec<ContractEvent>,
+    pub events: Vec<ContractEvent>,
     pub transaction_info_hashes: Vec<HashValue>,
     pub state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
     pub sharded_state_cache: ShardedStateCache,
@@ -172,7 +172,7 @@ impl LedgerUpdateOutput {
             next_epoch_state,
             self.status.clone(),
             self.transaction_info_hashes.clone(),
-            self.reconfig_events.clone(),
+            self.events.clone(),
         )
     }
 
@@ -180,7 +180,7 @@ impl LedgerUpdateOutput {
         let Self {
             status,
             to_commit,
-            reconfig_events,
+            events,
             transaction_info_hashes,
             state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
             sharded_state_cache,
@@ -196,7 +196,7 @@ impl LedgerUpdateOutput {
 
         self.status.extend(status);
         self.to_commit.extend(to_commit);
-        self.reconfig_events.extend(reconfig_events);
+        self.events.extend(events);
         self.transaction_info_hashes.extend(transaction_info_hashes);
         self.sharded_state_cache.combine(sharded_state_cache);
         self.transaction_accumulator = transaction_accumulator;

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -321,7 +321,8 @@ pub struct StateComputeResult {
     /// The transaction info hashes of all success txns.
     transaction_info_hashes: Vec<HashValue>,
 
-    reconfig_events: Vec<ContractEvent>,
+    /// The events produced by all successful txns.
+    events: Vec<ContractEvent>,
 }
 
 impl StateComputeResult {
@@ -334,7 +335,7 @@ impl StateComputeResult {
         epoch_state: Option<EpochState>,
         compute_status: Vec<TransactionStatus>,
         transaction_info_hashes: Vec<HashValue>,
-        reconfig_events: Vec<ContractEvent>,
+        events: Vec<ContractEvent>,
     ) -> Self {
         Self {
             root_hash,
@@ -345,7 +346,7 @@ impl StateComputeResult {
             epoch_state,
             compute_status,
             transaction_info_hashes,
-            reconfig_events,
+            events,
         }
     }
 
@@ -362,7 +363,7 @@ impl StateComputeResult {
             epoch_state: None,
             compute_status: vec![],
             transaction_info_hashes: vec![],
-            reconfig_events: vec![],
+            events: vec![],
         }
     }
 
@@ -426,8 +427,8 @@ impl StateComputeResult {
         self.epoch_state.is_some()
     }
 
-    pub fn reconfig_events(&self) -> &[ContractEvent] {
-        &self.reconfig_events
+    pub fn events(&self) -> &[ContractEvent] {
+        &self.events
     }
 }
 

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -140,7 +140,7 @@ impl ApplyChunkOutput {
             .with_label_values(&["assemble_ledger_diff_for_block"])
             .start_timer();
 
-        let (to_commit, transaction_info_hashes, reconfig_events) =
+        let (to_commit, transaction_info_hashes, events) =
             Self::assemble_ledger_diff(to_keep, state_updates_vec, state_checkpoint_hashes);
         let transaction_accumulator =
             Arc::new(base_txn_accumulator.append(&transaction_info_hashes));
@@ -148,7 +148,7 @@ impl ApplyChunkOutput {
             LedgerUpdateOutput {
                 status,
                 to_commit,
-                reconfig_events,
+                events,
                 transaction_info_hashes,
                 state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
                 sharded_state_cache,
@@ -317,7 +317,7 @@ impl ApplyChunkOutput {
             })
             .collect();
 
-        let mut all_reconfig_events = Vec::new();
+        let mut all_events = Vec::new();
         let (to_keep_txns, to_keep_outputs) = to_keep.into_inner();
         for (
             txn,
@@ -353,13 +353,14 @@ impl ApplyChunkOutput {
                 txn_info,
                 state_updates,
                 write_set,
-                events,
+                events.clone(),
                 !per_txn_reconfig_events.is_empty(),
             );
-            all_reconfig_events.extend(per_txn_reconfig_events);
+            all_events.extend(events);
             to_commit.push(txn_to_commit);
         }
-        (to_commit, txn_info_hashes, all_reconfig_events)
+
+        (to_commit, txn_info_hashes, all_events)
     }
 
     fn calculate_events_and_writeset_hashes(

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -497,7 +497,7 @@ fn apply_transaction_by_writeset(
     let LedgerUpdateOutput {
         status: _,
         to_commit,
-        reconfig_events: _,
+        events: _,
         transaction_info_hashes: _,
         state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
         sharded_state_cache,
@@ -720,7 +720,7 @@ fn run_transactions_naive(
         let LedgerUpdateOutput {
             status: _,
             to_commit,
-            reconfig_events: _,
+            events: _,
             transaction_info_hashes: _,
             state_updates_until_last_checkpoint: state_updates_before_last_checkpoint,
             sharded_state_cache,

--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -36,11 +36,11 @@ pub enum Error {
 /// synchronization notifications to state sync.
 #[async_trait]
 pub trait ConsensusNotificationSender: Send + Sync {
-    /// Notify state sync of newly committed transactions and reconfiguration events.
+    /// Notify state sync of newly committed transactions and events.
     async fn notify_new_commit(
         &self,
         transactions: Vec<Transaction>,
-        reconfiguration_events: Vec<ContractEvent>,
+        events: Vec<ContractEvent>,
     ) -> Result<(), Error>;
 
     /// Notify state sync to synchronize storage to the specified target.
@@ -93,7 +93,7 @@ impl ConsensusNotificationSender for ConsensusNotifier {
     async fn notify_new_commit(
         &self,
         transactions: Vec<Transaction>,
-        reconfiguration_events: Vec<ContractEvent>,
+        events: Vec<ContractEvent>,
     ) -> Result<(), Error> {
         // Only send a notification if transactions have been committed
         if transactions.is_empty() {
@@ -105,7 +105,7 @@ impl ConsensusNotificationSender for ConsensusNotifier {
         let commit_notification =
             ConsensusNotification::NotifyCommit(ConsensusCommitNotification {
                 transactions,
-                reconfiguration_events,
+                events,
                 callback,
             });
 
@@ -225,19 +225,19 @@ pub enum ConsensusNotification {
 #[derive(Debug)]
 pub struct ConsensusCommitNotification {
     pub transactions: Vec<Transaction>,
-    pub reconfiguration_events: Vec<ContractEvent>,
+    pub events: Vec<ContractEvent>,
     pub(crate) callback: oneshot::Sender<ConsensusNotificationResponse>,
 }
 
 impl ConsensusCommitNotification {
     pub fn new(
         transactions: Vec<Transaction>,
-        reconfiguration_events: Vec<ContractEvent>,
+        events: Vec<ContractEvent>,
     ) -> (Self, oneshot::Receiver<ConsensusNotificationResponse>) {
         let (callback, callback_receiver) = oneshot::channel();
         let commit_notification = ConsensusCommitNotification {
             transactions,
-            reconfiguration_events,
+            events,
             callback,
         };
 
@@ -334,21 +334,16 @@ mod tests {
 
         // Send a commit notification
         let transactions = vec![create_user_transaction()];
-        let reconfiguration_events = vec![create_contract_event()];
-        let _ = block_on(
-            consensus_notifier
-                .notify_new_commit(transactions.clone(), reconfiguration_events.clone()),
-        );
+        let events = vec![create_contract_event()];
+        let _ =
+            block_on(consensus_notifier.notify_new_commit(transactions.clone(), events.clone()));
 
         // Verify the notification arrives at the receiver
         match consensus_listener.select_next_some().now_or_never() {
             Some(consensus_notification) => match consensus_notification {
                 ConsensusNotification::NotifyCommit(commit_notification) => {
                     assert_eq!(transactions, commit_notification.transactions);
-                    assert_eq!(
-                        reconfiguration_events,
-                        commit_notification.reconfiguration_events
-                    );
+                    assert_eq!(events, commit_notification.events);
                 },
                 result => panic!(
                     "Expected consensus commit notification but got: {:?}",

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -15,7 +15,6 @@ use aptos_types::{
     contract_event::ContractEvent,
     event::EventKey,
     move_resource::MoveStorage,
-    on_chain_config,
     on_chain_config::{OnChainConfig, OnChainConfigPayload, OnChainConfigProvider},
     transaction::Version,
 };
@@ -203,13 +202,6 @@ impl EventSubscriptionService {
         self.subscription_id_generator.next()
     }
 
-    fn is_new_epoch_event(&self, event: &ContractEvent) -> bool {
-        match event {
-            ContractEvent::V1(evt) => *evt.key() == on_chain_config::new_epoch_event_key(),
-            ContractEvent::V2(_) => false,
-        }
-    }
-
     /// This notifies all the event subscribers of the new events found at the
     /// specified version. If a reconfiguration event (i.e., new epoch) is found,
     /// this method will return true.
@@ -248,7 +240,7 @@ impl EventSubscriptionService {
             }
 
             // Take note if a reconfiguration (new epoch) has occurred
-            if self.is_new_epoch_event(event) {
+            if event.is_new_epoch_event() {
                 reconfig_event_found = true;
             }
         }

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -12,7 +12,7 @@ use crate::{
     metrics,
     metrics::ExecutingComponent,
     notification_handlers::{
-        CommitNotification, CommitNotificationListener, CommittedTransactions,
+        CommitNotification, CommitNotificationListener, CommittedTransactionsAndEvents,
         ConsensusNotificationHandler, ErrorNotification, ErrorNotificationListener,
         MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
@@ -307,12 +307,12 @@ impl<
         // TODO(joshlind): can we get consensus to forward the events?
 
         // Handle the commit notification
-        let committed_transactions = CommittedTransactions {
+        let committed_transactions_and_events = CommittedTransactionsAndEvents {
             events: consensus_commit_notification.reconfiguration_events.clone(),
             transactions: consensus_commit_notification.transactions.clone(),
         };
         utils::handle_committed_transactions(
-            committed_transactions,
+            committed_transactions_and_events,
             self.storage.clone(),
             self.mempool_notification_handler.clone(),
             self.event_subscription_service.clone(),
@@ -428,7 +428,7 @@ impl<
 
         // Handle the committed transactions and events
         utils::handle_committed_transactions(
-            committed_snapshot.committed_transaction,
+            committed_snapshot.committed_transactions_and_events,
             self.storage.clone(),
             self.mempool_notification_handler.clone(),
             self.event_subscription_service.clone(),

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -8,8 +8,8 @@ use crate::{
     metadata_storage::MetadataStorageInterface,
     metrics,
     notification_handlers::{
-        CommitNotification, CommittedTransactions, ErrorNotification, MempoolNotificationHandler,
-        StorageServiceNotificationHandler,
+        CommitNotification, CommittedTransactionsAndEvents, ErrorNotification,
+        MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     utils,
 };
@@ -659,12 +659,12 @@ fn spawn_committer<
                     // Handle the committed transaction notification (e.g., notify mempool).
                     // We do this here due to synchronization issues with mempool and
                     // storage. See: https://github.com/aptos-labs/aptos-core/issues/553
-                    let committed_transactions = CommittedTransactions {
+                    let committed_transactions_and_events = CommittedTransactionsAndEvents {
                         events: notification.committed_events,
                         transactions: notification.committed_transactions,
                     };
                     utils::handle_committed_transactions(
-                        committed_transactions,
+                        committed_transactions_and_events,
                         storage.clone(),
                         mempool_notification_handler.clone(),
                         event_subscription_service.clone(),

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     metadata_storage::PersistentMetadataStorage,
     notification_handlers::{
-        CommitNotification, CommitNotificationListener, CommittedTransactions,
+        CommitNotification, CommitNotificationListener, CommittedTransactionsAndEvents,
         ErrorNotificationListener, MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     storage_synchronizer::{StorageSynchronizer, StorageSynchronizerInterface},
@@ -643,13 +643,13 @@ async fn test_save_states_completion() {
 
     // Verify we get a commit notification
     let expected_transaction = output_list_with_proof.transactions_and_outputs[0].0.clone();
-    let expected_committed_transactions = CommittedTransactions {
+    let expected_transactions_and_events = CommittedTransactionsAndEvents {
         events: vec![expected_event.clone()],
         transactions: vec![expected_transaction.clone()],
     };
     verify_snapshot_commit_notification(
         &mut commit_listener,
-        expected_committed_transactions.clone(),
+        expected_transactions_and_events.clone(),
     )
     .await;
 
@@ -830,13 +830,13 @@ fn create_storage_synchronizer(
 /// Verifies that the expected snapshot commit notification is received by the listener
 async fn verify_snapshot_commit_notification(
     commit_listener: &mut CommitNotificationListener,
-    expected_committed_transactions: CommittedTransactions,
+    expected_transactions_and_events: CommittedTransactionsAndEvents,
 ) {
     let CommitNotification::CommittedStateSnapshot(committed_snapshot) =
         commit_listener.select_next_some().await;
     assert_eq!(
-        committed_snapshot.committed_transaction,
-        expected_committed_transactions
+        committed_snapshot.committed_transactions_and_events,
+        expected_transactions_and_events
     );
 }
 

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -8,7 +8,7 @@ use crate::{
     logging::{LogEntry, LogSchema},
     metrics,
     notification_handlers::{
-        CommitNotification, CommittedTransactions, MempoolNotificationHandler,
+        CommitNotification, CommittedTransactionsAndEvents, MempoolNotificationHandler,
         StorageServiceNotificationHandler,
     },
     storage_synchronizer::StorageSynchronizerInterface,
@@ -313,7 +313,7 @@ pub async fn handle_committed_transactions<
     M: MempoolNotificationSender,
     S: StorageServiceNotificationSender,
 >(
-    committed_transactions: CommittedTransactions,
+    committed_transactions_and_events: CommittedTransactionsAndEvents,
     storage: Arc<dyn DbReader>,
     mempool_notification_handler: MempoolNotificationHandler<M>,
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
@@ -341,8 +341,7 @@ pub async fn handle_committed_transactions<
 
     // Handle the commit notification
     if let Err(error) = CommitNotification::handle_transaction_notification(
-        committed_transactions.events,
-        committed_transactions.transactions,
+        committed_transactions_and_events,
         latest_synced_version,
         latest_synced_ledger_info,
         mempool_notification_handler,

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -5,6 +5,7 @@
 use crate::{
     account_config::{DepositEvent, NewBlockEvent, NewEpochEvent, WithdrawEvent},
     event::EventKey,
+    on_chain_config,
     transaction::Version,
 };
 use anyhow::{bail, Error, Result};
@@ -143,6 +144,13 @@ impl ContractEvent {
         }
 
         Ok(None)
+    }
+
+    pub fn is_new_epoch_event(&self) -> bool {
+        match self {
+            ContractEvent::V1(event) => *event.key() == on_chain_config::new_epoch_event_key(),
+            ContractEvent::V2(_) => false,
+        }
     }
 }
 


### PR DESCRIPTION
Note: this is a draft!

### Description
This PR updates consensus to notify state sync and the event subscription service of all transaction events (instead of just reconfiguration events).

The PR offers several commits:
1. Rename `CommittedTransactions` to `CommittedTransactionsAndEvents` (it's more complete 😄).
2. Update consensus to notify state sync of all transactions and events.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
