### PR TITLE
[Quorum Store] batch request changed to short circuit on expired

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -93,7 +93,7 @@ impl Default for QuorumStoreConfig {
             batch_request_retry_limit: 10,
             batch_request_retry_interval_ms: 1000,
             batch_request_rpc_timeout_ms: 5000,
-            batch_expiry_gap_when_init_usecs: Duration::from_secs(60).as_micros() as u64,
+            batch_expiry_gap_when_init_usecs: Duration::from_secs(1).as_micros() as u64,
             memory_quota: 120_000_000,
             db_quota: 300_000_000,
             batch_quota: 300_000,

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -93,7 +93,7 @@ impl Default for QuorumStoreConfig {
             batch_request_retry_limit: 10,
             batch_request_retry_interval_ms: 1000,
             batch_request_rpc_timeout_ms: 5000,
-            batch_expiry_gap_when_init_usecs: Duration::from_secs(1).as_micros() as u64,
+            batch_expiry_gap_when_init_usecs: Duration::from_secs(60).as_micros() as u64,
             memory_quota: 120_000_000,
             db_quota: 300_000_000,
             batch_quota: 300_000,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -419,7 +419,13 @@ impl QuorumStoreSender for NetworkSender {
                 batch.verify_with_digest(request_digest)?;
                 Ok(BatchResponse::Batch(*batch))
             },
-            ConsensusMsg::BatchResponseV2(maybe_batch) => Ok(*maybe_batch),
+            ConsensusMsg::BatchResponseV2(maybe_batch) => {
+                if let BatchResponse::Batch(batch) = maybe_batch.as_ref() {
+                    batch.verify_with_digest(request_digest)?;
+                }
+                // Note BatchResponse::NotFound(ledger_info) is verified later with a ValidatorVerifier
+                Ok(*maybe_batch)
+            },
             _ => Err(anyhow!("Invalid batch response")),
         }
     }

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -7,7 +7,7 @@
 use crate::{
     dag::DAGNetworkMessage,
     pipeline,
-    quorum_store::types::{Batch, BatchMsg, BatchRequest},
+    quorum_store::types::{Batch, BatchMsg, BatchRequest, BatchResponse},
     rand::rand_gen::RandGenMessage,
 };
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
@@ -73,6 +73,8 @@ pub enum ConsensusMsg {
     CommitMessage(Box<CommitMessage>),
     /// Randomness generation message
     RandGenMessage(RandGenMessage),
+    /// Quorum Store: Response to the batch request.
+    BatchResponseV2(Box<BatchResponse>),
 }
 
 /// Network type for consensus
@@ -98,6 +100,7 @@ impl ConsensusMsg {
             ConsensusMsg::DAGMessage(_) => "DAGMessage",
             ConsensusMsg::CommitMessage(_) => "CommitMessage",
             ConsensusMsg::RandGenMessage(_) => "RandGenMessage",
+            ConsensusMsg::BatchResponseV2(_) => "BatchResponseV2",
         }
     }
 }

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -81,17 +81,15 @@ impl BatchRequesterState {
                     digest
                 )
             };
-        } else {
-            if self
-                .ret_tx
-                .send(Err(ExecutorError::CouldNotGetData))
-                .is_err()
-            {
-                debug!(
-                    "Receiver of requested batch not available for unavailable digest {}",
-                    digest
-                );
-            }
+        } else if self
+            .ret_tx
+            .send(Err(ExecutorError::CouldNotGetData))
+            .is_err()
+        {
+            debug!(
+                "Receiver of requested batch not available for unavailable digest {}",
+                digest
+            );
         }
     }
 }
