### PR TITLE
Cherry pick 8f56310fae4e1ad9d262b33e05dbcd5393f0e67c and aba6f6f4433d1f29986ec2c190e8c50628748f1a into 1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,30 +25,30 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "crypto-common",
  "generic-array 0.14.6",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -121,6 +121,12 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -2650,7 +2656,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.149",
  "serde_json",
- "time 0.3.24",
+ "time",
  "tokio",
  "tracing",
  "url",
@@ -4740,9 +4746,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitmaps"
@@ -5056,18 +5062,17 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits 0.2.15",
  "serde 1.0.149",
- "time 0.1.44",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -5100,11 +5105,12 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array 0.14.6",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -5152,7 +5158,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -5446,15 +5452,26 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
  "aes-gcm",
- "base64 0.13.0",
+ "base64 0.21.2",
  "hkdf 0.12.3",
  "hmac 0.12.1",
  "percent-encoding",
  "rand 0.8.5",
  "sha2 0.10.6",
  "subtle",
- "time 0.3.24",
+ "time",
  "version_check",
 ]
 
@@ -5464,13 +5481,13 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
 dependencies = [
- "cookie",
+ "cookie 0.16.0",
  "idna 0.2.3",
  "log",
  "publicsuffix",
  "serde 1.0.149",
  "serde_json",
- "time 0.3.24",
+ "time",
  "url",
 ]
 
@@ -5707,6 +5724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -5763,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -6009,7 +6027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
  "bigdecimal",
- "bitflags 2.0.2",
+ "bitflags 2.4.1",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -6356,6 +6374,12 @@ name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
@@ -6951,7 +6975,7 @@ dependencies = [
  "serde 1.0.149",
  "serde_json",
  "thiserror",
- "time 0.3.24",
+ "time",
  "tokio",
  "tokio-stream",
  "url",
@@ -7048,9 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -7168,7 +7192,7 @@ dependencies = [
  "serde 1.0.149",
  "serde_json",
  "thiserror",
- "time 0.3.24",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -7255,7 +7279,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "thiserror",
- "time 0.3.24",
+ "time",
  "tokio",
  "tracing",
  "url",
@@ -7282,7 +7306,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.3",
@@ -7876,6 +7900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7917,7 +7951,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap",
+ "indexmap 1.9.3",
  "is-terminal",
  "itoa",
  "log",
@@ -7926,6 +7960,15 @@ dependencies = [
  "quick-xml 0.26.0",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -8994,7 +9037,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "backtrace",
- "indexmap",
+ "indexmap 1.9.3",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -9990,6 +10033,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10064,7 +10118,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "syn 1.0.105",
@@ -10491,7 +10545,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "syn 1.0.105",
@@ -10503,7 +10557,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "syn 1.0.105",
@@ -10689,7 +10743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset 0.2.0",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -10699,7 +10753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -10858,26 +10912,27 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.3.55"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0608069d4999c3c02d49dff261663f2e73a8f7b00b7cd364fb5e93e419dafa1"
+checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
- "cookie",
+ "cookie 0.17.0",
  "futures-util",
  "headers",
  "http",
  "hyper",
  "mime",
  "multer",
+ "nix 0.27.1",
  "parking_lot 0.12.1",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
- "quick-xml 0.26.0",
+ "quick-xml 0.30.0",
  "regex",
  "rfc7239",
  "rustls-pemfile 1.0.1",
@@ -10887,24 +10942,25 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
- "time 0.3.24",
+ "time",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-util 0.7.3",
  "tracing",
+ "wildmatch",
 ]
 
 [[package]]
 name = "poem-derive"
-version = "1.3.55"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b839bad877aa933dd00901abd127a44496130e3def48e079d60e43f2c8a33cc"
+checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 2.0.0",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
- "syn 1.0.105",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -10940,9 +10996,9 @@ checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
 dependencies = [
  "darling",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "mime",
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "regex",
@@ -10966,9 +11022,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -11014,7 +11070,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "parking_lot 0.12.1",
  "protobuf",
@@ -11156,6 +11212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11253,7 +11318,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.149",
  "serde_json",
- "time 0.3.24",
+ "time",
  "url",
 ]
 
@@ -11475,6 +11540,15 @@ name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
  "serde 1.0.149",
@@ -11802,7 +11876,7 @@ checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes",
- "cookie",
+ "cookie 0.16.0",
  "cookie_store",
  "encoding_rs",
  "futures-core",
@@ -12244,7 +12318,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.64",
  "quote 1.0.29",
  "syn 1.0.105",
@@ -12472,7 +12546,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde 1.0.149",
@@ -12537,7 +12611,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde 1.0.149",
  "yaml-rust",
@@ -12549,7 +12623,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde 1.0.149",
@@ -12675,7 +12749,7 @@ dependencies = [
  "const_format",
  "git2 0.15.0",
  "is_debug",
- "time 0.3.24",
+ "time",
  "tzdb",
 ]
 
@@ -12795,7 +12869,7 @@ dependencies = [
  "num-bigint 0.4.3",
  "num-traits 0.2.15",
  "thiserror",
- "time 0.3.24",
+ "time",
 ]
 
 [[package]]
@@ -13396,17 +13470,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
@@ -13690,9 +13753,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde 1.0.149",
 ]
@@ -13704,7 +13767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
  "combine",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "serde 1.0.149",
 ]
