### PR TITLE
[Node Config] Log each config individually.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "poem-openapi",
  "rand 0.7.3",
  "serde",
+ "serde_json",
  "serde_merge",
  "serde_yaml 0.8.26",
  "thiserror",

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -552,7 +552,7 @@ pub fn setup_environment_and_start_node(
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> anyhow::Result<AptosHandle> {
     // Log the node config at node startup
-    info!("Using node config {:?}", &node_config);
+    node_config.log_all_configs();
 
     // Starts the admin service
     let admin_service = services::start_admin_service(&node_config);

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -35,6 +35,7 @@ number_range = { workspace = true }
 poem-openapi = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_merge = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/config/src/config/node_config.rs
+++ b/config/src/config/node_config.rs
@@ -13,12 +13,14 @@ use crate::{
     network_id::NetworkId,
 };
 use aptos_crypto::x25519;
+use aptos_logger::info;
 use aptos_temppath::TempPath;
 use aptos_types::account_address::AccountAddress as PeerId;
 use rand::{prelude::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    fmt::Debug,
     path::{Path, PathBuf},
 };
 
@@ -68,6 +70,24 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
+    /// Logs the node config using INFO level logging. This is useful for
+    /// working around the length restrictions in the logger.
+    pub fn log_all_configs(&self) {
+        // Parse the node config as serde JSON
+        let config_value =
+            serde_json::to_value(self).expect("Failed to serialize the node config!");
+        let config_map = config_value
+            .as_object()
+            .expect("Failed to get the config map!");
+
+        // Log each config entry
+        for (config_name, config_value) in config_map {
+            let config_string =
+                serde_json::to_string(config_value).expect("Failed to parse the config value!");
+            info!("Using {} config: {}", config_name, config_string);
+        }
+    }
+
     /// Returns the data directory for this config
     pub fn get_data_dir(&self) -> &Path {
         &self.base.data_dir


### PR DESCRIPTION
### Description
This PR logs the node config in multiple separate `info!` level logs, instead of a single `info!` call (which is truncated -- because the config is too large).

### Test Plan
Manual verification. The logs now look as follows:
```
2023-11-21T13:37:10.051845Z [main] INFO config/src/config/node_config.rs:88 Using full_node_networks config: [{"max_connection_delay_ms":60000,"connection_backoff_base":2,"connectivity_check_interval_ms":5000,"network_channel_size":1024,"max_concurrent_network_reqs":100,"discovery_method":"onchain","discovery_methods":[],"identity":{"type":"from_config","key":"0xe81faac74fea2b3264038e3fe18b1a95d87d948c2d092b4365b704cc7ce79770","peer_id":"e596594ffc659d80515ad648ae59b318f1841c4d11a6a62d5b91550a3e6b6a5d"},"listen_address":"/ip4/127.0.0.1/tcp/6180","mutual_authentication":false,"network_id":"public","runtime_threads":null,"inbound_rx_buffer_size_bytes":null,"inbound_tx_buffer_size_bytes":null,"outbound_rx_buffer_size_bytes":null,"outbound_tx_buffer_size_bytes":null,"seed_addrs":{},"seeds":{},"max_frame_size":4194304,"enable_proxy_protocol":false,"ping_interval_ms":10000,"ping_timeout_ms":20000,"ping_failures_tolerated":3,"max_outbound_connections":4,"max_inbound_connections":100,"inbound_rate_limit_config":null,"outbound_rate_limit_config":null,"max_message_size":67108864,"max_parallel_deserialization_tasks":10}]
2023-11-21T13:37:10.051851Z [main] INFO config/src/config/node_config.rs:88 Using indexer config: {"enabled":false}
2023-11-21T13:37:10.051860Z [main] INFO config/src/config/node_config.rs:88 Using indexer_grpc config: {"enabled":false,"use_data_service_interface":false,"address":"0.0.0.0:50051","processor_task_count":20,"processor_batch_size":1000,"output_batch_size":100}
2023-11-21T13:37:10.051868Z [main] INFO config/src/config/node_config.rs:88 Using inspection_service config: {"address":"0.0.0.0","port":9101,"expose_configuration":true,"expose_peer_information":true,"expose_system_information":true}
...
```

Also see [Humio](https://cloud.us.humio.com/k8s/search?columns=%5B%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40timestamp%22%2C%22format%22%3A%22datetime%22%2C%22width%22%3A180%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22level%22%2C%22format%22%3A%22text%22%2C%22width%22%3A54%7D%2C%7B%22type%22%3A%22link%22%2C%22openInNewBrowserTab%22%3Afalse%2C%22style%22%3A%22button%22%2C%22hrefTemplate%22%3A%22https%3A%2F%2Fgithub.com%2Faptos-labs%2Faptos-core%2Fpull%2F%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22textTemplate%22%3A%22%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22header%22%3A%22Forge%20PR%22%2C%22width%22%3A79%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.namespace%22%2C%22format%22%3A%22text%22%2C%22width%22%3A104%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.pod_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A126%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.container_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A85%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22message%22%2C%22format%22%3A%22text%22%7D%5D&end=1700540052000&live=false&newestAtBottom=false&query=%24forgeLogs(validator_instance%3D*)%20%7C%0A%20%20%20%20%22k8s.namespace%22%20%3D%20%22forge-e2e-pr-11002%22%20%2F%2F%20filters%20on%20namespace%20which%20contains%20validator%20logs%0A%20%20%20OR%20%20%2F%2F%20remove%20either%20side%20of%20the%20OR%20operator%20to%20only%20display%20validator%20or%20forge-runner%20logs%0A%20%20%20%20%22k8s.labels.forge-namespace%22%20%3D%20%22forge-e2e-pr-11002%22%20%2F%2F%20filters%20on%20specific%20forge-runner%20pod%20in%20default%20namespace%0A%7C%20%22%20config%3A%20%7B%22%0A&showOnlyFirstLine=false&start=1700539391000&tz=America%2FNew_York&widgetType=list-view).
