### PR TITLE
Add BlockLimitReachedEvent to StateCheckpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,6 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "itertools 0.10.5",
- "log",
  "lru 0.7.8",
  "move-binary-format",
  "move-core-types",
@@ -11051,11 +11050,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -11083,9 +11082,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1029,8 +1029,14 @@ impl Context {
                     } else if let Some(full_block_gas_used) =
                         block_config.block_gas_limit_type.block_gas_limit()
                     {
-                        prices_and_used.iter().map(|(_, used)| *used).sum::<u64>()
-                            >= full_block_gas_used
+                        // be pesimistic for conflicts, as such information is not onchain
+                        let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
+                        let max_conflict_multiplier = block_config
+                            .block_gas_limit_type
+                            .conflict_penalty_window()
+                            .unwrap_or(1)
+                            as u64;
+                        gas_used * max_conflict_multiplier >= full_block_gas_used
                     } else {
                         false
                     };

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -580,7 +580,7 @@ impl StateApi {
                         "StateKey({}) and Ledger version({})",
                         request.key, ledger_version
                     ),
-                    AptosErrorCode::StateValueNotFound,
+                    AptosErrorCode::TableItemNotFound,
                     &ledger_info,
                 )
             })?;

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -27,7 +27,6 @@ async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 itertools = { workspace = true }
-log = "0.4.17"
 lru = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -209,8 +209,7 @@ impl AptosValidatorInterface for RestDebuggerInterface {
                 RestError::Api(AptosErrorResponse {
                     error:
                         AptosError {
-                            error_code:
-                                AptosErrorCode::StateValueNotFound | AptosErrorCode::TableItemNotFound, /* bug in pre 1.9 nodes */
+                            error_code: AptosErrorCode::StateValueNotFound,
                             ..
                         },
                     ..

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -460,7 +460,6 @@ impl VMChangeSet {
             .collect::<anyhow::Result<BTreeMap<StateKey, WriteOp>, VMStatus>>()?;
         self.aggregator_v1_write_set
             .extend(materialized_aggregator_delta_set);
-
         Ok(())
     }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -15,7 +15,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     errors::Error, executor::BlockExecutor,
     task::TransactionOutput as BlockExecutorTransactionOutput,
-    txn_commit_hook::TransactionCommitHook,
+    txn_commit_hook::TransactionCommitHook, types::InputOutputKey,
 };
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
@@ -36,7 +36,10 @@ use aptos_vm_types::{abstract_write_op::AbstractResourceWriteOp, output::VMOutpu
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -315,6 +318,61 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .as_ref()
             .expect("Output to be set to get fee statement")
             .fee_statement()
+    }
+
+    fn output_approx_size(&self) -> u64 {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut size = 0;
+        for (state_key, write_size) in change_set.write_set_size_iter() {
+            size += state_key.size() as u64 + write_size.write_len().unwrap_or(0);
+        }
+
+        for (event, _) in change_set.events() {
+            size += event.size() as u64;
+        }
+
+        size
+    }
+
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag, DelayedFieldID>> {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut writes = HashSet::new();
+
+        for (state_key, write) in change_set.resource_write_set() {
+            match write {
+                AbstractResourceWriteOp::Write(_)
+                | AbstractResourceWriteOp::WriteWithDelayedFields(_) => {
+                    writes.insert(InputOutputKey::Resource(state_key.clone()));
+                },
+                AbstractResourceWriteOp::WriteResourceGroup(write) => {
+                    for tag in write.inner_ops().keys() {
+                        writes.insert(InputOutputKey::Group(state_key.clone(), tag.clone()));
+                    }
+                },
+                AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)
+                | AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_) => {
+                    // No conflicts on resources from in-place delayed field changes.
+                    // Delayed fields conflicts themselves are handled via
+                    // delayed_field_change_set below.
+                },
+            }
+        }
+
+        for identifier in change_set.delayed_field_change_set().keys() {
+            writes.insert(InputOutputKey::DelayedField(*identifier));
+        }
+
+        writes
     }
 }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -58,6 +58,13 @@ impl AptosTransactionOutput {
         }
     }
 
+    pub(crate) fn new_from_committed_output(output: TransactionOutput) -> Self {
+        Self {
+            vm_output: Mutex::new(None),
+            committed_output: OnceCell::from(output),
+        }
+    }
+
     pub(crate) fn committed_output(&self) -> &TransactionOutput {
         self.committed_output.get().unwrap()
     }