@@ -13715,11 +13778,22 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "serde 1.0.149",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.6",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.0.1",
+ "toml_datetime",
+ "winnow 0.5.19",
 ]
 
 [[package]]
@@ -13813,7 +13887,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.5",
@@ -14221,11 +14295,11 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array 0.14.6",
+ "crypto-common",
  "subtle",
 ]
 
@@ -14629,6 +14703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
+name = "wildmatch"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14850,6 +14930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14913,7 +15002,7 @@ dependencies = [
  "seahash",
  "serde 1.0.149",
  "serde_json",
- "time 0.3.24",
+ "time",
  "tokio",
  "tower-service",
  "url",
@@ -14961,7 +15050,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "time 0.3.24",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-node"
-version = "1.8.0"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "aptos-admin-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,7 +554,7 @@ parking_lot = "0.12.0"
 paste = "1.0.7"
 percent-encoding = "2.1.0"
 pin-project = "1.0.10"
-poem = { version = "=1.3.55", features = ["anyhow", "rustls"] }
+poem = { version = "=1.3.59", features = ["anyhow", "rustls"] }
 poem-openapi = { version = "=2.0.11", features = ["swagger-ui", "url"] }
 poem-openapi-derive = "=2.0.11"
 pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }

--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -7,7 +7,7 @@ use poem::{web::Accept, FromRequest, Request, RequestBody, Result};
 /// Accept types from input headers
 ///
 /// Determines the output type of each API
-#[derive(PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AcceptType {
     /// Convert and resolve types to JSON
     Json,

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     failpoint::fail_point_poem,
     page::determine_limit,
     response::{
@@ -66,14 +66,13 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account")?;
         self.context
             .check_api_output_enabled("Get account", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            None,
-            None,
-        )?;
-        account.account(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(context, address.0, ledger_version.0, None, None)?;
+            account.account(&accept_type)
+        })
+        .await
     }
 
     /// Get account resources
@@ -113,14 +112,19 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account_resources")?;
         self.context
             .check_api_output_enabled("Get account resources", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            start.0.map(StateKey::from),
-            limit.0,
-        )?;
-        account.resources(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(
+                context,
+                address.0,
+                ledger_version.0,
+                start.0.map(StateKey::from),
+                limit.0,
+            )?;
+            account.resources(&accept_type)
+        })
+        .await
     }
 
     /// Get account modules
@@ -160,14 +164,19 @@ impl AccountsApi {
         fail_point_poem("endpoint_get_account_modules")?;
         self.context
             .check_api_output_enabled("Get account modules", &accept_type)?;
-        let account = Account::new(
-            self.context.clone(),
-            address.0,
-            ledger_version.0,
-            start.0.map(StateKey::from),
-            limit.0,
-        )?;
-        account.modules(&accept_type)
+
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let account = Account::new(
+                context,
+                address.0,
+                ledger_version.0,
+                start.0.map(StateKey::from),
+                limit.0,
+            )?;
+            account.modules(&accept_type)
+        })
+        .await
     }
 }
 

--- a/api/src/basic.rs
+++ b/api/src/basic.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     generate_error_response, generate_success_response,
     response::{InternalError, ServiceUnavailableError},
     ApiTags,
