### PR TITLE
fix cancellation of ts-sdk tests workflow

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -20,7 +20,7 @@ permissions:
 # cancel redundant builds
 concurrency:
   # cancel redundant builds on PRs (only on PR, not on branches)
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request_target' && github.ref) || github.sha }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
fix the concurrency rule to avoid concurrent PRs cancelling each others jobs