@@ -67,12 +74,13 @@ impl AptosTransactionOutput {
             Some(output) => output,
             // TODO: revisit whether we should always get it via committed, or o.w. create a
             // dedicated API without creating empty data structures.
+            // This is currently used because we do not commit skip_output() transactions.
             None => self
                 .vm_output
                 .lock()
                 .take()
                 .expect("Output must be set")
-                .into_transaction_output_with_materialized_write_set(vec![], vec![], vec![])
+                .into_transaction_output()
                 .expect("Transaction output is not alerady materialized"),
         }
     }

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use anyhow::bail;
 use aptos_aggregator::{
     delta_math::DeltaHistory,
@@ -335,8 +336,6 @@ impl<T: Transaction> CapturedReads<T> {
         &'a self,
         skip: &'a HashSet<T::Key>,
     ) -> impl Iterator<Item = (&T::Key, &GroupRead<T>)> {
-        // TODO[agg_v2](optimize) - We could potentially filter out inner_reads
-        // to only contain those that have Some(layout)
         self.group_reads.iter().filter(|(key, group_read)| {
             !skip.contains(key)
                 && group_read
@@ -662,12 +661,79 @@ impl<T: Transaction> CapturedReads<T> {
         Ok(true)
     }
 
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for (key, read) in &self.data_reads {
+            if let DataRead::Versioned(_, _, _) = read {
+                ret.insert(InputOutputKey::Resource(key.clone()));
+            }
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for (tag, read) in &group_reads.inner_reads {
+                if let DataRead::Versioned(_, _, _) = read {
+                    ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+                }
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, read) in &self.delayed_field_reads {
+            if let DelayedFieldRead::Value { .. } = read {
+                ret.insert(InputOutputKey::DelayedField(*key));
+            }
+        }
+
+        ret
+    }
+
     pub(crate) fn mark_failure(&mut self) {
         self.speculative_failure = true;
     }
 
     pub(crate) fn mark_incorrect_use(&mut self) {
         self.incorrect_use = true;
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default(bound = "", new = "true"))]
+pub(crate) struct UnsyncReadSet<T: Transaction> {
+    pub(crate) resource_reads: HashSet<T::Key>,
+    pub(crate) module_reads: HashSet<T::Key>,
+    pub(crate) group_reads: HashMap<T::Key, HashSet<T::Tag>>,
+    pub(crate) delayed_field_reads: HashSet<T::Identifier>,
+}
+
+impl<T: Transaction> UnsyncReadSet<T> {
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for key in &self.resource_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for tag in group_reads {
+                ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for key in &self.delayed_field_reads {
+            ret.insert(InputOutputKey::DelayedField(*key));
+        }
+
+        ret
     }
 }
 

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -26,34 +26,6 @@ impl Mode {
     pub const SEQUENTIAL: &'static str = "sequential";
 }
 
-/// Record the block gas during parallel execution.
-fn observe_parallel_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during parallel execution.
-fn observe_parallel_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the block gas during sequential execution.
-fn observe_sequential_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during sequential execution.
-fn observe_sequential_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
 /// Count of times the module publishing fallback was triggered in parallel execution.
 pub static MODULE_PUBLISHING_FALLBACK_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -77,6 +49,16 @@ pub static EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| 
     register_int_counter_vec!(
         "aptos_execution_gas_limit_count",
         "Count of times the BlockSTM is early halted due to exceeding the per-block gas limit",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+/// Count of times the BlockSTM is early halted due to exceeding the per-block output size limit.
+pub static EXCEED_PER_BLOCK_OUTPUT_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_execution_output_limit_count",
+        "Count of times the BlockSTM is early halted due to exceeding the per-block output size limit",
         &["mode"]
     )
     .unwrap()
@@ -166,6 +148,25 @@ pub static BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static EFFECTIVE_BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_effective_block_gas",
+        "Histogram for different effective block gas costs - used for evaluating block gas limit. \
+        This can be different from actual gas consumed in a block, due to applied adjustements",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+pub static APPROX_BLOCK_OUTPUT_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_approx_block_output_size",
+        "Historgram for different approx block output sizes - used for evaluting block ouptut limit.",
+        &["mode"]
+    )
+    .unwrap()
+});
+
 pub static TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_execution_txn_gas",
@@ -185,100 +186,67 @@ pub static BLOCK_COMMITTED_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) fn update_parallel_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_parallel_execution_block_gas(accumulated_fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_parallel_execution_block_gas(accumulated_fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
+fn observe_gas(counter: &Lazy<HistogramVec>, mode_str: &str, fee_statement: &FeeStatement) {
+    counter
+        .with_label_values(&[mode_str, GasType::TOTAL_GAS])
+        .observe(fee_statement.gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::EXECUTION_GAS])
+        .observe(fee_statement.execution_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::IO_GAS])
+        .observe(fee_statement.io_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::NON_STORAGE_GAS])
+        .observe((fee_statement.execution_gas_used() + fee_statement.io_gas_used()) as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE])
+        .observe(fee_statement.storage_fee_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE_REFUND])
+        .observe(fee_statement.storage_fee_refund() as f64);
 }
 
