### PR TITLE
Fixed several documentation errors

### DIFF
--- a/developer-docs-site/docs/move/book/abilities.md
+++ b/developer-docs-site/docs/move/book/abilities.md
@@ -186,7 +186,7 @@ fun invalid_unused() {
 }
 
 fun invalid_left_in_local(): u64 {
-    let n = Cup<NoAbilities> { item: NoAbilities {}};
+    let c_n = Cup<NoAbilities> { item: NoAbilities {}};
     // Invalid return: 'c_n' has a value
     // and 'Cup<NoAbilities>' does not have 'drop'
     0

--- a/developer-docs-site/docs/move/book/abort-and-assert.md
+++ b/developer-docs-site/docs/move/book/abort-and-assert.md
@@ -13,7 +13,7 @@ More information on [`return` can be found in the linked section](./functions.md
 abort 42
 ```
 
-The `abort` expression halts execution the current function and reverts all changes made to global
+The `abort` expression halts execution of the current function and reverts all changes made to global
 state by the current transaction. There is no mechanism for "catching" or otherwise handling an
 `abort`.
 

--- a/developer-docs-site/docs/move/book/functions.md
+++ b/developer-docs-site/docs/move/book/functions.md
@@ -115,7 +115,7 @@ script {
 
 ### `entry` modifier
 
-The `entry` modifier is designed to allow module functions to be safely and directly invoked much like scripts. This allows module writers to specify which functions can be to begin execution. The module writer then knows that any non-`entry` function will be called from a Move program already in execution.
+The `entry` modifier is designed to allow module functions to be safely and directly invoked much like scripts. This allows module writers to specify which functions can be invoked to begin execution. The module writer then knows that any non-`entry` function will be called from a Move program already in execution.
 
 Essentially, `entry` functions are the "main" functions of a module, and they specify where Move programs start executing.
 
@@ -189,9 +189,13 @@ must not have any return values.
 Function names can start with letters `a` to `z` or letters `A` to `Z`. After the first character, function names can contain underscores `_`, letters `a` to `z`, letters `A` to `Z`, or digits `0` to `9`.
 
 ```move
+// all valid
 fun FOO() {}
 fun bar_42() {}
-fun _bAZ19() {}
+fun bAZ19() {}
+
+// invalid
+fun _bAZ19() {} // Function names cannot start with '_'
 ```
 
 ### Type Parameters
@@ -463,7 +467,7 @@ fun add(x: u64, y: u64): u64 {
 }
 ```
 
-[As mentioned above](#function-body), the function's body is an [expression block](./variables.md). The expression block can sequence various statements, and the final expression in the block will be the value of that block
+[As mentioned above](#function-body), the function's body is an [expression block](./variables.md). The expression block can be a sequence of various statements, and the final expression in the block will be the value of that block.
 
 ```move=
 fun double_and_add(x: u64, y: u64): u64 {
@@ -495,7 +499,7 @@ fun safe_sub(x: u64, y: u64): u64 {
 
 Note that the body of this function could also have been written as `if (y > x) 0 else x - y`.
 
-However `return` really shines is in exiting deep within other control flow constructs. In this example, the function iterates through a vector to find the index of a given value:
+However where `return` really shines is in exiting deep within other control flow constructs. In this example, the function iterates through a vector to find the index of a given value:
 
 ```move=
 use std::vector;

--- a/developer-docs-site/docs/move/book/integers.md
+++ b/developer-docs-site/docs/move/book/integers.md
@@ -137,7 +137,7 @@ Casts *do not* truncate. Casting will abort if the result is too large for the s
 |------------|---------------------------------------------------------------------------------|---------------------------------------
 | `(e as T)`| Cast integer expression `e` into an integer type `T` | `e` is too large to represent as a `T`
 
-Here, the type of `e` must be `8`, `16`, `32`, `64`, `128` or `256` and `T` must be `u8`, `u16`, `u32`, `u64`, `u128` oe `u256`.
+Here, the type of `e` must be `8`, `16`, `32`, `64`, `128` or `256` and `T` must be `u8`, `u16`, `u32`, `u64`, `u128` or `u256`.
 
 For example:
 

--- a/developer-docs-site/docs/move/book/structs-and-resources.md
+++ b/developer-docs-site/docs/move/book/structs-and-resources.md
@@ -517,10 +517,10 @@ module circle {
     }
 
     public fun overlaps(c1: &Circle, c2: &Circle): bool {
-        let d = point::dist_squared(&c1.center, &c2.center);
+        let dist_squared_value = point::dist_squared(&c1.center, &c2.center);
         let r1 = c1.radius;
         let r2 = c2.radius;
-        d*d <= r1*r1 + 2*r1*r2 + r2*r2
+        dist_squared_value <= r1*r1 + 2*r1*r2 + r2*r2
     }
 }
 }

--- a/developer-docs-site/docs/move/book/tuples.md
+++ b/developer-docs-site/docs/move/book/tuples.md
@@ -107,8 +107,8 @@ For more details, see [Move Variables](./variables.md).
 
 ## Subtyping
 
-Along with references, tuples are the only types that have [subtyping](https://en.wikipedia.org/wiki/Subtyping) in Move. Tuples do have
-subtyping only in the sense that subtype with references (in a covariant way).
+Along with references, tuples are the only other type that have [subtyping](https://en.wikipedia.org/wiki/Subtyping) in Move. Tuples have
+subtyping only in the sense that they subtype with references (in a covariant way).
 
 For example:
 

--- a/developer-docs-site/docs/move/book/unit-testing.md
+++ b/developer-docs-site/docs/move/book/unit-testing.md
@@ -93,7 +93,7 @@ command](./packages.md).
 
 When running tests, every test will either `PASS`, `FAIL`, or `TIMEOUT`. If a test case fails, the location of the failure along with the function name that caused the failure will be reported if possible. You can see an example of this below.
 
-A test will be marked as timing out if it exceeds the maximum number of instructions that can be executed for any single test. This bound can be changed using the options below, and its default value is set to 5000 instructions. Additionally, while the result of a test is always deterministic, tests are run in parallel by default, so the ordering of test results in a test run is non-deterministic unless running with only one thread (see `OPTIONS` below).
+A test will be marked as timing out if it exceeds the maximum number of instructions that can be executed for any single test. This bound can be changed using the options below, and its default value is set to 100000 instructions. Additionally, while the result of a test is always deterministic, tests are run in parallel by default, so the ordering of test results in a test run is non-deterministic unless running with only one thread (see `OPTIONS` below).
 
 There are also a number of options that can be passed to the unit testing binary to fine-tune testing and to help debug failing tests. These can be found using the help flag:
 


### PR DESCRIPTION
For files in developer-docs-site/docs/move/book/:

1. abilities.md - Replaced n with c_n.
2. abort-and-assert.md - Added "of" in sentence.
3. functions.md - Fixed example where function names can't start with underscore. Made various sentences read better.
4. integers.md - Replaced "oe" with "or".
5. structs-and-resources.md - The "d" returned is actually already d*d. Renamed "d" to "dist_squared_value". Replaced d*d with dist_squared_value.
6. tuples.md - Improved sentence readability.100000
7. unit-testing.md - Current default max instructions in aptos 2.3.1 is 100000 from "aptos move test -h".

### Description
Fixed several documentation errors in several `.md` files.

### Test Plan
I changed the `.md` files and after running:
```
./scripts/rust_lint.s
```
I got these errors:
```
error: use of `or_insert_with` to construct default value
  --> third_party/move/move-borrow-graph/src/graph.rs:71:26
   |
71 |                         .or_insert_with(BTreeMap::new)
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
   = note: `-D clippy::unwrap-or-default` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`

    Checking chrono v0.4.31
error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> third_party/move/move-borrow-graph/src/references.rs:212:1
    |
212 | /  impl<Loc: Copy, Lbl: Clone + Ord> PartialOrd for BorrowEdge<Loc, Lbl> {
213 | |      fn partial_cmp(&self, other: &BorrowEdge<Loc, Lbl>) -> Option<Ordering> {
    | | _____________________________________________________________________________-
214 | ||         BorrowEdgeNoLoc::new(self).partial_cmp(&BorrowEdgeNoLoc::new(other))
215 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
216 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_partial_ord_impl
    = note: `-D clippy::non-canonical-partial-ord-impl` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_partial_ord_impl)]`

error: could not compile `move-borrow-graph` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

When I checked on the upstream master branch, these errors are pre-existing.