@@ -83,7 +83,8 @@ impl BasicApi {
         /// If not provided, the healthcheck will always succeed
         duration_secs: Query<Option<u32>>,
     ) -> HealthCheckResult<HealthCheckSuccess> {
-        let ledger_info = self.context.get_latest_ledger_info()?;
+        let context = self.context.clone();
+        let ledger_info = api_spawn_blocking(move || context.get_latest_ledger_info()).await?;
 
         // If we have a duration, check that it's close to the current time, otherwise it's ok
         if let Some(duration) = duration_secs.0 {

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1280,3 +1280,16 @@ pub struct GasLimitCache {
     last_updated_epoch: Option<u64>,
     block_gas_limit: Option<u64>,
 }
+
+/// This function just calls tokio::task::spawn_blocking with the given closure and in
+/// the case of an error when joining the task converts it into a 500.
+pub async fn api_spawn_blocking<F, T, E>(func: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: InternalError + Send + 'static,
+{
+    tokio::task::spawn_blocking(func)
+        .await
+        .map_err(|err| E::internal_with_code_no_info(err, AptosErrorCode::InternalError))?
+}

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     response::{BasicResponse, BasicResponseStatus, BasicResult},
     ApiTags,
 };
@@ -36,7 +36,7 @@ impl IndexApi {
 
         let node_role = self.context.node_role();
 
-        match accept_type {
+        api_spawn_blocking(move || match accept_type {
             AcceptType::Json => {
                 let index_response = IndexResponse::new(
                     ledger_info.clone(),
@@ -53,6 +53,7 @@ impl IndexApi {
                 let index_response = IndexResponseBcs::new(ledger_info.clone(), node_role);
                 BasicResponse::try_from_bcs((index_response, &ledger_info, BasicResponseStatus::Ok))
             },
-        }
+        })
+        .await
     }
 }

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    context::api_spawn_blocking,
     failpoint::fail_point_poem,
     response::{
         api_forbidden, build_not_found, module_not_found, resource_not_found, table_item_not_found,
@@ -35,6 +36,7 @@ use poem_openapi::{
 use std::{convert::TryInto, sync::Arc};
 
 /// API for retrieving individual state
+#[derive(Clone)]
 pub struct StateApi {
     pub context: Arc<Context>,
 }
@@ -76,12 +78,17 @@ impl StateApi {
         fail_point_poem("endpoint_get_account_resource")?;
         self.context
             .check_api_output_enabled("Get account resource", &accept_type)?;
-        self.resource(
-            &accept_type,
-            address.0,
-            resource_type.0,
-            ledger_version.0.map(|inner| inner.0),
-        )
+
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.resource(
+                &accept_type,
+                address.0,
+                resource_type.0,
+                ledger_version.0.map(|inner| inner.0),
+            )
+        })
+        .await
     }
 
     /// Get account module
@@ -117,7 +124,11 @@ impl StateApi {
         fail_point_poem("endpoint_get_account_module")?;
         self.context
             .check_api_output_enabled("Get account module", &accept_type)?;
-        self.module(&accept_type, address.0, module_name.0, ledger_version.0)
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.module(&accept_type, address.0, module_name.0, ledger_version.0)
+        })
+        .await
     }
 
     /// Get table item
@@ -160,12 +171,16 @@ impl StateApi {
         fail_point_poem("endpoint_get_table_item")?;
         self.context
             .check_api_output_enabled("Get table item", &accept_type)?;
-        self.table_item(
-            &accept_type,
-            table_handle.0,
-            table_item_request.0,
-            ledger_version.0,
-        )
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.table_item(
+                &accept_type,
+                table_handle.0,
+                table_item_request.0,
+                ledger_version.0,
+            )
+        })
+        .await
     }
 
     /// Get raw table item
@@ -207,12 +222,16 @@ impl StateApi {
         self.context
             .check_api_output_enabled("Get raw table item", &accept_type)?;
 
-        self.raw_table_item(
-            &accept_type,
-            table_handle.0,
-            table_item_request.0,
-            ledger_version.0,
-        )
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.raw_table_item(
+                &accept_type,
+                table_handle.0,
+                table_item_request.0,
+                ledger_version.0,
+            )
+        })
+        .await
     }
 
     /// Get raw state value.
