### PR TITLE
Improved block gas limit - output size limit, conflict aware, io/compute multipliers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11056,11 +11056,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -11088,9 +11088,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1029,7 +1029,7 @@ impl Context {
                     } else if let Some(full_block_gas_used) =
                         block_config.block_gas_limit_type.block_gas_limit()
                     {
-                        // be pesimistic for conflicts, as such information is not onchain
+                        // be pessimistic for conflicts, as such information is not onchain
                         let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
                         let max_conflict_multiplier = block_config
                             .block_gas_limit_type

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1029,8 +1029,14 @@ impl Context {
                     } else if let Some(full_block_gas_used) =
                         block_config.block_gas_limit_type.block_gas_limit()
                     {
-                        prices_and_used.iter().map(|(_, used)| *used).sum::<u64>()
-                            >= full_block_gas_used
+                        // be pesimistic for conflicts, as such information is not onchain
+                        let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
+                        let max_conflict_multiplier = block_config
+                            .block_gas_limit_type
+                            .conflict_penalty_window()
+                            .unwrap_or(1)
+                            as u64;
+                        gas_used * max_conflict_multiplier >= full_block_gas_used
                     } else {
                         false
                     };

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -460,7 +460,6 @@ impl VMChangeSet {
             .collect::<anyhow::Result<BTreeMap<StateKey, WriteOp>, VMStatus>>()?;
         self.aggregator_v1_write_set
             .extend(materialized_aggregator_delta_set);
-
         Ok(())
     }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -15,7 +15,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     errors::Error, executor::BlockExecutor,
     task::TransactionOutput as BlockExecutorTransactionOutput,
-    txn_commit_hook::TransactionCommitHook,
+    txn_commit_hook::TransactionCommitHook, types::InputOutputKey,
 };
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
@@ -36,7 +36,10 @@ use aptos_vm_types::{abstract_write_op::AbstractResourceWriteOp, output::VMOutpu
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -315,6 +318,61 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .as_ref()
             .expect("Output to be set to get fee statement")
             .fee_statement()
+    }
+
+    fn output_approx_size(&self) -> u64 {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut size = 0;
+        for (state_key, write_size) in change_set.write_set_size_iter() {
+            size += state_key.size() as u64 + write_size.write_len().unwrap_or(0);
+        }
+
+        for (event, _) in change_set.events() {
+            size += event.size() as u64;
+        }
+
+        size
+    }
+
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag, DelayedFieldID>> {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut writes = HashSet::new();
+
+        for (state_key, write) in change_set.resource_write_set() {
+            match write {
+                AbstractResourceWriteOp::Write(_)
+                | AbstractResourceWriteOp::WriteWithDelayedFields(_) => {
+                    writes.insert(InputOutputKey::Resource(state_key.clone()));
+                },
+                AbstractResourceWriteOp::WriteResourceGroup(write) => {
+                    for tag in write.inner_ops().keys() {
+                        writes.insert(InputOutputKey::Group(state_key.clone(), tag.clone()));
+                    }
+                },
+                AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)
+                | AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_) => {
+                    // No conflicts on resources from in-place delayed field changes.
+                    // Delayed fields conflicts themselves are handled via
+                    // delayed_field_change_set below.
+                },
+            }
+        }
+
+        for identifier in change_set.delayed_field_change_set().keys() {
+            writes.insert(InputOutputKey::DelayedField(*identifier));
+        }
+
+        writes
     }
 }
 

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use anyhow::bail;
 use aptos_aggregator::{
     delta_math::DeltaHistory,
@@ -335,8 +336,6 @@ impl<T: Transaction> CapturedReads<T> {
         &'a self,
         skip: &'a HashSet<T::Key>,
     ) -> impl Iterator<Item = (&T::Key, &GroupRead<T>)> {
-        // TODO[agg_v2](optimize) - We could potentially filter out inner_reads
-        // to only contain those that have Some(layout)
         self.group_reads.iter().filter(|(key, group_read)| {
             !skip.contains(key)
                 && group_read
@@ -662,12 +661,79 @@ impl<T: Transaction> CapturedReads<T> {
         Ok(true)
     }
 
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for (key, read) in &self.data_reads {
+            if let DataRead::Versioned(_, _, _) = read {
+                ret.insert(InputOutputKey::Resource(key.clone()));
+            }
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for (tag, read) in &group_reads.inner_reads {
+                if let DataRead::Versioned(_, _, _) = read {
+                    ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+                }
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, read) in &self.delayed_field_reads {
+            if let DelayedFieldRead::Value { .. } = read {
+                ret.insert(InputOutputKey::DelayedField(*key));
+            }
+        }
+
+        ret
+    }
+
     pub(crate) fn mark_failure(&mut self) {
         self.speculative_failure = true;
     }
 
     pub(crate) fn mark_incorrect_use(&mut self) {
         self.incorrect_use = true;
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default(bound = "", new = "true"))]
+pub(crate) struct UnsyncReadSet<T: Transaction> {
+    pub(crate) resource_reads: HashSet<T::Key>,
+    pub(crate) module_reads: HashSet<T::Key>,
+    pub(crate) group_reads: HashMap<T::Key, HashSet<T::Tag>>,
+    pub(crate) delayed_field_reads: HashSet<T::Identifier>,
+}
+
+impl<T: Transaction> UnsyncReadSet<T> {
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for key in &self.resource_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for tag in group_reads {
+                ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for key in &self.delayed_field_reads {
+            ret.insert(InputOutputKey::DelayedField(*key));
+        }
+
+        ret
     }
 }
 

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -26,34 +26,6 @@ impl Mode {
     pub const SEQUENTIAL: &'static str = "sequential";
 }
 
-/// Record the block gas during parallel execution.
-fn observe_parallel_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during parallel execution.
-fn observe_parallel_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the block gas during sequential execution.
-fn observe_sequential_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during sequential execution.
-fn observe_sequential_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
 /// Count of times the module publishing fallback was triggered in parallel execution.
 pub static MODULE_PUBLISHING_FALLBACK_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -77,6 +49,16 @@ pub static EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| 
     register_int_counter_vec!(
         "aptos_execution_gas_limit_count",
         "Count of times the BlockSTM is early halted due to exceeding the per-block gas limit",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+/// Count of times the BlockSTM is early halted due to exceeding the per-block output size limit.
+pub static EXCEED_PER_BLOCK_OUTPUT_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_execution_output_limit_count",
+        "Count of times the BlockSTM is early halted due to exceeding the per-block output size limit",
         &["mode"]
     )
     .unwrap()
@@ -166,6 +148,25 @@ pub static BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static EFFECTIVE_BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_effective_block_gas",
+        "Histogram for different effective block gas costs - used for evaluating block gas limit. \
+        This can be different from actual gas consumed in a block, due to applied adjustements",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+pub static APPROX_BLOCK_OUTPUT_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_approx_block_output_size",
+        "Historgram for different approx block output sizes - used for evaluting block ouptut limit.",
+        &["mode"]
+    )
+    .unwrap()
+});
+
 pub static TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_execution_txn_gas",
@@ -185,100 +186,67 @@ pub static BLOCK_COMMITTED_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) fn update_parallel_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_parallel_execution_block_gas(accumulated_fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_parallel_execution_block_gas(accumulated_fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
+fn observe_gas(counter: &Lazy<HistogramVec>, mode_str: &str, fee_statement: &FeeStatement) {
+    counter
+        .with_label_values(&[mode_str, GasType::TOTAL_GAS])
+        .observe(fee_statement.gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::EXECUTION_GAS])
+        .observe(fee_statement.execution_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::IO_GAS])
+        .observe(fee_statement.io_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::NON_STORAGE_GAS])
+        .observe((fee_statement.execution_gas_used() + fee_statement.io_gas_used()) as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE])
+        .observe(fee_statement.storage_fee_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE_REFUND])
+        .observe(fee_statement.storage_fee_refund() as f64);
 }
 
-pub(crate) fn update_parallel_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>) {
+pub(crate) fn update_block_gas_counters(
+    accumulated_fee_statement: &FeeStatement,
+    accumulated_effective_gas: u64,
+    accumulated_approx_output_size: u64,
+    num_committed: usize,
+    is_parallel: bool,
+) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
+    observe_gas(&BLOCK_GAS, mode_str, accumulated_fee_statement);
+    BLOCK_COMMITTED_TXNS
+        .with_label_values(&[mode_str])
+        .observe(num_committed as f64);
+
+    EFFECTIVE_BLOCK_GAS
+        .with_label_values(&[mode_str])
+        .observe(accumulated_effective_gas as f64);
+
+    APPROX_BLOCK_OUTPUT_SIZE
+        .with_label_values(&[mode_str])
+        .observe(accumulated_approx_output_size as f64);
+}
+
+pub(crate) fn update_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>, is_parallel: bool) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
     for fee_statement in txn_fee_statements {
-        observe_parallel_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-        observe_parallel_execution_txn_gas(
-            fee_statement.storage_fee_refund(),
-            GasType::STORAGE_FEE_REFUND,
-        );
+        observe_gas(&TXN_GAS, mode_str, fee_statement);
     }
