### PR TITLE
[compiler v2] Make type inference complete in the presence of structs

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
@@ -36,11 +36,11 @@ error: invalid call of `M::wrongly_typed_callee`: expected `bool` but found `u25
 32 │       wrongly_typed_callee(1, 1) // Wrongly typed function application
    │                               ^
 
-error: expected `num` but found `bool`
-   ┌─ tests/checking/specs/expressions_err.move:37:40
+error: invalid call of `M::wrongly_typed_fun_arg_callee`: expected `num` but found `bool` for argument 1
+   ┌─ tests/checking/specs/expressions_err.move:37:36
    │
 37 │       wrongly_typed_fun_arg_callee(|x| false) // Wrongly typed function argument.
-   │                                        ^^^^^
+   │                                    ^^^^^^^^^
 
 error: invalid call of `M::wrong_instantiation`: generic count mismatch (expected 2 but found 1)
    ┌─ tests/checking/specs/expressions_err.move:42:7

--- a/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
@@ -21,19 +21,19 @@ error: invalid reference to post state
    │     │         expression referring to post state
    │     not allowed to refer to post state
 
-error: The type argument to `exists` and `global` must be a struct type but `u64` is not
+error: expected a struct with  but found `u64`
    ┌─ tests/checking/specs/invariants_err.move:36:15
    │
 36 │     invariant exists<u64>(@0x0);
    │               ^^^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: expected a struct with  but found `T`
    ┌─ tests/checking/specs/invariants_err.move:37:18
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
    │                  ^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: expected a struct with  but found `T`
    ┌─ tests/checking/specs/invariants_err.move:37:37
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);

--- a/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
@@ -21,19 +21,19 @@ error: invalid reference to post state
    │     │         expression referring to post state
    │     not allowed to refer to post state
 
-error: expected a struct with  but found `u64`
+error: expected a struct but found `u64`
    ┌─ tests/checking/specs/invariants_err.move:36:15
    │
 36 │     invariant exists<u64>(@0x0);
    │               ^^^^^^^^^^^^^^^^^
 
-error: expected a struct with  but found `T`
+error: expected a struct but found `T`
    ┌─ tests/checking/specs/invariants_err.move:37:18
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
    │                  ^^^^^^^^^^^^^^^
 
-error: expected a struct with  but found `T`
+error: expected a struct but found `T`
    ┌─ tests/checking/specs/invariants_err.move:37:37
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);

--- a/third_party/move/move-compiler-v2/tests/checking/specs/structs_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/structs_err.exp
@@ -4,7 +4,7 @@ error: field `xx` not declared in struct `M::S`
    ┌─ tests/checking/specs/structs_err.move:26:7
    │
 26 │       s.xx
-   │       ^^^^
+   │       ^
 
 error: expected `bool` but found `u64`
    ┌─ tests/checking/specs/structs_err.move:31:7

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field.exp
@@ -6,7 +6,5 @@ module 0x8675309::M {
     private fun t0(s: &M::S,s_mut: &mut M::S,s_mut2: &mut M::S): (&u64, &u64, &mut u64) {
         Tuple(Borrow(Immutable)(select M::S.f(s)), Borrow(Immutable)(select M::S.f(s_mut)), Borrow(Mutable)(select M::S.f(s_mut2)))
     }
-    spec fun $t0(s: M::S,s_mut: M::S,s_mut2: M::S): (&u64, &u64, &mut u64) {
-        Tuple(select M::S.f(s), select M::S.f(s_mut), select M::S.f(s_mut2))
-    }
+    spec fun $t0(s: &M::S,s_mut: &mut M::S,s_mut2: &mut M::S): (&u64, &u64, &mut u64);
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field.exp
@@ -6,5 +6,7 @@ module 0x8675309::M {
     private fun t0(s: &M::S,s_mut: &mut M::S,s_mut2: &mut M::S): (&u64, &u64, &mut u64) {
         Tuple(Borrow(Immutable)(select M::S.f(s)), Borrow(Immutable)(select M::S.f(s_mut)), Borrow(Mutable)(select M::S.f(s_mut2)))
     }
-    spec fun $t0(s: &M::S,s_mut: &mut M::S,s_mut2: &mut M::S): (&u64, &u64, &mut u64);
+    spec fun $t0(s: M::S,s_mut: M::S,s_mut2: M::S): (&u64, &u64, &mut u64) {
+        Tuple(select M::S.f(s), select M::S.f(s_mut), select M::S.f(s_mut2))
+    }
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_chain_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_chain_missing.exp
@@ -4,52 +4,52 @@ error: field `f` not declared in struct `M::X1`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:7:10
   │
 7 │         &x1.f;
-  │          ^^^^
+  │          ^^
 
 error: field `f` not declared in struct `M::X2`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:8:10
   │
 8 │         &x1.x2.f;
-  │          ^^^^^^^
+  │          ^^^^^
 
 error: field `g` not declared in struct `M::X3`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:9:10
   │
 9 │         &x1.x2.x3.g;
-  │          ^^^^^^^^^^
+  │          ^^^^^^^^
 
 error: field `f` not declared in struct `M::X1`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:11:10
    │
 11 │         &x1_mut.f;
-   │          ^^^^^^^^
+   │          ^^^^^^
 
 error: field `f` not declared in struct `M::X2`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:12:10
    │
 12 │         &x1_mut.x2.f;
-   │          ^^^^^^^^^^^
+   │          ^^^^^^^^^
 
 error: field `g` not declared in struct `M::X3`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:13:10
    │
 13 │         &x1_mut.x2.x3.g;
-   │          ^^^^^^^^^^^^^^
+   │          ^^^^^^^^^^^^
 
 error: field `f` not declared in struct `M::X1`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:15:14
    │
 15 │         &mut x1_mut.f;
-   │              ^^^^^^^^
+   │              ^^^^^^
 
 error: field `f` not declared in struct `M::X2`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:16:14
    │
 16 │         &mut x1_mut.x2.f;
-   │              ^^^^^^^^^^^
+   │              ^^^^^^^^^
 
 error: field `g` not declared in struct `M::X3`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:17:14
    │
 17 │         &mut x1_mut.x2.x3.g;
-   │              ^^^^^^^^^^^^^^
+   │              ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: constraint `<some struct>{f: ?1}` incompatible with `integer`
+error: struct incompatible with integer
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:6:10
   │
 6 │         &0.f;
   │          ^
 
-error: constraint `<some struct>{g: ?5}` incompatible with `integer`
+error: struct incompatible with integer
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:7:10
   │
 7 │         &0.g;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
@@ -1,49 +1,49 @@
 
 Diagnostics:
-error: type `integer` cannot be resolved as a struct
+error: constraint `<some struct>{f: ?1}` incompatible with `integer`
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:6:10
   │
 6 │         &0.f;
-  │          ^^^
+  │          ^
 
-error: type `integer` cannot be resolved as a struct
+error: constraint `<some struct>{g: ?5}` incompatible with `integer`
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:7:10
   │
 7 │         &0.g;
-  │          ^^^
+  │          ^
 
-error: type `u64` cannot be resolved as a struct
+error: expected a struct with field `value` but found `u64`
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:8:10
   │
 8 │         &u.value;
-  │          ^^^^^^^
+  │          ^
 
-error: type `bool` cannot be resolved as a struct
+error: expected a struct with field `value` but found `bool`
   ┌─ tests/checking/typing/borrow_field_from_non_struct.move:9:10
   │
 9 │         &cond.value;
-  │          ^^^^^^^^^^
+  │          ^^^^
 
-error: type `address` cannot be resolved as a struct
+error: expected a struct with field `R` but found `address`
    ┌─ tests/checking/typing/borrow_field_from_non_struct.move:10:10
    │
 10 │         &addr.R;
-   │          ^^^^^^
+   │          ^^^^
 
-error: type `address` cannot be resolved as a struct
+error: expected a struct with field `f` but found `address`
    ┌─ tests/checking/typing/borrow_field_from_non_struct.move:11:10
    │
 11 │         &addr.f;
-   │          ^^^^^^
+   │          ^^^^
 
-error: type `()` cannot be resolved as a struct
+error: expected a struct with field `R` but found `()`
    ┌─ tests/checking/typing/borrow_field_from_non_struct.move:12:10
    │
 12 │         &().R;
-   │          ^^^^
+   │          ^^
 
-error: type `(&M::S, &M::S)` cannot be resolved as a struct
+error: expected a struct with field `f` but found `(?26, ?27)`
    ┌─ tests/checking/typing/borrow_field_from_non_struct.move:13:10
    │
 13 │         &(&S{f: 0}, &S{f:0}).f;
-   │          ^^^^^^^^^^^^^^^^^^^^^
+   │          ^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_internal.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_internal.exp
@@ -1,13 +1,24 @@
-
-Diagnostics:
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/borrow_field_internal.move:13:18
-   │
-13 │         (&X::s().f: &u64);
-   │                  ^
-
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/borrow_field_internal.move:15:13
-   │
-15 │         (&s.f: &u64);
-   │             ^
+// ---- Model Dump
+module 0x2::X {
+    struct S {
+        f: u64,
+    }
+    public fun s(): X::S {
+        pack X::S(0)
+    }
+    spec fun $s(): X::S {
+        pack X::S(0)
+    }
+} // end 0x2::X
+module 0x2::M {
+    use 0x2::X; // resolved as: 0x2::X
+    private fun t0() {
+        Borrow(Immutable)(select X::S.f(X::s()));
+        {
+          let s: &X::S = Borrow(Immutable)(X::s());
+          Borrow(Immutable)(select X::S.f(s));
+          Abort(0)
+        }
+    }
+    spec fun $t0();
+} // end 0x2::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_missing.exp
@@ -4,10 +4,10 @@ error: field `g` not declared in struct `M::S`
   ┌─ tests/checking/typing/borrow_field_missing.move:5:10
   │
 5 │         &s.g;
-  │          ^^^
+  │          ^
 
 error: field `h` not declared in struct `M::S`
   ┌─ tests/checking/typing/borrow_field_missing.move:6:10
   │
 6 │         &s_mut.h;
-  │          ^^^^^^^
+  │          ^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
@@ -36,12 +36,6 @@ error: invalid call of `move_to`: expected `&signer` but found `signer` for argu
 30 │         move_to(s, R{});
    │                 ^
 
-error: The type argument to `exists` and `global` must be a struct type but `?26` is not
-   ┌─ tests/checking/typing/constant_unsupported_exps.move:31:15
-   │
-31 │         R{} = move_from(@0x42);
-   │               ^^^^^^^^^^^^^^^^
-
 error: expected `()` but found `integer`
    ┌─ tests/checking/typing/constant_unsupported_exps.move:39:16
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
@@ -1,22 +1,22 @@
 
 Diagnostics:
 error: expected `bool` but found `u64`
-  ┌─ tests/checking/typing/derefrence_invalid.move:6:11
+  ┌─ tests/checking/typing/derefrence_invalid.move:6:10
   │
 6 │         (*x : bool);
-  │           ^
+  │          ^^
 
 error: expected `&u64` but found `u64`
-  ┌─ tests/checking/typing/derefrence_invalid.move:7:11
+  ┌─ tests/checking/typing/derefrence_invalid.move:7:10
   │
 7 │         (*x_mut: &u64);
-  │           ^^^^^
+  │          ^^^^^^
 
 error: expected `M::X` but found `M::S`
-  ┌─ tests/checking/typing/derefrence_invalid.move:9:11
+  ┌─ tests/checking/typing/derefrence_invalid.move:9:10
   │
 9 │         (*s: X);
-  │           ^
+  │          ^^
 
 error: expected `bool` but found `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:10:12