@@ -250,7 +269,8 @@ impl StateApi {
         self.context
             .check_api_output_enabled("Get raw state value", &accept_type)?;
 
-        self.raw_value(&accept_type, request.0, ledger_version.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.raw_value(&accept_type, request.0, ledger_version.0)).await
     }
 }
 

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -6,7 +6,7 @@ use crate::{
     accept_type::AcceptType,
     accounts::Account,
     bcs_payload::Bcs,
-    context::Context,
+    context::{api_spawn_blocking, Context},
     failpoint::fail_point_poem,
     generate_error_response, generate_success_response,
     page::Page,
@@ -129,6 +129,7 @@ impl VerifyInput for SubmitTransactionsBatchPost {
 }
 
 /// API for interacting with transactions
+#[derive(Clone)]
 pub struct TransactionsApi {
     pub context: Arc<Context>,
 }
@@ -169,7 +170,9 @@ impl TransactionsApi {
             limit.0,
             self.context.max_transactions_page_size(),
         );
-        self.list(&accept_type, page)
+
+        let api = self.clone();
+        api_spawn_blocking(move || api.list(&accept_type, page)).await
     }
 
     /// Get transaction by hash
@@ -225,8 +228,11 @@ impl TransactionsApi {
         fail_point_poem("endpoint_transaction_by_version")?;
         self.context
             .check_api_output_enabled("Get transactions by version", &accept_type)?;
-        self.get_transaction_by_version_inner(&accept_type, txn_version.0)
-            .await
+        let api = self.clone();
+        api_spawn_blocking(move || {
+            api.get_transaction_by_version_inner(&accept_type, txn_version.0)
+        })
+        .await
     }
 
     /// Get account transactions
@@ -265,7 +271,8 @@ impl TransactionsApi {
             limit.0,
             self.context.max_transactions_page_size(),
         );
-        self.list_by_account(&accept_type, page, address.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.list_by_account(&accept_type, page, address.0)).await
     }
 
     /// Submit transaction
@@ -429,101 +436,107 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Simulate transaction", &accept_type)?;
-        let ledger_info = self.context.get_latest_ledger_info()?;
-        let mut signed_transaction = self.get_signed_transaction(&ledger_info, data)?;
 
-        let estimated_gas_unit_price = match (
-            estimate_gas_unit_price.0.unwrap_or_default(),
-            estimate_prioritized_gas_unit_price.0.unwrap_or_default(),
-        ) {
-            (_, true) => {
-                let gas_estimation = self.context.estimate_gas_price(&ledger_info)?;
-                // The prioritized gas estimate should always be set, but if it's not use the gas estimate
-                Some(
-                    gas_estimation
-                        .prioritized_gas_estimate
-                        .unwrap_or(gas_estimation.gas_estimate),
-                )
-            },
-            (true, false) => Some(self.context.estimate_gas_price(&ledger_info)?.gas_estimate),
-            (false, false) => None,
-        };
+        let api = self.clone();
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let ledger_info = context.get_latest_ledger_info()?;
+            let mut signed_transaction = api.get_signed_transaction(&ledger_info, data)?;
 
