### PR TITLE
[Compiler-v2] Bug fixes in serializer, compiled unit and enable compiler v2 in framework and package system unit test 

### DIFF
--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -7,25 +7,30 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_package::CompilerConfig;
+use move_command_line_common::env::read_env_var;
+use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use tempfile::tempdir;
 
+const ENABLE_V2: &str = "ENABLE_V2";
+
 fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
-    let ok = run_move_unit_tests(
+    let mut compiler_config = CompilerConfig {
+        known_attributes: extended_checks::get_all_attribute_names().clone(),
+        ..Default::default()
+    };
+    let mut build_config = move_package::BuildConfig {
+        test_mode: true,
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        compiler_config: compiler_config.clone(),
+        full_model_generation: true, // Run extended checks also on test code
+        ..Default::default()
+    };
+    let mut ok = run_move_unit_tests(
         &pkg_path,
-        move_package::BuildConfig {
-            test_mode: true,
-            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-            compiler_config: CompilerConfig {
-                known_attributes: extended_checks::get_all_attribute_names().clone(),
-                ..Default::default()
-            },
-            full_model_generation: true, // Run extended checks also on test code
-            ..Default::default()
-        },
+        build_config.clone(),
         // TODO(Gas): double check if this is correct
         UnitTestingConfig::default_with_bound(Some(100_000)),
         aptos_test_natives(),
@@ -36,6 +41,23 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     .unwrap();
     if ok != UnitTestResult::Success {
         panic!("move unit tests failed")
+    }
+    if read_env_var(ENABLE_V2) == "1" {
+        compiler_config.compiler_version = Some(CompilerVersion::V2);
+        build_config.compiler_config = compiler_config;
+        ok = run_move_unit_tests(
+            &pkg_path,
+            build_config,
+            UnitTestingConfig::default_with_bound(Some(100_000)),
+            aptos_test_natives(),
+            /* cost_table */ None,
+            /* compute_coverage */ false,
+            &mut std::io::stdout(),
+        )
+        .unwrap();
+    }
+    if ok != UnitTestResult::Success {
+        panic!("move unit tests failed for compiler v2")
     }
 }
 

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -7,13 +7,11 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_command_line_common::env::read_env_var;
+use move_command_line_common::{env::read_env_var, testing::ENABLE_V2};
 use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use tempfile::tempdir;
-
-const ENABLE_V2: &str = "ENABLE_V2";
 
 fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -41,6 +41,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         panic!("move unit tests failed")
     }
     if read_env_var(ENABLE_V2) == "1" {
+        // Run test against v2 when ENABLE_V2 is set
         compiler_config.compiler_version = Some(CompilerVersion::V2);
         build_config.compiler_config = compiler_config;
         ok = run_move_unit_tests(

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -887,7 +887,9 @@ pub struct AccessSpecifier {
 }
 
 impl AccessSpecifier {
-    pub fn is_traditional_acquires(&self) -> bool {
+    // Old style of acquires is by default for bytecode version 6 or below.
+    // New style of acquires was introduced in AIP-56: Resource Access Control
+    pub fn is_old_style_acquires(&self) -> bool {
         self.kind == AccessKind::Acquires
             && !self.negated
             && self.address == AddressSpecifier::Any

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -886,6 +886,15 @@ pub struct AccessSpecifier {
     pub address: AddressSpecifier,
 }
 
+impl AccessSpecifier {
+    pub fn is_traditional_acquires(&self) -> bool {
+        self.kind == AccessKind::Acquires
+            && !self.negated
+            && self.address == AddressSpecifier::Any
+            && matches!(self.resource, ResourceSpecifier::Resource(_))
+    }
+}
+
 /// The kind of specified access.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -496,7 +496,14 @@ fn serialize_function_handle(
     serialize_ability_sets(binary, &function_handle.type_parameters)?;
     if major_version >= VERSION_7 {
         serialize_access_specifiers(binary, &function_handle.access_specifiers)
-    } else if function_handle.access_specifiers.is_some() {
+    } else if function_handle.access_specifiers.is_some()
+        && function_handle
+            .access_specifiers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|sp| !sp.is_traditional_acquires())
+    {
         Err(anyhow!(
             "Access specifiers not supported in bytecode version {}",
             major_version

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -502,7 +502,7 @@ fn serialize_function_handle(
             .as_ref()
             .unwrap()
             .iter()
-            .any(|sp| !sp.is_traditional_acquires())
+            .any(|sp| !sp.is_old_style_acquires())
     {
         Err(anyhow!(
             "Access specifiers not supported in bytecode version {}",

--- a/third_party/move/move-command-line-common/src/testing.rs
+++ b/third_party/move/move-command-line-common/src/testing.rs
@@ -8,6 +8,8 @@ use crate::env::read_bool_env_var;
 pub const OUT_EXT: &str = "out";
 /// Extension for expected output files
 pub const EXP_EXT: &str = "exp";
+/// Extension for expected output files compiled by v2
+pub const EXP_EXT_V2: &str = "exp.v2";
 
 /// If any of these env vars is set, the test harness should overwrite
 /// the existing .exp files with the output instead of checking
@@ -15,6 +17,9 @@ pub const EXP_EXT: &str = "exp";
 pub const UPDATE_BASELINE: &str = "UPDATE_BASELINE";
 pub const UPBL: &str = "UPBL";
 pub const UB: &str = "UB";
+
+/// Env variable to enable compiler v2 in tests
+pub const ENABLE_V2: &str = "ENABLE_V2";
 
 pub const PRETTY: &str = "PRETTY";
 pub const FILTER: &str = "FILTER";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -70,7 +70,7 @@ pub fn run_move_compiler(
     check_errors(&env, error_writer, "stackless-bytecode analysis errors")?;
     let modules_and_scripts = run_file_format_gen(&env, &targets);
     check_errors(&env, error_writer, "assembling errors")?;
-    let annotated = annotate_units(&env, modules_and_scripts);
+    let annotated = annotate_units(modules_and_scripts);
     Ok((env, annotated))
 }
 
@@ -168,15 +168,14 @@ pub fn check_errors<W: WriteColor>(
 /// Annotate the given compiled units.
 /// TODO: this currently only fills in defaults. The annotations are only used in
 /// the prover, and compiler v2 is not yet connected to the prover.
-pub fn annotate_units(env: &GlobalEnv, units: Vec<CompiledUnit>) -> Vec<AnnotatedCompiledUnit> {
-    let loc = env.unknown_move_ir_loc();
+pub fn annotate_units(units: Vec<CompiledUnit>) -> Vec<AnnotatedCompiledUnit> {
     units
         .into_iter()
         .map(|u| match u {
             CompiledUnit::Module(named_module) => {
                 AnnotatedCompiledUnit::Module(AnnotatedCompiledModule {
-                    loc,
-                    module_name_loc: loc,
+                    loc: named_module.source_map.definition_location,
+                    module_name_loc: named_module.source_map.definition_location,
                     address_name: None,
                     named_module,
                     function_infos: UniqueMap::new(),
@@ -184,7 +183,7 @@ pub fn annotate_units(env: &GlobalEnv, units: Vec<CompiledUnit>) -> Vec<Annotate
             },
             CompiledUnit::Script(named_script) => {
                 AnnotatedCompiledUnit::Script(AnnotatedCompiledScript {
-                    loc,
+                    loc: named_script.source_map.definition_location,
                     named_script,
                     function_info: FunctionInfo {
                         spec_info: Default::default(),

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -173,9 +173,10 @@ pub fn annotate_units(units: Vec<CompiledUnit>) -> Vec<AnnotatedCompiledUnit> {
         .into_iter()
         .map(|u| match u {
             CompiledUnit::Module(named_module) => {
+                let loc = named_module.source_map.definition_location;
                 AnnotatedCompiledUnit::Module(AnnotatedCompiledModule {
-                    loc: named_module.source_map.definition_location,
-                    module_name_loc: named_module.source_map.definition_location,
+                    loc,
+                    module_name_loc: loc,
                     address_name: None,
                     named_module,
                     function_infos: UniqueMap::new(),

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -3643,7 +3643,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         }
         let mut function_data: BTreeMap<FunId, FunctionData> = Default::default();
         for (name, entry) in &self.parent.fun_table {
-            if name.module_name != self.module_name {
+            if entry.module_id != self.module_id {
                 continue;
             }
             // New function

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -559,7 +559,11 @@ impl CompiledPackage {
                 },
             )
             .collect::<Vec<_>>();
-        for (dep_package_name, _, _, _) in &transitive_dependencies {
+        let mut source_package_map: BTreeMap<String, Symbol> = BTreeMap::new();
+        for (dep_package_name, source_paths, _, _) in &transitive_dependencies {
+            for dep_path in source_paths.clone() {
+                source_package_map.insert(dep_path.as_str().to_string(), *dep_package_name);
+            }
             writeln!(
                 w,
                 "{} {}",
@@ -575,6 +579,9 @@ impl CompiledPackage {
             &resolved_package,
             transitive_dependencies,
         )?;
+        for source_path in &sources_package_paths.paths {
+            source_package_map.insert(source_path.as_str().to_string(), root_package_name);
+        }
         let mut flags = if resolution_graph.build_options.test_mode {
             Flags::testing()
         } else {
@@ -675,11 +682,23 @@ impl CompiledPackage {
         };
         let mut root_compiled_units = vec![];
         let mut deps_compiled_units = vec![];
+        let obtain_package_name = |default: Option<Symbol>, source_path_str: &str| -> Symbol {
+            if default.is_none() && source_package_map.contains_key(source_path_str) {
+                *source_package_map.get(source_path_str).unwrap()
+            } else {
+                default.unwrap()
+            }
+        };
         for annot_unit in all_compiled_units {
-            let source_path = PathBuf::from(file_map[&annot_unit.loc().file_hash()].0.as_str());
+            let source_path_str = file_map[&annot_unit.loc().file_hash()].0.as_str();
+            let source_path = PathBuf::from(source_path_str);
             let package_name = match &annot_unit {
-                compiled_unit::CompiledUnitEnum::Module(m) => m.named_module.package_name.unwrap(),
-                compiled_unit::CompiledUnitEnum::Script(s) => s.named_script.package_name.unwrap(),
+                compiled_unit::CompiledUnitEnum::Module(m) => {
+                    obtain_package_name(m.named_module.package_name, source_path_str)
+                },
+                compiled_unit::CompiledUnitEnum::Script(s) => {
+                    obtain_package_name(s.named_script.package_name, source_path_str)
+                },
             };
             let unit = CompiledUnitWithSource {
                 unit: annot_unit.into_compiled_unit(),

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -73,9 +73,9 @@ fn run_test_impl(path: &Path, v2_flag: bool) -> datatest_stable::Result<String> 
                 .into())
             },
             (true, _) => match BuildPlan::create(resolved_package)
-                .and_then(|bp| bp.compile(&compiler_config.clone(), &mut Vec::new()))
+                .and_then(|bp| bp.compile_no_exit(&compiler_config.clone(), &mut Vec::new()))
             {
-                Ok(mut pkg) => {
+                Ok((mut pkg, _)) => {
                     pkg.compiled_package_info.source_digest =
                         Some(PackageDigest::from("ELIDED_FOR_TEST"));
                     pkg.compiled_package_info.build_flags.install_dir =
@@ -155,6 +155,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let update_baseline = read_env_update_baseline();
     let res_v1 = check_or_update(path, output_v1.clone(), update_baseline, false);
     if read_env_var(ENABLE_V2) == "1" {
+        // Run test against v2 when ENABLE_V2 is set
         let output_v2 = run_test_impl(path, true)?;
         if output_v1 != output_v2 {
             // TODO: compare the result between V1 and V2.

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -21,7 +21,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -24,7 +24,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -24,7 +24,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -25,7 +25,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -25,7 +25,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -23,7 +23,15 @@ CompiledPackageInfo {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -17,7 +17,15 @@ ResolutionGraph {
         skip_fetch_latest_git_deps: false,
         compiler_config: CompilerConfig {
             bytecode_version: None,
-            known_attributes: {},
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "native_interface",
+                "test",
+                "test_only",
+                "verify_only",
+            },
             skip_attribute_checks: false,
             compiler_version: None,
         },


### PR DESCRIPTION
### Description

This PR:
- Close #10936
- Close #10958
- Close #10992 
- Add a new env variable "ENABLE_V2". If it is set to "1", unit tests in framework, move-example and third_party/move_package will run v2 as well.
- Change the compiler config when running unit tests in move_package so that known_attributes will be printed out. Baseline in the exp files are updated accordingly.

TODO: 
- This PR does not compare output between V1 and V2 in the move_package test. Once the compiler V2 is more stable, the comparison will be added.

### Testing

For both the fix of #10936 and #10958, testing is done using `aptos move compile --compiler-version=v2` against `move-stdlib`. framework unit-test will cover them once the flag `ENABLE_V2` is set to 1 by default. The fix of #10992 is verified by running the test case `third_party/move/tools/movepackage/tests/test_sources/compilation/case_insensitive_check` with `ENABLE_V2` set to 1.