-}
-
-pub(crate) fn update_sequential_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.gas_used(),
-        GasType::TOTAL_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.io_gas_used(),
-        GasType::IO_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
-}
-
-pub(crate) fn update_sequential_txn_gas_counters(fee_statement: &FeeStatement) {
-    observe_sequential_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-    observe_sequential_execution_txn_gas(
-        fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -10,10 +10,12 @@ use crate::{
     },
     errors::*,
     explicit_sync_wrapper::ExplicitSyncWrapper,
+    limit_processor::BlockGasLimitProcessor,
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::{KeyKind, TxnLastInputOutput},
+    types::ReadWriteSummary,
     view::{LatestView, ParallelState, SequentialState, ViewState},
 };
 use aptos_aggregator::{
@@ -35,7 +37,7 @@ use aptos_types::{
     block_executor::config::BlockExecutorConfig,
     contract_event::TransactionEvent,
     executable::Executable,
-    fee_statement::FeeStatement,
+    on_chain_config::BlockGasLimitType,
     transaction::BlockExecutableTransaction as Transaction,
     write_set::{TransactionWrite, WriteOp},
 };
@@ -57,9 +59,8 @@ use std::{
 pub struct BlockExecutor<T, E, S, L, X> {
     // Number of active concurrent tasks, corresponding to the maximum number of rayon
     // threads that may be concurrently participating in parallel execution.
-    concurrency_level: usize,
+    config: BlockExecutorConfig,
     executor_thread_pool: Arc<ThreadPool>,
-    maybe_block_gas_limit: Option<u64>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<(T, E, S, L, X)>,
 }
@@ -85,9 +86,8 @@ where
             config.local.concurrency_level
         );
         Self {
-            concurrency_level: config.local.concurrency_level,
+            config,
             executor_thread_pool,
-            maybe_block_gas_limit: config.onchain.block_gas_limit_type.block_gas_limit(),
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -118,7 +118,7 @@ where
             .delayed_field_keys(idx_to_execute)
             .map_or(HashSet::new(), |keys| keys.collect());
 
-        let mut read_set = sync_view.take_reads();
+        let mut read_set = sync_view.take_parallel_reads();
 
         // For tracking whether the recent execution wrote outside of the previous write/delta set.
         let mut updates_outside = false;
@@ -404,6 +404,19 @@ where
         Ok(execution_still_valid)
     }
 
+    fn get_txn_read_write_summary(
+        txn_idx: TxnIndex,
+        last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
+    ) -> ReadWriteSummary<T> {
+        let read_set = last_input_output
+            .read_set(txn_idx)
+            .expect("Read set must be recorded");
+
+        let reads = read_set.get_read_summary();
+        let writes = last_input_output.get_write_summary(txn_idx);
+        ReadWriteSummary::new(reads, writes)
+    }
+
     /// This method may be executed by different threads / workers, but is guaranteed to be executed
     /// non-concurrently by the scheduling in parallel executor. This allows to perform light logic
     /// related to committing a transaction in a simple way and without excessive synchronization
@@ -414,14 +427,13 @@ where
     /// way, the materialization can be almost embarassingly parallelizable.
     fn prepare_and_queue_commit_ready_txns(
         &self,
-        maybe_block_gas_limit: Option<u64>,
+        block_gas_limit_type: &BlockGasLimitType,
         scheduler: &Scheduler,
         versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         scheduler_task: &mut SchedulerTask,
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         shared_commit_state: &ExplicitSyncWrapper<(
-            FeeStatement,
-            Vec<FeeStatement>,
+            BlockGasLimitProcessor<T>,
             Option<Error<E::Error>>,
         )>,
         base_view: &S,
@@ -431,30 +443,7 @@ where
         block: &[T],
     ) -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
         let mut shared_commit_state_guard = shared_commit_state.acquire();
-        let (accumulated_fee_statement, txn_fee_statements, shared_maybe_error) =
-            shared_commit_state_guard.dereference_mut();
-
-        let update_counters_and_log_info =
-            |txn_idx: u32,
-             accumulated_fee_statement: &mut FeeStatement,
-             txn_fee_statements: &mut Vec<FeeStatement>| {
-                counters::update_parallel_block_gas_counters(
-                    accumulated_fee_statement,
-                    (txn_idx + 1) as usize,
-                );
-                counters::update_parallel_txn_gas_counters(txn_fee_statements);
-
-                let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                    + accumulated_fee_statement.io_gas_used();
-                info!(
-                    "[BlockSTM]: Parallel execution completed. {} out of {} txns committed. \
-		         accumulated_non_storage_gas = {}, limit = {:?}",
-                    txn_idx + 1,
-                    scheduler.num_txns(),
-                    accumulated_non_storage_gas,
-                    maybe_block_gas_limit,
-                );
-            };
+        let (accumulator, shared_maybe_error) = shared_commit_state_guard.dereference_mut();
 
         while let Some((txn_idx, incarnation)) = scheduler.try_commit() {
             if !Self::validate_commit_ready(txn_idx, versioned_cache, last_input_output)? {
@@ -502,30 +491,28 @@ where
             }
 
             if let Some(fee_statement) = last_input_output.fee_statement(txn_idx) {
+                let approx_output_size = if block_gas_limit_type.block_output_limit().is_some() {
+                    last_input_output.output_approx_size(txn_idx)
+                } else {
+                    None
+                };
+                let txn_read_write_summary =
+                    if block_gas_limit_type.conflict_penalty_window().is_some() {
+                        Some(Self::get_txn_read_write_summary(txn_idx, last_input_output))
+                    } else {
+                        None
+                    };
+
                 // For committed txns with Success status, calculate the accumulated gas costs.
-                accumulated_fee_statement.add_fee_statement(&fee_statement);
-                txn_fee_statements.push(fee_statement);
+                accumulator.accumulate_fee_statement(
+                    fee_statement,
+                    txn_read_write_summary,
+                    approx_output_size,
+                );
 
-                if let Some(per_block_gas_limit) = maybe_block_gas_limit {
-                    // When the accumulated execution and io gas of the committed txns exceeds
-                    // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage gas does not count towards
-                    // the per block gas limit, as we measure execution related cost here.
-                    let accumulated_non_storage_gas = accumulated_fee_statement
-                        .execution_gas_used()
-                        + accumulated_fee_statement.io_gas_used();
-                    if accumulated_non_storage_gas >= per_block_gas_limit {
-                        counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
-                            .with_label_values(&[counters::Mode::PARALLEL])
-                            .inc();
-                        info!(
-                            "[BlockSTM]: Parallel execution early halted due to \
-                             accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}",
-                            accumulated_non_storage_gas, per_block_gas_limit,
-                        );
-
-                        // Set the execution output status to be SkipRest, to skip the rest of the txns.
-                        last_input_output.update_to_skip_rest(txn_idx);
-                    }
+                if accumulator.should_end_block_parallel() {
+                    // Set the execution output status to be SkipRest, to skip the rest of the txns.
+                    last_input_output.update_to_skip_rest(txn_idx);
                 }
             }
 
@@ -620,10 +607,9 @@ where
                         "Block execution was aborted due to {:?}",
                         shared_maybe_error.as_ref().unwrap()
                     );
-                    update_counters_and_log_info(
-                        txn_idx,
-                        accumulated_fee_statement,
-                        txn_fee_statements,
+                    accumulator.finish_parallel_update_counters_and_log_info(
+                        txn_idx + 1,
+                        scheduler.num_txns(),
                     );
                 } // else it's already halted
                 break;
@@ -642,10 +628,9 @@ where
                 }
 
                 if scheduler.halt() {
-                    update_counters_and_log_info(
-                        txn_idx,
-                        accumulated_fee_statement,
-                        txn_fee_statements,
+                    accumulator.finish_parallel_update_counters_and_log_info(
+                        txn_idx + 1,
+                        scheduler.num_txns(),
                     );
                 }
                 break;
@@ -961,8 +946,7 @@ where
         start_shared_counter: u32,
         shared_counter: &AtomicU32,
         shared_commit_state: &ExplicitSyncWrapper<(
-            FeeStatement,
-            Vec<FeeStatement>,
+            BlockGasLimitProcessor<T>,
             Option<Error<E::Error>>,
         )>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
@@ -996,7 +980,7 @@ where
             // Priorotize committing validated transactions
             while scheduler.should_coordinate_commits() {
                 self.prepare_and_queue_commit_ready_txns(
-                    self.maybe_block_gas_limit,
+                    &self.config.onchain.block_gas_limit_type,
                     scheduler,
                     versioned_cache,
                     &mut scheduler_task,
@@ -1078,7 +1062,10 @@ where
         // will only have a coordinator role but no workers for rolling commit.
         // Need to special case no roles (commit hook by thread itself) to run
         // w. concurrency_level = 1 for some reason.
-        assert!(self.concurrency_level > 1, "Must use sequential execution");
+        assert!(
+            self.config.local.concurrency_level > 1,
+            "Must use sequential execution"
+        );
 
         let versioned_cache = MVHashMap::new();
         let start_shared_counter = gen_id_start_value(false);
@@ -1091,8 +1078,7 @@ where
         let num_txns = signature_verified_block.len();
 
         let shared_commit_state = ExplicitSyncWrapper::new((
-            FeeStatement::zero(),
-            Vec::<FeeStatement>::with_capacity(num_txns),
+            BlockGasLimitProcessor::new(self.config.onchain.block_gas_limit_type.clone(), num_txns),
             None,
         ));
 
@@ -1111,7 +1097,7 @@ where
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
         self.executor_thread_pool.scope(|s| {
-            for _ in 0..self.concurrency_level {
+            for _ in 0..self.config.local.concurrency_level {
                 s.spawn(|_| {
                     if let Err(e) = self.worker_loop(
                         &executor_initial_arguments,
@@ -1127,7 +1113,7 @@ where
                     ) {
                         if scheduler.halt() {
                             let mut shared_commit_state_guard = shared_commit_state.acquire();
-                            let (_, _, maybe_error) = shared_commit_state_guard.dereference_mut();
+                            let (_, maybe_error) = shared_commit_state_guard.dereference_mut();
                             *maybe_error = Some(Error::FallbackToSequential(e));
                         }
                     }
@@ -1137,7 +1123,7 @@ where
         drop(timer);
         // Explicit async drops.
         DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
-        let (_, _, maybe_error) = shared_commit_state.into_inner();
+        let (_, maybe_error) = shared_commit_state.into_inner();
         match maybe_error {
             Some(err) => Err(err),
             None => Ok(final_results.into_inner()),
@@ -1238,7 +1224,10 @@ where
         let counter = RefCell::new(start_counter);
         let unsync_map = UnsyncMap::new();
         let mut ret = Vec::with_capacity(num_txns);
-        let mut accumulated_fee_statement = FeeStatement::zero();
+        let mut accumulator = BlockGasLimitProcessor::<T>::new(
+            self.config.onchain.block_gas_limit_type.clone(),
+            num_txns,
+        );
 
         for (idx, txn) in signature_verified_block.iter().enumerate() {
             let latest_view = LatestView::<T, S, X>::new(
@@ -1256,17 +1245,47 @@ where
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
                 ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                    // Calculating the accumulated gas costs of the committed txns.
+                    let fee_statement = output.fee_statement();
+
+                    let approx_output_size = if self
+                        .config
+                        .onchain
+                        .block_gas_limit_type
+                        .block_output_limit()
+                        .is_some()
+                    {
+                        Some(output.output_approx_size())
+                    } else {
+                        None
+                    };
+
+                    let read_write_summary = if self
+                        .config
+                        .onchain
+                        .block_gas_limit_type
+                        .conflict_penalty_window()
+                        .is_some()
+                    {
+                        Some(ReadWriteSummary::new(
+                            latest_view.take_sequential_reads().get_read_summary(),
+                            output.get_write_summary(),
+                        ))
+                    } else {
+                        None
+                    };
+                    accumulator.accumulate_fee_statement(
+                        fee_statement,
+                        read_write_summary,
+                        approx_output_size,
+                    );
+
                     output.materialize_agg_v1(&latest_view);
                     assert_eq!(
                         output.aggregator_v1_delta_set().len(),
                         0,
                         "Sequential execution must materialize deltas"
                     );
-
-                    // Calculating the accumulated gas costs of the committed txns.
-                    let fee_statement = output.fee_statement();
-                    accumulated_fee_statement.add_fee_statement(&fee_statement);
-                    counters::update_sequential_txn_gas_counters(&fee_statement);
 
                     // Apply the writes.
                     // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
@@ -1400,41 +1419,14 @@ where
                 break;
             }
 
-            if let Some(per_block_gas_limit) = self.maybe_block_gas_limit {
-                // When the accumulated gas of the committed txns
-                // exceeds per_block_gas_limit, halt sequential execution.
-                let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                    + accumulated_fee_statement.io_gas_used();
-                if accumulated_non_storage_gas >= per_block_gas_limit {
-                    counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
-                        .with_label_values(&[counters::Mode::SEQUENTIAL])
-                        .inc();
-                    info!(
-                        "[Execution]: Sequential execution early halted due to \
-                        accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed.",
-                        accumulated_non_storage_gas,
-                        per_block_gas_limit,
-                        ret.len()
-                    );
-                    break;
-                }
+            if accumulator.should_end_block_sequential() {
+                break;
             }
         }
 
-        if ret.len() == num_txns {
-            let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                + accumulated_fee_statement.io_gas_used();
-            info!(
-                "[Execution]: Sequential execution completed. \
-		 {} out of {} txns committed. accumulated_non_storage_gas = {}, limit = {:?}",
-                ret.len(),
-                num_txns,
-                accumulated_non_storage_gas,
-                self.maybe_block_gas_limit,
-            );
-        }
+        accumulator
+            .finish_sequential_update_counters_and_log_info(ret.len() as u32, num_txns as u32);
 
-        counters::update_sequential_block_gas_counters(&accumulated_fee_statement, ret.len());
         ret.resize_with(num_txns, E::Output::skip_output);
         Ok(ret)
     }
@@ -1448,7 +1440,9 @@ where
         let dynamic_change_set_optimizations_enabled = signature_verified_block.len() != 1
             || E::is_transaction_dynamic_change_set_capable(&signature_verified_block[0]);
 
-        let mut ret = if self.concurrency_level > 1 && dynamic_change_set_optimizations_enabled {
+        let mut ret = if self.config.local.concurrency_level > 1
+            && dynamic_change_set_optimizations_enabled
+        {
             self.execute_transactions_parallel(
                 executor_arguments,
                 signature_verified_block,
@@ -1465,7 +1459,7 @@ where
 
         // Sequential execution fallback
         // Only worth doing if we did parallel before, i.e. if we did a different pass.
-        if self.concurrency_level > 1 {
+        if self.config.local.concurrency_level > 1 {
             if let Err(Error::FallbackToSequential(e)) = &ret {
                 match e {
                     PanicOr::Or(IntentionalFallbackToSequential::ModulePathReadWrite) => {

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -144,12 +144,14 @@ pub mod counters;
 pub mod errors;
 pub mod executor;
 pub mod explicit_sync_wrapper;
+mod limit_processor;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 mod scheduler;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;
+pub mod types;
 #[cfg(test)]
 mod unit_tests;
 pub mod view;

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -1,0 +1,206 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{counters, types::ReadWriteSummary};
+use aptos_logger::info;
+use aptos_types::{
+    fee_statement::FeeStatement, on_chain_config::BlockGasLimitType,
+    transaction::BlockExecutableTransaction as Transaction,
+};
+use claims::assert_le;
+
+pub struct BlockGasLimitProcessor<T: Transaction> {
+    block_gas_limit_type: BlockGasLimitType,
+    accumulated_effective_block_gas: u64,
+    accumulated_approx_output_size: u64,
+    accumulated_fee_statement: FeeStatement,
+    txn_fee_statements: Vec<FeeStatement>,
+    txn_read_write_summaries: Vec<ReadWriteSummary<T>>,
+}
+
+impl<T: Transaction> BlockGasLimitProcessor<T> {
+    pub fn new(block_gas_limit_type: BlockGasLimitType, init_size: usize) -> Self {
+        Self {
+            block_gas_limit_type,
+            accumulated_effective_block_gas: 0,
+            accumulated_approx_output_size: 0,
+            accumulated_fee_statement: FeeStatement::zero(),
+            txn_fee_statements: Vec::with_capacity(init_size),
+            txn_read_write_summaries: Vec::with_capacity(init_size),
+        }
+    }
+
+    pub(crate) fn accumulate_fee_statement(
+        &mut self,
+        fee_statement: FeeStatement,
+        txn_read_write_summary: Option<ReadWriteSummary<T>>,
+        approx_output_size: Option<u64>,
+    ) {
+        self.accumulated_fee_statement
+            .add_fee_statement(&fee_statement);
+        self.txn_fee_statements.push(fee_statement);
+
+        let conflict_multiplier = if let Some(conflict_overlap_length) =
+            self.block_gas_limit_type.conflict_penalty_window()
+        {
+            self.txn_read_write_summaries.push(
+                if self
+                    .block_gas_limit_type
+                    .use_granular_resource_group_conflicts()
+                {
+                    txn_read_write_summary.unwrap()
+                } else {
+                    txn_read_write_summary
+                        .unwrap()
+                        .collapse_resource_group_conflicts()
+                },
+            );
+            self.compute_conflict_multiplier(conflict_overlap_length as usize)
+        } else {
+            1
+        };
+
+        // println!("[{}] Multiplier {}, with read/write summary: {:?}", self.txn_fee_statements.len() - 1, conflict_multiplier, self.txn_read_write_summaries.last());
+
+        // When the accumulated execution and io gas of the committed txns exceeds
+        // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage fee does not count towards
+        // the per block gas limit, as we measure execution related cost here.
+        self.accumulated_effective_block_gas += conflict_multiplier
+            * (fee_statement.execution_gas_used()
+                * self
+                    .block_gas_limit_type
+                    .execution_gas_effective_multiplier()
+                + fee_statement.io_gas_used()
+                    * self.block_gas_limit_type.io_gas_effective_multiplier());
+
+        self.accumulated_approx_output_size += approx_output_size.unwrap_or(0);
+    }
+
+    fn should_end_block(&self, is_parallel: bool) -> bool {
+        let mode = if is_parallel {
+            counters::Mode::PARALLEL
+        } else {
+            counters::Mode::SEQUENTIAL
+        };
+        if let Some(per_block_gas_limit) = self.block_gas_limit_type.block_gas_limit() {
+            // When the accumulated block gas of the committed txns exceeds
+            // PER_BLOCK_GAS_LIMIT, early halt BlockSTM.
+            let accumulated_block_gas = self.get_effective_accumulated_block_gas();
+            if accumulated_block_gas >= per_block_gas_limit {
+                counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                    .with_label_values(&[mode])
+                    .inc();
+                info!(
+                    "[BlockSTM]: execution (is_parallel = {}) early halted due to \
+                    accumulated_block_gas {} >= PER_BLOCK_GAS_LIMIT {}",
+                    is_parallel, accumulated_block_gas, per_block_gas_limit,
+                );
+
+                return true;
+            }
+        }
+
+        if let Some(per_block_output_limit) = self.block_gas_limit_type.block_output_limit() {
+            let accumulated_output = self.get_accumulated_approx_output_size();
+            if accumulated_output >= per_block_output_limit {
+                counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                    .with_label_values(&[mode])
+                    .inc();
+                info!(
+                    "[BlockSTM]: execution (is_parallel = {}) early halted due to \
+                    accumulated_output {} >= PER_BLOCK_OUTPUT_LIMIT {}",
+                    is_parallel, accumulated_output, per_block_output_limit,
+                );
+
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub(crate) fn should_end_block_parallel(&self) -> bool {
+        self.should_end_block(true)
+    }
+
+    pub(crate) fn should_end_block_sequential(&self) -> bool {
+        self.should_end_block(false)
+    }
+
+    fn get_effective_accumulated_block_gas(&self) -> u64 {
+        self.accumulated_effective_block_gas
+    }
+
+    fn get_accumulated_approx_output_size(&self) -> u64 {
+        self.accumulated_approx_output_size
+    }
+
+    fn compute_conflict_multiplier(&self, conflict_overlap_length: usize) -> u64 {
+        let start = self
+            .txn_read_write_summaries
+            .len()
+            .saturating_sub(conflict_overlap_length);
+        let end = self.txn_read_write_summaries.len() - 1;
+
+        let mut conflict_count = 0;
+        let current = &self.txn_read_write_summaries[end];
+        for prev in &self.txn_read_write_summaries[start..end] {
+            if current.conflicts_with_previous(prev) {
+                conflict_count += 1;
+            }
+        }
+        assert_le!(conflict_count + 1, conflict_overlap_length);
+        (conflict_count + 1) as u64
+    }
+
+    fn finish_update_counters_and_log_info(
+        &self,
+        is_parallel: bool,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        let accumulated_effective_block_gas = self.get_effective_accumulated_block_gas();
+        let accumulated_approx_output_size = self.get_accumulated_approx_output_size();
+
+        counters::update_block_gas_counters(
+            &self.accumulated_fee_statement,
+            accumulated_effective_block_gas,
+            accumulated_approx_output_size,
+            num_committed as usize,
+            is_parallel,
+        );
+        counters::update_txn_gas_counters(&self.txn_fee_statements, is_parallel);
+
+        info!(
+            "[BlockSTM]: {} execution completed. {} out of {} txns committed. \
+            accumulated_effective_block_gas = {}, limit = {:?}",
+            if is_parallel {
+                "Parallel"
+            } else {
+                "Sequential"
+            },
+            num_committed,
+            num_total,
+            accumulated_effective_block_gas,
+            self.block_gas_limit_type,
+        );
+    }
+
+    pub(crate) fn finish_parallel_update_counters_and_log_info(
+        &self,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        self.finish_update_counters_and_log_info(true, num_committed, num_total)
+    }
+
+    pub(crate) fn finish_sequential_update_counters_and_log_info(
+        &self,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        self.finish_update_counters_and_log_info(false, num_committed, num_total)
+    }
+}
+
+// TODO: add tests for accumulate_fee_statement / compute_conflict_multiplier for different BlockGasLimitType configs

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1132,6 +1132,23 @@ where
             0,
         )
     }
+
+    fn output_approx_size(&self) -> u64 {
+        // TODO add block output limit testing
+        0
+    }
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        crate::types::InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    > {
+        HashSet::new()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use aptos_aggregator::{
     delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
 };
@@ -12,7 +13,11 @@ use aptos_types::{
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Debug,
+    sync::Arc,
+};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -182,4 +187,16 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     /// Return the fee statement of the transaction.
     fn fee_statement(&self) -> FeeStatement;
+
+    fn output_approx_size(&self) -> u64;
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    >;
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -188,6 +188,10 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// Return the fee statement of the transaction.
     fn fee_statement(&self) -> FeeStatement;
 
+    /// Deterministic, but approximate size of the output, as
+    /// before creating actual TransactionOutput, we don't know the exact size of it.
+    ///
+    /// Sum of all sizes of writes (keys + write_ops) and events.
     fn output_approx_size(&self) -> u64;
 
     fn get_write_summary(

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -6,6 +6,7 @@ use crate::{
     errors::{Error, IntentionalFallbackToSequential},
     explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
+    types::InputOutputKey,
 };
 use aptos_aggregator::types::PanicOr;
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
@@ -18,7 +19,7 @@ use crossbeam::utils::CachePadded;
 use dashmap::DashSet;
 use move_core_types::value::MoveTypeLayout;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     iter::{empty, Iterator},
     sync::{
@@ -173,6 +174,19 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 Some(output.fee_statement())
+            },
+            _ => None,
+        }
+    }
+
+    pub(crate) fn output_approx_size(&self, txn_idx: TxnIndex) -> Option<u64> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("[BlockSTM]: Execution output must be recorded after execution")
+            .output_status
+        {
+            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                Some(output.output_approx_size())
             },
             _ => None,
         }
@@ -418,6 +432,23 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {},
         };
+    }
+
+    pub(crate) fn get_write_summary(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("Output must exist")
+            .output_status
+        {
+            ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
+            ExecutionStatus::Abort(_)
+            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
+            | ExecutionStatus::SpeculativeExecutionAbortError(_)
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => HashSet::new(),
+        }
     }
 
     // Must be executed after parallel execution is done, grabs outputs. Will panic if

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::transaction::BlockExecutableTransaction as Transaction;
 use std::{collections::HashSet, fmt};

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -1,0 +1,56 @@
+// Copyright © Aptos Foundation
+
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::{collections::HashSet, fmt};
+
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum InputOutputKey<K, T, I> {
+    Resource(K),
+    Group(K, T),
+    DelayedField(I),
+}
+
+pub struct ReadWriteSummary<T: Transaction> {
+    reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+}
+
+impl<T: Transaction> ReadWriteSummary<T> {
+    pub fn new(
+        reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+        writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    ) -> Self {
+        Self { reads, writes }
+    }
+
+    pub fn conflicts_with_previous(&self, previous: &Self) -> bool {
+        !self.reads.is_disjoint(&previous.writes)
+    }
+
+    pub fn collapse_resource_group_conflicts(self) -> Self {
+        let collapse = |k: InputOutputKey<T::Key, T::Tag, T::Identifier>| match k {
+            InputOutputKey::Resource(k) => InputOutputKey::Resource(k),
+            InputOutputKey::Group(k, _) => InputOutputKey::Resource(k),
+            InputOutputKey::DelayedField(id) => InputOutputKey::DelayedField(id),
+        };
+        Self {
+            reads: self.reads.into_iter().map(collapse).collect(),
+            writes: self.writes.into_iter().map(collapse).collect(),
+        }
+    }
+}
+
+impl<T: Transaction> fmt::Debug for ReadWriteSummary<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "ReadWriteSummary")?;
+        writeln!(f, "reads:")?;
+        for read in &self.reads {
+            writeln!(f, "    {:?}", read)?;
+        }
+        writeln!(f, "writes:")?;
+        for write in &self.writes {
+            writeln!(f, "    {:?}", write)?;
+        }
+        Ok(())
+    }
+}

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
+use crate::types::InputOutputKey;
 use crate::{
     captured_reads::{
         CapturedReads, DataRead, DelayedFieldRead, DelayedFieldReadKind, GroupRead, ReadKind,
@@ -955,12 +957,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
     }
 
     #[cfg(test)]
-    fn get_resource_with_layout_read_set_sequential(&self) -> HashSet<T::Key> {
+    fn get_read_summary(&self) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
         match &self.latest_view {
-            ViewState::Sync(_) => {
-                unreachable!("Get resource read set called in parallel setting")
-            },
-            ViewState::Unsync(state) => state.read_set.borrow().resource_reads.clone(),
+            ViewState::Sync(state) => state.captured_reads.borrow().get_read_summary(),
+            ViewState::Unsync(state) => state.read_set.borrow().get_read_summary(),
         }
     }
 
@@ -1277,6 +1277,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             .filter(|(key, _tags)| !skip.contains(key))
             .flat_map(|(key, tags)| {
                 if let Some(value_vec) = unsync_map.fetch_group_data(key) {
+                    // TODO[agg_v2](cleanup) - can we use .any() instead?
                     let mut resources_needing_delayed_field_exchange = false;
                     for (tag, value_with_layout) in value_vec {
                         if tags.contains(&tag) {
@@ -1291,6 +1292,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                                         resources_needing_delayed_field_exchange = true;
                                         break;
                                     }
+                                } else {
+                                    return Some(Err(code_invariant_error(
+                                        "Delete shouldn't be in get_group_reads_needing_exchange_sequential",
+                                    )));
                                 }
                             }
                         }
@@ -2493,6 +2498,67 @@ mod test {
         );
     }
 
+    fn create_struct_layout(inner: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::new(vec![inner]))
+    }
+
+    fn create_vector_layout(inner: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Vector(Box::new(inner))
+    }
+
+    fn create_aggregator_layout(inner: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::new(vec![
+            MoveTypeLayout::Tagged(
+                LayoutTag::IdentifierMapping(IdentifierMappingKind::Aggregator),
+                Box::new(inner.clone()),
+            ),
+            inner.clone(),
+        ]))
+    }
+
+    fn create_aggregator_layout_u64() -> MoveTypeLayout {
+        create_aggregator_layout(MoveTypeLayout::U64)
+    }
+
+    fn create_snapshot_layout(inner: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Tagged(
+            LayoutTag::IdentifierMapping(IdentifierMappingKind::Snapshot),
+            Box::new(inner),
+        )]))
+    }
+
+    fn create_string_layout() -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Vector(
+            Box::new(MoveTypeLayout::U8),
+        )]))
+    }
+
+    fn create_aggregator_value_u64(value: u64, max_value: u64) -> Value {
+        Value::struct_(Struct::pack(vec![Value::u64(value), Value::u64(max_value)]))
+    }
+
+    fn create_snapshot_value(value: Value) -> Value {
+        Value::struct_(Struct::pack(vec![value]))
+    }
+
+    fn create_struct_value(inner: Value) -> Value {
+        Value::struct_(Struct::pack(vec![inner]))
+    }
+
+    fn create_vector_value(inner: Vec<Value>) -> Value {
+        Value::vector_for_testing_only(inner)
+    }
+
+    fn create_string_value(value: &str) -> Value {
+        Value::struct_(Struct::pack(vec![Value::vector_u8(
+            bcs::to_bytes(value).unwrap().to_vec(),
+        )]))
+    }
+
+    fn create_state_value(value: &Value, layout: &MoveTypeLayout) -> StateValue {
+        StateValue::new_legacy(value.simple_serialize(layout).unwrap().into())
+    }
+
     // TODO: Check how to import MockStateView from other tests
     // rather than rewriting it here again
     struct MockStateView {
@@ -2574,19 +2640,8 @@ mod test {
                 agg: Aggregator<u64>
             }
         */
-        let layout = MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Struct(
-            MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Aggregator),
-                    Box::new(MoveTypeLayout::U64),
-                ),
-                MoveTypeLayout::U64,
-            ]),
-        )]));
-        let value = Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-            Value::u64(25),
-            Value::u64(30),
-        ]))]));
+        let layout = create_struct_layout(create_aggregator_layout_u64());
+        let value = create_struct_value(create_aggregator_value_u64(25, 30));
         let state_value = StateValue::new_legacy(value.simple_serialize(&layout).unwrap().into());
         let (patched_state_value, identifiers) = latest_view
             .replace_values_with_identifiers(state_value.clone(), &layout)