-pub(crate) fn update_parallel_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>) {
+pub(crate) fn update_block_gas_counters(
+    accumulated_fee_statement: &FeeStatement,
+    accumulated_effective_gas: u64,
+    accumulated_approx_output_size: u64,
+    num_committed: usize,
+    is_parallel: bool,
+) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
+    observe_gas(&BLOCK_GAS, mode_str, accumulated_fee_statement);
+    BLOCK_COMMITTED_TXNS
+        .with_label_values(&[mode_str])
+        .observe(num_committed as f64);
+
+    EFFECTIVE_BLOCK_GAS
+        .with_label_values(&[mode_str])
+        .observe(accumulated_effective_gas as f64);
+
+    APPROX_BLOCK_OUTPUT_SIZE
+        .with_label_values(&[mode_str])
+        .observe(accumulated_approx_output_size as f64);
+}
+
+pub(crate) fn update_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>, is_parallel: bool) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
     for fee_statement in txn_fee_statements {
-        observe_parallel_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-        observe_parallel_execution_txn_gas(
-            fee_statement.storage_fee_refund(),
-            GasType::STORAGE_FEE_REFUND,
-        );
+        observe_gas(&TXN_GAS, mode_str, fee_statement);
     }
-}
-
-pub(crate) fn update_sequential_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.gas_used(),
-        GasType::TOTAL_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.io_gas_used(),
-        GasType::IO_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
-}
-
-pub(crate) fn update_sequential_txn_gas_counters(fee_statement: &FeeStatement) {
-    observe_sequential_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-    observe_sequential_execution_txn_gas(
-        fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
 }

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -150,6 +150,7 @@ mod scheduler;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;
+pub mod types;
 #[cfg(test)]
 mod unit_tests;
 pub mod view;

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1132,6 +1132,23 @@ where
             0,
         )
     }
+
+    fn output_approx_size(&self) -> u64 {
+        // TODO add block output limit testing
+        0
+    }
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        crate::types::InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    > {
+        HashSet::new()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -17,6 +17,7 @@ use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
+    aggregator::PanicError,
     contract_event::TransactionEvent,
     executable::ModulePath,
     fee_statement::FeeStatement,
@@ -963,6 +964,15 @@ where
             MockTransaction::SkipRest => ExecutionStatus::SkipRest(MockOutput::skip_output()),
             MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
+    }
+
+    fn execute_skipped_checkpoint(
+        _txn: &Self::Txn,
+        _output: &mut Self::Output,
+        _block_limit_reached_event: Option<aptos_types::account_config::BlockLimitReachedEvent>,
+    ) -> Result<(), PanicError> {
+        // no distinction of whether it is skip_output or not
+        Ok(())
     }
 
     fn is_transaction_dynamic_change_set_capable(_txn: &Self::Txn) -> bool {

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,8 +8,8 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    fee_statement::FeeStatement, transaction::BlockExecutableTransaction as Transaction,
-    write_set::WriteOp,
+    account_config::BlockLimitReachedEvent, aggregator::PanicError, fee_statement::FeeStatement,
+    transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
@@ -82,6 +82,12 @@ pub trait ExecutorTask: Sync {
         txn: &Self::Txn,
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
+
+    fn execute_skipped_checkpoint(
+        txn: &Self::Txn,
+        output: &mut Self::Output,
+        block_limit_reached_event: Option<BlockLimitReachedEvent>,
+    ) -> Result<(), PanicError>;
 
     fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool;
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use aptos_aggregator::{
     delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
 };
@@ -12,7 +13,11 @@ use aptos_types::{
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Debug,
+    sync::Arc,
+};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -182,4 +187,16 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     /// Return the fee statement of the transaction.
     fn fee_statement(&self) -> FeeStatement;
+
+    fn output_approx_size(&self) -> u64;
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    >;
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -6,6 +6,7 @@ use crate::{
     errors::{Error, IntentionalFallbackToSequential},
     explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
+    types::InputOutputKey,
 };
 use aptos_aggregator::types::PanicOr;
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
@@ -18,7 +19,7 @@ use crossbeam::utils::CachePadded;
 use dashmap::DashSet;
 use move_core_types::value::MoveTypeLayout;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     iter::{empty, Iterator},
     sync::{
@@ -173,6 +174,19 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 Some(output.fee_statement())
+            },
+            _ => None,
+        }
+    }
+
+    pub(crate) fn output_approx_size(&self, txn_idx: TxnIndex) -> Option<u64> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("[BlockSTM]: Execution output must be recorded after execution")
+            .output_status
+        {
+            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                Some(output.output_approx_size())
             },
             _ => None,
         }
@@ -418,6 +432,23 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {},
         };
