### PR TITLE
[gha] Add some debug logging for workflow cancellation

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -37,6 +37,12 @@ jobs:
         with:
           required-permission: write
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+      - name: Debug concurrency
+        run: |
+          echo "GITHUB EVENT NAME: ${{ github.event_name }}"
+          echo "GITHUB REF: ${{ github.ref }}"
+          echo "GITHUB SHA: ${{ github.sha }}"
+          echo "CONCURRENCY GROUP: ${{ github.workflow }}-${{ (github.event_name == 'pull_request_target' && github.ref) || github.sha }}"
 
   # This job determines which files were changed
   file_change_determinator:


### PR DESCRIPTION
Log the key that will be used for concurrency control to help debug strange cancellation issues

Test Plan: add pull_request block, test on PR then remove it

Passing run https://github.com/aptos-labs/aptos-core/actions/runs/7105415573/job/19342559894