@@ -2613,20 +2668,12 @@ mod test {
                 aggregators: vec![Aggregator<u64>]
             }
         */
-        let layout = MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Vector(
-            Box::new(MoveTypeLayout::Struct(MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Aggregator),
-                    Box::new(MoveTypeLayout::U64),
-                ),
-                MoveTypeLayout::U64,
-            ]))),
-        )]));
-        let value = Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
-            Value::struct_(Struct::pack(vec![Value::u64(20), Value::u64(50)])),
-            Value::struct_(Struct::pack(vec![Value::u64(35), Value::u64(65)])),
-            Value::struct_(Struct::pack(vec![Value::u64(0), Value::u64(20)])),
-        ])]));
+        let layout = create_struct_layout(create_vector_layout(create_aggregator_layout_u64()));
+        let value = create_struct_value(create_vector_value(vec![
+            create_aggregator_value_u64(20, 50),
+            create_aggregator_value_u64(35, 65),
+            create_aggregator_value_u64(0, 20),
+        ]));
         let state_value = StateValue::new_legacy(value.simple_serialize(&layout).unwrap().into());
         let (patched_state_value, identifiers) = latest_view
             .replace_values_with_identifiers(state_value.clone(), &layout)
@@ -2663,19 +2710,14 @@ mod test {
                 aggregators: vec![AggregatorSnapshot<u128>]
             }
         */
