### PR TITLE
[docs] Update Algolia key

### DIFF
--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -308,7 +308,7 @@ const config = {
     },
     algolia: {
       appId: "HM7UY0NMLG",
-      apiKey: "63c5819714b74e64977337e61a1e3ae6",
+      apiKey: "9e564585ae0eeac4f41758c47c24d27f",
       indexName: "aptos",
       contextualSearch: true,
       debug: false,


### PR DESCRIPTION
### Description
Search was completely broken, due to API key being rotated and not updated within Docusaurus config. 

<img width="1950" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/98909677/7b21cc0e-af2a-4dae-8771-be293dfc2b10">

### Test Plan

Test search functionality with updated key. 