### PR TITLE
[Execution] Move the transaction shuffling and dedup to the block preparation phase

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -410,22 +410,20 @@ impl Block {
         Ok(())
     }
 
-    pub fn transactions_to_execute(
-        &self,
-        validators: &[AccountAddress],
+    pub fn transactions_to_execute_for_metadata(
+        block_id: HashValue,
         validator_txns: Vec<ValidatorTransaction>,
-        user_txns: Vec<SignedTransaction>,
+        txns: Vec<SignedTransaction>,
+        metadata: BlockMetadata,
         is_block_gas_limit: bool,
     ) -> Vec<Transaction> {
-        let txns = once(Transaction::BlockMetadata(
-            self.new_block_metadata(validators),
-        ))
-        .chain(
-            validator_txns
-                .into_iter()
-                .map(Transaction::ValidatorTransaction),
-        )
-        .chain(user_txns.into_iter().map(Transaction::UserTransaction));
+        let txns = once(Transaction::BlockMetadata(metadata))
+            .chain(
+                validator_txns
+                    .into_iter()
+                    .map(Transaction::ValidatorTransaction),
+            )
+            .chain(txns.into_iter().map(Transaction::UserTransaction));
 
         if is_block_gas_limit {
             // After the per-block gas limit change, StateCheckpoint txn
@@ -434,9 +432,26 @@ impl Block {
         } else {
             // Before the per-block gas limit change, StateCheckpoint txn
             // is inserted here for compatibility.
-            txns.chain(once(Transaction::StateCheckpoint(self.id)))
+            txns.chain(once(Transaction::StateCheckpoint(block_id)))
                 .collect()
         }
+    }
+
+    pub fn transactions_to_execute(
+        &self,
+        validators: &[AccountAddress],
+        validator_txns: Vec<ValidatorTransaction>,
+        txns: Vec<SignedTransaction>,
+        is_block_gas_limit: bool,
+    ) -> Vec<Transaction> {
+        let metadata = self.new_block_metadata(validators);
+        Self::transactions_to_execute_for_metadata(
+            self.id,
+            validator_txns,
+            txns,
+            metadata,
+            is_block_gas_limit,
+        )
     }
 
     fn previous_bitvec(&self) -> BitVec {
@@ -447,7 +462,7 @@ impl Block {
         }
     }
 
-    fn new_block_metadata(&self, validators: &[AccountAddress]) -> BlockMetadata {
+    pub fn new_block_metadata(&self, validators: &[AccountAddress]) -> BlockMetadata {
         BlockMetadata::new(
             self.id(),
             self.epoch(),

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -28,6 +28,8 @@ use std::fmt::{Debug, Display, Formatter};
 pub struct ExecutedBlock {
     /// Block data that cannot be regenerated.
     block: Block,
+    /// Input transactions in the order of execution
+    input_transactions: Vec<SignedTransaction>,
     /// The state_compute_result is calculated for all the pending blocks prior to insertion to
     /// the tree. The execution results are not persisted: they're recalculated again for the
     /// pending blocks upon restart.
@@ -36,8 +38,13 @@ pub struct ExecutedBlock {
 }
 
 impl ExecutedBlock {
-    pub fn replace_result(mut self, result: StateComputeResult) -> Self {
+    pub fn replace_result(
+        mut self,
+        input_transactions: Vec<SignedTransaction>,
+        result: StateComputeResult,
+    ) -> Self {
         self.state_compute_result = result;
+        self.input_transactions = input_transactions;
         self
     }
 
@@ -59,9 +66,14 @@ impl Display for ExecutedBlock {
 }
 
 impl ExecutedBlock {
-    pub fn new(block: Block, state_compute_result: StateComputeResult) -> Self {
+    pub fn new(
+        block: Block,
+        input_transactions: Vec<SignedTransaction>,
+        state_compute_result: StateComputeResult,
+    ) -> Self {
         Self {
             block,
+            input_transactions,
             state_compute_result,
             randomness: OnceCell::new(),
         }
@@ -73,6 +85,10 @@ impl ExecutedBlock {
 
     pub fn id(&self) -> HashValue {
         self.block().id()
+    }
+
+    pub fn input_transactions(&self) -> &Vec<SignedTransaction> {
+        &self.input_transactions
     }
 
     pub fn epoch(&self) -> u64 {

--- a/consensus/src/block_preparer.rs
+++ b/consensus/src/block_preparer.rs
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    payload_manager::PayloadManager, transaction_deduper::TransactionDeduper,
+    transaction_filter::TransactionFilter, transaction_shuffler::TransactionShuffler,
+};
+use aptos_consensus_types::block::Block;
+use aptos_executor_types::ExecutorResult;
+use aptos_types::transaction::SignedTransaction;
+use std::sync::Arc;
+
+pub struct BlockPreparer {
+    payload_manager: Arc<PayloadManager>,
+    txn_filter: Arc<TransactionFilter>,
+    txn_deduper: Arc<dyn TransactionDeduper>,
+    txn_shuffler: Arc<dyn TransactionShuffler>,
+}
+
+impl BlockPreparer {
+    pub fn new(
+        payload_manager: Arc<PayloadManager>,
+        txn_filter: Arc<TransactionFilter>,
+        txn_deduper: Arc<dyn TransactionDeduper>,
+        txn_shuffler: Arc<dyn TransactionShuffler>,
+    ) -> Self {
+        Self {
+            payload_manager,
+            txn_filter,
+            txn_deduper,
+            txn_shuffler,
+        }
+    }
+
+    pub async fn prepare_block(&self, block: &Block) -> ExecutorResult<Vec<SignedTransaction>> {
+        let txns = self.payload_manager.get_transactions(block).await?;
+        let txn_filter = self.txn_filter.clone();
+        let txn_deduper = self.txn_deduper.clone();
+        let txn_shuffler = self.txn_shuffler.clone();
+        let block_id = block.id();
+        let block_timestamp_usecs = block.timestamp_usecs();
+        // Transaction filtering, deduplication and shuffling are CPU intensive tasks, so we run them in a blocking task.
+        tokio::task::spawn_blocking(move || {
+            let filtered_txns = txn_filter.filter(block_id, block_timestamp_usecs, txns);
+            let deduped_txns = txn_deduper.dedup(filtered_txns);
+            Ok(txn_shuffler.shuffle(deduped_txns))
+        })
+        .await
+        .expect("Failed to spawn blocking task for transaction generation")
+    }
+}

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -165,6 +165,7 @@ impl OrderedNotifier for OrderedNotifierAdapter {
                 parents_bitvec,
                 node_digests,
             ),
+            vec![],
             StateComputeResult::new_dummy(),
         );
         let block_info = block.block_info();

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -3,23 +3,32 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{monitor, state_computer::StateComputeResultFut};
+use crate::{
+    block_preparer::BlockPreparer,
+    monitor,
+    state_computer::{PipelineExecutionResult, StateComputeResultFut},
+};
+use aptos_consensus_types::block::Block;
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
     state_checkpoint_output::StateCheckpointOutput, BlockExecutorTrait, ExecutorError,
-    ExecutorResult, StateComputeResult,
+    ExecutorResult,
 };
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::{debug, error};
 use aptos_types::{
     block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
-    transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
+    block_metadata::BlockMetadata,
+    transaction::{
+        signature_verified_transaction::SignatureVerifiedTransaction, SignedTransaction,
+    },
 };
 use fail::fail_point;
 use once_cell::sync::Lazy;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
+
 pub static SIG_VERIFY_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
     Arc::new(
         rayon::ThreadPoolBuilder::new()
@@ -54,18 +63,21 @@ impl ExecutionPipeline {
 
     pub async fn queue(
         &self,
-        block_id: HashValue,
+        block: Block,
+        metadata: BlockMetadata,
         parent_block_id: HashValue,
-        txns_to_execute: Vec<Transaction>,
+        txn_generator: BlockPreparer,
         block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     ) -> StateComputeResultFut {
         let (result_tx, result_rx) = oneshot::channel();
+        let block_id = block.id();
         self.prepare_block_tx
             .send(PrepareBlockCommand {
-                block_id,
-                txns_to_execute,
+                block,
+                metadata,
                 block_executor_onchain_config,
                 parent_block_id,
+                block_preparer: txn_generator,
                 result_tx,
             })
             .expect("Failed to send block to execution pipeline.");
@@ -82,47 +94,77 @@ impl ExecutionPipeline {
         })
     }
 
-    async fn prepare_block_stage(
-        mut prepare_block_rx: mpsc::UnboundedReceiver<PrepareBlockCommand>,
+    async fn prepare_block(
         execute_block_tx: mpsc::UnboundedSender<ExecuteBlockCommand>,
+        command: PrepareBlockCommand,
     ) {
-        while let Some(PrepareBlockCommand {
-            block_id,
-            txns_to_execute,
+        let PrepareBlockCommand {
+            block,
+            metadata,
             block_executor_onchain_config,
             parent_block_id,
+            block_preparer,
             result_tx,
-        }) = prepare_block_rx.recv().await
-        {
-            debug!("prepare_block received block {}.", block_id);
-            let execute_block_tx = execute_block_tx.clone();
-            let sig_verified_txns = monitor!(
-                "prepare_block",
-                tokio::task::spawn_blocking(move || {
-                    let sig_verified_txns: Vec<SignatureVerifiedTransaction> = SIG_VERIFY_POOL
-                        .install(|| {
-                            let num_txns = txns_to_execute.len();
-                            txns_to_execute
-                                .into_par_iter()
-                                .with_min_len(optimal_min_len(num_txns, 32))
-                                .map(|t| t.into())
-                                .collect::<Vec<_>>()
-                        });
-                    sig_verified_txns
-                })
-                .await
-            )
-            .expect("Failed to spawn_blocking.");
+        } = command;
 
+        debug!("prepare_block received block {}.", block.id());
+        let input_txns = block_preparer.prepare_block(&block).await;
+        if let Err(e) = input_txns {
+            result_tx.send(Err(e)).unwrap_or_else(|err| {
+                error!(
+                    block_id = block.id(),
+                    "Failed to send back execution result for block {}: {:?}.",
+                    block.id(),
+                    err,
+                );
+            });
+            return;
+        }
+        let validator_txns = block.validator_txns().cloned().unwrap_or_default();
+        let input_txns = input_txns.unwrap();
+        let is_block_gas_limit = block_executor_onchain_config.has_any_block_gas_limit();
+        tokio::task::spawn_blocking(move || {
+            let txns_to_execute = Block::transactions_to_execute_for_metadata(
+                block.id(),
+                validator_txns,
+                input_txns.clone(),
+                metadata,
+                is_block_gas_limit,
+            );
+            let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
+                SIG_VERIFY_POOL.install(|| {
+                    let num_txns = txns_to_execute.len();
+                    txns_to_execute
+                        .into_par_iter()
+                        .with_min_len(optimal_min_len(num_txns, 32))
+                        .map(|t| t.into())
+                        .collect::<Vec<_>>()
+                });
             execute_block_tx
                 .send(ExecuteBlockCommand {
-                    block: (block_id, sig_verified_txns).into(),
+                    input_txns,
+                    block: (block.id(), sig_verified_txns).into(),
                     parent_block_id,
                     block_executor_onchain_config,
                     result_tx,
                 })
                 .expect("Failed to send block to execution pipeline.");
+        })
+        .await
+        .expect("Failed to spawn_blocking.");
+    }
+
+    async fn prepare_block_stage(
+        mut prepare_block_rx: mpsc::UnboundedReceiver<PrepareBlockCommand>,
+        execute_block_tx: mpsc::UnboundedSender<ExecuteBlockCommand>,
+    ) {
+        while let Some(command) = prepare_block_rx.recv().await {
+            monitor!(
+                "prepare_block",
+                Self::prepare_block(execute_block_tx.clone(), command).await
+            );
         }
+        debug!("prepare_block_stage quitting.");
     }
 
     async fn execute_stage(
@@ -131,6 +173,7 @@ impl ExecutionPipeline {
         executor: Arc<dyn BlockExecutorTrait>,
     ) {
         while let Some(ExecuteBlockCommand {
+            input_txns,
             block,
             parent_block_id,
             block_executor_onchain_config,
@@ -160,6 +203,7 @@ impl ExecutionPipeline {
 
             ledger_apply_tx
                 .send(LedgerApplyCommand {
+                    input_txns,
                     block_id,
                     parent_block_id,
                     state_checkpoint_output,
@@ -175,6 +219,7 @@ impl ExecutionPipeline {
         executor: Arc<dyn BlockExecutorTrait>,
     ) {
         while let Some(LedgerApplyCommand {
+            input_txns,
             block_id,
             parent_block_id,
             state_checkpoint_output,
@@ -194,7 +239,8 @@ impl ExecutionPipeline {
                 .expect("Failed to spawn_blocking().")
             }
             .await;
-            result_tx.send(res).unwrap_or_else(|err| {
+            let pipe_line_res = res.map(|output| PipelineExecutionResult::new(input_txns, output));
+            result_tx.send(pipe_line_res).unwrap_or_else(|err| {
                 error!(
                     block_id = block_id,
                     "Failed to send back execution result for block {}: {:?}", block_id, err,
@@ -206,24 +252,27 @@ impl ExecutionPipeline {
 }
 
 struct PrepareBlockCommand {
-    block_id: HashValue,
-    txns_to_execute: Vec<Transaction>,
+    block: Block,
+    metadata: BlockMetadata,
     block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     // The parent block id.
     parent_block_id: HashValue,
-    result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
+    block_preparer: BlockPreparer,
+    result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
 }
 
 struct ExecuteBlockCommand {
+    input_txns: Vec<SignedTransaction>,
     block: ExecutableBlock,
     parent_block_id: HashValue,
     block_executor_onchain_config: BlockExecutorConfigFromOnchain,
-    result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
+    result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
 }
 
 struct LedgerApplyCommand {
+    input_txns: Vec<SignedTransaction>,
     block_id: HashValue,
     parent_block_id: HashValue,
     state_checkpoint_output: ExecutorResult<StateCheckpointOutput>,
-    result_tx: oneshot::Sender<ExecutorResult<StateComputeResult>>,
+    result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
 }

--- a/consensus/src/experimental/execution_schedule_phase.rs
+++ b/consensus/src/experimental/execution_schedule_phase.rs
@@ -6,6 +6,7 @@ use crate::{
         execution_wait_phase::ExecutionWaitRequest,
         pipeline_phase::{CountedRequest, StatelessPipeline},
     },
+    state_computer::PipelineExecutionResult,
     state_replication::StateComputer,
 };
 use aptos_consensus_types::executed_block::ExecutedBlock;
@@ -92,7 +93,8 @@ impl StatelessPipeline for ExecutionSchedulePhase {
             let mut results = vec![];
             for (block, fut) in itertools::zip_eq(ordered_blocks, futs) {
                 debug!("try to receive compute result for block {}", block.id());
-                results.push(block.replace_result(fut.await?));
+                let PipelineExecutionResult { input_txns, result } = fut.await?;
+                results.push(block.replace_result(input_txns, result));
             }
             drop(lifetime_guard);
             Ok(results)

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -9,6 +9,7 @@ use crate::{
         errors::Error,
     },
     payload_manager::PayloadManager,
+    state_computer::PipelineExecutionResult,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
@@ -16,7 +17,7 @@ use crate::{
 use anyhow::Result;
 use aptos_consensus_types::{block::Block, executed_block::ExecutedBlock};
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutorResult, StateComputeResult};
+use aptos_executor_types::ExecutorResult;
 use aptos_logger::prelude::*;
 use aptos_types::{
     block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
@@ -64,12 +65,12 @@ impl StateComputer for OrderingStateComputer {
         _block: &Block,
         // The parent block id.
         _parent_block_id: HashValue,
-    ) -> ExecutorResult<StateComputeResult> {
+    ) -> ExecutorResult<PipelineExecutionResult> {
         // Return dummy block and bypass the execution phase.
         // This will break the e2e smoke test (for now because
         // no one is actually handling the next phase) if the
         // decoupled execution feature is turned on.
-        Ok(StateComputeResult::new_dummy())
+        Ok(PipelineExecutionResult::new_dummy())
     }
 
     /// Send ordered blocks to the real execution phase through the channel.
@@ -170,7 +171,7 @@ impl StateComputer for DagStateSyncComputer {
         _block: &Block,
         // The parent block root hash.
         _parent_block_id: HashValue,
-    ) -> ExecutorResult<StateComputeResult> {
+    ) -> ExecutorResult<PipelineExecutionResult> {
         unimplemented!("method not supported")
     }
 

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -90,7 +90,11 @@ fn add_execution_phase_test_cases(
     // happy path
     phase_tester.add_test_case(
         ExecutionRequest {
-            ordered_blocks: vec![ExecutedBlock::new(block, StateComputeResult::new_dummy())],
+            ordered_blocks: vec![ExecutedBlock::new(
+                block,
+                vec![],
+                StateComputeResult::new_dummy(),
+            )],
             lifetime_guard: dummy_guard(),
         },
         Box::new(move |resp| {
@@ -121,6 +125,7 @@ fn add_execution_phase_test_cases(
         ExecutionRequest {
             ordered_blocks: vec![ExecutedBlock::new(
                 bad_block,
+                vec![],
                 StateComputeResult::new_dummy(),
             )],
             lifetime_guard: dummy_guard(),

--- a/consensus/src/experimental/tests/test_utils.rs
+++ b/consensus/src/experimental/tests/test_utils.rs
@@ -110,7 +110,9 @@ pub fn prepare_executed_blocks_with_ledger_info(
 
     let executed_blocks: Vec<ExecutedBlock> = proposals
         .iter()
-        .map(|proposal| ExecutedBlock::new(proposal.block().clone(), compute_result.clone()))
+        .map(|proposal| {
+            ExecutedBlock::new(proposal.block().clone(), vec![], compute_result.clone())
+        })
         .collect();
 
     (executed_blocks, li_sig, proposals)

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -47,6 +47,7 @@ mod twins;
 mod txn_notifier;
 pub mod util;
 
+mod block_preparer;
 /// AptosBFT implementation
 pub mod consensus_provider;
 /// Required by the telemetry service

--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -165,6 +165,7 @@ mod tests {
                         ),
                         None,
                     ),
+                    vec![],
                     StateComputeResult::new_dummy(),
                 )
             })

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    block_preparer::BlockPreparer,
     block_storage::tracing::{observe_block, BlockStage},
     counters,
     error::StateSyncError,
@@ -23,16 +24,39 @@ use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResul
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    account_address::AccountAddress, block_executor::config::BlockExecutorConfigFromOnchain,
-    contract_event::ContractEvent, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::OnChainExecutionConfig, transaction::Transaction,
+    account_address::AccountAddress,
+    block_executor::config::BlockExecutorConfigFromOnchain,
+    contract_event::ContractEvent,
+    epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+    on_chain_config::OnChainExecutionConfig,
+    transaction::{SignedTransaction, Transaction},
 };
 use fail::fail_point;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
 use std::{boxed::Box, sync::Arc};
 use tokio::sync::Mutex as AsyncMutex;
 
-pub type StateComputeResultFut = BoxFuture<'static, ExecutorResult<StateComputeResult>>;
+pub type StateComputeResultFut = BoxFuture<'static, ExecutorResult<PipelineExecutionResult>>;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PipelineExecutionResult {
+    pub input_txns: Vec<SignedTransaction>,
+    pub result: StateComputeResult,
+}
+
+impl PipelineExecutionResult {
+    pub fn new(input_txns: Vec<SignedTransaction>, result: StateComputeResult) -> Self {
+        Self { input_txns, result }
+    }
+
+    pub fn new_dummy() -> Self {
+        Self {
+            input_txns: vec![],
+            result: StateComputeResult::new_dummy(),
+        }
+    }
+}
 
 type NotificationType = (
     Box<dyn FnOnce() + Send + Sync>,
@@ -65,7 +89,7 @@ pub struct ExecutionProxy {
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
     block_executor_onchain_config: Mutex<BlockExecutorConfigFromOnchain>,
     transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
-    transaction_filter: TransactionFilter,
+    transaction_filter: Arc<TransactionFilter>,
     execution_pipeline: ExecutionPipeline,
 }
 
@@ -106,7 +130,7 @@ impl ExecutionProxy {
                 OnChainExecutionConfig::default_if_missing().block_executor_onchain_config(),
             ),
             transaction_deduper: Mutex::new(None),
-            transaction_filter: txn_filter,
+            transaction_filter: Arc::new(txn_filter),
             execution_pipeline,
         }
     }
@@ -128,40 +152,27 @@ impl StateComputer for ExecutionProxy {
             "Executing block",
         );
 
-        let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
-        let txn_deduper = self.transaction_deduper.lock().as_ref().unwrap().clone();
-        let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
         let txn_notifier = self.txn_notifier.clone();
-        let validator_txns = block.validator_txns().cloned().unwrap_or_default();
-        let user_txns = match payload_manager.get_transactions(block).await {
-            Ok(txns) => txns,
-            Err(err) => return Box::pin(async move { Err(err) }),
-        };
-
-        let filtered_txns =
-            self.transaction_filter
-                .filter(block_id, block.timestamp_usecs(), user_txns);
-        let deduped_txns = txn_deduper.dedup(filtered_txns);
-        let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
-
-        let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
-
-        // TODO: figure out error handling for the prologue txn
-        let timestamp = block.timestamp_usecs();
-        let transactions_to_execute = block.transactions_to_execute(
-            &self.validators.lock(),
-            validator_txns,
-            shuffled_txns.clone(),
-            block_executor_onchain_config.has_any_block_gas_limit(),
+        let transaction_generator = BlockPreparer::new(
+            self.payload_manager.lock().as_ref().unwrap().clone(),
+            self.transaction_filter.clone(),
+            self.transaction_deduper.lock().as_ref().unwrap().clone(),
+            self.transaction_shuffler.lock().as_ref().unwrap().clone(),
         );
 
+        let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
+        let block_gas_limit_enabled = block_executor_onchain_config.has_any_block_gas_limit();
+
+        let timestamp = block.timestamp_usecs();
+        let metadata = block.new_block_metadata(&self.validators.lock());
         let fut = self
             .execution_pipeline
             .queue(
-                block_id,
+                block.clone(),
+                metadata,
                 parent_block_id,
-                transactions_to_execute,
-                block_executor_onchain_config.clone(),
+                transaction_generator,
+                block_executor_onchain_config,
             )
             .await;
 
@@ -170,24 +181,22 @@ impl StateComputer for ExecutionProxy {
                 block_id = block_id,
                 "Got state compute result, post processing."
             );
-            let compute_result = fut.await?;
+            let pipeline_execution_result = fut.await?;
+            let input_txns = pipeline_execution_result.input_txns.clone();
+            let result = &pipeline_execution_result.result;
+
             observe_block(timestamp, BlockStage::EXECUTED);
 
             // notify mempool about failed transaction
             if let Err(e) = txn_notifier
-                .notify_failed_txn(
-                    shuffled_txns,
-                    &compute_result,
-                    block_executor_onchain_config.has_any_block_gas_limit(),
-                )
+                .notify_failed_txn(input_txns, result, block_gas_limit_enabled)
                 .await
             {
                 error!(
                     error = ?e, "Failed to notify mempool of rejected txns",
                 );
             }
-
-            Ok(compute_result)
+            Ok(pipeline_execution_result)
         })
     }
 
@@ -209,12 +218,9 @@ impl StateComputer for ExecutionProxy {
             finality_proof.ledger_info().round(),
         );
         let block_timestamp = finality_proof.commit_info().timestamp_usecs();
-
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
-        let txn_deduper = self.transaction_deduper.lock().as_ref().unwrap().clone();
-        let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
-
         let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
+        let is_block_gas_limit = block_executor_onchain_config.has_any_block_gas_limit();
 
         for block in blocks {
             block_ids.push(block.id());
@@ -223,19 +229,12 @@ impl StateComputer for ExecutionProxy {
                 payloads.push(payload.clone());
             }
 
-            let validator_txns = block.validator_txns().map_or(vec![], Vec::clone);
-            let user_txns = payload_manager.get_transactions(block.block()).await?;
-            let filtered_txns =
-                self.transaction_filter
-                    .filter(block.id(), block.timestamp_usecs(), user_txns);
-            let deduped_txns = txn_deduper.dedup(filtered_txns);
-            let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
-
+            let input_txns = block.input_transactions().clone();
             txns.extend(block.transactions_to_commit(
                 &self.validators.lock(),
-                validator_txns,
-                shuffled_txns,
-                block_executor_onchain_config.has_any_block_gas_limit(),
+                block.validator_txns().cloned().unwrap_or_default(),
+                input_txns,
+                is_block_gas_limit,
             ));
             reconfig_events.extend(block.reconfig_event());
         }

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -216,7 +216,11 @@ async fn commit_should_discover_validator_txns() {
             4
         ]);
 
-    let blocks = vec![Arc::new(ExecutedBlock::new(block, state_compute_result))];
+    let blocks = vec![Arc::new(ExecutedBlock::new(
+        block,
+        vec![],
+        state_compute_result,
+    ))];
     let epoch_state = EpochState::empty();
 
     execution_policy.new_epoch(

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error::StateSyncError, payload_manager::PayloadManager, state_computer::StateComputeResultFut,
-    transaction_deduper::TransactionDeduper, transaction_shuffler::TransactionShuffler,
+    error::StateSyncError,
+    payload_manager::PayloadManager,
+    state_computer::{PipelineExecutionResult, StateComputeResultFut},
+    transaction_deduper::TransactionDeduper,
+    transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
 use aptos_consensus_types::{block::Block, executed_block::ExecutedBlock};
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutorResult, StateComputeResult};
+use aptos_executor_types::ExecutorResult;
 use aptos_types::{
     block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
@@ -33,7 +36,7 @@ pub trait StateComputer: Send + Sync {
         block: &Block,
         // The parent block root hash.
         parent_block_id: HashValue,
-    ) -> ExecutorResult<StateComputeResult> {
+    ) -> ExecutorResult<PipelineExecutionResult> {
         self.schedule_compute(block, parent_block_id).await.await
     }
 

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -6,7 +6,7 @@ use crate::{
     error::StateSyncError,
     experimental::buffer_manager::OrderedBlocks,
     payload_manager::PayloadManager,
-    state_computer::StateComputeResultFut,
+    state_computer::{PipelineExecutionResult, StateComputeResultFut},
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     test_utils::mock_storage::MockStorage,
     transaction_deduper::TransactionDeduper,
@@ -86,12 +86,12 @@ impl StateComputer for MockStateComputer {
         &self,
         block: &Block,
         _parent_block_id: HashValue,
-    ) -> ExecutorResult<StateComputeResult> {
+    ) -> ExecutorResult<PipelineExecutionResult> {
         self.block_cache.lock().insert(
             block.id(),
             block.payload().unwrap_or(&Payload::empty(false)).clone(),
         );
-        let result = StateComputeResult::new_dummy();
+        let result = PipelineExecutionResult::new_dummy();
         Ok(result)
     }
 
@@ -157,8 +157,8 @@ impl StateComputer for EmptyStateComputer {
         &self,
         _block: &Block,
         _parent_block_id: HashValue,
-    ) -> ExecutorResult<StateComputeResult> {
-        Ok(StateComputeResult::new_dummy())
+    ) -> ExecutorResult<PipelineExecutionResult> {
+        Ok(PipelineExecutionResult::new_dummy())
     }
 
     async fn commit(
@@ -221,7 +221,8 @@ impl StateComputer for RandomComputeResultStateComputer {
                 self.random_compute_result_root_hash,
             ))
         };
-        Box::pin(async move { res })
+        let pipeline_execution_res = res.map(|res| PipelineExecutionResult::new(vec![], res));
+        Box::pin(async move { pipeline_execution_res })
     }
 
     async fn commit(


### PR DESCRIPTION
### Description

We observed in previewnet that for large block and higher conflict, the shuffling is pretty expensive takes around 150 ms. This PR moves the transaction fetching, dedup, shuffling to the block preparation phase and also avoids redoing all the above operations in the commit phase by storing the input transaction in the executed block. 

### Test Plan

Ran Forge.
