### PR TITLE
[Aptos Data Client] Add multi-fetch support.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -298,6 +298,36 @@ impl Default for AptosDataPollerConfig {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
+pub struct AptosDataMultiFetchConfig {
+    /// Whether or not to enable multi-fetch for data client requests
+    pub enable_multi_fetch: bool,
+    /// The number of additional requests to send per peer bucket
+    pub additional_requests_per_peer_bucket: usize,
+    /// The minimum number of peers for each multi-fetch request
+    pub min_peers_for_multi_fetch: usize,
+    /// The maximum number of peers for each multi-fetch request
+    pub max_peers_for_multi_fetch: usize,
+    /// The number of peers per multi-fetch bucket. We use buckets
+    /// to track the number of peers that can service a multi-fetch
+    /// request and determine the number of requests to send based on
+    /// the configured min, max and additional requests per bucket.
+    pub multi_fetch_peer_bucket_size: usize,
+}
+
+impl Default for AptosDataMultiFetchConfig {
+    fn default() -> Self {
+        Self {
+            enable_multi_fetch: true,
+            additional_requests_per_peer_bucket: 1,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 5,
+            multi_fetch_peer_bucket_size: 10,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct AptosLatencyFilteringConfig {
     /// The reduction factor for latency filtering when selecting peers
     pub latency_filtering_reduction_factor: u64,
@@ -322,6 +352,8 @@ impl Default for AptosLatencyFilteringConfig {
 pub struct AptosDataClientConfig {
     /// The aptos data poller config for the data client
     pub data_poller_config: AptosDataPollerConfig,
+    /// The aptos data multi-fetch config for the data client
+    pub data_multi_fetch_config: AptosDataMultiFetchConfig,
     /// The aptos latency filtering config for the data client
     pub latency_filtering_config: AptosLatencyFilteringConfig,
     /// The interval (milliseconds) at which to refresh the latency monitor
@@ -356,6 +388,7 @@ impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
             data_poller_config: AptosDataPollerConfig::default(),
+            data_multi_fetch_config: AptosDataMultiFetchConfig::default(),
             latency_filtering_config: AptosLatencyFilteringConfig::default(),
             latency_monitor_loop_interval_ms: 100,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -15,7 +15,9 @@ use crate::{
     },
     peer_states::{ErrorType, PeerStates},
     poller::DataSummaryPoller,
-    priority, utils,
+    priority,
+    priority::PeerPriority,
+    utils,
 };
 use aptos_config::{
     config::{AptosDataClientConfig, BaseConfig},
@@ -23,7 +25,7 @@ use aptos_config::{
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_infallible::Mutex;
-use aptos_logger::{debug, info, sample, sample::SampleRate, trace, warn};
+use aptos_logger::{info, sample, sample::SampleRate, trace, warn};
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
     protocols::network::RpcError,
@@ -52,12 +54,20 @@ use aptos_types::{
 };
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use futures::{stream::FuturesUnordered, StreamExt};
 use maplit::hashset;
-use std::{collections::HashSet, fmt, ops::Deref, sync::Arc, time::Duration};
+use std::{
+    cmp::min,
+    collections::{BTreeMap, HashSet},
+    fmt,
+    ops::Deref,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::runtime::Handle;
 
 // Useful constants
-const PEER_LOG_FREQ_SECS: u64 = 10;
+const PEER_METRICS_FREQ_SECS: u64 = 5; // The frequency to update peer metrics and logs
 
 /// An [`AptosDataClientInterface`] that fulfills requests from remote peers' Storage Service
 /// over AptosNet.
@@ -145,9 +155,47 @@ impl AptosDataClient {
         self.storage_service_client.get_peers_and_metadata()
     }
 
-    /// Updates the logs and metrics for the peer request distributions
-    pub fn update_peer_request_logs_and_metrics(&self) {
+    /// Updates the metrics and logs for peer states. This includes
+    /// peer priorities and request distributions.
+    pub fn update_peer_metrics_and_logs(&self) {
+        // Update the peer request logs and metrics
         self.peer_states.update_peer_request_logs_and_metrics();
+
+        // Update the peer priority metrics and logs (infrequently)
+        sample!(
+            SampleRate::Duration(Duration::from_secs(PEER_METRICS_FREQ_SECS)),
+            {
+                // Update the priority and regular peer metrics
+                match self.get_priority_and_regular_peers() {
+                    Ok((priority_peers, regular_peers)) => {
+                        update_priority_and_regular_peer_metrics(&priority_peers, &regular_peers);
+                    },
+                    Err(error) => {
+                        warn!(
+                            (LogSchema::new(LogEntry::PeerStates)
+                                .event(LogEvent::PriorityAndRegularPeers)
+                                .message("Unable to update priority and regular peer metrics!")
+                                .error(&error))
+                        );
+                    },
+                };
+
+                // Update the fine-grained peer priority metrics
+                match self.get_peers_by_priorities() {
+                    Ok(peers_by_priorities) => {
+                        update_peer_priority_metrics(&peers_by_priorities);
+                    },
+                    Err(error) => {
+                        warn!(
+                            (LogSchema::new(LogEntry::PeerStates)
+                                .event(LogEvent::PriorityPeerCategories)
+                                .message("Unable to update peer priority metrics!")
+                                .error(&error))
+                        );
+                    },
+                };
+            }
+        );
     }
 
     /// Update a peer's storage summary
@@ -183,60 +231,218 @@ impl AptosDataClient {
         Ok(())
     }
 
-    /// Chooses a peer randomly weighted by distance and
+    /// Chooses peers randomly weighted by distance and
     /// latency from the given set of serviceable peers.
-    fn choose_random_peer_by_distance_and_latency(
+    fn choose_random_peers_by_distance_and_latency(
         &self,
-        request: &StorageServiceRequest,
         serviceable_peers: HashSet<PeerNetworkId>,
-    ) -> Result<PeerNetworkId, Error> {
-        // Choose a peer weighted by distance and latency
-        if let Some(peer) = utils::choose_random_peer_by_distance_and_latency(
+        num_peers_to_choose: usize,
+    ) -> HashSet<PeerNetworkId> {
+        // Choose peers weighted by distance and latency
+        let selected_peers = utils::choose_random_peers_by_distance_and_latency(
             serviceable_peers.clone(),
             self.get_peers_and_metadata(),
-        ) {
-            return Ok(peer); // Return the peer if we found one
-        }
+            num_peers_to_choose,
+        );
 
-        // Otherwise, simply select a peer at random
-        self.choose_random_peer(request, serviceable_peers)
+        // Extend the selected peers with random peers (if necessary)
+        utils::extend_with_random_peers(selected_peers, serviceable_peers, num_peers_to_choose)
     }
 
-    /// Choose a connected peer that can service the given request.
-    /// Returns an error if no such peer can be found.
-    pub(crate) fn choose_peer_for_request(
+    /// Chooses several connected peers to service the given request.
+    /// Returns an error if no single peer can service the request.
+    pub(crate) fn choose_peers_for_request(
         &self,
         request: &StorageServiceRequest,
-    ) -> crate::error::Result<PeerNetworkId, Error> {
-        // All requests should be sent to prioritized peers (if possible).
-        // If none can handle the request, fall back to the regular peers.
-        let (priority_peers, regular_peers) = self.get_priority_and_regular_peers()?;
-        let priority_serviceable = self.identify_serviceable(priority_peers, request);
-        let serviceable_peers = if !priority_serviceable.is_empty() {
-            priority_serviceable
+    ) -> crate::error::Result<HashSet<PeerNetworkId>, Error> {
+        // Get all peers grouped by priorities
+        let peers_by_priorities = self.get_peers_by_priorities()?;
+
+        // Identify the peers that can service the request (ordered by priority)
+        let mut serviceable_peers_by_priorities = vec![];
+        for priority in PeerPriority::get_all_ordered_priorities() {
+            // Identify the serviceable peers for the priority
+            let peers = self.identify_serviceable(&peers_by_priorities, priority, request);
+
+            // Add the serviceable peers to the ordered list
+            serviceable_peers_by_priorities.push(peers);
+        }
+
+        // If the request is a subscription request, select a single
+        // peer (as we can only subscribe to a single peer at a time).
+        if request.data_request.is_subscription_request() {
+            return self
+                .choose_peer_for_subscription_request(request, serviceable_peers_by_priorities);
+        }
+
+        // Otherwise, determine the number of peers to select for the request
+        let multi_fetch_config = self.data_client_config.data_multi_fetch_config;
+        let num_peers_for_request = if multi_fetch_config.enable_multi_fetch {
+            // Calculate the total number of priority serviceable peers
+            let mut num_serviceable_peers = 0;
+            for (index, peers) in serviceable_peers_by_priorities.iter().enumerate() {
+                // Only include the lowest priority peers if no other peers are
+                // available (the lowest priority peers are generally unreliable).
+                if (num_serviceable_peers == 0)
+                    || (index < serviceable_peers_by_priorities.len() - 1)
+                {
+                    num_serviceable_peers += peers.len();
+                }
+            }
+
+            // Calculate the number of peers to select for the request
+            let peer_ratio_for_request =
+                num_serviceable_peers / multi_fetch_config.multi_fetch_peer_bucket_size;
+            let mut num_peers_for_request = multi_fetch_config.min_peers_for_multi_fetch
+                + (peer_ratio_for_request * multi_fetch_config.additional_requests_per_peer_bucket);
+
+            // Bound the number of peers by the number of serviceable peers
+            num_peers_for_request = min(num_peers_for_request, num_serviceable_peers);
+
+            // Ensure the number of peers is no larger than the maximum
+            min(
+                num_peers_for_request,
+                multi_fetch_config.max_peers_for_multi_fetch,
+            )
         } else {
-            self.identify_serviceable(regular_peers, request)
+            1 // Multi-fetch is disabled (only select a single peer)
         };
 
-        // Identify the peer based on the request type
-        if request.data_request.is_subscription_request() {
-            // Choose a peer to handle the subscription request
-            self.choose_peer_for_subscription_request(request, serviceable_peers)
-        } else if request.data_request.is_optimistic_fetch() {
-            // Choose a peer to handle the optimistic fetch request
-            self.choose_random_peer_by_distance_and_latency(request, serviceable_peers)
+        // Verify that we have at least one peer to service the request
+        if num_peers_for_request == 0 {
+            return Err(Error::DataIsUnavailable(format!(
+                "No peers are available to service the given request: {:?}",
+                request
+            )));
+        }
+
+        // Choose the peers based on the request type
+        if request.data_request.is_optimistic_fetch() {
+            self.choose_peers_for_optimistic_fetch(
+                request,
+                serviceable_peers_by_priorities,
+                num_peers_for_request,
+            )
         } else {
-            // Choose the peer randomly weighted by latency
-            self.choose_random_peer_by_latency(request, serviceable_peers)
+            self.choose_peers_for_specific_data_request(
+                request,
+                serviceable_peers_by_priorities,
+                num_peers_for_request,
+            )
         }
     }
 
-    /// Choose a peer that can service the given subscription request
+    /// Chooses several peers to service the given optimistic fetch
+    /// request. Peers are selected first by priority, and then by
+    /// validator distance and latency (within priority groups).
+    fn choose_peers_for_optimistic_fetch(
+        &self,
+        request: &StorageServiceRequest,
+        serviceable_peers_by_priorities: Vec<HashSet<PeerNetworkId>>,
+        num_peers_for_request: usize,
+    ) -> crate::error::Result<HashSet<PeerNetworkId>, Error> {
+        // Select peers by priority (starting with the highest priority first)
+        let mut selected_peers = HashSet::new();
+        for serviceable_peers in serviceable_peers_by_priorities {
+            // Select peers by distance and latency
+            let num_peers_remaining = num_peers_for_request.saturating_sub(selected_peers.len());
+            let peers = self.choose_random_peers_by_distance_and_latency(
+                serviceable_peers,
+                num_peers_remaining,
+            );
+
+            // Add the peers to the entire set
+            selected_peers.extend(peers);
+
+            // If we have selected enough peers, return early
+            if selected_peers.len() >= num_peers_for_request {
+                return Ok(selected_peers);
+            }
+        }
+
+        // If selected peers is empty, return an error
+        if !selected_peers.is_empty() {
+            Ok(selected_peers)
+        } else {
+            Err(Error::DataIsUnavailable(format!(
+                "Unable to select peers for optimistic fetch request: {:?}",
+                request
+            )))
+        }
+    }
+
+    /// Chooses several peers to service the specific data request.
+    /// Peers are selected first by priority, and then by latency
+    /// (within priority groups).
+    fn choose_peers_for_specific_data_request(
+        &self,
+        request: &StorageServiceRequest,
+        serviceable_peers_by_priorities: Vec<HashSet<PeerNetworkId>>,
+        num_peers_for_request: usize,
+    ) -> crate::error::Result<HashSet<PeerNetworkId>, Error> {
+        // Select peers by priority (starting with the highest priority first)
+        let mut selected_peers = HashSet::new();
+        for serviceable_peers in serviceable_peers_by_priorities {
+            // Select peers by distance and latency
+            let num_peers_remaining = num_peers_for_request.saturating_sub(selected_peers.len());
+            let peers = self.choose_random_peers_by_latency(serviceable_peers, num_peers_remaining);
+
+            // Add the peers to the entire set
+            selected_peers.extend(peers);
+
+            // If we have selected enough peers, return early
+            if selected_peers.len() >= num_peers_for_request {
+                return Ok(selected_peers);
+            }
+        }
+
+        // If selected peers is empty, return an error
+        if !selected_peers.is_empty() {
+            Ok(selected_peers)
+        } else {
+            Err(Error::DataIsUnavailable(format!(
+                "Unable to select peers for specific data request: {:?}",
+                request
+            )))
+        }
+    }
+
+    /// Chooses a single peer to service the given subscription request.
+    /// Peers are selected first by priority, and then by validator
+    /// distance and latency (within priority groups).
     fn choose_peer_for_subscription_request(
         &self,
         request: &StorageServiceRequest,
+        serviceable_peers_by_priorities: Vec<HashSet<PeerNetworkId>>,
+    ) -> crate::error::Result<HashSet<PeerNetworkId>, Error> {
+        // Prioritize peer selection by choosing the highest priority peer first
+        for serviceable_peers in serviceable_peers_by_priorities {
+            if let Some(selected_peer) =
+                self.choose_serviceable_peer_for_subscription_request(request, serviceable_peers)?
+            {
+                return Ok(hashset![selected_peer]); // A peer was found!
+            }
+        }
+
+        // Otherwise, no peer was selected, return an error
+        Err(Error::DataIsUnavailable(format!(
+            "Unable to select peers for subscription request: {:?}",
+            request
+        )))
+    }
+
+    /// Chooses a peer that can service the given subscription request.
+    /// If not peer can service the request, None is returned.
+    fn choose_serviceable_peer_for_subscription_request(
+        &self,
+        request: &StorageServiceRequest,
         serviceable_peers: HashSet<PeerNetworkId>,
-    ) -> crate::error::Result<PeerNetworkId, Error> {
+    ) -> crate::error::Result<Option<PeerNetworkId>, Error> {
+        // If there are no serviceable peers, return None
+        if serviceable_peers.is_empty() {
+            return Ok(None);
+        }
+
         // Get the stream ID from the request
         let request_stream_id = match &request.data_request {
             DataRequest::SubscribeTransactionsWithProof(request) => {
@@ -265,74 +471,71 @@ impl AptosDataClient {
             if subscription_state.subscription_stream_id == request_stream_id {
                 // The stream IDs match. Verify that the request is still serviceable.
                 let peer_network_id = subscription_state.peer_network_id;
-                if serviceable_peers.contains(&peer_network_id) {
+                return if serviceable_peers.contains(&peer_network_id) {
                     // The previously chosen peer can still service the request
                     *active_subscription_state = Some(subscription_state);
-                    return Ok(peer_network_id);
+                    Ok(Some(peer_network_id))
                 } else {
-                    // The previously chosen peer can no longer service
-                    // the request, so we need to return an error.
-                    return Err(Error::DataIsUnavailable(format!(
-                        "The peer that we were previously subscribing to can no longer service \
-                         the subscriptions! Peer: {:?}, request: {:?}",
+                    // The previously chosen peer is either: (i) unable to service
+                    // the request; or (ii) no longer the highest priority peer. So
+                    // we need to return an error so the stream will be terminated.
+                    Err(Error::DataIsUnavailable(format!(
+                        "The peer that we were previously subscribing to should no \
+                        longer service the subscriptions! Peer: {:?}, request: {:?}",
                         peer_network_id, request
-                    )));
-                }
+                    )))
+                };
             }
         }
 
-        // Otherwise, we need to choose a new peer and update the subscription state
-        let peer_network_id =
-            self.choose_random_peer_by_distance_and_latency(request, serviceable_peers)?;
-        let subscription_state = SubscriptionState::new(peer_network_id, request_stream_id);
-        *active_subscription_state = Some(subscription_state);
+        // Otherwise, choose a new peer to handle the subscription request
+        let selected_peer = self
+            .choose_random_peers_by_distance_and_latency(serviceable_peers, 1)
+            .into_iter()
+            .next();
 
-        Ok(peer_network_id)
+        // If a peer was selected, update the active subscription state
+        if let Some(selected_peer) = selected_peer {
+            let subscription_state = SubscriptionState::new(selected_peer, request_stream_id);
+            *active_subscription_state = Some(subscription_state);
+        }
+
+        Ok(selected_peer)
     }
 
-    /// Chooses a peer at random from the given set of serviceable peers
-    fn choose_random_peer(
+    /// Chooses peers randomly weighted by latency from the given set of serviceable peers
+    fn choose_random_peers_by_latency(
         &self,
-        request: &StorageServiceRequest,
         serviceable_peers: HashSet<PeerNetworkId>,
-    ) -> Result<PeerNetworkId, Error> {
-        utils::choose_random_peer(serviceable_peers).ok_or_else(|| {
-            Error::DataIsUnavailable(format!(
-                "Unable to select random peer for request: {:?}",
-                request
-            ))
-        })
-    }
-
-    /// Chooses a peer randomly weighted by latency from the given set of serviceable peers
-    fn choose_random_peer_by_latency(
-        &self,
-        request: &StorageServiceRequest,
-        serviceable_peers: HashSet<PeerNetworkId>,
-    ) -> Result<PeerNetworkId, Error> {
-        // Choose a peer weighted by latency
-        let peer_set = utils::choose_peers_by_latency(
+        num_peers_to_choose: usize,
+    ) -> HashSet<PeerNetworkId> {
+        // Choose peers weighted by latency
+        let selected_peers = utils::choose_peers_by_latency(
             self.data_client_config.clone(),
-            1,
+            num_peers_to_choose as u64,
             serviceable_peers.clone(),
             self.get_peers_and_metadata(),
             true,
         );
-        if let Some(peer) = peer_set.into_iter().next() {
-            return Ok(peer); // Return the peer if we found one
-        }
 
-        // Otherwise, simply select a peer at random
-        self.choose_random_peer(request, serviceable_peers)
+        // Extend the selected peers with random peers (if necessary)
+        utils::extend_with_random_peers(selected_peers, serviceable_peers, num_peers_to_choose)
     }
 
-    /// Identifies the peers in the given set of prospective peers
-    /// that can service the specified request.
+    /// Identifies the peers with the specified priority that can service the given request
     fn identify_serviceable(
         &self,
-        prospective_peers: HashSet<PeerNetworkId>,
+        peers_by_priorities: &BTreeMap<PeerPriority, HashSet<PeerNetworkId>>,
+        priority: PeerPriority,
         request: &StorageServiceRequest,
     ) -> HashSet<PeerNetworkId> {
+        // Get the peers for the specified priority
+        let prospective_peers = peers_by_priorities
+            .get(&priority)
+            .unwrap_or(&hashset![])
+            .clone();
+
+        // Identify and return the serviceable peers
         prospective_peers
             .into_iter()
             .filter(|peer| {
@@ -346,12 +549,39 @@ impl AptosDataClient {
     fn get_all_connected_peers(&self) -> crate::error::Result<HashSet<PeerNetworkId>, Error> {
         let connected_peers = self.storage_service_client.get_available_peers()?;
         if connected_peers.is_empty() {
-            return Err(Error::DataIsUnavailable(
-                "No connected AptosNet peers!".to_owned(),
+            return Err(Error::NoConnectedPeers(
+                "No available peers found!".to_owned(),
             ));
         }
 
         Ok(connected_peers)
+    }
+
+    /// Returns all peers grouped by priorities
+    fn get_peers_by_priorities(
+        &self,
+    ) -> crate::error::Result<BTreeMap<PeerPriority, HashSet<PeerNetworkId>>, Error> {
+        // Get all connected peers
+        let all_connected_peers = self.get_all_connected_peers()?;
+
+        // Group the peers by priority
+        let mut peers_by_priorities = BTreeMap::new();
+        for peer in all_connected_peers {
+            // Get the priority for the peer
+            let priority = priority::get_peer_priority(
+                self.base_config.clone(),
+                self.get_peers_and_metadata(),
+                &peer,
+            );
+
+            // Insert the peer into the priority map
+            peers_by_priorities
+                .entry(priority)
+                .or_insert_with(HashSet::new)
+                .insert(peer);
+        }
+
+        Ok(peers_by_priorities)
     }
 
     /// Returns all priority and regular peers. We define "priority peers" as
@@ -362,7 +592,7 @@ impl AptosDataClient {
         // Get all connected peers
         let all_connected_peers = self.get_all_connected_peers()?;
 
-        // Gather the peers based on priority
+        // Gather the priority and regular peers
         let mut priority_peers = hashset![];
         let mut regular_peers = hashset![];
         for peer in all_connected_peers {
@@ -377,39 +607,84 @@ impl AptosDataClient {
             }
         }
 
-        // Log the peers, periodically.
-        sample!(
-            SampleRate::Duration(Duration::from_secs(PEER_LOG_FREQ_SECS)),
-            update_connected_peer_metrics(priority_peers.len(), regular_peers.len());
-        );
-
         Ok((priority_peers, regular_peers))
     }
 
-    /// Sends a request (to an undecided peer) and decodes the response
+    /// Sends the specified storage request to a number of peers
+    /// in the network and decodes the first successful response.
     async fn send_request_and_decode<T, E>(
         &self,
         request: StorageServiceRequest,
         request_timeout_ms: u64,
     ) -> crate::error::Result<Response<T>>
     where
-        T: TryFrom<StorageServiceResponse, Error = E>,
+        T: TryFrom<StorageServiceResponse, Error = E> + Send + Sync + 'static,
         E: Into<Error>,
     {
-        // Select a peer to service the request
-        let peer = self.choose_peer_for_request(&request).map_err(|error| {
-            debug!(
-                (LogSchema::new(LogEntry::StorageServiceRequest)
-                    .event(LogEvent::PeerSelectionError)
-                    .message("Unable to select peer for request!")
-                    .error(&error))
-            );
-            error
-        })?;
+        // Select the peers to service the request
+        let peers = self.choose_peers_for_request(&request)?;
 
-        // Send the request to the peer and transform the response
-        self.send_request_to_peer_and_decode(peer, request, request_timeout_ms)
-            .await
+        // If peers is empty, return an error
+        if peers.is_empty() {
+            return Err(Error::DataIsUnavailable(format!(
+                "No peers were chosen to service the given request: {:?}",
+                request
+            )));
+        }
+
+        // Update the metrics for the number of selected peers (for the request)
+        metrics::observe_value_with_label(
+            &metrics::MULTI_FETCHES_PER_REQUEST,
+            &request.get_label(),
+            peers.len() as f64,
+        );
+
+        // Send the requests to the peers (and gather abort handles for the tasks)
+        let mut sent_requests = FuturesUnordered::new();
+        let mut abort_handles = vec![];
+        for peer in peers {
+            // Send the request to the peer
+            let aptos_data_client = self.clone();
+            let request = request.clone();
+            let sent_request = tokio::spawn(async move {
+                aptos_data_client
+                    .send_request_to_peer_and_decode(peer, request, request_timeout_ms)
+                    .await
+            });
+            let abort_handle = sent_request.abort_handle();
+
+            // Gather the tasks and abort handles
+            sent_requests.push(sent_request);
+            abort_handles.push(abort_handle);
+        }
+
+        // Wait for the first successful response and abort all other tasks.
+        // If all requests fail, gather the errors and return them.
+        let num_sent_requests = sent_requests.len();
+        let mut sent_request_errors = vec![];
+        for _ in 0..num_sent_requests {
+            if let Ok(response_result) = sent_requests.select_next_some().await {
+                match response_result {
+                    Ok(response) => {
+                        // We received a valid response. Abort all pending tasks.
+                        for abort_handle in abort_handles {
+                            abort_handle.abort();
+                        }
+                        return Ok(response); // Return the response
+                    },
+                    Err(error) => {
+                        // Gather the error and continue waiting for a response
+                        sent_request_errors.push(error)
+                    },
+                }
+            }
+        }
+
+        // Otherwise, all requests failed and we should return an error
+        Err(Error::DataIsUnavailable(format!(
+            "All {} attempts failed for the given request: {:?}. Errors: {:?}",
+            num_sent_requests, request, sent_request_errors
+        )))
     }
 
     /// Sends a request to a specific peer and decodes the response
@@ -596,7 +871,7 @@ impl AptosDataClient {
         data_request: DataRequest,
     ) -> crate::error::Result<Response<T>>
     where
-        T: TryFrom<StorageServiceResponse, Error = E>,
+        T: TryFrom<StorageServiceResponse, Error = E> + Send + Sync + 'static,
         E: Into<Error>,
     {
         let storage_request =
@@ -903,8 +1178,13 @@ impl SubscriptionState {
 }
 
 /// Updates the metrics for the number of connected peers (priority and regular)
-fn update_connected_peer_metrics(num_priority_peers: usize, num_regular_peers: usize) {
+fn update_priority_and_regular_peer_metrics(
+    priority_peers: &HashSet<PeerNetworkId>,
+    regular_peers: &HashSet<PeerNetworkId>,
+) {
     // Log the number of connected peers
+    let num_priority_peers = priority_peers.len();
+    let num_regular_peers = regular_peers.len();
     info!(
         (LogSchema::new(LogEntry::PeerStates)
             .event(LogEvent::PriorityAndRegularPeers)
@@ -925,4 +1205,34 @@ fn update_connected_peer_metrics(num_priority_peers: usize, num_regular_peers: u
         REGULAR_PEER,
         num_regular_peers as u64,
     );
+}
+
+/// Updates the metrics for the number of connected peers by priority
+fn update_peer_priority_metrics(
+    peers_by_priority: &BTreeMap<PeerPriority, HashSet<PeerNetworkId>>,
+) {
+    // Calculate the number of peers by priority
+    let mut num_peers_by_priority = BTreeMap::new();
+    for (priority, peers) in peers_by_priority {
+        num_peers_by_priority.insert(priority, peers.len());
+    }
+
+    // Log the number of connected peers by priority
+    info!(
+        (LogSchema::new(LogEntry::PeerStates)
+            .event(LogEvent::PriorityPeerCategories)
+            .message(&format!(
+                "Number of connected peers by priority: {:?}",
+                num_peers_by_priority,
+            )))
+    );
+
+    // Update the connected peer priority metrics
+    for (priority, num_peers) in num_peers_by_priority {
+        set_gauge(
+            &metrics::CONNECTED_PEERS_AND_PRIORITIES,
+            &priority.get_label(),
+            num_peers as u64,
+        );
+    }
 }

--- a/state-sync/aptos-data-client/src/error.rs
+++ b/state-sync/aptos-data-client/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     InvalidRequest(String),
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
+    #[error("No connected peers: {0}")]
+    NoConnectedPeers(String),
     #[error("The subscription stream is lagging behind the data advertisements: {0}")]
     SubscriptionStreamIsLagging(String),
     #[error("Timed out waiting for a response: {0}")]
@@ -33,6 +35,7 @@ impl Error {
             Self::DataIsTooLarge(_) => "data_is_too_large",
             Self::InvalidRequest(_) => "invalid_request",
             Self::InvalidResponse(_) => "invalid_response",
+            Self::NoConnectedPeers(_) => "no_connected_peers",
             Self::SubscriptionStreamIsLagging(_) => "subscription_stream_is_lagging",
             Self::TimeoutWaitingForResponse(_) => "timeout_waiting_for_response",
             Self::UnexpectedErrorEncountered(_) => "unexpected_error_encountered",

--- a/state-sync/aptos-data-client/src/logging.rs
+++ b/state-sync/aptos-data-client/src/logging.rs
@@ -60,6 +60,7 @@ pub enum LogEvent {
     PeerRequestResponseCounts,
     PeerSelectionError,
     PriorityAndRegularPeers,
+    PriorityPeerCategories,
     ResponseError,
     ResponseSuccess,
     SendRequest,

--- a/state-sync/aptos-data-client/src/metrics.rs
+++ b/state-sync/aptos-data-client/src/metrics.rs
@@ -48,6 +48,22 @@ pub static ERROR_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+// Buckets for tracking the number of multi-fetches sent per request
+const MULTI_FETCH_BUCKETS: &[f64] = &[
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0,
+    80.0, 90.0, 100.0, 150.0, 200.0, 300.0, 400.0, 500.0,
+];
+
+/// Counter for tracking the number of multi-fetches sent per request
+pub static MULTI_FETCHES_PER_REQUEST: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram_opts = histogram_opts!(
+        "aptos_data_client_multi_fetches_per_request",
+        "Counters related to the number of multi-fetches sent per request",
+        MULTI_FETCH_BUCKETS.to_vec()
+    );
+    register_histogram_vec!(histogram_opts, &["label"]).unwrap()
+});
+
 // Latency buckets for network latencies (seconds)
 const REQUEST_LATENCY_BUCKETS_SECS: &[f64] = &[
     0.05, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.5, 10.0, 15.0, 20.0, 30.0, 40.0,
@@ -79,6 +95,16 @@ pub static CONNECTED_PEERS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "aptos_data_client_connected_peers",
         "Gauge related to the number of connected peers",
+        &["peer_type"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the number of connected peers by priority
+pub static CONNECTED_PEERS_AND_PRIORITIES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_data_client_connected_peers_and_priorities",
+        "Gauge related to the number of connected peers by priority",
         &["peer_type"]
     )
     .unwrap()

--- a/state-sync/aptos-data-client/src/poller.rs
+++ b/state-sync/aptos-data-client/src/poller.rs
@@ -11,7 +11,6 @@ use crate::{
     metrics,
     metrics::{set_gauge, DataType, PRIORITIZED_PEER, REGULAR_PEER},
     utils,
-    utils::choose_peers_by_latency,
 };
 use aptos_config::{
     config::{AptosDataClientConfig, AptosDataPollerConfig},
@@ -117,7 +116,7 @@ impl DataSummaryPoller {
         );
 
         // Select a subset of the priority peers to poll
-        self.select_peers_to_poll(all_priority_peers, num_peers_to_poll)
+        self.select_peers_to_poll(all_priority_peers, num_peers_to_poll as usize)
     }
 
     /// Identifies the next set of regular peers to poll from
@@ -146,7 +145,7 @@ impl DataSummaryPoller {
         );
 
         // Select a subset of the regular peers to poll
-        self.select_peers_to_poll(all_regular_peers, num_peers_to_poll)
+        self.select_peers_to_poll(all_regular_peers, num_peers_to_poll as usize)
     }
 
     /// Selects the peers to poll from the given peer
@@ -154,7 +153,7 @@ impl DataSummaryPoller {
     fn select_peers_to_poll(
         &self,
         mut potential_peers: HashSet<PeerNetworkId>,
-        num_peers_to_poll: u64,
+        num_peers_to_poll: usize,
     ) -> HashSet<PeerNetworkId> {
         // Filter out the peers that have an in-flight request
         let peers_with_in_flight_polls = self.all_peers_with_in_flight_polls();
@@ -186,9 +185,9 @@ impl DataSummaryPoller {
                     .collect();
 
                 // Select the latency weighted peers
-                let peers_to_poll_by_latency = choose_peers_by_latency(
+                let peers_to_poll_by_latency = utils::choose_peers_by_latency(
                     self.data_client_config.clone(),
-                    num_peers_to_poll_by_latency,
+                    num_peers_to_poll_by_latency as u64,
                     potential_peers,
                     self.peers_and_metadata.clone(),
                     false,
@@ -303,8 +302,8 @@ pub async fn start_poller(poller: DataSummaryPoller) {
             );
         }
 
-        // Update the logs and metrics for the peer request distributions
-        poller.data_client.update_peer_request_logs_and_metrics();
+        // Update the metrics and logs for the peer states
+        poller.data_client.update_peer_metrics_and_logs();
 
         // Determine the peers to poll this round. If the round is even, poll
         // the priority peers. Otherwise, poll the regular peers. This allows

--- a/state-sync/aptos-data-client/src/priority.rs
+++ b/state-sync/aptos-data-client/src/priority.rs
@@ -10,8 +10,11 @@ use aptos_network::application::storage::PeersAndMetadata;
 use itertools::Itertools;
 use std::sync::Arc;
 
-/// A simple enum containing the different categories for peer prioritization
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// A simple enum containing the different categories for peer prioritization.
+///
+/// Note: If another priority is added to this enum, it should also be added
+/// to `get_all_ordered_priorities`, below.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum PeerPriority {
     HighPriority,   // Peers to highly prioritize when requesting data
     MediumPriority, // Peers to prioritize iff high priority peers are unavailable
@@ -19,6 +22,16 @@ pub enum PeerPriority {
 }
 
 impl PeerPriority {
+    /// Returns a list of all peer priorities, ordered from
+    /// highest to lowest priority.
+    pub fn get_all_ordered_priorities() -> Vec<PeerPriority> {
+        vec![
+            PeerPriority::HighPriority,
+            PeerPriority::MediumPriority,
+            PeerPriority::LowPriority,
+        ]
+    }
+
     /// Returns the label for the peer priority
     pub fn get_label(&self) -> String {
         let label = match self {
@@ -136,11 +149,11 @@ mod tests {
     use aptos_network::{application::storage::PeersAndMetadata, transport::ConnectionMetadata};
     use aptos_types::PeerId;
     use maplit::hashmap;
-    use std::sync::Arc;
+    use std::{assert_eq, sync::Arc};
 
     #[test]
     fn test_is_high_priority_peer_validator() {
-        // Create a base config for a validator node
+        // Create a base config for a validator
         let base_config = Arc::new(BaseConfig {
             role: RoleType::Validator,
             ..Default::default()
@@ -177,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_is_priority_peer_vfn() {
-        // Create a base config for a VFN node
+        // Create a base config for a VFN
         let base_config = Arc::new(BaseConfig {
             role: RoleType::FullNode,
             ..Default::default()
@@ -300,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_validator_priorities() {
-        // Create a base config for a validator node
+        // Create a base config for a validator
         let base_config = Arc::new(BaseConfig {
             role: RoleType::Validator,
             ..Default::default()
@@ -338,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_vfn_priorities() {
-        // Create a base config for a VFN node
+        // Create a base config for a VFN
         let base_config = Arc::new(BaseConfig {
             role: RoleType::FullNode,
             ..Default::default()

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -7,10 +7,11 @@ use crate::{
     global_summary::GlobalDataSummary,
     interface::{AptosDataClientInterface, Response, SubscriptionRequestMetadata},
     poller::DataSummaryPoller,
+    priority::PeerPriority,
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
-    config::{AptosDataClientConfig, BaseConfig},
+    config::{AptosDataClientConfig, BaseConfig, RoleType},
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_netcore::transport::ConnectionOrigin;
@@ -47,9 +48,11 @@ use std::{collections::HashMap, sync::Arc};
 
 /// A simple mock network for testing the data client
 pub struct MockNetwork {
+    base_config: BaseConfig,                   // The base config of the node
+    networks: Vec<NetworkId>,                  // The networks that the node is connected to
+    peers_and_metadata: Arc<PeersAndMetadata>, // The peers and metadata struct
     peer_mgr_reqs_rxs:
-        HashMap<NetworkId, aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>>,
-    peers_and_metadata: Arc<PeersAndMetadata>,
+        HashMap<NetworkId, aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>>, // The peer manager request receivers
 }
 
 impl MockNetwork {
@@ -103,7 +106,7 @@ impl MockNetwork {
         let data_client_config = data_client_config.unwrap_or_default();
         let (client, poller) = AptosDataClient::new(
             data_client_config,
-            base_config,
+            base_config.clone(),
             mock_time.clone(),
             create_mock_db_reader(),
             storage_service_client,
@@ -112,6 +115,8 @@ impl MockNetwork {
 
         // Create the mock network
         let mock_network = Self {
+            base_config,
+            networks,
             peer_mgr_reqs_rxs,
             peers_and_metadata,
         };
@@ -120,14 +125,41 @@ impl MockNetwork {
     }
 
     /// Add a new peer to the network peer DB
-    pub fn add_peer(&mut self, priority: bool) -> PeerNetworkId {
-        // Get the network id
-        let network_id = if priority {
-            NetworkId::Validator
-        } else {
-            NetworkId::Public
+    pub fn add_peer(&mut self, peer_priority: PeerPriority) -> PeerNetworkId {
+        // Determine the network ID and connection direction
+        // based on the given peer priority and the node role.
+        let (network_id, outbound_connection) = match self.base_config.role {
+            RoleType::Validator => {
+                // Validators prioritize other validators, then VFNs, then PFNs
+                match peer_priority {
+                    PeerPriority::HighPriority => (NetworkId::Validator, true),
+                    PeerPriority::MediumPriority => (NetworkId::Vfn, false),
+                    PeerPriority::LowPriority => (NetworkId::Public, false),
+                }
+            },
+            RoleType::FullNode => {
+                if self.networks.contains(&NetworkId::Vfn) {
+                    // VFNs prioritize validators, then other VFNs, then PFNs
+                    match peer_priority {
+                        PeerPriority::HighPriority => (NetworkId::Vfn, true),
+                        PeerPriority::MediumPriority => (NetworkId::Public, true), // Outbound connection to VFN
+                        PeerPriority::LowPriority => (NetworkId::Public, false), // Inbound connection from PFN
+                    }
+                } else {
+                    // PFNs prioritize VFNs, then other PFNs
+                    match peer_priority {
+                        PeerPriority::HighPriority => (NetworkId::Public, true), // Outbound connection to VFN
+                        PeerPriority::MediumPriority => {
+                            unimplemented!("Medium priority peers are not yet supported for PFNs!")
+                        },
+                        PeerPriority::LowPriority => (NetworkId::Public, false), // Inbound connection from PFN
+                    }
+                }
+            },
         };
-        self.add_peer_with_network_id(network_id, false)
+
+        // Create and add the new peer
+        self.add_peer_with_network_id(network_id, outbound_connection)
     }
 
     /// Add a new peer to the network peer DB with the specified network

--- a/state-sync/aptos-data-client/src/tests/mod.rs
+++ b/state-sync/aptos-data-client/src/tests/mod.rs
@@ -4,7 +4,9 @@
 mod advertise;
 mod compression;
 pub mod mock;
+mod multi_fetch;
 mod peers;
 mod poller;
 mod priority;
 mod utils;
+mod weighted_selection;

--- a/state-sync/aptos-data-client/src/tests/multi_fetch.rs
+++ b/state-sync/aptos-data-client/src/tests/multi_fetch.rs
@@ -1,0 +1,1493 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::AptosDataClient,
+    priority::PeerPriority,
+    tests::{mock::MockNetwork, utils, utils::NUM_SELECTION_ITERATIONS},
+};
+use aptos_config::{
+    config::{AptosDataClientConfig, AptosDataMultiFetchConfig},
+    network_id::NetworkId,
+};
+use aptos_storage_service_types::requests::{
+    DataRequest, StorageServiceRequest, TransactionOutputsWithProofRequest,
+};
+use aptos_time_service::TimeServiceTrait;
+use maplit::hashset;
+use std::collections::{HashMap, HashSet};
+
+#[tokio::test]
+async fn multi_fetch_disabled_trivial_request() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client config with multi-fetch disabled
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create a server version request that is trivially serviceable
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Ensure no peers can service the request (we have no connections)
+    utils::verify_request_is_unserviceable(&client, &server_version_request, true);
+
+    // Ensure the properties hold for all peer priorities (with increasing priority)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Add many peers for the current priority
+        let peers = utils::add_several_peers(&mut mock_network, 100, *peer_priority);
+
+        // Verify only a single peer is selected from the current priority set
+        utils::verify_selected_peer_from_set(&client, &server_version_request, &peers);
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_disabled_optimistic_fetch_request() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client config with multi-fetch disabled
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+
+    // Ensure the properties hold for all optimistic fetch requests
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+        // Ensure the properties hold for all peer priorities
+        for peer_priority in PeerPriority::get_all_ordered_priorities() {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request.clone(), true);
+
+            // Create the mock network, time service and client
+            let (mut mock_network, time_service, client, _) = MockNetwork::new(
+                Some(base_config.clone()),
+                Some(data_client_config),
+                Some(networks.clone()),
+            );
+
+            // Ensure no peers can service the request (we have no connections)
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
+
+            // Add several peers and verify the request is still unserviceable
+            let peers = utils::add_several_peers(&mut mock_network, 100, peer_priority);
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Advertise the data for the peers and verify a single peer is selected
+            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+            for peer in peers.iter() {
+                client.update_peer_storage_summary(
+                    *peer,
+                    utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+                );
+            }
+            utils::verify_selected_peer_from_set(&client, &storage_request, &peers);
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_optimistic_fetch_extend_with_random_peers() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 5;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let min_validator_distance = 0;
+    let max_validator_distance = 3;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Ensure the properties hold for both distance and latency metadata
+            for remove_distance_metadata in [true, false] {
+                // Create the mock network and client
+                let (mut mock_network, time_service, client, _) =
+                    MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+                // Create the storage request
+                let storage_request = StorageServiceRequest::new(data_request.clone(), true);
+
+                // Add several peers
+                let num_peers = 50;
+                let peers = utils::add_several_peers_with_metadata(
+                    &mut mock_network,
+                    &client,
+                    num_peers as u64,
+                    min_validator_distance,
+                    max_validator_distance,
+                    peer_priority,
+                );
+
+                // Remove the distance or latency metadata for all except some peers
+                let num_peers_with_latency_metadata = 2;
+                let peers: Vec<_> = peers.into_iter().collect();
+                for peer in peers[num_peers_with_latency_metadata..].iter() {
+                    if remove_distance_metadata {
+                        utils::remove_distance_metadata(&client, *peer)
+                    } else {
+                        utils::remove_latency_metadata(&client, *peer);
+                    }
+                }
+
+                // Advertise the data for the peers
+                utils::update_storage_summaries_for_peers(
+                    &client,
+                    &HashSet::from_iter(peers.clone()),
+                    known_version,
+                    time_service.now_unix_time().as_micros(),
+                );
+
+                // Select peers to service the request multiple times
+                let peers_and_selection_counts = utils::select_peers_multiple_times(
+                    &client,
+                    num_peers_for_multi_fetch,
+                    &storage_request,
+                );
+
+                // Build a max-heap of all peers by their selection counts
+                let mut max_heap_selection_counts =
+                    utils::build_selection_count_max_heap(&peers_and_selection_counts);
+
+                // Verify the top peers in the max-heap are the peers with latency metadata
+                for _ in 0..num_peers_with_latency_metadata {
+                    // Get the peer monitoring metadata
+                    let peer_monitoring_metadata = utils::get_peer_monitoring_metadata(
+                        &mut mock_network,
+                        max_heap_selection_counts.pop().unwrap().1,
+                    );
+
+                    // Verify the appropriate metadata is present
+                    if remove_distance_metadata {
+                        assert!(peer_monitoring_metadata
+                            .latest_network_info_response
+                            .is_some());
+                    } else {
+                        assert!(peer_monitoring_metadata.average_ping_latency_secs.is_some());
+                    }
+                }
+
+                // Verify the rest of the peers in the max-heap are the peers without latency metadata
+                for _ in num_peers_with_latency_metadata..num_peers {
+                    // Get the peer monitoring metadata
+                    let peer_monitoring_metadata = utils::get_peer_monitoring_metadata(
+                        &mut mock_network,
+                        max_heap_selection_counts.pop().unwrap().1,
+                    );
+
+                    // Verify the appropriate metadata has been removed
+                    if remove_distance_metadata {
+                        assert!(peer_monitoring_metadata
+                            .latest_network_info_response
+                            .is_none());
+                    } else {
+                        assert!(peer_monitoring_metadata.average_ping_latency_secs.is_none());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_optimistic_fetch_priority() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client with a max lag of 10 and multi-fetch enabled (3 peers per request)
+    let peers_for_multi_fetch = 3;
+    let max_optimistic_fetch_lag_secs = 10;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: peers_for_multi_fetch,
+            max_peers_for_multi_fetch: peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, time_service, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create test data
+    let known_version = 1000;
+    let known_epoch = 5;
+
+    // Ensure the properties hold for all peer priorities (in increasing priority order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Add several peers and verify the request is unserviceable
+            let peers = utils::add_several_peers(&mut mock_network, 100, *peer_priority);
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Advertise the data for the peers and verify multiple peers are selected
+            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+            for peer in peers.iter() {
+                client.update_peer_storage_summary(
+                    *peer,
+                    utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+                );
+            }
+            verify_num_selected_peers(&client, &storage_request, 3);
+
+            // Disconnect all peers
+            utils::disconnect_all_peers(&mut mock_network, &HashSet::from_iter(peers));
+
+            // Add a single peer and advertise the data for the peer
+            let peer = mock_network.add_peer(*peer_priority);
+            client.update_peer_storage_summary(
+                peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+
+            // Verify the peer is selected
+            utils::verify_selected_peers_match(&client, hashset![peer], &storage_request);
+
+            // Disconnect the peer and verify the request is unserviceable
+            mock_network.disconnect_peer(peer);
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_optimistic_fetch_priority_mix() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client with a max lag of 1 and multi-fetch enabled (4 peers per request)
+    let peers_for_multi_fetch = 4;
+    let max_optimistic_fetch_lag_secs = 1;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 1,
+            max_peers_for_multi_fetch: peers_for_multi_fetch,
+            multi_fetch_peer_bucket_size: 2,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, time_service, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Create test data
+    let known_version = 1000;
+    let known_epoch = 5;
+
+    // Ensure the properties hold for all optimistic fetch requests
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+        // Create the storage request
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several low priority peers and verify the request is unserviceable
+        let low_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::LowPriority);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+        // Advertise the data for the low priority peers and verify multiple peers are selected
+        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+        for peer in low_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+        utils::verify_selected_peers_from_set(
+            &client,
+            &storage_request,
+            peers_for_multi_fetch,
+            &low_priority_peers,
+        );
+
+        // Add several medium priority peers
+        let medium_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::MediumPriority);
+
+        // Verify the request is still serviced by low priority peers
+        utils::verify_selected_peers_from_set(
+            &client,
+            &storage_request,
+            peers_for_multi_fetch,
+            &low_priority_peers,
+        );
+
+        // Advertise the data for the medium priority peers
+        for peer in medium_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+
+        // Make several requests and verify medium priority peers are selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_from_set(
+                &client,
+                &storage_request,
+                peers_for_multi_fetch,
+                &medium_priority_peers,
+            );
+        }
+
+        // Add several high priority peers
+        let high_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::HighPriority);
+
+        // Verify the request is still serviced by medium priority peers
+        utils::verify_selected_peers_from_set(
+            &client,
+            &storage_request,
+            peers_for_multi_fetch,
+            &medium_priority_peers,
+        );
+
+        // Advertise the data for the high priority peers
+        for peer in high_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+
+        // Make several requests and verify high priority peers are selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_from_set(
+                &client,
+                &storage_request,
+                peers_for_multi_fetch,
+                &high_priority_peers,
+            );
+        }
+
+        // Disconnect all high priority peers (except a single one)
+        for (index, peer) in high_priority_peers.iter().enumerate() {
+            if index != 0 {
+                mock_network.disconnect_peer(*peer);
+            }
+        }
+        let high_priority_peer = *high_priority_peers.iter().next().unwrap();
+
+        // Make several requests and verify medium priority peers are selected (alongside the high priority peer)
+        for _ in 0..100 {
+            let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+            assert_eq!(selected_peers.len(), peers_for_multi_fetch);
+            assert!(selected_peers.contains(&high_priority_peer));
+            let selected_medium_priority_peers: HashSet<_> = selected_peers
+                .difference(&hashset![high_priority_peer])
+                .cloned()
+                .collect();
+            medium_priority_peers.is_superset(&selected_medium_priority_peers);
+        }
+
+        // Disconnect all medium priority peers
+        utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+
+        // Make several requests and verify only the high priority peer is selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_match(
+                &client,
+                hashset![high_priority_peer],
+                &storage_request,
+            );
+        }
+
+        // Disconnect the high priority peer
+        mock_network.disconnect_peer(high_priority_peer);
+
+        // Make several requests and verify low priority peers are selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_from_set(
+                &client,
+                &storage_request,
+                peers_for_multi_fetch,
+                &low_priority_peers,
+            );
+        }
+
+        // Add two medium priority peers
+        let medium_priority_peers = hashset![
+            mock_network.add_peer(PeerPriority::MediumPriority),
+            mock_network.add_peer(PeerPriority::MediumPriority)
+        ];
+
+        // Advertise the data for the medium priority peers
+        for peer in medium_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+
+        // Make several requests and verify the medium priority peers are selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_match(
+                &client,
+                medium_priority_peers.clone(),
+                &storage_request,
+            );
+        }
+
+        // Disconnect all medium priority peers
+        utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+
+        // Make several requests and verify the low priority peers are selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_from_set(
+                &client,
+                &storage_request,
+                peers_for_multi_fetch,
+                &low_priority_peers,
+            );
+        }
+
+        // Disconnect all low priority peers
+        utils::disconnect_all_peers(&mut mock_network, &low_priority_peers);
+
+        // Verify the request is unserviceable
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_peer_bucket_sizes() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client config with multi-fetch enabled
+    let additional_requests_per_peer_bucket = 2;
+    let min_peers_for_multi_fetch = 2;
+    let max_peers_for_multi_fetch = 1000;
+    let multi_fetch_peer_bucket_size = 4;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            additional_requests_per_peer_bucket,
+            min_peers_for_multi_fetch,
+            max_peers_for_multi_fetch,
+            multi_fetch_peer_bucket_size,
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Create a server version request that is trivially serviceable
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Add the minimum number of low priority peers and verify the correct number of peers are selected
+    let low_priority_peers = utils::add_several_peers(
+        &mut mock_network,
+        min_peers_for_multi_fetch as u64,
+        PeerPriority::LowPriority,
+    );
+    utils::verify_selected_peers_match(
+        &client,
+        low_priority_peers.clone(),
+        &server_version_request,
+    );
+
+    // Add a large number of low priority peers and verify the correct number of peers are selected
+    let _ = utils::add_several_peers(
+        &mut mock_network,
+        (max_peers_for_multi_fetch * 2) as u64,
+        PeerPriority::LowPriority,
+    );
+    verify_num_selected_peers(&client, &server_version_request, max_peers_for_multi_fetch);
+
+    // Add less than the minimum number of medium priority peers and verify the correct number of peers are selected
+    let medium_priority_peers = utils::add_several_peers(
+        &mut mock_network,
+        (min_peers_for_multi_fetch - 1) as u64,
+        PeerPriority::MediumPriority,
+    );
+    verify_num_selected_peers(
+        &client,
+        &server_version_request,
+        min_peers_for_multi_fetch - 1,
+    );
+
+    // Disconnect all medium priority peers and verify the correct number of peers are selected
+    utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+    verify_num_selected_peers(&client, &server_version_request, max_peers_for_multi_fetch);
+
+    // Add exactly a single bucket of high priority peers and verify the correct number of peers are selected
+    let mut high_priority_peers = utils::add_several_peers(
+        &mut mock_network,
+        multi_fetch_peer_bucket_size as u64,
+        PeerPriority::HighPriority,
+    );
+    verify_num_selected_peers(
+        &client,
+        &server_version_request,
+        min_peers_for_multi_fetch + additional_requests_per_peer_bucket,
+    );
+
+    // Continue to add buckets of high priority peers and verify the correct number of peers are selected
+    for index in 0..10 {
+        for _ in 0..multi_fetch_peer_bucket_size {
+            let high_priority_peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(high_priority_peer);
+        }
+        verify_num_selected_peers(
+            &client,
+            &server_version_request,
+            min_peers_for_multi_fetch + additional_requests_per_peer_bucket * (index + 2),
+        );
+    }
+
+    // Disconnect all high priority peers and verify the correct number of peers are selected
+    utils::disconnect_all_peers(&mut mock_network, &high_priority_peers);
+    verify_num_selected_peers(&client, &server_version_request, max_peers_for_multi_fetch);
+}
+
+#[tokio::test]
+async fn multi_fetch_peer_bucket_sizes_across_buckets() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client config with multi-fetch enabled
+    let additional_requests_per_peer_bucket = 10;
+    let min_peers_for_multi_fetch = 5;
+    let max_peers_for_multi_fetch = 1000;
+    let multi_fetch_peer_bucket_size = 1;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            additional_requests_per_peer_bucket,
+            min_peers_for_multi_fetch,
+            max_peers_for_multi_fetch,
+            multi_fetch_peer_bucket_size,
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Create a server version request that is trivially serviceable
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Add a large number of low priority peers and verify the correct number of peers are selected
+    let low_priority_peers = utils::add_several_peers(
+        &mut mock_network,
+        (max_peers_for_multi_fetch * 2) as u64,
+        PeerPriority::LowPriority,
+    );
+    verify_num_selected_peers(&client, &server_version_request, max_peers_for_multi_fetch);
+
+    // Add less than the minimum number of medium priority peers and verify the correct number of peers are selected
+    let medium_priority_peers = utils::add_several_peers(
+        &mut mock_network,
+        (min_peers_for_multi_fetch - 1) as u64,
+        PeerPriority::MediumPriority,
+    );
+    verify_num_selected_peers(
+        &client,
+        &server_version_request,
+        min_peers_for_multi_fetch - 1,
+    );
+
+    // Add a single high priority peer and verify the correct peers are selected
+    let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+    let expected_peers = hashset![high_priority_peer_1]
+        .union(&medium_priority_peers)
+        .cloned()
+        .collect();
+    utils::verify_selected_peers_match(&client, expected_peers, &server_version_request);
+
+    // Remove all medium priority peers and verify the correct peers are selected
+    utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add another high priority peer and verify the correct peers are selected
+    let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, high_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Remove all high priority peers and verify the correct peers are selected
+    utils::disconnect_all_peers(&mut mock_network, &hashset![
+        high_priority_peer_1,
+        high_priority_peer_2
+    ]);
+    verify_num_selected_peers(&client, &server_version_request, max_peers_for_multi_fetch);
+
+    // Disconnect all low priority peers
+    utils::disconnect_all_peers(&mut mock_network, &low_priority_peers);
+
+    // Connect a single high priority peer and medium priority peer
+    let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+    let medium_priority_peer_1 = mock_network.add_peer(PeerPriority::MediumPriority);
+
+    // Verify the correct peers are selected
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, medium_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Disconnect all peers
+    utils::disconnect_all_peers(&mut mock_network, &hashset![
+        high_priority_peer_1,
+        medium_priority_peer_1
+    ]);
+
+    // Verify the request is unserviceable
+    utils::verify_request_is_unserviceable(&client, &server_version_request, true);
+}
+
+#[tokio::test]
+async fn multi_fetch_request_selection_extend_with_random_peers() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client with multi-fetch enabled (4 peers per request)
+    let num_peers_for_multi_fetch = 4;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create the storage request
+        let server_version_request =
+            StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+        // Create the mock network and client
+        let (mut mock_network, _, client, _) =
+            MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+        // Add several peers
+        let num_peers = 50;
+        let peers = utils::add_several_peers_with_metadata(
+            &mut mock_network,
+            &client,
+            num_peers as u64,
+            0,
+            3,
+            peer_priority,
+        );
+
+        // Remove the latency metadata for all except some peers
+        let num_peers_with_latency_metadata = 2;
+        let peers: Vec<_> = peers.into_iter().collect();
+        for peer in peers[num_peers_with_latency_metadata..].iter() {
+            utils::remove_latency_metadata(&client, *peer);
+        }
+
+        // Select peers to service the request multiple times
+        let mut peers_and_selection_counts = HashMap::new();
+        for _ in 0..NUM_SELECTION_ITERATIONS {
+            // Select peers to service the request
+            let selected_peers = client
+                .choose_peers_for_request(&server_version_request)
+                .unwrap();
+            assert_eq!(selected_peers.len(), num_peers_for_multi_fetch);
+
+            // Update the peer selection counts
+            for selected_peer in selected_peers {
+                *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
+            }
+        }
+
+        // Build a max-heap of all peers by their selection counts
+        let mut max_heap_selection_counts =
+            utils::build_selection_count_max_heap(&peers_and_selection_counts);
+
+        // Verify the top peers in the max-heap are the peers with latency metadata
+        for _ in 0..num_peers_with_latency_metadata {
+            let peer_monitoring_metadata = utils::get_peer_monitoring_metadata(
+                &mut mock_network,
+                max_heap_selection_counts.pop().unwrap().1,
+            );
+            assert!(peer_monitoring_metadata.average_ping_latency_secs.is_some())
+        }
+
+        // Verify the rest of the peers in the max-heap are the peers without latency metadata
+        for _ in num_peers_with_latency_metadata..num_peers {
+            // Get the peer monitoring metadata
+            let peer_monitoring_metadata = utils::get_peer_monitoring_metadata(
+                &mut mock_network,
+                max_heap_selection_counts.pop().unwrap().1,
+            );
+            assert!(peer_monitoring_metadata.average_ping_latency_secs.is_none())
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_request_selection_priority() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client with multi-fetch enabled (4 peers per request)
+    let peers_for_multi_fetch = 4;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: peers_for_multi_fetch,
+            max_peers_for_multi_fetch: peers_for_multi_fetch,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Ensure the properties hold for all peer priorities (in increasing priority order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Create the storage request
+        let server_version_request =
+            StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+        // Add several peers
+        let peers = utils::add_several_peers(&mut mock_network, 100, *peer_priority);
+
+        // Verify multiple peers are selected
+        utils::verify_selected_peers_from_set(
+            &client,
+            &server_version_request,
+            peers_for_multi_fetch,
+            &peers,
+        );
+
+        // Disconnect all peers
+        utils::disconnect_all_peers(&mut mock_network, &peers);
+
+        // Add a single peer
+        let peer = mock_network.add_peer(*peer_priority);
+
+        // Verify the peer is selected
+        utils::verify_selected_peers_match(&client, hashset![peer], &server_version_request);
+
+        // Disconnect the peer and verify the request is unserviceable
+        mock_network.disconnect_peer(peer);
+        utils::verify_request_is_unserviceable(&client, &server_version_request, true);
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_request_selection_priority_mix() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client with multi-fetch enabled (3 peers per request)
+    let peers_for_multi_fetch = 3;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: peers_for_multi_fetch,
+            multi_fetch_peer_bucket_size: 3,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Create the storage request
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Add several low priority peers
+    let low_priority_peers =
+        utils::add_several_peers(&mut mock_network, 100, PeerPriority::LowPriority);
+
+    // Verify the low priority peers are selected
+    utils::verify_selected_peers_from_set(
+        &client,
+        &server_version_request,
+        peers_for_multi_fetch,
+        &low_priority_peers,
+    );
+
+    // Add several medium priority peers
+    let medium_priority_peers =
+        utils::add_several_peers(&mut mock_network, 100, PeerPriority::MediumPriority);
+
+    // Verify the medium priority peers are selected
+    utils::verify_selected_peers_from_set(
+        &client,
+        &server_version_request,
+        peers_for_multi_fetch,
+        &medium_priority_peers,
+    );
+
+    // Add several high priority peers
+    let high_priority_peers =
+        utils::add_several_peers(&mut mock_network, 100, PeerPriority::HighPriority);
+
+    // Verify the high priority peers are selected
+    utils::verify_selected_peers_from_set(
+        &client,
+        &server_version_request,
+        peers_for_multi_fetch,
+        &high_priority_peers,
+    );
+
+    // Disconnect all high priority peers
+    utils::disconnect_all_peers(&mut mock_network, &high_priority_peers);
+
+    // Add a single high priority peer
+    let high_priority_peer = mock_network.add_peer(PeerPriority::HighPriority);
+
+    // Verify the high priority peer is selected (along side several medium priority peers)
+    let selected_peers = client
+        .choose_peers_for_request(&server_version_request)
+        .unwrap();
+    assert_eq!(selected_peers.len(), peers_for_multi_fetch);
+    let selected_medium_priority_peers: HashSet<_> = selected_peers
+        .difference(&hashset![high_priority_peer])
+        .cloned()
+        .collect();
+    medium_priority_peers.is_superset(&selected_medium_priority_peers);
+
+    // Disconnect all medium priority peers
+    utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+
+    // Make several requests and verify only the high priority peer is selected
+    for _ in 0..100 {
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer],
+            &server_version_request,
+        );
+    }
+
+    // Disconnect the high priority peer
+    mock_network.disconnect_peer(high_priority_peer);
+
+    // Make several requests and verify the low priority peers are selected
+    for _ in 0..100 {
+        utils::verify_selected_peers_from_set(
+            &client,
+            &server_version_request,
+            peers_for_multi_fetch,
+            &low_priority_peers,
+        );
+    }
+
+    // Add two medium priority peers
+    let medium_priority_peers = hashset![
+        mock_network.add_peer(PeerPriority::MediumPriority),
+        mock_network.add_peer(PeerPriority::MediumPriority)
+    ];
+
+    // Make several requests and verify the medium priority peers are selected
+    for _ in 0..100 {
+        utils::verify_selected_peers_match(
+            &client,
+            medium_priority_peers.clone(),
+            &server_version_request,
+        );
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_simple_peer_selection() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create a data client config with multi-fetch enabled (2 -> 3 peers per request)
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 3,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Create a storage request for transaction outputs
+    let output_data_request =
+        DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            proof_version: 100,
+            start_version: 0,
+            end_version: 100,
+        });
+    let storage_request = StorageServiceRequest::new(output_data_request, false);
+
+    // Ensure no peers can service the request (we have no connections)
+    utils::verify_request_is_unserviceable(&client, &storage_request, true);
+
+    // Add a low priority peer and verify it cannot service the request (no advertised data)
+    let low_priority_peer = mock_network.add_peer(PeerPriority::LowPriority);
+    utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+    // Add a medium priority peer and verify it cannot service the request (no advertised data)
+    let medium_priority_peer = mock_network.add_peer(PeerPriority::MediumPriority);
+    utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+    // Add two high priority peers and verify they cannot service the request (no advertised data)
+    let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+    let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+    utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+    // Request data that is not being advertised (by anyone) and verify we get an error
+    let output_data_request =
+        DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            proof_version: 100,
+            start_version: 0,
+            end_version: 100,
+        });
+    let storage_request = StorageServiceRequest::new(output_data_request, false);
+    utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+    // Advertise the data for the low priority peer and verify it is now selected
+    client.update_peer_storage_summary(low_priority_peer, utils::create_storage_summary(100));
+    utils::verify_selected_peers_match(&client, hashset![low_priority_peer], &storage_request);
+
+    // Advertise the data for high priority peer 2 and verify the peer is selected
+    client.update_peer_storage_summary(high_priority_peer_2, utils::create_storage_summary(100));
+    utils::verify_selected_peers_match(&client, hashset![high_priority_peer_2], &storage_request);
+
+    // Reconnect high priority peer 1 and remove the advertised data for high priority peer 2
+    mock_network.reconnect_peer(high_priority_peer_1);
+    client.update_peer_storage_summary(high_priority_peer_2, utils::create_storage_summary(0));
+
+    // Request the data again and verify the low priority peer is chosen
+    utils::verify_selected_peers_match(&client, hashset![low_priority_peer], &storage_request);
+
+    // Advertise the data for high priority peer 1 and verify the peer is selected
+    client.update_peer_storage_summary(high_priority_peer_1, utils::create_storage_summary(100));
+    utils::verify_selected_peers_match(&client, hashset![high_priority_peer_1], &storage_request);
+
+    // Advertise the data for high priority peer 2 and verify both high priority peers are selected
+    client.update_peer_storage_summary(high_priority_peer_2, utils::create_storage_summary(100));
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, high_priority_peer_2],
+        &storage_request,
+    );
+
+    // Disconnect both high priority peers and verify the low priority peer is selected
+    utils::disconnect_all_peers(&mut mock_network, &hashset![
+        high_priority_peer_1,
+        high_priority_peer_2
+    ]);
+    utils::verify_selected_peers_match(&client, hashset![low_priority_peer], &storage_request);
+
+    // Advertise the data for the medium priority peer and verify the peer is selected
+    client.update_peer_storage_summary(medium_priority_peer, utils::create_storage_summary(100));
+    utils::verify_selected_peers_match(&client, hashset![medium_priority_peer], &storage_request);
+}
+
+#[tokio::test]
+async fn multi_fetch_subscription_selection_priority() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client with a max lag of 10 and multi-fetch enabled (2 peers per request)
+    let max_subscription_lag_secs = 10;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 2,
+            ..Default::default()
+        },
+        max_subscription_lag_secs,
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, time_service, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create test data
+    let known_version = 1000;
+    let known_epoch = 5;
+
+    // Ensure the properties hold for all peer priorities (in increasing priority order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Ensure the properties hold for all subscription requests
+        for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Add several peers and verify the request is unserviceable
+            let peers = utils::add_several_peers(&mut mock_network, 100, *peer_priority);
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Advertise the data for the peers and verify a single peer is selected
+            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+            for peer in peers.iter() {
+                client.update_peer_storage_summary(
+                    *peer,
+                    utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+                );
+            }
+            utils::verify_selected_peer_from_set(&client, &storage_request, &peers);
+
+            // Disconnect all peers and verify the request is unserviceable
+            utils::disconnect_all_peers(&mut mock_network, &HashSet::from_iter(peers));
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
+
+            // Add a single peer and advertise the data for the peer
+            let peer = mock_network.add_peer(*peer_priority);
+            client.update_peer_storage_summary(
+                peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+
+            // Verify the peer is not selected (the previous request went to a different peer)
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Update the stream ID and verify the peer is selected
+            let storage_request = utils::update_subscription_request_id(&storage_request);
+            utils::verify_selected_peers_match(&client, hashset![peer], &storage_request);
+
+            // Disconnect the peer and verify the request is unserviceable
+            mock_network.disconnect_peer(peer);
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
+        }
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_subscription_selection_priority_mix() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client with a max lag of 100 and multi-fetch enabled (2 peers per request)
+    let max_subscription_lag_secs = 100;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 2,
+            ..Default::default()
+        },
+        max_subscription_lag_secs,
+        ..Default::default()
+    };
+
+    // Create the mock network, time service and client
+    let (mut mock_network, time_service, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create test data
+    let known_version = 1000;
+    let known_epoch = 5;
+
+    // Ensure the properties hold for all subscription requests
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
+        // Create the storage request
+        let mut storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several low priority peers and verify the request is unserviceable
+        let low_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::LowPriority);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+        // Advertise the data for the low priority peers and verify a single peer is selected
+        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+        for peer in low_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert_eq!(selected_peers.len(), 1);
+        assert!(low_priority_peers.contains(selected_peers.iter().next().unwrap()));
+
+        // Add several medium priority peers and verify the request is still serviced by the same low priority peer
+        let medium_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::MediumPriority);
+        utils::verify_selected_peers_match(&client, selected_peers.clone(), &storage_request);
+
+        // Advertise the data for the medium priority peers
+        for peer in medium_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+
+        // Update the subscription stream ID and verify a medium priority peer is selected
+        storage_request = utils::update_subscription_request_id(&storage_request);
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(medium_priority_peers.contains(selected_peers.iter().next().unwrap()));
+
+        // Make several more requests and verify the same medium priority peer is selected
+        for _ in 0..100 {
+            utils::verify_selected_peers_match(&client, selected_peers.clone(), &storage_request);
+        }
+
+        // Update the stream request ID and verify medium priority peers are selected
+        for _ in 0..100 {
+            storage_request = utils::update_subscription_request_id(&storage_request);
+            utils::verify_selected_peer_from_set(&client, &storage_request, &medium_priority_peers);
+        }
+
+        // Add several high priority peers and verify the request is still serviced by the same medium priority peer
+        let high_priority_peers =
+            utils::add_several_peers(&mut mock_network, 100, PeerPriority::HighPriority);
+        utils::verify_selected_peers_match(&client, selected_peers, &storage_request);
+
+        // Advertise the data for the high priority peers
+        for peer in high_priority_peers.iter() {
+            client.update_peer_storage_summary(
+                *peer,
+                utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
+            );
+        }
+
+        // Verify the next request is unserviceable (the previous request went to a medium priority peer)
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+        // Make several requests and verify the high priority peers are selected
+        for _ in 0..100 {
+            storage_request = utils::update_subscription_request_id(&storage_request);
+            utils::verify_selected_peer_from_set(&client, &storage_request, &high_priority_peers);
+        }
+
+        // Disconnect all high priority peers
+        utils::disconnect_all_peers(&mut mock_network, &HashSet::from_iter(high_priority_peers));
+
+        // Make several requests and verify the medium priority peers are selected
+        for _ in 0..100 {
+            storage_request = utils::update_subscription_request_id(&storage_request);
+            utils::verify_selected_peer_from_set(&client, &storage_request, &medium_priority_peers);
+        }
+
+        // Disconnect all medium priority peers
+        utils::disconnect_all_peers(
+            &mut mock_network,
+            &HashSet::from_iter(medium_priority_peers),
+        );
+
+        // Make several requests and verify the low priority peers are selected
+        for _ in 0..100 {
+            storage_request = utils::update_subscription_request_id(&storage_request);
+            utils::verify_selected_peer_from_set(&client, &storage_request, &low_priority_peers);
+        }
+
+        // Disconnect all low priority peers and verify the request is unserviceable
+        utils::disconnect_all_peers(&mut mock_network, &HashSet::from_iter(low_priority_peers));
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
+    }
+}
+
+#[tokio::test]
+async fn multi_fetch_trivial_serviceability() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create a data client config with multi-fetch enabled (2 peers per request)
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create a server version request that is trivially serviceable
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Ensure no peers can service the request (we have no connections)
+    utils::verify_request_is_unserviceable(&client, &server_version_request, true);
+
+    // Add a low priority peer and verify the peer is selected as the request recipient
+    let low_priority_peer_1 = mock_network.add_peer(PeerPriority::LowPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add a medium priority peer and verify the peer is selected as the recipient.
+    // (Low priority peers are ignored if there are higher priority peers available).
+    let medium_priority_peer_1 = mock_network.add_peer(PeerPriority::MediumPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![medium_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add another medium priority peer and verify both medium priority peers are selected
+    let medium_priority_peer_2 = mock_network.add_peer(PeerPriority::MediumPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![medium_priority_peer_1, medium_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Add two high priority peers
+    let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+    let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+
+    // Verify both high priority peers are selected
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, high_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Disconnect the first high priority peer
+    mock_network.disconnect_peer(high_priority_peer_1);
+
+    // Verify the other high priority peer is selected (alongside one medium priority peer)
+    let selected_peers = client
+        .choose_peers_for_request(&server_version_request)
+        .unwrap();
+    assert_eq!(selected_peers.len(), 2);
+    assert!(selected_peers.contains(&high_priority_peer_2));
+    assert!(
+        selected_peers.contains(&medium_priority_peer_1)
+            || selected_peers.contains(&medium_priority_peer_2)
+    );
+
+    // Disconnect the second high priority peer
+    mock_network.disconnect_peer(high_priority_peer_2);
+
+    // Verify both medium priority peers are selected
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![medium_priority_peer_1, medium_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Disconnect the first medium priority peer and reconnect the first high priority peer
+    mock_network.disconnect_peer(medium_priority_peer_1);
+    mock_network.reconnect_peer(high_priority_peer_1);
+
+    // Verify the first high priority peer is selected (alongside the second medium priority peer)
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, medium_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Disconnect the second medium priority peer and verify the first high priority peer is selected
+    mock_network.disconnect_peer(medium_priority_peer_2);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Disconnect the first high priority peer and verify the low priority peer is selected
+    mock_network.disconnect_peer(high_priority_peer_1);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add another low priority peer and verify both low priority peers are selected
+    let low_priority_peer_2 = mock_network.add_peer(PeerPriority::LowPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1, low_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Add another low priority peer and verify only two low priority peers are selected
+    let low_priority_peer_3 = mock_network.add_peer(PeerPriority::LowPriority);
+    let selected_peers = client
+        .choose_peers_for_request(&server_version_request)
+        .unwrap();
+    assert_eq!(selected_peers.len(), 2);
+
+    // Verify that two low priority peers are selected
+    let all_low_priority_peers = hashset![
+        low_priority_peer_1,
+        low_priority_peer_2,
+        low_priority_peer_3
+    ];
+    let difference: HashSet<_> = all_low_priority_peers.difference(&selected_peers).collect();
+    assert_eq!(difference.len(), 1);
+}
+
+#[tokio::test]
+async fn multi_fetch_trivial_serviceability_pfn() {
+    // Create a base config for a PFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Public];
+
+    // Create a data client config with multi-fetch enabled (2 peers per request)
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 2,
+            max_peers_for_multi_fetch: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
+
+    // Create a server version request that is trivially serviceable
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
+
+    // Add a low priority peer and verify the peer is selected as the request recipient
+    let low_priority_peer_1 = mock_network.add_peer(PeerPriority::LowPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add a high priority peer and verify the peer is selected as the request recipient
+    let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add another high priority peer and verify both high priority peers are selected
+    let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_1, high_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Disconnect the first high priority peer
+    mock_network.disconnect_peer(high_priority_peer_1);
+
+    // Verify the other high priority peer is selected
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![high_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Disconnect the second high priority peer
+    mock_network.disconnect_peer(high_priority_peer_2);
+
+    // Verify the low priority peer is selected
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1],
+        &server_version_request,
+    );
+
+    // Add another low priority peer and verify both low priority peers are selected
+    let low_priority_peer_2 = mock_network.add_peer(PeerPriority::LowPriority);
+    utils::verify_selected_peers_match(
+        &client,
+        hashset![low_priority_peer_1, low_priority_peer_2],
+        &server_version_request,
+    );
+
+    // Add another low priority peer and verify only two low priority peers are selected
+    let low_priority_peer_3 = mock_network.add_peer(PeerPriority::LowPriority);
+    let selected_peers = client
+        .choose_peers_for_request(&server_version_request)
+        .unwrap();
+    assert_eq!(selected_peers.len(), 2);
+
+    // Verify that two low priority peers are selected
+    let all_low_priority_peers = hashset![
+        low_priority_peer_1,
+        low_priority_peer_2,
+        low_priority_peer_3
+    ];
+    let difference: HashSet<_> = all_low_priority_peers.difference(&selected_peers).collect();
+    assert_eq!(difference.len(), 1);
+}
+
+/// Verifies that the number of selected peers for the
+/// given request matches expectations.
+fn verify_num_selected_peers(
+    client: &AptosDataClient,
+    storage_request: &StorageServiceRequest,
+    num_expected_peers: usize,
+) {
+    let selected_peers = client.choose_peers_for_request(storage_request).unwrap();
+    assert_eq!(selected_peers.len(), num_expected_peers);
+}

--- a/state-sync/aptos-data-client/src/tests/peers.rs
+++ b/state-sync/aptos-data-client/src/tests/peers.rs
@@ -7,9 +7,13 @@ use crate::{
     interface::AptosDataClientInterface,
     poller,
     poller::{poll_peer, DataSummaryPoller},
+    priority::PeerPriority,
     tests::{mock::MockNetwork, utils},
 };
-use aptos_config::{config::AptosDataClientConfig, network_id::PeerNetworkId};
+use aptos_config::{
+    config::AptosDataClientConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
 use aptos_storage_service_types::{
     requests::DataRequest,
     responses::{CompleteDataRange, DataResponse, StorageServerSummary, StorageServiceResponse},
@@ -22,61 +26,71 @@ use std::{collections::HashSet, time::Duration};
 
 #[tokio::test]
 async fn bad_peer_is_eventually_banned_internal() {
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create a base config for a validator
+        let base_config = utils::create_validator_base_config();
+
         // Create the mock network and client
         let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
+            MockNetwork::new(Some(base_config), Some(data_client_config), None);
 
-        // Add a good and bad peer (on the same network)
+        // Add a good and a bad peer (with the same priority, on the same network)
         let (good_peer, good_network_id) =
-            utils::add_peer_to_network(poll_priority_peers, &mut mock_network);
-        let (bad_peer, network_id) =
-            utils::add_peer_to_network(poll_priority_peers, &mut mock_network);
+            utils::add_peer_to_network(peer_priority, &mut mock_network);
+        let (bad_peer, network_id) = utils::add_peer_to_network(peer_priority, &mut mock_network);
         assert_eq!(good_network_id, network_id);
 
-        // The good peer advertises txns 0 -> 100 and the bad peer advertises txns 0 -> 200.
+        // The good peer advertises txns 0 -> 100 and the bad peer advertises txns 0 -> 200
         client.update_peer_storage_summary(good_peer, utils::create_storage_summary(100));
         client.update_peer_storage_summary(bad_peer, utils::create_storage_summary(200));
         client.update_global_summary_cache().unwrap();
 
-        // The global summary should contain the bad peer's advertisement.
+        // Verify the global summary contains the bad peer's advertisement
         let global_summary = client.get_global_data_summary();
+        let transaction_range = CompleteDataRange::new(0, 200).unwrap();
         assert!(global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
 
-        // Spawn a handler for both peers.
+        // Spawn a handler for both peers
         tokio::spawn(async move {
             while let Some(network_request) = mock_network.next_request(network_id).await {
+                // Extract the peer network id and response sender
                 let peer_network_id = network_request.peer_network_id;
                 let response_sender = network_request.response_sender;
-                if peer_network_id == good_peer {
-                    // Good peer responds with good response.
+
+                // Determine the response to send based on the peer's network id
+                let response = if peer_network_id == good_peer {
                     let data_response =
                         DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
-                    response_sender
-                        .send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
+                    Ok(StorageServiceResponse::new(data_response, true).unwrap())
                 } else if peer_network_id == bad_peer {
-                    // Bad peer responds with error.
-                    response_sender.send(Err(StorageServiceError::InternalError("".to_string())));
-                }
+                    Err(StorageServiceError::InternalError(
+                        "Oops! Something went wrong!".to_string(),
+                    ))
+                } else {
+                    panic!("Unexpected peer network id: {:?}", peer_network_id);
+                };
+
+                // Send the response
+                response_sender.send(response);
             }
         });
 
-        // Sending a bunch of requests to the bad peer's upper range will fail.
+        // Sending a bunch of requests to the bad peer will fail
         let mut seen_data_unavailable_err = false;
-        let request_timeout = data_client_config.response_timeout_ms;
         for _ in 0..20 {
+            // Send a request to fetch transactions from the bad peer
+            let response_timeout_ms = data_client_config.response_timeout_ms;
             let result = client
-                .get_transactions_with_proof(200, 200, 200, false, request_timeout)
+                .get_transactions_with_proof(200, 200, 200, false, response_timeout_ms)
                 .await;
 
-            // While the score is still decreasing, we should see a bunch of
-            // InternalError's. Once we see a `DataIsUnavailable` error, we should
-            // only see that error.
+            // While the score is still decreasing, we should see internal errors.
+            // Once we see that data is unavailable, we should only see that error.
             if !seen_data_unavailable_err {
                 assert_err!(&result);
                 if let Err(Error::DataIsUnavailable(_)) = result {
@@ -87,21 +101,21 @@ async fn bad_peer_is_eventually_banned_internal() {
             }
         }
 
-        // Peer should eventually get ignored and we should consider this request
-        // range unserviceable.
+        // The bad peer should eventually get ignored
         assert!(seen_data_unavailable_err);
 
-        // The global summary should no longer contain the bad peer's advertisement.
+        // Verify the global summary no longer contains the bad peer's advertisement
         client.update_global_summary_cache().unwrap();
         let global_summary = client.get_global_data_summary();
         assert!(!global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
 
-        // We should still be able to send the good peer a request.
+        // Verify that we can still send a request to the good peer
+        let response_timeout_ms = data_client_config.response_timeout_ms;
         let response = client
-            .get_transactions_with_proof(100, 50, 100, false, request_timeout)
+            .get_transactions_with_proof(100, 50, 100, false, response_timeout_ms)
             .await
             .unwrap();
         assert_eq!(response.payload, TransactionListWithProof::new_empty());
@@ -110,23 +124,26 @@ async fn bad_peer_is_eventually_banned_internal() {
 
 #[tokio::test]
 async fn bad_peer_is_eventually_banned_callback() {
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create a base config for a VFN
+        let base_config = utils::create_fullnode_base_config();
+        let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
         // Create the mock network and client
         let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
+            MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
 
         // Add a bad peer
-        let (bad_peer, network_id) =
-            utils::add_peer_to_network(poll_priority_peers, &mut mock_network);
+        let (bad_peer, network_id) = utils::add_peer_to_network(peer_priority, &mut mock_network);
 
-        // Bypass poller and just add the storage summaries directly.
-        // Bad peer advertises txns 0 -> 200 (but can't actually service).
+        // Bypass the data poller and just add the storage summaries directly.
+        // Update the bad peer to advertise txns 0 -> 200.
         client.update_peer_storage_summary(bad_peer, utils::create_storage_summary(200));
         client.update_global_summary_cache().unwrap();
 
-        // Spawn a handler for both peers.
+        // Spawn a handler for the bad peer
         tokio::spawn(async move {
             while let Some(network_request) = mock_network.next_request(network_id).await {
                 let data_response =
@@ -137,18 +154,22 @@ async fn bad_peer_is_eventually_banned_callback() {
             }
         });
 
+        // Send a bunch of requests to the bad peer (that we later decide are invalid)
         let mut seen_data_unavailable_err = false;
-
-        // Sending a bunch of requests to the bad peer (that we later decide are bad).
-        let request_timeout = data_client_config.response_timeout_ms;
         for _ in 0..20 {
+            // Send a request to fetch transactions from the bad peer
             let result = client
-                .get_transactions_with_proof(200, 200, 200, false, request_timeout)
+                .get_transactions_with_proof(
+                    200,
+                    200,
+                    200,
+                    false,
+                    data_client_config.response_timeout_ms,
+                )
                 .await;
 
-            // While the score is still decreasing, we should see a bunch of
-            // InternalError's. Once we see a `DataIsUnavailable` error, we should
-            // only see that error.
+            // While the score is still decreasing, we should see internal errors.
+            // Once we see that data is unavailable, we should only see that error.
             if !seen_data_unavailable_err {
                 match result {
                     Ok(response) => {
@@ -166,71 +187,66 @@ async fn bad_peer_is_eventually_banned_callback() {
             }
         }
 
-        // Peer should eventually get ignored and we should consider this request
-        // range unserviceable.
+        // The bad peer should eventually get ignored
         assert!(seen_data_unavailable_err);
 
-        // The global summary should no longer contain the bad peer's advertisement.
+        // Verify the global summary no longer contains the bad peer's advertisement
         client.update_global_summary_cache().unwrap();
         let global_summary = client.get_global_data_summary();
+        let transaction_range = CompleteDataRange::new(0, 200).unwrap();
         assert!(!global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
     }
 }
 
 #[tokio::test]
 async fn bad_peer_is_eventually_added_back() {
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network, client and poller
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create a base config for a validator
+        let base_config = utils::create_validator_base_config();
+
+        // Create the mock network, mock time, client and poller
         let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, mock_time, client, poller) =
-            MockNetwork::new(None, Some(data_client_config), None);
+            MockNetwork::new(Some(base_config), Some(data_client_config), None);
 
         // Add a connected peer
-        let (_, network_id) = utils::add_peer_to_network(poll_priority_peers, &mut mock_network);
+        let (_, network_id) = utils::add_peer_to_network(peer_priority, &mut mock_network);
 
         // Start the poller
         tokio::spawn(poller::start_poller(poller));
 
-        // Spawn a handler that emulates peer responses
+        // Spawn a handler for the peer
         tokio::spawn(async move {
             while let Some(network_request) = mock_network.next_request(network_id).await {
-                match network_request.storage_service_request.data_request {
+                // Determine the data response based on the request
+                let data_response = match network_request.storage_service_request.data_request {
                     DataRequest::GetTransactionsWithProof(_) => {
-                        let data_response = DataResponse::TransactionsWithProof(
-                            TransactionListWithProof::new_empty(),
-                        );
-                        network_request
-                            .response_sender
-                            .send(Ok(StorageServiceResponse::new(
-                                data_response,
-                                network_request.storage_service_request.use_compression,
-                            )
-                            .unwrap()));
+                        DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty())
                     },
                     DataRequest::GetStorageServerSummary => {
-                        let data_response =
-                            DataResponse::StorageServerSummary(utils::create_storage_summary(200));
-                        network_request
-                            .response_sender
-                            .send(Ok(StorageServiceResponse::new(
-                                data_response,
-                                network_request.storage_service_request.use_compression,
-                            )
-                            .unwrap()));
+                        DataResponse::StorageServerSummary(utils::create_storage_summary(200))
                     },
                     _ => panic!(
                         "Unexpected storage request: {:?}",
                         network_request.storage_service_request
                     ),
-                }
+                };
+
+                // Send the response
+                let storage_response = StorageServiceResponse::new(
+                    data_response,
+                    network_request.storage_service_request.use_compression,
+                )
+                .unwrap();
+                network_request.response_sender.send(Ok(storage_response));
             }
         });
 
-        // Advance time so the poller sends data summary requests.
+        // Advance time so the poller sends data summary requests
         let poll_loop_interval_ms = data_client_config.data_poller_config.poll_loop_interval_ms;
         for _ in 0..10 {
             tokio::task::yield_now().await;
@@ -239,21 +255,24 @@ async fn bad_peer_is_eventually_added_back() {
                 .await;
         }
 
-        // Initially this request range is serviceable by this peer.
+        // Verify that this request range is serviceable by the peer
         let global_summary = client.get_global_data_summary();
+        let transaction_range = CompleteDataRange::new(0, 200).unwrap();
         assert!(global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
 
         // Keep decreasing this peer's score by considering its responses bad.
-        // Eventually its score drops below IGNORE_PEER_THRESHOLD.
-        let request_timeout = data_client_config.response_timeout_ms;
+        // Eventually its score drops below threshold and it is ignored.
         for _ in 0..20 {
+            // Send a request to fetch transactions from the peer
+            let request_timeout = data_client_config.response_timeout_ms;
             let result = client
                 .get_transactions_with_proof(200, 0, 200, false, request_timeout)
                 .await;
 
+            // Notify the client that the response was bad
             if let Ok(response) = result {
                 response
                     .context
@@ -262,16 +281,16 @@ async fn bad_peer_is_eventually_added_back() {
             }
         }
 
-        // Peer is eventually ignored and this request range unserviceable.
+        // Verify that the peer is eventually ignored and this data range becomes unserviceable
         client.update_global_summary_cache().unwrap();
         let global_summary = client.get_global_data_summary();
         assert!(!global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
 
-        // This peer still responds to the StorageServerSummary requests.
-        // Its score keeps increasing and this peer is eventually added back.
+        // Keep elapsed time so the peer is eventually added back (it
+        // will still respond to the storage summary requests).
         for _ in 0..100 {
             mock_time
                 .advance_async(Duration::from_millis(poll_loop_interval_ms))
@@ -283,66 +302,59 @@ async fn bad_peer_is_eventually_added_back() {
         assert!(global_summary
             .advertised_data
             .transactions
-            .contains(&CompleteDataRange::new(0, 200).unwrap()));
+            .contains(&transaction_range));
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn disconnected_peers_garbage_collection() {
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network, client and poller
-        let (mut mock_network, _, client, poller) = MockNetwork::new(None, None, None);
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create a base config for a validator
+        let base_config = utils::create_validator_base_config();
 
-        // Connect several priority peers
-        let priority_peer_1 = mock_network.add_peer(poll_priority_peers);
-        let priority_peer_2 = mock_network.add_peer(poll_priority_peers);
-        let priority_peer_3 = mock_network.add_peer(poll_priority_peers);
+        // Create the mock network, client and poller
+        let data_client_config = AptosDataClientConfig::default();
+        let (mut mock_network, _, client, poller) =
+            MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+        // Connect several peers
+        let peer_1 = mock_network.add_peer(peer_priority);
+        let peer_2 = mock_network.add_peer(peer_priority);
+        let peer_3 = mock_network.add_peer(peer_priority);
 
         // Poll all of the peers to initialize the peer states
-        let all_peers = hashset![priority_peer_1, priority_peer_2, priority_peer_3];
-        poll_peers(
-            &mut mock_network,
-            &poller,
-            poll_priority_peers,
-            all_peers.clone(),
-        )
-        .await;
+        let all_peers = hashset![peer_1, peer_2, peer_3];
+        poll_peers(&mut mock_network, &poller, peer_priority, all_peers.clone()).await;
 
         // Verify we have peer states for all peers
         verify_peer_states(&client, all_peers.clone());
 
-        // Disconnect priority peer 1 and update the global data summary
-        mock_network.disconnect_peer(priority_peer_1);
+        // Disconnect peer 1 and update the global data summary
+        mock_network.disconnect_peer(peer_1);
         client.update_global_summary_cache().unwrap();
 
-        // Verify we have peer states for only the remaining peers
-        verify_peer_states(&client, hashset![priority_peer_2, priority_peer_3]);
+        // Verify we have peer states for only peer 2 and 3
+        verify_peer_states(&client, hashset![peer_2, peer_3]);
 
-        // Disconnect priority peer 2 and update the global data summary
-        mock_network.disconnect_peer(priority_peer_2);
+        // Disconnect peer 2 and update the global data summary
+        mock_network.disconnect_peer(peer_2);
         client.update_global_summary_cache().unwrap();
 
-        // Verify we have peer states for only priority peer 3
-        verify_peer_states(&client, hashset![priority_peer_3]);
+        // Verify we have peer states for only peer 3
+        verify_peer_states(&client, hashset![peer_3]);
 
-        // Reconnect priority peer 1, poll it and update the global data summary
-        mock_network.reconnect_peer(priority_peer_1);
-        poll_peers(&mut mock_network, &poller, poll_priority_peers, hashset![
-            priority_peer_1
-        ])
-        .await;
+        // Reconnect peer 1, poll it and update the global data summary
+        mock_network.reconnect_peer(peer_1);
+        poll_peers(&mut mock_network, &poller, peer_priority, hashset![peer_1]).await;
         client.update_global_summary_cache().unwrap();
 
-        // Verify we have peer states for priority peer 1 and 3
-        verify_peer_states(&client, hashset![priority_peer_1, priority_peer_3]);
+        // Verify we have peer states for peers 1 and 3
+        verify_peer_states(&client, hashset![peer_1, peer_3]);
 
-        // Reconnect priority peer 2, poll it and update the global data summary
-        mock_network.reconnect_peer(priority_peer_2);
-        poll_peers(&mut mock_network, &poller, poll_priority_peers, hashset![
-            priority_peer_2
-        ])
-        .await;
+        // Reconnect peer 2, poll it and update the global data summary
+        mock_network.reconnect_peer(peer_2);
+        poll_peers(&mut mock_network, &poller, peer_priority, hashset![peer_2]).await;
         client.update_global_summary_cache().unwrap();
 
         // Verify we have peer states for all peers
@@ -355,19 +367,18 @@ async fn disconnected_peers_garbage_collection() {
 async fn poll_peers(
     mock_network: &mut MockNetwork,
     poller: &DataSummaryPoller,
-    poll_priority_peers: bool,
+    peer_priority: PeerPriority,
     all_peers: HashSet<PeerNetworkId>,
 ) {
     for peer in all_peers {
         // Poll the peer
-        let handle = poll_peer(poller.clone(), poll_priority_peers, peer);
+        let handle = poll_peer(poller.clone(), peer_priority.is_high_priority(), peer);
 
         // Respond to the poll request
         let network_request = mock_network.next_request(peer.network_id()).await.unwrap();
         let data_response = DataResponse::StorageServerSummary(StorageServerSummary::default());
-        network_request
-            .response_sender
-            .send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
+        let storage_response = StorageServiceResponse::new(data_response, true).unwrap();
+        network_request.response_sender.send(Ok(storage_response));
 
         // Wait for the poll to complete
         handle.await.unwrap();

--- a/state-sync/aptos-data-client/src/tests/priority.rs
+++ b/state-sync/aptos-data-client/src/tests/priority.rs
@@ -3,89 +3,34 @@
 
 use crate::{
     client::AptosDataClient,
-    error::Error,
+    priority::PeerPriority,
     tests::{mock::MockNetwork, utils},
 };
 use aptos_config::{
-    config::{AptosDataClientConfig, AptosLatencyFilteringConfig, BaseConfig, RoleType},
+    config::{AptosDataClientConfig, AptosDataMultiFetchConfig},
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::{
-    requests::{
-        DataRequest, NewTransactionOutputsWithProofRequest,
-        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
-        SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
-    },
+    requests::{DataRequest, StorageServiceRequest},
     responses::NUM_MICROSECONDS_IN_SECOND,
 };
 use aptos_time_service::TimeServiceTrait;
-use claims::assert_matches;
 use maplit::hashset;
-use ordered_float::OrderedFloat;
-use rand::Rng;
-use std::{cmp::Ordering, collections::HashMap};
-
-#[tokio::test]
-async fn all_peer_request_selection() {
-    // Create the mock network and client
-    let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
-
-    // Ensure no peers can service the given request (we have no connections)
-    let server_version_request =
-        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
-    verify_request_is_unserviceable(&client, &server_version_request);
-
-    // Add a regular peer and verify the peer is selected as the recipient
-    let regular_peer_1 = mock_network.add_peer(false);
-    verify_peer_selected_for_request(&client, regular_peer_1, &server_version_request);
-
-    // Add two prioritized peers
-    let priority_peer_1 = mock_network.add_peer(true);
-    let priority_peer_2 = mock_network.add_peer(true);
-
-    // Request data that is not being advertised and verify we get an error
-    let output_data_request =
-        DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
-            proof_version: 100,
-            start_version: 0,
-            end_version: 100,
-        });
-    let storage_request = StorageServiceRequest::new(output_data_request, false);
-    verify_request_is_unserviceable(&client, &storage_request);
-
-    // Advertise the data for the regular peer and verify it is now selected
-    client.update_peer_storage_summary(regular_peer_1, utils::create_storage_summary(100));
-    verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
-
-    // Advertise the data for the priority peer and verify the priority peer is selected
-    client.update_peer_storage_summary(priority_peer_2, utils::create_storage_summary(100));
-    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
-    assert_eq!(peer_for_request, priority_peer_2);
-
-    // Reconnect priority peer 1 and remove the advertised data for priority peer 2
-    mock_network.reconnect_peer(priority_peer_1);
-    client.update_peer_storage_summary(priority_peer_2, utils::create_storage_summary(0));
-
-    // Request the data again and verify the regular peer is chosen
-    verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
-
-    // Advertise the data for priority peer 1 and verify the priority peer is selected
-    client.update_peer_storage_summary(priority_peer_1, utils::create_storage_summary(100));
-    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
-    assert_eq!(peer_for_request, priority_peer_1);
-
-    // Advertise the data for priority peer 2 and verify either priority peer is selected
-    client.update_peer_storage_summary(priority_peer_2, utils::create_storage_summary(100));
-    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
-    assert!(peer_for_request == priority_peer_1 || peer_for_request == priority_peer_2);
-}
+use std::{cmp::Ordering, collections::HashSet};
 
 #[tokio::test]
 async fn prioritized_peer_request_selection() {
+    // Create a data client with multi-fetch disabled
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
     // Create the mock network and client
-    let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
+    let (mut mock_network, _, client, _) = MockNetwork::new(None, Some(data_client_config), None);
 
     // Ensure the properties hold for storage summary and version requests
     let storage_summary_request = DataRequest::GetStorageServerSummary;
@@ -94,347 +39,62 @@ async fn prioritized_peer_request_selection() {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
         // Ensure no peers can service the request (we have no connections)
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
 
-        // Add a regular peer and verify the peer is selected as the recipient
-        let regular_peer_1 = mock_network.add_peer(false);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
-
-        // Add a priority peer and verify the peer is selected as the recipient
-        let priority_peer_1 = mock_network.add_peer(true);
-        verify_peer_selected_for_request(&client, priority_peer_1, &storage_request);
-
-        // Disconnect the priority peer and verify the regular peer is now chosen
-        mock_network.disconnect_peer(priority_peer_1);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
-
-        // Connect a new priority peer and verify it is now selected
-        let priority_peer_2 = mock_network.add_peer(true);
-        verify_peer_selected_for_request(&client, priority_peer_2, &storage_request);
-
-        // Disconnect the priority peer and verify the regular peer is again chosen
-        mock_network.disconnect_peer(priority_peer_2);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
-
-        // Disconnect the regular peer so that we no longer have any connections
-        mock_network.disconnect_peer(regular_peer_1);
-    }
-}
-
-#[tokio::test]
-async fn prioritized_peer_request_latency_filtering() {
-    // Create the data client config with latency filtering configurations
-    let min_peers_for_latency_filtering = 100;
-    let latency_filtering_reduction_factor = 2;
-    let data_client_config = AptosDataClientConfig {
-        latency_filtering_config: AptosLatencyFilteringConfig {
-            min_peers_for_latency_filtering,
-            latency_filtering_reduction_factor,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network and client
-        let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
-
-        // Create the data request
-        let data_request = DataRequest::GetStorageServerSummary;
-        let storage_request = StorageServiceRequest::new(data_request, true);
-
-        // Add several peers (enough to trigger latency filtering)
-        let num_peers = min_peers_for_latency_filtering + 10;
-        let mut peers = vec![];
-        for _ in 0..num_peers {
-            let peer = mock_network.add_peer(poll_priority_peers);
-            peers.push(peer);
-        }
-
-        // Select a peer to service the request multiple times
-        let mut peers_and_selection_counts = HashMap::new();
-        for _ in 0..20_000 {
-            // Select a peer to service the request
-            let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-            // Update the peer selection counts
-            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-        }
-
-        // Verify the highest selected peers are the lowest latency peers
-        utils::verify_highest_peer_selection_latencies(
-            &mut mock_network,
-            &mut peers_and_selection_counts,
+        // Add a medium priority peer and verify the peer is selected as the recipient
+        let medium_priority_peer = mock_network.add_peer(PeerPriority::MediumPriority);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer],
+            &storage_request,
         );
 
-        // Build a list of all peers sorted by their latencies
-        let mut peers_and_latencies = vec![];
-        for peer in peers_and_selection_counts.keys() {
-            // Get the peer's ping latency
-            let ping_latency = utils::get_peer_ping_latency(&mut mock_network, *peer);
-
-            // Add the peer and latency to the list
-            peers_and_latencies.push((*peer, OrderedFloat(ping_latency)));
-        }
-        peers_and_latencies.sort_by_key(|(_, latency)| *latency);
-
-        // Verify that the top subset of peers have selection counts
-        let peers_to_verify = (num_peers / latency_filtering_reduction_factor) as usize;
-        for (peer, _) in peers_and_latencies[0..peers_to_verify].iter() {
-            match peers_and_selection_counts.get(peer) {
-                Some(selection_count) => assert!(*selection_count > 0),
-                None => panic!("Peer {:?} was not found in the selection counts!", peer),
-            }
-        }
-
-        // Verify that the bottom subset of peers do not have selection counts
-        // (as they were filtered out).
-        for (peer, _) in peers_and_latencies[peers_to_verify..].iter() {
-            if let Some(selection_count) = peers_and_selection_counts.get(peer) {
-                assert_eq!(*selection_count, 0);
-            }
-        }
-    }
-}
-
-#[tokio::test]
-async fn prioritized_peer_request_latency_filtering_ratio() {
-    // Create the data client config with latency filtering configurations
-    let min_peers_for_latency_filtering = 50;
-    let min_peer_ratio_for_latency_filtering = 10_000; // Set to a very high value
-    let latency_filtering_reduction_factor = 2;
-    let data_client_config = AptosDataClientConfig {
-        latency_filtering_config: AptosLatencyFilteringConfig {
-            min_peers_for_latency_filtering,
-            min_peer_ratio_for_latency_filtering,
-            latency_filtering_reduction_factor,
-        },
-        ..Default::default()
-    };
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network and client
-        let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
-
-        // Create the data request
-        let data_request = DataRequest::GetStorageServerSummary;
-        let storage_request = StorageServiceRequest::new(data_request, true);
-
-        // Add several peers (enough to satisfy the minimum number of peers)
-        let num_peers = min_peers_for_latency_filtering * 2;
-        let mut peers = vec![];
-        for _ in 0..num_peers {
-            let peer = mock_network.add_peer(poll_priority_peers);
-            peers.push(peer);
-        }
-
-        // Select a peer to service the request multiple times
-        let mut peers_and_selection_counts = HashMap::new();
-        for _ in 0..20_000 {
-            // Select a peer to service the request
-            let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-            // Update the peer selection counts
-            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-        }
-
-        // Verify the highest selected peers are the lowest latency peers
-        utils::verify_highest_peer_selection_latencies(
-            &mut mock_network,
-            &mut peers_and_selection_counts,
+        // Add a high priority peer and verify the peer is selected as the recipient
+        let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_1],
+            &storage_request,
         );
 
-        // Verify that the number of selected peers is more than
-        // half the total peers (as filtering was disabled).
-        let num_filtered_peers = (num_peers / latency_filtering_reduction_factor) as usize;
-        assert!(peers_and_selection_counts.len() > num_filtered_peers);
-    }
-}
-
-#[tokio::test]
-async fn prioritized_peer_request_latency_selection() {
-    // Create the data client config with latency filtering configurations
-    let min_peers_for_latency_filtering = 50;
-    let latency_filtering_reduction_factor = 2;
-    let data_client_config = AptosDataClientConfig {
-        latency_filtering_config: AptosLatencyFilteringConfig {
-            min_peers_for_latency_filtering,
-            latency_filtering_reduction_factor,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network and client
-        let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
-
-        // Create the data request
-        let data_request = DataRequest::GetStorageServerSummary;
-        let storage_request = StorageServiceRequest::new(data_request, true);
-
-        // Add several peers (but not enough to trigger latency filtering)
-        let num_peers = min_peers_for_latency_filtering - 1;
-        let mut peers = vec![];
-        for _ in 0..num_peers {
-            let peer = mock_network.add_peer(poll_priority_peers);
-            peers.push(peer);
-        }
-
-        // Select a peer to service the request multiple times
-        let mut peers_and_selection_counts = HashMap::new();
-        for _ in 0..20_000 {
-            // Select a peer to service the request
-            let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-            // Update the peer selection counts
-            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-        }
-
-        // Verify the highest selected peers are the lowest latency peers
-        utils::verify_highest_peer_selection_latencies(
-            &mut mock_network,
-            &mut peers_and_selection_counts,
+        // Disconnect the high priority peer and verify the medium priority peer is now chosen
+        mock_network.disconnect_peer(high_priority_peer_1);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer],
+            &storage_request,
         );
 
-        // Verify that the number of selected peers is more than
-        // half the total peers (as filtering was disabled).
-        let num_filtered_peers = (num_peers / latency_filtering_reduction_factor) as usize;
-        assert!(peers_and_selection_counts.len() > num_filtered_peers);
-    }
-}
-
-#[tokio::test]
-async fn prioritized_peer_request_missing_latencies() {
-    // Create the data client config with latency filtering configurations
-    let min_peers_for_latency_filtering = 50;
-    let data_client_config = AptosDataClientConfig {
-        latency_filtering_config: AptosLatencyFilteringConfig {
-            min_peers_for_latency_filtering,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network and client
-        let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
-
-        // Create the data request
-        let data_request = DataRequest::GetStorageServerSummary;
-        let storage_request = StorageServiceRequest::new(data_request, true);
-
-        // Add several peers
-        let num_peers = min_peers_for_latency_filtering + 10;
-        let mut peers = vec![];
-        for _ in 0..num_peers {
-            let peer = mock_network.add_peer(poll_priority_peers);
-            peers.push(peer);
-        }
-
-        // Remove the latency metadata for some peers
-        let num_peers_with_missing_latencies = (min_peers_for_latency_filtering / 3) as usize;
-        let mut peers_with_missing_latencies = vec![];
-        for peer in peers[0..num_peers_with_missing_latencies].iter() {
-            // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, *peer);
-
-            // Add the peer to the set of peers with missing latencies
-            peers_with_missing_latencies.push(*peer);
-        }
-
-        // Select a peer to service the request multiple times
-        let mut peers_and_selection_counts = HashMap::new();
-        for _ in 0..20_000 {
-            // Select a peer to service the request
-            let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-            // Update the peer selection counts
-            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-        }
-
-        // Verify the highest selected peers are the lowest latency peers
-        utils::verify_highest_peer_selection_latencies(
-            &mut mock_network,
-            &mut peers_and_selection_counts,
+        // Connect a new high priority peer and verify it is now selected
+        let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_2],
+            &storage_request,
         );
 
-        // Verify that the peers with missing latencies are not selected
-        for peer in peers_with_missing_latencies {
-            if let Some(selection_count) = peers_and_selection_counts.get(&peer) {
-                assert_eq!(*selection_count, 0);
-            }
-        }
-    }
-}
+        // Disconnect the high priority peer and verify the medium priority peer is again chosen
+        mock_network.disconnect_peer(high_priority_peer_2);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer],
+            &storage_request,
+        );
 
-#[tokio::test]
-async fn prioritized_peer_request_no_latencies() {
-    // Create the data client config with latency filtering configurations
-    let min_peers_for_latency_filtering = 50;
-    let data_client_config = AptosDataClientConfig {
-        latency_filtering_config: AptosLatencyFilteringConfig {
-            min_peers_for_latency_filtering,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for poll_priority_peers in [true, false] {
-        // Create the mock network and client
-        let (mut mock_network, _, client, _) =
-            MockNetwork::new(None, Some(data_client_config), None);
-
-        // Create the data request
-        let data_request = DataRequest::GetStorageServerSummary;
-        let storage_request = StorageServiceRequest::new(data_request, true);
-
-        // Add several peers and remove their latency metadata
-        let num_peers = min_peers_for_latency_filtering + 10;
-        let mut peers = vec![];
-        for _ in 0..num_peers {
-            // Add a peer
-            let peer = mock_network.add_peer(poll_priority_peers);
-            peers.push(peer);
-
-            // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, peer)
-        }
-
-        // Select a peer to service the request multiple times
-        let mut peers_and_selection_counts = HashMap::new();
-        for _ in 0..20_000 {
-            // Select a peer to service the request
-            let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-            // Update the peer selection counts
-            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-        }
-
-        // Verify that peers are still selected even though there are no recorded latencies
-        for peer in peers {
-            match peers_and_selection_counts.get(&peer) {
-                Some(selection_count) => assert!(*selection_count > 0),
-                None => panic!("Peer {:?} was not found in the selection counts!", peer),
-            }
-        }
+        // Disconnect the medium priority peer so that we no longer have any connections
+        mock_network.disconnect_peer(medium_priority_peer);
     }
 }
 
 #[tokio::test]
 async fn prioritized_peer_optimistic_fetch_selection() {
-    // Create a data client with a max lag of 100
+    // Create a data client with a max lag of 100 and multi-fetch disabled
     let max_optimistic_fetch_lag_secs = 100;
     let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: false,
+            ..Default::default()
+        },
         max_optimistic_fetch_lag_secs,
         ..Default::default()
     };
@@ -448,34 +108,46 @@ async fn prioritized_peer_optimistic_fetch_selection() {
     let known_epoch = 10;
 
     // Ensure the properties hold for all optimistic fetch requests
-    for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
         // Ensure no peers can service the request (we have no connections)
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
 
-        // Add a regular peer and verify the peer cannot service the request
-        let regular_peer_1 = mock_network.add_peer(false);
-        verify_request_is_unserviceable(&client, &storage_request);
+        // Add a medium priority peer and verify the peer cannot service the request
+        let medium_priority_peer_1 = mock_network.add_peer(PeerPriority::MediumPriority);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Advertise the data for the regular peer and verify it is now selected
+        // Advertise the data for the medium priority peer and verify it is now selected
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
         client.update_peer_storage_summary(
-            regular_peer_1,
+            medium_priority_peer_1,
             utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer_1],
+            &storage_request,
+        );
 
-        // Add a priority peer and verify the regular peer is still selected
-        let priority_peer_1 = mock_network.add_peer(true);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        // Add a high priority peer and verify the medium priority peer is still selected
+        let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer_1],
+            &storage_request,
+        );
 
-        // Advertise the data for the priority peer and verify it is now selected
+        // Advertise the data for the high priority peer and verify it is now selected
         client.update_peer_storage_summary(
-            priority_peer_1,
+            high_priority_peer_1,
             utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, priority_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_1],
+            &storage_request,
+        );
 
         // Elapse enough time for both peers to be too far behind
         time_service
@@ -483,55 +155,65 @@ async fn prioritized_peer_optimistic_fetch_selection() {
             .advance_secs(max_optimistic_fetch_lag_secs + 1);
 
         // Verify neither peer is now selected
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Update the regular peer to be up-to-date and verify it is now chosen
+        // Update the medium priority peer to be up-to-date and verify it is now chosen
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        let regular_peer_timestamp_usecs =
+        let peer_timestamp_usecs =
             timestamp_usecs - ((max_optimistic_fetch_lag_secs / 2) * NUM_MICROSECONDS_IN_SECOND);
         client.update_peer_storage_summary(
-            regular_peer_1,
-            utils::create_storage_summary_with_timestamp(
-                known_version,
-                regular_peer_timestamp_usecs,
-            ),
+            medium_priority_peer_1,
+            utils::create_storage_summary_with_timestamp(known_version, peer_timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer_1],
+            &storage_request,
+        );
 
-        // Update the priority peer to be up-to-date and verify it is now chosen
-        let priority_peer_timestamp_usecs =
+        // Update the high priority peer to be up-to-date and verify it is now chosen
+        let peer_timestamp_usecs =
             timestamp_usecs - ((max_optimistic_fetch_lag_secs / 2) * NUM_MICROSECONDS_IN_SECOND);
         client.update_peer_storage_summary(
-            priority_peer_1,
-            utils::create_storage_summary_with_timestamp(
-                known_version,
-                priority_peer_timestamp_usecs,
-            ),
+            high_priority_peer_1,
+            utils::create_storage_summary_with_timestamp(known_version, peer_timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, priority_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_1],
+            &storage_request,
+        );
 
-        // Disconnect the priority peer and verify the regular peer is selected
-        mock_network.disconnect_peer(priority_peer_1);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        // Disconnect the high priority peer and verify the medium priority peer is selected
+        mock_network.disconnect_peer(high_priority_peer_1);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![medium_priority_peer_1],
+            &storage_request,
+        );
 
-        // Elapse enough time for the regular peer to be too far behind
+        // Elapse enough time for the medium priority peer to be too far behind
         time_service
             .clone()
             .advance_secs(max_optimistic_fetch_lag_secs);
 
         // Verify neither peer is now select
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Disconnect the regular peer so that we no longer have any connections
-        mock_network.disconnect_peer(regular_peer_1);
+        // Disconnect the medium priority peer so that we no longer have any connections
+        mock_network.disconnect_peer(medium_priority_peer_1);
     }
 }
 
 #[tokio::test]
 async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
-    // Create a data client with a max lag of 100
+    // Create a data client with a max lag of 100 and multi-fetch disabled
     let max_optimistic_fetch_lag_secs = 100;
     let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: false,
+            ..Default::default()
+        },
         max_optimistic_fetch_lag_secs,
         ..Default::default()
     };
@@ -545,169 +227,106 @@ async fn prioritized_peer_optimistic_fetch_distance_latency_selection() {
     let known_epoch = 10;
 
     // Ensure the properties hold for all optimistic fetch requests
-    for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several regular peers and verify the peers cannot service the request
-        let mut regular_peers = vec![];
+        // Add several medium priority peers and verify the peers cannot service the request
+        let mut medium_priority_peers = hashset![];
         for _ in 0..5 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a medium priority peer
+            let peer = mock_network.add_peer(PeerPriority::MediumPriority);
+            medium_priority_peers.insert(peer);
 
             // Verify the peer cannot service the request
-            verify_request_is_unserviceable(&client, &storage_request);
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
         }
 
-        // Advertise the data for the regular peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-
-        // Verify the peer is selected by distance and latency
-        let selected_peer = verify_peer_selected_by_distance_and_latency(
-            &mut mock_network,
+        // Advertise the data for the medium priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &storage_request,
-            &mut regular_peers,
-        );
-
-        // Disconnect the selected peer and remove it from the list of regular peers
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
-
-        // Verify the next peer is selected by distance and latency
-        let selected_peer = verify_peer_selected_by_distance_and_latency(
-            &mut mock_network,
-            &client,
-            &storage_request,
-            &mut regular_peers,
-        );
-
-        // Add several priority peers and verify the regular peer is still selected
-        let mut priority_peers = vec![];
-        for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
-
-            // Verify the regular peer is still selected
-            verify_peer_selected_for_request(&client, selected_peer, &storage_request);
-        }
-
-        // Advertise the data for the priority peers
-        update_storage_summaries_for_peers(
-            &client,
-            &priority_peers,
+            &medium_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify the priority peers are selected by distance and latency
-        verify_peer_selected_by_distance_and_latency(
+        // Verify the peers are selected by distance and latency
+        let selected_peers = verify_peers_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
-            &mut priority_peers,
+            &mut medium_priority_peers,
         );
 
-        // Disconnect all but one priority peer and remove them from the list of priority peers
-        let last_priority_peer = priority_peers[0];
-        for priority_peer in priority_peers.clone() {
-            if priority_peer != last_priority_peer {
-                mock_network.disconnect_peer(priority_peer);
-            }
-        }
-        priority_peers.retain(|peer| *peer == last_priority_peer);
+        // Disconnect the selected peers and remove them from the list of medium priority peers
+        disconnect_and_remove_peers(
+            &mut mock_network,
+            &mut medium_priority_peers,
+            &selected_peers,
+        );
 
-        // Verify the last priority peer is selected for the request
-        verify_peer_selected_for_request(&client, last_priority_peer, &storage_request);
-
-        // Disconnect the final priority peer and remove it from the list of priority peers
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, last_priority_peer);
-
-        // Verify a regular peer is selected by distance and latency
-        verify_peer_selected_by_distance_and_latency(
+        // Verify the next set of peers are selected by distance and latency
+        let selected_peers = verify_peers_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
-            &mut regular_peers,
+            &mut medium_priority_peers,
         );
 
-        // Disconnect all regular peers and verify no peers can service the request
-        for regular_peer in regular_peers {
-            mock_network.disconnect_peer(regular_peer);
+        // Add several high priority peers and verify the medium priority peers are still selected
+        let mut high_priority_peers = hashset![];
+        for _ in 0..3 {
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
+
+            // Verify the medium priority peers are still selected
+            utils::verify_selected_peers_match(&client, selected_peers.clone(), &storage_request);
         }
-        verify_request_is_unserviceable(&client, &storage_request);
-    }
-}
 
-#[tokio::test]
-async fn prioritized_peer_optimistic_fetch_distance_latency_weights() {
-    // Create a data client with a max lag of 50
-    let max_optimistic_fetch_lag_secs = 50;
-    let data_client_config = AptosDataClientConfig {
-        max_optimistic_fetch_lag_secs,
-        ..Default::default()
-    };
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &high_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
 
-    // Create test data
-    let known_version = 10000000;
-    let known_epoch = 10;
-    let min_validator_distance = 0;
-    let max_validator_distance = 2;
+        // Verify the high priority peers are selected by distance and latency
+        verify_peers_selected_by_distance_and_latency(
+            &mut mock_network,
+            &client,
+            &storage_request,
+            &mut high_priority_peers,
+        );
 
-    // Ensure the properties hold for both priority and non-priority peers
-    for priority_peers in [true, false] {
-        // Ensure the properties hold for all optimistic fetch requests
-        for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
-            let storage_request = StorageServiceRequest::new(data_request, true);
-
-            // Create the mock network, time service and client
-            let (mut mock_network, time_service, client, _) =
-                MockNetwork::new(None, Some(data_client_config), None);
-
-            // Add several peers and verify the peers cannot service the request
-            let mut peers = vec![];
-            for _ in 0..50 {
-                // Add a peer
-                let peer = mock_network.add_peer(priority_peers);
-                peers.push(peer);
-
-                // Verify the peer cannot service the request
-                verify_request_is_unserviceable(&client, &storage_request);
-
-                // Generate a random distance for the peer and update the peer's distance metadata
-                let distance_from_validator =
-                    rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
-                utils::update_distance_metadata(&client, peer, distance_from_validator as u64);
+        // Disconnect all but one high priority peer and remove them from the list of peers
+        let last_priority_peer = *high_priority_peers.iter().next().unwrap();
+        for peer in high_priority_peers.clone() {
+            if peer != last_priority_peer {
+                mock_network.disconnect_peer(peer);
             }
-
-            // Advertise the data for the peers
-            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-            update_storage_summaries_for_peers(&client, &peers, known_version, timestamp_usecs);
-
-            // Select a peer to service the request multiple times
-            let mut peers_and_selection_counts = HashMap::new();
-            for _ in 0..20_000 {
-                // Select a peer to service the request
-                let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-                // Update the peer selection counts
-                *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-            }
-
-            // Verify all of the selected peers have the lowest distance
-            for peer in peers_and_selection_counts.keys() {
-                let distance_from_validator =
-                    utils::get_peer_distance_from_validators(&mut mock_network, *peer);
-                assert_eq!(distance_from_validator, min_validator_distance);
-            }
-
-            // Verify the highest selected peers are the lowest latency peers
-            utils::verify_highest_peer_selection_latencies(
-                &mut mock_network,
-                &mut peers_and_selection_counts,
-            );
         }
+        high_priority_peers.retain(|peer| *peer == last_priority_peer);
+
+        // Verify the last high priority peer is selected for the request
+        utils::verify_selected_peers_match(&client, hashset![last_priority_peer], &storage_request);
+
+        // Disconnect the final high priority peer and remove it from the list of peers
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &hashset![
+            last_priority_peer
+        ]);
+
+        // Verify a medium priority peer is selected by distance and latency
+        verify_peers_selected_by_distance_and_latency(
+            &mut mock_network,
+            &client,
+            &storage_request,
+            &mut medium_priority_peers,
+        );
+
+        // Disconnect all medium priority peers and verify no peers can service the request
+        utils::disconnect_all_peers(&mut mock_network, &medium_priority_peers);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
     }
 }
 
@@ -729,77 +348,81 @@ async fn prioritized_peer_optimistic_fetch_missing_distances() {
     let known_epoch = 5;
 
     // Ensure the properties hold for all optimistic fetch requests
-    for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several regular peers and remove their distance metadata
-        let mut regular_peers = vec![];
+        // Add several medium priority peers and remove their distance metadata
+        let mut medium_priority_peers = hashset![];
         for _ in 0..5 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a medium priority peer
+            let peer = mock_network.add_peer(PeerPriority::LowPriority);
+            medium_priority_peers.insert(peer);
 
             // Remove the distance metadata for the peer
-            utils::remove_distance_metadata(&client, regular_peer);
+            utils::remove_distance_metadata(&client, peer);
         }
 
-        // Advertise the data for the regular peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-
-        // Verify that a random peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
-
-        // Disconnect the selected peer and verify another peer is selected
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert_ne!(selected_peer, another_selected_peer);
-        assert!(regular_peers.contains(&another_selected_peer));
-
-        // Add several priority peers and remove their distance metadata
-        let mut priority_peers = vec![];
-        for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
-
-            // Remove the distance metadata for the peer
-            utils::remove_distance_metadata(&client, priority_peer);
-        }
-
-        // Verify that a random regular peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
-
-        // Advertise the data for the priority peers
-        update_storage_summaries_for_peers(
+        // Advertise the data for the medium priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &priority_peers,
+            &medium_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify that a random priority peer is now selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that random medium priority peers are selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(medium_priority_peers.is_superset(&selected_peers));
 
-        // Disconnect the priority peer and verify a random priority peer is selected
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, selected_peer);
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert_ne!(selected_peer, another_selected_peer);
-        assert!(priority_peers.contains(&another_selected_peer));
+        // Disconnect the selected peers and verify other peers are selected
+        disconnect_and_remove_peers(
+            &mut mock_network,
+            &mut medium_priority_peers,
+            &selected_peers,
+        );
+        let other_selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert_ne!(selected_peers, other_selected_peers);
+        assert!(medium_priority_peers.is_superset(&other_selected_peers));
 
-        // Disconnect and remove all regular and priority peers
-        for regular_peer in regular_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, regular_peer);
+        // Add several high priority peers and remove their distance metadata
+        let mut high_priority_peers = hashset![];
+        for _ in 0..3 {
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
+
+            // Remove the distance metadata for the peer
+            utils::remove_distance_metadata(&client, peer);
         }
-        for priority_peer in priority_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, priority_peer);
-        }
+
+        // Verify that medium priority peers are selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(medium_priority_peers.is_superset(&selected_peers));
+
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &high_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
+
+        // Verify that high priority peers are now selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(high_priority_peers.is_superset(&selected_peers));
+
+        // Disconnect the high priority peers and verify more high priority peers are selected
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &selected_peers);
+        let other_selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert_ne!(selected_peers, other_selected_peers);
+        assert!(high_priority_peers.is_superset(&other_selected_peers));
+
+        // Disconnect and remove all medium priority and high priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut medium_priority_peers);
+        disconnect_and_remove_all_peers(&mut mock_network, &mut high_priority_peers);
 
         // Verify no peers can service the request
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
     }
 }
 
@@ -821,77 +444,81 @@ async fn prioritized_peer_optimistic_fetch_missing_latencies() {
     let known_epoch = 5;
 
     // Ensure the properties hold for all optimistic fetch requests
-    for data_request in enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several regular peers and remove their latency metadata
-        let mut regular_peers = vec![];
+        // Add several medium priority peers and remove their latency metadata
+        let mut medium_priority_peers = hashset![];
         for _ in 0..5 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a medium priority peer
+            let peer = mock_network.add_peer(PeerPriority::LowPriority);
+            medium_priority_peers.insert(peer);
 
             // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, regular_peer);
+            utils::remove_latency_metadata(&client, peer);
         }
 
-        // Advertise the data for the regular peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-
-        // Verify that a random peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
-
-        // Disconnect the selected peer and verify another peer is selected
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert_ne!(selected_peer, another_selected_peer);
-        assert!(regular_peers.contains(&another_selected_peer));
-
-        // Add several priority peers and remove their latency metadata
-        let mut priority_peers = vec![];
-        for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
-
-            // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, priority_peer);
-        }
-
-        // Verify that a random regular peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
-
-        // Advertise the data for the priority peers
-        update_storage_summaries_for_peers(
+        // Advertise the data for the medium priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &priority_peers,
+            &medium_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify that a random priority peer is now selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that random medium priority peers are selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(medium_priority_peers.is_superset(&selected_peers));
 
-        // Disconnect the priority peer and verify a random priority peer is selected
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, selected_peer);
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert_ne!(selected_peer, another_selected_peer);
-        assert!(priority_peers.contains(&another_selected_peer));
+        // Disconnect the selected peers and verify other peers are selected
+        disconnect_and_remove_peers(
+            &mut mock_network,
+            &mut medium_priority_peers,
+            &selected_peers,
+        );
+        let other_selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert_ne!(selected_peers, other_selected_peers);
+        assert!(medium_priority_peers.is_superset(&other_selected_peers));
 
-        // Disconnect and remove all regular and priority peers
-        for regular_peer in regular_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, regular_peer);
+        // Add several high priority peers and remove their latency metadata
+        let mut high_priority_peers = hashset![];
+        for _ in 0..3 {
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
+
+            // Remove the latency metadata for the peer
+            utils::remove_latency_metadata(&client, peer);
         }
-        for priority_peer in priority_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, priority_peer);
-        }
+
+        // Verify that random medium priority peers are selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(medium_priority_peers.is_superset(&selected_peers));
+
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &high_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
+
+        // Verify that random high priority peers are now selected for the request
+        let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(high_priority_peers.is_superset(&selected_peers));
+
+        // Disconnect the high priority peers and verify more priority peers are selected
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &selected_peers);
+        let other_selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+        assert_ne!(selected_peers, other_selected_peers);
+        assert!(high_priority_peers.is_superset(&other_selected_peers));
+
+        // Disconnect and remove all medium priority and high priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut medium_priority_peers);
+        disconnect_and_remove_all_peers(&mut mock_network, &mut high_priority_peers);
 
         // Verify no peers can service the request
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
     }
 }
 
@@ -913,37 +540,43 @@ async fn prioritized_peer_subscription_requests() {
     let known_epoch = 5;
 
     // Ensure the properties hold for all subscription requests
-    for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
         // Ensure no peers can service the request (we have no connections)
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
 
-        // Add two priority peers and a regular peer
-        let priority_peer_1 = mock_network.add_peer(true);
-        let priority_peer_2 = mock_network.add_peer(true);
-        let regular_peer_1 = mock_network.add_peer(false);
+        // Add two high priority peers and a medium priority peer
+        let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+        let high_priority_peer_2 = mock_network.add_peer(PeerPriority::HighPriority);
+        let medium_priority_peer = mock_network.add_peer(PeerPriority::LowPriority);
 
         // Verify no peers can service the request (no peers are advertising data)
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
         // Advertise the data for all peers
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        for peer in [priority_peer_1, priority_peer_2, regular_peer_1] {
+        for peer in [
+            high_priority_peer_1,
+            high_priority_peer_2,
+            medium_priority_peer,
+        ] {
             client.update_peer_storage_summary(
                 peer,
                 utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
             );
         }
 
-        // Verify a priority peer is selected
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(selected_peer == priority_peer_1 || selected_peer == priority_peer_2);
+        // Verify a high priority peer is selected
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        assert!(
+            selected_peer == hashset![high_priority_peer_1]
+                || selected_peer == hashset![high_priority_peer_2]
+        );
 
         // Make several more requests and verify the same priority peer is selected
         for _ in 0..10 {
-            let current_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-            assert_eq!(selected_peer, current_selected_peer);
+            utils::verify_selected_peers_match(&client, selected_peer.clone(), &storage_request);
         }
 
         // Elapse enough time for all peers to be too far behind
@@ -953,8 +586,12 @@ async fn prioritized_peer_subscription_requests() {
 
         // Advertise new data for all peers (except the selected peer)
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        for peer in [priority_peer_1, priority_peer_2, regular_peer_1] {
-            if peer != selected_peer {
+        for peer in [
+            high_priority_peer_1,
+            high_priority_peer_2,
+            medium_priority_peer,
+        ] {
+            if hashset![peer] != selected_peer {
                 client.update_peer_storage_summary(
                     peer,
                     utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
@@ -964,31 +601,42 @@ async fn prioritized_peer_subscription_requests() {
 
         // Verify no peers can service the request (because the
         // previously selected peer is still too far behind).
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Verify the other priority peer is now select (as the
+        // Verify the other high priority peer is now select (as the
         // previous request will terminate the subscription).
-        let next_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        let next_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, next_selected_peer);
-        assert!(selected_peer == priority_peer_1 || selected_peer == priority_peer_2);
+        assert!(
+            selected_peer == hashset![high_priority_peer_1]
+                || selected_peer == hashset![high_priority_peer_2]
+        );
 
-        // Update the request's subscription ID and verify the other priority peer is selected
-        let storage_request = update_subscription_request_id(&storage_request);
-        let next_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        // Update the request's subscription ID and verify the other high priority peer is selected
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        let next_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, next_selected_peer);
-        assert!(next_selected_peer == priority_peer_1 || next_selected_peer == priority_peer_2);
+        assert!(
+            next_selected_peer == hashset![high_priority_peer_1]
+                || next_selected_peer == hashset![high_priority_peer_2]
+        );
 
-        // Make several more requests and verify the same priority peer is selected
+        // Make several more requests and verify the same high priority peer is selected
         for _ in 0..10 {
-            let current_select_peer = client.choose_peer_for_request(&storage_request).unwrap();
-            assert_eq!(current_select_peer, next_selected_peer);
+            utils::verify_selected_peers_match(
+                &client,
+                next_selected_peer.clone(),
+                &storage_request,
+            );
         }
 
         // Disconnect all peers and verify no peers can service the request
-        for peer in [priority_peer_1, priority_peer_2, regular_peer_1] {
-            mock_network.disconnect_peer(peer);
-        }
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::disconnect_all_peers(&mut mock_network, &hashset![
+            high_priority_peer_1,
+            high_priority_peer_2,
+            medium_priority_peer
+        ]);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
     }
 }
 
@@ -1010,175 +658,114 @@ async fn prioritized_peer_subscription_distance_latency_selection() {
     let known_epoch = 1;
 
     // Ensure the properties hold for all subscription requests
-    for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several regular peers and verify the peers cannot service the request
-        let mut regular_peers = vec![];
+        // Add several low priority peers and verify the peers cannot service the request
+        let mut low_priority_peers = hashset![];
         for _ in 0..5 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a low priority peer
+            let peer = mock_network.add_peer(PeerPriority::LowPriority);
+            low_priority_peers.insert(peer);
 
             // Verify the peer cannot service the request
-            verify_request_is_unserviceable(&client, &storage_request);
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
         }
 
-        // Advertise the data for the regular peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-
-        // Verify the peer is selected by distance and latency
-        let selected_peer = verify_peer_selected_by_distance_and_latency(
-            &mut mock_network,
+        // Advertise the data for the low priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &storage_request,
-            &mut regular_peers,
-        );
-
-        // Add several priority peers and verify the regular peer is still selected
-        let mut priority_peers = vec![];
-        for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
-
-            // Verify the regular peer is still selected
-            verify_peer_selected_for_request(&client, selected_peer, &storage_request);
-        }
-
-        // Advertise the data for the priority peers
-        update_storage_summaries_for_peers(
-            &client,
-            &priority_peers,
+            &low_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify the request is unserviceable (the last request went to the regular peer)
-        verify_request_is_unserviceable(&client, &storage_request);
-
-        // Update the request's subscription ID and verify
-        // the peer is selected by distance and latency.
-        let storage_request = update_subscription_request_id(&storage_request);
-        verify_peer_selected_by_distance_and_latency(
+        // Verify the low priority peer is selected by distance and latency
+        let selected_peers = verify_peers_selected_by_distance_and_latency(
             &mut mock_network,
             &client,
             &storage_request,
-            &mut priority_peers,
+            &mut low_priority_peers,
         );
+        assert_eq!(selected_peers.len(), 1);
+        let low_priority_peer = selected_peers.iter().next().unwrap();
 
-        // Disconnect all but one priority peer and remove them from the list of priority peers
-        let last_priority_peer = priority_peers[0];
-        for priority_peer in priority_peers.clone() {
-            if priority_peer != last_priority_peer {
-                mock_network.disconnect_peer(priority_peer);
-            }
-        }
-        priority_peers.retain(|peer| *peer == last_priority_peer);
+        // Add several high priority peers and verify the low priority peer is still selected
+        let mut high_priority_peers = hashset![];
+        for _ in 0..3 {
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
 
-        // Update the request's subscription ID and verify the
-        // peer is selected by distance and latency.
-        let storage_request = update_subscription_request_id(&storage_request);
-        verify_peer_selected_by_distance_and_latency(
-            &mut mock_network,
-            &client,
-            &storage_request,
-            &mut priority_peers,
-        );
-
-        // Disconnect the final priority peer and remove it from the list of priority peers
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, last_priority_peer);
-
-        // Verify the request is unserviceable (the last request went to the priority peer)
-        verify_request_is_unserviceable(&client, &storage_request);
-
-        // Update the request's subscription ID and verify the
-        // peer is selected by distance and latency.
-        let storage_request = update_subscription_request_id(&storage_request);
-        verify_peer_selected_by_distance_and_latency(
-            &mut mock_network,
-            &client,
-            &storage_request,
-            &mut regular_peers,
-        );
-
-        // Disconnect all regular peers and verify no peers can service the request
-        for regular_peer in regular_peers {
-            mock_network.disconnect_peer(regular_peer);
-        }
-        verify_request_is_unserviceable(&client, &storage_request);
-    }
-}
-
-#[tokio::test]
-async fn prioritized_peer_subscription_distance_latency_weights() {
-    // Create a data client with a max lag of 500
-    let max_subscription_lag_secs = 500;
-    let data_client_config = AptosDataClientConfig {
-        max_subscription_lag_secs,
-        ..Default::default()
-    };
-
-    // Create test data
-    let known_version = 1;
-    let known_epoch = 1;
-    let min_validator_distance = 1;
-    let max_validator_distance = 3;
-
-    // Ensure the properties hold for both priority and non-priority peers
-    for priority_peers in [true, false] {
-        // Ensure the properties hold for all subscription requests
-        for data_request in enumerate_subscription_requests(known_version, known_epoch) {
-            let storage_request = StorageServiceRequest::new(data_request, true);
-
-            // Create the mock network, time service and client
-            let (mut mock_network, time_service, client, _) =
-                MockNetwork::new(None, Some(data_client_config), None);
-
-            // Add several peers and verify the peers cannot service the request
-            let mut peers = vec![];
-            for _ in 0..50 {
-                // Add a peer
-                let peer = mock_network.add_peer(priority_peers);
-                peers.push(peer);
-
-                // Verify the peer cannot service the request
-                verify_request_is_unserviceable(&client, &storage_request);
-
-                // Generate a random distance for the peer and update the peer's distance metadata
-                let distance_from_validator =
-                    rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
-                utils::update_distance_metadata(&client, peer, distance_from_validator as u64);
-            }
-
-            // Advertise the data for the peers
-            let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-            update_storage_summaries_for_peers(&client, &peers, known_version, timestamp_usecs);
-
-            // Select a peer to service the request multiple times
-            let mut peers_and_selection_counts = HashMap::new();
-            for _ in 0..20_000 {
-                // Select a peer to service the request
-                let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-
-                // Update the peer selection counts
-                *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
-            }
-
-            // Verify all of the selected peers have the lowest distance
-            for peer in peers_and_selection_counts.keys() {
-                let distance_from_validator =
-                    utils::get_peer_distance_from_validators(&mut mock_network, *peer);
-                assert_eq!(distance_from_validator, min_validator_distance);
-            }
-
-            // Verify the highest selected peers are the lowest latency peers
-            utils::verify_highest_peer_selection_latencies(
-                &mut mock_network,
-                &mut peers_and_selection_counts,
+            // Verify the low priority peer is still selected
+            utils::verify_selected_peers_match(
+                &client,
+                hashset![*low_priority_peer],
+                &storage_request,
             );
         }
+
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &high_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
+
+        // Verify the request is unserviceable (the last request went to the low priority peer)
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+        // Update the request's subscription ID and verify
+        // the high priority peer is selected by distance and latency.
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        verify_peers_selected_by_distance_and_latency(
+            &mut mock_network,
+            &client,
+            &storage_request,
+            &mut high_priority_peers,
+        );
+
+        // Disconnect all but one high priority peer and remove them from the list of peers
+        let last_priority_peer = *high_priority_peers.iter().next().unwrap();
+        for peer in high_priority_peers.clone() {
+            if peer != last_priority_peer {
+                mock_network.disconnect_peer(peer);
+            }
+        }
+        high_priority_peers.retain(|peer| *peer == last_priority_peer);
+
+        // Update the request's subscription ID and verify the
+        // high priority peer is selected by distance and latency.
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        verify_peers_selected_by_distance_and_latency(
+            &mut mock_network,
+            &client,
+            &storage_request,
+            &mut high_priority_peers,
+        );
+
+        // Disconnect the final high priority peer and remove it from the list of peers
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &hashset![
+            last_priority_peer
+        ]);
+
+        // Verify the request is unserviceable (the last request went to the high priority peer)
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+        // Update the request's subscription ID and verify the
+        // low priority peer is selected by distance and latency.
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        verify_peers_selected_by_distance_and_latency(
+            &mut mock_network,
+            &client,
+            &storage_request,
+            &mut low_priority_peers,
+        );
+
+        // Disconnect all low priority peers and verify no peers can service the request
+        utils::disconnect_all_peers(&mut mock_network, &low_priority_peers);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
     }
 }
 
@@ -1200,92 +787,92 @@ async fn prioritized_peer_subscription_missing_distances() {
     let known_epoch = 1;
 
     // Ensure the properties hold for all subscription requests
-    for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several priority peers and remove their distance metadata
-        let mut priority_peers = vec![];
+        // Add several high priority peers and remove their distance metadata
+        let mut high_priority_peers = hashset![];
         for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
 
             // Remove the distance metadata for the peer
-            utils::remove_distance_metadata(&client, priority_peer);
+            utils::remove_distance_metadata(&client, peer);
         }
 
-        // Advertise the data for the priority peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &priority_peers,
+            &high_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify that a random priority peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a random high priority peer is selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
         // Disconnect the selected peer and update the request's subscription ID
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, selected_peer);
-        let storage_request = update_subscription_request_id(&storage_request);
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &selected_peer);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that another priority peer is selected for the request
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        // Verify that another high priority peer is selected for the request
+        let another_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, another_selected_peer);
-        assert!(priority_peers.contains(&another_selected_peer));
+        verify_peer_in_set(&another_selected_peer, &high_priority_peers);
 
-        // Add several regular peers and remove their distance metadata
-        let mut regular_peers = vec![];
+        // Add several low priority peers and remove their distance metadata
+        let mut low_priority_peers = hashset![];
         for _ in 0..10 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a low priority peer
+            let peer = mock_network.add_peer(PeerPriority::LowPriority);
+            low_priority_peers.insert(peer);
 
             // Remove the distance metadata for the peer
-            utils::remove_distance_metadata(&client, regular_peer);
+            utils::remove_distance_metadata(&client, peer);
         }
 
-        // Verify that a priority peer is still selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a high priority peer is still selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
-        // Advertise the data for the regular peers and update the request's subscription ID
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-        let storage_request = update_subscription_request_id(&storage_request);
+        // Advertise the data for the low priority peers and update the request's subscription ID
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &low_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that a random priority peer is still selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a random high priority peer is still selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
-        // Disconnect and remove all priority peers
-        for priority_peer in priority_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, priority_peer);
-        }
+        // Disconnect and remove all high priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut high_priority_peers);
 
-        // Update the request's subscription ID and verify that a random regular peer is selected
-        let storage_request = update_subscription_request_id(&storage_request);
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
+        // Update the request's subscription ID and verify that a random low priority peer is selected
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &low_priority_peers);
 
         // Disconnect the selected peer and update the request's subscription ID
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
-        let storage_request = update_subscription_request_id(&storage_request);
+        disconnect_and_remove_peers(&mut mock_network, &mut low_priority_peers, &selected_peer);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that another regular peer is selected for the request
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        // Verify that another low priority peer is selected for the request
+        let another_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, another_selected_peer);
-        assert!(regular_peers.contains(&another_selected_peer));
+        verify_peer_in_set(&another_selected_peer, &low_priority_peers);
 
-        // Disconnect and remove all regular peers
-        for regular_peer in regular_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, regular_peer);
-        }
+        // Disconnect and remove all low priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut low_priority_peers);
 
         // Verify no peers can service the request
         for _ in 0..10 {
-            verify_request_is_unserviceable(&client, &storage_request);
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
         }
     }
 }
@@ -1308,92 +895,96 @@ async fn prioritized_peer_subscription_missing_latencies() {
     let known_epoch = 1;
 
     // Ensure the properties hold for all subscription requests
-    for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
-        // Add several priority peers and remove their latency metadata
-        let mut priority_peers = vec![];
+        // Add several high priority peers and remove their latency metadata
+        let mut high_priority_peers = hashset![];
         for _ in 0..3 {
-            // Add a priority peer
-            let priority_peer = mock_network.add_peer(true);
-            priority_peers.push(priority_peer);
+            // Add a high priority peer
+            let peer = mock_network.add_peer(PeerPriority::HighPriority);
+            high_priority_peers.insert(peer);
 
             // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, priority_peer);
+            utils::remove_latency_metadata(&client, peer);
         }
 
-        // Advertise the data for the priority peers
-        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        update_storage_summaries_for_peers(
+        // Advertise the data for the high priority peers
+        utils::update_storage_summaries_for_peers(
             &client,
-            &priority_peers,
+            &high_priority_peers,
             known_version,
-            timestamp_usecs,
+            time_service.now_unix_time().as_micros(),
         );
 
-        // Verify that a random priority peer is selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a random high priority peer is selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
         // Disconnect the selected peer and update the request's subscription ID
-        disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, selected_peer);
-        let storage_request = update_subscription_request_id(&storage_request);
+        disconnect_and_remove_peers(&mut mock_network, &mut high_priority_peers, &selected_peer);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that another priority peer is selected for the request
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        // Verify that another high priority peer is selected for the request
+        let another_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, another_selected_peer);
-        assert!(priority_peers.contains(&another_selected_peer));
+        verify_peer_in_set(&another_selected_peer, &high_priority_peers);
 
-        // Add several regular peers and remove their latency metadata
-        let mut regular_peers = vec![];
+        // Add several medium priority peers and remove their latency metadata
+        let mut medium_priority_peers = hashset![];
         for _ in 0..10 {
-            // Add a regular peer
-            let regular_peer = mock_network.add_peer(false);
-            regular_peers.push(regular_peer);
+            // Add a medium priority peer
+            let peer = mock_network.add_peer(PeerPriority::MediumPriority);
+            medium_priority_peers.insert(peer);
 
             // Remove the latency metadata for the peer
-            utils::remove_latency_metadata(&client, regular_peer);
+            utils::remove_latency_metadata(&client, peer);
         }
 
-        // Verify that a priority peer is still selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a high priority peer is still selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
-        // Advertise the data for the regular peers and update the request's subscription ID
-        update_storage_summaries_for_peers(&client, &regular_peers, known_version, timestamp_usecs);
-        let storage_request = update_subscription_request_id(&storage_request);
+        // Advertise the data for the medium priority peers and update the request's subscription ID
+        utils::update_storage_summaries_for_peers(
+            &client,
+            &medium_priority_peers,
+            known_version,
+            time_service.now_unix_time().as_micros(),
+        );
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that a random priority peer is still selected for the request
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(priority_peers.contains(&selected_peer));
+        // Verify that a random high priority peer is still selected for the request
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &high_priority_peers);
 
-        // Disconnect and remove all priority peers
-        for priority_peer in priority_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut priority_peers, priority_peer);
-        }
+        // Disconnect and remove all high priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut high_priority_peers);
 
-        // Update the request's subscription ID and verify that a random regular peer is selected
-        let storage_request = update_subscription_request_id(&storage_request);
-        let selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
-        assert!(regular_peers.contains(&selected_peer));
+        // Update the request's subscription ID and verify that a random medium priority peer is selected
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        let selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
+        verify_peer_in_set(&selected_peer, &medium_priority_peers);
 
         // Disconnect the selected peer and update the request's subscription ID
-        disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, selected_peer);
-        let storage_request = update_subscription_request_id(&storage_request);
+        disconnect_and_remove_peers(
+            &mut mock_network,
+            &mut medium_priority_peers,
+            &selected_peer,
+        );
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Verify that another regular peer is selected for the request
-        let another_selected_peer = client.choose_peer_for_request(&storage_request).unwrap();
+        // Verify that another medium priority peer is selected for the request
+        let another_selected_peer = client.choose_peers_for_request(&storage_request).unwrap();
         assert_ne!(selected_peer, another_selected_peer);
-        assert!(regular_peers.contains(&another_selected_peer));
+        verify_peer_in_set(&another_selected_peer, &medium_priority_peers);
 
-        // Disconnect and remove all regular peers
-        for regular_peer in regular_peers.clone() {
-            disconnect_and_remove_peer(&mut mock_network, &mut regular_peers, regular_peer);
-        }
+        // Disconnect and remove all medium priority peers
+        disconnect_and_remove_all_peers(&mut mock_network, &mut medium_priority_peers);
 
         // Verify no peers can service the request
         for _ in 0..10 {
-            verify_request_is_unserviceable(&client, &storage_request);
+            utils::verify_request_is_unserviceable(&client, &storage_request, true);
         }
     }
 }
@@ -1416,39 +1007,51 @@ async fn prioritized_peer_subscription_sticky_selection() {
     let known_epoch = 10;
 
     // Ensure the properties hold for all subscription requests
-    for data_request in enumerate_subscription_requests(known_version, known_epoch) {
+    for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
         // Ensure no peers can service the request (we have no connections)
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, true);
 
-        // Add a regular peer and verify the peer cannot service the request
-        let regular_peer_1 = mock_network.add_peer(false);
-        verify_request_is_unserviceable(&client, &storage_request);
+        // Add a low priority peer and verify the peer cannot service the request
+        let low_priority_peer_1 = mock_network.add_peer(PeerPriority::LowPriority);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Advertise the data for the regular peer and verify it is now selected
+        // Advertise the data for the low priority peer and verify it is now selected
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
         client.update_peer_storage_summary(
-            regular_peer_1,
+            low_priority_peer_1,
             utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![low_priority_peer_1],
+            &storage_request,
+        );
 
-        // Add a priority peer and verify the regular peer is still selected
-        let priority_peer_1 = mock_network.add_peer(true);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        // Add a high priority peer and verify the low priority peer is still selected
+        let high_priority_peer_1 = mock_network.add_peer(PeerPriority::HighPriority);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![low_priority_peer_1],
+            &storage_request,
+        );
 
-        // Advertise the data for the priority peer and verify it is not selected
-        // (the previous subscription request went to the regular peer).
+        // Advertise the data for the high priority peer and verify it is not selected
+        // (the previous subscription request went to the low priority peer).
         client.update_peer_storage_summary(
-            priority_peer_1,
+            high_priority_peer_1,
             utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
         );
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Update the request's subscription ID and verify it now goes to the priority peer
-        let storage_request = update_subscription_request_id(&storage_request);
-        verify_peer_selected_for_request(&client, priority_peer_1, &storage_request);
+        // Update the request's subscription ID and verify it now goes to the high priority peer
+        let storage_request = utils::update_subscription_request_id(&storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_1],
+            &storage_request,
+        );
 
         // Elapse enough time for both peers to be too far behind
         time_service
@@ -1456,64 +1059,67 @@ async fn prioritized_peer_subscription_sticky_selection() {
             .advance_secs(max_subscription_lag_secs + 1);
 
         // Verify neither peer is now selected
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
         // Update the request's subscription ID
-        let storage_request = update_subscription_request_id(&storage_request);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Update the regular peer to be up-to-date and verify it is now chosen
+        // Update the low priority peer to be up-to-date and verify it is now chosen
         let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
-        let regular_peer_timestamp_usecs =
+        let peer_timestamp_usecs =
             timestamp_usecs - ((max_subscription_lag_secs / 2) * NUM_MICROSECONDS_IN_SECOND);
         client.update_peer_storage_summary(
-            regular_peer_1,
-            utils::create_storage_summary_with_timestamp(
-                known_version,
-                regular_peer_timestamp_usecs,
-            ),
+            low_priority_peer_1,
+            utils::create_storage_summary_with_timestamp(known_version, peer_timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![low_priority_peer_1],
+            &storage_request,
+        );
 
         // Update the request's subscription ID
-        let storage_request = update_subscription_request_id(&storage_request);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Update the priority peer to be up-to-date and verify it is now chosen
-        let priority_peer_timestamp_usecs =
+        // Update the high priority peer to be up-to-date and verify it is now chosen
+        let peer_timestamp_usecs =
             timestamp_usecs - ((max_subscription_lag_secs / 2) * NUM_MICROSECONDS_IN_SECOND);
         client.update_peer_storage_summary(
-            priority_peer_1,
-            utils::create_storage_summary_with_timestamp(
-                known_version,
-                priority_peer_timestamp_usecs,
-            ),
+            high_priority_peer_1,
+            utils::create_storage_summary_with_timestamp(known_version, peer_timestamp_usecs),
         );
-        verify_peer_selected_for_request(&client, priority_peer_1, &storage_request);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![high_priority_peer_1],
+            &storage_request,
+        );
 
         // Update the request's subscription ID
-        let storage_request = update_subscription_request_id(&storage_request);
+        let storage_request = utils::update_subscription_request_id(&storage_request);
 
-        // Disconnect the priority peer and verify the regular peer is selected
-        mock_network.disconnect_peer(priority_peer_1);
-        verify_peer_selected_for_request(&client, regular_peer_1, &storage_request);
+        // Disconnect the high priority peer and verify the low priority peer is selected
+        mock_network.disconnect_peer(high_priority_peer_1);
+        utils::verify_selected_peers_match(
+            &client,
+            hashset![low_priority_peer_1],
+            &storage_request,
+        );
 
-        // Elapse enough time for the regular peer to be too far behind
+        // Elapse enough time for the low priority peer to be too far behind
         time_service.clone().advance_secs(max_subscription_lag_secs);
 
         // Verify neither peer is now select
-        verify_request_is_unserviceable(&client, &storage_request);
+        utils::verify_request_is_unserviceable(&client, &storage_request, false);
 
-        // Disconnect the regular peer so that we no longer have any connections
-        mock_network.disconnect_peer(regular_peer_1);
+        // Disconnect the low priority peer so that we no longer have any connections
+        mock_network.disconnect_peer(low_priority_peer_1);
     }
 }
 
 #[tokio::test]
 async fn validator_peer_prioritization() {
-    // Create a validator node
-    let base_config = BaseConfig {
-        role: RoleType::Validator,
-        ..Default::default()
-    };
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
 
     // Create the mock network and client
     let (mut mock_network, _, client, _) = MockNetwork::new(Some(base_config), None, None);
@@ -1522,7 +1128,7 @@ async fn validator_peer_prioritization() {
     let validator_peer = mock_network.add_peer_with_network_id(NetworkId::Validator, false);
     let (priority_peers, regular_peers) = client.get_priority_and_regular_peers().unwrap();
     assert_eq!(priority_peers, hashset![validator_peer]);
-    assert_eq!(regular_peers, hashset![]);
+    assert!(regular_peers.is_empty());
 
     // Add a vfn peer and ensure it's not prioritized
     let vfn_peer = mock_network.add_peer_with_network_id(NetworkId::Vfn, true);
@@ -1533,11 +1139,8 @@ async fn validator_peer_prioritization() {
 
 #[tokio::test]
 async fn vfn_peer_prioritization() {
-    // Create a validator fullnode
-    let base_config = BaseConfig {
-        role: RoleType::FullNode,
-        ..Default::default()
-    };
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
 
     // Create the mock network and client
     let (mut mock_network, _, client, _) = MockNetwork::new(Some(base_config), None, None);
@@ -1546,7 +1149,7 @@ async fn vfn_peer_prioritization() {
     let validator_peer = mock_network.add_peer_with_network_id(NetworkId::Vfn, false);
     let (priority_peers, regular_peers) = client.get_priority_and_regular_peers().unwrap();
     assert_eq!(priority_peers, hashset![validator_peer]);
-    assert_eq!(regular_peers, hashset![]);
+    assert!(regular_peers.is_empty());
 
     // Add a pfn peer and ensure it's not prioritized
     let pfn_peer = mock_network.add_peer_with_network_id(NetworkId::Public, true);
@@ -1557,11 +1160,8 @@ async fn vfn_peer_prioritization() {
 
 #[tokio::test]
 async fn pfn_peer_prioritization() {
-    // Create a public fullnode
-    let base_config = BaseConfig {
-        role: RoleType::FullNode,
-        ..Default::default()
-    };
+    // Create a base config for a PFN
+    let base_config = utils::create_fullnode_base_config();
 
     // Create the mock network and client
     let (mut mock_network, _, client, _) =
@@ -1570,7 +1170,7 @@ async fn pfn_peer_prioritization() {
     // Add an inbound pfn peer and ensure it's not prioritized
     let inbound_peer = mock_network.add_peer_with_network_id(NetworkId::Public, false);
     let (priority_peers, regular_peers) = client.get_priority_and_regular_peers().unwrap();
-    assert_eq!(priority_peers, hashset![]);
+    assert!(priority_peers.is_empty());
     assert_eq!(regular_peers, hashset![inbound_peer]);
 
     // Add an outbound pfn peer and ensure it's prioritized
@@ -1580,101 +1180,33 @@ async fn pfn_peer_prioritization() {
     assert_eq!(regular_peers, hashset![inbound_peer]);
 }
 
-/// Disconnects the given peer and removes it from the list of specified peers
-fn disconnect_and_remove_peer(
+/// Disconnects all the given peers and removes them from the list of specified peers
+fn disconnect_and_remove_all_peers(
     mock_network: &mut MockNetwork,
-    peers: &mut Vec<PeerNetworkId>,
-    peer_to_disconnect: PeerNetworkId,
+    peers: &mut HashSet<PeerNetworkId>,
 ) {
-    // Disconnect the peer
-    mock_network.disconnect_peer(peer_to_disconnect);
-
-    // Remove the peer from the list of given peers
-    peers.retain(|peer| *peer != peer_to_disconnect);
+    utils::disconnect_all_peers(mock_network, peers);
+    peers.clear();
 }
 
-/// Enumerates all optimistic fetch request types
-fn enumerate_optimistic_fetch_requests(known_version: u64, known_epoch: u64) -> Vec<DataRequest> {
-    // Create all optimistic fetch requests
-    let new_transactions_request =
-        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
-            known_version,
-            known_epoch,
-            include_events: false,
-        });
-    let new_outputs_requests =
-        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
-            known_version,
-            known_epoch,
-        });
-    let new_transactions_or_outputs_request = DataRequest::GetNewTransactionsOrOutputsWithProof(
-        NewTransactionsOrOutputsWithProofRequest {
-            known_version,
-            known_epoch,
-            include_events: false,
-            max_num_output_reductions: 0,
-        },
-    );
-
-    // Return all optimistic fetch requests
-    vec![
-        new_transactions_request,
-        new_outputs_requests,
-        new_transactions_or_outputs_request,
-    ]
-}
-
-/// Enumerates all subscription request types
-fn enumerate_subscription_requests(known_version: u64, known_epoch: u64) -> Vec<DataRequest> {
-    // Create all subscription requests
-    let subscribe_transactions_request =
-        DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
-            subscription_stream_metadata: SubscriptionStreamMetadata {
-                known_version_at_stream_start: known_version,
-                known_epoch_at_stream_start: known_epoch,
-                subscription_stream_id: 100,
-            },
-            subscription_stream_index: 0,
-            include_events: false,
-        });
-    let subscribe_outputs_request = DataRequest::SubscribeTransactionOutputsWithProof(
-        SubscribeTransactionOutputsWithProofRequest {
-            subscription_stream_metadata: SubscriptionStreamMetadata {
-                known_version_at_stream_start: known_version,
-                known_epoch_at_stream_start: known_epoch,
-                subscription_stream_id: 200,
-            },
-            subscription_stream_index: 0,
-        },
-    );
-    let subscribe_transactions_or_outputs_request =
-        DataRequest::SubscribeTransactionsOrOutputsWithProof(
-            SubscribeTransactionsOrOutputsWithProofRequest {
-                subscription_stream_metadata: SubscriptionStreamMetadata {
-                    known_version_at_stream_start: known_version,
-                    known_epoch_at_stream_start: known_epoch,
-                    subscription_stream_id: 300,
-                },
-                subscription_stream_index: 0,
-                include_events: false,
-                max_num_output_reductions: 0,
-            },
-        );
-
-    // Return all subscription requests
-    vec![
-        subscribe_transactions_request,
-        subscribe_outputs_request,
-        subscribe_transactions_or_outputs_request,
-    ]
+/// Disconnects the given peers and removes them from the list of specified peers
+fn disconnect_and_remove_peers(
+    mock_network: &mut MockNetwork,
+    peers: &mut HashSet<PeerNetworkId>,
+    peers_to_disconnect: &HashSet<PeerNetworkId>,
+) {
+    for peer_to_disconnect in peers_to_disconnect {
+        mock_network.disconnect_peer(*peer_to_disconnect);
+        peers.retain(|peer| *peer != *peer_to_disconnect);
+    }
 }
 
 /// Returns the peers with the lowest validator distance from the given list of peers
 fn get_lowest_distance_peers(
-    peers: &[PeerNetworkId],
+    peers: &HashSet<PeerNetworkId>,
     mock_network: &mut MockNetwork,
-) -> Vec<PeerNetworkId> {
-    let mut lowest_distance_peers = vec![];
+) -> HashSet<PeerNetworkId> {
+    let mut lowest_distance_peers = hashset![];
     let mut lowest_distance = u64::MAX;
 
     // Identify the peers with the lowest distance
@@ -1686,12 +1218,12 @@ fn get_lowest_distance_peers(
         match distance.cmp(&lowest_distance) {
             Ordering::Equal => {
                 // Add the peer to the list of lowest distance peers
-                lowest_distance_peers.push(*peer)
+                lowest_distance_peers.insert(*peer);
             },
             Ordering::Less => {
                 // We found a new lowest distance!
                 lowest_distance = distance;
-                lowest_distance_peers = vec![*peer];
+                lowest_distance_peers = hashset![*peer];
             },
             Ordering::Greater => {
                 // The peer is not a lowest distance peer
@@ -1702,84 +1234,32 @@ fn get_lowest_distance_peers(
     lowest_distance_peers
 }
 
-/// Updates the storage summaries for the given peers using the specified
-/// version and timestamp.
-fn update_storage_summaries_for_peers(
-    client: &AptosDataClient,
-    peers: &[PeerNetworkId],
-    known_version: u64,
-    timestamp_usecs: u64,
-) {
-    for peer in peers.iter() {
-        client.update_peer_storage_summary(
-            *peer,
-            utils::create_storage_summary_with_timestamp(known_version, timestamp_usecs),
-        );
-    }
+/// Verifies that the given peer set contains a single entry
+/// and that the single peer is in the superset.
+fn verify_peer_in_set(single_peer: &HashSet<PeerNetworkId>, peers: &HashSet<PeerNetworkId>) {
+    assert_eq!(single_peer.len(), 1);
+    assert!(peers.is_superset(single_peer));
 }
 
-/// Updates the subscription request ID in the given storage request
-/// and returns the updated storage request.
-fn update_subscription_request_id(
-    storage_service_request: &StorageServiceRequest,
-) -> StorageServiceRequest {
-    let mut storage_service_request = storage_service_request.clone();
-
-    // Update the subscription's request ID
-    match &mut storage_service_request.data_request {
-        DataRequest::SubscribeTransactionsWithProof(request) => {
-            request.subscription_stream_metadata.subscription_stream_id += 1
-        },
-        DataRequest::SubscribeTransactionOutputsWithProof(request) => {
-            request.subscription_stream_metadata.subscription_stream_id += 1
-        },
-        DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => {
-            request.subscription_stream_metadata.subscription_stream_id += 1
-        },
-        _ => panic!(
-            "Unexpected subscription request type! {:?}",
-            storage_service_request
-        ),
-    }
-
-    storage_service_request
-}
-
-/// Verifies that a low distance and latency peer is selected for
+/// Verifies that low distance and latency peers are selected for
 /// the given request (from the specified list of potential peers)
-/// and returns the select peer.
-fn verify_peer_selected_by_distance_and_latency(
+/// and returns the selected peers.
+fn verify_peers_selected_by_distance_and_latency(
     mock_network: &mut MockNetwork,
     client: &AptosDataClient,
     storage_request: &StorageServiceRequest,
-    potential_peers: &mut [PeerNetworkId],
-) -> PeerNetworkId {
-    // Select a peer for the given request
-    let selected_peer = client.choose_peer_for_request(storage_request).unwrap();
+    potential_peers: &mut HashSet<PeerNetworkId>,
+) -> HashSet<PeerNetworkId> {
+    // Select peers for the given request
+    let selected_peers = client.choose_peers_for_request(storage_request).unwrap();
+    for selected_peer in &selected_peers {
+        // Verify the selected peer is in the list of potential peers
+        assert!(potential_peers.contains(selected_peer));
 
-    // Verify the selected peer is in the list of potential peers
-    assert!(potential_peers.contains(&selected_peer));
+        // Verify the selected peer has the lowest distance
+        let lowest_distance_peers = get_lowest_distance_peers(potential_peers, mock_network);
+        assert!(lowest_distance_peers.contains(selected_peer));
+    }
 
-    // Verify the selected peer has the lowest distance
-    let lowest_distance_peers = get_lowest_distance_peers(potential_peers, mock_network);
-    assert!(lowest_distance_peers.contains(&selected_peer));
-
-    selected_peer
-}
-
-/// Verifies that the peer is selected to service the given request
-fn verify_peer_selected_for_request(
-    client: &AptosDataClient,
-    peer: PeerNetworkId,
-    request: &StorageServiceRequest,
-) {
-    assert_eq!(client.choose_peer_for_request(request), Ok(peer));
-}
-
-/// Verifies that the given request is unserviceable
-fn verify_request_is_unserviceable(client: &AptosDataClient, request: &StorageServiceRequest) {
-    assert_matches!(
-        client.choose_peer_for_request(request),
-        Err(Error::DataIsUnavailable(_))
-    );
+    selected_peers
 }

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -1,16 +1,24 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{client::AptosDataClient, tests::mock::MockNetwork};
+use crate::{
+    client::AptosDataClient, error::Error, priority::PeerPriority, tests::mock::MockNetwork,
+};
 use aptos_config::{
-    config::AptosDataClientConfig,
+    config::{AptosDataClientConfig, BaseConfig, RoleType},
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_crypto::HashValue;
 use aptos_peer_monitoring_service_types::PeerMonitoringMetadata;
 use aptos_storage_service_server::network::NetworkRequest;
 use aptos_storage_service_types::{
-    requests::DataRequest,
+    requests::{
+        DataRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
+        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
+        SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
+        SubscriptionStreamMetadata,
+    },
     responses::{
         CompleteDataRange, DataResponse, DataSummary, ProtocolMetadata, StorageServerSummary,
         StorageServiceResponse,
@@ -24,18 +32,66 @@ use aptos_types::{
     transaction::{TransactionListWithProof, Version},
 };
 use claims::assert_matches;
+use maplit::hashset;
+use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::{BinaryHeap, HashMap},
+    collections::{BinaryHeap, HashMap, HashSet},
     time::Duration,
 };
 
+// Useful test constants
+pub const NUM_SELECTION_ITERATIONS: u64 = 15_000;
+
 /// Adds a peer to the mock network and returns the peer and network id
 pub fn add_peer_to_network(
-    poll_priority_peers: bool,
+    peer_priority: PeerPriority,
     mock_network: &mut MockNetwork,
 ) -> (PeerNetworkId, NetworkId) {
-    let peer = mock_network.add_peer(poll_priority_peers);
+    let peer = mock_network.add_peer(peer_priority);
     (peer, peer.network_id())
+}
+
+/// Adds several peers to the mock network and returns the set of peers
+pub fn add_several_peers(
+    mock_network: &mut MockNetwork,
+    num_peers: u64,
+    peer_priority: PeerPriority,
+) -> HashSet<PeerNetworkId> {
+    let mut peers = hashset![];
+
+    // Add the peers
+    for _ in 0..num_peers {
+        let peer = mock_network.add_peer(peer_priority);
+        peers.insert(peer);
+    }
+
+    peers
+}
+
+/// Adds several peers with metadata to the mock network and returns the set of peers
+pub fn add_several_peers_with_metadata(
+    mock_network: &mut MockNetwork,
+    client: &AptosDataClient,
+    num_peers: u64,
+    min_validator_distance: u64,
+    max_validator_distance: u64,
+    peer_priority: PeerPriority,
+) -> HashSet<PeerNetworkId> {
+    let mut peers = hashset![];
+
+    // Add the peers and metadata
+    for _ in 0..num_peers {
+        // Add a peer
+        let peer = mock_network.add_peer(peer_priority);
+        peers.insert(peer);
+
+        // Generate a random distance for the peer and update the peer's distance metadata
+        let distance_from_validator =
+            rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
+        update_distance_metadata(client, peer, distance_from_validator as u64);
+    }
+
+    peers
 }
 
 /// Advances time by at least the polling loop interval
@@ -97,6 +153,108 @@ pub fn create_storage_summary_with_timestamp(
     }
 }
 
+/// Creates and returns a base config for a fullnode
+pub fn create_fullnode_base_config() -> BaseConfig {
+    BaseConfig {
+        role: RoleType::FullNode,
+        ..Default::default()
+    }
+}
+
+/// Creates and returns a base config for a validator node
+pub fn create_validator_base_config() -> BaseConfig {
+    BaseConfig {
+        role: RoleType::Validator,
+        ..Default::default()
+    }
+}
+
+/// Disconnect all peers from the network
+pub fn disconnect_all_peers(mock_network: &mut MockNetwork, peers: &HashSet<PeerNetworkId>) {
+    for peer in peers.iter() {
+        mock_network.disconnect_peer(*peer);
+    }
+}
+
+/// Enumerates all optimistic fetch request types
+pub fn enumerate_optimistic_fetch_requests(
+    known_version: u64,
+    known_epoch: u64,
+) -> Vec<DataRequest> {
+    // Create all optimistic fetch requests
+    let new_transactions_request =
+        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version,
+            known_epoch,
+            include_events: false,
+        });
+    let new_outputs_requests =
+        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
+            known_version,
+            known_epoch,
+        });
+    let new_transactions_or_outputs_request = DataRequest::GetNewTransactionsOrOutputsWithProof(
+        NewTransactionsOrOutputsWithProofRequest {
+            known_version,
+            known_epoch,
+            include_events: false,
+            max_num_output_reductions: 0,
+        },
+    );
+
+    // Return all optimistic fetch requests
+    vec![
+        new_transactions_request,
+        new_outputs_requests,
+        new_transactions_or_outputs_request,
+    ]
+}
+
+/// Enumerates all subscription request types
+pub fn enumerate_subscription_requests(known_version: u64, known_epoch: u64) -> Vec<DataRequest> {
+    // Create all subscription requests
+    let subscribe_transactions_request =
+        DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
+            subscription_stream_metadata: SubscriptionStreamMetadata {
+                known_version_at_stream_start: known_version,
+                known_epoch_at_stream_start: known_epoch,
+                subscription_stream_id: 100,
+            },
+            subscription_stream_index: 0,
+            include_events: false,
+        });
+    let subscribe_outputs_request = DataRequest::SubscribeTransactionOutputsWithProof(
+        SubscribeTransactionOutputsWithProofRequest {
+            subscription_stream_metadata: SubscriptionStreamMetadata {
+                known_version_at_stream_start: known_version,
+                known_epoch_at_stream_start: known_epoch,
+                subscription_stream_id: 200,
+            },
+            subscription_stream_index: 0,
+        },
+    );
+    let subscribe_transactions_or_outputs_request =
+        DataRequest::SubscribeTransactionsOrOutputsWithProof(
+            SubscribeTransactionsOrOutputsWithProofRequest {
+                subscription_stream_metadata: SubscriptionStreamMetadata {
+                    known_version_at_stream_start: known_version,
+                    known_epoch_at_stream_start: known_epoch,
+                    subscription_stream_id: 300,
+                },
+                subscription_stream_index: 0,
+                include_events: false,
+                max_num_output_reductions: 0,
+            },
+        );
+
+    // Return all subscription requests
+    vec![
+        subscribe_transactions_request,
+        subscribe_outputs_request,
+        subscribe_transactions_or_outputs_request,
+    ]
+}
+
 /// Returns the next network request for the given network id
 pub async fn get_network_request(
     mock_network: &mut MockNetwork,
@@ -124,7 +282,7 @@ pub fn get_peer_ping_latency(mock_network: &mut MockNetwork, peer: PeerNetworkId
 }
 
 /// Returns the peer monitoring metadata for the given peer
-fn get_peer_monitoring_metadata(
+pub fn get_peer_monitoring_metadata(
     mock_network: &mut MockNetwork,
     peer: PeerNetworkId,
 ) -> PeerMonitoringMetadata {
@@ -134,6 +292,24 @@ fn get_peer_monitoring_metadata(
 
     // Return the peer monitoring metadata
     peer_metadata.get_peer_monitoring_metadata()
+}
+
+/// Returns the peer priority for polling based on if `poll_priority_peers` is true
+pub fn get_peer_priority_for_polling(poll_priority_peers: bool) -> PeerPriority {
+    if poll_priority_peers {
+        PeerPriority::HighPriority
+    } else {
+        // Generate a random u64
+        let random_number: u64 = OsRng.gen();
+
+        // If the random number is even, return medium priority.
+        // Otherwise, return low priority.
+        if random_number % 2 == 0 {
+            PeerPriority::MediumPriority
+        } else {
+            PeerPriority::LowPriority
+        }
+    }
 }
 
 /// Handles a storage server summary request by sending the specified storage summary
@@ -205,6 +381,30 @@ pub fn remove_latency_metadata(client: &AptosDataClient, peer: PeerNetworkId) {
         .unwrap();
 }
 
+/// Chooses peers to service the given request multiple times and
+/// returns a map of the peers and their selection counts.
+pub fn select_peers_multiple_times(
+    client: &AptosDataClient,
+    expected_num_peers_for_request: usize,
+    storage_request: &StorageServiceRequest,
+) -> HashMap<PeerNetworkId, i32> {
+    let mut peers_and_selection_counts = HashMap::new();
+
+    // Select the peers multiple times and collect the selection counts
+    for _ in 0..NUM_SELECTION_ITERATIONS {
+        // Select peers to service the request
+        let selected_peers = client.choose_peers_for_request(storage_request).unwrap();
+        assert_eq!(selected_peers.len(), expected_num_peers_for_request);
+
+        // Update the peer selection counts
+        for selected_peer in selected_peers {
+            *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
+        }
+    }
+
+    peers_and_selection_counts
+}
+
 /// Updates the distance metadata for the specified peer
 pub fn update_distance_metadata(
     client: &AptosDataClient,
@@ -229,16 +429,56 @@ pub fn update_distance_metadata(
         .unwrap();
 }
 
+/// Updates the storage summaries for the given peers using the specified
+/// version and timestamp.
+pub fn update_storage_summaries_for_peers(
+    client: &AptosDataClient,
+    peers: &HashSet<PeerNetworkId>,
+    known_version: u64,
+    timestamp_usecs: u128,
+) {
+    for peer in peers.iter() {
+        client.update_peer_storage_summary(
+            *peer,
+            create_storage_summary_with_timestamp(known_version, timestamp_usecs as u64),
+        );
+    }
+}
+
+/// Updates the subscription request ID in the given storage request
+/// and returns the updated storage request.
+pub fn update_subscription_request_id(
+    storage_service_request: &StorageServiceRequest,
+) -> StorageServiceRequest {
+    let mut storage_service_request = storage_service_request.clone();
+
+    // Update the subscription's request ID
+    match &mut storage_service_request.data_request {
+        DataRequest::SubscribeTransactionsWithProof(request) => {
+            request.subscription_stream_metadata.subscription_stream_id += 1
+        },
+        DataRequest::SubscribeTransactionOutputsWithProof(request) => {
+            request.subscription_stream_metadata.subscription_stream_id += 1
+        },
+        DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => {
+            request.subscription_stream_metadata.subscription_stream_id += 1
+        },
+        _ => panic!(
+            "Unexpected subscription request type! {:?}",
+            storage_service_request
+        ),
+    }
+
+    storage_service_request
+}
+
 /// Verifies the top 10% of selected peers are the lowest latency peers
 pub fn verify_highest_peer_selection_latencies(
     mock_network: &mut MockNetwork,
     peers_and_selection_counts: &mut HashMap<PeerNetworkId, i32>,
 ) {
     // Build a max-heap of all peers by their selection counts
-    let mut max_heap_selection_counts = BinaryHeap::new();
-    for (peer, selection_count) in peers_and_selection_counts.clone() {
-        max_heap_selection_counts.push((selection_count, peer));
-    }
+    let mut max_heap_selection_counts = build_selection_count_max_heap(peers_and_selection_counts);
 
     // Verify the top 10% of polled peers are the lowest latency peers
     let peers_to_verify = peers_and_selection_counts.len() / 10;
@@ -262,4 +502,67 @@ pub fn verify_highest_peer_selection_latencies(
         // Update the highest seen latency
         highest_seen_latency = ping_latency;
     }
+}
+
+/// Builds and returns a max-heap of all peers by their selection counts
+pub fn build_selection_count_max_heap(
+    peers_and_selection_counts: &HashMap<PeerNetworkId, i32>,
+) -> BinaryHeap<(i32, PeerNetworkId)> {
+    let mut max_heap_selection_counts = BinaryHeap::new();
+    for (peer, selection_count) in peers_and_selection_counts.clone() {
+        max_heap_selection_counts.push((selection_count, peer));
+    }
+    max_heap_selection_counts
+}
+
+/// Verifies that the selected peers for the given request match the expected peers
+pub fn verify_selected_peers_match(
+    client: &AptosDataClient,
+    expected_peers: HashSet<PeerNetworkId>,
+    request: &StorageServiceRequest,
+) {
+    let selected_peers = client.choose_peers_for_request(request).unwrap();
+    assert_eq!(selected_peers, expected_peers);
+}
+
+/// Verifies that the given request is unserviceable
+pub fn verify_request_is_unserviceable(
+    client: &AptosDataClient,
+    request: &StorageServiceRequest,
+    no_connected_peers: bool,
+) {
+    let result = client.choose_peers_for_request(request);
+    if no_connected_peers {
+        assert_matches!(result, Err(Error::NoConnectedPeers(_)));
+    } else {
+        assert_matches!(result, Err(Error::DataIsUnavailable(_)));
+    }
+}
+
+/// Selects peers to service the given request and verifies
+/// that: (i) only a single peer is selected; and (ii) that
+/// peer is contained in the broader set.
+pub fn verify_selected_peer_from_set(
+    client: &AptosDataClient,
+    storage_request: &StorageServiceRequest,
+    peers: &HashSet<PeerNetworkId>,
+) {
+    verify_selected_peers_from_set(client, storage_request, 1, peers)
+}
+
+/// Selects peers to service the given request and verifies that:
+/// (i) the correct number of peers are selection; and
+/// (ii) the peers are contained in the broader set.
+pub fn verify_selected_peers_from_set(
+    client: &AptosDataClient,
+    storage_request: &StorageServiceRequest,
+    num_expected_peers: usize,
+    peers: &HashSet<PeerNetworkId>,
+) {
+    // Select peers to service the request
+    let selected_peers = client.choose_peers_for_request(storage_request).unwrap();
+
+    // Verify the selected peers
+    assert_eq!(selected_peers.len(), num_expected_peers);
+    assert!(peers.is_superset(&selected_peers));
 }

--- a/state-sync/aptos-data-client/src/tests/weighted_selection.rs
+++ b/state-sync/aptos-data-client/src/tests/weighted_selection.rs
@@ -1,0 +1,894 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::AptosDataClient,
+    priority::PeerPriority,
+    tests::{mock::MockNetwork, utils, utils::NUM_SELECTION_ITERATIONS},
+};
+use aptos_config::{
+    config::{AptosDataClientConfig, AptosDataMultiFetchConfig, AptosLatencyFilteringConfig},
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_storage_service_types::requests::{DataRequest, StorageServiceRequest};
+use aptos_time_service::TimeServiceTrait;
+use maplit::hashset;
+use ordered_float::OrderedFloat;
+use rand::Rng;
+use std::collections::{HashMap, HashSet};
+
+// Useful test constants
+const NUM_PEERS_TO_ADD: u64 = 50;
+
+#[tokio::test]
+async fn optimistic_fetch_distance_latency_weights() {
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 3;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let min_validator_distance = 0;
+    let max_validator_distance = 2;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network, time service and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(None, Some(data_client_config), None);
+
+            // Add several peers with metadata
+            let peers = utils::add_several_peers_with_metadata(
+                &mut mock_network,
+                &client,
+                NUM_PEERS_TO_ADD,
+                min_validator_distance,
+                max_validator_distance,
+                peer_priority,
+            );
+
+            // Verify none of the peers can service the request
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &peers,
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select peers to service the request multiple times
+            let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+                &client,
+                num_peers_for_multi_fetch,
+                &storage_request,
+            );
+
+            // Verify all of the selected peers have the lowest distance
+            verify_lowest_distance_from_validators(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+                min_validator_distance,
+            );
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn optimistic_fetch_missing_distances() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 4;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let validator_distance = 2;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+            // Add several peers with metadata
+            let peers = utils::add_several_peers_with_metadata(
+                &mut mock_network,
+                &client,
+                NUM_PEERS_TO_ADD,
+                validator_distance,
+                validator_distance,
+                peer_priority,
+            );
+
+            // Remove the distance metadata for some peers
+            let peers_with_missing_distances =
+                remove_metadata_for_several_peers(&client, &peers, false);
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &HashSet::from_iter(peers),
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select peers to service the request multiple times
+            let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+                &client,
+                num_peers_for_multi_fetch,
+                &storage_request,
+            );
+
+            // Verify all of the selected peers have the lowest distance
+            verify_lowest_distance_from_validators(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+                validator_distance,
+            );
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+
+            // Verify that the peers with missing distances are not selected
+            verify_zero_selection_counts(
+                &peers_with_missing_distances,
+                &peers_and_selection_counts,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn optimistic_fetch_no_distances() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 2;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let min_validator_distance = 0;
+    let max_validator_distance = 3;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+            // Add several peers with metadata
+            let peers = utils::add_several_peers_with_metadata(
+                &mut mock_network,
+                &client,
+                NUM_PEERS_TO_ADD,
+                min_validator_distance,
+                max_validator_distance,
+                peer_priority,
+            );
+
+            // Remove the distance metadata for all peers
+            for peer in peers.iter() {
+                utils::remove_distance_metadata(&client, *peer);
+            }
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &HashSet::from_iter(peers.clone()),
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select peers to service the request multiple times
+            let peers_and_selection_counts = utils::select_peers_multiple_times(
+                &client,
+                num_peers_for_multi_fetch,
+                &storage_request,
+            );
+
+            // Verify that peers are still selected even though there are no recorded distances
+            verify_all_peers_are_selected(peers, peers_and_selection_counts);
+        }
+    }
+}
+
+#[tokio::test]
+async fn optimistic_fetch_missing_latencies() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 3;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let validator_distance = 1;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+            // Add several peers with metadata
+            let peers = utils::add_several_peers_with_metadata(
+                &mut mock_network,
+                &client,
+                NUM_PEERS_TO_ADD,
+                validator_distance,
+                validator_distance,
+                peer_priority,
+            );
+
+            // Remove the latency metadata for some peers
+            let peers_with_missing_latencies =
+                remove_metadata_for_several_peers(&client, &peers, true);
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &HashSet::from_iter(peers),
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select peers to service the request multiple times
+            let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+                &client,
+                num_peers_for_multi_fetch,
+                &storage_request,
+            );
+
+            // Verify all of the selected peers have the lowest distance
+            verify_lowest_distance_from_validators(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+                validator_distance,
+            );
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+
+            // Verify that the peers with missing latencies are not selected
+            verify_zero_selection_counts(
+                &peers_with_missing_latencies,
+                &peers_and_selection_counts,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn optimistic_fetch_no_latencies() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with a max lag of 5 and multi-fetch enabled
+    let max_optimistic_fetch_lag_secs = 5;
+    let num_peers_for_multi_fetch = 3;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        max_optimistic_fetch_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+    let min_validator_distance = 0;
+    let max_validator_distance = 3;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all optimistic fetch requests
+        for data_request in utils::enumerate_optimistic_fetch_requests(known_version, known_epoch) {
+            // Create the storage request
+            let storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+            // Add several peers and remove their latency metadata
+            let mut peers = vec![];
+            for _ in 0..NUM_PEERS_TO_ADD {
+                // Add a peer
+                let peer = mock_network.add_peer(peer_priority);
+                peers.push(peer);
+
+                // Generate a random distance for the peer and update the peer's distance metadata
+                let distance_from_validator =
+                    rand::thread_rng().gen_range(min_validator_distance..=max_validator_distance);
+                utils::update_distance_metadata(&client, peer, distance_from_validator as u64);
+
+                // Remove the latency metadata for the peer
+                utils::remove_latency_metadata(&client, peer);
+            }
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &HashSet::from_iter(peers.clone()),
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select peers to service the request multiple times
+            let peers_and_selection_counts = utils::select_peers_multiple_times(
+                &client,
+                num_peers_for_multi_fetch,
+                &storage_request,
+            );
+
+            // Verify that peers are still selected even though there are no recorded latencies
+            verify_all_peers_are_selected(HashSet::from_iter(peers), peers_and_selection_counts);
+        }
+    }
+}
+
+#[tokio::test]
+async fn request_latency_filtering() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with latency filtering and multi-fetch enabled
+    let num_peers_for_multi_fetch = 3;
+    let min_peers_for_latency_filtering = 100;
+    let latency_filtering_reduction_factor = 2;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 1,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        latency_filtering_config: AptosLatencyFilteringConfig {
+            min_peers_for_latency_filtering,
+            latency_filtering_reduction_factor,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+    // Ensure the properties hold for all peer priorities (in ascending order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Create the data request
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several peers (enough to trigger latency filtering)
+        let peers = utils::add_several_peers(
+            &mut mock_network,
+            min_peers_for_latency_filtering + 10,
+            *peer_priority,
+        );
+
+        // Select peers to service the request multiple times
+        let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+            &client,
+            num_peers_for_multi_fetch,
+            &storage_request,
+        );
+
+        // Verify the highest selected peers are the lowest latency peers
+        utils::verify_highest_peer_selection_latencies(
+            &mut mock_network,
+            &mut peers_and_selection_counts,
+        );
+
+        // Build a list of all peers sorted by their latencies
+        let mut peers_and_latencies = vec![];
+        for peer in peers_and_selection_counts.keys() {
+            // Get the peer's ping latency
+            let ping_latency = utils::get_peer_ping_latency(&mut mock_network, *peer);
+
+            // Add the peer and latency to the list
+            peers_and_latencies.push((*peer, OrderedFloat(ping_latency)));
+        }
+        peers_and_latencies.sort_by_key(|(_, latency)| *latency);
+
+        // Verify that the top subset of peers have selection counts
+        let peers_to_verify = peers.len() / (latency_filtering_reduction_factor as usize);
+        for (peer, _) in peers_and_latencies[0..peers_to_verify].iter() {
+            match peers_and_selection_counts.get(peer) {
+                Some(selection_count) => assert!(*selection_count > 0),
+                None => panic!("Peer {:?} was not found in the selection counts!", peer),
+            }
+        }
+
+        // Verify that the bottom subset of peers do not have
+        // selection counts (as they were filtered out).
+        let peers_with_zero_selection_counts = peers_and_latencies[peers_to_verify..]
+            .iter()
+            .map(|(peer, _)| *peer)
+            .collect();
+        verify_zero_selection_counts(
+            &peers_with_zero_selection_counts,
+            &peers_and_selection_counts,
+        );
+    }
+}
+
+#[tokio::test]
+async fn request_latency_filtering_ratio() {
+    // Create a base config for a validatorpeers_with_zero_selection_counts
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with latency filtering and multi-fetch enabled
+    let num_peers_for_multi_fetch = 5;
+    let min_peers_for_latency_filtering = 50;
+    let min_peer_ratio_for_latency_filtering = 10_000; // Set to a very high value
+    let latency_filtering_reduction_factor = 2;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        latency_filtering_config: AptosLatencyFilteringConfig {
+            min_peers_for_latency_filtering,
+            min_peer_ratio_for_latency_filtering,
+            latency_filtering_reduction_factor,
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+    // Ensure the properties hold for all peer priorities (in ascending order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Create the data request
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several peers (enough to satisfy the minimum number of peers)
+        let peers = utils::add_several_peers(
+            &mut mock_network,
+            min_peers_for_latency_filtering * 2,
+            *peer_priority,
+        );
+
+        // Select peers to service the request multiple times
+        let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+            &client,
+            num_peers_for_multi_fetch,
+            &storage_request,
+        );
+
+        // Verify the highest selected peers are the lowest latency peers
+        utils::verify_highest_peer_selection_latencies(
+            &mut mock_network,
+            &mut peers_and_selection_counts,
+        );
+
+        // Verify that the number of selected peers is more than
+        // half the total peers (as filtering was disabled).
+        let num_filtered_peers = peers.len() / latency_filtering_reduction_factor as usize;
+        assert!(peers_and_selection_counts.len() > num_filtered_peers);
+    }
+}
+
+#[tokio::test]
+async fn request_latency_selection() {
+    // Create a base config for a validator
+    let base_config = utils::create_validator_base_config();
+
+    // Create the data client config with latency filtering and multi-fetch enabled
+    let num_peers_for_multi_fetch = 1;
+    let min_peers_for_latency_filtering = 50;
+    let latency_filtering_reduction_factor = 2;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        latency_filtering_config: AptosLatencyFilteringConfig {
+            min_peers_for_latency_filtering,
+            latency_filtering_reduction_factor,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create the mock network and client
+        let (mut mock_network, _, client, _) =
+            MockNetwork::new(Some(base_config.clone()), Some(data_client_config), None);
+
+        // Create the data request
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several peers (but not enough to trigger latency filtering)
+        let peers = utils::add_several_peers(
+            &mut mock_network,
+            min_peers_for_latency_filtering - 1,
+            peer_priority,
+        );
+
+        // Select peers to service the request multiple times
+        let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+            &client,
+            num_peers_for_multi_fetch,
+            &storage_request,
+        );
+
+        // Verify the highest selected peers are the lowest latency peers
+        utils::verify_highest_peer_selection_latencies(
+            &mut mock_network,
+            &mut peers_and_selection_counts,
+        );
+
+        // Verify that the number of selected peers is more than
+        // half the total peers (as filtering was disabled).
+        let num_filtered_peers = peers.len() / (latency_filtering_reduction_factor as usize);
+        assert!(peers_and_selection_counts.len() > num_filtered_peers);
+    }
+}
+
+#[tokio::test]
+async fn request_missing_latencies() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create the data client config with latency filtering and multi-fetch enabled
+    let num_peers_for_multi_fetch = 2;
+    let min_peers_for_latency_filtering = 50;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            ..Default::default()
+        },
+        latency_filtering_config: AptosLatencyFilteringConfig {
+            min_peers_for_latency_filtering,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) = MockNetwork::new(
+        Some(base_config.clone()),
+        Some(data_client_config),
+        Some(networks.clone()),
+    );
+
+    // Ensure the properties hold for all peer priorities (in ascending order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Create the data request
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several peers
+        let peers = utils::add_several_peers(
+            &mut mock_network,
+            min_peers_for_latency_filtering + 10,
+            *peer_priority,
+        );
+
+        // Remove the latency metadata for some peers
+        let peers_with_missing_latencies = remove_metadata_for_several_peers(&client, &peers, true);
+
+        // Select peers to service the request multiple times
+        let mut peers_and_selection_counts = utils::select_peers_multiple_times(
+            &client,
+            num_peers_for_multi_fetch,
+            &storage_request,
+        );
+
+        // Verify the highest selected peers are the lowest latency peers
+        utils::verify_highest_peer_selection_latencies(
+            &mut mock_network,
+            &mut peers_and_selection_counts,
+        );
+
+        // Verify that the peers with missing latencies are not selected
+        verify_zero_selection_counts(&peers_with_missing_latencies, &peers_and_selection_counts);
+    }
+}
+
+#[tokio::test]
+async fn request_no_latencies() {
+    // Create a base config for a VFN
+    let base_config = utils::create_fullnode_base_config();
+    let networks = vec![NetworkId::Vfn, NetworkId::Public];
+
+    // Create the data client config with latency filtering and multi-fetch enabled
+    let num_peers_for_multi_fetch = 2;
+    let min_peers_for_latency_filtering = 50;
+    let data_client_config = AptosDataClientConfig {
+        data_multi_fetch_config: AptosDataMultiFetchConfig {
+            enable_multi_fetch: true,
+            min_peers_for_multi_fetch: 1,
+            max_peers_for_multi_fetch: num_peers_for_multi_fetch,
+            multi_fetch_peer_bucket_size: 1,
+            ..Default::default()
+        },
+        latency_filtering_config: AptosLatencyFilteringConfig {
+            min_peers_for_latency_filtering,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) = MockNetwork::new(
+        Some(base_config.clone()),
+        Some(data_client_config),
+        Some(networks.clone()),
+    );
+
+    // Ensure the properties hold for all peer priorities (in ascending order)
+    for peer_priority in PeerPriority::get_all_ordered_priorities().iter().rev() {
+        // Create the data request
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Add several peers and remove their latency metadata
+        let mut peers = hashset![];
+        for _ in 0..min_peers_for_latency_filtering + 10 {
+            // Add a peer
+            let peer = mock_network.add_peer(*peer_priority);
+            peers.insert(peer);
+
+            // Remove the latency metadata for the peer
+            utils::remove_latency_metadata(&client, peer)
+        }
+
+        // Select peers to service the request multiple times
+        let peers_and_selection_counts = utils::select_peers_multiple_times(
+            &client,
+            num_peers_for_multi_fetch,
+            &storage_request,
+        );
+
+        // Verify that peers are still selected even though there are no recorded latencies
+        verify_all_peers_are_selected(peers, peers_and_selection_counts);
+    }
+}
+
+#[tokio::test]
+async fn subscription_distance_latency_weights() {
+    // Create a data client with a max lag of 500
+    let max_subscription_lag_secs = 500;
+    let data_client_config = AptosDataClientConfig {
+        max_subscription_lag_secs,
+        ..Default::default()
+    };
+
+    // Create test data
+    let known_version = 1;
+    let known_epoch = 1;
+    let min_validator_distance = 1;
+    let max_validator_distance = 3;
+
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Ensure the properties hold for all subscription requests
+        for data_request in utils::enumerate_subscription_requests(known_version, known_epoch) {
+            // Create the storage request
+            let mut storage_request = StorageServiceRequest::new(data_request, true);
+
+            // Create the mock network, time service and client
+            let (mut mock_network, time_service, client, _) =
+                MockNetwork::new(None, Some(data_client_config), None);
+
+            // Add several peers with metadata
+            let peers = utils::add_several_peers_with_metadata(
+                &mut mock_network,
+                &client,
+                NUM_PEERS_TO_ADD,
+                min_validator_distance,
+                max_validator_distance,
+                peer_priority,
+            );
+
+            // Verify none of the peers can service the request
+            utils::verify_request_is_unserviceable(&client, &storage_request, false);
+
+            // Advertise the data for the peers
+            utils::update_storage_summaries_for_peers(
+                &client,
+                &peers,
+                known_version,
+                time_service.now_unix_time().as_micros(),
+            );
+
+            // Select a peer to service the request multiple times
+            let mut peers_and_selection_counts = HashMap::new();
+            for _ in 0..NUM_SELECTION_ITERATIONS {
+                // Select a peer to service the request
+                let selected_peers = client.choose_peers_for_request(&storage_request).unwrap();
+                assert_eq!(selected_peers.len(), 1);
+
+                // Update the peer selection counts
+                for selected_peer in selected_peers {
+                    *peers_and_selection_counts.entry(selected_peer).or_insert(0) += 1;
+                }
+
+                // Update the request's subscription ID
+                storage_request = utils::update_subscription_request_id(&storage_request);
+            }
+
+            // Verify all of the selected peers have the lowest distance
+            verify_lowest_distance_from_validators(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+                min_validator_distance,
+            );
+
+            // Verify the highest selected peers are the lowest latency peers
+            utils::verify_highest_peer_selection_latencies(
+                &mut mock_network,
+                &mut peers_and_selection_counts,
+            );
+        }
+    }
+}
+
+/// Removes metadata for several peers and returns the set of peers with missing metadata.
+/// If `remove_latency_metadata` is true, then the latency metadata is removed. Otherwise,
+/// distance metadata is removed.
+fn remove_metadata_for_several_peers(
+    client: &AptosDataClient,
+    peers: &HashSet<PeerNetworkId>,
+    remove_latency_metadata: bool,
+) -> Vec<PeerNetworkId> {
+    // Remove 1/3 of the peers' appropriate metadata
+    let num_peers_with_missing_metadata = peers.len() / 3;
+    let mut peers_with_missing_metadata = vec![];
+
+    // Remove the metadata for some peers
+    let peers: Vec<_> = peers.iter().cloned().collect();
+    for peer in peers[0..num_peers_with_missing_metadata].iter() {
+        // Remove the appropriate metadata for the peer
+        if remove_latency_metadata {
+            utils::remove_latency_metadata(client, *peer);
+        } else {
+            utils::remove_distance_metadata(client, *peer);
+        }
+
+        // Add the peer to the set of peers with missing metadata
+        peers_with_missing_metadata.push(*peer);
+    }
+
+    peers_with_missing_metadata
+}
+
+/// Verifies all peers are selected at least once
+fn verify_all_peers_are_selected(
+    peers: HashSet<PeerNetworkId>,
+    peers_and_selection_counts: HashMap<PeerNetworkId, i32>,
+) {
+    for peer in peers {
+        match peers_and_selection_counts.get(&peer) {
+            Some(selection_count) => assert!(*selection_count > 0),
+            None => panic!("Peer {:?} was not found in the selection counts!", peer),
+        }
+    }
+}
+
+/// Verifies that all of the selected peers have the lowest distance from the validators
+fn verify_lowest_distance_from_validators(
+    mock_network: &mut MockNetwork,
+    peers_and_selection_counts: &mut HashMap<PeerNetworkId, i32>,
+    min_validator_distance: u64,
+) {
+    for peer in peers_and_selection_counts.keys() {
+        let distance_from_validator = utils::get_peer_distance_from_validators(mock_network, *peer);
+        assert_eq!(distance_from_validator, min_validator_distance);
+    }
+}
+
+/// Verifies that all of the specified peers have zero selection counts
+fn verify_zero_selection_counts(
+    peers_with_zero_counts: &Vec<PeerNetworkId>,
+    peers_and_selection_counts: &HashMap<PeerNetworkId, i32>,
+) {
+    for peer in peers_with_zero_counts {
+        if let Some(selection_count) = peers_and_selection_counts.get(peer) {
+            assert_eq!(*selection_count, 0);
+        }
+    }
+}


### PR DESCRIPTION
Note: 90% of this PR is unit test changes (in the second and third commits).

### Description
This PR introduces multi-fetch support to the data client. More specifically, whenever a data client request is created by the data streaming service, the data client will send the request to multiple peers simultaneously and use the first response. This is helpful to guard against unreliable peers, transient network errors and RPC timeouts, hopefully making things more reliable in practice.

The minimum and maximum number of peers to select for each request is configurable and depends on the number of potential peers that can service the request (as well as the request type). We've currently set the default minimum to `2` and the default maximum to `5`, respectively. If we have less than the minimum number of peers that can service the request, then only those peers are chosen. Peer selection follows the existing selection criteria.

The PR offers several commits:
1. Add multi-fetch support to the data client.
2. Update existing unit tests to handle the fact that multiple peers may now be selected for a single request (including small cleanups along the way).
3. Add new unit tests to verify the multi-fetch functionality.

### Test Plan
New and existing unit tests.