### PR TITLE
[cli] Hide V2 Compiler

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Hide the V2 compiler from input options until the V2 compiler is ready for release
 
 ## [2.3.2] - 2023/11/28
 - Services in the local testnet now bind to 127.0.0.1 by default (unless the CLI is running inside a container, which most users should not do) rather than 0.0.0.0. You can override this behavior with the `--bind-to` flag. This fixes an issue preventing the local testnet from working on Windows.

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1057,7 +1057,9 @@ pub struct MovePackageDir {
     pub bytecode_version: Option<u32>,
 
     /// Specify the version of the compiler.
-    #[clap(long)]
+    ///
+    /// Currently hidden until the official launch of Compiler V2
+    #[clap(long, hide = true)]
     pub compiler_version: Option<CompilerVersion>,
 
     /// Do not complain about unknown attributes in Move code.


### PR DESCRIPTION
### Description
It's not ready for outside use, and users are confused and try to use it when things don't work for them in V1, which leads to more confusion because they definitely don't work in V2.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
