### PR TITLE
Use async dropper to drop block executor data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-drop-helper",
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
+aptos-drop-helper = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1118,6 +1118,7 @@ where
             }
         });
         drop(timer);
+        // Explicit async drops.
         DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
         let (_, _, maybe_error) = shared_commit_state.into_inner();
         match maybe_error {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -21,6 +21,7 @@ use aptos_aggregator::{
     delta_change_set::serialize,
     types::{code_invariant_error, expect_ok, PanicOr},
 };
+use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_logger::{debug, error, info};
 use aptos_mvhashmap::{
     types::{Incarnation, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
@@ -1117,13 +1118,7 @@ where
             }
         });
         drop(timer);
-        self.executor_thread_pool.spawn(move || {
-            // Explicit async drops.
-            drop(last_input_output);
-            drop(scheduler);
-            // TODO: re-use the code cache.
-            drop(versioned_cache);
-        });
+        DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
         let (_, _, maybe_error) = shared_commit_state.into_inner();
         match maybe_error {
             Some(err) => Err(err),


### PR DESCRIPTION
### Description

We observed the drop is pretty expensive, doing this in the executor thread can potentially block execution. Use the async dropper instead so that drop can happen in a lower priority thread. 

### Test Plan

Existing UTs