### PR TITLE
Add 'inlined from' annotations to locations in diagnostics about code that has been inlined

### DIFF
--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -809,8 +809,10 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                 // TODO(10731): ideally, each Parameter has its own loc.  For now, we use the
                 // function location.  body should have types rewritten, other inlining complete,
                 // lambdas inlined, etc.
-                let id = env.new_node(function_loc.clone().inlined_from(call_site_loc),
-                                      ty.instantiate(self.type_args));
+                let id = env.new_node(
+                    function_loc.clone().inlined_from(call_site_loc),
+                    ty.instantiate(self.type_args)
+                );
                 if let Some(new_sym) = self.shadow_stack.get_shadow_symbol(*sym, true) {
                     Pattern::Var(id, new_sym)
                 } else {

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -811,7 +811,7 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                 // lambdas inlined, etc.
                 let id = env.new_node(
                     function_loc.clone().inlined_from(call_site_loc),
-                    ty.instantiate(self.type_args)
+                    ty.instantiate(self.type_args),
                 );
                 if let Some(new_sym) = self.shadow_stack.get_shadow_symbol(*sym, true) {
                     Pattern::Var(id, new_sym)

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.exp
@@ -11,3 +11,6 @@ error: Invalid call target: currently indirect call must be a parameter to an in
   │
 3 │     f(b)
   │     ^
+  ·
+7 │     inline_apply(f, b)
+  │     ------------------ in a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.exp
@@ -6,11 +6,8 @@ error: Currently, a function-typed parameter to an inline function must be a lit
 7 │     inline_apply(f, b)
   │                  ^
 
-error: Invalid call target: currently indirect call must be a parameter to an inline function called with an argument which is a literal lambda expression
-  ┌─ tests/checking/inlining/lambda_param.move:3:2
-  │
-3 │     f(b)
-  │     ^
-  ·
-7 │     inline_apply(f, b)
-  │     ------------------ in a call inlined at this callsite
+error: Currently, a function-typed parameter to an inline function must be a literal lambda expression
+   ┌─ tests/checking/inlining/lambda_param.move:11:16
+   │
+11 │     inline_apply4(f, b)
+   │                   ^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_param.move
@@ -7,8 +7,20 @@ module 0x42::LambdaParam {
 	inline_apply(f, b)
     }
 
+    public inline fun inline_apply3(f: |u64|u64, b: u64) : u64 {
+	inline_apply4(f, b)
+    }
+
+    public inline fun inline_apply4(_f: |u64|u64, b: u64) : u64 {
+	b
+    }
+
     fun test_lambda_symbol_param() {
 	let a = inline_apply2(|x| x, 3);
 	assert!(a == 3, 0);
+	let b = inline_apply(|x| x, 3);
+	assert!(b == 3, 0);
+	let b = inline_apply3(|x| x, 3);
+	assert!(b == 3, 0);
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call.exp
@@ -31,7 +31,10 @@ module 0x42::n {
 
 Diagnostics:
 error: function `0x42::m::bar` cannot be called here because it is private to module `0x42::m`
-  ┌─ tests/checking/inlining/private_call.move:4:9
-  │
-4 │         bar()
-  │         ^^^^^
+   ┌─ tests/checking/inlining/private_call.move:4:9
+   │
+ 4 │         bar()
+   │         ^^^^^
+   ·
+14 │         assert!(m::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_2.exp
@@ -45,13 +45,22 @@ module 0x42::n {
 
 Diagnostics:
 error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
-  ┌─ tests/checking/inlining/private_call_2.move:4:9
-  │
-4 │         bar()
-  │         ^^^^^
+   ┌─ tests/checking/inlining/private_call_2.move:4:9
+   │
+ 4 │         bar()
+   │         ^^^^^
+   ·
+14 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+25 │         assert!(o::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite
 
 error: function `0x42::o::bar` cannot be called here because it is private to module `0x42::o`
    ┌─ tests/checking/inlining/private_call_2.move:15:2
    │
 15 │     bar()
    │     ^^^^^
+   ·
+25 │         assert!(o::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_3.exp
@@ -175,49 +175,199 @@ module 0x42::n {
 
 Diagnostics:
 error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
-  ┌─ tests/checking/inlining/private_call_3.move:5:9
-  │
-5 │         bar()
-  │         ^^^^^
+   ┌─ tests/checking/inlining/private_call_3.move:5:9
+   │
+ 5 │         bar()
+   │         ^^^^^
+   ·
+67 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+98 │         assert!(o_nonfriend::foo() == 42, 1);
+   │                 ------------------ in a call inlined at this callsite
 
 error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:21:9
    │
 21 │         bar()
    │         ^^^^^
+   ·
+68 │         m_nonfriend::foo();
+   │         ------------------ in a call inlined at this callsite
+   ·
+98 │         assert!(o_nonfriend::foo() == 42, 1);
+   │                 ------------------ in a call inlined at this callsite
 
 error: function `0x42::o_nonfriend::bar` cannot be called here because it is private to module `0x42::o_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:69:2
    │
 69 │     bar()
    │     ^^^^^
+   ·
+98 │         assert!(o_nonfriend::foo() == 42, 1);
+   │                 ------------------ in a call inlined at this callsite
+
+error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
+   ┌─ tests/checking/inlining/private_call_3.move:5:9
+   │
+ 5 │         bar()
+   │         ^^^^^
+   ·
+73 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+99 │     assert!(o_nonfriend::inaccessible() == 42, 1);
+   │             --------------------------- in a call inlined at this callsite
+
+error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:21:9
+   │
+21 │         bar()
+   │         ^^^^^
+   ·
+74 │         m_nonfriend::foo();
+   │         ------------------ in a call inlined at this callsite
+   ·
+99 │     assert!(o_nonfriend::inaccessible() == 42, 1);
+   │             --------------------------- in a call inlined at this callsite
 
 error: function `0x42::o_nonfriend::bar` cannot be called here because it is private to module `0x42::o_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:75:2
    │
 75 │     bar()
    │     ^^^^^
+   ·
+99 │     assert!(o_nonfriend::inaccessible() == 42, 1);
+   │             --------------------------- in a call inlined at this callsite
+
+error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
+    ┌─ tests/checking/inlining/private_call_3.move:5:9
+    │
+  5 │         bar()
+    │         ^^^^^
+    ·
+ 79 │         m::foo();
+    │         -------- in a call inlined at this callsite
+    ·
+100 │     assert!(o_nonfriend::friend_accessible() == 42, 1);
+    │             -------------------------------- in a call inlined at this callsite
+
+error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
+    ┌─ tests/checking/inlining/private_call_3.move:21:9
+    │
+ 21 │         bar()
+    │         ^^^^^
+    ·
+ 80 │         m_nonfriend::foo();
+    │         ------------------ in a call inlined at this callsite
+    ·
+100 │     assert!(o_nonfriend::friend_accessible() == 42, 1);
+    │             -------------------------------- in a call inlined at this callsite
 
 error: function `0x42::o_nonfriend::bar` cannot be called here because it is private to module `0x42::o_nonfriend`
-   ┌─ tests/checking/inlining/private_call_3.move:81:2
+    ┌─ tests/checking/inlining/private_call_3.move:81:2
+    │
+ 81 │     bar()
+    │     ^^^^^
+    ·
+100 │     assert!(o_nonfriend::friend_accessible() == 42, 1);
+    │             -------------------------------- in a call inlined at this callsite
+
+error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
+   ┌─ tests/checking/inlining/private_call_3.move:5:9
    │
-81 │     bar()
-   │     ^^^^^
+ 5 │         bar()
+   │         ^^^^^
+   ·
+41 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+92 │         assert!(o::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite
+
+error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:21:9
+   │
+21 │         bar()
+   │         ^^^^^
+   ·
+42 │         m_nonfriend::foo();
+   │         ------------------ in a call inlined at this callsite
+   ·
+92 │         assert!(o::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite
 
 error: function `0x42::o::bar` cannot be called here because it is private to module `0x42::o`
    ┌─ tests/checking/inlining/private_call_3.move:43:2
    │
 43 │     bar()
    │     ^^^^^
+   ·
+92 │         assert!(o::foo() == 42, 1);
+   │                 -------- in a call inlined at this callsite
+
+error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
+   ┌─ tests/checking/inlining/private_call_3.move:5:9
+   │
+ 5 │         bar()
+   │         ^^^^^
+   ·
+47 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+93 │     assert!(o::inaccessible() == 42, 1);
+   │             ----------------- in a call inlined at this callsite
+
+error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:21:9
+   │
+21 │         bar()
+   │         ^^^^^
+   ·
+48 │         m_nonfriend::foo();
+   │         ------------------ in a call inlined at this callsite
+   ·
+93 │     assert!(o::inaccessible() == 42, 1);
+   │             ----------------- in a call inlined at this callsite
 
 error: function `0x42::o::bar` cannot be called here because it is private to module `0x42::o`
    ┌─ tests/checking/inlining/private_call_3.move:49:2
    │
 49 │     bar()
    │     ^^^^^
+   ·
+93 │     assert!(o::inaccessible() == 42, 1);
+   │             ----------------- in a call inlined at this callsite
+
+error: friend function `0x42::m::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m`
+   ┌─ tests/checking/inlining/private_call_3.move:5:9
+   │
+ 5 │         bar()
+   │         ^^^^^
+   ·
+53 │         m::foo();
+   │         -------- in a call inlined at this callsite
+   ·
+94 │     assert!(o::friend_accessible() == 42, 1);
+   │             ---------------------- in a call inlined at this callsite
+
+error: friend function `0x42::m_nonfriend::bar` cannot be called here because `0x42::n` is not a friend of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:21:9
+   │
+21 │         bar()
+   │         ^^^^^
+   ·
+54 │         m_nonfriend::foo();
+   │         ------------------ in a call inlined at this callsite
+   ·
+94 │     assert!(o::friend_accessible() == 42, 1);
+   │             ---------------------- in a call inlined at this callsite
 
 error: function `0x42::o::bar` cannot be called here because it is private to module `0x42::o`
    ┌─ tests/checking/inlining/private_call_3.move:55:2
    │
 55 │     bar()
    │     ^^^^^
+   ·
+94 │     assert!(o::friend_accessible() == 42, 1);
+   │             ---------------------- in a call inlined at this callsite

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1049,7 +1049,8 @@ impl ExpData {
     }
 
     /// A function which can be used by a `node_rewriter` argument to `ExpData::rewrite_node_id` to
-    /// update node location (`Loc`), in addition to instantiating types.
+    /// update node location (`Loc`), in addition to instantiating types.  This is currently only
+    /// useful in inlining, but is cleaner to implement here.
     pub fn instantiate_node_new_loc(
         env: &GlobalEnv,
         id: NodeId,

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -102,6 +102,7 @@ pub const GHOST_MEMORY_PREFIX: &str = "Ghost$";
 pub struct Loc {
     file_id: FileId,
     span: Span,
+    inlined_from_loc: Option<Box<Loc>>,
 }
 
 impl AsRef<Loc> for Loc {
@@ -112,7 +113,31 @@ impl AsRef<Loc> for Loc {
 
 impl Loc {
     pub fn new(file_id: FileId, span: Span) -> Loc {
-        Loc { file_id, span }
+        Loc {
+            file_id,
+            span,
+            inlined_from_loc: None,
+        }
+    }
+
+    pub fn inlined_from(&self, inlined_from: &Loc) -> Loc {
+        Loc {
+            file_id: self.file_id,
+            span: self.span,
+            inlined_from_loc: Some(Box::new(match &self.inlined_from_loc {
+                None => inlined_from.clone(),
+                Some(locbox) => (*locbox.clone()).inlined_from(inlined_from),
+            })),
+        }
+    }
+
+    fn inline_if_needed(&self, loc: Loc) -> Loc {
+        if let Some(locbox) = &self.inlined_from_loc {
+            let source_loc = &**locbox;
+            loc.inlined_from(source_loc)
+        } else {
+            loc
+        }
     }
 
     pub fn span(&self) -> Span {
@@ -126,10 +151,10 @@ impl Loc {
     // Delivers a location pointing to the end of this one.
     pub fn at_end(&self) -> Loc {
         if self.span.end() > ByteIndex(0) {
-            Loc::new(
+            self.inline_if_needed(Loc::new(
                 self.file_id,
                 Span::new(self.span.end() - ByteOffset(1), self.span.end()),
-            )
+            ))
         } else {
             self.clone()
         }
@@ -137,10 +162,10 @@ impl Loc {
 
     // Delivers a location pointing to the start of this one.
     pub fn at_start(&self) -> Loc {
-        Loc::new(
+        self.inline_if_needed(Loc::new(
             self.file_id,
             Span::new(self.span.start(), self.span.start() + ByteOffset(1)),
-        )
+        ))
     }
 
     /// Creates a location which encloses all the locations in the provided slice,
@@ -156,12 +181,14 @@ impl Loc {
                 end = std::cmp::max(end, l.span().end());
             }
         }
-        Loc::new(loc.file_id(), Span::new(start, end))
+        loc.inline_if_needed(Loc::new(loc.file_id(), Span::new(start, end)))
     }
 
     /// Returns true if the other location is enclosed by this location.
     pub fn is_enclosing(&self, other: &Loc) -> bool {
-        self.file_id == other.file_id && GlobalEnv::enclosing_span(self.span, other.span)
+        self.file_id == other.file_id
+            && self.inlined_from_loc == other.inlined_from_loc
+            && GlobalEnv::enclosing_span(self.span, other.span)
     }
 }
 
@@ -798,21 +825,36 @@ impl GlobalEnv {
         self.diag_with_notes(Severity::Error, loc, msg, notes)
     }
 
+    fn add_inlined_from_labels(labels: &mut Vec<Label<FileId>>, inlined_from: &Option<Box<Loc>>) {
+        let mut inlined_from = inlined_from;
+        while let Some(boxed_loc) = inlined_from {
+            let loc = &**boxed_loc;
+            let new_label = Label::secondary(loc.file_id, loc.span)
+                .with_message("in a call inlined at this callsite");
+            labels.push(new_label);
+            inlined_from = &loc.inlined_from_loc;
+        }
+    }
+
     /// Adds a diagnostic of given severity to this environment.
     pub fn diag(&self, severity: Severity, loc: &Loc, msg: &str) {
         let new_msg = Self::add_backtrace(msg, severity == Severity::Bug);
+        let mut labels = vec![Label::primary(loc.file_id, loc.span)];
+        GlobalEnv::add_inlined_from_labels(&mut labels, &loc.inlined_from_loc);
         let diag = Diagnostic::new(severity)
             .with_message(new_msg)
-            .with_labels(vec![Label::primary(loc.file_id, loc.span)]);
+            .with_labels(labels);
         self.add_diag(diag);
     }
 
     /// Adds a diagnostic of given severity to this environment, with notes.
     pub fn diag_with_notes(&self, severity: Severity, loc: &Loc, msg: &str, notes: Vec<String>) {
         let new_msg = Self::add_backtrace(msg, severity == Severity::Bug);
+        let mut labels = vec![Label::primary(loc.file_id, loc.span)];
+        GlobalEnv::add_inlined_from_labels(&mut labels, &loc.inlined_from_loc);
         let diag = Diagnostic::new(severity)
             .with_message(new_msg)
-            .with_labels(vec![Label::primary(loc.file_id, loc.span)]);
+            .with_labels(labels);
         let diag = diag.with_notes(notes);
         self.add_diag(diag);
     }
@@ -843,10 +885,11 @@ impl GlobalEnv {
             .with_labels(vec![
                 Label::primary(loc.file_id, loc.span).with_message(primary)
             ]);
-        let labels = labels
+        let mut labels = labels
             .into_iter()
             .map(|(l, m)| Label::secondary(l.file_id, l.span).with_message(m))
             .collect_vec();
+        GlobalEnv::add_inlined_from_labels(&mut labels, &loc.inlined_from_loc);
         let diag = diag.with_labels(labels);
         self.add_diag(diag);
     }
@@ -891,6 +934,7 @@ impl GlobalEnv {
         Loc {
             file_id,
             span: Span::new(loc.start(), loc.end()),
+            inlined_from_loc: None, // move-compiler doesn't use "inlined from"
         }
     }
 
@@ -1445,12 +1489,15 @@ impl GlobalEnv {
         let field_name = self.symbol_pool.make("v");
         let mut field_data = BTreeMap::new();
         let field_id = FieldId::new(field_name);
-        field_data.insert(field_id, FieldData {
-            name: field_name,
-            loc: loc.clone(),
-            offset: 0,
-            ty,
-        });
+        field_data.insert(
+            field_id,
+            FieldData {
+                name: field_name,
+                loc: loc.clone(),
+                offset: 0,
+                ty,
+            },
+        );
         StructData {
             name: self.ghost_memory_name(var_name),
             loc,

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1490,15 +1490,12 @@ impl GlobalEnv {
         let field_name = self.symbol_pool.make("v");
         let mut field_data = BTreeMap::new();
         let field_id = FieldId::new(field_name);
-        field_data.insert(
-            field_id,
-            FieldData {
-                name: field_name,
-                loc: loc.clone(),
-                offset: 0,
-                ty,
-            },
-        );
+        field_data.insert(field_id, FieldData {
+            name: field_name,
+            loc: loc.clone(),
+            offset: 0,
+            ty,
+        });
         StructData {
             name: self.ghost_memory_name(var_name),
             loc,


### PR DESCRIPTION
### Description

Add 'inlined from' annotations to locations in diagnostics about code that has been inlined in move-compiler-v2

- Add an `Option<Box<Loc>>` field `inlined_from_loc` to struct `Loc` in move-model/src/model.rs, modify diagnostics to show it if present.
- Use it in move-compiler-v2/src/inliner.rs to augment code with information about where it was inlined.

### Test Plan
- Existing test cases private_call.move, private_call_2.move, and private_call_3.move show improved information in this case.
- Other test cases show lack of disruption.

### Fixes
Bug #10848 