+    }
+
+    pub(crate) fn get_write_summary(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("Output must exist")
+            .output_status
+        {
+            ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
+            ExecutionStatus::Abort(_)
+            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
+            | ExecutionStatus::SpeculativeExecutionAbortError(_)
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => HashSet::new(),
+        }
     }
 
     // Must be executed after parallel execution is done, grabs outputs. Will panic if

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -1,0 +1,44 @@
+// Copyright © Aptos Foundation
+
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::{collections::HashSet, fmt};
+
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum InputOutputKey<K, T, I> {
+    Resource(K),
+    Group(K, T),
+    DelayedField(I),
+}
+
+pub struct ReadWriteSummary<T: Transaction> {
+    reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+}
+
+impl<T: Transaction> ReadWriteSummary<T> {
+    pub fn new(
+        reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+        writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    ) -> Self {
+        Self { reads, writes }
+    }
+
+    pub fn conflicts_with_previous(&self, previous: &Self) -> bool {
+        !self.reads.is_disjoint(&previous.writes)
+    }
+}
+
+impl<T: Transaction> fmt::Debug for ReadWriteSummary<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "ReadWriteSummary")?;
+        writeln!(f, "reads:")?;
+        for read in &self.reads {
+            writeln!(f, "    {:?}", read)?;
+        }
+        writeln!(f, "writes:")?;
+        for write in &self.writes {
+            writeln!(f, "    {:?}", write)?;
+        }
+        Ok(())
+    }
+}

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -40,8 +40,8 @@ use aptos_types::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     on_chain_config::{
-        BlockGasLimitType, FeatureFlag, Features, OnChainConfig, TimedFeatureOverride,
-        TimedFeaturesBuilder, ValidatorSet, Version,
+        FeatureFlag, Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder,
+        ValidatorSet, Version,
     },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -516,10 +516,8 @@ impl FakeExecutor {
             }
         });
 