@@ -177,7 +175,7 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                             // Short-circuit if the chain has moved beyond expiration
                             Ok(BatchResponse::NotFound(ledger_info)) => {
                                 counters::RECEIVED_BATCH_NOT_FOUND_COUNT.inc();
-                                if ledger_info.commit_info().epoch() == self.epoch
+                                if ledger_info.commit_info().epoch() == epoch
                                     && ledger_info.commit_info().timestamp_usecs() > expiration
                                     && ledger_info.verify_signatures(&validator_verifier).is_ok()
                                 {

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -4,16 +4,19 @@
 use crate::{
     monitor,
     network::QuorumStoreSender,
-    quorum_store::{counters, types::BatchRequest},
+    quorum_store::{
+        counters,
+        types::{BatchRequest, BatchResponse},
+    },
 };
-use aptos_consensus_types::proof_of_store::BatchInfo;
+use aptos_consensus_types::proof_of_store::{BatchInfo, ProofOfStore};
 use aptos_crypto::HashValue;
 use aptos_executor_types::*;
 use aptos_logger::prelude::*;
-use aptos_types::{transaction::SignedTransaction, PeerId};
+use aptos_types::{transaction::SignedTransaction, validator_verifier::ValidatorVerifier, PeerId};
 use futures::{stream::FuturesUnordered, StreamExt};
 use rand::Rng;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tokio::{sync::oneshot, time};
 
 struct BatchRequesterState {
@@ -65,7 +68,6 @@ impl BatchRequesterState {
         }
     }
 
-    // TODO: if None, then return an error to the caller
     fn serve_request(self, digest: HashValue, maybe_payload: Option<Vec<SignedTransaction>>) {
         if let Some(payload) = maybe_payload {
             trace!(
@@ -80,15 +82,13 @@ impl BatchRequesterState {
                 )
             };
         } else {
-            counters::RECEIVED_BATCH_REQUEST_TIMEOUT_COUNT.inc();
-            debug!("QS: batch timed out, digest {}", digest);
             if self
                 .ret_tx
                 .send(Err(ExecutorError::CouldNotGetData))
                 .is_err()
             {
                 debug!(
-                    "Receiver of requested batch not available for timed out digest {}",
+                    "Receiver of requested batch not available for unavailable digest {}",
                     digest
                 );
             }
@@ -104,6 +104,7 @@ pub(crate) struct BatchRequester<T> {
     retry_interval_ms: usize,
     rpc_timeout_ms: usize,
     network_sender: T,
+    validator_verifier: Arc<ValidatorVerifier>,
 }
 
 impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
@@ -115,6 +116,7 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
         retry_interval_ms: usize,
         rpc_timeout_ms: usize,
         network_sender: T,
+        validator_verifier: ValidatorVerifier,
     ) -> Self {
         Self {
             epoch,
@@ -124,15 +126,19 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
             retry_interval_ms,
             rpc_timeout_ms,
             network_sender,
+            validator_verifier: Arc::new(validator_verifier),
         }
     }
 
     pub(crate) async fn request_batch(
         &self,
-        digest: HashValue,
-        signers: Vec<PeerId>,
+        proof: ProofOfStore,
         ret_tx: oneshot::Sender<ExecutorResult<Vec<SignedTransaction>>>,
     ) -> Option<(BatchInfo, Vec<SignedTransaction>)> {
+        let digest = *proof.digest();
+        let expiration = proof.expiration();
+        let signers = proof.shuffled_signers(&self.validator_verifier);
+        let validator_verifier = self.validator_verifier.clone();
         let mut request_state = BatchRequesterState::new(signers, ret_tx, self.retry_limit);
         let network_sender = self.network_sender.clone();
         let request_num_peers = self.request_num_peers;
@@ -157,19 +163,37 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                             // end the loop when the futures are drained
                             break;
                         }
-                    }
+                    },
                     Some(response) = futures.next() => {
-                        if let Ok(batch) = response {
-                            counters::RECEIVED_BATCH_RESPONSE_COUNT.inc();
-                            let digest = *batch.digest();
-                            let batch_info = batch.batch_info().clone();
-                            let payload = batch.into_transactions();
-                            request_state.serve_request(digest, Some(payload.clone()));
-                            return Some((batch_info, payload));
+                        match response {
+                            Ok(BatchResponse::Batch(batch)) => {
+                                counters::RECEIVED_BATCH_RESPONSE_COUNT.inc();
+                                let digest = *batch.digest();
+                                let batch_info = batch.batch_info().clone();
+                                let payload = batch.into_transactions();
+                                request_state.serve_request(digest, Some(payload.clone()));
+                                return Some((batch_info, payload));
+                            }
+                            // Short-circuit if the chain has moved beyond expiration
+                            Ok(BatchResponse::NotFound(ledger_info)) => {
+                                counters::RECEIVED_BATCH_NOT_FOUND_COUNT.inc();
+                                if ledger_info.commit_info().epoch() == self.epoch
+                                    && ledger_info.commit_info().timestamp_usecs() > expiration
+                                    && ledger_info.verify_signatures(&validator_verifier).is_ok()
+                                {
+                                    counters::RECEIVED_BATCH_EXPIRED_COUNT.inc();
+                                    debug!("QS: batch request expired, digest:{}", digest);
+                                    request_state.serve_request(digest, None);
+                                    return None;
+                                }
+                            }
+                            _ => (),
                         }
                     },
                 }
             }