@@ -43,10 +43,10 @@ error: cannot borrow from a reference
    │           ^^^^
 
 error: expected `M::X` but found `M::S`
-   ┌─ tests/checking/typing/derefrence_invalid.move:14:11
+   ┌─ tests/checking/typing/derefrence_invalid.move:14:10
    │
 14 │         (*s_mut: X);
-   │           ^^^^^
+   │          ^^^^^^
 
 error: expected `bool` but found `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:15:12

--- a/third_party/move/move-compiler-v2/tests/checking/typing/exp_list.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/exp_list.exp
@@ -12,7 +12,9 @@ module 0x8675309::M {
     private fun t1(s: &M::S,r: &mut M::R<u64>): (u64, &M::S, &mut M::R<u64>) {
         Tuple(0, s, r)
     }
-    spec fun $t0(): (u64, M::S, M::R<M::R<u64>>);
+    spec fun $t0(): (u64, M::S, M::R<M::R<u64>>) {
+        Tuple(0, pack M::S(false), pack M::R<M::R<u256>>(pack M::R<u256>(1)))
+    }
     spec fun $t1(s: M::S,r: M::R<u64>): (u64, &M::S, &mut M::R<u64>) {
         Tuple(0, s, r)
     }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_inferred.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_inferred.exp
@@ -1,0 +1,18 @@
+// ---- Model Dump
+module 0x42::m {
+    struct A {
+        addr: address,
+    }
+    public fun foo(input: address): address
+        acquires m::A(*)
+     {
+        {
+          let a: m::A = MoveFrom<m::A>(input);
+          {
+            let m::A{ addr: addr: address } = a;
+            addr
+          }
+        }
+    }
+    spec fun $foo(input: address): address;
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_inferred.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_inferred.move
@@ -1,0 +1,11 @@
+module 0x42::m {
+    struct A has key {
+        addr: address,
+    }
+
+    public fun foo(input: address): address acquires A {
+        let a = move_from(input);
+        let A { addr } = a;
+        addr
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
@@ -42,12 +42,6 @@ error: invalid call of `move_to`: expected `M::R` but found `integer` for argume
 14 │         let () = move_to<R>(a, 0);
    │                                ^
 
-error: The type argument to `exists` and `global` must be a struct type but `integer` is not
-   ┌─ tests/checking/typing/global_builtins_invalid.move:15:18
-   │
-15 │         let () = move_to(a, 0);
-   │                  ^^^^^^^^^^^^^
-
 error: invalid call of `borrow_global`: expected `address` but found `integer` for argument 1
    ┌─ tests/checking/typing/global_builtins_invalid.move:16:39
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
@@ -42,6 +42,12 @@ error: invalid call of `move_to`: expected `M::R` but found `integer` for argume
 14 │         let () = move_to<R>(a, 0);
    │                                ^
 
+error: struct incompatible with integer
+   ┌─ tests/checking/typing/global_builtins_invalid.move:15:18
+   │
+15 │         let () = move_to(a, 0);
+   │                  ^^^^^^^^^^^^^
+
 error: invalid call of `borrow_global`: expected `address` but found `integer` for argument 1
    ┌─ tests/checking/typing/global_builtins_invalid.move:16:39
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_chain_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_chain_missing.exp
@@ -4,46 +4,46 @@ error: field `f` not declared in struct `M::X1`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:7:9
   │
 7 │         x1.f;
-  │         ^^^^
+  │         ^^
 
 error: field `f` not declared in struct `M::X2`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:8:9
   │
 8 │         x1.x2.f;
-  │         ^^^^^^^
+  │         ^^^^^
 
 error: field `g` not declared in struct `M::X3`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:9:9
   │
 9 │         x1.x2.x3.g;
-  │         ^^^^^^^^^^
+  │         ^^^^^^^^
 
-error: type `u64` cannot be resolved as a struct
+error: expected a struct with field `g` but found `u64`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:10:9
    │
 10 │         x1.x2.x3.f.g;
-   │         ^^^^^^^^^^^^
+   │         ^^^^^^^^^^
 
 error: field `f` not declared in struct `M::X1`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:11:9
    │
 11 │         x1_mut.f;
-   │         ^^^^^^^^
+   │         ^^^^^^
 
 error: field `f` not declared in struct `M::X2`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:12:9
    │
 12 │         x1_mut.x2.f;
-   │         ^^^^^^^^^^^
+   │         ^^^^^^^^^
 
 error: field `g` not declared in struct `M::X3`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:13:9
    │
 13 │         x1_mut.x2.x3.g;
-   │         ^^^^^^^^^^^^^^
+   │         ^^^^^^^^^^^^
 
-error: type `u64` cannot be resolved as a struct
+error: expected a struct with field `g` but found `u64`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:14:9
    │
 14 │         x1_mut.x2.x3.f.g;
-   │         ^^^^^^^^^^^^^^^^
+   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: constraint `<some struct>{f: ?0}` incompatible with `integer`
+error: struct incompatible with integer
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:6:9
   │
 6 │         0.f;
   │         ^
 
-error: constraint `<some struct>{g: ?3}` incompatible with `integer`
+error: struct incompatible with integer
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:7:9
   │
 7 │         0.g;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
@@ -1,49 +1,49 @@
 
 Diagnostics:
-error: type `integer` cannot be resolved as a struct
+error: constraint `<some struct>{f: ?0}` incompatible with `integer`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:6:9
   │
 6 │         0.f;
-  │         ^^^
+  │         ^
 
-error: type `integer` cannot be resolved as a struct
+error: constraint `<some struct>{g: ?3}` incompatible with `integer`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:7:9
   │
 7 │         0.g;
-  │         ^^^
+  │         ^
 
-error: type `u64` cannot be resolved as a struct
+error: expected a struct with field `value` but found `u64`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:8:9
   │
 8 │         u.value;
-  │         ^^^^^^^
+  │         ^
 
-error: type `bool` cannot be resolved as a struct
+error: expected a struct with field `value` but found `bool`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:9:9
   │
 9 │         cond.value;
-  │         ^^^^^^^^^^
+  │         ^^^^
 
-error: type `address` cannot be resolved as a struct
+error: expected a struct with field `R` but found `address`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:10:9
    │
 10 │         addr.R;
-   │         ^^^^^^
+   │         ^^^^
 
-error: type `address` cannot be resolved as a struct
+error: expected a struct with field `f` but found `address`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:11:9
    │
 11 │         addr.f;
-   │         ^^^^^^
+   │         ^^^^
 
-error: type `()` cannot be resolved as a struct
+error: expected a struct with field `R` but found `()`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:12:9
    │
 12 │         ().R;
-   │         ^^^^
+   │         ^^
 
-error: type `(M::S, M::S)` cannot be resolved as a struct
+error: expected a struct with field `f` but found `(?18, ?19)`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:13:9
    │
 13 │         (S{f: 0}, S{f:0}).f;
-   │         ^^^^^^^^^^^^^^^^^^^
+   │         ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_internal.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_internal.exp
@@ -1,13 +1,24 @@
-
-Diagnostics:
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/implicit_deref_borrow_field_internal.move:13:17
-   │
-13 │         (X::s().f: u64);
-   │                 ^
-
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/implicit_deref_borrow_field_internal.move:15:12
-   │
-15 │         (s.f: u64);
-   │            ^
+// ---- Model Dump
+module 0x2::X {
+    struct S {
+        f: u64,
+    }
+    public fun s(): X::S {
+        pack X::S(0)
+    }
+    spec fun $s(): X::S {
+        pack X::S(0)
+    }
+} // end 0x2::X
+module 0x2::M {
+    use 0x2::X; // resolved as: 0x2::X
+    private fun t0() {
+        select X::S.f(X::s());
+        {
+          let s: &X::S = Borrow(Immutable)(X::s());
+          select X::S.f(s);
+          Abort(0)
+        }
+    }
+    spec fun $t0();
+} // end 0x2::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_missing.exp
@@ -4,16 +4,16 @@ error: field `g` not declared in struct `M::S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:5:9
   │
 5 │         s.g;
