### PR TITLE
[docker] separate build target for grpc

### DIFF
--- a/docker/builder/README.md
+++ b/docker/builder/README.md
@@ -29,10 +29,11 @@ The builder can produce the following Docker images. To build a particular image
 ## How the builder works
 
 At a high level, the builder works as follows. By default, the builder builds all images.
-1. Either or both the `aptos-node-builder` and `tools-builder` targets are invoked depending on what image is being built.
+
+1. One of `aptos-node-builder`, `indexer-builder`, or `tools-builder` targets are invoked depending on what image is being built.
 2. The target image is built by copying the output of either the `aptos-node-builder` or `tools-builder` target into the target image.
 
-The `aptos-node-builder` is separate from the `tools-builder` because it allows to build different `aptos-node` binary variants with different features and profiles. 
+The `aptos-node-builder` is separate from the the other builder targets because it allows to build different `aptos-node` binary variants with different features and profiles.
 
 Using a builder step allows us to cache the build artifacts and reuse them across different images. Our binaries have a lot of common dependencies, so this is a significant time saver. Furthermore, most `RUN` instructions use a cache mount that allows us to cache the output of the command leading to significant build time improvements.
 
@@ -43,8 +44,8 @@ Using a builder step allows us to cache the build artifacts and reuse them acros
 > Note: If your requirements doesn't fit into the instructions below, please reach out to the team for help.
 
 1. Modify the `cargo build` step in `build-tools.sh` to include the new binary.
-2. Create a new Dockerfile by cloning an existing target Dockerfile (e.g. `validator.Dockerfile`). When you use a `RUN` instruction, try to use a mount cache as they can improve build times by caching the output of the command. 
-3. Add the following `FROM` statements to the new Dockerfile depending on whether you need to copy from the `aptos-node-builder` or the `tools-builder`. This ensures that your image references the required builder images to copy the binaries from. These image references are injected as build contexts at build time. This is defined in the `contexts` field in `_common` target in [docker-bake-rust-all.hcl](docker-bake-rust-all.hcl).
+2. Create a new Dockerfile by cloning an existing target Dockerfile (e.g. `validator.Dockerfile`). When you use a `RUN` instruction, try to use a mount cache as they can improve build times by caching the output of the command.
+3. Add the following `FROM` statements to the new Dockerfile depending on whether you need to copy from the `aptos-node-builder`, `indexer-builder`, `tools-builder`. This ensures that your image references the required builder images to copy the binaries from. These image references are injected as build contexts at build time. This is defined in the `contexts` field in `_common` target in [docker-bake-rust-all.hcl](docker-bake-rust-all.hcl).
 
 ```
 FROM node-builder
@@ -52,23 +53,24 @@ FROM node-builder
 FROM tools-builder
 ```
 
-4. In your new Dockerfile, use the COPY command to copy the output of the `aptos-node-builder` or `tools-builder` target into the image. For example, to copy the `aptos-node` binary into the `validator` image, use the following command:
-    ```
-    COPY --link --from=node-builder /aptos/dist/aptos-node /usr/local/bin/
-    ```
+4. In your new Dockerfile, use the COPY command to copy the output of the `aptos-node-builder`, `indexer-builder`, `tools-builder` target into the image. For example, to copy the `aptos-node` binary into the `validator` image, use the following command:
+   ```
+   COPY --link --from=node-builder /aptos/dist/aptos-node /usr/local/bin/
+   ```
 5. Add a new target defition in [docker-bake-rust-all.hcl](docker-bake-rust-all.hcl) file by copying another target (e.g. `validator`). The target definition should have the following fields:
