### PR TITLE
[forge-cli] Fix Lazy to be the right lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "clap 4.3.21",
  "futures",
  "jemallocator",
+ "once_cell",
  "rand 0.7.3",
  "random_word",
  "reqwest",

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
+once_cell = { workspace = true }
 rand = { workspace = true }
 random_word = { workspace = true }
 reqwest = { workspace = true }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -56,8 +56,9 @@ use aptos_testcases::{
     validator_reboot_stress_test::ValidatorRebootStressTest,
     CompositeNetworkTest,
 };
-use clap::{Parser, Subcommand, __derive_refs::once_cell::sync::Lazy};
+use clap::{Parser, Subcommand};
 use futures::stream::{FuturesUnordered, StreamExt};
+use once_cell::sync::Lazy;
 use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
 use std::{
     env,


### PR DESCRIPTION
### Description
This lazy was using a private field, it should be using the oncecell directly.

### Test Plan
Ran rust lint locally, worked properly.  CI should ensure compatibility
