### PR TITLE
Fix pipeline backpressure to exclude treating committed block as pending

### DIFF
--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -83,6 +83,10 @@ impl StateComputer for OrderingStateComputer {
     ) -> ExecutorResult<()> {
         assert!(!blocks.is_empty());
 
+        for block in blocks {
+            block.set_insertion_time();
+        }
+
         if self
             .executor_channel
             .clone()

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -296,7 +296,7 @@ impl ProposalGenerator {
             let voting_power_ratio = proposer_election.get_voting_power_participation_ratio(round);
 
             let (max_block_txns, max_block_bytes, proposal_delay) = self
-                .calculate_max_block_sizes(voting_power_ratio, timestamp)
+                .calculate_max_block_sizes(voting_power_ratio, timestamp, round)
                 .await;
 
             PROPOSER_DELAY_PROPOSAL.set(proposal_delay.as_secs_f64());
@@ -383,6 +383,7 @@ impl ProposalGenerator {
         &mut self,
         voting_power_ratio: f64,
         timestamp: Duration,
+        round: Round,
     ) -> (u64, u64, Duration) {
         let mut values_max_block_txns = vec![self.max_block_txns];
         let mut values_max_block_bytes = vec![self.max_block_bytes];
@@ -418,12 +419,13 @@ impl ProposalGenerator {
 
         if pipeline_backpressure.is_some() || chain_health_backoff.is_some() {
             warn!(
-                "Generating proposal: reducing limits to {} txns and {} bytes, due to pipeline_backpressure: {}, chain health backoff: {}. Delaying sending proposal by {}ms",
+                "Generating proposal: reducing limits to {} txns and {} bytes, due to pipeline_backpressure: {}, chain health backoff: {}. Delaying sending proposal by {}ms. Round: {}",
                 max_block_txns,
                 max_block_bytes,
                 pipeline_backpressure.is_some(),
                 chain_health_backoff.is_some(),
                 proposal_delay.as_millis(),
+                round,
             );
         }
         (max_block_txns, max_block_bytes, proposal_delay)

--- a/consensus/src/payload_client/user/quorum_store_client.rs
+++ b/consensus/src/payload_client/user/quorum_store_client.rs
@@ -125,15 +125,15 @@ impl UserPayloadClient for QuorumStoreClient {
             break payload;
         };
         info!(
-            elapsed_time = start_time.elapsed(),
-            max_poll_time = max_poll_time,
+            elapsed_time_ms = start_time.elapsed().as_millis() as u64,
+            max_poll_time_ms = max_poll_time.as_millis() as u64,
             payload_len = payload.len(),
             max_items = max_items,
             max_bytes = max_bytes,
             pending_ordering = pending_ordering,
             return_empty = return_empty,
             return_non_full = return_non_full,
-            duration = start_time.elapsed().as_secs_f32(),
+            duration_ms = start_time.elapsed().as_millis() as u64,
             "Pull payloads from QuorumStore: proposal"
         );
 

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -198,6 +198,7 @@ async fn test_onchain_config_change() {
             let inner = match genesis_config.consensus_config.clone() {
                 OnChainConsensusConfig::V1(inner) => inner,
                 OnChainConsensusConfig::V2(inner) => inner,
+                OnChainConsensusConfig::V3(inner) => inner.main,
                 _ => unimplemented!(),
             };
 


### PR DESCRIPTION
* Fix pipeline backpressure to exclude treating committed block as pending

For pipeline backpressure we were looking at latency between ordered and committed block.
But committed block is not in the pipeline any more, and next block after it could've
been created significantly later (and so got into the pipeline significantly later).

Second it is better to take actual time block is in the pipeline, than  use ordered timestamp.

if it took us 1s to order oldest_not_committed_block, but 100ms to order
currently ordered block, we don’t want to backpressure if it
is 1.5s passed the oldest_not_committed_block - because it was really only 500ms in the pipeline