-    - `inherits`
-    - `target`: Name of the target. This should be the same as the name of the Dockerfile.
-    - `dockerfile`: Path to the Dockerfile.
-    - `tags`: Create a unique tag for the image using `generate_tags` function.
-    - `cache-from`: Create a unique cache key using `generate_cache_from` function.
-    - `cache-to`: Create a unique cache key using `generate_cache_to` function.
+
+   - `inherits`
+   - `target`: Name of the target. This should be the same as the name of the Dockerfile.
+   - `dockerfile`: Path to the Dockerfile.
+   - `tags`: Create a unique tag for the image using `generate_tags` function.
+   - `cache-from`: Create a unique cache key using `generate_cache_from` function.
+   - `cache-to`: Create a unique cache key using `generate_cache_to` function.
 
 6. Optionally, you can create a `group` definition to build multiple tagets at once.
 
 ## Image tagging strategy
 
-The `aptos-node-builder` and `tools-builder` targets build the `aptos-node` binary and the remaining rust binaries, respectively, and is the most expensive. Its output is used by all the other targets that follow.
+The `aptos-node-builder`, `indexer-builder`, `tools-builder` targets build the `aptos-node` binary and the remaining rust binaries, respectively, and is the most expensive. Its output is used by all the other targets that follow.
 
 The `*-builder` itself takes in a few build arguments. Most are build metadata, such as `GIT_SHA` and `GIT_BRANCH`, but others change the build entirely, such as cargo flags `PROFILE` and `FEATURES`. Arguments like these necessitate a different cache to prevent clobbering. The general strategy is to use image tags and cache keys that use these variables. An example image tag might be:
 

--- a/docker/builder/build-indexer.sh
+++ b/docker/builder/build-indexer.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+PROFILE=${PROFILE:-release}
+
+echo "Building indexer and related binaries"
+echo "PROFILE: $PROFILE"
+
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+
+# Build all the rust binaries
+cargo build --locked --profile=$PROFILE \
+    -p aptos-indexer-grpc-cache-worker \
+    -p aptos-indexer-grpc-file-store \
+    -p aptos-indexer-grpc-data-service \
+    -p aptos-indexer-grpc-post-processor \
+    -p aptos-nft-metadata-crawler-parser \
+    "$@"
+
+# After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
+BINS=(
+    aptos-indexer-grpc-cache-worker
+    aptos-indexer-grpc-file-store
+    aptos-indexer-grpc-data-service
+    aptos-indexer-grpc-post-processor
+    aptos-nft-metadata-crawler-parser
+)
+
+mkdir dist
+
+for BIN in "${BINS[@]}"; do
+    cp $CARGO_TARGET_DIR/$PROFILE/$BIN dist/$BIN
+done

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -21,11 +21,6 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-telemetry-service \
     -p aptos-debugger \
     -p aptos-transaction-emitter \
-    -p aptos-indexer-grpc-cache-worker \
-    -p aptos-indexer-grpc-file-store \
-    -p aptos-indexer-grpc-data-service \
-    -p aptos-indexer-grpc-post-processor \
-    -p aptos-nft-metadata-crawler-parser \
     -p aptos-api-tester \
     "$@"
 
@@ -40,11 +35,6 @@ BINS=(
     aptos-debugger
     forge
     aptos-transaction-emitter
-    aptos-indexer-grpc-cache-worker
-    aptos-indexer-grpc-file-store
-    aptos-indexer-grpc-data-service
-    aptos-indexer-grpc-post-processor
-    aptos-nft-metadata-crawler-parser
     aptos-api-tester
 )
 

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -7,17 +7,17 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt update && apt-get --no-install-recommends install -y \
-        cmake \
-        curl \
-        clang \
-        git \
-        pkg-config \
-        libssl-dev \
-        libpq-dev \
-        libdw-dev \
-        binutils \
-        lld \
-        libudev-dev
+    cmake \
+    curl \
+    clang \
+    git \
+    pkg-config \
+    libssl-dev \
+    libpq-dev \
+    libdw-dev \
+    binutils \
+    lld \
+    libudev-dev
 
 ### Build Rust code ###
 FROM rust-base as builder-base
@@ -44,7 +44,7 @@ RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarc
     && chmod +x "/usr/local/bin/protoc" \
     && rm "protoc-21.5-linux-$ARCHITECTURE.zip"
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git_credentials \
-        git config --global credential.helper store
+    git config --global credential.helper store
 
 COPY --link . /aptos/
 
