### PR TITLE
[gha] Set concurrency correctly on ts sdk check

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -20,7 +20,7 @@ permissions:
 # cancel redundant builds
 concurrency:
   # cancel redundant builds on PRs (only on PR, not on branches)
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request_target' && github.ref) || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Because this check usese pull request target trigger the concurrency was actually incorrect and causing jobs to get randomly canceled

Test Plan: there is unfortunately not really a great way to test pull_request_target because it runs off the main branch on the workflow