-        // If estimate max gas amount is provided, we will just make it the maximum value
-        let estimated_max_gas_amount = if estimate_max_gas_amount.0.unwrap_or_default() {
-            // Retrieve max possible gas units
-            let (_, gas_params) = self.context.get_gas_schedule(&ledger_info)?;
-            let min_number_of_gas_units = u64::from(gas_params.vm.txn.min_transaction_gas_units)
-                / u64::from(gas_params.vm.txn.gas_unit_scaling_factor);
-            let max_number_of_gas_units = u64::from(gas_params.vm.txn.maximum_number_of_gas_units);
-
-            // Retrieve account balance to determine max gas available
-            let account_state = self
-                .context
-                .get_account_state(
-                    signed_transaction.sender(),
-                    ledger_info.version(),
-                    &ledger_info,
-                )?
-                .ok_or_else(|| {
-                    SubmitTransactionError::bad_request_with_code(
-                        "Account not found",
-                        AptosErrorCode::InvalidInput,
-                        &ledger_info,
+            let estimated_gas_unit_price = match (
+                estimate_gas_unit_price.0.unwrap_or_default(),
+                estimate_prioritized_gas_unit_price.0.unwrap_or_default(),
+            ) {
+                (_, true) => {
+                    let gas_estimation = context.estimate_gas_price(&ledger_info)?;
+                    // The prioritized gas estimate should always be set, but if it's not use the gas estimate
+                    Some(
+                        gas_estimation
+                            .prioritized_gas_estimate
+                            .unwrap_or(gas_estimation.gas_estimate),
                     )
-                })?;
-            let coin_store: CoinStoreResource = account_state
-                .get_coin_store_resource()
-                .and_then(|inner| {
-                    inner.ok_or_else(|| {
-                        anyhow!(
-                            "No coin store found for account {}",
-                            signed_transaction.sender()
-                        )
-                    })
-                })
-                .map_err(|err| {
-                    SubmitTransactionError::internal_with_code(
-                        format!("Failed to get coin store resource {}", err),
-                        AptosErrorCode::InternalError,
-                        &ledger_info,
-                    )
-                })?;
-
-            let gas_unit_price =
-                estimated_gas_unit_price.unwrap_or_else(|| signed_transaction.gas_unit_price());
-
-            // With 0 gas price, we set it to max gas units, since we can't divide by 0
-            let max_account_gas_units = if gas_unit_price == 0 {
-                coin_store.coin()
-            } else {
-                coin_store.coin() / gas_unit_price
+                },
+                (true, false) => Some(context.estimate_gas_price(&ledger_info)?.gas_estimate),
+                (false, false) => None,
             };
 
-            // To give better error messaging, we should not go below the minimum number of gas units
-            let max_account_gas_units =
-                std::cmp::max(min_number_of_gas_units, max_account_gas_units);
+            // If estimate max gas amount is provided, we will just make it the maximum value
+            let estimated_max_gas_amount = if estimate_max_gas_amount.0.unwrap_or_default() {
+                // Retrieve max possible gas units
+                let (_, gas_params) = context.get_gas_schedule(&ledger_info)?;
+                let min_number_of_gas_units =
+                    u64::from(gas_params.vm.txn.min_transaction_gas_units)
+                        / u64::from(gas_params.vm.txn.gas_unit_scaling_factor);
+                let max_number_of_gas_units =
+                    u64::from(gas_params.vm.txn.maximum_number_of_gas_units);
 
-            // Minimum of the max account and the max total needs to be used for estimation
-            Some(std::cmp::min(
-                max_account_gas_units,
-                max_number_of_gas_units,
-            ))
-        } else {
-            None
-        };
+                // Retrieve account balance to determine max gas available
+                let account_state = context
+                    .get_account_state(
+                        signed_transaction.sender(),
+                        ledger_info.version(),
+                        &ledger_info,
+                    )?
+                    .ok_or_else(|| {
+                        SubmitTransactionError::bad_request_with_code(
+                            "Account not found",
+                            AptosErrorCode::InvalidInput,
+                            &ledger_info,
+                        )
+                    })?;
+                let coin_store: CoinStoreResource = account_state
+                    .get_coin_store_resource()
+                    .and_then(|inner| {
+                        inner.ok_or_else(|| {
+                            anyhow!(
+                                "No coin store found for account {}",
+                                signed_transaction.sender()
+                            )
+                        })
+                    })
+                    .map_err(|err| {
+                        SubmitTransactionError::internal_with_code(
+                            format!("Failed to get coin store resource {}", err),
+                            AptosErrorCode::InternalError,
+                            &ledger_info,
+                        )
+                    })?;
 
-        // If there is an estimation of either, replace the values
-        if estimated_max_gas_amount.is_some() || estimated_gas_unit_price.is_some() {
-            signed_transaction = override_gas_parameters(
-                &signed_transaction,
-                estimated_max_gas_amount,
-                estimated_gas_unit_price,
-            );
-        }
+                let gas_unit_price =
+                    estimated_gas_unit_price.unwrap_or_else(|| signed_transaction.gas_unit_price());
 
-        self.simulate(&accept_type, ledger_info, signed_transaction)
-            .await
+                // With 0 gas price, we set it to max gas units, since we can't divide by 0
+                let max_account_gas_units = if gas_unit_price == 0 {
+                    coin_store.coin()
+                } else {
+                    coin_store.coin() / gas_unit_price
+                };
+
+                // To give better error messaging, we should not go below the minimum number of gas units
+                let max_account_gas_units =
+                    std::cmp::max(min_number_of_gas_units, max_account_gas_units);
+
+                // Minimum of the max account and the max total needs to be used for estimation
+                Some(std::cmp::min(
+                    max_account_gas_units,
+                    max_number_of_gas_units,
+                ))
+            } else {
+                None
+            };
+
+            // If there is an estimation of either, replace the values
+            if estimated_max_gas_amount.is_some() || estimated_gas_unit_price.is_some() {
+                signed_transaction = override_gas_parameters(
+                    &signed_transaction,
+                    estimated_max_gas_amount,
+                    estimated_gas_unit_price,
+                );
+            }
+
+            api.simulate(&accept_type, ledger_info, signed_transaction)
+        })
+        .await
     }
 
     /// Encode submission
