### PR TITLE
[move-vm] Create a stress test suite for module upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "aptos-native-interface",
  "aptos-proptest-helpers",
  "aptos-state-view",
+ "aptos-temppath",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-genesis",

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -30,6 +30,7 @@ aptos-memory-usage-tracker = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-state-view = { workspace = true }
+aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 aptos-vm-genesis = { workspace = true }

--- a/aptos-move/e2e-tests/src/loader/mod.rs
+++ b/aptos-move/e2e-tests/src/loader/mod.rs
@@ -328,7 +328,7 @@ impl Arbitrary for LoaderTransactionGen {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         prop_oneof![
             9 => any::<Index>().prop_map(Self::Invoke),
-            1 => any::<(Index, Index)>().prop_map(Self::UpdateEdge),
+            1 => any::<(Index, Index)>().prop_map(|(i1, i2)| Self::UpdateEdge(i1, i2)),
         ]
         .boxed()
     }

--- a/aptos-move/e2e-tests/src/loader/mod.rs
+++ b/aptos-move/e2e-tests/src/loader/mod.rs
@@ -40,7 +40,12 @@ pub struct DependencyGraph {
 
 #[derive(Debug)]
 pub enum LoaderTransactionGen {
+    // Generate a transaction to mutate the module dependency graph such that:
+    // - If the edge exists, removes the edge from the graph.
+    // - If such edge doesn't exist, add the dependency edge to the graph.
+    // Then recompile the package based on the updated graph structure and publish updated package.
     UpdateEdge(Index, Index),
+    // Invoke the corresponing function at a given pacakge.
     Invoke(Index),
 }
 
@@ -89,14 +94,9 @@ pub enum LoaderTransactionGen {
 // }
 // }
 //
-// By using this strategy, we can generate a set of modules with complex depenency relationship and assert that the new loader is always
+// By using this strategy, we can generate a set of move packages with complex depenency relationship and assert that the new loader is always
 // linking the call to the right module. We can also invoke the entrypoint function to validate if the module dependencies have been
-// resolved properly.
-//
-// TODOs:
-// - randomly generate module upgrade request to mutate the structure of DAG to make sure the VM will be able to handle
-// invaldation properly.
-//
+// resolved properly. Using LoaderTransactionGen we can also mutate the structure of the graph and invoke the corresponding entry point function.
 impl DependencyGraph {
     /// Returns a [`Strategy`] that generates a universe of accounts with pre-populated initial
     /// balances.

--- a/aptos-move/e2e-tests/src/loader/mod.rs
+++ b/aptos-move/e2e-tests/src/loader/mod.rs
@@ -5,17 +5,23 @@
 //! Logic for account universes. This is not in the parent module to enforce privacy.
 
 use crate::{account::AccountData, executor::FakeExecutor};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_proptest_helpers::Index;
+use aptos_temppath::TempPath;
+use aptos_types::transaction::{
+    EntryFunction, ExecutionStatus, SignedTransaction, TransactionStatus,
+};
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, value::MoveValue};
-use move_ir_compiler::Compiler;
 use petgraph::{algo::toposort, graph::NodeIndex, Direction, Graph};
 use proptest::{
     collection::{vec, SizeRange},
     prelude::*,
 };
-use std::{cmp::Ordering, collections::HashMap};
-
+use std::cmp::Ordering;
 mod module_generator;
+
+const DEFAULT_BALANCE: u64 = 1_000_000_000;
 
 #[derive(Debug)]
 pub struct Node {
@@ -28,7 +34,14 @@ pub struct Node {
 #[derive(Debug)]
 pub struct DependencyGraph {
     graph: Graph<Node, ()>,
-    address_to_node: HashMap<ModuleId, NodeIndex>,
+    base_directory: TempPath,
+    sender_account: AccountData,
+}
+
+#[derive(Debug)]
+pub enum LoaderTransactionGen {
+    UpdateEdge(Index, Index),
+    Invoke(Index),
 }
 
 // This module generates a sets of modules that could be used to test the loader.
@@ -42,47 +55,48 @@ pub struct DependencyGraph {
 //
 // This will generate three modules: M1, M2 and M3. Where each module will look like following:
 //
-// module 0x3cf3846156a51da7251ccc84b5e4be10c5ab33049b7692d1164fd2c73ef3638b.M2 {
-// public entry foo(): u64 {
-//     let a: u64;
-// label b0:
-//     a = 49252;                          // randomly generated integer for self node.
-//     assert(copy(a) == 49252, 42);       // assert execution result matches expected value. Expected value can be derived from traversing the DAG.
-//     return move(a);
+// module 0x3cf3846156a51da7251ccc84b5e4be10c5ab33049b7692d1164fd2c73ef3638b::M2 {
+// public fun foo(): u64 {
+//     a = 49252;                              // randomly generated integer for self node.
+//     a
+// }
+// public entry fun foo_entry(expected_value: u64) {
+//     assert!(Self::foo() == expected_value, 42);       // assert execution result matches expected value. Expected value can be derived from traversing the DAG.
 // }
 // }
 //
-// module e57d457d2ffacab8f46dea9779f8ad8135c68fd3574eb2902b3da0cfa67cf9d1.M3 {
-// public entry foo(): u64 {
-//     let a: u64;
-// label b0:
-//     a = 41973;                          // randomly generated integer for self node.
-//     assert(copy(a) == 41973, 42);       // assert execution result matches expected value. Expected value can be derived from traversing the DAG.
-//     return move(a);
+// module e57d457d2ffacab8f46dea9779f8ad8135c68fd3574eb2902b3da0cfa67cf9d1::M3 {
+// public fun foo(expected_value: u64): u64 {
+//     a = 41973;                              // randomly generated integer for self node.
+//     a
+// }
+// public entry fun foo_entry(expected_value: u64) {
+//     assert!(Self::foo() == expected_value, 42);       // assert execution result matches expected value. Expected value can be derived from traversing the DAG.
 // }
 // }
 //
 // M2 and M3 are leaf nodes so the it should be a no-op function call. M1 will look like following:
 //
-// module 0x61da74259dae2c25beb41d11e43c6f5c00cc72d151d8a4f382b02e4e6c420d17.M1 {
-// import 0x3cf3846156a51da7251ccc84b5e4be10c5ab33049b7692d1164fd2c73ef3638b.M2;
-// import e57d457d2ffacab8f46dea9779f8ad8135c68fd3574eb2902b3da0cfa67cf9d1.M3;
-// public entry foo(): u64 {
-//     let a: u64;
-// label b0:
-//     a = 27856 + M2.foo()+ M3.foo();  // The dependency edge will be converted invocation into dependent module.
-//     assert(copy(a) == 119081, 42);   // The expected value is the sum of self and all its dependent modules.
-//     return move(a);
+// module 0x61da74259dae2c25beb41d11e43c6f5c00cc72d151d8a4f382b02e4e6c420d17::M1 {
+// use 0x3cf3846156a51da7251ccc84b5e4be10c5ab33049b7692d1164fd2c73ef3638b::M2;
+// use e57d457d2ffacab8f46dea9779f8ad8135c68fd3574eb2902b3da0cfa67cf9d1::M3;
+// public fun foo(expected_value: u64): u64 {
+//     a = 27856 + M2::foo(49252)+ M3::foo(41973);  // The dependency edge will be converted invocation into dependent module.
+//     a                                            // Return the sum of self and all its dependent modules.
+// }
+// public entry fun foo_entry(expected_value: u64) {
+//     assert!(Self::foo() == expected_value, 42);       // assert execution result matches expected value. Expected value can be derived from traversing the DAG.
 // }
 // }
 //
 // By using this strategy, we can generate a set of modules with complex depenency relationship and assert that the new loader is always
-// linking the call to the right module.
+// linking the call to the right module. We can also invoke the entrypoint function to validate if the module dependencies have been
+// resolved properly.
 //
 // TODOs:
-// - Use Move source language rather than MVIR to generate the modules.
-// - randomly generate module upgrade request to change the structure of DAG to make sure the VM will be able to handle
+// - randomly generate module upgrade request to mutate the structure of DAG to make sure the VM will be able to handle
 // invaldation properly.
+//
 impl DependencyGraph {
     /// Returns a [`Strategy`] that generates a universe of accounts with pre-populated initial
     /// balances.
@@ -92,14 +106,13 @@ impl DependencyGraph {
     pub fn strategy(
         num_accounts: impl Into<SizeRange>,
         expected_num_edges: impl Into<SizeRange>,
-        balance_strategy: impl Strategy<Value = u64>,
     ) -> impl Strategy<Value = Self> {
         (
             vec(
                 (
-                    AccountData::strategy(balance_strategy),
+                    AccountData::strategy(DEFAULT_BALANCE..DEFAULT_BALANCE * 2),
                     any::<u16>(),
-                    any::<Identifier>(),
+                    proptest::string::string_regex("[a-z]{10}").unwrap(),
                 ),
                 num_accounts,
             ),
@@ -108,26 +121,22 @@ impl DependencyGraph {
             .prop_map(move |(accounts, edge_indices)| Self::create(accounts, edge_indices))
     }
 
-    fn create(accounts: Vec<(AccountData, u16, Identifier)>, edges: Vec<(Index, Index)>) -> Self {
+    fn create(accounts: Vec<(AccountData, u16, String)>, edges: Vec<(Index, Index)>) -> Self {
         let mut graph = Graph::new();
         let indices = accounts
             .into_iter()
             .map(|(account_data, self_value, module_name)| {
                 graph.add_node(Node {
-                    name: ModuleId::new(*account_data.address(), module_name),
+                    name: ModuleId::new(
+                        *account_data.address(),
+                        Identifier::new(module_name).unwrap(),
+                    ),
                     self_value: self_value as u64,
                     account_data,
                     expected_value: 0,
                 })
             })
             .collect::<Vec<_>>();
-
-        let address_to_node: HashMap<ModuleId, NodeIndex> = indices
-            .iter()
-            .map(|node_idx| {
-                (graph.node_weight(*node_idx).unwrap().name.clone(), *node_idx)
-            })
-            .collect();
 
         for (lhs_idx, rhs_idx) in edges {
             let lhs = lhs_idx.get(&indices);
@@ -143,9 +152,12 @@ impl DependencyGraph {
                 Ordering::Equal => (),
             }
         }
+        let base_directory = TempPath::new();
+        base_directory.create_as_dir().unwrap();
         Self {
             graph,
-            address_to_node,
+            base_directory,
+            sender_account: AccountData::new(DEFAULT_BALANCE, 0),
         }
     }
 
@@ -154,6 +166,7 @@ impl DependencyGraph {
         for node in self.graph.raw_nodes().iter() {
             executor.add_account_data(&node.weight.account_data);
         }
+        executor.add_account_data(&self.sender_account);
     }
 
     pub fn caculate_expected_values(&mut self) {
@@ -181,66 +194,142 @@ impl DependencyGraph {
         }
     }
 
-    pub fn execute(&self, executor: &mut FakeExecutor) {
+    fn invoke_at(&mut self, node_idx: &NodeIndex) -> SignedTransaction {
+        let txn = self
+            .sender_account
+            .account()
+            .transaction()
+            .sequence_number(self.sender_account.sequence_number())
+            .entry_function(EntryFunction::new(
+                self.graph.node_weight(*node_idx).unwrap().name.clone(),
+                Identifier::new("foo_entry").unwrap(),
+                vec![],
+                vec![
+                    MoveValue::U64(self.graph.node_weight(*node_idx).unwrap().expected_value)
+                        .simple_serialize()
+                        .unwrap(),
+                ],
+            ))
+            .sign();
+
+        self.sender_account.increment_sequence_number();
+        txn
+    }
+
+    fn build_package_for_node(&mut self, node_idx: &NodeIndex) -> SignedTransaction {
+        let node = self
+            .graph
+            .node_weight(*node_idx)
+            .expect("Node should exist");
+        let mut deps = vec![];
+
+        for successor in self
+            .graph
+            .neighbors_directed(*node_idx, Direction::Outgoing)
+        {
+            deps.push(self.graph.node_weight(successor).unwrap().name.clone());
+        }
+
+        let package_path = module_generator::generate_package(
+            &self.base_directory.path(),
+            &node.name,
+            &deps,
+            node.self_value,
+        );
+
+        let package = BuiltPackage::build(package_path, BuildOptions::default()).unwrap();
+
+        let code = package.extract_code();
+        let metadata = package
+            .extract_metadata()
+            .expect("extracting package metadata must succeed");
+        let txn = node
+            .account_data
+            .account()
+            .transaction()
+            .sequence_number(node.account_data.sequence_number())
+            .payload(aptos_stdlib::code_publish_package_txn(
+                bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
+                code,
+            ))
+            .sign();
+
+        self.graph
+            .node_weight_mut(*node_idx)
+            .unwrap()
+            .account_data
+            .increment_sequence_number();
+        txn
+    }
+
+    pub fn execute(
+        &mut self,
+        executor: &mut FakeExecutor,
+        additional_txns: Vec<LoaderTransactionGen>,
+    ) {
         // Generate a list of modules
         let accounts = toposort(&self.graph, None).expect("Dep graph should be acyclic");
-        let mut modules = vec![];
+        let mut txns = vec![];
         for account_idx in accounts.iter().rev() {
-            let node = self
-                .graph
-                .node_weight(*account_idx)
-                .expect("Node should exist");
-            let mut deps = vec![];
-
-            // Calculate the expected result of module entry function
-            for successor in self
-                .graph
-                .neighbors_directed(*account_idx, Direction::Outgoing)
-            {
-                deps.push(self.graph.node_weight(successor).unwrap().name.clone());
-            }
-
-            let module_str = module_generator::generate_module(
-                &node.name,
-                &deps,
-                node.self_value,
-                |module_id| {
-                    self.graph
-                        .node_weight(*self.address_to_node.get(module_id).unwrap())
-                        .unwrap()
-                        .expected_value
-                },
-            );
-            let module = Compiler {
-                deps: modules.iter().collect(),
-            }
-            .into_compiled_module(&module_str)
-            .expect("Module compilation failed");
-
-            // Publish Module into executor.
-            let mut module_bytes = vec![];
-            module.serialize(&mut module_bytes).unwrap();
-
-            // TODO: Generate transactions instead of using add_module api.
-            executor.add_module(&node.name, module_bytes);
-
-            modules.push(module);
+            let txn = self.build_package_for_node(account_idx);
+            txns.push(txn);
         }
+
         for account_idx in accounts.iter() {
-            let node = self
-                .graph
-                .node_weight(*account_idx)
-                .expect("Node should exist");
-
-            // TODO: Generate transactions instead of using exec api.
-            executor.exec_module(
-                &node.name,
-                "foo",
-                vec![],
-                vec![MoveValue::U64(self.graph.node_weight(*account_idx).unwrap().expected_value)
-                    .simple_serialize()
-                    .unwrap()],
-            );
+            txns.push(self.invoke_at(account_idx));
         }
+
+        for txn_gen in additional_txns {
+            if let Some(txn) = self.generate_txn(txn_gen) {
+                txns.push(txn)
+            }
+        }
+
+        let outputs = executor.execute_block(txns).unwrap();
+
+        for output in outputs {
+            assert_eq!(
+                output.status(),
+                &TransactionStatus::Keep(ExecutionStatus::Success)
+            )
+        }
+    }
+
+    pub fn generate_txn(&mut self, gen: LoaderTransactionGen) -> Option<SignedTransaction> {
+        Some(match gen {
+            LoaderTransactionGen::Invoke(idx) => {
+                self.invoke_at(&NodeIndex::new(idx.index(self.graph.node_count())))
+            },
+            LoaderTransactionGen::UpdateEdge(lhs, rhs) => {
+                let mut lhs_idx = NodeIndex::new(lhs.index(self.graph.node_count()));
+                let mut rhs_idx = NodeIndex::new(rhs.index(self.graph.node_count()));
+                match lhs_idx.cmp(&rhs_idx) {
+                    Ordering::Greater => (),
+                    Ordering::Less => std::mem::swap(&mut lhs_idx, &mut rhs_idx),
+                    Ordering::Equal => return None,
+                }
+                if let Some(edge) = self.graph.find_edge(lhs_idx, rhs_idx) {
+                    self.graph.remove_edge(edge);
+                } else {
+                    self.graph.add_edge(lhs_idx, rhs_idx, ());
+                }
+
+                self.caculate_expected_values();
+                self.build_package_for_node(&lhs_idx)
+            },
+        })
+    }
+}
+
+impl Arbitrary for LoaderTransactionGen {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            9 => any::<Index>().prop_map(|idx| Self::Invoke(idx)),
+            1 => any::<(Index, Index)>().prop_map(|(i1, i2)| Self::UpdateEdge(i1, i2)),
+        ]
+        .boxed()
     }
 }

--- a/aptos-move/e2e-tests/src/loader/mod.rs
+++ b/aptos-move/e2e-tests/src/loader/mod.rs
@@ -231,7 +231,7 @@ impl DependencyGraph {
         }
 
         let package_path = module_generator::generate_package(
-            &self.base_directory.path(),
+            self.base_directory.path(),
             &node.name,
             &deps,
             node.self_value,
@@ -327,8 +327,8 @@ impl Arbitrary for LoaderTransactionGen {
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            9 => any::<Index>().prop_map(|idx| Self::Invoke(idx)),
-            1 => any::<(Index, Index)>().prop_map(|(i1, i2)| Self::UpdateEdge(i1, i2)),
+            9 => any::<Index>().prop_map(Self::Invoke),
+            1 => any::<(Index, Index)>().prop_map(Self::UpdateEdge),
         ]
         .boxed()
     }

--- a/aptos-move/e2e-tests/src/loader/module_generator.rs
+++ b/aptos-move/e2e-tests/src/loader/module_generator.rs
@@ -6,43 +6,99 @@
 
 use move_core_types::language_storage::ModuleId;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
+use std::{
+    collections::HashSet,
+    fs::create_dir,
+    path::{Path, PathBuf},
+};
 
-// TODO: Use Move source language to generate the modules.
-pub fn generate_module(
+pub fn generate_package(
+    base_path: &Path,
     self_addr: &ModuleId,
     deps: &[ModuleId],
     self_val: u64,
-    deps_expected_value: impl Fn(&ModuleId) -> u64,
-) -> String {
+) -> PathBuf {
+    let mut package_path = base_path.to_path_buf();
+    package_path.push(self_addr.name().as_str());
+
+    let mut source_path = package_path.clone();
+    source_path.push("sources");
+
+    if !package_path.exists() {
+        create_dir(&package_path).unwrap();
+        create_dir(&source_path).unwrap();
+    }
+
+    source_path.push(format!("{}.move", self_addr.name()));
+    std::fs::write(&source_path, generate_module(self_addr, deps, self_val)).unwrap();
+
+    package_path.push("Move.toml");
+    std::fs::write(&package_path, generate_package_toml(self_addr, deps)).unwrap();
+    package_path.pop();
+    package_path
+}
+
+pub fn generate_package_toml(self_addr: &ModuleId, deps: &[ModuleId]) -> String {
+    let writer = CodeWriter::new(Loc::default());
+    emitln!(
+        writer,
+        r#"[package]
+name = "{}"
+version = "0.0.0"
+
+[dependencies]"#,
+        self_addr.name(),
+    );
+    let mut visited = HashSet::new();
+    for dep in deps {
+        if !visited.contains(dep) {
+            emitln!(
+                writer,
+                r#"{} = {{ local = "../{}"}}"#,
+                dep.name(),
+                dep.name()
+            );
+            visited.insert(dep);
+        }
+    }
+    writer.process_result(|s| s.to_string())
+}
+
+pub fn generate_module(self_addr: &ModuleId, deps: &[ModuleId], self_val: u64) -> String {
     let writer = CodeWriter::new(Loc::default());
     emit!(
         writer,
-        "module {}.{} ",
+        "module {}::{} ",
         self_addr.address(),
         self_addr.name()
     );
     emitln!(writer, "{");
     writer.indent();
+    let mut visited = HashSet::new();
     for dep in deps {
-        emitln!(writer, "import {}.{};", dep.address(), dep.name());
+        if !visited.contains(dep) {
+            emitln!(writer, "use {}::{};", dep.address(), dep.name());
+            visited.insert(dep);
+        }
     }
     emitln!(writer);
-    emitln!(writer, "public entry foo(expected_value: u64): u64 {");
+    emitln!(writer, "public fun foo(): u64 {");
     writer.indent();
-    emitln!(writer, "let a: u64;");
-    writer.unindent();
-    emitln!(writer, "label b0:");
-    writer.indent();
-    emit!(writer, "a = {}", self_val);
+    emit!(writer, "let a = {}", self_val);
     for dep in deps {
-        emit!(writer, "+ {}.foo({})", dep.name(), deps_expected_value(dep));
+        emit!(writer, "+ {}::foo()", dep.name(),);
     }
     emit!(writer, ";\n");
-    emitln!(writer, "assert(copy(a) == move(expected_value), 42);");
-    emitln!(writer, "return move(a);");
+    emitln!(writer, "a");
     writer.unindent();
     emitln!(writer, "}");
     writer.unindent();
+    emitln!(writer, "public entry fun foo_entry(expected_value: u64) {");
+    writer.indent();
+    emitln!(writer, "assert!(Self::foo() == expected_value, 42);");
+    writer.unindent();
+    emitln!(writer, "}");
+
     emitln!(writer, "}");
     writer.process_result(|s| s.to_string())
 }

--- a/aptos-move/e2e-tests/src/loader/module_generator.rs
+++ b/aptos-move/e2e-tests/src/loader/module_generator.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Logic for account universes. This is not in the parent module to enforce privacy.
+//! Logic for loader module universes.
 
 use move_core_types::language_storage::ModuleId;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};

--- a/aptos-move/e2e-testsuite/src/tests/loader.rs
+++ b/aptos-move/e2e-testsuite/src/tests/loader.rs
@@ -7,9 +7,10 @@ use aptos_language_e2e_tests::{
 use proptest::prelude::*;
 
 /// Run these transactions and verify the expected output.
-pub fn run_and_assert_universe(universe: DependencyGraph) {
+pub fn run_and_assert_universe(mut universe: DependencyGraph) {
     let mut executor = FakeExecutor::from_head_genesis();
     universe.setup(&mut executor);
+    universe.caculate_expected_values();
     universe.execute(&mut executor);
 }
 

--- a/aptos-move/e2e-testsuite/src/tests/loader.rs
+++ b/aptos-move/e2e-testsuite/src/tests/loader.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_language_e2e_tests::{
-    executor::FakeExecutor, loader::{DependencyGraph, LoaderTransactionGen},
+    executor::FakeExecutor,
+    loader::{DependencyGraph, LoaderTransactionGen},
 };
-use proptest::prelude::*;
-use proptest::collection::vec;
+use proptest::{collection::vec, prelude::*};
 
 /// Run these transactions and verify the expected output.
-pub fn run_and_assert_universe(mut universe: DependencyGraph, additional_txns: Vec<LoaderTransactionGen>) {
+pub fn run_and_assert_universe(
+    mut universe: DependencyGraph,
+    additional_txns: Vec<LoaderTransactionGen>,
+) {
     let mut executor = FakeExecutor::from_head_genesis().set_parallel();
 
     universe.setup(&mut executor);

--- a/aptos-move/e2e-testsuite/src/tests/loader.rs
+++ b/aptos-move/e2e-testsuite/src/tests/loader.rs
@@ -2,30 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_language_e2e_tests::{
-    account_universe::log_balance_strategy, executor::FakeExecutor, loader::DependencyGraph,
+    executor::FakeExecutor, loader::{DependencyGraph, LoaderTransactionGen},
 };
 use proptest::prelude::*;
+use proptest::collection::vec;
 
 /// Run these transactions and verify the expected output.
-pub fn run_and_assert_universe(mut universe: DependencyGraph) {
-    let mut executor = FakeExecutor::from_head_genesis();
+pub fn run_and_assert_universe(mut universe: DependencyGraph, additional_txns: Vec<LoaderTransactionGen>) {
+    let mut executor = FakeExecutor::from_head_genesis().set_parallel();
+
     universe.setup(&mut executor);
     universe.caculate_expected_values();
-    universe.execute(&mut executor);
+    universe.execute(&mut executor, additional_txns);
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(32))]
+    #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]
+    #[ignore]
     fn all_transactions(
         universe in DependencyGraph::strategy(
             // Number of modules
             20,
             // Number of dependency edges
             30..150,
-            log_balance_strategy(1_000_000),
-        )
+        ),
+        additional_txns in vec(any::<LoaderTransactionGen>(), 10..80),
     ) {
-        run_and_assert_universe(universe);
+        run_and_assert_universe(universe, additional_txns);
+    }
+
+    #[test]
+    fn smaller_world(
+        universe in DependencyGraph::strategy(
+            // Number of modules
+            5,
+            // Number of dependency edges
+            10..20,
+        ),
+        additional_txns in vec(any::<LoaderTransactionGen>(), 10..20),
+    ) {
+        run_and_assert_universe(universe, additional_txns);
     }
 }


### PR DESCRIPTION
### Description

Refactored the loader proptest to allow generating random packages and mutate them during execution. This would give us a stress test on loader's behavior over module republishing.

### Test Plan

Updated an ran the tests. Make sure they passed.