### PR TITLE
[compiler v2] Fix bug in mutability conversion and higher-order functions

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -6,7 +6,7 @@ error: `M::reduce` is a function and not a macro
 34 │         foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
    │                                     ^^^^^^
 
-error: invalid call of `M::foreach`: expected `&?19` but found `integer` for argument 2
+error: invalid call of `M::foreach`: expected `integer` but found `&?19` for argument 2
    ┌─ tests/checking/typing/lambda.move:67:21
    │
 67 │         foreach(&v, |e| sum = sum + e) // expected to cannot infer type
@@ -18,13 +18,13 @@ error: invalid call of `M::foreach`: expected `()` but found `integer` for argum
 73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `(&T, u64)` but found `&T`
+error: expected `&T` but found `(&T, u64)`
    ┌─ tests/checking/typing/lambda.move:40:13
    │
 40 │             action(XVector::borrow(v, i), i); // expected to have wrong argument count
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `u64` but found `&T`
+error: expected `&T` but found `u64`
    ┌─ tests/checking/typing/lambda.move:48:13
    │
 48 │             action(i); // expected to have wrong argument type

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
@@ -29,7 +29,9 @@ module 0x8675309::M {
         Tuple()
     }
     private inline fun t2(f: |(&u64, &mut u64)|()) {
-        (f)(Borrow(Mutable)(0), Borrow(Mutable)(0))
+        (f)(Borrow(Mutable)(0), Borrow(Mutable)(0));
+        (f)(Borrow(Immutable)(0), Borrow(Mutable)(0));
+        Tuple()
     }
     spec fun $imm<T>(_x: #0) {
         Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
@@ -28,6 +28,9 @@ module 0x8675309::M {
         M::imm_imm<u64>(Borrow(Mutable)(0), Borrow(Mutable)(0));
         Tuple()
     }
+    private inline fun t2(f: |(&u64, &mut u64)|()) {
+        (f)(Borrow(Mutable)(0), Borrow(Mutable)(0))
+    }
     spec fun $imm<T>(_x: #0) {
         Tuple()
     }
@@ -42,4 +45,5 @@ module 0x8675309::M {
     }
     spec fun $t0();
     spec fun $t1();
+    spec fun $t2(f: |(&u64, &mut u64)|());
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.move
@@ -21,6 +21,8 @@ module 0x8675309::M {
     }
 
     inline fun t2(f: |&u64, &mut u64|) {
-        f(&mut 0, &mut 0)
+        f(&mut 0, &mut 0);
+        f(&0, &mut 0);
     }
+
 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.move
@@ -19,4 +19,8 @@ module 0x8675309::M {
         mut_imm(&mut 0, &mut 0);
         imm_imm(&mut 0, &mut 0);
     }
+
+    inline fun t2(f: |&u64, &mut u64|) {
+        f(&mut 0, &mut 0)
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.exp
@@ -29,3 +29,9 @@ error: invalid call of `M::mut_mut`: mutability mismatch (&mut != &) for argumen
    │
 17 │         mut_mut<u64>(&0, &0);
    │                      ^^
+
+error: mutability mismatch (&mut != &)
+   ┌─ tests/checking/typing/subtype_args_invalid.move:21:9
+   │
+21 │         f(&0, &0); // not okay
+   │         ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.move
@@ -16,4 +16,8 @@ module 0x8675309::M {
         mut_imm<u64>(&0, &0);
         mut_mut<u64>(&0, &0);
     }
+
+    inline fun t2(f: |&mut u64, &u64|) {
+        f(&0, &0); // not okay
+    }
 }


### PR DESCRIPTION
Type inference wasn't considering variance and contra-variance in function type checking.

Closes #10913.