@@ -572,7 +585,8 @@ impl TransactionsApi {
         }
         self.context
             .check_api_output_enabled("Encode submission", &accept_type)?;
-        self.get_signing_message(&accept_type, data.0)
+        let api = self.clone();
+        api_spawn_blocking(move || api.get_signing_message(&accept_type, data.0)).await
     }
 
     /// Estimate gas price
@@ -598,26 +612,31 @@ impl TransactionsApi {
         fail_point_poem("endpoint_encode_submission")?;
         self.context
             .check_api_output_enabled("Estimate gas price", &accept_type)?;
-        let latest_ledger_info = self.context.get_latest_ledger_info()?;
-        let gas_estimation = self.context.estimate_gas_price(&latest_ledger_info)?;
 
-        match accept_type {
-            AcceptType::Json => BasicResponse::try_from_json((
-                gas_estimation,
-                &latest_ledger_info,
-                BasicResponseStatus::Ok,
-            )),
-            AcceptType::Bcs => {
-                let gas_estimation_bcs = GasEstimationBcs {
-                    gas_estimate: gas_estimation.gas_estimate,
-                };
-                BasicResponse::try_from_bcs((
-                    gas_estimation_bcs,
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let latest_ledger_info = context.get_latest_ledger_info()?;
+            let gas_estimation = context.estimate_gas_price(&latest_ledger_info)?;
+
+            match accept_type {
+                AcceptType::Json => BasicResponse::try_from_json((
+                    gas_estimation,
                     &latest_ledger_info,
                     BasicResponseStatus::Ok,
-                ))
-            },
-        }
+                )),
+                AcceptType::Bcs => {
+                    let gas_estimation_bcs = GasEstimationBcs {
+                        gas_estimate: gas_estimation.gas_estimate,
+                    };
+                    BasicResponse::try_from_bcs((
+                        gas_estimation_bcs,
+                        &latest_ledger_info,
+                        BasicResponseStatus::Ok,
+                    ))
+                },
+            }
+        })
+        .await
     }
 }
 
