### PR TITLE
Fixing a panic when parsing /**/

### DIFF
--- a/third_party/move/move-compiler/src/parser/lexer.rs
+++ b/third_party/move/move-compiler/src/parser/lexer.rs
@@ -212,7 +212,7 @@ impl<'input> Lexer<'input> {
     /// Block comments can be nested.
     ///
     /// Documentation comments are comments which start with
-    /// `///` or `/**`, but not `////` or `/***`. The actually comment delimiters
+    /// `///` or `/**`, but not `////` or `/***`. The actual comment delimiters
     /// (`/// .. <newline>` and `/** .. */`) will be not included in extracted comment string. The
     /// span in the returned map, however, covers the whole region of the comment, including the
     /// delimiters.
@@ -257,10 +257,12 @@ impl<'input> Lexer<'input> {
                         let start = get_offset(text);
                         text = &text[2..];
 
-                        // Check if this is a documentation comment: '/**', but not '/***'.
+                        // Check if this is a documentation comment: '/**', but neither '/***' nor '/**/'.
                         // A documentation comment cannot be nested within another comment.
-                        let is_doc =
-                            text.starts_with('*') && !text.starts_with("**") && locs.is_empty();
+                        let is_doc = text.starts_with('*')
+                            && !text.starts_with("**")
+                            && !text.starts_with("*/")
+                            && locs.is_empty();
 
                         locs.push((start, is_doc));
                     } else if text.starts_with("*/") {

--- a/third_party/move/move-compiler/tests/move_check/parser/not_doc_comment.move
+++ b/third_party/move/move-compiler/tests/move_check/parser/not_doc_comment.move
@@ -1,0 +1,5 @@
+module 0xdecafbad::m {
+    /**/
+    fun /**/foo() { }
+    /* /**/ */
+}


### PR DESCRIPTION
### Description

When parsing a move file containing `/**/`, the parser panics. This was first reported by @CapCap in the move eng channel.

This PR contains a fix, and a simplified test case that showcases the panic without this fix.

### Test Plan

Added a test case to demonstrate the fix.