-  │         ^^^
+  │         ^
 
 error: field `g` not declared in struct `M::S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:6:9
   │
 6 │         sref.g;
-  │         ^^^^^^
+  │         ^^^^
 
 error: field `h` not declared in struct `M::S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:7:9
   │
 7 │         s_mut.h;
-  │         ^^^^^^^
+  │         ^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -6,17 +6,17 @@ error: `M::reduce` is a function and not a macro
 34 │         foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
    │                                     ^^^^^^
 
-error: invalid call of `+`: expected `integer` but found `&integer` for argument 2
-   ┌─ tests/checking/typing/lambda.move:67:37
+error: invalid call of `M::foreach`: expected `&?19` but found `integer` for argument 2
+   ┌─ tests/checking/typing/lambda.move:67:21
    │
 67 │         foreach(&v, |e| sum = sum + e) // expected to cannot infer type
-   │                                     ^
+   │                     ^^^^^^^^^^^^^^^^^
 
-error: expected `()` but found `integer`
-   ┌─ tests/checking/typing/lambda.move:73:43
+error: invalid call of `M::foreach`: expected `()` but found `integer` for argument 2
+   ┌─ tests/checking/typing/lambda.move:73:21
    │
 73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
-   │                                           ^^
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected `(&T, u64)` but found `&T`
    ┌─ tests/checking/typing/lambda.move:40:13

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -13,10 +13,10 @@ error: invalid call of `+`: expected `integer` but found `&integer` for argument
    │                                     ^
 
 error: expected `()` but found `integer`
