### PR TITLE
fix that aptos remote debugger coerces remote state value read result…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "itertools 0.10.5",
+ "log",
  "lru 0.7.8",
  "move-binary-format",
  "tokio",

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -580,7 +580,7 @@ impl StateApi {
                         "StateKey({}) and Ledger version({})",
                         request.key, ledger_version
                     ),
-                    AptosErrorCode::TableItemNotFound,
+                    AptosErrorCode::StateValueNotFound,
                     &ledger_info,
                 )
             })?;

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -24,6 +24,7 @@ aptos-types = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 itertools = { workspace = true }
+log = "0.4.17"
 lru = { workspace = true }
 move-binary-format = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -55,7 +55,8 @@ impl AptosValidatorInterface for RestDebuggerInterface {
                 RestError::Api(AptosErrorResponse {
                     error:
                         AptosError {
-                            error_code: AptosErrorCode::StateValueNotFound,
+                            error_code:
+                                AptosErrorCode::StateValueNotFound | AptosErrorCode::TableItemNotFound, /* bug in pre 1.9 nodes */
                             ..
                         },
                     ..

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -359,11 +359,10 @@ impl Dag {
             .map(|(_, round_nodes)| round_nodes.iter().map(|node| node.is_some()).collect())
             .collect();
 
-        bitmask.resize((target_round - lowest_round + 1) as usize, vec![
-            false;
-            self.author_to_index
-                .len()
-        ]);
+        bitmask.resize(
+            (target_round - lowest_round + 1) as usize,
+            vec![false; self.author_to_index.len()],
+        );
 
         DagSnapshotBitmask::new(lowest_round, bitmask)
     }


### PR DESCRIPTION
…s to StateValue::Legacy

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```bash
aptos-debugger.fix-state-value \
move \
execute-past-transactions \
--begin-version 345700653 --limit 1 --rest-endpoint https://mainnet.aptoslabs.com/v1
```
now calculates storage refunds correctly and no longer ends in a mismatch.