@@ -667,7 +686,11 @@ impl TransactionsApi {
         accept_type: &AcceptType,
         hash: HashValue,
     ) -> BasicResultWith404<Transaction> {
-        let ledger_info = self.context.get_latest_ledger_info()?;
+        let context = self.context.clone();
+        let accept_type = accept_type.clone();
+
+        let ledger_info = api_spawn_blocking(move || context.get_latest_ledger_info()).await?;
+
         let txn_data = self
             .get_by_hash(hash.into(), &ledger_info)
             .await
@@ -682,11 +705,12 @@ impl TransactionsApi {
             .context(format!("Failed to find transaction with hash: {}", hash))
             .map_err(|_| transaction_not_found_by_hash(hash, &ledger_info))?;
 
-        self.get_transaction_inner(accept_type, txn_data, &ledger_info)
+        let api = self.clone();
+        api_spawn_blocking(move || api.get_transaction_inner(&accept_type, txn_data, &ledger_info))
             .await
     }
 
-    async fn get_transaction_by_version_inner(
+    fn get_transaction_by_version_inner(
         &self,
         accept_type: &AcceptType,
         version: U64,
@@ -706,7 +730,6 @@ impl TransactionsApi {
         match txn_data {
             GetByVersionResponse::Found(txn_data) => {
                 self.get_transaction_inner(accept_type, txn_data, &ledger_info)
-                    .await
             },
             GetByVersionResponse::VersionTooNew => {
                 Err(transaction_not_found_by_version(version.0, &ledger_info))
@@ -716,7 +739,7 @@ impl TransactionsApi {
     }
 
     /// Converts a transaction into the outgoing type
-    async fn get_transaction_inner(
+    fn get_transaction_inner(
         &self,
         accept_type: &AcceptType,
         transaction_data: TransactionData,
@@ -793,9 +816,13 @@ impl TransactionsApi {
         hash: aptos_crypto::HashValue,
         ledger_info: &LedgerInfo,
     ) -> anyhow::Result<Option<TransactionData>> {
-        let from_db = self
-            .context
-            .get_transaction_by_hash(hash, ledger_info.version())?;
+        let context = self.context.clone();
+        let version = ledger_info.version();
+        let from_db =
+            tokio::task::spawn_blocking(move || context.get_transaction_by_hash(hash, version))
+                .await
+                .context("Failed to join task to read transaction by hash")?
+                .context("Failed to read transaction by hash from DB")?;
         Ok(match from_db {
             None => self
                 .context
@@ -1171,7 +1198,7 @@ impl TransactionsApi {
     ///
     /// Note: this returns a `Vec<UserTransaction>`, but for backwards compatibility, this can't
     /// be removed even though, there is only one possible transaction
-    pub async fn simulate(
+    pub fn simulate(
         &self,
         accept_type: &AcceptType,
         ledger_info: LedgerInfo,

--- a/api/src/view_function.rs
+++ b/api/src/view_function.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    context::api_spawn_blocking,
     failpoint::fail_point_poem,
     response::{
         BadRequestError, BasicErrorWith404, BasicResponse, BasicResponseStatus, BasicResultWith404,
@@ -16,6 +17,7 @@ use poem_openapi::{param::Query, payload::Json, OpenApi};
 use std::sync::Arc;
 
 /// API for executing Move view function.
+#[derive(Clone)]
 pub struct ViewFunctionApi {
     pub context: Arc<Context>,
 }
@@ -48,87 +50,91 @@ impl ViewFunctionApi {
         self.context
             .check_api_output_enabled("View function", &accept_type)?;
 
-        let (ledger_info, requested_version) = self
-            .context
-            .get_latest_ledger_info_and_verify_lookup_version(
-                ledger_version.map(|inner| inner.0),
-            )?;
+        let context = self.context.clone();
+        api_spawn_blocking(move || {
+            let (ledger_info, requested_version) = context
+                .get_latest_ledger_info_and_verify_lookup_version(
+                    ledger_version.map(|inner| inner.0),
+                )?;
 
-        let state_view = self.context.latest_state_view_poem(&ledger_info)?;
-        let resolver = state_view.as_move_resolver();
+            let state_view = context.latest_state_view_poem(&ledger_info)?;
+            let resolver = state_view.as_move_resolver();
 
-        let entry_func = resolver
-            .as_converter(self.context.db.clone())
-            .convert_view_function(request.0)
+            let entry_func = resolver
+                .as_converter(context.db.clone())
+                .convert_view_function(request.0)
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InvalidInput,
+                        &ledger_info,
+                    )
+                })?;
+            let state_view = context
+                .state_view_at_version(requested_version)
+                .map_err(|err| {
+                    BasicErrorWith404::bad_request_with_code(
+                        err,
+                        AptosErrorCode::InternalError,
+                        &ledger_info,
+                    )
+                })?;
+
+            let return_vals = AptosVM::execute_view_function(
+                &state_view,
+                entry_func.module().clone(),
+                entry_func.function().to_owned(),
+                entry_func.ty_args().to_owned(),
+                entry_func.args().to_owned(),
+                context.node_config.api.max_gas_view_function,
+            )
             .map_err(|err| {
-                BasicErrorWith404::bad_request_with_code(
-                    err,
-                    AptosErrorCode::InvalidInput,
-                    &ledger_info,
-                )
+                BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
             })?;
-        let state_view = self
-            .context
-            .state_view_at_version(requested_version)
-            .map_err(|err| {
-                BasicErrorWith404::bad_request_with_code(
-                    err,
-                    AptosErrorCode::InternalError,
+            match accept_type {
+                AcceptType::Bcs => BasicResponse::try_from_bcs((
+                    return_vals,
                     &ledger_info,
-                )
-            })?;
+                    BasicResponseStatus::Ok,
+                )),
+                AcceptType::Json => {
+                    let return_types = resolver
+                        .as_converter(context.db.clone())
+                        .function_return_types(&entry_func)
+                        .and_then(|tys| {
+                            tys.into_iter()
+                                .map(TypeTag::try_from)
+                                .collect::<anyhow::Result<Vec<_>>>()
+                        })
+                        .map_err(|err| {
+                            BasicErrorWith404::bad_request_with_code(
+                                err,
+                                AptosErrorCode::InternalError,
+                                &ledger_info,
+                            )
+                        })?;
 
-        let return_vals = AptosVM::execute_view_function(
-            &state_view,
-            entry_func.module().clone(),
-            entry_func.function().to_owned(),
-            entry_func.ty_args().to_owned(),
-            entry_func.args().to_owned(),
-            self.context.node_config.api.max_gas_view_function,
-        )
-        .map_err(|err| {
-            BasicErrorWith404::bad_request_with_code_no_info(err, AptosErrorCode::InvalidInput)
-        })?;
-        match accept_type {
-            AcceptType::Bcs => {
-                BasicResponse::try_from_bcs((return_vals, &ledger_info, BasicResponseStatus::Ok))
-            },
-            AcceptType::Json => {
-                let return_types = resolver
-                    .as_converter(self.context.db.clone())
-                    .function_return_types(&entry_func)
-                    .and_then(|tys| {
-                        tys.into_iter()
-                            .map(TypeTag::try_from)
-                            .collect::<anyhow::Result<Vec<_>>>()
-                    })
-                    .map_err(|err| {
-                        BasicErrorWith404::bad_request_with_code(
-                            err,
-                            AptosErrorCode::InternalError,
-                            &ledger_info,
-                        )
-                    })?;
+                    let move_vals = return_vals
+                        .into_iter()
+                        .zip(return_types.into_iter())
+                        .map(|(v, ty)| {
+                            resolver
+                                .as_converter(context.db.clone())
+                                .try_into_move_value(&ty, &v)
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()
+                        .map_err(|err| {
+                            BasicErrorWith404::bad_request_with_code(
+                                err,
+                                AptosErrorCode::InternalError,
+                                &ledger_info,
+                            )
+                        })?;
 
-                let move_vals = return_vals
-                    .into_iter()
-                    .zip(return_types.into_iter())
-                    .map(|(v, ty)| {
-                        resolver
-                            .as_converter(self.context.db.clone())
-                            .try_into_move_value(&ty, &v)
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()
-                    .map_err(|err| {
-                        BasicErrorWith404::bad_request_with_code(
-                            err,
-                            AptosErrorCode::InternalError,
-                            &ledger_info,
-                        )
-                    })?;
-
-                BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
-            },
-        }
+                    BasicResponse::try_from_json((move_vals, &ledger_info, BasicResponseStatus::Ok))
+                },
+            }
+        })
+        .await
     }
 }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-node"
 description = "Aptos node"
-version = "1.8.0"
+version = "1.8.3"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1647,6 +1647,7 @@ impl Time {
     pub fn new(time: Duration) -> Self {
         let date_time =
             NaiveDateTime::from_timestamp_opt(time.as_secs() as i64, time.subsec_nanos()).unwrap();
+        #[allow(deprecated)]
         let utc_time = DateTime::from_utc(date_time, Utc);
         // TODO: Allow configurable time zone
         Self {


### PR DESCRIPTION
This PR cherry picks the following two commits into aptos-release-v1.8:
- 8f56310fae4e1ad9d262b33e05dbcd5393f0e67c (https://github.com/aptos-labs/aptos-core/pull/10643)
- aba6f6f4433d1f29986ec2c190e8c50628748f1a (https://github.com/aptos-labs/aptos-core/pull/11050)

Rationale: https://aptos-org.slack.com/archives/C067LJNM2NL/p1700671856025839?thread_ts=1700671630.035739&cid=C067LJNM2NL.