### PR TITLE
[Forge] Bump catchup time for `realistic_network_tuned_for_throughput_test`

### DIFF
--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -38,7 +38,10 @@ use claims::assert_matches;
 use futures::StreamExt;
 use mockall::predicate::always;
 use std::{sync::Arc, time::Duration};
-use tokio::task::JoinHandle;
+use tokio::{task::JoinHandle, time::timeout};
+
+// Useful test constants
+const TEST_TIMEOUT_SECS: u64 = 30;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_apply_transaction_outputs() {
@@ -832,8 +835,12 @@ async fn verify_snapshot_commit_notification(
     commit_listener: &mut CommitNotificationListener,
     expected_committed_transactions: CommittedTransactions,
 ) {
-    let CommitNotification::CommittedStateSnapshot(committed_snapshot) =
-        commit_listener.select_next_some().await;
+    let CommitNotification::CommittedStateSnapshot(committed_snapshot) = timeout(
+        Duration::from_secs(TEST_TIMEOUT_SECS),
+        commit_listener.select_next_some(),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         committed_snapshot.committed_transaction,
         expected_committed_transactions
@@ -845,7 +852,12 @@ async fn verify_error_notification(
     error_listener: &mut ErrorNotificationListener,
     expected_notification_id: NotificationId,
 ) {
-    let error_notification = error_listener.select_next_some().await;
+    let error_notification = timeout(
+        Duration::from_secs(TEST_TIMEOUT_SECS),
+        error_listener.select_next_some(),
+    )
+    .await
+    .unwrap();
     assert_eq!(error_notification.notification_id, expected_notification_id);
     assert_matches!(error_notification.error, Error::UnexpectedError(_));
 }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1908,7 +1908,8 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
             .with_success_criteria(
                 SuccessCriteria::new(25000)
                     .add_no_restarts()
-                    .add_wait_for_catchup_s(60),
+                    /* This test runs at high load, so we need more catchup time */
+                    .add_wait_for_catchup_s(120),
                 /* Doesn't work without event indices
                 .add_chain_progress(StateProgressThreshold {
                     max_no_progress_secs: 10.0,
@@ -1920,7 +1921,8 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
         forge_config = forge_config.with_success_criteria(
             SuccessCriteria::new(12000)
                 .add_no_restarts()
-                .add_wait_for_catchup_s(60)
+                /* This test runs at high load, so we need more catchup time */
+                .add_wait_for_catchup_s(120)
                 .add_system_metrics_threshold(SystemMetricsThreshold::new(
                     // Tuned for throughput uses more cores than regular tests,
                     // as it achieves higher throughput.


### PR DESCRIPTION
### Description
This PR makes two small test only changes:
1. `realistic_network_tuned_for_throughput_test` is now using big machines and running at a higher TPS, so we need to bump the catch up time for slow nodes.
2. Use a timeout to prevent some failed tests from hanging.

### Test Plan
Existing test infrastructure.
