### PR TITLE
[Data Streaming Service] Continue to pre-fetch even when head of line blocked.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -229,7 +229,9 @@ pub struct DataStreamingServiceConfig {
     /// the subscription stream is terminated and a new stream must be created.
     pub max_num_consecutive_subscriptions: u64,
 
-    /// Maximum number of pending requests per data stream.
+    /// Maximum number of pending requests per data stream. This includes the
+    /// requests that have already succeeded but have not yet been consumed
+    /// because they're head-of-line blocked by other requests.
     pub max_pending_requests: u64,
 
     /// Maximum number of retries for a single client request before a data

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -221,10 +221,6 @@ pub struct DataStreamingServiceConfig {
     /// messages will be retrieved using FIFO ordering.
     pub max_data_stream_channel_sizes: u64,
 
-    /// Maximum number of retries for a single client request before a data
-    /// stream will terminate.
-    pub max_request_retry: u64,
-
     /// Maximum number of notification ID to response context mappings held in
     /// memory. Once the number grows beyond this value, garbage collection occurs.
     pub max_notification_id_mappings: u64,
@@ -232,6 +228,13 @@ pub struct DataStreamingServiceConfig {
     /// Maximum number of consecutive subscriptions that can be made before
     /// the subscription stream is terminated and a new stream must be created.
     pub max_num_consecutive_subscriptions: u64,
+
+    /// Maximum number of pending requests per data stream.
+    pub max_pending_requests: u64,
+
+    /// Maximum number of retries for a single client request before a data
+    /// stream will terminate.
+    pub max_request_retry: u64,
 
     /// Maximum lag (in seconds) we'll tolerate when sending subscription requests
     pub max_subscription_stream_lag_secs: u64,
@@ -248,10 +251,11 @@ impl Default for DataStreamingServiceConfig {
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,
             max_data_stream_channel_sizes: 300,
-            max_request_retry: 5,
             max_notification_id_mappings: 300,
             max_num_consecutive_subscriptions: 40, // At ~4 blocks per second, this should last 10 seconds
-            max_subscription_stream_lag_secs: 15,  // 15 seconds
+            max_pending_requests: 50,
+            max_request_retry: 5,
+            max_subscription_stream_lag_secs: 15, // 15 seconds
             progress_check_interval_ms: 50,
         }
     }

--- a/state-sync/data-streaming-service/src/metrics.rs
+++ b/state-sync/data-streaming-service/src/metrics.rs
@@ -141,6 +141,15 @@ pub static PENDING_DATA_RESPONSES: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for the number of complete pending data responses
+pub static COMPLETE_PENDING_DATA_RESPONSES: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_data_streaming_service_complete_pending_data_responses",
+        "Counters related to the number of complete pending data responses",
+    )
+    .unwrap()
+});
+
 /// Counter for tracking received data responses
 pub static RECEIVED_DATA_RESPONSE: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
@@ -223,8 +232,13 @@ pub fn set_active_data_streams(value: usize) {
     ACTIVE_DATA_STREAMS.set(value as i64);
 }
 
+/// Sets the number of complete pending data responses
+pub fn set_complete_pending_data_responses(value: u64) {
+    COMPLETE_PENDING_DATA_RESPONSES.set(value as i64);
+}
+
 /// Sets the number of pending data responses
-pub fn set_pending_data_responses(value: usize) {
+pub fn set_pending_data_responses(value: u64) {
     PENDING_DATA_RESPONSES.set(value as i64);
 }
 


### PR DESCRIPTION
### Description
This PR updates the data streaming service to continue pre-fetching, even when head of line blocked.

Previously, the pre-fetcher would stop when there were `max_concurrent_requests` in the queue (even if only the first request was blocked/processing and the rest were already complete). To prevent head of line blocking from slowing synchronization down, the pre-fetcher now maintains two windows: (i) `max_concurrent_requests` -- the max in-flight requests (at any one time); and (ii) `max_pending_requests` -- the max pending requests (at any one time) in the pre-fetcher queue (this is required to bound memory use). Now, the pre-fetcher is able to continue pre-fetching up to a larger number of requests when head of line blocked.

The PR offers several commits:
1. Fix the request latency metrics to only observe latencies on successful responses. Otherwise, timeouts and errors skew the metric.
2. Update the pre-fetcher to continue pre-fetching even when head of line blocked.
3. Add tests for the new pre-fetching logic.

### Test Plan
New and existing test infrastructure.