+            counters::RECEIVED_BATCH_REQUEST_TIMEOUT_COUNT.inc();
+            debug!("QS: batch request timed out, digest:{}", digest);
             request_state.serve_request(digest, None);
             None
         })

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -185,7 +185,10 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                                     return None;
                                 }
                             }
-                            _ => (),
+                            Err(e) => {
+                                counters::RECEIVED_BATCH_RESPONSE_ERROR_COUNT.inc();
+                                debug!("QS: batch request error, digest:{}, error:{:?}", digest, e);
+                            }
                         }
                     },
                 }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -518,6 +518,15 @@ pub static RECEIVED_BATCH_EXPIRED_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Count of the number of error batches received from other nodes.
+pub static RECEIVED_BATCH_RESPONSE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_received_batch_response_error_count",
+        "Count of the number of error batches received from other nodes."
+    )
+    .unwrap()
+});
+
 pub static QS_BACKPRESSURE_TXN_COUNT: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(
         "quorum_store_backpressure_txn_count",

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -500,6 +500,24 @@ pub static RECEIVED_BATCH_RESPONSE_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Count of the number of batch not found responses received from other nodes.
+pub static RECEIVED_BATCH_NOT_FOUND_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_received_batch_not_found_count",
+        "Count of the number of batch not found responses received from other nodes."
+    )
+    .unwrap()
+});
+
+/// Count of the number of batch expired responses received from other nodes.
+pub static RECEIVED_BATCH_EXPIRED_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_received_batch_expired_count",
+        "Count of the number of batch expired responses received from other nodes."
+    )
+    .unwrap()
+});
+
 pub static QS_BACKPRESSURE_TXN_COUNT: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(
         "quorum_store_backpressure_txn_count",

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -392,8 +392,8 @@ impl InnerBuilder {
                     match aptos_db_clone.get_latest_ledger_info() {
                         Ok(ledger_info) => BatchResponse::NotFound(ledger_info),
                         Err(e) => {
-                            warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
-                            BatchResponse::Uninitialized
+                            error!(epoch = epoch, error = ?e, kind = error_kind(&e));
+                            continue;
                         },
                     }
                 };

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -18,6 +18,7 @@ use crate::{
         proof_coordinator::{ProofCoordinator, ProofCoordinatorCommand},
         proof_manager::{ProofManager, ProofManagerCommand},
         quorum_store_coordinator::{CoordinatorCommand, QuorumStoreCoordinator},
+        types::{Batch, BatchResponse},
     },
     round_manager::VerifiedEvent,
 };