-        let layout = MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Vector(
-            Box::new(MoveTypeLayout::Struct(MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Snapshot),
-                    Box::new(MoveTypeLayout::U128),
-                ),
-            ]))),
-        )]));
-        let value = Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
-            Value::struct_(Struct::pack(vec![Value::u128(20)])),
-            Value::struct_(Struct::pack(vec![Value::u128(35)])),
-            Value::struct_(Struct::pack(vec![Value::u128(0)])),
-        ])]));
+        let layout = create_struct_layout(create_vector_layout(create_snapshot_layout(
+            MoveTypeLayout::U128,
+        )));
+        let value = create_struct_value(create_vector_value(vec![
+            create_snapshot_value(Value::u128(20)),
+            create_snapshot_value(Value::u128(35)),
+            create_snapshot_value(Value::u128(0)),
+        ]));
         let state_value = StateValue::new_legacy(value.simple_serialize(&layout).unwrap().into());
         let (patched_state_value, identifiers) = latest_view
             .replace_values_with_identifiers(state_value.clone(), &layout)
@@ -2690,9 +2732,9 @@ mod test {
         );
         let patched_value =
             Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
-                Value::struct_(Struct::pack(vec![Value::u128(9)])),
-                Value::struct_(Struct::pack(vec![Value::u128(10)])),
-                Value::struct_(Struct::pack(vec![Value::u128(11)])),
+                create_snapshot_value(Value::u128(9)),
+                create_snapshot_value(Value::u128(10)),
+                create_snapshot_value(Value::u128(11)),
             ])]));
         assert_eq!(
             patched_state_value,
@@ -2713,27 +2755,14 @@ mod test {
                 snap: vec![AggregatorSnapshot<string>]
             }
         */
-        let layout = MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Vector(
-            Box::new(MoveTypeLayout::Struct(MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Snapshot),
-                    Box::new(MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
-                        MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-                    ]))),
-                ),
-            ]))),
-        )]));
-        let value = Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
-            Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-                Value::vector_u8(bcs::to_bytes("hello").unwrap().to_vec()),
-            ]))])),
-            Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-                Value::vector_u8(bcs::to_bytes("ab").unwrap().to_vec()),
-            ]))])),
-            Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-                Value::vector_u8(bcs::to_bytes("c").unwrap().to_vec()),
-            ]))])),
-        ])]));
+        let layout = create_struct_layout(create_vector_layout(create_snapshot_layout(
+            create_string_layout(),
+        )));
+        let value = create_struct_value(create_vector_value(vec![
+            create_snapshot_value(create_string_value("hello")),
+            create_snapshot_value(create_string_value("ab")),
+            create_snapshot_value(create_string_value("c")),
+        ]));
         let state_value = StateValue::new_legacy(value.simple_serialize(&layout).unwrap().into());
         let (patched_state_value, identifiers) = latest_view
             .replace_values_with_identifiers(state_value.clone(), &layout)
