### PR TITLE
[Aptos Data Client] Introduce priority categories.

### DIFF
--- a/network/framework/src/transport/mod.rs
+++ b/network/framework/src/transport/mod.rs
@@ -154,6 +154,11 @@ impl ConnectionMetadata {
             application_protocols: ProtocolIdSet::empty(),
         }
     }
+
+    /// Returns true iff the connection origin is outbound
+    pub fn is_outbound_connection(&self) -> bool {
+        self.origin == ConnectionOrigin::Outbound
+    }
 }
 
 impl fmt::Debug for ConnectionMetadata {

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     peer_states::{ErrorType, PeerStates},
     poller::DataSummaryPoller,
-    utils,
+    priority, utils,
 };
 use aptos_config::{
     config::{AptosDataClientConfig, BaseConfig},
@@ -354,18 +354,19 @@ impl AptosDataClient {
         Ok(connected_peers)
     }
 
-    /// Returns all priority and regular peers
+    /// Returns all priority and regular peers. We define "priority peers" as
+    /// high-priority peers only, and "regular peers" as all other priority categories.
     pub fn get_priority_and_regular_peers(
         &self,
     ) -> crate::error::Result<(HashSet<PeerNetworkId>, HashSet<PeerNetworkId>), Error> {
         // Get all connected peers
         let all_connected_peers = self.get_all_connected_peers()?;
 
-        // Filter the peers based on priority
+        // Gather the peers based on priority
         let mut priority_peers = hashset![];
         let mut regular_peers = hashset![];
         for peer in all_connected_peers {
-            if utils::is_priority_peer(
+            if priority::is_high_priority_peer(
                 self.base_config.clone(),
                 self.get_peers_and_metadata(),
                 &peer,

--- a/state-sync/aptos-data-client/src/lib.rs
+++ b/state-sync/aptos-data-client/src/lib.rs
@@ -12,6 +12,7 @@ mod logging;
 mod metrics;
 pub mod peer_states;
 pub mod poller;
+pub mod priority;
 mod utils;
 
 #[cfg(test)]

--- a/state-sync/aptos-data-client/src/priority.rs
+++ b/state-sync/aptos-data-client/src/priority.rs
@@ -1,0 +1,394 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::utils;
+use aptos_config::{
+    config::BaseConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_network::application::storage::PeersAndMetadata;
+use itertools::Itertools;
+use std::sync::Arc;
+
+/// A simple enum containing the different categories for peer prioritization
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PeerPriority {
+    HighPriority,
+    MediumPriority,
+    LowPriority,
+}
+
+impl PeerPriority {
+    /// Returns the label for the peer priority
+    pub fn get_label(&self) -> String {
+        let label = match self {
+            Self::HighPriority => "high_priority",
+            Self::MediumPriority => "medium_priority",
+            Self::LowPriority => "low_priority",
+        };
+        label.into()
+    }
+
+    /// Returns true iff the priority is high priority
+    pub fn is_high_priority(&self) -> bool {
+        matches!(self, Self::HighPriority)
+    }
+}
+
+/// Returns the priority for the specified peer, according
+/// to the node's config and the peer metadata.
+pub fn get_peer_priority(
+    base_config: Arc<BaseConfig>,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer: &PeerNetworkId,
+) -> PeerPriority {
+    // Handle the case that this node is a validator
+    let peer_network_id = peer.network_id();
+    if base_config.role.is_validator() {
+        // Validators should highly prioritize other validators, and
+        // VFNs should be prioritized over PFNs. Note: having PFNs
+        // connected to a validator is a rare (but possible) scenario.
+        return if peer_network_id.is_validator_network() {
+            PeerPriority::HighPriority
+        } else if peer_network_id.is_vfn_network() {
+            PeerPriority::MediumPriority
+        } else {
+            PeerPriority::LowPriority
+        };
+    }
+
+    // Handle the case that this node is a VFN
+    if peers_and_metadata
+        .get_registered_networks()
+        .contains(&NetworkId::Vfn)
+    {
+        // VFNs should highly prioritize validators, and outbound
+        // connections should be prioritized over inbound connections
+        // (this prioritizes other VFNs/seed peers over regular PFNs).
+        return if peer_network_id.is_vfn_network() {
+            PeerPriority::HighPriority
+        } else if let Some(peer_metadata) = utils::get_metadata_for_peer(&peers_and_metadata, *peer)
+        {
+            if peer_metadata
+                .get_connection_metadata()
+                .is_outbound_connection()
+            {
+                PeerPriority::MediumPriority
+            } else {
+                PeerPriority::LowPriority
+            }
+        } else {
+            PeerPriority::LowPriority // We don't have connection metadata
+        };
+    }
+
+    // Otherwise, handle the case that this node is a PFN.
+    // PFNs only highly prioritize outbound connections.
+    // Inbound connections are always medium priority.
+    if let Some(peer_metadata) = utils::get_metadata_for_peer(&peers_and_metadata, *peer) {
+        if peer_metadata
+            .get_connection_metadata()
+            .is_outbound_connection()
+        {
+            PeerPriority::HighPriority
+        } else {
+            PeerPriority::MediumPriority
+        }
+    } else {
+        PeerPriority::LowPriority // We don't have connection metadata
+    }
+}
+
+/// Returns true iff the specified peer is a high priority peer.
+/// This is a useful utility function for the data poller.
+pub fn is_high_priority_peer(
+    base_config: Arc<BaseConfig>,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer: &PeerNetworkId,
+) -> bool {
+    let peer_priority = get_peer_priority(base_config, peers_and_metadata, peer);
+    peer_priority.is_high_priority()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::priority::{get_peer_priority, is_high_priority_peer, PeerPriority};
+    use aptos_config::{
+        config::{BaseConfig, PeerRole, RoleType},
+        network_id::{NetworkId, PeerNetworkId},
+    };
+    use aptos_netcore::transport::ConnectionOrigin;
+    use aptos_network::{application::storage::PeersAndMetadata, transport::ConnectionMetadata};
+    use aptos_types::PeerId;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_is_high_priority_peer_validator() {
+        // Create a base config for a validator node
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::Validator,
+            ..Default::default()
+        });
+
+        // Create a peers and metadata struct with all networks registered
+        let peers_and_metadata =
+            PeersAndMetadata::new(&[NetworkId::Validator, NetworkId::Vfn, NetworkId::Public]);
+
+        // Create a VFN peer and verify it is not high priority
+        let vfn_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+        assert!(!is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &vfn_peer
+        ));
+
+        // Create a PFN peer and verify it is not high priority
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        assert!(!is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &pfn_peer
+        ));
+
+        // Create a validator peer and verify it is high priority
+        let validator_peer = PeerNetworkId::new(NetworkId::Validator, PeerId::random());
+        assert!(is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &validator_peer
+        ));
+    }
+
+    #[test]
+    fn test_is_priority_peer_vfn() {
+        // Create a base config for a VFN
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::FullNode,
+            ..Default::default()
+        });
+
+        // Create a peers and metadata struct with a VFN network
+        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Vfn]);
+
+        // Create a PFN peer and verify it is not high priority
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        assert!(!is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &pfn_peer
+        ));
+
+        // Create a validator peer and verify it is high priority
+        let validator_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+        assert!(is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &validator_peer
+        ));
+    }
+
+    #[test]
+    fn test_is_priority_peer_pfn() {
+        // Create a base config for a PFN
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::FullNode,
+            ..Default::default()
+        });
+
+        // Create two PFN peers
+        let pfn_peer_1 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        let pfn_peer_2 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+
+        // Create a peers and metadata struct with a PFN network
+        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Public]);
+
+        // Insert the connection metadata for PFN 1 and mark it as having dialed us
+        let connection_metadata = ConnectionMetadata::mock_with_role_and_origin(
+            pfn_peer_1.peer_id(),
+            PeerRole::Unknown,
+            ConnectionOrigin::Inbound,
+        );
+        peers_and_metadata
+            .insert_connection_metadata(pfn_peer_1, connection_metadata)
+            .unwrap();
+
+        // Insert the connection metadata for PFN 2 and mark it as having been dialed by us
+        let connection_metadata = ConnectionMetadata::mock_with_role_and_origin(
+            pfn_peer_2.peer_id(),
+            PeerRole::Upstream,
+            ConnectionOrigin::Outbound,
+        );
+        peers_and_metadata
+            .insert_connection_metadata(pfn_peer_2, connection_metadata)
+            .unwrap();
+
+        // Verify that PFN 1 is not high priority
+        assert!(!is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &pfn_peer_1
+        ));
+
+        // Verify that PFN 2 is high priority
+        assert!(is_high_priority_peer(
+            base_config.clone(),
+            peers_and_metadata.clone(),
+            &pfn_peer_2
+        ));
+    }
+
+    #[test]
+    fn test_validator_priorities() {
+        // Create a base config for a validator node
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::Validator,
+            ..Default::default()
+        });
+
+        // Create a peers and metadata struct with all networks registered
+        let peers_and_metadata =
+            PeersAndMetadata::new(&[NetworkId::Validator, NetworkId::Vfn, NetworkId::Public]);
+
+        // Create a validator peer and verify it is highly prioritized
+        let validator_peer = PeerNetworkId::new(NetworkId::Validator, PeerId::random());
+        assert_eq!(
+            get_peer_priority(
+                base_config.clone(),
+                peers_and_metadata.clone(),
+                &validator_peer
+            ),
+            PeerPriority::HighPriority
+        );
+
+        // Create a VFN peer and verify it is medium prioritized
+        let vfn_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &vfn_peer),
+            PeerPriority::MediumPriority
+        );
+
+        // Create a PFN peer and verify it is low prioritized
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &pfn_peer),
+            PeerPriority::LowPriority
+        );
+    }
+
+    #[test]
+    fn test_vfn_priorities() {
+        // Create a base config for a VFN node
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::FullNode,
+            ..Default::default()
+        });
+
+        // Create a peers and metadata struct with VFN and public networks registered
+        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Vfn, NetworkId::Public]);
+
+        // Create a validator peer and verify it is highly prioritized
+        let validator_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+        assert_eq!(
+            get_peer_priority(
+                base_config.clone(),
+                peers_and_metadata.clone(),
+                &validator_peer
+            ),
+            PeerPriority::HighPriority
+        );
+
+        // Create a VFN peer (with an outbound connection) and verify it is medium prioritized
+        let vfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        peers_and_metadata
+            .insert_connection_metadata(
+                vfn_peer,
+                ConnectionMetadata::mock_with_role_and_origin(
+                    vfn_peer.peer_id(),
+                    PeerRole::Upstream,
+                    ConnectionOrigin::Outbound,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &vfn_peer),
+            PeerPriority::MediumPriority
+        );
+
+        // Create a PFN peer (with an inbound connection) and verify it is low prioritized
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        peers_and_metadata
+            .insert_connection_metadata(
+                pfn_peer,
+                ConnectionMetadata::mock_with_role_and_origin(
+                    pfn_peer.peer_id(),
+                    PeerRole::Unknown,
+                    ConnectionOrigin::Inbound,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &pfn_peer),
+            PeerPriority::LowPriority
+        );
+
+        // Create a PFN peer (with missing connection metadata) and verify it is low prioritized
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &pfn_peer),
+            PeerPriority::LowPriority
+        );
+    }
+
+    #[test]
+    fn test_pfn_priorities() {
+        // Create a base config for a PFN
+        let base_config = Arc::new(BaseConfig {
+            role: RoleType::FullNode,
+            ..Default::default()
+        });
+
+        // Create a peers and metadata struct with the public networks registered
+        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Public]);
+
+        // Create a PFN peer (with an outbound connection) and verify it is highly prioritized
+        let vfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        peers_and_metadata
+            .insert_connection_metadata(
+                vfn_peer,
+                ConnectionMetadata::mock_with_role_and_origin(
+                    vfn_peer.peer_id(),
+                    PeerRole::Upstream,
+                    ConnectionOrigin::Outbound,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &vfn_peer),
+            PeerPriority::HighPriority
+        );
+
+        // Create a PFN peer (with an inbound connection) and verify it is medium prioritized
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        peers_and_metadata
+            .insert_connection_metadata(
+                pfn_peer,
+                ConnectionMetadata::mock_with_role_and_origin(
+                    pfn_peer.peer_id(),
+                    PeerRole::Unknown,
+                    ConnectionOrigin::Inbound,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &pfn_peer),
+            PeerPriority::MediumPriority
+        );
+
+        // Create a PFN peer (with missing connection metadata) and verify it is low prioritized
+        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+        assert_eq!(
+            get_peer_priority(base_config.clone(), peers_and_metadata.clone(), &pfn_peer),
+            PeerPriority::LowPriority
+        );
+    }
+}