-   ┌─ tests/checking/typing/lambda.move:73:44
+   ┌─ tests/checking/typing/lambda.move:73:43
    │
 73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
-   │                                            ^
+   │                                           ^^
 
 error: expected `(&T, u64)` but found `&T`
    ┌─ tests/checking/typing/lambda.move:40:13

--- a/third_party/move/move-compiler-v2/tests/checking/typing/move_from_type_argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/move_from_type_argument.exp
@@ -1,7 +1,18 @@
-
-Diagnostics:
-error: The type argument to `exists` and `global` must be a struct type but `?0` is not
-  ┌─ tests/checking/typing/move_from_type_argument.move:8:17
-  │
-8 │         let a = move_from(input);
-  │                 ^^^^^^^^^^^^^^^^
+// ---- Model Dump
+module 0x42::m {
+    struct A {
+        addr: address,
+    }
+    public fun foo(input: address): address
+        acquires m::A(*)
+     {
+        {
+          let a: m::A = MoveFrom<m::A>(input);
+          {
+            let m::A{ addr: addr: address } = a;
+            addr
+          }
+        }
+    }
+    spec fun $foo(input: address): address;
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutate_field_internal.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutate_field_internal.exp
@@ -1,13 +1,24 @@
-
-Diagnostics:
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/mutate_field_internal.move:13:16
-   │
-13 │         X::s().f = 0;
-   │                ^
-
-error: field `f` of struct `X::S` is private to its module
-   ┌─ tests/checking/typing/mutate_field_internal.move:15:11
-   │
-15 │         s.f = 0;
-   │           ^
+// ---- Model Dump
+module 0x2::X {
+    struct S {
+        f: u64,
+    }
+    public fun s(): X::S {
+        pack X::S(0)
+    }
+    spec fun $s(): X::S {
+        pack X::S(0)
+    }
+} // end 0x2::X
+module 0x2::M {
+    use 0x2::X; // resolved as: 0x2::X
+    private fun t0() {
+        select X::S.f(X::s()) = 0;
+        {
+          let s: &mut X::S = Borrow(Mutable)(X::s());
+          select X::S.f(s) = 0;
+          Abort(0)
+        }
+    }
+    spec fun $t0();
+} // end 0x2::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/native_structs_pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/native_structs_pack_unpack.exp
@@ -6,11 +6,11 @@ error: native struct `C::T` cannot be packed or unpacked
 12 │         let C::T {} = c;
    │             ^^^^
 
-error: struct `C::T` is native and does not support field selection
+error: field `f` not declared in struct `C::T`
    ┌─ tests/checking/typing/native_structs_pack_unpack.move:15:17
    │
 15 │         let f = c.f;
-   │                 ^^^
+   │                 ^
 
 error: native struct `C::T` cannot be packed or unpacked
   ┌─ tests/checking/typing/native_structs_pack_unpack.move:9:9

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -12,12 +12,12 @@ use crate::{
         module_builder::{ModuleBuilder, SpecBlockContext},
     },
     model::{
-        FieldId, Loc, ModuleId, NodeId, Parameter, QualifiedId, QualifiedInstId, SpecFunId,
-        StructId, TypeParameter, TypeParameterKind,
+        FieldId, Loc, ModuleId, NodeId, Parameter, QualifiedInstId, SpecFunId, StructId,
+        TypeParameter, TypeParameterKind,
     },
     symbol::{Symbol, SymbolPool},
     ty::{
-        Constraint, PrimitiveType, ReferenceKind, Substitution, Type, Type::Struct,
+        CachedUnificationContext, Constraint, PrimitiveType, ReferenceKind, Substitution, Type,
         TypeDisplayContext, TypeUnificationError, Variance, WideningOrder, BOOL_TYPE,
     },
 };
@@ -73,17 +73,27 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub called_spec_funs: BTreeSet<(ModuleId, SpecFunId)>,
     /// A mapping from SpecId to SpecBlock (expansion ast)
     pub spec_block_map: BTreeMap<EA::SpecId, EA::SpecBlock>,
-    /// A mapping from expression node id to associated specification block info.
-    /// If such an id is found for a Nop expression, that expression serves as a placeholder
-    /// for a spec block. We need to check spec blocks at the end of checking
-    /// the function body such that they do not influence type inference.
-    pub spec_placeholder_map: BTreeMap<NodeId, SpecBlockInfo>,
+    /// A mapping from expression node id to associated placeholders which are to be processed
+    /// after function body checking and all type inference is done.
+    pub placeholder_map: BTreeMap<NodeId, ExpPlaceholder>,
+    /// A cached unification context, containing information about structs in the context.
+    pub unification_context: CachedUnificationContext,
 }
 
 #[derive(Debug)]
-pub struct SpecBlockInfo {
-    spec_id: EA::SpecId,
-    locals: BTreeMap<Symbol, (Loc, Type, Option<TempIndex>)>, // local variables are represented as temp_index in the bytecode
+pub enum ExpPlaceholder {
+    /// If attached to an expression, a placeholder for a spec block.  We need to check spec
+    /// blocks at the end of checking the function body such that they do not influence type
+    /// inference.
+    SpecBlockInfo {
+        /// Spec block id assigned by the parser
+        spec_id: EA::SpecId,
+        /// Locals at the point of the spec block, with an optional assigned TempIndex.
+        locals: BTreeMap<Symbol, (Loc, Type, Option<TempIndex>)>,
+    },
+    /// If attached to an expression, a placeholder for an field selection for which the full
+    /// structure type was not known yet, but should be at the end of function body checking.
+    FieldSelectInfo { struct_ty: Type, field_name: Symbol },
 }
 
 /// Mode of translation
@@ -110,6 +120,15 @@ pub(crate) enum OldExpStatus {
 impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
     pub fn new(parent: &'module_translator mut ModuleBuilder<'env, 'translator>) -> Self {
         let node_counter_start = parent.parent.env.next_free_node_number();
+        // Build cached unification context. Unfortunately we need to clone some of the
+        // information in the builder to work around borrowing restrictions.
+        let mut struct_cache = BTreeMap::new();
+        for id in parent.parent.get_struct_ids() {
+            struct_cache.insert(
+                id,
+                parent.parent.lookup_struct_fields(id.instantiate(vec![])),
+            );
+        }
         Self {
             parent,
             mode: ExpTranslationMode::Spec,
@@ -128,7 +147,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             had_errors: false,
             called_spec_funs: BTreeSet::new(),
             spec_block_map: BTreeMap::new(),
-            spec_placeholder_map: BTreeMap::new(),
+            placeholder_map: BTreeMap::new(),
+            unification_context: CachedUnificationContext(struct_cache),
         }
     }
 
@@ -269,7 +289,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     fn fresh_type_var_constr(&mut self, loc: Loc, order: WideningOrder, ctr: Constraint) -> Type {
         let idx = self.fresh_type_var_idx();
         self.subs
-            .add_constraint(idx, loc, order, ctr)
+            .add_constraint(&self.unification_context, idx, loc, order, ctr)
             .expect("success on fresh var");
         Type::Var(idx)
     }
@@ -1375,10 +1395,11 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let id = self.new_node_id_with_type_loc(&rt, &loc);
                 if self.mode == ExpTranslationMode::Impl {
                     // Remember information about this spec block for deferred checking.
-                    self.spec_placeholder_map.insert(id, SpecBlockInfo {
-                        spec_id: *spec_id,
-                        locals: self.get_locals(),
-                    });
+                    self.placeholder_map
+                        .insert(id, ExpPlaceholder::SpecBlockInfo {
+                            spec_id: *spec_id,
+                            locals: self.get_locals(),
+                        });
                 }
                 ExpData::Call(id, Operation::NoOp, vec![])
             },
@@ -1406,41 +1427,68 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         locals
     }
 