@@ -2766,29 +2795,6 @@ mod test {
             "Three identifiers should have been replaced in this case"
         );
         assert_eq!(identifiers, identifiers2);
-    }
-
-    fn create_aggregator_layout() -> MoveTypeLayout {
-        MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Struct(
-            MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Aggregator),
-                    Box::new(MoveTypeLayout::U64),
-                ),
-                MoveTypeLayout::U64,
-            ]),
-        )]))
-    }
-
-    fn create_aggregator_value(value: u64, max_value: u64) -> Value {
-        Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-            Value::u64(value),
-            Value::u64(max_value),
-        ]))]))
-    }
-
-    fn create_state_value(value: &Value, layout: &MoveTypeLayout) -> StateValue {
-        StateValue::new_legacy(value.simple_serialize(layout).unwrap().into())
     }
 
     struct Holder {
@@ -2829,55 +2835,187 @@ mod test {
         )
     }
 
-    #[test]
-    fn test_sequential_missing_not_recorded() {
-        let h = Holder::new(HashMap::new(), 1000);
-        let latest_view = create_sequential_latest_view(&h, true);
+    struct ComparisonHolder {
+        start_counter: u32,
+        holder: Holder,
+        counter: AtomicU32,
+        base_view: MockStateView,
+        versioned_map: MVHashMap<KeyType<u32>, u32, ValueType, MockExecutable, DelayedFieldID>,
+        scheduler: Scheduler,
+    }
 
-        assert_ok_eq!(
-            latest_view.get_resource_state_value(&KeyType::<u32>(1, false), None),
-            None
-        );
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
+    impl ComparisonHolder {
+        fn new(data: HashMap<KeyType<u32>, StateValue>, start_counter: u32) -> Self {
+            let holder = Holder::new(data.clone(), start_counter);
+            let counter = AtomicU32::new(start_counter);
+            let base_view = MockStateView::new(data);
+            let versioned_map = MVHashMap::new();
+            let scheduler = Scheduler::new(30);
 
-        assert_ok_eq!(
-            latest_view.resource_exists(&KeyType::<u32>(1, false)),
-            false,
-        );
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
+            Self {
+                start_counter,
+                holder,
+                counter,
+                base_view,
+                versioned_map,
+                scheduler,
+            }
+        }
 
-        assert_ok_eq!(
-            latest_view.get_resource_state_value_metadata(&KeyType::<u32>(1, false)),
-            None,
-        );
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
+        fn new_view(&self) -> ViewsComparison<'_> {
+            let latest_view_seq = create_sequential_latest_view(&self.holder, true);
+            let latest_view_par =
+                LatestView::<TestTransactionType, MockStateView, MockExecutable>::new(
+                    &self.base_view,
+                    ViewState::Sync(ParallelState::new(
+                        &self.versioned_map,
+                        &self.scheduler,
+                        self.start_counter,
+                        &self.counter,
+                    )),
+                    1,
+                );
+
+            ViewsComparison {
+                latest_view_seq,
+                latest_view_par,
+            }
+        }
+    }
+
+    struct ViewsComparison<'a> {
+        latest_view_seq: LatestView<'a, TestTransactionType, MockStateView, MockExecutable>,
+        latest_view_par: LatestView<'a, TestTransactionType, MockStateView, MockExecutable>,
+    }
+
+    impl<'a> ViewsComparison<'a> {
+        fn assert_res_eq<T, E>(&self, res_seq: Result<T, E>, res_par: Result<T, E>) -> Result<T, E>
+        where
+            T: std::fmt::Debug + PartialEq,
+            E: std::fmt::Debug,
+        {
+            assert_eq!(res_seq.is_ok(), res_par.is_ok());
+            if let Ok(res_seq) = res_seq {
+                assert_ok_eq!(&res_par, &res_seq);
+            }
+
+            assert_eq!(
+                self.latest_view_par.get_read_summary(),
+                self.latest_view_seq.get_read_summary()
+            );
+
+            res_par
+        }
+
+        fn get_resource_state_value(
+            &self,
+            state_key: &KeyType<u32>,
+            maybe_layout: Option<&MoveTypeLayout>,
+        ) -> anyhow::Result<Option<StateValue>> {
+            let seq = self
+                .latest_view_seq
+                .get_resource_state_value(state_key, maybe_layout);
+            let par = self
+                .latest_view_par
+                .get_resource_state_value(state_key, maybe_layout);
+
+            self.assert_res_eq(seq, par)
+        }
+
+        fn resource_exists(&self, state_key: &KeyType<u32>) -> anyhow::Result<bool> {
+            let seq = self.latest_view_seq.resource_exists(state_key);
+            let par = self.latest_view_par.resource_exists(state_key);
+
+            self.assert_res_eq(seq, par)
+        }
+
+        fn get_resource_state_value_metadata(
+            &self,
+            state_key: &KeyType<u32>,
+        ) -> anyhow::Result<Option<StateValueMetadataKind>> {
+            let seq = self
+                .latest_view_seq
+                .get_resource_state_value_metadata(state_key);
+            let par = self
+                .latest_view_par
+                .get_resource_state_value_metadata(state_key);
+
+            self.assert_res_eq(seq, par)
+        }
+
+        fn get_reads_needing_exchange(
+            &self,
+            delayed_write_set_keys: &HashSet<DelayedFieldID>,
+            skip: &HashSet<KeyType<u32>>,
+        ) -> Result<BTreeMap<KeyType<u32>, (ValueType, Arc<MoveTypeLayout>)>, PanicError> {
+            let seq = self
+                .latest_view_seq
+                .get_reads_needing_exchange(delayed_write_set_keys, skip);
+            let par = self
+                .latest_view_par
+                .get_reads_needing_exchange(delayed_write_set_keys, skip);
+
+            self.assert_res_eq(
+                seq.as_ref().map(|m| {
+                    m.iter()
+                        .map(|(k, (v, l))| (*k, (v.as_state_value(), l.clone())))
+                        .collect::<BTreeMap<_, _>>()
+                }),
+                par.as_ref().map(|m| {
+                    m.iter()
+                        .map(|(k, (v, l))| (*k, (v.as_state_value(), l.clone())))
+                        .collect::<BTreeMap<_, _>>()
+                }),
+            )
+            .unwrap();
+            par
+        }
+
+        fn get_delayed_field_value(
+            &self,
+            id: &DelayedFieldID,
+        ) -> Result<DelayedFieldValue, PanicOr<DelayedFieldsSpeculativeError>> {
+            let seq = self.latest_view_seq.get_delayed_field_value(id);
+            let par = self.latest_view_par.get_delayed_field_value(id);
+
+            self.assert_res_eq(seq, par)
+        }
     }
 
     #[test]
