### PR TITLE
Propagate BlockExecutorOnchainConfig instead of maybe_block_gas_limit

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -29,6 +29,7 @@ use aptos_types::{
     access_path::{AccessPath, Path},
     account_address::AccountAddress,
     account_config::{AccountResource, NewBlockEvent},
+    block_executor::config::BlockExecutorOnchainConfig,
     chain_id::ChainId,
     contract_event::EventWithVersion,
     event::EventKey,
@@ -98,7 +99,8 @@ impl Context {
             })),
             gas_limit_cache: Arc::new(RwLock::new(GasLimitCache {
                 last_updated_epoch: None,
-                block_gas_limit: None,
+                block_executor_onchain_config: OnChainExecutionConfig::default_if_missing()
+                    .block_executor_onchain_config(),
             })),
         }
     }
@@ -935,7 +937,7 @@ impl Context {
     ) -> Result<GasEstimation, E> {
         let config = &self.node_config.api.gas_estimation;
         let min_gas_unit_price = self.min_gas_unit_price(ledger_info)?;
-        let block_gas_limit = self.block_gas_limit(ledger_info)?;
+        let block_config = self.block_executor_onchain_config(ledger_info)?;
         if !config.enabled {
             return Ok(self.default_gas_estimation(min_gas_unit_price));
         }
@@ -1024,7 +1026,9 @@ impl Context {
                 Ok(prices_and_used) => {
                     let is_full_block = if prices_and_used.len() >= config.full_block_txns {
                         true
-                    } else if let Some(full_block_gas_used) = block_gas_limit {
+                    } else if let Some(full_block_gas_used) =
+                        block_config.block_gas_limit_type.block_gas_limit()
+                    {
                         prices_and_used.iter().map(|(_, used)| *used).sum::<u64>()
                             >= full_block_gas_used
                     } else {
@@ -1207,16 +1211,16 @@ impl Context {
         }
     }
 
-    pub fn block_gas_limit<E: InternalError>(
+    pub fn block_executor_onchain_config<E: InternalError>(
         &self,
         ledger_info: &LedgerInfo,
-    ) -> Result<Option<u64>, E> {
+    ) -> Result<BlockExecutorOnchainConfig, E> {
         // If it's the same epoch, use the cached results
         {
             let cache = self.gas_limit_cache.read().unwrap();
             if let Some(ref last_updated_epoch) = cache.last_updated_epoch {
                 if *last_updated_epoch == ledger_info.epoch.0 {
-                    return Ok(cache.block_gas_limit);
+                    return Ok(cache.block_executor_onchain_config.clone());
                 }
             }
         }
@@ -1227,7 +1231,7 @@ impl Context {
             // If a different thread updated the cache, we can exit early
             if let Some(ref last_updated_epoch) = cache.last_updated_epoch {
                 if *last_updated_epoch == ledger_info.epoch.0 {
-                    return Ok(cache.block_gas_limit);
+                    return Ok(cache.block_executor_onchain_config.clone());
                 }
             }
 
@@ -1240,13 +1244,14 @@ impl Context {
                 })?;
             let resolver = state_view.as_move_resolver();
 
-            let block_gas_limit = OnChainExecutionConfig::fetch_config(&resolver)
-                .and_then(|config| config.block_gas_limit());
+            let block_executor_onchain_config = OnChainExecutionConfig::fetch_config(&resolver)
+                .unwrap_or_else(OnChainExecutionConfig::default_if_missing)
+                .block_executor_onchain_config();
 
             // Update the cache
-            cache.block_gas_limit = block_gas_limit;
+            cache.block_executor_onchain_config = block_executor_onchain_config.clone();
             cache.last_updated_epoch = Some(ledger_info.epoch.0);
-            Ok(block_gas_limit)
+            Ok(block_executor_onchain_config)
         }
     }
 
@@ -1298,7 +1303,7 @@ pub struct GasEstimationCache {
 
 pub struct GasLimitCache {
     last_updated_epoch: Option<u64>,
-    block_gas_limit: Option<u64>,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
 }
 
 /// This function just calls tokio::task::spawn_blocking with the given closure and in

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -29,7 +29,7 @@ use aptos_types::{
     access_path::{AccessPath, Path},
     account_address::AccountAddress,
     account_config::{AccountResource, NewBlockEvent},
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
     contract_event::EventWithVersion,
     event::EventKey,
@@ -1214,7 +1214,7 @@ impl Context {
     pub fn block_executor_onchain_config<E: InternalError>(
         &self,
         ledger_info: &LedgerInfo,
-    ) -> Result<BlockExecutorOnchainConfig, E> {
+    ) -> Result<BlockExecutorConfigFromOnchain, E> {
         // If it's the same epoch, use the cached results
         {
             let cache = self.gas_limit_cache.read().unwrap();
@@ -1303,7 +1303,7 @@ pub struct GasEstimationCache {
 
 pub struct GasLimitCache {
     last_updated_epoch: Option<u64>,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
 }
 
 /// This function just calls tokio::task::spawn_blocking with the given closure and in

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -35,7 +35,7 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     account_address::{create_multisig_account_address, AccountAddress},
     aggregate_signature::AggregateSignature,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
@@ -614,7 +614,7 @@ impl TestContext {
             .execute_block(
                 (metadata.id(), into_signature_verified_block(txns.clone())).into(),
                 parent_id,
-                BlockExecutorOnchainConfig::new_no_block_limit(),
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
             )
             .unwrap();
         let mut compute_status = result.compute_status().clone();

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -35,6 +35,7 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     account_address::{create_multisig_account_address, AccountAddress},
     aggregate_signature::AggregateSignature,
+    block_executor::config::BlockExecutorOnchainConfig,
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
@@ -613,7 +614,7 @@ impl TestContext {
             .execute_block(
                 (metadata.id(), into_signature_verified_block(txns.clone())).into(),
                 parent_id,
-                None,
+                BlockExecutorOnchainConfig::new_no_block_limit(),
             )
             .unwrap();
         let mut compute_status = result.compute_status().clone();

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -11,6 +11,7 @@ use aptos_rest_client::Client;
 use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
+    block_executor::config::BlockExecutorOnchainConfig,
     chain_id::ChainId,
     on_chain_config::{Features, OnChainConfig, TimedFeaturesBuilder},
     transaction::{
@@ -59,8 +60,12 @@ impl AptosDebugger {
         let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
             txns.into_iter().map(|x| x.into()).collect::<Vec<_>>();
         let state_view = DebuggerStateView::new(self.debugger.clone(), version);
-        AptosVM::execute_block(&sig_verified_txns, &state_view, None)
-            .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
+        AptosVM::execute_block(
+            &sig_verified_txns,
+            &state_view,
+            BlockExecutorOnchainConfig::new_no_block_limit(),
+        )
+        .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
     }
 
     pub fn execute_transaction_at_version_with_gas_profiler(

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -11,7 +11,7 @@ use aptos_rest_client::Client;
 use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
     on_chain_config::{Features, OnChainConfig, TimedFeaturesBuilder},
     transaction::{
@@ -63,7 +63,7 @@ impl AptosDebugger {
         AptosVM::execute_block(
             &sig_verified_txns,
             &state_view,
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
     }

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -14,7 +14,7 @@ use aptos_language_e2e_tests::{
 };
 use aptos_types::{
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorOnchainConfig},
+        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain},
         partitioner::PartitionedTransactions,
     },
     block_metadata::BlockMetadata,
@@ -243,7 +243,7 @@ where
                 self.state_view.clone(),
                 transactions,
                 concurrency_level_per_shard,
-                BlockExecutorOnchainConfig::new_maybe_block_limit(maybe_block_gas_limit),
+                BlockExecutorConfigFromOnchain::new_maybe_block_limit(maybe_block_gas_limit),
             )
             .expect("VM should not fail to start");
         let exec_time = timer.elapsed().as_millis();

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -13,7 +13,10 @@ use aptos_language_e2e_tests::{
     executor::FakeExecutor,
 };
 use aptos_types::{
-    block_executor::partitioner::PartitionedTransactions,
+    block_executor::{
+        config::{BlockExecutorConfig, BlockExecutorOnchainConfig},
+        partitioner::PartitionedTransactions,
+    },
     block_metadata::BlockMetadata,
     on_chain_config::{OnChainConfig, ValidatorSet},
     transaction::{
@@ -215,8 +218,7 @@ where
             Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             self.state_view.as_ref(),
-            1,
-            maybe_block_gas_limit,
+            BlockExecutorConfig::new_maybe_block_limit(1, maybe_block_gas_limit),
             None,
         )
         .expect("VM should not fail to start");
@@ -241,7 +243,7 @@ where
                 self.state_view.clone(),
                 transactions,
                 concurrency_level_per_shard,
-                maybe_block_gas_limit,
+                BlockExecutorOnchainConfig::new_maybe_block_limit(maybe_block_gas_limit),
             )
             .expect("VM should not fail to start");
         let exec_time = timer.elapsed().as_millis();
@@ -264,8 +266,10 @@ where
             Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             self.state_view.as_ref(),
-            concurrency_level_per_shard,
-            maybe_block_gas_limit,
+            BlockExecutorConfig::new_maybe_block_limit(
+                concurrency_level_per_shard,
+                maybe_block_gas_limit,
+            ),
             None,
         )
         .expect("VM should not fail to start");

--- a/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use aptos_language_e2e_tests::{account::AccountData, data_store::FakeDataStore};
 use aptos_types::{
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
     write_set::WriteSet,
 };
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     let res = AptosVM::execute_block(
         &txns,
         &state_store,
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )?;
     for i in 0..NUM_TXNS {
         assert!(res[i as usize].status().status().unwrap().is_success());

--- a/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use aptos_language_e2e_tests::{account::AccountData, data_store::FakeDataStore};
 use aptos_types::{
+    block_executor::config::BlockExecutorOnchainConfig,
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
     write_set::WriteSet,
 };
@@ -48,7 +49,11 @@ fn main() -> Result<()> {
         })
         .collect();
 
-    let res = AptosVM::execute_block(&txns, &state_store, None)?;
+    let res = AptosVM::execute_block(
+        &txns,
+        &state_store,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
+    )?;
     for i in 0..NUM_TXNS {
         assert!(res[i as usize].status().status().unwrap().is_success());
     }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -29,7 +29,10 @@ use aptos_state_view::StateView;
 use aptos_types::{
     account_config,
     account_config::new_block_event_key,
-    block_executor::partitioner::PartitionedTransactions,
+    block_executor::{
+        config::{BlockExecutorConfig, BlockExecutorLocalConfig, BlockExecutorOnchainConfig},
+        partitioner::PartitionedTransactions,
+    },
     block_metadata::BlockMetadata,
     fee_statement::FeeStatement,
     on_chain_config::{new_epoch_event_key, FeatureFlag, TimedFeatureOverride},
@@ -1803,7 +1806,7 @@ impl VMExecutor for AptosVM {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         fail_point!("move_adapter::execute_block", |_| {
             Err(VMStatus::error(
@@ -1826,8 +1829,12 @@ impl VMExecutor for AptosVM {
             Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             state_view,
-            Self::get_concurrency_level(),
-            maybe_block_gas_limit,
+            BlockExecutorConfig {
+                local: BlockExecutorLocalConfig {
+                    concurrency_level: Self::get_concurrency_level(),
+                },
+                onchain: onchain_config,
+            },
             None,
         );
         if ret.is_ok() {
@@ -1841,7 +1848,7 @@ impl VMExecutor for AptosVM {
         sharded_block_executor: &ShardedBlockExecutor<S, C>,
         transactions: PartitionedTransactions,
         state_view: Arc<S>,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
         info!(
@@ -1855,7 +1862,7 @@ impl VMExecutor for AptosVM {
             state_view,
             transactions,
             AptosVM::get_concurrency_level(),
-            maybe_block_gas_limit,
+            onchain_config,
         );
         if ret.is_ok() {
             // Record the histogram count for transactions per block.

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -30,7 +30,7 @@ use aptos_types::{
     account_config,
     account_config::new_block_event_key,
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorLocalConfig, BlockExecutorOnchainConfig},
+        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         partitioner::PartitionedTransactions,
     },
     block_metadata::BlockMetadata,
@@ -1806,7 +1806,7 @@ impl VMExecutor for AptosVM {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         fail_point!("move_adapter::execute_block", |_| {
             Err(VMStatus::error(
@@ -1848,7 +1848,7 @@ impl VMExecutor for AptosVM {
         sharded_block_executor: &ShardedBlockExecutor<S, C>,
         transactions: PartitionedTransactions,
         state_view: Arc<S>,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
         info!(

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -126,7 +126,7 @@ pub use crate::aptos_vm::AptosVM;
 use crate::sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor};
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::PartitionedTransactions,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, SignedTransaction,
         TransactionOutput, VMValidatorResult,
@@ -157,7 +157,7 @@ pub trait VMExecutor: Send + Sync {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 
     /// Executes a block of transactions using a sharded block executor and returns the results.
@@ -165,7 +165,7 @@ pub trait VMExecutor: Send + Sync {
         sharded_block_executor: &ShardedBlockExecutor<S, E>,
         transactions: PartitionedTransactions,
         state_view: Arc<S>,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -126,7 +126,9 @@ pub use crate::aptos_vm::AptosVM;
 use crate::sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor};
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
+    },
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, SignedTransaction,
         TransactionOutput, VMValidatorResult,
@@ -157,7 +159,7 @@ pub trait VMExecutor: Send + Sync {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 
     /// Executes a block of transactions using a sharded block executor and returns the results.
@@ -165,7 +167,7 @@ pub trait VMExecutor: Send + Sync {
         sharded_block_executor: &ShardedBlockExecutor<S, E>,
         transactions: PartitionedTransactions,
         state_view: Arc<S>,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
@@ -3,7 +3,9 @@
 
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
+    },
     transaction::TransactionOutput,
 };
 use move_core_types::vm_status::VMStatus;
@@ -41,7 +43,7 @@ pub trait ExecutorClient<S: StateView + Sync + Send + 'static>: Send + Sync {
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ShardedExecutionOutput, VMStatus>;
 
     fn shutdown(&mut self);

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
@@ -3,7 +3,8 @@
 
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::PartitionedTransactions, transaction::TransactionOutput,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    transaction::TransactionOutput,
 };
 use move_core_types::vm_status::VMStatus;
 use std::sync::Arc;
@@ -40,7 +41,7 @@ pub trait ExecutorClient<S: StateView + Sync + Send + 'static>: Send + Sync {
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ShardedExecutionOutput, VMStatus>;
 
     fn shutdown(&mut self);

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -8,7 +8,7 @@ use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{TransactionWithDependencies, GLOBAL_ROUND_ID},
     },
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
@@ -45,7 +45,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
         &self,
         transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
         state_view: &S,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         trace!("executing the last round in global executor",);
         if transactions.is_empty() {

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -7,7 +7,10 @@ use crate::sharded_block_executor::{
 use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::{TransactionWithDependencies, GLOBAL_ROUND_ID},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{TransactionWithDependencies, GLOBAL_ROUND_ID},
+    },
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
 };
 use move_core_types::vm_status::VMStatus;
@@ -42,7 +45,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
         &self,
         transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
         state_view: &S,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         trace!("executing the last round in global executor",);
         if transactions.is_empty() {
@@ -57,7 +60,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
             GLOBAL_ROUND_ID,
             state_view,
             self.concurrency_level,
-            maybe_block_gas_limit,
+            onchain_config,
         )
     }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -16,7 +16,7 @@ use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{
             PartitionedTransactions, RoundId, ShardId, GLOBAL_ROUND_ID,
             MAX_ALLOWED_PARTITIONING_ROUNDS,
@@ -185,7 +185,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ShardedExecutionOutput, VMStatus> {
         assert_eq!(transactions.num_shards(), self.num_shards());
         let (sub_blocks, global_txns) = transactions.into();

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -12,7 +12,10 @@ use crate::sharded_block_executor::{
 use aptos_logger::info;
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::{PartitionedTransactions, SubBlocksForShard},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{PartitionedTransactions, SubBlocksForShard},
+    },
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
 };
 use move_core_types::vm_status::VMStatus;
@@ -42,7 +45,7 @@ pub enum ExecutorShardCommand<S> {
         Arc<S>,
         SubBlocksForShard<AnalyzedTransaction>,
         usize,
-        Option<u64>,
+        BlockExecutorOnchainConfig,
     ),
     Stop,
 }
@@ -70,7 +73,7 @@ impl<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>> ShardedBlockExe
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let _timer = SHARDED_BLOCK_EXECUTION_SECONDS.start_timer();
         let num_executor_shards = self.executor_client.num_shards();
@@ -87,7 +90,7 @@ impl<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>> ShardedBlockExe
                 state_view,
                 transactions,
                 concurrency_level_per_shard,
-                maybe_block_gas_limit,
+                onchain_config,
             )?
             .into_inner();
         // wait for all remote executors to send the result back and append them in order by shard id

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -13,7 +13,7 @@ use aptos_logger::info;
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{PartitionedTransactions, SubBlocksForShard},
     },
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
@@ -45,7 +45,7 @@ pub enum ExecutorShardCommand<S> {
         Arc<S>,
         SubBlocksForShard<AnalyzedTransaction>,
         usize,
-        BlockExecutorOnchainConfig,
+        BlockExecutorConfigFromOnchain,
     ),
     Stop,
 }
@@ -73,7 +73,7 @@ impl<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>> ShardedBlockExe
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let _timer = SHARDED_BLOCK_EXECUTION_SECONDS.start_timer();
         let num_executor_shards = self.executor_client.num_shards();

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -19,7 +19,7 @@ use aptos_logger::{info, trace};
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorLocalConfig, BlockExecutorOnchainConfig},
+        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         partitioner::{ShardId, SubBlock, SubBlocksForShard, TransactionWithDependencies},
     },
     transaction::{
@@ -72,7 +72,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         round: usize,
         state_view: &S,
         concurrency_level: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         disable_speculative_logging();
         trace!(
@@ -104,7 +104,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         round: usize,
         state_view: &S,
         concurrency_level: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let (callback, callback_receiver) = oneshot::channel();
 
@@ -179,7 +179,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         transactions: SubBlocksForShard<AnalyzedTransaction>,
         state_view: &S,
         concurrency_level: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<Vec<TransactionOutput>>, VMStatus> {
         let mut result = vec![];
         for (round, sub_block) in transactions.into_sub_blocks().into_iter().enumerate() {

--- a/aptos-move/aptos-vm/tests/sharded_block_executor.rs
+++ b/aptos-move/aptos-vm/tests/sharded_block_executor.rs
@@ -193,7 +193,7 @@ mod test_utils {
     };
     use aptos_types::{
         block_executor::{
-            config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions,
+            config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         },
         transaction::{
             analyzed_transaction::AnalyzedTransaction,
@@ -298,7 +298,7 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns.clone(),
                 2,
-                BlockExecutorOnchainConfig::new_no_block_limit(),
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
             )
             .unwrap();
 
@@ -310,7 +310,7 @@ mod test_utils {
         let unsharded_txn_output = AptosVM::execute_block(
             &ordered_txns,
             executor.data_store(),
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
@@ -356,14 +356,14 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns,
                 concurrency,
-                BlockExecutorOnchainConfig::new_no_block_limit(),
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
             )
             .unwrap();
 
         let unsharded_txn_output = AptosVM::execute_block(
             &execution_ordered_txns,
             executor.data_store(),
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
@@ -413,14 +413,14 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns,
                 concurrency,
-                BlockExecutorOnchainConfig::new_no_block_limit(),
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
             )
             .unwrap();
 
         let unsharded_txn_output = AptosVM::execute_block(
             &execution_ordered_txns,
             executor.data_store(),
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);

--- a/aptos-move/aptos-vm/tests/sharded_block_executor.rs
+++ b/aptos-move/aptos-vm/tests/sharded_block_executor.rs
@@ -192,7 +192,9 @@ mod test_utils {
         executor::FakeExecutor,
     };
     use aptos_types::{
-        block_executor::partitioner::PartitionedTransactions,
+        block_executor::{
+            config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions,
+        },
         transaction::{
             analyzed_transaction::AnalyzedTransaction,
             signature_verified_transaction::SignatureVerifiedTransaction, Transaction,
@@ -296,7 +298,7 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns.clone(),
                 2,
-                None,
+                BlockExecutorOnchainConfig::new_no_block_limit(),
             )
             .unwrap();
 
@@ -305,8 +307,12 @@ mod test_utils {
                 .into_iter()
                 .map(|t| t.into_txn())
                 .collect();
-        let unsharded_txn_output =
-            AptosVM::execute_block(&ordered_txns, executor.data_store(), None).unwrap();
+        let unsharded_txn_output = AptosVM::execute_block(
+            &ordered_txns,
+            executor.data_store(),
+            BlockExecutorOnchainConfig::new_no_block_limit(),
+        )
+        .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }
 
@@ -350,12 +356,16 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns,
                 concurrency,
-                None,
+                BlockExecutorOnchainConfig::new_no_block_limit(),
             )
             .unwrap();
 
-        let unsharded_txn_output =
-            AptosVM::execute_block(&execution_ordered_txns, executor.data_store(), None).unwrap();
+        let unsharded_txn_output = AptosVM::execute_block(
+            &execution_ordered_txns,
+            executor.data_store(),
+            BlockExecutorOnchainConfig::new_no_block_limit(),
+        )
+        .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }
 
@@ -403,12 +413,16 @@ mod test_utils {
                 Arc::new(executor.data_store().clone()),
                 partitioned_txns,
                 concurrency,
-                None,
+                BlockExecutorOnchainConfig::new_no_block_limit(),
             )
             .unwrap();
 
-        let unsharded_txn_output =
-            AptosVM::execute_block(&execution_ordered_txns, executor.data_store(), None).unwrap();
+        let unsharded_txn_output = AptosVM::execute_block(
+            &execution_ordered_txns,
+            executor.data_store(),
+            BlockExecutorOnchainConfig::new_no_block_limit(),
+        )
+        .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -32,6 +32,7 @@ use aptos_mvhashmap::{
 use aptos_state_view::TStateView;
 use aptos_types::{
     aggregator::PanicError,
+    block_executor::config::BlockExecutorConfig,
     contract_event::TransactionEvent,
     executable::Executable,
     fee_statement::FeeStatement,
@@ -74,20 +75,19 @@ where
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
     pub fn new(
-        concurrency_level: usize,
+        config: BlockExecutorConfig,
         executor_thread_pool: Arc<ThreadPool>,
-        maybe_block_gas_limit: Option<u64>,
         transaction_commit_hook: Option<L>,
     ) -> Self {
         assert!(
-            concurrency_level > 0 && concurrency_level <= num_cpus::get(),
+            config.local.concurrency_level > 0 && config.local.concurrency_level <= num_cpus::get(),
             "Parallel execution concurrency level {} should be between 1 and number of CPUs",
-            concurrency_level
+            config.local.concurrency_level
         );
         Self {
-            concurrency_level,
+            concurrency_level: config.local.concurrency_level,
             executor_thread_pool,
-            maybe_block_gas_limit,
+            maybe_block_gas_limit: config.onchain.block_gas_limit_type.block_gas_limit(),
             transaction_commit_hook,
             phantom: PhantomData,
         }

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -13,7 +13,10 @@ use crate::{
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
-use aptos_types::{contract_event::TransactionEvent, executable::ExecutableTestType};
+use aptos_types::{
+    block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
+    executable::ExecutableTestType,
+};
 use criterion::{BatchSize, Bencher as CBencher};
 use num_cpus;
 use proptest::{
@@ -125,13 +128,14 @@ where
                 .unwrap(),
         );
 
+        let config = BlockExecutorConfig::new_no_block_limit(num_cpus::get());
         let output = BlockExecutor::<
             MockTransaction<KeyType<K>, E>,
             MockTask<KeyType<K>, E>,
             EmptyDataView<KeyType<K>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
-        >::new(num_cpus::get(), executor_thread_pool, None, None)
+        >::new(config, executor_thread_pool, None)
         .execute_transactions_parallel((), &self.transactions, &data_view);
 
         self.baseline_output.assert_output(&output);

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -16,7 +16,10 @@ use crate::{
     txn_commit_hook::NoOpTransactionCommitHook,
 };
 use aptos_aggregator::types::PanicOr;
-use aptos_types::{contract_event::TransactionEvent, executable::ExecutableTestType};
+use aptos_types::{
+    block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
+    executable::ExecutableTestType,
+};
 use claims::assert_ok;
 use num_cpus;
 use proptest::{
@@ -76,9 +79,8 @@ fn run_transactions<K, V, E>(
             NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
         >::new(
-            num_cpus::get(),
+            BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
-            maybe_block_gas_limit,
             None,
         )
         .execute_transactions_parallel((), &transactions, &data_view);
@@ -216,9 +218,8 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
-            num_cpus::get(),
+            BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
-            maybe_block_gas_limit,
             None,
         )
         .execute_transactions_parallel((), &transactions, &data_view);
@@ -267,9 +268,8 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
-            num_cpus::get(),
+            BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
-            maybe_block_gas_limit,
             None,
         )
         .execute_transactions_parallel((), &transactions, &data_view);
@@ -423,9 +423,8 @@ fn publishing_fixed_params_with_block_gas_limit(
         NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
         ExecutableTestType,
     >::new(
-        num_cpus::get(),
+        BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
         executor_thread_pool,
-        maybe_block_gas_limit,
         None,
     )
     .execute_transactions_parallel((), &transactions, &data_view);
@@ -466,9 +465,11 @@ fn publishing_fixed_params_with_block_gas_limit(
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
         >::new(
-            num_cpus::get(),
+            BlockExecutorConfig::new_maybe_block_limit(
+                num_cpus::get(),
+                Some(max(w_index, r_index) as u64 * MAX_GAS_PER_TXN + 1),
+            ),
             executor_thread_pool.clone(),
-            Some(max(w_index, r_index) as u64 * MAX_GAS_PER_TXN + 1),
             None,
         ) // Ensure enough gas limit to commit the module txns (4 is maximum gas per txn)
         .execute_transactions_parallel((), &transactions, &data_view);
@@ -550,7 +551,11 @@ fn non_empty_group(
             NonEmptyGroupDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
-        >::new(num_cpus::get(), executor_thread_pool.clone(), None, None)
+        >::new(
+            BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
+            executor_thread_pool.clone(),
+            None,
+        )
         .execute_transactions_parallel((), &transactions, &data_view);
 
         BaselineOutput::generate(&transactions, None).assert_output(&output);
@@ -563,7 +568,11 @@ fn non_empty_group(
             NonEmptyGroupDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
-        >::new(num_cpus::get(), executor_thread_pool.clone(), None, None)
+        >::new(
+            BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
+            executor_thread_pool.clone(),
+            None,
+        )
         .execute_transactions_sequential((), &transactions, &data_view, true);
         // TODO: test dynamic disabled as well.
 

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -23,6 +23,7 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
+    block_executor::config::BlockExecutorConfig,
     contract_event::TransactionEvent,
     executable::{ExecutableTestType, ModulePath},
 };
@@ -55,7 +56,11 @@ where
         DeltaDataView<K>,
         NoOpTransactionCommitHook<MockOutput<K, E>, usize>,
         ExecutableTestType,
-    >::new(num_cpus::get(), executor_thread_pool, None, None)
+    >::new(
+        BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
+        executor_thread_pool,
+        None,
+    )
     .execute_transactions_parallel((), &transactions, &data_view);
 
     let baseline = BaselineOutput::generate(&transactions, None);

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -33,11 +33,15 @@ use aptos_types::{
         new_block_event_key, AccountResource, CoinInfoResource, CoinStoreResource, NewBlockEvent,
         CORE_CODE_ADDRESS,
     },
+    block_executor::config::{
+        BlockExecutorConfig, BlockExecutorLocalConfig, BlockExecutorOnchainConfig,
+    },
     block_metadata::BlockMetadata,
     chain_id::ChainId,
     contract_event::ContractEvent,
     on_chain_config::{
-        Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder, ValidatorSet, Version,
+        BlockGasLimitType, Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder,
+        ValidatorSet, Version,
     },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -465,13 +469,18 @@ impl FakeExecutor {
     pub fn execute_transaction_block_parallel(
         &self,
         txn_block: &[SignatureVerifiedTransaction],
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         BlockAptosVM::execute_block::<_, NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>>(
             self.executor_thread_pool.clone(),
             txn_block,
             &self.data_store,
-            usize::min(4, num_cpus::get()),
-            None,
+            BlockExecutorConfig {
+                local: BlockExecutorLocalConfig {
+                    concurrency_level: usize::min(4, num_cpus::get()),
+                },
+                onchain: onchain_config,
+            },
             None,
         )
     }
@@ -503,18 +512,23 @@ impl FakeExecutor {
             }
         });
 
+        let onchain_config = BlockExecutorOnchainConfig {
+            // TODO fetch values from state?
+            block_gas_limit_type: BlockGasLimitType::Limit(30000),
+        };
+
         let sequential_output = if mode != ExecutorMode::ParallelOnly {
             Some(AptosVM::execute_block(
                 &sig_verified_block,
                 &self.data_store,
-                None,
+                onchain_config.clone(),
             ))
         } else {
             None
         };
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
-            Some(self.execute_transaction_block_parallel(&sig_verified_block))
+            Some(self.execute_transaction_block_parallel(&sig_verified_block, onchain_config))
         } else {
             None
         };

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -34,7 +34,7 @@ use aptos_types::{
         CORE_CODE_ADDRESS,
     },
     block_executor::config::{
-        BlockExecutorConfig, BlockExecutorLocalConfig, BlockExecutorOnchainConfig,
+        BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig,
     },
     block_metadata::BlockMetadata,
     chain_id::ChainId,
@@ -469,7 +469,7 @@ impl FakeExecutor {
     pub fn execute_transaction_block_parallel(
         &self,
         txn_block: &[SignatureVerifiedTransaction],
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         BlockAptosVM::execute_block::<_, NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>>(
             self.executor_thread_pool.clone(),
@@ -512,7 +512,7 @@ impl FakeExecutor {
             }
         });
 
-        let onchain_config = BlockExecutorOnchainConfig {
+        let onchain_config = BlockExecutorConfigFromOnchain {
             // TODO fetch values from state?
             block_gas_limit_type: BlockGasLimitType::Limit(30000),
         };

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -377,9 +377,9 @@ impl Block {
         &self,
         validators: &[AccountAddress],
         txns: Vec<SignedTransaction>,
-        block_gas_limit: Option<u64>,
+        is_block_gas_limit: bool,
     ) -> Vec<Transaction> {
-        if block_gas_limit.is_some() {
+        if is_block_gas_limit {
             // After the per-block gas limit change, StateCheckpoint txn
             // is inserted after block execution
             once(Transaction::BlockMetadata(

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -115,7 +115,7 @@ impl ExecutedBlock {
         &self,
         validators: &[AccountAddress],
         txns: Vec<SignedTransaction>,
-        block_gas_limit: Option<u64>,
+        is_block_gas_limit: bool,
     ) -> Vec<Transaction> {
         // reconfiguration suffix don't execute
 
@@ -125,8 +125,8 @@ impl ExecutedBlock {
 
         let mut txns_with_state_checkpoint =
             self.block
-                .transactions_to_execute(validators, txns, block_gas_limit);
-        if block_gas_limit.is_some() && !self.state_compute_result.has_reconfiguration() {
+                .transactions_to_execute(validators, txns, is_block_gas_limit);
+        if is_block_gas_limit && !self.state_compute_result.has_reconfiguration() {
             // After the per-block gas limit change,
             // insert state checkpoint at the position
             // 1) after last txn if there is no Retry

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -735,14 +735,15 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     ) {
         let transaction_shuffler =
             create_transaction_shuffler(onchain_execution_config.transaction_shuffler_type());
-        let block_gas_limit = onchain_execution_config.block_gas_limit();
+        let block_executor_onchain_config =
+            onchain_execution_config.block_executor_onchain_config();
         let transaction_deduper =
             create_transaction_deduper(onchain_execution_config.transaction_deduper_type());
         self.commit_state_computer.new_epoch(
             epoch_state,
             payload_manager,
             transaction_shuffler,
-            block_gas_limit,
+            block_executor_onchain_config,
             transaction_deduper,
         );
     }

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -12,7 +12,7 @@ use aptos_executor_types::{
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::{debug, error};
 use aptos_types::{
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock},
+    block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
 };
 use fail::fail_point;
@@ -57,7 +57,7 @@ impl ExecutionPipeline {
         block_id: HashValue,
         parent_block_id: HashValue,
         txns_to_execute: Vec<Transaction>,
-        block_executor_onchain_config: BlockExecutorOnchainConfig,
+        block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     ) -> StateComputeResultFut {
         let (result_tx, result_rx) = oneshot::channel();
         self.prepare_block_tx
@@ -208,7 +208,7 @@ impl ExecutionPipeline {
 struct PrepareBlockCommand {
     block_id: HashValue,
     txns_to_execute: Vec<Transaction>,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     // The parent block id.
     parent_block_id: HashValue,
     result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
@@ -217,7 +217,7 @@ struct PrepareBlockCommand {
 struct ExecuteBlockCommand {
     block: ExecutableBlock,
     parent_block_id: HashValue,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
 }
 

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -12,7 +12,7 @@ use aptos_executor_types::{
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::{debug, error};
 use aptos_types::{
-    block_executor::partitioner::ExecutableBlock,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock},
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
 };
 use fail::fail_point;
@@ -57,14 +57,14 @@ impl ExecutionPipeline {
         block_id: HashValue,
         parent_block_id: HashValue,
         txns_to_execute: Vec<Transaction>,
-        maybe_block_gas_limit: Option<u64>,
+        block_executor_onchain_config: BlockExecutorOnchainConfig,
     ) -> StateComputeResultFut {
         let (result_tx, result_rx) = oneshot::channel();
         self.prepare_block_tx
             .send(PrepareBlockCommand {
                 block_id,
                 txns_to_execute,
-                maybe_block_gas_limit,
+                block_executor_onchain_config,
                 parent_block_id,
                 result_tx,
             })
@@ -89,7 +89,7 @@ impl ExecutionPipeline {
         while let Some(PrepareBlockCommand {
             block_id,
             txns_to_execute,
-            maybe_block_gas_limit,
+            block_executor_onchain_config,
             parent_block_id,
             result_tx,
         }) = prepare_block_rx.recv().await
@@ -118,7 +118,7 @@ impl ExecutionPipeline {
                 .send(ExecuteBlockCommand {
                     block: (block_id, sig_verified_txns).into(),
                     parent_block_id,
-                    maybe_block_gas_limit,
+                    block_executor_onchain_config,
                     result_tx,
                 })
                 .expect("Failed to send block to execution pipeline.");
@@ -133,7 +133,7 @@ impl ExecutionPipeline {
         while let Some(ExecuteBlockCommand {
             block,
             parent_block_id,
-            maybe_block_gas_limit,
+            block_executor_onchain_config,
             result_tx,
         }) = block_rx.recv().await
         {
@@ -151,7 +151,7 @@ impl ExecutionPipeline {
                     executor.execute_and_state_checkpoint(
                         block,
                         parent_block_id,
-                        maybe_block_gas_limit,
+                        block_executor_onchain_config,
                     )
                 })
                 .await
@@ -208,7 +208,7 @@ impl ExecutionPipeline {
 struct PrepareBlockCommand {
     block_id: HashValue,
     txns_to_execute: Vec<Transaction>,
-    maybe_block_gas_limit: Option<u64>,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
     // The parent block id.
     parent_block_id: HashValue,
     result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
@@ -217,7 +217,7 @@ struct PrepareBlockCommand {
 struct ExecuteBlockCommand {
     block: ExecutableBlock,
     parent_block_id: HashValue,
-    maybe_block_gas_limit: Option<u64>,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
     result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
 }
 

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -18,7 +18,10 @@ use aptos_consensus_types::{block::Block, executed_block::ExecutedBlock};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorResult, StateComputeResult};
 use aptos_logger::prelude::*;
-use aptos_types::{epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures};
+use aptos_types::{
+    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+};
 use async_trait::async_trait;
 use fail::fail_point;
 use futures::{
@@ -128,7 +131,7 @@ impl StateComputer for OrderingStateComputer {
         _: &EpochState,
         _payload_manager: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: Option<u64>,
+        _: BlockExecutorOnchainConfig,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -195,7 +198,7 @@ impl StateComputer for DagStateSyncComputer {
         _epoch_state: &EpochState,
         _payload_manager: Arc<PayloadManager>,
         _transaction_shuffler: Arc<dyn TransactionShuffler>,
-        _block_gas_limit: Option<u64>,
+        _block_executor_onchain_config: BlockExecutorOnchainConfig,
         _transaction_deduper: Arc<dyn TransactionDeduper>,
     ) {
         unimplemented!("method not supported");

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -19,7 +19,7 @@ use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorResult, StateComputeResult};
 use aptos_logger::prelude::*;
 use aptos_types::{
-    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
 };
 use async_trait::async_trait;
@@ -131,7 +131,7 @@ impl StateComputer for OrderingStateComputer {
         _: &EpochState,
         _payload_manager: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: BlockExecutorOnchainConfig,
+        _: BlockExecutorConfigFromOnchain,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -198,7 +198,7 @@ impl StateComputer for DagStateSyncComputer {
         _epoch_state: &EpochState,
         _payload_manager: Arc<PayloadManager>,
         _transaction_shuffler: Arc<dyn TransactionShuffler>,
-        _block_executor_onchain_config: BlockExecutorOnchainConfig,
+        _block_executor_onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_deduper: Arc<dyn TransactionDeduper>,
     ) {
         unimplemented!("method not supported");

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -23,7 +23,7 @@ use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResul
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    account_address::AccountAddress, block_executor::config::BlockExecutorOnchainConfig,
+    account_address::AccountAddress, block_executor::config::BlockExecutorConfigFromOnchain,
     contract_event::ContractEvent, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
     on_chain_config::OnChainExecutionConfig, transaction::Transaction,
 };
@@ -63,7 +63,7 @@ pub struct ExecutionProxy {
     write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
-    block_executor_onchain_config: Mutex<BlockExecutorOnchainConfig>,
+    block_executor_onchain_config: Mutex<BlockExecutorConfigFromOnchain>,
     transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
     transaction_filter: TransactionFilter,
     execution_pipeline: ExecutionPipeline,
@@ -326,7 +326,7 @@ impl StateComputer for ExecutionProxy {
         epoch_state: &EpochState,
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
-        block_executor_onchain_config: BlockExecutorOnchainConfig,
+        block_executor_onchain_config: BlockExecutorConfigFromOnchain,
         transaction_deduper: Arc<dyn TransactionDeduper>,
     ) {
         *self.validators.lock() = epoch_state
@@ -384,7 +384,7 @@ async fn test_commit_sync_race() {
             &self,
             _block: ExecutableBlock,
             _parent_block_id: HashValue,
-            _onchain_config: BlockExecutorOnchainConfig,
+            _onchain_config: BlockExecutorConfigFromOnchain,
         ) -> ExecutorResult<StateComputeResult> {
             Ok(StateComputeResult::new_dummy())
         }
@@ -393,7 +393,7 @@ async fn test_commit_sync_race() {
             &self,
             _block: ExecutableBlock,
             _parent_block_id: HashValue,
-            _onchain_config: BlockExecutorOnchainConfig,
+            _onchain_config: BlockExecutorConfigFromOnchain,
         ) -> ExecutorResult<StateCheckpointOutput> {
             todo!()
         }
@@ -485,7 +485,7 @@ async fn test_commit_sync_race() {
         &EpochState::empty(),
         Arc::new(PayloadManager::DirectMempool),
         create_transaction_shuffler(TransactionShufflerType::NoShuffling),
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
         create_transaction_deduper(TransactionDeduperType::NoDedup),
     );
     executor

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -23,8 +23,9 @@ use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResul
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    account_address::AccountAddress, contract_event::ContractEvent, epoch_state::EpochState,
-    ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
+    account_address::AccountAddress, block_executor::config::BlockExecutorOnchainConfig,
+    contract_event::ContractEvent, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    on_chain_config::OnChainExecutionConfig, transaction::Transaction,
 };
 use fail::fail_point;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
@@ -62,7 +63,7 @@ pub struct ExecutionProxy {
     write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
-    maybe_block_gas_limit: Mutex<Option<u64>>,
+    block_executor_onchain_config: Mutex<BlockExecutorOnchainConfig>,
     transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
     transaction_filter: TransactionFilter,
     execution_pipeline: ExecutionPipeline,
@@ -101,7 +102,9 @@ impl ExecutionProxy {
             write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
             payload_manager: Mutex::new(None),
             transaction_shuffler: Mutex::new(None),
-            maybe_block_gas_limit: Mutex::new(None),
+            block_executor_onchain_config: Mutex::new(
+                OnChainExecutionConfig::default_if_missing().block_executor_onchain_config(),
+            ),
             transaction_deduper: Mutex::new(None),
             transaction_filter: txn_filter,
             execution_pipeline,
@@ -141,14 +144,14 @@ impl StateComputer for ExecutionProxy {
         let deduped_txns = txn_deduper.dedup(filtered_txns);
         let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
 
-        let maybe_block_gas_limit = *self.maybe_block_gas_limit.lock();
+        let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
 
         // TODO: figure out error handling for the prologue txn
         let timestamp = block.timestamp_usecs();
         let transactions_to_execute = block.transactions_to_execute(
             &self.validators.lock(),
             shuffled_txns.clone(),
-            maybe_block_gas_limit,
+            block_executor_onchain_config.has_any_block_gas_limit(),
         );
 
         let fut = self
@@ -157,7 +160,7 @@ impl StateComputer for ExecutionProxy {
                 block_id,
                 parent_block_id,
                 transactions_to_execute,
-                maybe_block_gas_limit,
+                block_executor_onchain_config.clone(),
             )
             .await;
 
@@ -174,7 +177,7 @@ impl StateComputer for ExecutionProxy {
                 .notify_failed_txn(
                     shuffled_txns,
                     &compute_result,
-                    maybe_block_gas_limit.is_some(),
+                    block_executor_onchain_config.has_any_block_gas_limit(),
                 )
                 .await
             {
@@ -210,7 +213,7 @@ impl StateComputer for ExecutionProxy {
         let txn_deduper = self.transaction_deduper.lock().as_ref().unwrap().clone();
         let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
 
-        let block_gas_limit = *self.maybe_block_gas_limit.lock();
+        let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
 
         for block in blocks {
             block_ids.push(block.id());
@@ -229,7 +232,7 @@ impl StateComputer for ExecutionProxy {
             txns.extend(block.transactions_to_commit(
                 &self.validators.lock(),
                 shuffled_txns,
-                block_gas_limit,
+                block_executor_onchain_config.has_any_block_gas_limit(),
             ));
             reconfig_events.extend(block.reconfig_event());
         }
@@ -323,7 +326,7 @@ impl StateComputer for ExecutionProxy {
         epoch_state: &EpochState,
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
-        block_gas_limit: Option<u64>,
+        block_executor_onchain_config: BlockExecutorOnchainConfig,
         transaction_deduper: Arc<dyn TransactionDeduper>,
     ) {
         *self.validators.lock() = epoch_state
@@ -334,7 +337,7 @@ impl StateComputer for ExecutionProxy {
         self.transaction_shuffler
             .lock()
             .replace(transaction_shuffler);
-        *self.maybe_block_gas_limit.lock() = block_gas_limit;
+        *self.block_executor_onchain_config.lock() = block_executor_onchain_config;
         self.transaction_deduper.lock().replace(transaction_deduper);
     }
 
@@ -381,7 +384,7 @@ async fn test_commit_sync_race() {
             &self,
             _block: ExecutableBlock,
             _parent_block_id: HashValue,
-            _maybe_block_gas_limit: Option<u64>,
+            _onchain_config: BlockExecutorOnchainConfig,
         ) -> ExecutorResult<StateComputeResult> {
             Ok(StateComputeResult::new_dummy())
         }
@@ -390,7 +393,7 @@ async fn test_commit_sync_race() {
             &self,
             _block: ExecutableBlock,
             _parent_block_id: HashValue,
-            _maybe_block_gas_limit: Option<u64>,
+            _onchain_config: BlockExecutorOnchainConfig,
         ) -> ExecutorResult<StateCheckpointOutput> {
             todo!()
         }
@@ -482,7 +485,7 @@ async fn test_commit_sync_race() {
         &EpochState::empty(),
         Arc::new(PayloadManager::DirectMempool),
         create_transaction_shuffler(TransactionShufflerType::NoShuffling),
-        None,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
         create_transaction_deduper(TransactionDeduperType::NoDedup),
     );
     executor

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -17,7 +17,10 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorResult, StateComputeResult};
-use aptos_types::{epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures};
+use aptos_types::{
+    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+};
 use futures::future::BoxFuture;
 use std::{sync::Arc, time::Duration};
 
@@ -91,7 +94,7 @@ pub trait StateComputer: Send + Sync {
         epoch_state: &EpochState,
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
-        block_gas_limit: Option<u64>,
+        block_executor_onchain_config: BlockExecutorOnchainConfig,
         transaction_deduper: Arc<dyn TransactionDeduper>,
     );
 

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -18,7 +18,7 @@ use aptos_consensus_types::{
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorResult, StateComputeResult};
 use aptos_types::{
-    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
 };
 use futures::future::BoxFuture;
@@ -94,7 +94,7 @@ pub trait StateComputer: Send + Sync {
         epoch_state: &EpochState,
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
-        block_executor_onchain_config: BlockExecutorOnchainConfig,
+        block_executor_onchain_config: BlockExecutorConfigFromOnchain,
         transaction_deduper: Arc<dyn TransactionDeduper>,
     );
 

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -19,7 +19,8 @@ use aptos_executor_types::{ExecutorError, ExecutorResult, StateComputeResult};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures, transaction::SignedTransaction,
+    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures, transaction::SignedTransaction,
 };
 use futures::{channel::mpsc, SinkExt};
 use futures_channel::mpsc::UnboundedSender;
@@ -140,7 +141,7 @@ impl StateComputer for MockStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: Option<u64>,
+        _: BlockExecutorOnchainConfig,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -178,7 +179,7 @@ impl StateComputer for EmptyStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: Option<u64>,
+        _: BlockExecutorOnchainConfig,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -241,7 +242,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: Option<u64>,
+        _: BlockExecutorOnchainConfig,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -19,7 +19,7 @@ use aptos_executor_types::{ExecutorError, ExecutorResult, StateComputeResult};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    block_executor::config::BlockExecutorOnchainConfig, epoch_state::EpochState,
+    block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures, transaction::SignedTransaction,
 };
 use futures::{channel::mpsc, SinkExt};
@@ -141,7 +141,7 @@ impl StateComputer for MockStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: BlockExecutorOnchainConfig,
+        _: BlockExecutorConfigFromOnchain,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -179,7 +179,7 @@ impl StateComputer for EmptyStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: BlockExecutorOnchainConfig,
+        _: BlockExecutorConfigFromOnchain,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }
@@ -242,7 +242,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         _: &EpochState,
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
-        _: BlockExecutorOnchainConfig,
+        _: BlockExecutorConfigFromOnchain,
         _: Arc<dyn TransactionDeduper>,
     ) {
     }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_benchmark() {
+    fn test_benchmark_default() {
         test_generic_benchmark::<AptosVM>(None, true);
     }
 

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -13,7 +13,7 @@ use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{deposit::DepositEvent, withdraw::WithdrawEvent},
-    block_executor::partitioner::ExecutableTransactions,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableTransactions},
     contract_event::ContractEvent,
     event::EventKey,
     state_store::state_key::StateKey,
@@ -339,7 +339,7 @@ impl TransactionBlockExecutor for NativeExecutor {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ChunkOutput> {
         let transactions = match transactions {
             ExecutableTransactions::Unsharded(txns) => txns,

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -13,7 +13,7 @@ use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{deposit::DepositEvent, withdraw::WithdrawEvent},
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableTransactions},
+    block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableTransactions},
     contract_event::ContractEvent,
     event::EventKey,
     state_store::state_key::StateKey,
@@ -339,7 +339,7 @@ impl TransactionBlockExecutor for NativeExecutor {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ChunkOutput> {
         let transactions = match transactions {
             ExecutableTransactions::Unsharded(txns) => txns,

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -7,10 +7,19 @@ use aptos_crypto::hash::HashValue;
 use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_logger::info;
-use aptos_types::block_executor::partitioner::ExecutableBlock;
+use aptos_types::block_executor::{
+    config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock,
+};
 use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
+};
+
+pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorOnchainConfig =
+    BlockExecutorOnchainConfig {
+    block_gas_limit_type:
+        // present, but large to not limit blocks
+        aptos_types::on_chain_config::BlockGasLimitType::Limit(1_000_000_000),
 };
 
 pub struct TransactionExecutor<V> {
@@ -57,10 +66,19 @@ where
         let num_txns = executable_block.transactions.num_transactions();
         let output = self
             .executor
-            .execute_and_state_checkpoint(executable_block, self.parent_block_id, None)
+            .execute_and_state_checkpoint(
+                executable_block,
+                self.parent_block_id,
+                BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+            )
             .unwrap();
 
-        assert_eq!(output.txn_statuses().len(), num_txns);
+        let diff = if BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
+            1
+        } else {
+            0
+        };
+        assert_eq!(output.txn_statuses().len(), num_txns + diff);
 
         let msg = LedgerUpdateMessage {
             current_block_start_time,

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -8,15 +8,15 @@ use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_logger::info;
 use aptos_types::block_executor::{
-    config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock,
+    config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock,
 };
 use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
 };
 
-pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorOnchainConfig =
-    BlockExecutorOnchainConfig {
+pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
+    BlockExecutorConfigFromOnchain {
     block_gas_limit_type:
         // present, but large to not limit blocks
         aptos_types::on_chain_config::BlockGasLimitType::Limit(1_000_000_000),

--- a/execution/executor-service/src/lib.rs
+++ b/execution/executor-service/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ShardId, SubBlocksForShard},
     },
     state_store::{state_key::StateKey, state_value::StateValue},
@@ -48,7 +48,7 @@ pub enum RemoteExecutionRequest {
 pub struct ExecuteBlockCommand {
     pub(crate) sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub(crate) concurrency_level: usize,
-    pub(crate) onchain_config: BlockExecutorOnchainConfig,
+    pub(crate) onchain_config: BlockExecutorConfigFromOnchain,
 }
 
 impl ExecuteBlockCommand {
@@ -57,7 +57,7 @@ impl ExecuteBlockCommand {
     ) -> (
         SubBlocksForShard<AnalyzedTransaction>,
         usize,
-        BlockExecutorOnchainConfig,
+        BlockExecutorConfigFromOnchain,
     ) {
         (self.sub_blocks, self.concurrency_level, self.onchain_config)
     }

--- a/execution/executor-service/src/lib.rs
+++ b/execution/executor-service/src/lib.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 use aptos_types::{
-    block_executor::partitioner::{ShardId, SubBlocksForShard},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ShardId, SubBlocksForShard},
+    },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
     vm_status::VMStatus,
@@ -45,16 +48,18 @@ pub enum RemoteExecutionRequest {
 pub struct ExecuteBlockCommand {
     pub(crate) sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub(crate) concurrency_level: usize,
-    pub(crate) maybe_block_gas_limit: Option<u64>,
+    pub(crate) onchain_config: BlockExecutorOnchainConfig,
 }
 
 impl ExecuteBlockCommand {
-    pub fn into(self) -> (SubBlocksForShard<AnalyzedTransaction>, usize, Option<u64>) {
-        (
-            self.sub_blocks,
-            self.concurrency_level,
-            self.maybe_block_gas_limit,
-        )
+    pub fn into(
+        self,
+    ) -> (
+        SubBlocksForShard<AnalyzedTransaction>,
+        usize,
+        BlockExecutorOnchainConfig,
+    ) {
+        (self.sub_blocks, self.concurrency_level, self.onchain_config)
     }
 }
 

--- a/execution/executor-service/src/remote_cordinator_client.rs
+++ b/execution/executor-service/src/remote_cordinator_client.rs
@@ -98,12 +98,12 @@ impl CoordinatorClient<RemoteStateViewClient> for RemoteCoordinatorClient {
                         self.state_view_client.init_for_block(state_keys);
                         drop(init_prefetch_timer);
 
-                        let (sub_blocks, concurrency, gas_limit) = command.into();
+                        let (sub_blocks, concurrency, onchain_config) = command.into();
                         ExecutorShardCommand::ExecuteSubBlocks(
                             self.state_view_client.clone(),
                             sub_blocks,
                             concurrency,
-                            gas_limit,
+                            onchain_config,
                         )
                     },
                 }

--- a/execution/executor-service/src/remote_executor_client.rs
+++ b/execution/executor-service/src/remote_executor_client.rs
@@ -10,7 +10,8 @@ use aptos_secure_net::network_controller::{Message, NetworkController};
 use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
-    block_executor::partitioner::PartitionedTransactions, transaction::TransactionOutput,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    transaction::TransactionOutput,
     vm_status::VMStatus,
 };
 use aptos_vm::sharded_block_executor::{
@@ -180,7 +181,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for RemoteExecutorC
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ShardedExecutionOutput, VMStatus> {
         trace!("RemoteExecutorClient Sending block to shards");
         self.state_view_service.set_state_view(state_view);
@@ -193,7 +194,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for RemoteExecutorC
             let execution_request = RemoteExecutionRequest::ExecuteBlock(ExecuteBlockCommand {
                 sub_blocks,
                 concurrency_level: concurrency_level_per_shard,
-                maybe_block_gas_limit,
+                onchain_config: onchain_config.clone(),
             });
 
             senders[shard_id]

--- a/execution/executor-service/src/remote_executor_client.rs
+++ b/execution/executor-service/src/remote_executor_client.rs
@@ -10,7 +10,9 @@ use aptos_secure_net::network_controller::{Message, NetworkController};
 use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
+    },
     transaction::TransactionOutput,
     vm_status::VMStatus,
 };
@@ -181,7 +183,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for RemoteExecutorC
         state_view: Arc<S>,
         transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ShardedExecutionOutput, VMStatus> {
         trace!("RemoteExecutorClient Sending block to shards");
         self.state_view_service.set_state_view(state_view);

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -7,7 +7,7 @@ use aptos_language_e2e_tests::{
 };
 use aptos_types::{
     account_address::AccountAddress,
-    block_executor::partitioner::PartitionedTransactions,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
     state_store::state_key::StateKeyInner,
     transaction::{
         analyzed_transaction::AnalyzedTransaction,
@@ -125,7 +125,7 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
             Arc::new(executor.data_store().clone()),
             partitioned_txns.clone(),
             2,
-            None,
+            BlockExecutorOnchainConfig::new_no_block_limit(),
         )
         .unwrap();
     let txns: Vec<SignatureVerifiedTransaction> =
@@ -133,7 +133,12 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
             .into_iter()
             .map(|t| t.into_txn())
             .collect();
-    let unsharded_txn_output = AptosVM::execute_block(&txns, executor.data_store(), None).unwrap();
+    let unsharded_txn_output = AptosVM::execute_block(
+        &txns,
+        executor.data_store(),
+        BlockExecutorOnchainConfig::new_no_block_limit(),
+    )
+    .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     sharded_block_executor.shutdown();
 }
@@ -182,12 +187,16 @@ pub fn sharded_block_executor_with_conflict<E: ExecutorClient<FakeDataStore>>(
             Arc::new(executor.data_store().clone()),
             partitioned_txns,
             concurrency,
-            None,
+            BlockExecutorOnchainConfig::new_no_block_limit(),
         )
         .unwrap();
 
-    let unsharded_txn_output =
-        AptosVM::execute_block(&execution_ordered_txns, executor.data_store(), None).unwrap();
+    let unsharded_txn_output = AptosVM::execute_block(
+        &execution_ordered_txns,
+        executor.data_store(),
+        BlockExecutorOnchainConfig::new_no_block_limit(),
+    )
+    .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     sharded_block_executor.shutdown();
 }

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -7,7 +7,9 @@ use aptos_language_e2e_tests::{
 };
 use aptos_types::{
     account_address::AccountAddress,
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
+    },
     state_store::state_key::StateKeyInner,
     transaction::{
         analyzed_transaction::AnalyzedTransaction,
@@ -125,7 +127,7 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
             Arc::new(executor.data_store().clone()),
             partitioned_txns.clone(),
             2,
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .unwrap();
     let txns: Vec<SignatureVerifiedTransaction> =
@@ -136,7 +138,7 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
     let unsharded_txn_output = AptosVM::execute_block(
         &txns,
         executor.data_store(),
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )
     .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
@@ -187,14 +189,14 @@ pub fn sharded_block_executor_with_conflict<E: ExecutorClient<FakeDataStore>>(
             Arc::new(executor.data_store().clone()),
             partitioned_txns,
             concurrency,
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )
         .unwrap();
 
     let unsharded_txn_output = AptosVM::execute_block(
         &execution_ordered_txns,
         executor.data_store(),
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )
     .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -22,7 +22,7 @@ use aptos_types::{
     block_metadata::BlockMetadata,
     chain_id::ChainId,
     event::EventKey,
-    test_helpers::transaction_test_helpers::{block, BLOCK_GAS_LIMIT},
+    test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
     transaction::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
@@ -173,13 +173,13 @@ pub fn test_execution_with_storage_impl_inner(
             txn_factory.transfer(account3.address(), 10 * B),
         )));
     }
-    let block3 = block(block3, BLOCK_GAS_LIMIT); // append state checkpoint txn
+    let block3 = block(block3, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG); // append state checkpoint txn
 
     let output1 = executor
         .execute_block(
             (block1_id, block1.clone()).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let li1 = gen_ledger_info_with_sigs(1, &output1, block1_id, &[signer.clone()]);
@@ -386,7 +386,7 @@ pub fn test_execution_with_storage_impl_inner(
         .execute_block(
             (block2_id, block2).into(),
             epoch2_genesis_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let li2 = gen_ledger_info_with_sigs(2, &output2, block2_id, &[signer.clone()]);
@@ -405,7 +405,7 @@ pub fn test_execution_with_storage_impl_inner(
         .execute_block(
             (block3_id, block3.clone()).into(),
             epoch3_genesis_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let li3 = gen_ledger_info_with_sigs(3, &output3, block3_id, &[signer]);
@@ -450,7 +450,11 @@ pub fn test_execution_with_storage_impl_inner(
     .unwrap();
 
     // With block gas limit, StateCheckpoint txn is inserted to block after execution.
-    let diff = BLOCK_GAS_LIMIT.map(|_| 0).unwrap_or(1);
+    let diff = if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
+        0
+    } else {
+        1
+    };
 
     let transaction_list_with_proof = db
         .reader

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -11,7 +11,7 @@ use aptos_crypto::{
 };
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
 use aptos_types::{
-    block_executor::partitioner::ExecutableBlock,
+    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock},
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
@@ -138,11 +138,11 @@ pub trait BlockExecutorTrait: Send + Sync {
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> ExecutorResult<StateComputeResult> {
         let block_id = block.block_id;
         let state_checkpoint_output =
-            self.execute_and_state_checkpoint(block, parent_block_id, maybe_block_gas_limit)?;
+            self.execute_and_state_checkpoint(block, parent_block_id, onchain_config)?;
         self.ledger_update(block_id, parent_block_id, state_checkpoint_output)
     }
 
@@ -151,7 +151,7 @@ pub trait BlockExecutorTrait: Send + Sync {
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> ExecutorResult<StateCheckpointOutput>;
 
     fn ledger_update(

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -11,7 +11,7 @@ use aptos_crypto::{
 };
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
 use aptos_types::{
-    block_executor::{config::BlockExecutorOnchainConfig, partitioner::ExecutableBlock},
+    block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
@@ -138,7 +138,7 @@ pub trait BlockExecutorTrait: Send + Sync {
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> ExecutorResult<StateComputeResult> {
         let block_id = block.block_id;
         let state_checkpoint_output =
@@ -151,7 +151,7 @@ pub trait BlockExecutorTrait: Send + Sync {
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> ExecutorResult<StateCheckpointOutput>;
 
     fn ledger_update(

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -32,7 +32,7 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ExecutableBlock, ExecutableTransactions},
     },
     ledger_info::LedgerInfoWithSignatures,
@@ -46,7 +46,7 @@ pub trait TransactionBlockExecutor: Send + Sync {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ChunkOutput>;
 }
 
@@ -54,7 +54,7 @@ impl TransactionBlockExecutor for AptosVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ChunkOutput> {
         ChunkOutput::by_transaction_execution::<AptosVM>(transactions, state_view, onchain_config)
     }
@@ -114,7 +114,7 @@ where
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> ExecutorResult<StateCheckpointOutput> {
         self.maybe_initialize()?;
         self.inner
@@ -192,7 +192,7 @@ where
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> ExecutorResult<StateCheckpointOutput> {
         let _timer = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
         let ExecutableBlock {

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -31,7 +31,10 @@ use aptos_storage_interface::{
     async_proof_fetcher::AsyncProofFetcher, cached_state_view::CachedStateView, DbReaderWriter,
 };
 use aptos_types::{
-    block_executor::partitioner::{ExecutableBlock, ExecutableTransactions},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ExecutableBlock, ExecutableTransactions},
+    },
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValue,
 };
@@ -43,7 +46,7 @@ pub trait TransactionBlockExecutor: Send + Sync {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ChunkOutput>;
 }
 
@@ -51,13 +54,9 @@ impl TransactionBlockExecutor for AptosVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ChunkOutput> {
-        ChunkOutput::by_transaction_execution::<AptosVM>(
-            transactions,
-            state_view,
-            maybe_block_gas_limit,
-        )
+        ChunkOutput::by_transaction_execution::<AptosVM>(transactions, state_view, onchain_config)
     }
 }
 
@@ -115,14 +114,14 @@ where
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> ExecutorResult<StateCheckpointOutput> {
         self.maybe_initialize()?;
         self.inner
             .read()
             .as_ref()
             .expect("BlockExecutor is not reset")
-            .execute_and_state_checkpoint(block, parent_block_id, maybe_block_gas_limit)
+            .execute_and_state_checkpoint(block, parent_block_id, onchain_config)
     }
 
     fn ledger_update(
@@ -193,7 +192,7 @@ where
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> ExecutorResult<StateCheckpointOutput> {
         let _timer = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
         let ExecutableBlock {
@@ -246,7 +245,7 @@ where
                             "Injected error in vm_execute_block"
                         )))
                     });
-                    V::execute_transaction_block(transactions, state_view, maybe_block_gas_limit)?
+                    V::execute_transaction_block(transactions, state_view, onchain_config.clone())?
                 };
 
                 let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
@@ -256,7 +255,7 @@ where
                 THREAD_MANAGER.get_exe_cpu_pool().install(|| {
                     chunk_output.into_state_checkpoint_output(
                         parent_output.state(),
-                        maybe_block_gas_limit.map(|_| block_id),
+                        onchain_config.has_any_block_gas_limit().then_some(block_id),
                     )
                 })?
             };

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -33,7 +33,7 @@ use aptos_storage_interface::{
     state_delta::StateDelta, DbReaderWriter, ExecutedTrees,
 };
 use aptos_types::{
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{
@@ -276,7 +276,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             ChunkOutput::by_transaction_execution::<V>(
                 sig_verified_txns.into(),
                 state_view,
-                BlockExecutorOnchainConfig::new_no_block_limit(),
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
             )?
         };
 
@@ -682,7 +682,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let chunk_output = ChunkOutput::by_transaction_execution::<V>(
             txns.into(),
             state_view,
-            BlockExecutorOnchainConfig::new_no_block_limit(),
+            BlockExecutorConfigFromOnchain::new_no_block_limit(),
         )?;
         // not `zip_eq`, deliberately
         for (version, txn_out, txn_info, write_set, events) in multizip((

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -33,6 +33,7 @@ use aptos_storage_interface::{
     state_delta::StateDelta, DbReaderWriter, ExecutedTrees,
 };
 use aptos_types::{
+    block_executor::config::BlockExecutorOnchainConfig,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{
@@ -272,7 +273,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let chunk_output = {
             let _timer = APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS.start_timer();
             // State sync executor shouldn't have block gas limit.
-            ChunkOutput::by_transaction_execution::<V>(sig_verified_txns.into(), state_view, None)?
+            ChunkOutput::by_transaction_execution::<V>(
+                sig_verified_txns.into(),
+                state_view,
+                BlockExecutorOnchainConfig::new_no_block_limit(),
+            )?
         };
 
         // Calcualte state snapshot
@@ -674,8 +679,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             .collect::<Vec<SignatureVerifiedTransaction>>();
 
         // State sync executor shouldn't have block gas limit.
-        let chunk_output =
-            ChunkOutput::by_transaction_execution::<V>(txns.into(), state_view, None)?;
+        let chunk_output = ChunkOutput::by_transaction_execution::<V>(
+            txns.into(),
+            state_view,
+            BlockExecutorOnchainConfig::new_no_block_limit(),
+        )?;
         // not `zip_eq`, deliberately
         for (version, txn_out, txn_info, write_set, events) in multizip((
             begin_version..end_version,

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -20,7 +20,10 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
-    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ExecutableTransactions, PartitionedTransactions},
+    },
     contract_event::ContractEvent,
     epoch_state::EpochState,
     transaction::{
@@ -49,18 +52,14 @@ impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Self> {
         match transactions {
             ExecutableTransactions::Unsharded(txns) => {
-                Self::by_transaction_execution_unsharded::<V>(
-                    txns,
-                    state_view,
-                    maybe_block_gas_limit,
-                )
+                Self::by_transaction_execution_unsharded::<V>(txns, state_view, onchain_config)
             },
             ExecutableTransactions::Sharded(txns) => {
-                Self::by_transaction_execution_sharded::<V>(txns, state_view, maybe_block_gas_limit)
+                Self::by_transaction_execution_sharded::<V>(txns, state_view, onchain_config)
             },
         }
     }
@@ -68,10 +67,10 @@ impl ChunkOutput {
     fn by_transaction_execution_unsharded<V: VMExecutor>(
         transactions: Vec<SignatureVerifiedTransaction>,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Self> {
         let transaction_outputs =
-            Self::execute_block::<V>(&transactions, &state_view, maybe_block_gas_limit)?;
+            Self::execute_block::<V>(&transactions, &state_view, onchain_config)?;
 
         Ok(Self {
             transactions: transactions.into_iter().map(|t| t.into_inner()).collect(),
@@ -83,13 +82,13 @@ impl ChunkOutput {
     pub fn by_transaction_execution_sharded<V: VMExecutor>(
         transactions: PartitionedTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Self> {
         let state_view_arc = Arc::new(state_view);
         let transaction_outputs = Self::execute_block_sharded::<V>(
             transactions.clone(),
             state_view_arc.clone(),
-            maybe_block_gas_limit,
+            onchain_config,
         )?;
 
         // TODO(skedia) add logic to emit counters per shard instead of doing it globally.
@@ -174,21 +173,21 @@ impl ChunkOutput {
     fn execute_block_sharded<V: VMExecutor>(
         partitioned_txns: PartitionedTransactions,
         state_view: Arc<CachedStateView>,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>> {
         if !get_remote_addresses().is_empty() {
             Ok(V::execute_block_sharded(
                 REMOTE_SHARDED_BLOCK_EXECUTOR.lock().deref(),
                 partitioned_txns,
                 state_view,
-                maybe_block_gas_limit,
+                onchain_config,
             )?)
         } else {
             Ok(V::execute_block_sharded(
                 SHARDED_BLOCK_EXECUTOR.lock().deref(),
                 partitioned_txns,
                 state_view,
-                maybe_block_gas_limit,
+                onchain_config,
             )?)
         }
     }
@@ -199,13 +198,9 @@ impl ChunkOutput {
     fn execute_block<V: VMExecutor>(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>> {
-        Ok(V::execute_block(
-            transactions,
-            state_view,
-            maybe_block_gas_limit,
-        )?)
+        Ok(V::execute_block(transactions, state_view, onchain_config)?)
     }
 
     /// In consensus-only mode, executes the block of [Transaction]s using the
@@ -216,7 +211,7 @@ impl ChunkOutput {
     fn execute_block<V: VMExecutor>(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>> {
         use aptos_state_view::{StateViewId, TStateView};
         use aptos_types::write_set::WriteSet;
@@ -224,7 +219,7 @@ impl ChunkOutput {
         let transaction_outputs = match state_view.id() {
             // this state view ID implies a genesis block in non-test cases.
             StateViewId::Miscellaneous => {
-                V::execute_block(transactions, state_view, maybe_block_gas_limit)?
+                V::execute_block(transactions, state_view, onchain_config)?
             },
             _ => transactions
                 .iter()

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -21,7 +21,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ExecutableTransactions, PartitionedTransactions},
     },
     contract_event::ContractEvent,
@@ -52,7 +52,7 @@ impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Self> {
         match transactions {
             ExecutableTransactions::Unsharded(txns) => {
@@ -67,7 +67,7 @@ impl ChunkOutput {
     fn by_transaction_execution_unsharded<V: VMExecutor>(
         transactions: Vec<SignatureVerifiedTransaction>,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Self> {
         let transaction_outputs =
             Self::execute_block::<V>(&transactions, &state_view, onchain_config)?;
@@ -82,7 +82,7 @@ impl ChunkOutput {
     pub fn by_transaction_execution_sharded<V: VMExecutor>(
         transactions: PartitionedTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Self> {
         let state_view_arc = Arc::new(state_view);
         let transaction_outputs = Self::execute_block_sharded::<V>(
@@ -173,7 +173,7 @@ impl ChunkOutput {
     fn execute_block_sharded<V: VMExecutor>(
         partitioned_txns: PartitionedTransactions,
         state_view: Arc<CachedStateView>,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>> {
         if !get_remote_addresses().is_empty() {
             Ok(V::execute_block_sharded(
@@ -198,7 +198,7 @@ impl ChunkOutput {
     fn execute_block<V: VMExecutor>(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>> {
         Ok(V::execute_block(transactions, state_view, onchain_config)?)
     }
@@ -211,7 +211,7 @@ impl ChunkOutput {
     fn execute_block<V: VMExecutor>(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>> {
         use aptos_state_view::{StateViewId, TStateView};
         use aptos_types::write_set::WriteSet;

--- a/execution/executor/src/components/in_memory_state_calculator_v2.rs
+++ b/execution/executor/src/components/in_memory_state_calculator_v2.rs
@@ -454,7 +454,7 @@ impl InMemoryStateCalculatorV2 {
         for (i, (txn, txn_output)) in to_keep.iter().enumerate() {
             ensure!(
                 TransactionsWithParsedOutput::need_checkpoint(txn, txn_output) ^ (i != num_txns - 1),
-                "Checkpoint is allowed iff it's the last txn in the block. index: {i}, is_last: {}, txn: {txn:?}, is_reconfig: {}",
+                "Checkpoint is allowed iff it's the last txn in the block. index: {i}, num_txns: {num_txns}, is_last: {}, txn: {txn:?}, is_reconfig: {}",
                 i == num_txns - 1,
                 txn_output.is_reconfig()
             );

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -18,7 +18,7 @@ use aptos_types::{
     access_path::AccessPath,
     account_config::CORE_CODE_ADDRESS,
     aggregate_signature::AggregateSignature,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     block_info::{BlockInfo, GENESIS_EPOCH, GENESIS_ROUND, GENESIS_TIMESTAMP_USECS},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     on_chain_config::ConfigurationResource,
@@ -150,7 +150,7 @@ pub fn calculate_genesis<V: VMExecutor>(
     let (mut output, _, _) = ChunkOutput::by_transaction_execution::<V>(
         vec![genesis_txn.clone().into()].into(),
         base_state_view,
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )?
     .apply_to_ledger(&executed_trees, None, None)?;
     ensure!(

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -18,6 +18,7 @@ use aptos_types::{
     access_path::AccessPath,
     account_config::CORE_CODE_ADDRESS,
     aggregate_signature::AggregateSignature,
+    block_executor::config::BlockExecutorOnchainConfig,
     block_info::{BlockInfo, GENESIS_EPOCH, GENESIS_ROUND, GENESIS_TIMESTAMP_USECS},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     on_chain_config::ConfigurationResource,
@@ -149,7 +150,7 @@ pub fn calculate_genesis<V: VMExecutor>(
     let (mut output, _, _) = ChunkOutput::by_transaction_execution::<V>(
         vec![genesis_txn.clone().into()].into(),
         base_state_view,
-        None,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
     )?
     .apply_to_ledger(&executed_trees, None, None)?;
     ensure!(

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -17,7 +17,7 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ExecutableTransactions, PartitionedTransactions},
     },
     ledger_info::LedgerInfoWithSignatures,
@@ -73,7 +73,7 @@ impl TransactionBlockExecutor for FakeVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ChunkOutput> {
         ChunkOutput::by_transaction_execution::<FakeVM>(transactions, state_view, onchain_config)
     }
@@ -84,7 +84,7 @@ impl VMExecutor for FakeVM {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }
@@ -92,7 +92,7 @@ impl VMExecutor for FakeVM {
     fn execute_block(
         _transactions: &[SignatureVerifiedTransaction],
         _state_view: &impl StateView,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -16,10 +16,13 @@ use aptos_storage_interface::{
     DbReader, DbReaderWriter, DbWriter,
 };
 use aptos_types::{
-    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ExecutableTransactions, PartitionedTransactions},
+    },
     ledger_info::LedgerInfoWithSignatures,
     state_store::ShardedStateUpdates,
-    test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
+    test_helpers::transaction_test_helpers::TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
     transaction::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
@@ -55,7 +58,7 @@ pub fn fuzz_execute_and_commit_blocks(
         let _execution_results = executor.execute_block(
             (block_id, sig_verified_block).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         );
         parent_block_id = block_id;
         block_ids.push(block_id);
@@ -70,13 +73,9 @@ impl TransactionBlockExecutor for FakeVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ChunkOutput> {
-        ChunkOutput::by_transaction_execution::<FakeVM>(
-            transactions,
-            state_view,
-            maybe_block_gas_limit,
-        )
+        ChunkOutput::by_transaction_execution::<FakeVM>(transactions, state_view, onchain_config)
     }
 }
 
@@ -85,7 +84,7 @@ impl VMExecutor for FakeVM {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }
@@ -93,7 +92,7 @@ impl VMExecutor for FakeVM {
     fn execute_block(
         _transactions: &[SignatureVerifiedTransaction],
         _state_view: &impl StateView,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     bytes::NumToBytes,
     state_store::{
         state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
@@ -47,7 +47,7 @@ fn test_mock_vm_different_senders() {
     let outputs = MockVM::execute_block(
         &into_signature_verified_block(txns.clone()),
         &MockStateView,
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )
     .expect("MockVM should not fail to start");
 
@@ -87,7 +87,7 @@ fn test_mock_vm_same_sender() {
     let outputs = MockVM::execute_block(
         &into_signature_verified_block(txns),
         &MockStateView,
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )
     .expect("MockVM should not fail to start");
 
@@ -125,7 +125,7 @@ fn test_mock_vm_payment() {
     let output = MockVM::execute_block(
         &into_signature_verified_block(txns),
         &MockStateView,
-        BlockExecutorOnchainConfig::new_no_block_limit(),
+        BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )
     .expect("MockVM should not fail to start");
 

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
+    block_executor::config::BlockExecutorOnchainConfig,
     bytes::NumToBytes,
     state_store::{
         state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
@@ -46,7 +47,7 @@ fn test_mock_vm_different_senders() {
     let outputs = MockVM::execute_block(
         &into_signature_verified_block(txns.clone()),
         &MockStateView,
-        None,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
     )
     .expect("MockVM should not fail to start");
 
@@ -83,8 +84,12 @@ fn test_mock_vm_same_sender() {
         txns.push(encode_mint_transaction(sender, amount));
     }
 
-    let outputs = MockVM::execute_block(&into_signature_verified_block(txns), &MockStateView, None)
-        .expect("MockVM should not fail to start");
+    let outputs = MockVM::execute_block(
+        &into_signature_verified_block(txns),
+        &MockStateView,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
+    )
+    .expect("MockVM should not fail to start");
 
     for (i, output) in outputs.iter().enumerate() {
         assert_eq!(
@@ -117,8 +122,12 @@ fn test_mock_vm_payment() {
         encode_transfer_transaction(gen_address(0), gen_address(1), 50),
     ];
 
-    let output = MockVM::execute_block(&into_signature_verified_block(txns), &MockStateView, None)
-        .expect("MockVM should not fail to start");
+    let output = MockVM::execute_block(
+        &into_signature_verified_block(txns),
+        &MockStateView,
+        BlockExecutorOnchainConfig::new_no_block_limit(),
+    )
+    .expect("MockVM should not fail to start");
 
     let mut output_iter = output.iter();
     output_iter.next();

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -14,7 +14,10 @@ use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::CORE_CODE_ADDRESS,
-    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ExecutableTransactions, PartitionedTransactions},
+    },
     bytes::NumToBytes,
     chain_id::ChainId,
     contract_event::ContractEvent,
@@ -66,13 +69,9 @@ impl TransactionBlockExecutor for MockVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<ChunkOutput> {
-        ChunkOutput::by_transaction_execution::<MockVM>(
-            transactions,
-            state_view,
-            maybe_block_gas_limit,
-        )
+        ChunkOutput::by_transaction_execution::<MockVM>(transactions, state_view, onchain_config)
     }
 }
 
@@ -80,7 +79,7 @@ impl VMExecutor for MockVM {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &impl StateView,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
@@ -195,7 +194,7 @@ impl VMExecutor for MockVM {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> std::result::Result<Vec<TransactionOutput>, VMStatus> {
         todo!()
     }

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config::CORE_CODE_ADDRESS,
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ExecutableTransactions, PartitionedTransactions},
     },
     bytes::NumToBytes,
@@ -69,7 +69,7 @@ impl TransactionBlockExecutor for MockVM {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<ChunkOutput> {
         ChunkOutput::by_transaction_execution::<MockVM>(transactions, state_view, onchain_config)
     }
@@ -79,7 +79,7 @@ impl VMExecutor for MockVM {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &impl StateView,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
@@ -194,7 +194,7 @@ impl VMExecutor for MockVM {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> std::result::Result<Vec<TransactionOutput>, VMStatus> {
         todo!()
     }

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -17,7 +17,7 @@ use aptos_executor_types::{BlockExecutorTrait, ChunkExecutorTrait};
 use aptos_storage_interface::DbReaderWriter;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    test_helpers::transaction_test_helpers::{block, BLOCK_GAS_LIMIT},
+    test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
     transaction::TransactionListWithProof,
 };
 use rand::Rng;
@@ -235,9 +235,9 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
             .collect::<Vec<_>>();
         let output = executor
             .execute_block(
-                (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
+                (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
                 parent_block_id,
-                BLOCK_GAS_LIMIT,
+                TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
             )
             .unwrap();
         let ledger_info = tests::gen_ledger_info(5 + 1, output.root_hash(), block_id, 1);

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -24,7 +24,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     account_address::AccountAddress,
     aggregate_signature::AggregateSignature,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     block_info::BlockInfo,
     bytes::NumToBytes,
     chain_id::ChainId,
@@ -355,7 +355,7 @@ fn test_executor_execute_same_block_multiple_times() {
 
 fn ledger_version_from_block_size(
     block_size: usize,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
 ) -> usize {
     // With block gas limit, StateCheckpoint txn is inserted to block after execution.
     // So the ledger_info version needs to block_size + 1 with block gas limit.
@@ -653,7 +653,7 @@ fn test_reconfig_suffix_empty_blocks() {
         10000,
         1,
         gen_block_id(2),
-        BlockExecutorOnchainConfig::new_maybe_block_limit(Some(0)),
+        BlockExecutorConfigFromOnchain::new_maybe_block_limit(Some(0)),
     );
     let block_c = TestBlock::new(1, 1, gen_block_id(3), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
     let block_d = TestBlock::new(1, 1, gen_block_id(4), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
@@ -710,7 +710,7 @@ impl TestBlock {
         num_user_txns: u64,
         amount: u32,
         id: HashValue,
-        block_executor_onchain_config: BlockExecutorOnchainConfig,
+        block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Self {
         let txns = if num_user_txns == 0 {
             Vec::new()
@@ -734,7 +734,7 @@ impl TestBlock {
 // the root hash after all transactions are committed.
 fn run_transactions_naive(
     transactions: Vec<SignatureVerifiedTransaction>,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
 ) -> HashValue {
     let executor = TestExecutor::new();
     let db = &executor.db;

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -24,13 +24,14 @@ use aptos_storage_interface::{
 use aptos_types::{
     account_address::AccountAddress,
     aggregate_signature::AggregateSignature,
+    block_executor::config::BlockExecutorOnchainConfig,
     block_info::BlockInfo,
     bytes::NumToBytes,
     chain_id::ChainId,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::definition::LeafCount,
     state_store::{state_key::StateKey, state_value::StateValue},
-    test_helpers::transaction_test_helpers::{block, BLOCK_GAS_LIMIT},
+    test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, ExecutionStatus,
         RawTransaction, Script, SignedTransaction, Transaction, TransactionListWithProof,
@@ -53,9 +54,9 @@ fn execute_and_commit_block(
 
     let output = executor
         .execute_block(
-            (id, block(vec![txn], BLOCK_GAS_LIMIT)).into(),
+            (id, block(vec![txn], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let version = 2 * (txn_index + 1);
@@ -152,9 +153,13 @@ fn test_executor_status() {
 
     let output = executor
         .execute_block(
-            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)).into(),
+            (
+                block_id,
+                block(vec![txn0, txn1, txn2], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+            )
+                .into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 
@@ -182,9 +187,13 @@ fn test_executor_status_consensus_only() {
 
     let output = executor
         .execute_block(
-            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)).into(),
+            (
+                block_id,
+                block(vec![txn0, txn1, txn2], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+            )
+                .into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 
@@ -212,9 +221,9 @@ fn test_executor_one_block() {
         .collect::<Vec<_>>();
     let output = executor
         .execute_block(
-            (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
+            (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let version = num_user_txns + 1;
@@ -258,16 +267,24 @@ fn test_executor_two_blocks_with_failed_txns() {
         .collect::<Vec<_>>();
     let _output1 = executor
         .execute_block(
-            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)).into(),
+            (
+                block1_id,
+                block(block1_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+            )
+                .into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let output2 = executor
         .execute_block(
-            (block2_id, block(block2_txns, BLOCK_GAS_LIMIT)).into(),
+            (
+                block2_id,
+                block(block2_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+            )
+                .into(),
             block1_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 
@@ -287,9 +304,13 @@ fn test_executor_commit_twice() {
     let block1_id = gen_block_id(1);
     let output1 = executor
         .execute_block(
-            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)).into(),
+            (
+                block1_id,
+                block(block1_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+            )
+                .into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let ledger_info = gen_ledger_info(6, output1.root_hash(), block1_id, 1);
@@ -317,9 +338,13 @@ fn test_executor_execute_same_block_multiple_times() {
     for _i in 0..100 {
         let output = executor
             .execute_block(
-                (block_id, block(txns.clone(), BLOCK_GAS_LIMIT)).into(),
+                (
+                    block_id,
+                    block(txns.clone(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
+                )
+                    .into(),
                 parent_block_id,
-                BLOCK_GAS_LIMIT,
+                TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
             )
             .unwrap();
         responses.push(output);
@@ -328,10 +353,18 @@ fn test_executor_execute_same_block_multiple_times() {
     assert_eq!(responses.len(), 1);
 }
 
-fn ledger_version_from_block_size(block_size: usize, maybe_block_gas_limit: Option<u64>) -> usize {
+fn ledger_version_from_block_size(
+    block_size: usize,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
+) -> usize {
     // With block gas limit, StateCheckpoint txn is inserted to block after execution.
     // So the ledger_info version needs to block_size + 1 with block gas limit.
-    block_size + maybe_block_gas_limit.map(|_| 1).unwrap_or(0)
+    block_size
+        + if block_executor_onchain_config.has_any_block_gas_limit() {
+            1
+        } else {
+            0
+        }
 }
 
 /// Generates a list of `TransactionListWithProof`s according to the given ranges.
@@ -357,7 +390,7 @@ fn create_transaction_chunks(
         let txn = encode_mint_transaction(gen_address(i), 100);
         txns.push(txn.into());
     }
-    if BLOCK_GAS_LIMIT.is_none() {
+    if !TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
         txns.push(Transaction::StateCheckpoint(HashValue::random()).into());
     }
     let id = gen_block_id(1);
@@ -366,11 +399,12 @@ fn create_transaction_chunks(
         .execute_block(
             (id, txns.clone()).into(),
             executor.committed_block_id(),
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 
-    let ledger_version = ledger_version_from_block_size(txns.len(), BLOCK_GAS_LIMIT) as u64;
+    let ledger_version =
+        ledger_version_from_block_size(txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64;
     let ledger_info = gen_ledger_info(ledger_version, output.root_hash(), id, 1);
     executor
         .commit_blocks(vec![id], ledger_info.clone())
@@ -406,16 +440,16 @@ fn test_noop_block_after_reconfiguration() {
         .execute_block(
             (first_block_id, vec![first_txn]).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     parent_block_id = first_block_id;
-    let second_block = TestBlock::new(10, 10, gen_block_id(2), BLOCK_GAS_LIMIT);
+    let second_block = TestBlock::new(10, 10, gen_block_id(2), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
     let output2 = executor
         .execute_block(
             (second_block.id, second_block.txns).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     assert_eq!(output1.root_hash(), output2.root_hash());
@@ -608,11 +642,21 @@ fn test_reconfig_suffix_empty_blocks() {
         db: _,
         executor,
     } = TestExecutor::new();
-    let block_a = TestBlock::new(10000, 1, gen_block_id(1), BLOCK_GAS_LIMIT);
+    let block_a = TestBlock::new(
+        10000,
+        1,
+        gen_block_id(1),
+        TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+    );
     // add block gas limit to be consistent with block executor that will add state checkpoint txn
-    let mut block_b = TestBlock::new(10000, 1, gen_block_id(2), Some(0));
-    let block_c = TestBlock::new(1, 1, gen_block_id(3), BLOCK_GAS_LIMIT);
-    let block_d = TestBlock::new(1, 1, gen_block_id(4), BLOCK_GAS_LIMIT);
+    let mut block_b = TestBlock::new(
+        10000,
+        1,
+        gen_block_id(2),
+        BlockExecutorOnchainConfig::new_maybe_block_limit(Some(0)),
+    );
+    let block_c = TestBlock::new(1, 1, gen_block_id(3), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+    let block_d = TestBlock::new(1, 1, gen_block_id(4), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
     block_b
         .txns
         .push(encode_reconfiguration_transaction().into());
@@ -621,28 +665,28 @@ fn test_reconfig_suffix_empty_blocks() {
         .execute_block(
             (block_a.id, block_a.txns).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let output = executor
         .execute_block(
             (block_b.id, block_b.txns).into(),
             block_a.id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     executor
         .execute_block(
             (block_c.id, block_c.txns).into(),
             block_b.id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     executor
         .execute_block(
             (block_d.id, block_d.txns).into(),
             block_c.id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 
@@ -666,7 +710,7 @@ impl TestBlock {
         num_user_txns: u64,
         amount: u32,
         id: HashValue,
-        maybe_block_gas_limit: Option<u64>,
+        block_executor_onchain_config: BlockExecutorOnchainConfig,
     ) -> Self {
         let txns = if num_user_txns == 0 {
             Vec::new()
@@ -675,7 +719,7 @@ impl TestBlock {
                 (0..num_user_txns)
                     .map(|index| encode_mint_transaction(gen_address(index), u64::from(amount)))
                     .collect(),
-                maybe_block_gas_limit,
+                block_executor_onchain_config,
             )
         };
         TestBlock { txns, id }
@@ -690,7 +734,7 @@ impl TestBlock {
 // the root hash after all transactions are committed.
 fn run_transactions_naive(
     transactions: Vec<SignatureVerifiedTransaction>,
-    maybe_block_gas_limit: Option<u64>,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
 ) -> HashValue {
     let executor = TestExecutor::new();
     let db = &executor.db;
@@ -706,7 +750,7 @@ fn run_transactions_naive(
                     Arc::new(AsyncProofFetcher::new(db.reader.clone())),
                 )
                 .unwrap(),
-            maybe_block_gas_limit,
+            block_executor_onchain_config.clone(),
         )
         .unwrap();
         let (executed, _, _) = out.apply_to_ledger(&ledger_view, None, None).unwrap();
@@ -758,13 +802,13 @@ proptest! {
             let executor = TestExecutor::new();
 
             let block_id = gen_block_id(1);
-            let mut block = TestBlock::new(num_user_txns, 10, block_id, BLOCK_GAS_LIMIT);
+            let mut block = TestBlock::new(num_user_txns, 10, block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
             let num_txns = block.txns.len() as LeafCount;
             block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction().into();
 
             let parent_block_id = executor.committed_block_id();
             let output = executor.execute_block(
-                (block_id, block.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT
+                (block_id, block.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
             ).unwrap();
 
             // assert: txns after the reconfiguration are with status "Retry"
@@ -783,11 +827,11 @@ proptest! {
             // retry txns after reconfiguration
             let retry_block_id = gen_block_id(2);
             let retry_output = executor.execute_block(
-                (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect::<Vec<SignatureVerifiedTransaction>>()).into(), parent_block_id, BLOCK_GAS_LIMIT
+                (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect::<Vec<SignatureVerifiedTransaction>>()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
             ).unwrap();
             prop_assert!(retry_output.compute_status().iter().all(|s| matches!(*s, TransactionStatus::Keep(_))));
 
-            let ledger_version = ledger_version_from_block_size(num_txns as usize, BLOCK_GAS_LIMIT) as u64;
+            let ledger_version = ledger_version_from_block_size(num_txns as usize, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64;
 
             // commit
             let ledger_info = gen_ledger_info(ledger_version, retry_output.root_hash(), retry_block_id, 12345 /* timestamp */);
@@ -819,8 +863,8 @@ proptest! {
     fn test_executor_restart(a_size in 1..30u64, b_size in 1..30u64, amount in any::<u32>()) {
         let TestExecutor { _path, db, executor } = TestExecutor::new();
 
-        let block_a = TestBlock::new(a_size, amount, gen_block_id(1), BLOCK_GAS_LIMIT);
-        let block_b = TestBlock::new(b_size, amount, gen_block_id(2), BLOCK_GAS_LIMIT);
+        let block_a = TestBlock::new(a_size, amount, gen_block_id(1), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+        let block_b = TestBlock::new(b_size, amount, gen_block_id(2), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
 
         let mut parent_block_id;
         let mut root_hash;
@@ -829,10 +873,10 @@ proptest! {
         {
             parent_block_id = executor.committed_block_id();
             let output_a = executor.execute_block(
-                (block_a.id, block_a.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT
+                (block_a.id, block_a.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
             ).unwrap();
             root_hash = output_a.root_hash();
-            let ledger_info = gen_ledger_info(ledger_version_from_block_size(block_a.txns.len(), BLOCK_GAS_LIMIT) as u64, root_hash, block_a.id, 1);
+            let ledger_info = gen_ledger_info(ledger_version_from_block_size(block_a.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64, root_hash, block_a.id, 1);
             executor.commit_blocks(vec![block_a.id], ledger_info).unwrap();
             parent_block_id = block_a.id;
             drop(executor);
@@ -841,10 +885,10 @@ proptest! {
         // Now we construct a new executor and run one more block.
         {
             let executor = BlockExecutor::<MockVM>::new(db);
-            let output_b = executor.execute_block((block_b.id, block_b.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT).unwrap();
+            let output_b = executor.execute_block((block_b.id, block_b.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG).unwrap();
             root_hash = output_b.root_hash();
             let ledger_info = gen_ledger_info(
-                (ledger_version_from_block_size(block_a.txns.len(), BLOCK_GAS_LIMIT) + ledger_version_from_block_size(block_b.txns.len(), BLOCK_GAS_LIMIT)) as u64,
+                (ledger_version_from_block_size(block_a.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) + ledger_version_from_block_size(block_b.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)) as u64,
                 root_hash,
                 block_b.id,
                 2,
@@ -855,15 +899,15 @@ proptest! {
         let expected_root_hash = run_transactions_naive({
             let mut txns = vec![];
             txns.extend(block_a.txns.iter().cloned());
-            if BLOCK_GAS_LIMIT.is_some() {
+            if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
                 txns.push(Transaction::StateCheckpoint(block_a.id).into());
             }
             txns.extend(block_b.txns.iter().cloned());
-            if BLOCK_GAS_LIMIT.is_some() {
+            if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
                 txns.push(Transaction::StateCheckpoint(block_b.id).into());
             }
             txns
-        }, BLOCK_GAS_LIMIT);
+        }, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
         prop_assert_eq!(root_hash, expected_root_hash);
     }
 }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -30,7 +30,7 @@ use aptos_types::{
     event::EventHandle,
     on_chain_config::{access_path_for_config, ConfigurationResource, OnChainConfig, ValidatorSet},
     state_store::state_key::StateKey,
-    test_helpers::transaction_test_helpers::{block, BLOCK_GAS_LIMIT},
+    test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
     trusted_state::TrustedState,
     validator_signer::ValidatorSigner,
@@ -89,9 +89,9 @@ fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter, signer: &Vali
     let executor = BlockExecutor::<AptosVM>::new(db.clone());
     let output = executor
         .execute_block(
-            (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
+            (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
             executor.committed_block_id(),
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     assert_eq!(output.num_leaves(), target_version + 1);

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -19,7 +19,7 @@ use aptos_types::{
     account_view::AccountView,
     block_metadata::BlockMetadata,
     state_store::state_key::StateKey,
-    test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
+    test_helpers::transaction_test_helpers::TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
     transaction::{
         signature_verified_transaction::into_signature_verified_block, Transaction, WriteSetPayload,
     },
@@ -148,7 +148,7 @@ fn test_reconfiguration() {
         .execute_block(
             (block_id, txn_block.clone()).into(),
             parent_block_id,
-            BLOCK_GAS_LIMIT,
+            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
 

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -30,7 +30,10 @@ use aptos_metrics_core::TimerHelper;
 use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
-    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
+    block_executor::{
+        config::BlockExecutorOnchainConfig,
+        partitioner::{ExecutableTransactions, PartitionedTransactions},
+    },
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, TransactionOutput,
     },
@@ -48,7 +51,7 @@ impl VMExecutor for PtxBlockExecutor {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let _timer = TIMER.timer_with(&["block_total"]);
 
@@ -104,7 +107,7 @@ impl VMExecutor for PtxBlockExecutor {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _maybe_block_gas_limit: Option<u64>,
+        _onchain_config: BlockExecutorOnchainConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         unimplemented!()
     }
@@ -114,12 +117,12 @@ impl TransactionBlockExecutor for PtxBlockExecutor {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        maybe_block_gas_limit: Option<u64>,
+        onchain_config: BlockExecutorOnchainConfig,
     ) -> anyhow::Result<ChunkOutput> {
         ChunkOutput::by_transaction_execution::<PtxBlockExecutor>(
             transactions,
             state_view,
-            maybe_block_gas_limit,
+            onchain_config,
         )
     }
 }

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -31,7 +31,7 @@ use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorOnchainConfig,
+        config::BlockExecutorConfigFromOnchain,
         partitioner::{ExecutableTransactions, PartitionedTransactions},
     },
     transaction::{
@@ -51,7 +51,7 @@ impl VMExecutor for PtxBlockExecutor {
     fn execute_block(
         transactions: &[SignatureVerifiedTransaction],
         state_view: &(impl StateView + Sync),
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let _timer = TIMER.timer_with(&["block_total"]);
 
@@ -107,7 +107,7 @@ impl VMExecutor for PtxBlockExecutor {
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
         _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
-        _onchain_config: BlockExecutorOnchainConfig,
+        _onchain_config: BlockExecutorConfigFromOnchain,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         unimplemented!()
     }
@@ -117,7 +117,7 @@ impl TransactionBlockExecutor for PtxBlockExecutor {
     fn execute_transaction_block(
         transactions: ExecutableTransactions,
         state_view: CachedStateView,
-        onchain_config: BlockExecutorOnchainConfig,
+        onchain_config: BlockExecutorConfigFromOnchain,
     ) -> anyhow::Result<ChunkOutput> {
         ChunkOutput::by_transaction_execution::<PtxBlockExecutor>(
             transactions,

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -3,17 +3,20 @@
 use crate::on_chain_config::BlockGasLimitType;
 use serde::{Deserialize, Serialize};
 
+/// Local, per-node configuration.
 #[derive(Clone, Debug)]
 pub struct BlockExecutorLocalConfig {
     pub concurrency_level: usize,
 }
 
+/// Configuration from on-chain configuration, that is
+/// required to be the same across all nodes.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BlockExecutorOnchainConfig {
+pub struct BlockExecutorConfigFromOnchain {
     pub block_gas_limit_type: BlockGasLimitType,
 }
 
-impl BlockExecutorOnchainConfig {
+impl BlockExecutorConfigFromOnchain {
     pub fn new_no_block_limit() -> Self {
         Self {
             block_gas_limit_type: BlockGasLimitType::NoLimit,
@@ -32,17 +35,21 @@ impl BlockExecutorOnchainConfig {
     }
 }
 
+/// Configuration for the BlockExecutor.
 #[derive(Clone, Debug)]
 pub struct BlockExecutorConfig {
+    /// Local, per-node configuration.
     pub local: BlockExecutorLocalConfig,
-    pub onchain: BlockExecutorOnchainConfig,
+    /// Configuration from on-chain configuration, that is
+    /// required to be the same across all nodes.
+    pub onchain: BlockExecutorConfigFromOnchain,
 }
 
 impl BlockExecutorConfig {
     pub fn new_no_block_limit(concurrency_level: usize) -> Self {
         Self {
             local: BlockExecutorLocalConfig { concurrency_level },
-            onchain: BlockExecutorOnchainConfig::new_no_block_limit(),
+            onchain: BlockExecutorConfigFromOnchain::new_no_block_limit(),
         }
     }
 
@@ -52,7 +59,7 @@ impl BlockExecutorConfig {
     ) -> Self {
         Self {
             local: BlockExecutorLocalConfig { concurrency_level },
-            onchain: BlockExecutorOnchainConfig::new_maybe_block_limit(maybe_block_gas_limit),
+            onchain: BlockExecutorConfigFromOnchain::new_maybe_block_limit(maybe_block_gas_limit),
         }
     }
 }

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -1,0 +1,58 @@
+// Copyright © Aptos Foundation
+
+use crate::on_chain_config::BlockGasLimitType;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug)]
+pub struct BlockExecutorLocalConfig {
+    pub concurrency_level: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BlockExecutorOnchainConfig {
+    pub block_gas_limit_type: BlockGasLimitType,
+}
+
+impl BlockExecutorOnchainConfig {
+    pub fn new_no_block_limit() -> Self {
+        Self {
+            block_gas_limit_type: BlockGasLimitType::NoLimit,
+        }
+    }
+
+    pub fn new_maybe_block_limit(maybe_block_gas_limit: Option<u64>) -> Self {
+        Self {
+            block_gas_limit_type: maybe_block_gas_limit
+                .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+        }
+    }
+
+    pub fn has_any_block_gas_limit(&self) -> bool {
+        self.block_gas_limit_type.block_gas_limit().is_some()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BlockExecutorConfig {
+    pub local: BlockExecutorLocalConfig,
+    pub onchain: BlockExecutorOnchainConfig,
+}
+
+impl BlockExecutorConfig {
+    pub fn new_no_block_limit(concurrency_level: usize) -> Self {
+        Self {
+            local: BlockExecutorLocalConfig { concurrency_level },
+            onchain: BlockExecutorOnchainConfig::new_no_block_limit(),
+        }
+    }
+
+    pub fn new_maybe_block_limit(
+        concurrency_level: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Self {
+        Self {
+            local: BlockExecutorLocalConfig { concurrency_level },
+            onchain: BlockExecutorOnchainConfig::new_maybe_block_limit(maybe_block_gas_limit),
+        }
+    }
+}

--- a/types/src/block_executor/mod.rs
+++ b/types/src/block_executor/mod.rs
@@ -2,4 +2,5 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod config;
 pub mod partitioner;

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{block_executor::config::BlockExecutorOnchainConfig, on_chain_config::OnChainConfig};
+use crate::{
+    block_executor::config::BlockExecutorConfigFromOnchain, on_chain_config::OnChainConfig,
+};
 use anyhow::{format_err, Result};
 use serde::{Deserialize, Serialize};
 
@@ -43,8 +45,8 @@ impl OnChainExecutionConfig {
         }
     }
 
-    pub fn block_executor_onchain_config(&self) -> BlockExecutorOnchainConfig {
-        BlockExecutorOnchainConfig {
+    pub fn block_executor_onchain_config(&self) -> BlockExecutorConfigFromOnchain {
+        BlockExecutorConfigFromOnchain {
             block_gas_limit_type: self.block_gas_limit_type(),
         }
     }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::on_chain_config::OnChainConfig;
+use crate::{block_executor::config::BlockExecutorOnchainConfig, on_chain_config::OnChainConfig};
 use anyhow::{format_err, Result};
 use serde::{Deserialize, Serialize};
 
@@ -30,12 +30,22 @@ impl OnChainExecutionConfig {
     }
 
     /// The per-block gas limit being used.
-    pub fn block_gas_limit(&self) -> Option<u64> {
+    pub fn block_gas_limit_type(&self) -> BlockGasLimitType {
         match &self {
-            OnChainExecutionConfig::Missing => None,
-            OnChainExecutionConfig::V1(_config) => None,
-            OnChainExecutionConfig::V2(config) => config.block_gas_limit,
-            OnChainExecutionConfig::V3(config) => config.block_gas_limit,
+            OnChainExecutionConfig::Missing => BlockGasLimitType::NoLimit,
+            OnChainExecutionConfig::V1(_config) => BlockGasLimitType::NoLimit,
+            OnChainExecutionConfig::V2(config) => config
+                .block_gas_limit
+                .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+            OnChainExecutionConfig::V3(config) => config
+                .block_gas_limit
+                .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+        }
+    }
+
+    pub fn block_executor_onchain_config(&self) -> BlockExecutorOnchainConfig {
+        BlockExecutorOnchainConfig {
+            block_gas_limit_type: self.block_gas_limit_type(),
         }
     }
 
@@ -118,6 +128,21 @@ pub enum TransactionDeduperType {
     TxnHashAndAuthenticatorV1,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum BlockGasLimitType {
+    NoLimit,
+    Limit(u64),
+}
+
+impl BlockGasLimitType {
+    pub fn block_gas_limit(&self) -> Option<u64> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(limit) => Some(*limit),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -167,7 +192,10 @@ mod test {
             result.transaction_shuffler_type(),
             TransactionShufflerType::SenderAwareV2(32)
         ));
-        assert!(result.block_gas_limit() == Some(rand_gas_limit));
+        assert_eq!(
+            result.block_gas_limit_type(),
+            BlockGasLimitType::Limit(rand_gas_limit)
+        );
 
         // V2 test with no per-block gas limit
         let config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
@@ -181,7 +209,7 @@ mod test {
             result.transaction_shuffler_type(),
             TransactionShufflerType::SenderAwareV2(32)
         ));
-        assert!(result.block_gas_limit().is_none());
+        assert_eq!(result.block_gas_limit_type(), BlockGasLimitType::NoLimit);
     }
 
     #[test]
@@ -226,7 +254,10 @@ mod test {
             result.transaction_shuffler_type(),
             TransactionShufflerType::SenderAwareV2(32)
         ));
-        assert!(result.block_gas_limit() == Some(rand_gas_limit));
+        assert_eq!(
+            result.block_gas_limit_type(),
+            BlockGasLimitType::Limit(rand_gas_limit)
+        );
 
         // V2 test with no per-block gas limit
         let execution_config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
@@ -248,6 +279,6 @@ mod test {
             result.transaction_shuffler_type(),
             TransactionShufflerType::SenderAwareV2(32)
         ));
-        assert!(result.block_gas_limit().is_none());
+        assert_eq!(result.block_gas_limit_type(), BlockGasLimitType::NoLimit);
     }
 }

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -41,8 +41,8 @@ pub use self::{
         ProposerAndVoterConfig, ProposerElectionType,
     },
     execution_config::{
-        ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig, TransactionDeduperType,
-        TransactionShufflerType,
+        BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig,
+        TransactionDeduperType, TransactionShufflerType,
     },
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures, TimedFeaturesBuilder},

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -4,7 +4,9 @@
 
 use crate::{
     account_address::AccountAddress,
+    block_executor::config::BlockExecutorOnchainConfig,
     chain_id::ChainId,
+    on_chain_config::BlockGasLimitType,
     transaction::{
         authenticator::AccountAuthenticator,
         signature_verified_transaction::{
@@ -19,9 +21,11 @@ use aptos_crypto::{ed25519::*, traits::*, HashValue};
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TEST_GAS_PRICE: u64 = 100;
 
-// The block gas limit parameter for executor tests
-pub const BLOCK_GAS_LIMIT: Option<u64> = Some(1000);
-// pub const BLOCK_GAS_LIMIT: Option<u64> = None;
+// The block executor onchain config (gas limit parameters) for executor tests
+pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorOnchainConfig =
+    BlockExecutorOnchainConfig {
+        block_gas_limit_type: BlockGasLimitType::Limit(1000),
+    };
 
 static EMPTY_SCRIPT: &[u8] = include_bytes!("empty_script.mv");
 
@@ -249,9 +253,9 @@ pub fn get_test_txn_with_chain_id(
 
 pub fn block(
     mut user_txns: Vec<Transaction>,
-    maybe_block_gas_limit: Option<u64>,
+    block_executor_onchain_config: BlockExecutorOnchainConfig,
 ) -> Vec<SignatureVerifiedTransaction> {
-    if maybe_block_gas_limit.is_none() {
+    if !block_executor_onchain_config.has_any_block_gas_limit() {
         user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
     }
     into_signature_verified_block(user_txns)

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     account_address::AccountAddress,
-    block_executor::config::BlockExecutorOnchainConfig,
+    block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
     on_chain_config::BlockGasLimitType,
     transaction::{
@@ -22,8 +22,8 @@ const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TEST_GAS_PRICE: u64 = 100;
 
 // The block executor onchain config (gas limit parameters) for executor tests
-pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorOnchainConfig =
-    BlockExecutorOnchainConfig {
+pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
+    BlockExecutorConfigFromOnchain {
         block_gas_limit_type: BlockGasLimitType::Limit(1000),
     };
 
@@ -253,7 +253,7 @@ pub fn get_test_txn_with_chain_id(
 
 pub fn block(
     mut user_txns: Vec<Transaction>,
-    block_executor_onchain_config: BlockExecutorOnchainConfig,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
 ) -> Vec<SignatureVerifiedTransaction> {
     if !block_executor_onchain_config.has_any_block_gas_limit() {
         user_txns.push(Transaction::StateCheckpoint(HashValue::random()));


### PR DESCRIPTION
As we add more complexities to block gas limit, and if we want to add other onchain configs to BlockExecutor (or other local configs other than concurrency_level) - it is much cleaner to not need to change the whole codebase every time, but pass a BlockExecutorConfig / BlockExecutorOnchainConfig instead, and modify inside only.

Should have no behavior change