@@ -54,7 +54,7 @@ RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=node-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=node-builder-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
-        docker/builder/build-node.sh
+    docker/builder/build-node.sh
 
 FROM builder-base as tools-builder
 
@@ -62,4 +62,12 @@ RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=tools-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \
-        docker/builder/build-tools.sh
+    docker/builder/build-tools.sh
+
+FROM builder-base as indexer-builder
+
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
+    --mount=type=cache,target=/usr/local/cargo/git,id=indexer-builder-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=indexer-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=indexer-builder-target-cache \
+    docker/builder/build-indexer.sh

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -115,11 +115,23 @@ target "tools-builder" {
   ]
 }
 
+target "indexer-builder" {
+  dockerfile = "docker/builder/builder.Dockerfile"
+  target     = "indexer-builder"
+  contexts = {
+    builder-base = "target:builder-base"
+  }
+  secret = [
+    "id=GIT_CREDENTIALS"
+  ]
+}
+
 target "_common" {
   contexts = {
     debian-base   = "target:debian-base"
     node-builder  = "target:aptos-node-builder"
     tools-builder = "target:tools-builder"
+    indexer-builder = "target:indexer-builder"
   }
   labels = {
     "org.label-schema.schema-version" = "1.0",

--- a/docker/builder/indexer-grpc.Dockerfile
+++ b/docker/builder/indexer-grpc.Dockerfile
@@ -5,19 +5,19 @@ FROM debian-base AS indexer-grpc
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \   
     apt-get update && apt-get install --no-install-recommends -y \    
-        libssl1.1 \
-        ca-certificates \
-        net-tools \
-        tcpdump \
-        iproute2 \
-        netcat \
-        libpq-dev \
-        curl
+    libssl1.1 \
+    ca-certificates \
+    net-tools \
+    tcpdump \
+    iproute2 \
+    netcat \
+    libpq-dev \
+    curl
 
-COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-cache-worker /usr/local/bin/aptos-indexer-grpc-cache-worker
-COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-file-store /usr/local/bin/aptos-indexer-grpc-file-store
-COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-data-service /usr/local/bin/aptos-indexer-grpc-data-service
-COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-post-processor /usr/local/bin/aptos-indexer-grpc-post-processor
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-cache-worker /usr/local/bin/aptos-indexer-grpc-cache-worker
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-file-store /usr/local/bin/aptos-indexer-grpc-file-store
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-data-service /usr/local/bin/aptos-indexer-grpc-data-service
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-post-processor /usr/local/bin/aptos-indexer-grpc-post-processor
 
 # The health check port
 EXPOSE 8080

--- a/docker/builder/nft-metadata-crawler.Dockerfile
+++ b/docker/builder/nft-metadata-crawler.Dockerfile
@@ -1,22 +1,22 @@
 ### NFT Metadata Crawler Image ###
 
-FROM tools-builder
+FROM indexer-builder
 
 FROM debian-base AS nft-metadata-crawler
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \   
     apt-get update && apt-get install --no-install-recommends -y \    
-        libssl1.1 \
-        ca-certificates \
-        net-tools \
-        tcpdump \
-        iproute2 \
-        netcat \
-        libpq-dev \
-        curl
+    libssl1.1 \
+    ca-certificates \
+    net-tools \
+    tcpdump \
+    iproute2 \
+    netcat \
+    libpq-dev \
+    curl
 
-COPY --link --from=tools-builder /aptos/dist/aptos-nft-metadata-crawler-parser /usr/local/bin/aptos-nft-metadata-crawler-parser
+COPY --link --from=indexer-builder /aptos/dist/aptos-nft-metadata-crawler-parser /usr/local/bin/aptos-nft-metadata-crawler-parser
 
 # The health check port
 EXPOSE 8080


### PR DESCRIPTION
### Description

Separate build target for indexer (grpc) and related images. This is to unstrip them, since other CLIs are stripped in the `tools` builder.

### Test Plan

CI builds image on this PR

<!-- Please provide us with clear details for verifying that your changes work. -->
