### PR TITLE
Make is_enabled in features.move a view function

### DIFF
--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -1782,7 +1782,8 @@ Function to enable and disable features. Can only be called by a signer of @std.
 Check whether the feature is enabled.
 
 
-<pre><code><b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool
 </code></pre>
 
 
@@ -1791,7 +1792,7 @@ Check whether the feature is enabled.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <b>exists</b>&lt;<a href="features.md#0x1_features_Features">Features</a>&gt;(@std) &&
         <a href="features.md#0x1_features_contains">contains</a>(&<b>borrow_global</b>&lt;<a href="features.md#0x1_features_Features">Features</a>&gt;(@std).<a href="features.md#0x1_features">features</a>, feature)
 }
@@ -1981,7 +1982,8 @@ Helper to check whether a feature flag is enabled.
 ### Function `is_enabled`
 
 
-<pre><code><b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_enabled">is_enabled</a>(feature: u64): bool
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -347,8 +347,9 @@ module std::features {
         });
     }
 
+    #[view]
     /// Check whether the feature is enabled.
-    fun is_enabled(feature: u64): bool acquires Features {
+    public fun is_enabled(feature: u64): bool acquires Features {
         exists<Features>(@std) &&
             contains(&borrow_global<Features>(@std).features, feature)
     }


### PR DESCRIPTION
### Description
This provides an easy way to check if a feature is enabled.

I see we have no other view functions in move-stdlib. Asking here if that's intentional.

### Test Plan
Move tests:
```
cd aptos-move/framework/move-stdlib
aptos move test
```

Run a local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes
```

Call the view function:
```
$ aptos move view --function-id 0x1::features::is_enabled --args u64:41 --url http://127.0.0.1:8080/v1
{
  "Result": [
    false
  ]
}
$ aptos move view --function-id 0x1::features::is_enabled --args u64:28 --url http://127.0.0.1:8080/v1
{
  "Result": [
    true
  ]
}
```