### PR TITLE
[docs] Add beta admonition to indexer pages

### DIFF
--- a/developer-docs-site/docs/apis/aptos-labs-developer-portal.md
+++ b/developer-docs-site/docs/apis/aptos-labs-developer-portal.md
@@ -1,7 +1,10 @@
 ---
-title: "[Beta] Aptos Labs Developer Portal"
-slug: "aptos-labs-developer-portal"
+title: "Aptos Labs Developer Portal"
 ---
+
+import BetaNotice from '../../src/components/_dev_portal_beta_notice.mdx';
+
+<BetaNotice />
 
 The [Aptos Labs Developer Portal](https://developers.aptoslabs.com) is a your gateway to access Aptos Labs provided APIs in a quick and easy fashion to power your dApp.
 It consists of a Portal (UI) and a set of API Gateways operated by Aptos Labs.

--- a/developer-docs-site/docs/indexer/api/example-queries.md
+++ b/developer-docs-site/docs/indexer/api/example-queries.md
@@ -4,6 +4,10 @@ title: "Example Queries"
 
 # Example Indexer API Queries
 
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
+
 ## Running example queries
 
 1. Open the Hasura Explorer for the network you want to query. You can find the URLs [here](/indexer/api/labs-hosted#hasura-explorer).

--- a/developer-docs-site/docs/indexer/api/index.md
+++ b/developer-docs-site/docs/indexer/api/index.md
@@ -2,7 +2,9 @@
 title: "Indexer API"
 ---
 
-# Indexer API
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 This section contains documentation for the Aptos Indexer API, the API built upon the standard set of processors provided in the [aptos-labs/aptos-indexer-processors](https://github.com/aptos-labs/aptos-indexer-processors) repo.
 

--- a/developer-docs-site/docs/indexer/api/labs-hosted.md
+++ b/developer-docs-site/docs/indexer/api/labs-hosted.md
@@ -2,7 +2,9 @@
 title: "Labs-Hosted Indexer API"
 ---
 
-# Labs-Hosted Indexer API
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 ## GraphQL API Endpoints
 

--- a/developer-docs-site/docs/indexer/api/self-hosted.md
+++ b/developer-docs-site/docs/indexer/api/self-hosted.md
@@ -2,7 +2,9 @@
 title: "Self-Hosted Indexer API"
 ---
 
-# Self-Hosted Indexer API
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 This guide will walk you through setting up a self-hosted Indexer API.
 

--- a/developer-docs-site/docs/indexer/api/usage-guide.md
+++ b/developer-docs-site/docs/indexer/api/usage-guide.md
@@ -2,7 +2,9 @@
 title: "Indexer API Usage Guide"
 ---
 
-# Indexer API Usage Guide
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 Coming soon!
 

--- a/developer-docs-site/docs/indexer/custom-processors/e2e-tutorial.md
+++ b/developer-docs-site/docs/indexer/custom-processors/e2e-tutorial.md
@@ -4,6 +4,10 @@ title: "End-to-End Tutorial"
 
 # Creating a Custom Indexer Processor
 
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
+
 In this tutorial, we're going to walk you through all the steps involved with creating a very basic custom indexer processor to track events and data on the Aptos blockchain.
 
 We use a very simple smart contract called **Coin Flip** that has already emitted events for us.

--- a/developer-docs-site/docs/indexer/custom-processors/index.md
+++ b/developer-docs-site/docs/indexer/custom-processors/index.md
@@ -2,7 +2,9 @@
 title: "Custom Processors"
 ---
 
-# Custom Processors
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 This section explains what a custom processor is, how to write and deploy one, and how to parse transactions from the [Transaction Stream Service](/indexer/txn-stream).
 

--- a/developer-docs-site/docs/indexer/custom-processors/parsing-txns.md
+++ b/developer-docs-site/docs/indexer/custom-processors/parsing-txns.md
@@ -2,7 +2,9 @@
 title: "Parsing Transactions"
 ---
 
-# Parsing Transactions
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 <!--
 Things to add:

--- a/developer-docs-site/docs/indexer/indexer-landing.md
+++ b/developer-docs-site/docs/indexer/indexer-landing.md
@@ -2,10 +2,11 @@
 title: "Learn about Indexing"
 ---
 
+import BetaNotice from '../../src/components/_indexer_beta_notice.mdx';
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-# Learn about Indexing
+<BetaNotice />
 
 ## Quick Start
 

--- a/developer-docs-site/docs/indexer/txn-stream/index.md
+++ b/developer-docs-site/docs/indexer/txn-stream/index.md
@@ -2,6 +2,8 @@
 title: "Transaction Stream Service"
 ---
 
-# Transaction Stream Service
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 The Transaction Stream Service is a service that listens to the Aptos blockchain and emits transactions as they are processed. These docs explain how this system works, how to use the Labs-Hosted instance of the service, and how to deploy it yourself.

--- a/developer-docs-site/docs/indexer/txn-stream/labs-hosted.md
+++ b/developer-docs-site/docs/indexer/txn-stream/labs-hosted.md
@@ -2,7 +2,9 @@
 title: "Labs-Hosted Transaction Stream Service"
 ---
 
-# Labs-Hosted Transaction Stream Service
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 If you are running your own instance of the [Indexer API](/indexer/api), or a [custom processor](/indexer/custom-processors), you must have access to an instance of the Transaction Stream Service. This page contains information about how to use the Labs-Hosted Transaction Stream Service.
 

--- a/developer-docs-site/docs/indexer/txn-stream/local-development.md
+++ b/developer-docs-site/docs/indexer/txn-stream/local-development.md
@@ -4,6 +4,10 @@ title: "Running Locally"
 
 # Running the Transaction Stream Service Locally
 
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
+
 :::info
 This has been tested on MacOS 13 on ARM and Debian 11 on x86_64.
 :::

--- a/developer-docs-site/docs/indexer/txn-stream/self-hosted.md
+++ b/developer-docs-site/docs/indexer/txn-stream/self-hosted.md
@@ -2,6 +2,8 @@
 title: "Self-Hosted Transaction Stream Service"
 ---
 
-# Self-Hosted Transaction Stream Service
+import BetaNotice from '../../../src/components/_indexer_beta_notice.mdx';
+
+<BetaNotice />
 
 Coming soon!

--- a/developer-docs-site/scripts/additional_dict.txt
+++ b/developer-docs-site/scripts/additional_dict.txt
@@ -30,6 +30,7 @@ AptosRelease
 AptosToken
 AptosWalletAdapterProvider
 BCS
+BetaNotice
 BFT
 BIP
 BLS

--- a/developer-docs-site/src/components/_dev_portal_beta_notice.mdx
+++ b/developer-docs-site/src/components/_dev_portal_beta_notice.mdx
@@ -1,0 +1,5 @@
+:::info Beta
+
+Developer Portal is currently in beta. Please report any problems you encounter by creating an issue in the [aptos-core](https://github.com/aptos-labs/aptos-core/issues/new?assignees=@geekflyer,@dport,@blakezimmerman&labels=api-gateway&projects=&template=dev_portal_issue.md&title=%5BDev+Portal%5D+) repo.
+
+:::

--- a/developer-docs-site/src/components/_indexer_beta_notice.mdx
+++ b/developer-docs-site/src/components/_indexer_beta_notice.mdx
@@ -1,0 +1,5 @@
+:::info Beta
+
+The Indexer API, Transaction Stream Service, and Custom Processors are currently in beta. Please report any problems you encounter by creating an issue in the [aptos-indexer-processors](https://github.com/aptos-labs/aptos-indexer-processors/issues/new/choose) repo.
+
+:::


### PR DESCRIPTION
### Description
This PR adds an admonition to each of the new indexer pages informing users that the new stack is in beta.

I remove redundant titles where appropriate as part of this.

Note: My original intent was to do something more lightweight by adding a beta badge above the title but I couldn't get it working. See https://github.com/facebook/docusaurus/issues/9588.

### Test Plan
Docs.