### PR TITLE
Move AggV1 materialize from transaction execution to block executor materialization

### DIFF
--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -53,7 +53,9 @@ fn test_ok_output_equality_no_deltas() {
     //       simply merges writes for materialized deltas & combined groups.
     let mut materialized_vm_output = vm_output.clone();
     assert_ok!(materialized_vm_output.try_materialize(&state_view));
-    let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
+    let txn_output_1 = assert_ok!(vm_output
+        .clone()
+        .try_materialize_into_transaction_output(&state_view));
     let txn_output_2 = assert_ok!(vm_output
         .clone()
         .into_transaction_output_with_materialized_write_set(vec![], vec![], vec![]));
@@ -81,7 +83,9 @@ fn test_ok_output_equality_with_deltas() {
 
     let mut materialized_vm_output = vm_output.clone();
     assert_ok!(materialized_vm_output.try_materialize(&state_view));
-    let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
+    let txn_output_1 = assert_ok!(vm_output
+        .clone()
+        .try_materialize_into_transaction_output(&state_view));
     let txn_output_2 = vm_output
         .clone()
         .into_transaction_output_with_materialized_write_set(
@@ -130,7 +134,7 @@ fn test_err_output_equality_with_deltas() {
     )]);
 
     let vm_status_1 = assert_err!(vm_output.clone().try_materialize(&state_view));
-    let vm_status_2 = assert_err!(vm_output.try_into_transaction_output(&state_view));
+    let vm_status_2 = assert_err!(vm_output.try_materialize_into_transaction_output(&state_view));
 
     // Error should be consistent.
     assert_eq!(vm_status_1, vm_status_2);

--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -51,7 +51,8 @@ fn test_ok_output_equality_no_deltas() {
     //   2. `try_into_transaction_output` changes the type and returns a result.
     //   3. `into_transaction_output_with_materialized_write_set` changes the type and
     //       simply merges writes for materialized deltas & combined groups.
-    let materialized_vm_output = assert_ok!(vm_output.clone().try_materialize(&state_view));
+    let mut materialized_vm_output = vm_output.clone();
+    assert_ok!(materialized_vm_output.try_materialize(&state_view));
     let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
     let txn_output_2 = assert_ok!(vm_output
         .clone()
@@ -78,7 +79,8 @@ fn test_ok_output_equality_with_deltas() {
         vec![mock_add(delta_key, 300)],
     );
 
-    let materialized_vm_output = assert_ok!(vm_output.clone().try_materialize(&state_view));
+    let mut materialized_vm_output = vm_output.clone();
+    assert_ok!(materialized_vm_output.try_materialize(&state_view));
     let txn_output_1 = assert_ok!(vm_output.clone().try_into_transaction_output(&state_view));
     let txn_output_2 = vm_output
         .clone()

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2019,7 +2019,7 @@ impl AptosSimulationVM {
         let (vm_status, vm_output) =
             vm.0.execute_user_transaction(&resolver, transaction, &log_context);
         let txn_output = vm_output
-            .try_into_transaction_output(&resolver)
+            .try_materialize_into_transaction_output(&resolver)
             .expect("Materializing aggregator V1 deltas should never fail");
         (vm_status, txn_output)
     }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -9,7 +9,8 @@ use crate::{
     counters::{BLOCK_EXECUTOR_CONCURRENCY, BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS},
 };
 use aptos_aggregator::{
-    delayed_change::DelayedChange, delta_change_set::DeltaOp, types::DelayedFieldID,
+    delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
+    types::DelayedFieldID,
 };
 use aptos_block_executor::{
     errors::Error, executor::BlockExecutor,
@@ -252,6 +253,18 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .change_set()
             .events()
             .to_vec()
+    }
+
+    fn materialize_agg_v1(
+        &self,
+        view: &impl TAggregatorV1View<Identifier = <Self::Txn as BlockExecutableTransaction>::Key>,
+    ) {
+        self.vm_output
+            .lock()
+            .as_mut()
+            .expect("Output must be set to incorporate materialized data")
+            .try_materialize(view)
+            .expect("Delta materialization failed");
     }
 
     fn incorporate_materialized_txn_output(

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -255,10 +255,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .to_vec()
     }
 
-    fn materialize_agg_v1(
-        &self,
-        view: &impl TAggregatorV1View<Identifier = <Self::Txn as BlockExecutableTransaction>::Key>,
-    ) {
+    fn materialize_agg_v1(&self, view: &impl TAggregatorV1View<Identifier = StateKey>) {
         self.vm_output
             .lock()
             .as_mut()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -108,7 +108,7 @@ where
 
         // VM execution.
         let sync_view = LatestView::new(base_view, ViewState::Sync(latest_view), idx_to_execute);
-        let execute_result = executor.execute_transaction(&sync_view, txn, idx_to_execute, false);
+        let execute_result = executor.execute_transaction(&sync_view, txn, idx_to_execute);
 
         let mut prev_modified_keys = last_input_output
             .modified_keys(idx_to_execute)
@@ -1251,11 +1251,12 @@ where
                 )),
                 idx as TxnIndex,
             );
-            let res = executor.execute_transaction(&latest_view, txn, idx as TxnIndex, true);
+            let res = executor.execute_transaction(&latest_view, txn, idx as TxnIndex);
 
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
                 ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                    output.materialize_agg_v1(&latest_view);
                     assert_eq!(
                         output.aggregator_v1_delta_set().len(),
                         0,

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -9,6 +9,7 @@ use crate::{
 use aptos_aggregator::{
     delayed_change::DelayedChange,
     delta_change_set::{delta_add, delta_sub, serialize, DeltaOp},
+    resolver::TAggregatorV1View,
     types::DelayedFieldID,
 };
 use aptos_mvhashmap::types::TxnIndex;
@@ -840,7 +841,6 @@ where
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>),
         txn: &Self::Txn,
         txn_idx: TxnIndex,
-        _materialize_deltas: bool,
     ) -> ExecutionStatus<Self::Output, Self::Error> {
         match txn {
             MockTransaction::Write {
@@ -1091,6 +1091,12 @@ where
             materialized_delta_writes: OnceCell::new(),
             total_gas: 0,
         }
+    }
+
+    fn materialize_agg_v1(
+        &self,
+        _view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
+    ) {
     }
 
     fn incorporate_materialized_txn_output(

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1097,6 +1097,8 @@ where
         &self,
         _view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
     ) {
+        // TODO[agg_v2](tests): implement this method and compare
+        // against sequential execution results v. aggregator v1.
     }
 
     fn incorporate_materialized_txn_output(

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -2,7 +2,9 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::{delayed_change::DelayedChange, delta_change_set::DeltaOp};
+use aptos_aggregator::{
+    delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
+};
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     fee_statement::FeeStatement, transaction::BlockExecutableTransaction as Transaction,
@@ -74,7 +76,6 @@ pub trait ExecutorTask: Sync {
         >),
         txn: &Self::Txn,
         txn_idx: TxnIndex,
-        materialize_deltas: bool,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
 
     fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool;
@@ -158,6 +159,11 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;
+
+    fn materialize_agg_v1(
+        &self,
+        view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
+    );
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized deltas and group updates

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -643,7 +643,7 @@ impl FakeExecutor {
         )?;
 
         Ok((
-            output.try_into_transaction_output(&resolver)?,
+            output.try_materialize_into_transaction_output(&resolver)?,
             gas_profiler.finish(),
         ))
     }

--- a/experimental/execution/ptx-executor/src/finalizer.rs
+++ b/experimental/execution/ptx-executor/src/finalizer.rs
@@ -119,7 +119,7 @@ impl<'view> Worker<'view> {
     fn finalize_one(&mut self) {
         let vm_output = self.buffer.pop_front().unwrap().unwrap();
         let txn_out = vm_output
-            .try_into_transaction_output(&self.state_view)
+            .try_materialize_into_transaction_output(&self.state_view)
             .unwrap();
         for (key, op) in txn_out.write_set() {
             // TODO(ptx): hack: deal only with the total supply


### PR DESCRIPTION
Extracted from block gas limit PR, for easier review - this is necessary there to be able to understand conflicts in sequential and parallel execution in the same way.

Also it is cleaner to have all materialization at the same place - in executor.rs