### PR TITLE
Fix compilation warning in bls12381_algebra.move

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
@@ -770,10 +770,11 @@ module aptos_std::bls12381_algebra {
         multi_scalar_mul(&elements, &scalars);
     }
 
+    #[test_only]
     /// The maximum number of `G1` elements that can be created in a transaction,
     /// calculated by the current memory limit (1MB) and the in-mem G1 representation size (144 bytes per element).
-    #[test_only]
     const G1_NUM_MAX_NUMERATOR: u64 = 1048576; // TODO(#9330)
+
     #[test_only]
     const G1_NUM_MAX_DENOMINATOR: u64 = 144; // TODO(#9330)
 


### PR DESCRIPTION
### Description
This warning causes the tests to fail.

### Test Plan
Before:
```
$ aptos move test
warning[W01004]: invalid documentation comment
    ┌─ /Users/dport/a/core/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move:773:5
    │
773 │     /// The maximum number of `G1` elements that can be created in a transaction,
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item

warning[W01004]: invalid documentation comment
    ┌─ /Users/dport/a/core/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move:774:5
    │
774 │     /// calculated by the current memory limit (1MB) and the in-mem G1 representation size (144 bytes per element).
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
```

After:
```
$ aptos move test
...
Test result: OK. Total tests: 252; passed: 252; failed: 0
{
  "Result": "Success"
}
```