-    /// Post processes any spec blocks which have been encountered while translating expressions
-    /// with this builder. This rewrites the given result expression and fills in any spec blocks
-    /// captured in the `self.spec_placeholder_map` which is populated during expression
-    /// translation.
-    pub fn post_process_spec_blocks(&mut self, result_exp: Exp) -> Exp {
-        if self.spec_placeholder_map.is_empty() {
-            // Shortcut case of no spec blocks
+    /// Post processes any placeholders which have been generated while translating expressions
+    /// with this builder. This rewrites the given result expression and fills in placeholders
+    /// with the final expressions.
+    pub fn post_process_placeholders(&mut self, result_exp: Exp) -> Exp {
+        if self.placeholder_map.is_empty() {
+            // Shortcut case of no placeholders
             result_exp
         } else {
             ExpData::rewrite(result_exp, &mut |e| {
-                let id = e.node_id();
-                let loc = self.get_node_loc(id);
-                if let Some(info) = self.spec_placeholder_map.get(&id) {
-                    let spec = if let Some(block) = self.spec_block_map.get(&info.spec_id).cloned()
-                    {
-                        // Specializes types of locals in the context. For a type correct program,
-                        // these types are concrete (otherwise there have been inference errors).
-                        // To avoid followup errors, we use specialize_with_defaults which allows
-                        // checking the spec block even with incomplete types.
-                        let locals = info
-                            .locals
-                            .iter()
-                            .map(|(s, (l, t, idx))| {
-                                let t = self.subs.specialize_with_defaults(t);
-                                (*s, (l.clone(), t, *idx))
-                            })
-                            .collect();
-                        self.translate_spec_block(&loc, locals, &block)
+                let exp_data: ExpData = e.into();
+                if let ExpData::Call(id, Operation::NoOp, args) = exp_data {
+                    if let Some(info) = self.placeholder_map.get(&id) {
+                        let loc = self.get_node_loc(id);
+                        match info {
+                            ExpPlaceholder::SpecBlockInfo { spec_id, locals } => {
+                                let spec = if let Some(block) =
+                                    self.spec_block_map.get(spec_id).cloned()
+                                {
+                                    // Specializes types of locals in the context. For a type correct program,
+                                    // these types are concrete (otherwise there have been inference errors).
+                                    // To avoid followup errors, we use specialize_with_defaults which allows
+                                    // checking the spec block even with incomplete types.
+                                    let locals = locals
+                                        .iter()
+                                        .map(|(s, (l, t, idx))| {
+                                            let t = self.subs.specialize_with_defaults(t);
+                                            (*s, (l.clone(), t, *idx))
+                                        })
+                                        .collect();
+                                    self.translate_spec_block(&loc, locals, &block)
+                                } else {
+                                    self.bug(&loc, "unresolved spec anchor");
+                                    Spec::default()
+                                };
+                                Ok(ExpData::SpecBlock(id, spec).into_exp())
+                            },
+                            ExpPlaceholder::FieldSelectInfo {
+                                struct_ty,
+                                field_name,
+                            } => {
+                                // Resolve a field selection into the inferred struct type.
+                                if let Type::Struct(mid, sid, _) = self
+                                    .subs
+                                    .specialize_with_defaults(struct_ty)
+                                    .skip_reference()
+                                {
+                                    Ok(ExpData::Call(
+                                        id,
+                                        Operation::Select(*mid, *sid, FieldId::new(*field_name)),
+                                        args,
+                                    )
+                                    .into_exp())
+                                } else {
+                                    Ok(self.new_error_exp().into_exp())
+                                }
+                            },
+                        }
                     } else {
-                        self.bug(&loc, "unresolved spec anchor");
-                        Spec::default()
-                    };
-                    Ok(ExpData::SpecBlock(id, spec).into_exp())
+                        Err(ExpData::Call(id, Operation::NoOp, args).into_exp())
+                    }
                 } else {
-                    Err(e)
+                    Err(exp_data.into_exp())
                 }
             })
         }
@@ -1611,7 +1659,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         self.check_type_with_order(expected_order, loc, &ty, &expected_type, "");
                     let id = self.new_node_id_with_type_loc(&ty, loc);
                     let mut std = struct_id;
-                    if let Struct(_, _, types) = ty {
+                    if let Type::Struct(_, _, types) = ty {
                         std.inst = types;
                     }
                     Pattern::Struct(id, std, args)
@@ -2035,7 +2083,6 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         lvlist,
                         ty,
                         //ty.display(&self.parent.parent.env.get_type_display_ctx()),
-                        if let Some(e) = &binding {
                             format!("{:?}", e)
                             //e.display(self.parent.parent.env).to_string()
                         } else {
@@ -2085,6 +2132,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         // If this is a totally unbound item, assign default unit type.
                         self.subs
                             .add_constraint(
+                                &self.unification_context,
                                 var,
                                 exp_loc,
                                 WideningOrder::LeftToRight,
@@ -2323,32 +2371,27 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             EA::ExpDotted_::Exp(e) => self.translate_exp(e, expected_type),
             EA::ExpDotted_::Dot(e, n) => {
                 let loc = self.to_loc(&dotted.loc);
-                let ty = self.fresh_type_var();
+                let field_name = self.symbol_pool().make(n.value.as_str());
+                let constraint = Constraint::SomeStruct(
+                    [(field_name, expected_type.clone())].into_iter().collect(),
+                );
+                let ty =
+                    self.fresh_type_var_constr(loc.clone(), WideningOrder::RightToLeft, constraint);
                 let exp = self.translate_dotted(e.as_ref(), &ty);
-                if let Some((struct_id, field_id, field_ty)) = self.lookup_field(&loc, &ty, n) {
-                    if self.mode == ExpTranslationMode::Impl
-                        && struct_id.module_id != self.parent.module_id
-                    {
-                        self.error(
-                            &self.to_loc(&n.loc),
-                            &format!(
-                                "field `{}` of struct `{}` is private to its module",
-                                n.value.as_str(),
-                                self.parent
-                                    .parent
-                                    .env
-                                    .get_struct(struct_id)
-                                    .get_full_name_str()
-                            ),
-                        )
-                    }
-                    let oper = Operation::Select(struct_id.module_id, struct_id.id, field_id);
-                    self.check_type(&loc, &field_ty, expected_type, "");
-                    let id = self.new_node_id_with_type_loc(&field_ty, &loc);
-                    ExpData::Call(id, oper, vec![exp.into_exp()])
+                let id = self.new_node_id_with_type_loc(expected_type, &loc);
+                let oper = if let Type::Struct(mid, sid, _inst) = self.subs.specialize(&ty) {
+                    // Struct known at this point
+                    Operation::Select(mid, sid, FieldId::new(field_name))
                 } else {
-                    self.new_error_exp()
-                }
+                    // Create a placeholder for later resolution.
+                    self.placeholder_map
+                        .insert(id, ExpPlaceholder::FieldSelectInfo {
+                            struct_ty: ty,
+                            field_name,
+                        });
+                    Operation::NoOp
+                };
+                ExpData::Call(id, oper, vec![exp.into_exp()])
             },
         }
     }
@@ -2370,8 +2413,6 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             self.error(loc, "`update_field` requires 3 arguments");
             return self.new_error_exp();
         }
-        let struct_exp = self.translate_exp(args[0], expected_type);
-        let expected_type = &self.subs.specialize(expected_type);
         if let EA::Exp_::Name(
             Spanned {
                 value: EA::ModuleAccess_::Name(name),
@@ -2380,16 +2421,37 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             None,
         ) = &args[1].value
         {
-            if let Some((struct_id, field_id, field_type)) =
-                self.lookup_field(loc, expected_type, name)
-            {
+            let field_name = self.symbol_pool().make(name.value.as_str());
+            let constraint =
+                Constraint::SomeStruct([(field_name, expected_type.clone())].into_iter().collect());
+            if let Err(e) = self.subs.eval_constraint(
+                &self.unification_context,
+                loc,
+                expected_type,
+                WideningOrder::RightToLeft,
+                constraint,
+            ) {
+                self.report_unification_error(loc, e, "update field")
+            }
+            let struct_exp = self.translate_exp(args[0], expected_type);
+            if let Type::Struct(mid, sid, inst) = self.subs.specialize(expected_type) {
+                // field_map contains the instantiated field type.
+                let field_map = self
+                    .parent
+                    .parent
+                    .lookup_struct_fields(mid.qualified_inst(sid, inst));
+                let field_type = field_map
+                    .get(&field_name)
+                    .cloned()
+                    .unwrap_or_else(|| Type::Error); // this error is reported via type unification
+
                 // Translate the new value with the field type as the expected type.
-                let value_exp = self.translate_exp(args[2], &self.subs.specialize(&field_type));
+                let value_exp = self.translate_exp(args[2], &field_type);
                 let id = self.new_node_id_with_type_loc(expected_type, loc);
                 self.set_node_instantiation(id, vec![expected_type.clone()]);
                 ExpData::Call(
                     id,
-                    Operation::UpdateField(struct_id.module_id, struct_id.id, field_id),
+                    Operation::UpdateField(mid, sid, FieldId::new(field_name)),
                     vec![struct_exp.into_exp(), value_exp.into_exp()],
                 )
             } else {
@@ -2402,84 +2464,6 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 "second argument of `update_field` must be a field name",
             );
             self.new_error_exp()
-        }
-    }
-
-    /// Loops up a field in a struct. Returns field information or None after reporting errors.
-    fn lookup_field(
-        &mut self,
-        loc: &Loc,
-        struct_ty: &Type,
-        name: &Name,
-    ) -> Option<(QualifiedId<StructId>, FieldId, Type)> {
-        // Similar as with Index, we must concretize the type of the expression on which
-        // field selection is performed, violating pure type inference rules, so we can actually
-        // check and retrieve the field. To avoid this, we would need to have a
-        // `Constraint::HasField` or similar.
-        let mut struct_ty = self.subs.specialize(struct_ty);
-        if let Type::Reference(_, ty) = struct_ty {
-            // Skip reference -- argument to field selection can be direct struct or reference
-            // to struct.
-            struct_ty = *ty
-        }
-        let field_name = self.symbol_pool().make(&name.value);
-        if let Type::Struct(mid, sid, targs) = &struct_ty {
-            // Lookup the StructEntry in the translator. It must be defined for valid
-            // Type::Struct instances.
-            let struct_name = self
-                .parent
-                .parent
-                .reverse_struct_table
-                .get(&(*mid, *sid))
-                .expect("invalid Type::Struct");
-            let entry = self
-                .parent
-                .parent
-                .struct_table
-                .get(struct_name)
-                .expect("invalid Type::Struct");
-            // Lookup the field in the struct.
-            if let Some(fields) = &entry.fields {
-                if let Some((_, _, field_ty)) = fields.get(&field_name) {
-                    // We must instantiate the field type by the provided type args.
-                    let field_ty = field_ty.instantiate(targs);
-                    Some((
-                        entry.module_id.qualified(entry.struct_id),
-                        FieldId::new(field_name),
-                        field_ty,
-                    ))
-                } else {
-                    self.error(
-                        loc,
-                        &format!(
-                            "field `{}` not declared in struct `{}`",
-                            field_name.display(self.symbol_pool()),
-                            struct_name.display(self.parent.parent.env)
-                        ),
-                    );
-                    None
-                }
-            } else {
-                self.error(
-                    loc,
-                    &format!(
-                        "struct `{}` is native and does not support field selection",
-                        struct_name.display(self.parent.parent.env)
-                    ),
-                );
-                None
-            }
-        } else {
-            if !struct_ty.is_error() {
-                self.error(
-                    loc,
-                    &format!(
-                        "type `{}` cannot be resolved as a struct",
-                        struct_ty.display(&self.type_display_context()),
-                    ),
-                );
-            }
-            None
         }
     }
 
@@ -2578,7 +2562,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     outruled.push((
                         cand,
                         err.specific_loc(),
-                        err.message(&self.type_display_context()),
+                        err.message(&self.unification_context, &self.type_display_context()),
                     ));
                     continue;
                 }
@@ -2597,6 +2581,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 };
                 let instantiated = params[i].1.instantiate(&instantiation);
                 if let Err(err) = subs.unify(
+                    &self.unification_context,
                     self.type_variance(),
                     WideningOrder::LeftToRight,
                     &arg_ty,
@@ -2617,7 +2602,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         arg_loc,
                         format!(
                             "{} for argument {}",
-                            err.message(&self.type_display_context()),
+                            err.message(&self.unification_context, &self.type_display_context()),
                             i + 1
                         ),
                     ));
@@ -2687,18 +2672,12 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     | Operation::BorrowGlobal(_)
                     | Operation::MoveFrom
                     | Operation::MoveTo => {
-                        let ty_inst = self.subs.specialize(&instantiation[0]);
-                        if !matches!(ty_inst, Type::Struct(..)) {
-                            self.error(
-                                loc,
-                                &format!(
-                                    "The type argument to `exists` and `global` must be a struct \
-                                    type but `{}` is not",
-                                    ty_inst.display(&self.type_display_context())
-                                ),
-                            );
-                            return self.new_error_exp();
-                        }
+                        // The instantiation must be a struct
+                        self.add_constraint_and_report(
+                            loc,
+                            &instantiation[0],
+                            Constraint::SomeStruct(BTreeMap::new()),
+                        );
                     },
                     _ => (),
                 };
@@ -2875,9 +2854,27 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     ) -> Result<(), TypeUnificationError> {
         for (idx, ctr) in constraints {
             let ty = &args[*idx];
-            subs.eval_constraint(loc, ty, WideningOrder::LeftToRight, ctr.to_owned())?;
+            subs.eval_constraint(
+                &self.unification_context,
+                loc,
+                &subs.specialize(ty),
+                WideningOrder::LeftToRight,
+                ctr.to_owned(),
+            )?;
         }
         Ok(())
+    }
+
+    fn add_constraint_and_report(&mut self, loc: &Loc, ty: &Type, c: Constraint) {
+        if let Err(e) = self.subs.eval_constraint(
+            &self.unification_context,
+            loc,
+            &self.subs.specialize(ty),
+            WideningOrder::LeftToRight,
+            c,
+        ) {
+            self.report_unification_error(loc, e, "")
+        }
     }
 
     fn translate_pack(
@@ -3335,9 +3332,13 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         ty2: &Type,
         context_msg: &str,
     ) -> Type {
-        let res = self
-            .subs
-            .unify(self.type_variance().shallow(), order, ty1, ty2);
+        let res = self.subs.unify(
+            &self.unification_context,
+            self.type_variance().shallow(),
+            order,
+            ty1,
+            ty2,
+        );
         match res {
             Ok(t) => t,
             Err(err) => {
@@ -3357,7 +3358,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             &err.specific_loc().unwrap_or_else(|| loc.clone()),
             &format!(
                 "{}{}",
-                err.message(&self.type_display_context()),
+                err.message(&self.unification_context, &self.type_display_context()),
                 if context_msg.is_empty() {
                     "".to_string()
                 } else {

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2673,9 +2673,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     | Operation::MoveFrom
                     | Operation::MoveTo => {
                         // The instantiation must be a struct
+                        let inst = self.subs.specialize(&instantiation[0]);
                         self.add_constraint_and_report(
                             loc,
-                            &instantiation[0],
+                            &inst,
                             Constraint::SomeStruct(BTreeMap::new()),
                         );
                     },

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -372,8 +372,8 @@ impl<'env> ModelBuilder<'env> {
     /// Get all the structs which have been build so far.
     pub fn get_struct_ids(&self) -> impl Iterator<Item = QualifiedId<StructId>> + '_ {
         self.struct_table
-            .iter()
-            .map(|(_, e)| e.module_id.qualified(e.struct_id))
+            .values()
+            .map(|e| e.module_id.qualified(e.struct_id))
     }
 
     /// Looks up the StructEntry for a qualified id.

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -12,8 +12,8 @@ use crate::{
     builder::builtins,
     intrinsics::IntrinsicDecl,
     model::{
-        FunId, FunctionKind, GlobalEnv, Loc, ModuleId, Parameter, QualifiedId, SpecFunId,
-        SpecVarId, StructId, TypeParameter,
+        FunId, FunctionKind, GlobalEnv, Loc, ModuleId, Parameter, QualifiedId, QualifiedInstId,
+        SpecFunId, SpecVarId, StructId, TypeParameter,
     },
     symbol::Symbol,
     ty::{Constraint, Type},
@@ -353,6 +353,38 @@ impl<'env> ModelBuilder<'env> {
                 );
                 Type::Error
             })
+    }
+
+    /// Looks up the fields of a structure, with instantiated field types.
+    pub fn lookup_struct_fields(&self, id: QualifiedInstId<StructId>) -> BTreeMap<Symbol, Type> {
+        let entry = self.lookup_struct_entry(id.to_qualified_id());
+        entry
+            .fields
+            .as_ref()
+            .map(|f| {
+                f.iter()
+                    .map(|(n, (_, _, field_ty))| (*n, field_ty.instantiate(&id.inst)))
+                    .collect::<BTreeMap<_, _>>()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get all the structs which have been build so far.
+    pub fn get_struct_ids(&self) -> impl Iterator<Item = QualifiedId<StructId>> + '_ {
+        self.struct_table
+            .iter()
+            .map(|(_, e)| e.module_id.qualified(e.struct_id))
+    }
+
+    /// Looks up the StructEntry for a qualified id.
+    pub fn lookup_struct_entry(&self, id: QualifiedId<StructId>) -> &StructEntry {
+        let struct_name = self
+            .reverse_struct_table
+            .get(&(id.module_id, id.id))
+            .expect("invalid Type::Struct");
+        self.struct_table
+            .get(struct_name)
+            .expect("invalid Type::Struct")
     }
 
     // Generate warnings about unused schemas.

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1280,9 +1280,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 };
                 let mut result = et.translate_seq(&loc, seq, &result_type);
                 et.finalize_types();
-                if !as_spec_fun {
-                    result = et.post_process_spec_blocks(result.into_exp()).into();
-                }
+                result = et.post_process_placeholders(result.into_exp()).into();
                 (result, access_specifiers)
             };
 

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -30,7 +30,8 @@ use crate::{
     },
     symbol::{Symbol, SymbolPool},
     ty::{
-        PrimitiveType, ReferenceKind, Type, TypeDisplayContext, TypeUnificationAdapter, Variance,
+        NoUnificationContext, PrimitiveType, ReferenceKind, Type, TypeDisplayContext,
+        TypeUnificationAdapter, Variance,
     },
     well_known,
 };
@@ -1045,7 +1046,7 @@ impl GlobalEnv {
             }
             assert_eq!(key.inst.len(), memory.inst.len());
             let adapter = TypeUnificationAdapter::new_vec(&memory.inst, &key.inst, true, true);
-            let rel = adapter.unify(Variance::SpecVariance, true);
+            let rel = adapter.unify(&NoUnificationContext, Variance::SpecVariance, true);
             if rel.is_some() {
                 inv_ids.extend(val.clone());
             }

--- a/third_party/move/move-model/tests/sources/expressions_err.exp
+++ b/third_party/move/move-model/tests/sources/expressions_err.exp
@@ -34,11 +34,11 @@ error: invalid call of `M::wrongly_typed_callee`: expected `bool` but found `u25
 37 │     fun wrongly_typed_caller(): num { wrongly_typed_callee(1, 1) }
    │                                                               ^
 
-error: expected `num` but found `bool`
-   ┌─ tests/sources/expressions_err.move:41:80
+error: invalid call of `M::wrongly_typed_fun_arg_callee`: expected `num` but found `bool` for argument 1
+   ┌─ tests/sources/expressions_err.move:41:76
    │
 41 │     fun wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
-   │                                                                                ^^^^^
+   │                                                                            ^^^^^^^^^
 
 error: invalid call of `M::wrong_instantiation`: generic count mismatch (expected 2 but found 1)
    ┌─ tests/sources/expressions_err.move:46:7

--- a/third_party/move/move-model/tests/sources/invariants_err.exp
+++ b/third_party/move/move-model/tests/sources/invariants_err.exp
@@ -19,19 +19,19 @@ error: invalid reference to post state
    │     │         expression referring to post state
    │     not allowed to refer to post state
 
-error: The type argument to `exists` and `global` must be a struct type but `u64` is not
+error: expected a struct but found `u64`
    ┌─ tests/sources/invariants_err.move:36:15
    │
 36 │     invariant exists<u64>(@0x0);
    │               ^^^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: expected a struct but found `T`
    ┌─ tests/sources/invariants_err.move:37:18
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
    │                  ^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: expected a struct but found `T`
    ┌─ tests/sources/invariants_err.move:37:37
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);

--- a/third_party/move/move-model/tests/sources/structs_err.exp
+++ b/third_party/move/move-model/tests/sources/structs_err.exp
@@ -2,7 +2,7 @@ error: field `xx` not declared in struct `M::S`
    ┌─ tests/sources/structs_err.move:26:7
    │
 26 │       s.xx
-   │       ^^^^
+   │       ^
 
 error: expected `bool` but found `u64`
    ┌─ tests/sources/structs_err.move:31:7

--- a/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
@@ -9,7 +9,10 @@ use move_binary_format::file_format::CodeOffset;
 use move_model::{
     ast::ConditionKind,
     model::{FunId, FunctionEnv, GlobalEnv, GlobalId, QualifiedId, QualifiedInstId, StructId},
-    ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
+    ty::{
+        NoUnificationContext, Type, TypeDisplayContext, TypeInstantiationDerivation,
+        TypeUnificationAdapter, Variance,
+    },
 };
 use move_stackless_bytecode::{
     function_target::{FunctionData, FunctionTarget},
@@ -434,7 +437,10 @@ impl PerFunctionRelevance {
 
                     // make sure these two types unify before trying to instantiate them
                     let adapter = TypeUnificationAdapter::new_pair(&rel_ty, &inv_ty, true, true);
-                    if adapter.unify(Variance::SpecVariance, false).is_none() {
+                    if adapter
+                        .unify(&NoUnificationContext, Variance::SpecVariance, false)
+                        .is_none()
+                    {
                         continue;
                     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_instrumentation_v2.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_instrumentation_v2.rs
@@ -16,7 +16,7 @@ use move_model::{
     model::{FunId, FunctionEnv, GlobalEnv, GlobalId, Loc, QualifiedId, QualifiedInstId, StructId},
     pragmas::CONDITION_ISOLATED_PROP,
     spec_translator::{SpecTranslator, TranslatedSpec},
-    ty::{Type, TypeUnificationAdapter, Variance},
+    ty::{NoUnificationContext, Type, TypeUnificationAdapter, Variance},
 };
 use move_stackless_bytecode::{
     function_data_builder::FunctionDataBuilder,
@@ -152,7 +152,11 @@ impl Analyzer {
                 }
                 let adapter =
                     TypeUnificationAdapter::new_vec(&fun_mem.inst, &inv_mem.inst, true, true);
-                let rel = adapter.unify(Variance::SpecVariance, /* shallow_subst */ false);
+                let rel = adapter.unify(
+                    &NoUnificationContext,
+                    Variance::SpecVariance,
+                    /* shallow_subst */ false,
+                );
                 match rel {
                     None => continue,
                     Some((subs_fun, _)) => {
@@ -748,7 +752,11 @@ impl<'a> Instrumenter<'a> {
                     self.builder.global_env().display(inv_mem),
                     inv.loc.display(self.builder.global_env())
                 );
-                let rel = adapter.unify(Variance::SpecVariance, /* shallow_subst */ false);
+                let rel = adapter.unify(
+                    &NoUnificationContext,
+                    Variance::SpecVariance,
+                    /* shallow_subst */ false,
+                );
                 match rel {
                     None => continue,
                     Some((_, subst_rhs)) => {

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -14,7 +14,10 @@ use move_model::{
         StructEnv, StructId,
     },
     pragmas::INTRINSIC_TYPE_MAP,
-    ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
+    ty::{
+        NoUnificationContext, Type, TypeDisplayContext, TypeInstantiationDerivation,
+        TypeUnificationAdapter, Variance,
+    },
     well_known::{
         TYPE_INFO_MOVE, TYPE_INFO_SPEC, TYPE_NAME_GET_MOVE, TYPE_NAME_GET_SPEC, TYPE_NAME_MOVE,
         TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT,
@@ -326,7 +329,10 @@ impl<'a> Analyzer<'a> {
 
                     // make sure these two types unify before trying to instantiate them
                     let adapter = TypeUnificationAdapter::new_pair(&lhs_ty, &rhs_ty, true, true);
-                    if adapter.unify(Variance::SpecVariance, false).is_none() {
+                    if adapter
+                        .unify(&NoUnificationContext, Variance::SpecVariance, false)
+                        .is_none()
+                    {
                         continue;
                     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
@@ -17,7 +17,7 @@ use move_model::{
         CONDITION_SUSPENDABLE_PROP, DELEGATE_INVARIANTS_TO_CALLER_PRAGMA,
         DISABLE_INVARIANTS_IN_BODY_PRAGMA, VERIFY_PRAGMA,
     },
-    ty::{TypeUnificationAdapter, Variance},
+    ty::{NoUnificationContext, TypeUnificationAdapter, Variance},
 };
 use move_stackless_bytecode::{
     function_target::{FunctionData, FunctionTarget},
@@ -584,7 +584,11 @@ impl VerificationAnalysisProcessor {
                     }
                     let adapter =
                         TypeUnificationAdapter::new_vec(&fun_mem.inst, &inv_mem.inst, true, true);
-                    let rel = adapter.unify(Variance::SpecVariance, /* shallow_subst */ false);
+                    let rel = adapter.unify(
+                        &NoUnificationContext,
+                        Variance::SpecVariance,
+                        /* shallow_subst */ false,
+                    );
                     if rel.is_some() {
                         inv_accessed.insert(inv.id);
 


### PR DESCRIPTION
Closes #10884.

Until now, type inference had some ad-hoc treatment when it comes to structs. In the case of field access, or in the case of resource operations, the inferred type was forced to be concrete at the point of the occurence of the particular operation. For example, in `s.f`, if the type of `s` is not known at this program point, an error was produced. Similar, `move_from(a)` could not be used without explicit type instantiation because the inferred resource type isn't known yet.

In this PR we make "type inference whole" by removing the ad-hoc treatment. To this end, the type constraint system is extended by a new constraint `SomeStruct(fields)`. Thus for `s.f`, we can represent the type of `s` as 'some type X which is SomeStruct(f:Y)'. This brings us again a step closer to full support of traits in type inference.