-    fn test_sequential_non_value_reads_not_recorded() {
+    fn test_missing_same() {
+        let holder = ComparisonHolder::new(HashMap::new(), 1000);
+        let views = holder.new_view();
+
+        assert_ok_eq!(
+            views.get_resource_state_value(&KeyType::<u32>(1, false), None),
+            None
+        );
+
+        assert_ok_eq!(views.resource_exists(&KeyType::<u32>(1, false)), false,);
+
+        assert_ok_eq!(
+            views.get_resource_state_value_metadata(&KeyType::<u32>(1, false)),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_non_value_reads_not_recorded() {
         let state_value = create_state_value(&Value::u64(12321), &MoveTypeLayout::U64);
         let data = HashMap::from([(KeyType::<u32>(1, false), state_value.clone())]);
-        let h = Holder::new(data, 1000);
-        let latest_view = create_sequential_latest_view(&h, true);
 
-        assert_ok_eq!(latest_view.resource_exists(&KeyType::<u32>(1, false)), true,);
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
+        let holder = ComparisonHolder::new(data, 1000);
+        let views = holder.new_view();
 
-        assert!(latest_view
+        assert_ok_eq!(views.resource_exists(&KeyType::<u32>(1, false)), true,);
+        assert!(views
             .get_resource_state_value_metadata(&KeyType::<u32>(1, false))
             .unwrap()
             .is_some(),);
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
+
+        assert_eq!(views.latest_view_par.get_read_summary(), HashSet::new());
+        assert_eq!(views.latest_view_seq.get_read_summary(), HashSet::new());
     }
 
     fn assert_fetch_eq<V: TransactionWrite>(
@@ -2905,22 +3043,23 @@ mod test {
     }
 
     #[test]
-    fn test_sequential_regular_read_operations() {
+    fn test_regular_read_operations() {
         let state_value = create_state_value(&Value::u64(12321), &MoveTypeLayout::U64);
         let data = HashMap::from([(KeyType::<u32>(1, false), state_value.clone())]);
-        let h = Holder::new(data, 1000);
-        let latest_view = create_sequential_latest_view(&h, true);
+
+        let holder = ComparisonHolder::new(data, 1000);
+        let views = holder.new_view();
 
         assert_ok_eq!(
-            latest_view.get_resource_state_value(&KeyType::<u32>(1, false), None),
+            views.get_resource_state_value(&KeyType::<u32>(1, false), None),
             Some(state_value.clone())
         );
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .is_empty());
 
         assert_fetch_eq(
-            h.unsync_map.fetch_data(&KeyType::<u32>(1, false)),
+            holder
+                .holder
+                .unsync_map
+                .fetch_data(&KeyType::<u32>(1, false)),
             Some(TransactionWrite::from_state_value(Some(state_value))),
             None,
         );
@@ -2929,38 +3068,46 @@ mod test {
     #[test_case(Some(true))]
     #[test_case(Some(false))]
     #[test_case(None)]
-    fn test_sequential_aggregator_read_operations(check_metadata: Option<bool>) {
-        let layout = create_aggregator_layout();
-        let value = create_aggregator_value(25, 30);
+    fn test_aggregator_read_operations(check_metadata: Option<bool>) {
+        let layout = create_struct_layout(create_aggregator_layout_u64());
+        let value = create_struct_value(create_aggregator_value_u64(25, 30));
         let state_value = create_state_value(&value, &layout);
         let data = HashMap::from([(KeyType::<u32>(1, false), state_value.clone())]);
-        let h = Holder::new(data, 1000);
-        let latest_view = create_sequential_latest_view(&h, true);
 
-        let patched_value = create_aggregator_value(1000, 30);
+        let holder = ComparisonHolder::new(data, 1000);
+        let views = holder.new_view();
+
+        let patched_value = create_struct_value(create_aggregator_value_u64(1000, 30));
         let patched_state_value = create_state_value(&patched_value, &layout);
 
         match check_metadata {
             Some(true) => {
-                latest_view
+                views
                     .get_resource_state_value_metadata(&KeyType::<u32>(1, false))
                     .unwrap();
             },
             Some(false) => {
-                assert_ok_eq!(latest_view.resource_exists(&KeyType::<u32>(1, false)), true,);
+                assert_ok_eq!(views.resource_exists(&KeyType::<u32>(1, false)), true,);
             },
             None => {},
         };
 
         assert_ok_eq!(
-            latest_view.get_resource_state_value(&KeyType::<u32>(1, false), Some(&layout)),
+            views.get_resource_state_value(&KeyType::<u32>(1, false), Some(&layout)),
             Some(patched_state_value.clone())
         );
-        assert!(latest_view
-            .get_resource_with_layout_read_set_sequential()
-            .contains(&KeyType(1, false)));
+        assert!(views
+            .get_reads_needing_exchange(
+                &HashSet::from([DelayedFieldID::new(1000)]),
+                &HashSet::new()
+            )
+            .unwrap()
+            .contains_key(&KeyType(1, false)));
         assert_fetch_eq(
-            h.unsync_map.fetch_data(&KeyType::<u32>(1, false)),
+            holder
+                .holder
+                .unsync_map
+                .fetch_data(&KeyType::<u32>(1, false)),
             Some(TransactionWrite::from_state_value(Some(
                 patched_state_value,
             ))),
@@ -2969,8 +3116,7 @@ mod test {
     }
 
     #[test]
-    fn test_read_operations_parallel() {
-        let counter = AtomicU32::new(5);
+    fn test_read_operations() {
         let state_value_3 = StateValue::new_legacy(Bytes::from(
             Value::u64(12321)
                 .simple_serialize(&MoveTypeLayout::U64)
@@ -2978,44 +3124,28 @@ mod test {
         ));
         let mut data = HashMap::new();
         data.insert(KeyType::<u32>(3, false), state_value_3.clone());
-        let layout = MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::Struct(
-            MoveStructLayout::new(vec![
-                MoveTypeLayout::Tagged(
-                    LayoutTag::IdentifierMapping(IdentifierMappingKind::Aggregator),
-                    Box::new(MoveTypeLayout::U64),
-                ),
-                MoveTypeLayout::U64,
-            ]),
-        )]));
-        let value = Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-            Value::u64(25),
-            Value::u64(30),
-        ]))]));
+        let layout = create_struct_layout(create_aggregator_layout_u64());
+        let value = create_struct_value(create_aggregator_value_u64(25, 30));
         let state_value_4 = StateValue::new_legacy(value.simple_serialize(&layout).unwrap().into());
         data.insert(KeyType::<u32>(4, false), state_value_4);
-        let base_view = MockStateView::new(data);
-        let versioned_map = MVHashMap::new();
-        let scheduler = Scheduler::new(10);
-        let latest_view = LatestView::<TestTransactionType, MockStateView, MockExecutable>::new(
-            &base_view,
-            ViewState::Sync(ParallelState::new(&versioned_map, &scheduler, 5, &counter)),
-            1,
-        );
+
+        let holder = ComparisonHolder::new(data, 1000);
+        let views = holder.new_view();
 
         assert_eq!(
-            latest_view
+            views
                 .get_resource_state_value(&KeyType::<u32>(1, false), None)
                 .unwrap(),
             None
         );
         assert_eq!(
-            latest_view
+            views
                 .get_resource_state_value(&KeyType::<u32>(2, false), Some(&layout))
                 .unwrap(),
             None
         );
         assert_eq!(
-            latest_view
+            views
                 .get_resource_state_value(&KeyType::<u32>(3, false), None)
                 .unwrap(),
             Some(state_value_3.clone())
@@ -3025,26 +3155,35 @@ mod test {
         // Is Err(StorageVersion) expected here?
         println!(
             "data: {:?}",
-            versioned_map
+            holder
+                .versioned_map
                 .data()
                 .fetch_data(&KeyType::<u32>(3, false), 1)
         );
 
-        let patched_value = Value::struct_(Struct::pack(vec![Value::struct_(Struct::pack(vec![
-            Value::u64(5),
-            Value::u64(30),
-        ]))]));
+        let patched_value = create_struct_value(create_aggregator_value_u64(1000, 30));
         let state_value_4 =
             StateValue::new_legacy(patched_value.simple_serialize(&layout).unwrap().into());
         assert_eq!(
-            latest_view
+            views
                 .get_resource_state_value(&KeyType::<u32>(4, false), Some(&layout))
                 .unwrap(),
             Some(state_value_4.clone())
         );
 
-        let captured_reads = latest_view.take_parallel_reads();
-        assert!(captured_reads.validate_data_reads(versioned_map.data(), 1));
+        // When we throw exception, it is not required read summaries to match, as they will not be used
+        // assert_err_eq!(
+        //     views.get_delayed_field_value(&DelayedFieldID::new(1005)),
+        //     PanicOr::Or(DelayedFieldsSpeculativeError::NotFound(DelayedFieldID::new(1005))),
+        // );
+
+        assert_ok_eq!(
+            views.get_delayed_field_value(&DelayedFieldID::new(1000)),
+            DelayedFieldValue::Aggregator(25),
+        );
+
+        let captured_reads = views.latest_view_par.take_parallel_reads();
+        assert!(captured_reads.validate_data_reads(holder.versioned_map.data(), 1));
         let read_set_with_delayed_fields = captured_reads.get_read_values_with_delayed_fields();
 
         // TODO: This prints

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -40,8 +40,8 @@ use aptos_types::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     on_chain_config::{
-        BlockGasLimitType, FeatureFlag, Features, OnChainConfig, TimedFeatureOverride,
-        TimedFeaturesBuilder, ValidatorSet, Version,
+        FeatureFlag, Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder,
+        ValidatorSet, Version,
     },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -517,10 +517,8 @@ impl FakeExecutor {
             }
         });
 
-        let onchain_config = BlockExecutorConfigFromOnchain {
-            // TODO fetch values from state?
-            block_gas_limit_type: BlockGasLimitType::Limit(30000),
-        };
+        // TODO fetch values from state?
+        let onchain_config = BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
         let sequential_output = if mode != ExecutorMode::ParallelOnly {
             Some(AptosVM::execute_block(

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,12 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_temppath::TempPath;
 use rand::{rngs::StdRng, SeedableRng};
 
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
+    test_config_with_custom_onchain(None)
+}
+
+pub fn test_config_with_custom_onchain(
+    init_genesis_config: Option<InitGenesisConfigFn>,
+) -> (NodeConfig, Ed25519PrivateKey) {
     let path = TempPath::new();
     path.create_as_dir().unwrap();
     let (root_key, _genesis, _genesis_waypoint, validators) = crate::builder::Builder::new(
@@ -14,6 +21,7 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         aptos_cached_packages::head_release_bundle().clone(),
     )
     .unwrap()
+    .with_init_genesis_config(init_genesis_config)
     .build(StdRng::from_seed([0; 32]))
     .unwrap();
     let (

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -181,6 +181,11 @@ where
                     executed
                 );
                 info!(
+                    "Overall execution effectiveGPS: {} gas/s (over {} txns)",
+                    delta_gas.effective_block_gas / elapsed,
+                    executed
+                );
+                info!(
                     "Overall execution ioGPS: {} gas/s (over {} txns)",
                     delta_gas.io_gas / elapsed,
                     executed
@@ -194,6 +199,10 @@ where
                     "Overall execution GPT: {} gas/txn (over {} txns)",
                     delta_gas.gas / (delta_gas.gas_count as f64).max(1.0),
                     executed
+                );
+                info!(
+                    "Overall execution approx_output: {} bytes/s",
+                    delta_gas.approx_block_output / elapsed
                 );
                 info!(
                     "Overall execution output: {} bytes/s",

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -16,11 +16,7 @@ use std::{
 };
 
 pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-    block_gas_limit_type:
-        // present, but large to not limit blocks
-        aptos_types::on_chain_config::BlockGasLimitType::Limit(1_000_000_000),
-};
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 pub struct TransactionExecutor<V> {
     num_blocks_processed: usize,

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -224,6 +224,7 @@ def execute_command(command):
 class RunResults:
     tps: float
     gps: float
+    effective_gps: float
     io_gps: float
     execution_gps: float
     gpt: float
@@ -253,6 +254,9 @@ def extract_run_results(
     if execution_only:
         tps = float(re.findall(r"Overall execution TPS: (\d+\.?\d*) txn/s", output)[-1])
         gps = float(re.findall(r"Overall execution GPS: (\d+\.?\d*) gas/s", output)[-1])
+        effective_gps = float(
+            re.findall(r"Overall execution effectiveGPS: (\d+\.?\d*) gas/s", output)[-1]
+        )
         io_gps = float(
             re.findall(r"Overall execution ioGPS: (\d+\.?\d*) gas/s", output)[-1]
         )
@@ -275,6 +279,7 @@ def extract_run_results(
             )
         )
         gps = 0
+        effective_gps = 0
         io_gps = 0
         execution_gps = 0
         gpt = 0
@@ -282,6 +287,9 @@ def extract_run_results(
     else:
         tps = float(get_only(re.findall(r"Overall TPS: (\d+\.?\d*) txn/s", output)))
         gps = float(get_only(re.findall(r"Overall GPS: (\d+\.?\d*) gas/s", output)))
+        effective_gps = float(
+            get_only(re.findall(r"Overall effectiveGPS: (\d+\.?\d*) gas/s", output))
+        )
         io_gps = float(
             get_only(re.findall(r"Overall ioGPS: (\d+\.?\d*) gas/s", output))
         )
@@ -313,6 +321,7 @@ def extract_run_results(
     return RunResults(
         tps=tps,
         gps=gps,
+        effective_gps=effective_gps,
         io_gps=io_gps,
         execution_gps=execution_gps,
         gpt=gpt,
@@ -353,6 +362,7 @@ def print_table(
                 "vm/exe",
                 "commit/total",
                 "g/s",
+                "eff g/s",
                 "io g/s",
                 "exe g/s",
                 "g/t",
@@ -386,6 +396,7 @@ def print_table(
             row.append(round(result.single_node_result.fraction_of_execution_in_vm, 3))
             row.append(round(result.single_node_result.fraction_in_commit, 3))
             row.append(int(round(result.single_node_result.gps)))
+            row.append(int(round(result.single_node_result.effective_gps)))
             row.append(int(round(result.single_node_result.io_gps)))
             row.append(int(round(result.single_node_result.execution_gps)))
             row.append(int(round(result.single_node_result.gpt)))
@@ -402,7 +413,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     execute_command(f"cargo build {BUILD_FLAG} --package aptos-executor-benchmark")
 
     print(f"Warmup - creating DB with {NUM_ACCOUNTS} accounts")
-    create_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
+    create_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
     results = []
@@ -459,14 +470,14 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         number_of_threads_results = {}
 
         for execution_threads in EXECUTION_ONLY_NUMBER_OF_THREADS:
-            test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
+            test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
             output = execute_command(test_db_command)
 
             number_of_threads_results[execution_threads] = extract_run_results(
                 output, execution_only=True
             )
 
-        test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
+        test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
         output = execute_command(test_db_command)
 
         single_node_result = extract_run_results(output, execution_only=False)

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -33,6 +33,22 @@ impl BlockExecutorConfigFromOnchain {
     pub fn has_any_block_gas_limit(&self) -> bool {
         self.block_gas_limit_type.block_gas_limit().is_some()
     }
+
+    pub const fn on_but_large_for_test() -> Self {
+        Self {
+            block_gas_limit_type:
+                // present, so code is excercised, but large to not limit blocks
+                BlockGasLimitType::ComplexLimitV1 {
+                    effective_block_gas_limit: 1_000_000_000,
+                    execution_gas_effective_multiplier: 1,
+                    io_gas_effective_multiplier: 1,
+                    block_output_limit: Some(1_000_000_000_000),
+                    conflict_penalty_window: 8,
+                    add_block_limit_outcome_onchain: false,
+                    use_granular_resource_group_conflicts: false,
+                },
+        }
+    }
 }
 
 /// Configuration for the BlockExecutor.

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -17,6 +17,7 @@ pub enum OnChainExecutionConfig {
     /// to previous behavior (before OnChainExecutionConfig was registered) in case of Missing.
     Missing,
     // Reminder: Add V4 and future versions here, after Missing (order matters for enums).
+    V4(ExecutionConfigV4),
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -28,6 +29,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type.clone(),
         }
     }
 
@@ -42,6 +44,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config
                 .block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+            OnChainExecutionConfig::V4(config) => config.block_gas_limit_type.clone(),
         }
     }
 
@@ -59,15 +62,24 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_deduper_type.clone(),
         }
     }
 
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+        OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            block_gas_limit: Some(35000),
+            block_gas_limit_type: BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit: 35000,
+                execution_gas_effective_multiplier: 1,
+                io_gas_effective_multiplier: 1,
+                block_output_limit: None,
+                conflict_penalty_window: 1,
+                add_block_limit_outcome_onchain: false,
+                use_granular_resource_group_conflicts: false,
+            },
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         })
     }
@@ -115,6 +127,13 @@ pub struct ExecutionConfigV3 {
     pub transaction_deduper_type: TransactionDeduperType,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV4 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+    pub block_gas_limit_type: BlockGasLimitType,
+    pub transaction_deduper_type: TransactionDeduperType,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionShufflerType {
@@ -134,6 +153,30 @@ pub enum TransactionDeduperType {
 pub enum BlockGasLimitType {
     NoLimit,
     Limit(u64),
+    /// Provides two separate block limits:
+    /// 1. effective_block_gas_limit
+    /// 2. block_output_limit
+    ComplexLimitV1 {
+        /// Formula for effective block gas limit:
+        /// effective_block_gas_limit <
+        /// (execution_gas_effective_multiplier * execution_gas_used +
+        ///  io_gas_effective_multiplier * io_gas_used
+        /// ) * (1 + num conflicts in conflict_penalty_window)
+        effective_block_gas_limit: u64,
+        execution_gas_effective_multiplier: u64,
+        io_gas_effective_multiplier: u64,
+        conflict_penalty_window: u32,
+        /// Block limit on the total (approximate) txn output size in bytes.
+        block_output_limit: Option<u64>,
+
+        add_block_limit_outcome_onchain: bool,
+
+        // If true we look at granular resource group conflicts (i.e. if same Tag
+        // within a resource group has a conflict)
+        // If false, we treat any conclicts inside of resource groups (even across
+        // non-overlapping tags) as conflicts).
+        use_granular_resource_group_conflicts: bool,
+    },
 }
 
 impl BlockGasLimitType {
@@ -141,6 +184,81 @@ impl BlockGasLimitType {
         match self {
             BlockGasLimitType::NoLimit => None,
             BlockGasLimitType::Limit(limit) => Some(*limit),
+            BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit,
+                ..
+            } => Some(*effective_block_gas_limit),
+        }
+    }
+
+    pub fn execution_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                execution_gas_effective_multiplier,
+                ..
+            } => *execution_gas_effective_multiplier,
+        }
+    }
+
+    pub fn io_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                io_gas_effective_multiplier,
+                ..
+            } => *io_gas_effective_multiplier,
+        }
+    }
+
+    pub fn block_output_limit(&self) -> Option<u64> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                block_output_limit, ..
+            } => *block_output_limit,
+        }
+    }
+
+    pub fn conflict_penalty_window(&self) -> Option<u32> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                conflict_penalty_window,
+                ..
+            } => {
+                if *conflict_penalty_window > 1 {
+                    Some(*conflict_penalty_window)
+                } else {
+                    None
+                }
+            },
+        }
+    }
+
+    pub fn add_block_limit_outcome_onchain(&self) -> bool {
+        match self {
+            BlockGasLimitType::NoLimit => false,
+            BlockGasLimitType::Limit(_) => false,
+            BlockGasLimitType::ComplexLimitV1 {
+                add_block_limit_outcome_onchain,
+                ..
+            } => *add_block_limit_outcome_onchain,
+        }
+    }
+
+    pub fn use_granular_resource_group_conflicts(&self) -> bool {
+        match self {
+            BlockGasLimitType::NoLimit => false,
+            BlockGasLimitType::Limit(_) => false,
+            BlockGasLimitType::ComplexLimitV1 {
+                use_granular_resource_group_conflicts,
+                ..
+            } => *use_granular_resource_group_conflicts,
         }
     }
 }

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -6,7 +6,6 @@ use crate::{
     account_address::AccountAddress,
     block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
-    on_chain_config::BlockGasLimitType,
     transaction::{
         authenticator::AccountAuthenticator,
         signature_verified_transaction::{
@@ -23,9 +22,7 @@ const TEST_GAS_PRICE: u64 = 100;
 
 // The block executor onchain config (gas limit parameters) for executor tests
 pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-        block_gas_limit_type: BlockGasLimitType::Limit(1000),
-    };
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 static EMPTY_SCRIPT: &[u8] = include_bytes!("empty_script.mv");
 


### PR DESCRIPTION
throughput changes based on whether there are conflicts between transactions (and they need to be executed sequentially), or if they are parallel. But the gas charged stays constant, as gas charging is independent for each transaction.

In order to limit to the total amount of time block can be executing, we introduce conflict-aware block gas limit - where we multiply gas used for individual transactions with the coefficient of how many of the recent 8 transaction it had conflicts with (including self, which we assume it had conflict with - to have the number in the [1, 8] range)


