### PR TITLE
[code-coverage] ignore md files for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ---
 ignore:
   - "testsuite"
+  - "**/*.md"
 
 coverage:
   # range for color spectrum display, red=50%, green=80%


### PR DESCRIPTION
### Description

Ignore md files in the repo when computing the coverage number.