--- a/state-sync/aptos-data-client/src/utils.rs
+++ b/state-sync/aptos-data-client/src/utils.rs
@@ -5,14 +5,9 @@ use crate::{
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
 };
-use aptos_config::{
-    config::{AptosDataClientConfig, BaseConfig},
-    network_id::{NetworkId, PeerNetworkId},
-};
+use aptos_config::{config::AptosDataClientConfig, network_id::PeerNetworkId};
 use aptos_logger::{sample, sample::SampleRate, warn};
-use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::application::{metadata::PeerMetadata, storage::PeersAndMetadata};
-use itertools::Itertools;
 use maplit::hashset;
 use ordered_float::OrderedFloat;
 use rand::seq::{IteratorRandom, SliceRandom};
@@ -24,51 +19,6 @@ use std::{
 
 // Useful constants
 const ERROR_LOG_FREQ_SECS: u64 = 3;
-
-/// Returns true iff the given peer is high-priority.
-///
-/// TODO(joshlind): make this less hacky using network topological awareness.
-pub fn is_priority_peer(
-    base_config: Arc<BaseConfig>,
-    peers_and_metadata: Arc<PeersAndMetadata>,
-    peer: &PeerNetworkId,
-) -> bool {
-    // Validators should only prioritize other validators
-    let peer_network_id = peer.network_id();
-    if base_config.role.is_validator() {
-        return peer_network_id.is_validator_network();
-    }
-
-    // VFNs should only prioritize validators
-    if peers_and_metadata
-        .get_registered_networks()
-        .contains(&NetworkId::Vfn)
-    {
-        return peer_network_id.is_vfn_network();
-    }
-
-    // PFNs should only prioritize outbound connections (this targets seed peers and VFNs)
-    match peers_and_metadata.get_metadata_for_peer(*peer) {
-        Ok(peer_metadata) => {
-            if peer_metadata.get_connection_metadata().origin == ConnectionOrigin::Outbound {
-                return true;
-            }
-        },
-        Err(error) => {
-            warn!(
-                (LogSchema::new(LogEntry::PeerStates)
-                    .event(LogEvent::PriorityAndRegularPeers)
-                    .message(&format!(
-                        "Unable to locate metadata for peer! Error: {:?}",
-                        error
-                    ))
-                    .peer(peer))
-            );
-        },
-    }
-
-    false
-}
 
 /// Chooses a peer with the lowest distance from the validator set weighted by
 /// latency (from the given set of peers). We prioritize distance over latency
@@ -277,7 +227,7 @@ fn get_distance_and_latency_for_peer(
 
 /// Returns the metadata for the specified peer. If no metadata
 /// is found, an error is logged and None is returned.
-fn get_metadata_for_peer(
+pub fn get_metadata_for_peer(
     peers_and_metadata: &Arc<PeersAndMetadata>,
     peer: PeerNetworkId,
 ) -> Option<PeerMetadata> {
@@ -307,21 +257,11 @@ fn log_warning_with_sample(log: LogSchema) {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{
-        choose_random_peer, choose_random_peers, choose_random_peers_by_weight, is_priority_peer,
-    };
-    use aptos_config::{
-        config::{BaseConfig, PeerRole, RoleType},
-        network_id::{NetworkId, PeerNetworkId},
-    };
-    use aptos_netcore::transport::ConnectionOrigin;
-    use aptos_network::{application::storage::PeersAndMetadata, transport::ConnectionMetadata};
+    use crate::utils::{choose_random_peer, choose_random_peers, choose_random_peers_by_weight};
+    use aptos_config::network_id::{NetworkId, PeerNetworkId};
     use aptos_types::PeerId;
     use maplit::hashset;
-    use std::{
-        collections::{HashMap, HashSet},
-        sync::Arc,
-    };
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn test_choose_random_peer() {
@@ -447,123 +387,6 @@ mod tests {
         let peer_count_3 = chosen_peers_and_counts.get(&peer_3).unwrap_or(&0);
         assert!(peer_count_1 > peer_count_2);
         assert!(peer_count_2 > peer_count_3);
-    }
-
-    #[test]
-    fn test_is_priority_peer_validator() {
-        // Create a base config for a validator node
-        let base_config = Arc::new(BaseConfig {
-            role: RoleType::Validator,
-            ..Default::default()
-        });
-
-        // Create a peers and metadata struct with all networks registered
-        let peers_and_metadata =
-            PeersAndMetadata::new(&[NetworkId::Validator, NetworkId::Vfn, NetworkId::Public]);
-
-        // Create a VFN peer and verify it is not prioritized
-        let vfn_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
-        assert!(!is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &vfn_peer
-        ));
-
-        // Create a PFN peer and verify it is not prioritized
-        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
-        assert!(!is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &pfn_peer
-        ));
-
-        // Create a validator peer and verify it is prioritized
-        let validator_peer = PeerNetworkId::new(NetworkId::Validator, PeerId::random());
-        assert!(is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &validator_peer
-        ));
-    }
-
-    #[test]
-    fn test_is_priority_peer_vfn() {
-        // Create a base config for a VFN
-        let base_config = Arc::new(BaseConfig {
-            role: RoleType::FullNode,
-            ..Default::default()
-        });
-
-        // Create a peers and metadata struct with a VFN network
-        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Vfn]);
-
-        // Create a PFN peer and verify it is not prioritized
-        let pfn_peer = PeerNetworkId::new(NetworkId::Public, PeerId::random());
-        assert!(!is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &pfn_peer
-        ));
-
-        // Create a validator peer and verify it is prioritized
-        let validator_peer = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
-        assert!(is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &validator_peer
-        ));
-    }
-
-    #[test]
-    fn test_is_priority_peer_pfn() {
-        // Create a base config for a PFN
-        let base_config = Arc::new(BaseConfig {
-            role: RoleType::FullNode,
-            ..Default::default()
-        });
-
-        // Create two PFN peers
-        let pfn_peer_1 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
-        let pfn_peer_2 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
-
-        // Create a peers and metadata struct with a PFN network
-        let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Public]);
-
-        // Insert the connection metadata for PFN 1 and
-        // mark it as having dialed us.
-        let connection_metadata = ConnectionMetadata::mock_with_role_and_origin(
-            pfn_peer_1.peer_id(),
-            PeerRole::Unknown,
-            ConnectionOrigin::Inbound,
-        );
-        peers_and_metadata
-            .insert_connection_metadata(pfn_peer_1, connection_metadata)
-            .unwrap();
-
-        // Insert the connection metadata for PFN 2 and
-        // mark it as having been dialed by us.
-        let connection_metadata = ConnectionMetadata::mock_with_role_and_origin(
-            pfn_peer_2.peer_id(),
-            PeerRole::Upstream,
-            ConnectionOrigin::Outbound,
-        );
-        peers_and_metadata
-            .insert_connection_metadata(pfn_peer_2, connection_metadata)
-            .unwrap();
-
-        // Verify that PFN 1 is not prioritized
-        assert!(!is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &pfn_peer_1
-        ));
-
-        // Verify that PFN 2 is prioritized
-        assert!(is_priority_peer(
-            base_config.clone(),
-            peers_and_metadata.clone(),
-            &pfn_peer_2
-        ));
     }
 
     /// Creates and returns a random peer network ID


### PR DESCRIPTION
Note: there should be no logic changes in this PR.

### Description
This PR introduces new priority categories for peers in the Aptos Data Client. We'll use these categories in the next PR (to implement multi-fetch), but for now the logic should not change. The peer poller still only cares about peers that are high-priority or not.

### Test Plan
New and existing unit tests. Note: some tests have been moved from the `utils.rs` file to `priority.rs`.