-        let onchain_config = BlockExecutorConfigFromOnchain {
-            // TODO fetch values from state?
-            block_gas_limit_type: BlockGasLimitType::Limit(30000),
-        };
+        // TODO fetch values from state?
+        let onchain_config = BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
         let sequential_output = if mode != ExecutorMode::ParallelOnly {
             Some(AptosVM::execute_block(

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -444,8 +444,14 @@ impl FakeExecutor {
             txn_block
                 .into_iter()
                 .map(Transaction::UserTransaction)
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect(),
         )
+        .map(|mut results| {
+            let result = results.pop().unwrap();
+            println!("Execution result for StateCheckpoint: {:?}", result);
+            results
+        })
     }
 
     /// Executes the transaction as a singleton block and applies the resulting write set to the

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -9,6 +9,7 @@ This module defines a struct storing the metadata of the block and new block eve
 -  [Resource `BlockResource`](#0x1_block_BlockResource)
 -  [Struct `NewBlockEvent`](#0x1_block_NewBlockEvent)
 -  [Struct `UpdateEpochIntervalEvent`](#0x1_block_UpdateEpochIntervalEvent)
+-  [Struct `BlockLimitReachedEvent`](#0x1_block_BlockLimitReachedEvent)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_block_initialize)
 -  [Function `update_epoch_interval_microsecs`](#0x1_block_update_epoch_interval_microsecs)
@@ -189,6 +190,43 @@ Event emitted when a proposal is created.
 </dt>
 <dd>
 
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_block_BlockLimitReachedEvent"></a>
+
+## Struct `BlockLimitReachedEvent`
+
+When the block limit is reached, this event is emitted.
+
+This is meant to emitted as a module event.
+
+
+<pre><code>#[<a href="event.md#0x1_event">event</a>]
+<b>struct</b> <a href="block.md#0x1_block_BlockLimitReachedEvent">BlockLimitReachedEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>block_gas_limit_reached: bool</code>
+</dt>
+<dd>
+ Whether block gas limit was reached
+</dd>
+<dt>
+<code>block_output_limit_reached: bool</code>
+</dt>
+<dd>
+ Whether block output limit was reached
 </dd>
 </dl>
 

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -48,6 +48,17 @@ module aptos_framework::block {
         new_epoch_interval: u64,
     }
 
+    #[event]
+    /// When the block limit is reached, this event is emitted.
+    ///
+    /// This is meant to emitted as a module event.
+    struct BlockLimitReachedEvent has drop, store {
+        /// Whether block gas limit was reached
+        block_gas_limit_reached: bool,
+        /// Whether block output limit was reached
+        block_output_limit_reached: bool,
+    }
+
     /// The number of new block events does not equal the current block height.
     const ENUM_NEW_BLOCK_EVENTS_DOES_NOT_MATCH_BLOCK_HEIGHT: u64 = 1;
     /// An invalid proposer was provided. Expected the proposer to be the VM or an active validator.

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -359,10 +359,11 @@ impl Dag {
             .map(|(_, round_nodes)| round_nodes.iter().map(|node| node.is_some()).collect())
             .collect();
 
-        bitmask.resize(
-            (target_round - lowest_round + 1) as usize,
-            vec![false; self.author_to_index.len()],
-        );
+        bitmask.resize((target_round - lowest_round + 1) as usize, vec![
+            false;
+            self.author_to_index
+                .len()
+        ]);
 
         DagSnapshotBitmask::new(lowest_round, bitmask)
     }

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -122,14 +122,12 @@ impl ExecutionPipeline {
         }
         let validator_txns = block.validator_txns().cloned().unwrap_or_default();
         let input_txns = input_txns.unwrap();
-        let is_block_gas_limit = block_executor_onchain_config.has_any_block_gas_limit();
         tokio::task::spawn_blocking(move || {
             let txns_to_execute = Block::transactions_to_execute_for_metadata(
                 block.id(),
                 validator_txns,
                 input_txns.clone(),
                 metadata,
-                is_block_gas_limit,
             );
             let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
                 SIG_VERIFY_POOL.install(|| {

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -64,7 +64,6 @@ impl TxnNotifier for DummyTxnNotifier {
         &self,
         _txns: Vec<SignedTransaction>,
         _compute_results: &StateComputeResult,
-        _block_gas_limit_enabled: bool,
     ) -> anyhow::Result<(), MempoolError> {
         Ok(())
     }

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,12 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_temppath::TempPath;
 use rand::{rngs::StdRng, SeedableRng};
 
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
+    test_config_with_custom_onchain(None)
+}
+
+pub fn test_config_with_custom_onchain(
+    init_genesis_config: Option<InitGenesisConfigFn>,
+) -> (NodeConfig, Ed25519PrivateKey) {
     let path = TempPath::new();
     path.create_as_dir().unwrap();
     let (root_key, _genesis, _genesis_waypoint, validators) = crate::builder::Builder::new(
@@ -14,6 +21,7 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         aptos_cached_packages::head_release_bundle().clone(),
     )
     .unwrap()
+    .with_init_genesis_config(init_genesis_config)
     .build(StdRng::from_seed([0; 32]))
     .unwrap();
     let (

--- a/execution/executor-benchmark/src/db_reliable_submitter.rs
+++ b/execution/executor-benchmark/src/db_reliable_submitter.rs
@@ -2,10 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    db_access::{CoinStore, DbAccessUtil},
-    transaction_executor::BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-};
+use crate::db_access::{CoinStore, DbAccessUtil};
 use anyhow::{Context, Result};
 use aptos_crypto::HashValue;
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
@@ -58,10 +55,7 @@ impl ReliableTransactionSubmitter for DbReliableTransactionSubmitter {
         self.block_sender.send(
             txns.iter()
                 .map(|t| Transaction::UserTransaction(t.clone()))
-                .chain(
-                    (!BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit())
-                        .then_some(Transaction::StateCheckpoint(HashValue::random())),
-                )
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect(),
         )?;
 

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -181,6 +181,11 @@ where
                     executed
                 );
                 info!(
+                    "Overall execution effectiveGPS: {} gas/s (over {} txns)",
+                    delta_gas.effective_block_gas / elapsed,
+                    executed
+                );
+                info!(
                     "Overall execution ioGPS: {} gas/s (over {} txns)",
                     delta_gas.io_gas / elapsed,
                     executed
@@ -194,6 +199,10 @@ where
                     "Overall execution GPT: {} gas/txn (over {} txns)",
                     delta_gas.gas / (delta_gas.gas_count as f64).max(1.0),
                     executed
+                );
+                info!(
+                    "Overall execution approx_output: {} bytes/s",
+                    delta_gas.approx_block_output / elapsed
                 );
                 info!(
                     "Overall execution output: {} bytes/s",

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -69,12 +69,7 @@ where
             )
             .unwrap();
 
-        let diff = if BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-            1
-        } else {
-            0
-        };
-        assert_eq!(output.txn_statuses().len(), num_txns + diff);
+        assert_eq!(output.txn_statuses().len(), num_txns);
 
         let msg = LedgerUpdateMessage {
             current_block_start_time,

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -16,11 +16,7 @@ use std::{
 };
 
 pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-    block_gas_limit_type:
-        // present, but large to not limit blocks
-        aptos_types::on_chain_config::BlockGasLimitType::Limit(1_000_000_000),
-};
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 pub struct TransactionExecutor<V> {
     num_blocks_processed: usize,

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -5,7 +5,6 @@
 use crate::{
     account_generator::{AccountCache, AccountGenerator},
     metrics::{NUM_TXNS, TIMER},
-    transaction_executor::BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue};
 use aptos_logger::info;
@@ -374,10 +373,7 @@ impl TransactionGenerator {
                     );
                     Transaction::UserTransaction(txn)
                 })
-                .chain(
-                    (!BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit())
-                        .then_some(Transaction::StateCheckpoint(HashValue::random())),
-                )
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect();
             bar.inc(transactions.len() as u64 - 1);
             if let Some(sender) = &self.block_sender {
@@ -672,10 +668,7 @@ impl TransactionGenerator {
         for i in 0..block_size {
             transactions.push(transactions_by_index.get(&i).unwrap().clone());
         }
-
-        if !BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-            transactions.push(Transaction::StateCheckpoint(HashValue::random()));
-        }
+        transactions.push(Transaction::StateCheckpoint(HashValue::random()));
 
         NUM_TXNS
             .with_label_values(&["generation_done"])

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -173,7 +173,7 @@ pub fn test_execution_with_storage_impl_inner(
             txn_factory.transfer(account3.address(), 10 * B),
         )));
     }
-    let block3 = block(block3, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG); // append state checkpoint txn
+    let block3 = block(block3); // append state checkpoint txn
 
     let output1 = executor
         .execute_block(
@@ -449,16 +449,9 @@ pub fn test_execution_with_storage_impl_inner(
     })
     .unwrap();
 
-    // With block gas limit, StateCheckpoint txn is inserted to block after execution.
-    let diff = if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-        0
-    } else {
-        1
-    };
-
     let transaction_list_with_proof = db
         .reader
-        .get_transactions(14, 15 + diff, current_version, false)
+        .get_transactions(14, 16, current_version, false)
         .unwrap();
     let expected_txns: Vec<Transaction> = block3.iter().map(|t| t.expect_valid().clone()).collect();
     verify_transactions(&transaction_list_with_proof, &expected_txns).unwrap();

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -253,10 +253,7 @@ where
                     .start_timer();
 
                 THREAD_MANAGER.get_exe_cpu_pool().install(|| {
-                    chunk_output.into_state_checkpoint_output(
-                        parent_output.state(),
-                        onchain_config.has_any_block_gas_limit().then_some(block_id),
-                    )
+                    chunk_output.into_state_checkpoint_output(parent_output.state(), None)
                 })?
             };
 

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -235,7 +235,7 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
             .collect::<Vec<_>>();
         let output = executor
             .execute_block(
-                (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+                (block_id, block(txns)).into(),
                 parent_block_id,
                 TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
             )
@@ -285,7 +285,7 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
             .map(|_| encode_mint_transaction(tests::gen_address(rng.gen::<u64>()), 100))
             .collect::<Vec<_>>();
         let output = executor
-            .execute_block((block_id, block(txns, None)).into(), parent_block_id, None)
+            .execute_block((block_id, block(txns)).into(), parent_block_id, None)
             .unwrap();
         let ledger_info = tests::gen_ledger_info(6, output.root_hash(), block_id, 1);
         executor.commit_blocks(vec![block_id], ledger_info).unwrap();

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -89,7 +89,7 @@ fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter, signer: &Vali
     let executor = BlockExecutor::<AptosVM>::new(db.clone());
     let output = executor
         .execute_block(
-            (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+            (block_id, block(txns)).into(),
             executor.committed_block_id(),
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -224,6 +224,7 @@ def execute_command(command):
 class RunResults:
     tps: float
     gps: float
+    effective_gps: float
     io_gps: float
     execution_gps: float
     gpt: float
@@ -253,6 +254,9 @@ def extract_run_results(
     if execution_only:
         tps = float(re.findall(r"Overall execution TPS: (\d+\.?\d*) txn/s", output)[-1])
         gps = float(re.findall(r"Overall execution GPS: (\d+\.?\d*) gas/s", output)[-1])
+        effective_gps = float(
+            re.findall(r"Overall execution effectiveGPS: (\d+\.?\d*) gas/s", output)[-1]
+        )
         io_gps = float(
             re.findall(r"Overall execution ioGPS: (\d+\.?\d*) gas/s", output)[-1]
         )
@@ -275,6 +279,7 @@ def extract_run_results(
             )
         )
         gps = 0
+        effective_gps = 0
         io_gps = 0
         execution_gps = 0
         gpt = 0
@@ -282,6 +287,9 @@ def extract_run_results(
     else:
         tps = float(get_only(re.findall(r"Overall TPS: (\d+\.?\d*) txn/s", output)))
         gps = float(get_only(re.findall(r"Overall GPS: (\d+\.?\d*) gas/s", output)))
+        effective_gps = float(
+            get_only(re.findall(r"Overall effectiveGPS: (\d+\.?\d*) gas/s", output))
+        )
         io_gps = float(
             get_only(re.findall(r"Overall ioGPS: (\d+\.?\d*) gas/s", output))
         )
@@ -313,6 +321,7 @@ def extract_run_results(
     return RunResults(
         tps=tps,
         gps=gps,
+        effective_gps=effective_gps,
         io_gps=io_gps,
         execution_gps=execution_gps,
         gpt=gpt,
@@ -353,6 +362,7 @@ def print_table(
                 "vm/exe",
                 "commit/total",
                 "g/s",
+                "eff g/s",
                 "io g/s",
                 "exe g/s",
                 "g/t",
@@ -386,6 +396,7 @@ def print_table(
             row.append(round(result.single_node_result.fraction_of_execution_in_vm, 3))
             row.append(round(result.single_node_result.fraction_in_commit, 3))
             row.append(int(round(result.single_node_result.gps)))
+            row.append(int(round(result.single_node_result.effective_gps)))
             row.append(int(round(result.single_node_result.io_gps)))
             row.append(int(round(result.single_node_result.execution_gps)))
             row.append(int(round(result.single_node_result.gpt)))
@@ -402,7 +413,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     execute_command(f"cargo build {BUILD_FLAG} --package aptos-executor-benchmark")
 
     print(f"Warmup - creating DB with {NUM_ACCOUNTS} accounts")
-    create_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
+    create_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
     results = []
@@ -459,14 +470,14 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         number_of_threads_results = {}
 
         for execution_threads in EXECUTION_ONLY_NUMBER_OF_THREADS:
-            test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
+            test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
             output = execute_command(test_db_command)
 
             number_of_threads_results[execution_threads] = extract_run_results(
                 output, execution_only=True
             )
 
-        test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
+        test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
         output = execute_command(test_db_command)
 
         single_node_result = extract_run_results(output, execution_only=False)

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -141,3 +141,12 @@ impl MoveStructType for BlockResource {
 }
 
 impl MoveResource for BlockResource {}
+
+/// (keep this doc in sync with the `struct BlockLimitReachedEvent` in Move.)
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockLimitReachedEvent {
+    pub block_gas_limit_reached: bool,
+    pub block_output_limit_reached: bool,
+}
+
+pub const BLOCK_LIMIT_REACHED_EVENT_TYPE_NAME: &str = "0x1::block::BlockLimitReachedEvent";

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -30,8 +30,18 @@ impl BlockExecutorConfigFromOnchain {
         }
     }
 
-    pub fn has_any_block_gas_limit(&self) -> bool {
-        self.block_gas_limit_type.block_gas_limit().is_some()
+    pub const fn on_but_large_for_test() -> Self {
+        Self {
+            block_gas_limit_type:
+                // present, so code is excercised, but large to not limit blocks
+                BlockGasLimitType::ComplexLimitV1 {
+                    effective_block_gas_limit: 1_000_000_000,
+                    execution_gas_effective_multiplier: 1,
+                    io_gas_effective_multiplier: 1,
+                    block_output_limit: Some(1_000_000_000_000),
+                    conflict_penalty_window: 8,
+                },
+        }
     }
 
     pub const fn on_but_large_for_test() -> Self {

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -33,6 +33,21 @@ impl BlockExecutorConfigFromOnchain {
     pub fn has_any_block_gas_limit(&self) -> bool {
         self.block_gas_limit_type.block_gas_limit().is_some()
     }
+
+    pub const fn on_but_large_for_test() -> Self {
+        Self {
+            block_gas_limit_type:
+                // present, so code is excercised, but large to not limit blocks
+                BlockGasLimitType::ComplexLimitV1 {
+                    effective_block_gas_limit: 1_000_000_000,
+                    execution_gas_effective_multiplier: 1,
+                    io_gas_effective_multiplier: 1,
+                    block_output_limit: Some(1_000_000_000_000),
+                    conflict_penalty_window: 8,
+                    add_block_limit_outcome_onchain: false,
+                },
+        }
+    }
 }
 
 /// Configuration for the BlockExecutor.

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -17,6 +17,7 @@ pub enum OnChainExecutionConfig {
     /// to previous behavior (before OnChainExecutionConfig was registered) in case of Missing.
     Missing,
     // Reminder: Add V4 and future versions here, after Missing (order matters for enums).
+    V4(ExecutionConfigV4),
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -28,6 +29,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type.clone(),
         }
     }
 
@@ -42,6 +44,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config
                 .block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+            OnChainExecutionConfig::V4(config) => config.block_gas_limit_type.clone(),
         }
     }
 
@@ -59,15 +62,23 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_deduper_type.clone(),
         }
     }
 
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+        OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            block_gas_limit: Some(35000),
+            block_gas_limit_type: BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit: 35000,
+                execution_gas_effective_multiplier: 1,
+                io_gas_effective_multiplier: 3,
+                block_output_limit: Some(2 * 1024 * 1024),
+                conflict_penalty_window: 8,
+                add_block_limit_outcome_onchain: false,
+            },
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         })
     }
@@ -115,6 +126,13 @@ pub struct ExecutionConfigV3 {
     pub transaction_deduper_type: TransactionDeduperType,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV4 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+    pub block_gas_limit_type: BlockGasLimitType,
+    pub transaction_deduper_type: TransactionDeduperType,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionShufflerType {
@@ -134,6 +152,24 @@ pub enum TransactionDeduperType {
 pub enum BlockGasLimitType {
     NoLimit,
     Limit(u64),
+    /// Provides two separate block limits:
+    /// 1. effective_block_gas_limit
+    /// 2. block_output_limit
+    ComplexLimitV1 {
+        /// Formula for effective block gas limit:
+        /// effective_block_gas_limit <
+        /// (execution_gas_effective_multiplier * execution_gas_used +
+        ///  io_gas_effective_multiplier * io_gas_used
+        /// ) * (1 + num conflicts in conflict_penalty_window)
+        effective_block_gas_limit: u64,
+        execution_gas_effective_multiplier: u64,
+        io_gas_effective_multiplier: u64,
+        conflict_penalty_window: u32,
+        /// Block limit on the total (approximate) txn output size in bytes.
+        block_output_limit: Option<u64>,
+
+        add_block_limit_outcome_onchain: bool,
+    },
 }
 
 impl BlockGasLimitType {
@@ -141,6 +177,59 @@ impl BlockGasLimitType {
         match self {
             BlockGasLimitType::NoLimit => None,
             BlockGasLimitType::Limit(limit) => Some(*limit),
+            BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit,
+                ..
+            } => Some(*effective_block_gas_limit),
+        }
+    }
+
+    pub fn execution_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                execution_gas_effective_multiplier,
+                ..
+            } => *execution_gas_effective_multiplier,
+        }
+    }
+
+    pub fn io_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                io_gas_effective_multiplier,
+                ..
+            } => *io_gas_effective_multiplier,
+        }
+    }
+
+    pub fn block_output_limit(&self) -> Option<u64> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                block_output_limit, ..
+            } => *block_output_limit,
+        }
+    }
+
+    pub fn conflict_penalty_window(&self) -> Option<u32> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                conflict_penalty_window,
+                ..
+            } => {
+                if *conflict_penalty_window > 1 {
+                    Some(*conflict_penalty_window)
+                } else {
+                    None
+                }
+            },
         }
     }
 }

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -6,7 +6,6 @@ use crate::{
     account_address::AccountAddress,
     block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
-    on_chain_config::BlockGasLimitType,
     transaction::{
         authenticator::AccountAuthenticator,
         signature_verified_transaction::{
@@ -23,9 +22,7 @@ const TEST_GAS_PRICE: u64 = 100;
 
 // The block executor onchain config (gas limit parameters) for executor tests
 pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-        block_gas_limit_type: BlockGasLimitType::Limit(1000),
-    };
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 static EMPTY_SCRIPT: &[u8] = include_bytes!("empty_script.mv");
 

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -248,12 +248,7 @@ pub fn get_test_txn_with_chain_id(
     SignedTransaction::new(raw_txn, public_key, signature)
 }
 
-pub fn block(
-    mut user_txns: Vec<Transaction>,
-    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
-) -> Vec<SignatureVerifiedTransaction> {
-    if !block_executor_onchain_config.has_any_block_gas_limit() {
-        user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
-    }
+pub fn block(mut user_txns: Vec<Transaction>) -> Vec<SignatureVerifiedTransaction> {
+    user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
     into_signature_verified_block(user_txns)
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1836,6 +1836,16 @@ impl Transaction {
             Transaction::ValidatorTransaction(_) => String::from("validator_transaction"),
         }
     }
+
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Transaction::UserTransaction(_) => "user_transaction",
+            Transaction::GenesisTransaction(_) => "genesis_transaction",
+            Transaction::BlockMetadata(_) => "block_metadata",
+            Transaction::StateCheckpoint(_) => "state_checkpoint",
+            Transaction::ValidatorTransaction(_) => "validator_transaction",
+        }
+    }
 }
 
 impl TryFrom<Transaction> for SignedTransaction {


### PR DESCRIPTION
Cleanup so BlockExecutor always marks StateCheckpoint as non-retry. simplifies a lot of logic outside.

In the StateCheckpoint, if block was ended early, we add BlockLimitReachedEvent, with information of why block limit was reached.

TODO:
 - use it in gas estimation, for whether blocks were full or not
 - gate adding event by field in onchain config

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
