### PR TITLE
Enables `OPERATOR_BENEFICIARY_CHANGE` in devnet by default

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -435,6 +435,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_CREATION,
         FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
         FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
+        FeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
     ]
 }
 


### PR DESCRIPTION
### Description
This enables `OPERATOR_BENEFICIARY_CHANGE` in the devnet to release (v1.8.4).