### PR TITLE
[DRAFT][pangu] update cpu/mem of running testnet

### DIFF
--- a/testsuite/pangu_lib/testnet_commands/update_nodes.py
+++ b/testsuite/pangu_lib/testnet_commands/update_nodes.py
@@ -37,6 +37,8 @@ def update_nodes_main(
         new_vfn_config_path = parsed_layout.blueprints[
             pangu_node_blueprint
         ].vfn_config_path
+        new_cpu = parsed_layout.blueprints[pangu_node_blueprint].cpu
+        new_memory = parsed_layout.blueprints[pangu_node_blueprint].memory
 
         vfns_enabled = parsed_layout.blueprints[pangu_node_blueprint].create_vfns
 
@@ -63,6 +65,8 @@ def update_nodes_main(
                     validator_name,
                     validator_image,
                     new_validator_config_path,
+                    new_cpu,
+                    new_memory,
                     system_context,
                 )
 
@@ -83,6 +87,8 @@ def update_nodes_main(
                         vfn_name,
                         vfn_image,
                         new_vfn_config_path,
+                        new_cpu,
+                        new_memory,
                         system_context,
                     )
                     node_futures.append(future)  # type: ignore
@@ -103,6 +109,8 @@ def update_node(
     node_name: str,
     new_image: str,
     new_config: str,
+    new_cpu: str,
+    new_memory: str,
     system_context: SystemContext,
 ):
     """Update a node
@@ -128,6 +136,24 @@ def update_node(
             "value": new_image,
         }
     ]
+
+    # if CPU and memory are specified, update them
+    if new_cpu != "":
+        patch_data_statefulset.append(
+            {
+                "op": "replace",
+                "path": "/spec/template/spec/containers/0/resources/requests/cpu",
+                "value": new_cpu,
+            }
+        )
+    if new_memory != "":
+        patch_data_statefulset.append(
+            {
+                "op": "replace",
+                "path": "/spec/template/spec/containers/0/resources/requests/memory",
+                "value": new_memory,
+            }
+        )
 
     #
     # Patch the statefulset


### PR DESCRIPTION
### Description

Ability to configure the CPU/memory of a pangu testnet on the fly. 
DRAFT for now, planning to revisit the ergonomics of the configs...

### Test Plan

Run testnet update on an existing testnet, to reduce the CPU/mem usage to fit on KinD

```
$ ./testsuite/testrun pangu.py testnet update pangu-rustielin-59qwdy2p rustie_pangu_node_config.yaml 
[Thu, 16 Nov 2023 21:58:45] INFO [testrun.run_test:29] Test file pangu.py not found, trying to find it in testsuite/
[Thu, 16 Nov 2023 21:58:45] INFO [testrun.run_test:38] Running test in testsuite/pangu.py...
[Thu, 16 Nov 2023 21:58:45] INFO [testrun.run_test:50] Running poetry command: $ poetry -C testsuite run python3 -u testsuite/pangu.py testnet update pangu-rustielin-59qwdy2p rustie_pangu_node_config.yaml
[Thu, 16 Nov 2023 21:58:46] INFO [kubernetes.py.__init__:80] : Operating in the cluster named "kind-kind"
[Thu, 16 Nov 2023 21:58:46] INFO [create_testnet.py.parse_pangu_node_config:295] : Loading the Pangu Node Configs from "rustie_pangu_node_config.yaml"
[Thu, 16 Nov 2023 21:58:46] INFO [update_nodes.py.update_nodes_main:28] Parsed pangu node config.
[Thu, 16 Nov 2023 21:58:46] INFO [update_nodes.py.update_nodes_main:61] Trying to update node: nodebp-node-1-validator
[Thu, 16 Nov 2023 21:58:46] INFO [update_nodes.py.update_nodes_main:83] Updating node: nodebp-node-1-vfn
[Thu, 16 Nov 2023 21:58:46] INFO [update_nodes.py.update_nodes_main:61] Trying to update node: nodebp-node-2-
...
```

<!-- Please provide us with clear details for verifying that your changes work. -->
