### PR TITLE
[test] Remove usage of private AsDisplay

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -72,9 +72,6 @@ use std::{
     time::Duration,
 };
 use tempfile::TempDir;
-use thiserror::__private::PathAsDisplay;
-#[cfg(feature = "cli-framework-test-move")]
-use thiserror::__private::PathAsDisplay;
 use tokio::time::{sleep, Instant};
 
 #[cfg(test)]
@@ -781,7 +778,7 @@ impl CliTestFramework {
         let source_path = sources_dir.join("hello_blockchain.move");
         write_to_file(
             source_path.as_path(),
-            &source_path.as_display().to_string(),
+            &source_path.display().to_string(),
             hello_blockchain_contents.as_bytes(),
         )
         .unwrap();
@@ -790,7 +787,7 @@ impl CliTestFramework {
         let test_path = sources_dir.join("hello_blockchain_test.move");
         write_to_file(
             test_path.as_path(),
-            &test_path.as_display().to_string(),
+            &test_path.display().to_string(),
             hello_blockchain_test_contents.as_bytes(),
         )
         .unwrap();
@@ -977,7 +974,7 @@ impl CliTestFramework {
         let source_path = temp_dir.path().join("script.move");
         write_to_file(
             source_path.as_path(),
-            &source_path.as_display().to_string(),
+            &source_path.display().to_string(),
             script_contents.as_bytes(),
         )
         .unwrap();


### PR DESCRIPTION
### Description
Display exists already in path, so no reason to use AsDisplay

### Test Plan
Build should work