@@ -240,6 +241,7 @@ impl InnerBuilder {
             self.config.batch_request_retry_interval_ms,
             self.config.batch_request_rpc_timeout_ms,
             self.network_sender.clone(),
+            self.verifier.clone(),
         );
         let batch_store = Arc::new(BatchStore::new(
             self.epoch,
@@ -251,11 +253,7 @@ impl InnerBuilder {
             signer,
         ));
         self.batch_store = Some(batch_store.clone());
-        let batch_reader = Arc::new(BatchReaderImpl::new(
-            batch_store.clone(),
-            batch_requester,
-            self.verifier.clone(),
-        ));
+        let batch_reader = Arc::new(BatchReaderImpl::new(batch_store.clone(), batch_requester));
         self.batch_reader = Some(batch_reader.clone());
 
         batch_reader
@@ -378,21 +376,33 @@ impl InnerBuilder {
                 10,
                 Some(&counters::BATCH_RETRIEVAL_TASK_MSGS),
             );
+        let aptos_db_clone = self.aptos_db.clone();
         spawn_named!("batch_serve", async move {
             info!(epoch = epoch, "Batch retrieval task starts");
             while let Some(rpc_request) = batch_retrieval_rx.next().await {
                 counters::RECEIVED_BATCH_REQUEST_COUNT.inc();
-                if let Ok(value) = batch_store.get_batch_from_local(&rpc_request.req.digest()) {
-                    let batch = value.try_into().unwrap();
-                    let msg = ConsensusMsg::BatchResponse(Box::new(batch));
-                    let bytes = rpc_request.protocol.to_bytes(&msg).unwrap();
-                    if let Err(e) = rpc_request
-                        .response_sender
-                        .send(Ok(bytes.into()))
-                        .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
-                    {
-                        warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
+                let response = if let Ok(value) =
+                    batch_store.get_batch_from_local(&rpc_request.req.digest())
+                {
+                    let batch: Batch = value.try_into().unwrap();
+                    BatchResponse::Batch(batch)
+                } else {
+                    match aptos_db_clone.get_latest_ledger_info() {
+                        Ok(ledger_info) => BatchResponse::NotFound(ledger_info),
+                        Err(e) => {
+                            warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
+                            BatchResponse::Uninitialized
+                        },
                     }
+                };
+                let msg = ConsensusMsg::BatchResponseV2(Box::new(response));
+                let bytes = rpc_request.protocol.to_bytes(&msg).unwrap();
+                if let Err(e) = rpc_request
+                    .response_sender
+                    .send(Ok(bytes.into()))
+                    .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
+                {
+                    warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
                 }
             }
             info!(epoch = epoch, "Batch retrieval task stops");

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -1,0 +1,258 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    network::QuorumStoreSender,
+    quorum_store::{
+        batch_requester::BatchRequester,
+        types::{Batch, BatchRequest, BatchResponse},
+    },
+};
+use aptos_consensus_types::{
+    common::Author,
+    proof_of_store::{BatchId, ProofOfStore, SignedBatchInfo},
+};
+use aptos_crypto::HashValue;
+use aptos_types::{
+    aggregate_signature::{AggregateSignature, PartialSignatures},
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_signer::ValidatorSigner,
+    validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
+};
+use move_core_types::account_address::AccountAddress;
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+struct MockBatchRequester {
+    return_value: BatchResponse,
+}
+
+impl MockBatchRequester {
+    fn new(return_value: BatchResponse) -> Self {
+        Self { return_value }
+    }
+}
+
+#[async_trait::async_trait]
+impl QuorumStoreSender for MockBatchRequester {
+    async fn send_batch_request(&self, _request: BatchRequest, _recipients: Vec<Author>) {
+        unimplemented!()
+    }
+
+    async fn request_batch(
+        &self,
+        _request: BatchRequest,
+        _recipient: Author,
+        _timeout: Duration,
+    ) -> anyhow::Result<BatchResponse> {
+        Ok(self.return_value.clone())
+    }
+
+    async fn send_batch(&self, _batch: Batch, _recipients: Vec<Author>) {
+        unimplemented!()
+    }
+
+    async fn send_signed_batch_info_msg(
+        &self,
+        _signed_batch_infos: Vec<SignedBatchInfo>,
+        _recipients: Vec<Author>,
+    ) {
+        unimplemented!()
+    }
+
+    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>) {
+        unimplemented!()
+    }
+
+    async fn broadcast_proof_of_store_msg(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+        unimplemented!()
+    }
+
+    async fn send_proof_of_store_msg_to_self(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+        unimplemented!()
+    }
+}
+
+#[tokio::test]
+async fn test_batch_request_exists() {
+    let batch = Batch::new(
+        BatchId::new_for_test(1),
+        vec![],
+        1,
+        1,
+        AccountAddress::random(),
+        0,
+    );
+    let batch_response = BatchResponse::Batch(batch.clone());
+
+    let validator_signer = ValidatorSigner::random(None);
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+    let batch_requester = BatchRequester::new(
+        1,
+        AccountAddress::random(),
+        1,
+        2,
+        1_000,
+        1_000,
+        MockBatchRequester::new(batch_response),
+        ValidatorVerifier::new_single(validator_signer.author(), validator_signer.public_key()),
+    );
+
+    let result = batch_requester
+        .request_batch(
+            ProofOfStore::new(
+                batch.batch_info().clone(),
+                AggregateSignature::new(vec![u8::MAX].into(), None),
+            ),
+            tx,
+        )
+        .await;
+    assert!(result.is_some());
+    if let Some((batch_info, _payload)) = result {
+        assert_eq!(batch_info, *batch.batch_info());
+    }
+    assert!(rx.try_recv().is_ok());
+}
+
+fn create_ledger_info_with_timestamp(
+    timestamp: u64,
+) -> (LedgerInfoWithSignatures, ValidatorVerifier) {
+    const NUM_SIGNERS: u8 = 1;
+    // Generate NUM_SIGNERS random signers.
+    let validator_signers: Vec<ValidatorSigner> = (0..NUM_SIGNERS)
+        .map(|i| ValidatorSigner::random([i; 32]))
+        .collect();
+    let block_info = BlockInfo::new(
+        1,
+        1,
+        HashValue::random(),
+        HashValue::random(),
+        0,
+        timestamp,
+        None,
+    );
+    let ledger_info = LedgerInfo::new(block_info, HashValue::random());
+
+    // Create a map from authors to public keys with equal voting power.
+    let mut validator_infos = vec![];
+    for validator in validator_signers.iter() {
+        validator_infos.push(ValidatorConsensusInfo::new(
+            validator.author(),
+            validator.public_key(),
+            1,
+        ));
+    }
+
+    // Create a map from author to signatures.
+    let mut partial_signature = PartialSignatures::empty();
+    for validator in validator_signers.iter() {
+        partial_signature.add_signature(validator.author(), validator.sign(&ledger_info).unwrap());
+    }
+
+    // Let's assume our verifier needs to satisfy all NUM_SIGNERS
+    let validator_verifier =
+        ValidatorVerifier::new_with_quorum_voting_power(validator_infos, NUM_SIGNERS as u128)
+            .expect("Incorrect quorum size.");
+    let aggregated_signature = validator_verifier
+        .aggregate_signatures(&partial_signature)
+        .unwrap();
+    let ledger_info_with_signatures =
+        LedgerInfoWithSignatures::new(ledger_info, aggregated_signature);
+
+    (ledger_info_with_signatures, validator_verifier)
+}
+
+#[tokio::test]
+async fn test_batch_request_not_exists_not_expired() {
+    let retry_interval_ms = 1_000;
+    let expiration = 10_000;
+
+    // Batch has not expired yet
+    let (ledger_info_with_signatures, validator_verifier) =
+        create_ledger_info_with_timestamp(expiration - 1);
+
+    let batch = Batch::new(
+        BatchId::new_for_test(1),
+        vec![],
+        1,
+        expiration,
+        AccountAddress::random(),
+        0,
+    );
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+    let batch_response = BatchResponse::NotFound(ledger_info_with_signatures);
+    let batch_requester = BatchRequester::new(
+        1,
+        AccountAddress::random(),
+        1,
+        2,
+        retry_interval_ms,
+        1_000,
+        MockBatchRequester::new(batch_response),
+        validator_verifier,
+    );
+
+    let request_start = Instant::now();
+    let result = batch_requester
+        .request_batch(
+            ProofOfStore::new(
+                batch.batch_info().clone(),
+                AggregateSignature::new(vec![u8::MAX].into(), None),
+            ),
+            tx,
+        )
+        .await;
+    let request_duration = request_start.elapsed();
+    assert!(result.is_none());
+    assert!(rx.try_recv().is_ok());
+    // Retried at least once
+    assert!(request_duration > Duration::from_millis(retry_interval_ms as u64));
+}
+
+#[tokio::test]
+async fn test_batch_request_not_exists_expired() {
+    let retry_interval_ms = 1_000;
+    let expiration = 10_000;
+
+    // Batch has expired according to the ledger info that will be returned
+    let (ledger_info_with_signatures, validator_verifier) =
+        create_ledger_info_with_timestamp(expiration + 1);
+
+    let batch = Batch::new(
+        BatchId::new_for_test(1),
+        vec![],
+        1,
+        expiration,
+        AccountAddress::random(),
+        0,
+    );
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+    let batch_response = BatchResponse::NotFound(ledger_info_with_signatures);
+    let batch_requester = BatchRequester::new(
+        1,
+        AccountAddress::random(),
+        1,
+        2,
+        retry_interval_ms,
+        1_000,
+        MockBatchRequester::new(batch_response),
+        validator_verifier,
+    );
+
+    let request_start = Instant::now();
+    let result = batch_requester
+        .request_batch(
+            ProofOfStore::new(
+                batch.batch_info().clone(),
+                AggregateSignature::new(vec![u8::MAX].into(), None),
+            ),
+            tx,
+        )
+        .await;
+    let request_duration = request_start.elapsed();
+    assert!(result.is_none());
+    assert!(rx.try_recv().is_ok());
+    // No retry because of short-circuiting of expired batch
+    assert!(request_duration < Duration::from_millis(retry_interval_ms as u64));
+}

--- a/consensus/src/quorum_store/tests/mod.rs
+++ b/consensus/src/quorum_store/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod batch_generator_test;
+mod batch_requester_test;
 mod batch_store_test;
 mod direct_mempool_quorum_store_test;
 mod proof_coordinator_test;

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -279,7 +279,6 @@ impl From<Batch> for PersistedValue {
 pub enum BatchResponse {
     Batch(Batch),
     NotFound(LedgerInfoWithSignatures),
-    Uninitialized,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -8,7 +8,7 @@ use aptos_crypto::{
     HashValue,
 };
 use aptos_crypto_derive::CryptoHasher;
-use aptos_types::{transaction::SignedTransaction, PeerId};
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::SignedTransaction, PeerId};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -273,6 +273,13 @@ impl From<Batch> for PersistedValue {
         } = value;
         PersistedValue::new(batch_info, Some(payload.into_transactions()))
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum BatchResponse {
+    Batch(Batch),
+    NotFound(LedgerInfoWithSignatures),
+    Uninitialized,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -72,11 +72,11 @@ impl<I: Ord + Hash> TimeExpirations<I> {
         self.expiries.push((Reverse(expiry_time), item));
     }
 
-    /// Expire and return items corresponding to round <= given (expired) round.
-    pub(crate) fn expire(&mut self, expiry_time: u64) -> HashSet<I> {
+    /// Expire and return items corresponding to expiration <= given certified time.
+    pub(crate) fn expire(&mut self, certified_time: u64) -> HashSet<I> {
         let mut ret = HashSet::new();
         while let Some((Reverse(t), _)) = self.expiries.peek() {
-            if *t <= expiry_time {
+            if *t <= certified_time {
                 let (_, item) = self.expiries.pop().unwrap();
                 ret.insert(item);
             } else {

--- a/consensus/src/test_utils/mock_quorum_store_sender.rs
+++ b/consensus/src/test_utils/mock_quorum_store_sender.rs
@@ -4,7 +4,7 @@
 use crate::{
     network::QuorumStoreSender,
     network_interface::ConsensusMsg,
-    quorum_store::types::{Batch, BatchRequest},
+    quorum_store::types::{Batch, BatchRequest, BatchResponse},
 };
 use aptos_consensus_types::{
     common::Author,
@@ -38,7 +38,7 @@ impl QuorumStoreSender for MockQuorumStoreSender {
         _request: BatchRequest,
         _recipient: Author,
         _timeout: Duration,
-    ) -> anyhow::Result<Batch> {
+    ) -> anyhow::Result<BatchResponse> {
         unimplemented!();
     }
 

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -85,6 +85,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<write_set::WriteOp>(&samples)?;
 
     tracer.trace_type::<StateKey>(&samples)?;
+    tracer.trace_type::<aptos_consensus::quorum_store::types::BatchResponse>(&samples)?;
     tracer.trace_type::<aptos_consensus::network_interface::ConsensusMsg>(&samples)?;
     tracer.trace_type::<aptos_consensus::network_interface::CommitMessage>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::block_data::BlockType>(&samples)?;

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -114,6 +114,18 @@ BatchRequest:
         TYPENAME: AccountAddress
     - digest:
         TYPENAME: HashValue
+BatchResponse:
+  ENUM:
+    0:
+      Batch:
+        NEWTYPE:
+          TYPENAME: Batch
+    1:
+      NotFound:
+        NEWTYPE:
+          TYPENAME: LedgerInfoWithSignatures
+    2:
+      Uninitialized: UNIT
 BitVec:
   STRUCT:
     - inner: BYTES
@@ -315,6 +327,10 @@ ConsensusMsg:
       RandGenMessage:
         NEWTYPE:
           TYPENAME: RandGenMessage
+    17:
+      BatchResponseV2:
+        NEWTYPE:
+          TYPENAME: BatchResponse
 ContractEvent:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -124,8 +124,6 @@ BatchResponse:
       NotFound:
         NEWTYPE:
           TYPENAME: LedgerInfoWithSignatures
-    2:
-      Uninitialized: UNIT
 BitVec:
   STRUCT:
     - inner: BYTES


### PR DESCRIPTION
### Description

Batches that are not available locally are requested for execution.

Previously, batch requests for locally unavailable batches were just ignored. The sender would have to wait to timeout. The worst case was when the batch was actually expired, as all retries would have to timeout.

In this PR, a negative acknowledgement is a response when the batch is unavailable. In addition, the current ledger info is given in the response. The sender checks if the batch is expired for the current ledger info, and short circuits further retries when this is the case. The validator will fail execution (and eventually go to state sync).

### Test Plan

Added unit tests. Hoping to get a forge-based repro and show the improved behavior.
