### PR TITLE
Quick fix to avoid too-aggressive move promotion of Assign (Issue 11139), deferring full solution to Issue 11223

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -715,7 +715,11 @@ impl<'a> FunctionGenerator<'a> {
                 Some(AssignKind::Copy) => {
                     self.emit(FF::Bytecode::CopyLoc(local));
                 },
-                Some(AssignKind::Inferred) | Some(AssignKind::Store) | None => {
+                Some(AssignKind::Inferred) | Some(AssignKind::Store) => {
+                    fun_ctx
+                        .internal_error("Inferred and Store AssignKind should be not appear here.");
+                },
+                None => {
                     // Copy the temporary if it is copyable and still used after this code point.
                     if fun_ctx.is_copyable(*temp) && ctx.is_alive_after(*temp) {
                         self.emit(FF::Bytecode::CopyLoc(local))

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -66,7 +66,7 @@ pub fn run_move_compiler(
     check_errors(&env, error_writer, "code generation errors")?;
     // Run transformation pipeline
     let pipeline = bytecode_pipeline(&env);
-    if options.dump_bytecode {
+    if options.debug || options.dump_bytecode {
         // Dump bytecode to files, using a basename for the individual sources derived
         // from the first input file.
         let dump_base_name = options
@@ -78,7 +78,7 @@ pub fn run_move_compiler(
                     .map(|f| f.to_string_lossy().as_ref().to_owned())
             })
             .unwrap_or_else(|| "dump".to_owned());
-        pipeline.run_with_dump(&env, &mut targets, &dump_base_name, false)
+        pipeline.run_with_dump(&env, &mut targets, &dump_base_name, options.debug)
     } else {
         pipeline.run(&env, &mut targets)
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -258,7 +258,14 @@ impl<'a> CopyTransformation<'a> {
         match bc {
             Assign(id, dst, src, kind) => match kind {
                 AssignKind::Inferred => {
-                    if self.check_implicit_copy(alive, id, false, src) {
+                    // TODO(https://github.com/aptos-labs/aptos-core/issues/11223):
+                    // Things which have references taken should never be handled by
+                    // this simple live variable analysis.  Until we have info about
+                    // whether a var may have had a reference taken, be very conservative
+                    // here and assume var is live.
+                    // Remove this hack after fixing that bug.
+                    let force_copy_hack = !self.target().get_local_type(src).is_mutable_reference();
+                    if force_copy_hack || self.check_implicit_copy(alive, id, false, src) {
                         self.data.code.push(Assign(id, dst, src, AssignKind::Copy))
                     } else {
                         self.data.code.push(Assign(id, dst, src, AssignKind::Move))

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -258,12 +258,9 @@ impl<'a> CopyTransformation<'a> {
         match bc {
             Assign(id, dst, src, kind) => match kind {
                 AssignKind::Inferred => {
-                    // TODO(https://github.com/aptos-labs/aptos-core/issues/11223):
-                    // Things which have references taken should never be handled by
-                    // this simple live variable analysis.  Until we have info about
-                    // whether a var may have had a reference taken, be very conservative
-                    // here and assume var is live.
-                    // Remove this hack after fixing that bug.
+                    // TODO(#11223): Until we have info about whether a var may have had a reference
+                    // taken, be very conservative here and assume var is live.  Remove this hack
+                    // after fixing that bug.
                     let force_copy_hack = !self.target().get_local_type(src).is_mutable_reference();
                     if force_copy_hack || self.check_implicit_copy(alive, id, false, src) {
                         self.data.code.push(Assign(id, dst, src, AssignKind::Copy))

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
@@ -33,6 +33,85 @@ module 0xcafe::vectors {
     }
 } // end 0xcafe::vectors
 
+============ initial bytecode ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: vector<u8>
+     var $t5: vector<u8>
+     var $t6: vector<u8>
+     var $t7: &vector<u8>
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t5 := copy($t0)
+  3: $t4 := infer($t5)
+  4: $t6 := infer($t0)
+  5: $t7 := infer($t2)
+  6: $t1 := vector::length<u8>($t7)
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: vector<u8>
+     var $t5: vector<u8>
+     var $t6: vector<u8>
+     var $t7: &vector<u8>
+     # live vars: $t0
+  0: $t3 := borrow_local($t0)
+     # live vars: $t3
+  1: $t2 := move($t3)
+     # live vars: $t2
+  2: $t5 := copy($t0)
+     # live vars: $t2
+  3: $t4 := move($t5)
+     # live vars: $t2
+  4: $t6 := move($t0)
+     # live vars: $t2
+  5: $t7 := move($t2)
+     # live vars: $t7
+  6: $t1 := vector::length<u8>($t7)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after VisibilityChecker: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: vector<u8>
+     var $t5: vector<u8>
+     var $t6: vector<u8>
+     var $t7: &vector<u8>
+     # live vars: $t0
+  0: $t3 := borrow_local($t0)
+     # live vars: $t3
+  1: $t2 := move($t3)
+     # live vars: $t2
+  2: $t5 := copy($t0)
+     # live vars: $t2
+  3: $t4 := move($t5)
+     # live vars: $t2
+  4: $t6 := move($t0)
+     # live vars: $t2
+  5: $t7 := move($t2)
+     # live vars: $t7
+  6: $t1 := vector::length<u8>($t7)
+     # live vars: $t1
+  7: return $t1
+}
+
 
 Diagnostics:
 error: cannot move local `flips` which is still borrowed
@@ -43,3 +122,64 @@ error: cannot move local `flips` which is still borrowed
    ·
 10 │         let _v2 = flips;
    │             ^^^ moved here
+
+============ after MemorySafetyProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: vector<u8>
+     var $t5: vector<u8>
+     var $t6: vector<u8>
+     var $t7: &vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t3 := borrow_local($t0)
+     # live vars: $t3
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[]}
+     # local_to_label: {$t0=L0,$t3=L1}
+     # global_to_label: {}
+     #
+  1: $t2 := move($t3)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
+     # global_to_label: {}
+     #
+  2: $t5 := copy($t0)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
+     # global_to_label: {}
+     #
+  3: $t4 := move($t5)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
+     # global_to_label: {}
+     #
+  4: $t6 := move($t0)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
+     # global_to_label: {}
+     #
+  5: $t7 := move($t2)
+     # live vars: $t7
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[skip -> L1281],L1281=local($t7)[]}
+     # local_to_label: {$t0=L0,$t2=L257,$t3=L1,$t7=L1281}
+     # global_to_label: {}
+     #
+  6: $t1 := vector::length<u8>($t7)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
@@ -68,15 +68,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t0
   0: $t3 := borrow_local($t0)
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t5 := copy($t0)
      # live vars: $t2
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2
-  4: $t6 := move($t0)
+  4: $t6 := copy($t0)
      # live vars: $t2
-  5: $t7 := move($t2)
+  5: $t7 := copy($t2)
      # live vars: $t7
   6: $t1 := vector::length<u8>($t7)
      # live vars: $t1
@@ -97,31 +97,20 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t0
   0: $t3 := borrow_local($t0)
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t5 := copy($t0)
      # live vars: $t2
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2
-  4: $t6 := move($t0)
+  4: $t6 := copy($t0)
      # live vars: $t2
-  5: $t7 := move($t2)
+  5: $t7 := copy($t2)
      # live vars: $t7
   6: $t1 := vector::length<u8>($t7)
      # live vars: $t1
   7: return $t1
 }
-
-
-Diagnostics:
-error: cannot move local `flips` which is still borrowed
-   ┌─ tests/checking/inlining/bug_11223.move:10:13
-   │
- 7 │         let flipsref5 = &flips;
-   │                         ------ previous local borrow
-   ·
-10 │         let _v2 = flips;
-   │             ^^^ moved here
 
 ============ after MemorySafetyProcessor: ================
 
@@ -145,7 +134,7 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L0,$t3=L1}
      # global_to_label: {}
      #
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
      # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
@@ -157,19 +146,19 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
      # global_to_label: {}
      #
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
      # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
      # global_to_label: {}
      #
-  4: $t6 := move($t0)
+  4: $t6 := copy($t0)
      # live vars: $t2
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[]}
      # local_to_label: {$t0=L0,$t2=L257,$t3=L1}
      # global_to_label: {}
      #
-  5: $t7 := move($t2)
+  5: $t7 := copy($t2)
      # live vars: $t7
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t3)[skip -> L257],L257=local($t2)[skip -> L1281],L1281=local($t7)[]}
      # local_to_label: {$t0=L0,$t2=L257,$t3=L1,$t7=L1281}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
@@ -1,0 +1,45 @@
+// ---- Model Dump
+module 0xcafe::vectors {
+    use std::vector;
+    public entry fun guess_flips_break2(flips: vector<u8>): u64 {
+        {
+          let flipsref5: &vector<u8> = Borrow(Immutable)(flips);
+          {
+            let _v: vector<u8> = Copy(flips);
+            {
+              let _v2: vector<u8> = flips;
+              {
+                let x: &vector<u8> = flipsref5;
+                vector::length<u8>(x)
+              }
+            }
+          }
+        }
+    }
+    spec fun $guess_flips_break2(flips: vector<u8>): u64 {
+        {
+          let flipsref5: vector<u8> = flips;
+          {
+            let _v: vector<u8> = Copy(flips);
+            {
+              let _v2: vector<u8> = flips;
+              {
+                let x: vector<u8> = flipsref5;
+                vector::$length<u8>(x)
+              }
+            }
+          }
+        }
+    }
+} // end 0xcafe::vectors
+
+
+Diagnostics:
+error: cannot move local `flips` which is still borrowed
+   ┌─ tests/checking/inlining/bug_11223.move:10:13
+   │
+ 7 │         let flipsref5 = &flips;
+   │                         ------ previous local borrow
+   ·
+10 │         let _v2 = flips;
+   │             ^^^ moved here

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.move
@@ -1,0 +1,14 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    // multi-break
+    public entry fun guess_flips_break2(flips: vector<u8>) : u64 {
+        let flipsref5 = &flips;
+        let _v = copy flips; // this is ok
+        // the following stresses live var analysis.
+        let _v2 = flips;
+	let x = flipsref5;
+	vector::length(x)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
@@ -1,0 +1,2523 @@
+// ---- Model Dump
+module 0xcafe::vectors {
+    use std::vector;
+    public entry fun guess_flips(flips: vector<u8>) {
+        {
+          let (flips: &vector<u8>) = Tuple(Borrow(Immutable)(flips));
+          {
+            let i: u64 = 0;
+            loop {
+              if Lt<u64>(i, vector::length<u8>(flips)) {
+                if Neq<u8>(Deref(vector::borrow<u8>(flips, i)), 0) {
+                  break
+                } else {
+                  Tuple()
+                };
+                i: u64 = Add<u64>(i, 1);
+                Tuple()
+              } else {
+                break
+              }
+            };
+            Tuple()
+          }
+        };
+        {
+          let _v: vector<u8> = Copy(flips);
+          {
+            let _v2: vector<u8> = flips;
+            Tuple()
+          }
+        }
+    }
+    public entry fun guess_flips_directly(flips: vector<u8>) {
+        {
+          let i: u64 = 0;
+          loop {
+            if Lt<u64>(i, vector::length<u8>(Borrow(Immutable)(flips))) {
+              if Neq<u8>(Deref(vector::borrow<u8>(Borrow(Immutable)(flips), i)), 0) {
+                break
+              } else {
+                Tuple()
+              };
+              i: u64 = Add<u64>(i, 1);
+              Tuple()
+            } else {
+              break
+            }
+          };
+          {
+            let _v: vector<u8> = Copy(flips);
+            {
+              let _v2: vector<u8> = flips;
+              Tuple()
+            }
+          }
+        }
+    }
+    public entry fun guess_with_break_without_inline(flips: vector<u8>) {
+        vectors::loops_with_break_no_inline(Borrow(Immutable)(flips));
+        {
+          let _v: vector<u8> = Copy(flips);
+          {
+            let _v2: vector<u8> = flips;
+            Tuple()
+          }
+        }
+    }
+    public entry fun guess_without_break_with_inline(flips: vector<u8>) {
+        {
+          let (flips: &vector<u8>) = Tuple(Borrow(Immutable)(flips));
+          {
+            let i: u64 = 0;
+            loop {
+              if Lt<u64>(i, vector::length<u8>(flips)) {
+                if Eq<u8>(Deref(vector::borrow<u8>(flips, i)), 0) {
+                  Tuple()
+                } else {
+                  Abort(3)
+                };
+                i: u64 = Add<u64>(i, 1);
+                Tuple()
+              } else {
+                break
+              }
+            };
+            Tuple()
+          }
+        };
+        {
+          let _v: vector<u8> = flips;
+          {
+            let _v2: vector<u8> = Copy(flips);
+            Tuple()
+          }
+        }
+    }
+    private fun loops_with_break_no_inline(flips: &vector<u8>) {
+        {
+          let i: u64 = 0;
+          loop {
+            if Lt<u64>(i, vector::length<u8>(flips)) {
+              if Neq<u8>(Deref(vector::borrow<u8>(flips, i)), 0) {
+                break
+              } else {
+                Tuple()
+              };
+              i: u64 = Add<u64>(i, 1);
+              Tuple()
+            } else {
+              break
+            }
+          };
+          Tuple()
+        }
+    }
+    private fun test_guess_directly() {
+        {
+          let flips: vector<u8> = Vector<u8>(0, 0, 0, 0);
+          vectors::guess_flips_directly(flips);
+          Tuple()
+        }
+    }
+    private fun test_guess_with_break_no_inline() {
+        {
+          let flips: vector<u8> = Vector<u8>(0, 0, 0, 0);
+          vectors::guess_with_break_without_inline(flips);
+          Tuple()
+        }
+    }
+    private fun test_guess_with_inline_break() {
+        {
+          let flips: vector<u8> = Vector<u8>(0, 0, 0, 0);
+          vectors::guess_flips(flips);
+          Tuple()
+        }
+    }
+    private fun test_guess_without_break() {
+        {
+          let flips: vector<u8> = Vector<u8>(0, 0, 0, 0);
+          vectors::guess_without_break_with_inline(flips);
+          Tuple()
+        }
+    }
+    spec fun $guess_flips(flips: vector<u8>);
+    spec fun $guess_flips_directly(flips: vector<u8>);
+    spec fun $guess_with_break_without_inline(flips: vector<u8>);
+    spec fun $guess_without_break_with_inline(flips: vector<u8>);
+    spec fun $loops_with_break(flips: &vector<u8>);
+    spec fun $loops_with_break_no_inline(flips: &vector<u8>);
+    spec fun $loops_without_break(flips: &vector<u8>);
+    spec fun $test_guess_directly();
+    spec fun $test_guess_with_break_no_inline();
+    spec fun $test_guess_with_inline_break();
+    spec fun $test_guess_without_break();
+} // end 0xcafe::vectors
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun vectors::guess_flips($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+  0: $t2 := borrow_local($t0)
+  1: $t1 := infer($t2)
+  2: $t4 := 0
+  3: $t3 := infer($t4)
+  4: label L0
+  5: $t6 := vector::length<u8>($t1)
+  6: $t5 := <($t3, $t6)
+  7: if ($t5) goto 8 else goto 23
+  8: label L2
+  9: $t9 := vector::borrow<u8>($t1, $t3)
+ 10: $t8 := read_ref($t9)
+ 11: $t10 := 0
+ 12: $t7 := !=($t8, $t10)
+ 13: if ($t7) goto 14 else goto 17
+ 14: label L5
+ 15: goto 27
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t12 := 1
+ 20: $t11 := +($t3, $t12)
+ 21: $t3 := infer($t11)
+ 22: goto 25
+ 23: label L3
+ 24: goto 27
+ 25: label L4
+ 26: goto 4
+ 27: label L1
+ 28: $t14 := copy($t0)
+ 29: $t13 := infer($t14)
+ 30: $t15 := infer($t0)
+ 31: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_flips_directly($t0: vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u8
+     var $t8: &u8
+     var $t9: &vector<u8>
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+  0: $t2 := 0
+  1: $t1 := infer($t2)
+  2: label L0
+  3: $t5 := borrow_local($t0)
+  4: $t4 := vector::length<u8>($t5)
+  5: $t3 := <($t1, $t4)
+  6: if ($t3) goto 7 else goto 23
+  7: label L2
+  8: $t9 := borrow_local($t0)
+  9: $t8 := vector::borrow<u8>($t9, $t1)
+ 10: $t7 := read_ref($t8)
+ 11: $t10 := 0
+ 12: $t6 := !=($t7, $t10)
+ 13: if ($t6) goto 14 else goto 17
+ 14: label L5
+ 15: goto 27
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t12 := 1
+ 20: $t11 := +($t1, $t12)
+ 21: $t1 := infer($t11)
+ 22: goto 25
+ 23: label L3
+ 24: goto 27
+ 25: label L4
+ 26: goto 2
+ 27: label L1
+ 28: $t14 := copy($t0)
+ 29: $t13 := infer($t14)
+ 30: $t15 := infer($t0)
+ 31: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: vector<u8>
+     var $t3: vector<u8>
+     var $t4: vector<u8>
+  0: $t1 := borrow_local($t0)
+  1: vectors::loops_with_break_no_inline($t1)
+  2: $t3 := copy($t0)
+  3: $t2 := infer($t3)
+  4: $t4 := infer($t0)
+  5: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: vector<u8>
+  0: $t2 := borrow_local($t0)
+  1: $t1 := infer($t2)
+  2: $t4 := 0
+  3: $t3 := infer($t4)
+  4: label L0
+  5: $t6 := vector::length<u8>($t1)
+  6: $t5 := <($t3, $t6)
+  7: if ($t5) goto 8 else goto 24
+  8: label L2
+  9: $t9 := vector::borrow<u8>($t1, $t3)
+ 10: $t8 := read_ref($t9)
+ 11: $t10 := 0
+ 12: $t7 := ==($t8, $t10)
+ 13: if ($t7) goto 14 else goto 16
+ 14: label L5
+ 15: goto 19
+ 16: label L6
+ 17: $t11 := 3
+ 18: abort($t11)
+ 19: label L7
+ 20: $t13 := 1
+ 21: $t12 := +($t3, $t13)
+ 22: $t3 := infer($t12)
+ 23: goto 26
+ 24: label L3
+ 25: goto 28
+ 26: label L4
+ 27: goto 4
+ 28: label L1
+ 29: $t14 := infer($t0)
+ 30: $t16 := copy($t0)
+ 31: $t15 := infer($t16)
+ 32: return ()
+}
+
+
+[variant baseline]
+fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u8
+     var $t7: &u8
+     var $t8: u8
+     var $t9: u64
+     var $t10: u64
+  0: $t2 := 0
+  1: $t1 := infer($t2)
+  2: label L0
+  3: $t4 := vector::length<u8>($t0)
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 21
+  6: label L2
+  7: $t7 := vector::borrow<u8>($t0, $t1)
+  8: $t6 := read_ref($t7)
+  9: $t8 := 0
+ 10: $t5 := !=($t6, $t8)
+ 11: if ($t5) goto 12 else goto 15
+ 12: label L5
+ 13: goto 25
+ 14: goto 16
+ 15: label L6
+ 16: label L7
+ 17: $t10 := 1
+ 18: $t9 := +($t1, $t10)
+ 19: $t1 := infer($t9)
+ 20: goto 23
+ 21: label L3
+ 22: goto 25
+ 23: label L4
+ 24: goto 2
+ 25: label L1
+ 26: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_directly() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+  0: $t2 := 0
+  1: $t3 := 0
+  2: $t4 := 0
+  3: $t5 := 0
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+  5: $t0 := infer($t1)
+  6: vectors::guess_flips_directly($t0)
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_break_no_inline() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+  0: $t2 := 0
+  1: $t3 := 0
+  2: $t4 := 0
+  3: $t5 := 0
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+  5: $t0 := infer($t1)
+  6: vectors::guess_with_break_without_inline($t0)
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_inline_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+  0: $t2 := 0
+  1: $t3 := 0
+  2: $t4 := 0
+  3: $t5 := 0
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+  5: $t0 := infer($t1)
+  6: vectors::guess_flips($t0)
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_without_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+  0: $t2 := 0
+  1: $t3 := 0
+  2: $t4 := 0
+  3: $t5 := 0
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+  5: $t0 := infer($t1)
+  6: vectors::guess_without_break_with_inline($t0)
+  7: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: &vector<u8>
+     var $t17: &vector<u8>
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t1 := move($t2)
+     # live vars: $t1
+  2: $t4 := 0
+     # live vars: $t1, $t4
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+  4: label L0
+     # live vars: $t1, $t3
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+  6: $t6 := vector::length<u8>($t16)
+     # live vars: $t1, $t3, $t6
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+  8: if ($t5) goto 9 else goto 25
+     # live vars: $t1, $t3
+  9: label L2
+     # live vars: $t1, $t3
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
+     # live vars: $t1, $t3, $t9
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := !=($t8, $t10)
+     # live vars: $t1, $t3, $t7
+ 15: if ($t7) goto 16 else goto 19
+     # live vars:
+ 16: label L5
+     # live vars:
+ 17: goto 29
+     # live vars: $t1, $t3
+ 18: goto 20
+     # live vars: $t1, $t3
+ 19: label L6
+     # live vars: $t1, $t3
+ 20: label L7
+     # live vars: $t1, $t3
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
+ 23: $t3 := move($t11)
+     # live vars: $t1, $t3
+ 24: goto 27
+     # live vars:
+ 25: label L3
+     # live vars:
+ 26: goto 29
+     # live vars: $t1, $t3
+ 27: label L4
+     # live vars: $t1, $t3
+ 28: goto 4
+     # live vars:
+ 29: label L1
+     # live vars:
+ 30: $t14 := copy($t0)
+     # live vars:
+ 31: $t13 := move($t14)
+     # live vars:
+ 32: $t15 := move($t0)
+     # live vars:
+ 33: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_flips_directly($t0: vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u8
+     var $t8: &u8
+     var $t9: &vector<u8>
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     # live vars: $t0
+  0: $t2 := 0
+     # live vars: $t0, $t2
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+  2: label L0
+     # live vars: $t0, $t1
+  3: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  4: $t4 := vector::length<u8>($t5)
+     # live vars: $t0, $t1, $t4
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+  7: label L2
+     # live vars: $t0, $t1
+  8: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t9
+  9: $t8 := vector::borrow<u8>($t9, $t1)
+     # live vars: $t0, $t1, $t8
+ 10: $t7 := read_ref($t8)
+     # live vars: $t0, $t1, $t7
+ 11: $t10 := 0
+     # live vars: $t0, $t1, $t7, $t10
+ 12: $t6 := !=($t7, $t10)
+     # live vars: $t0, $t1, $t6
+ 13: if ($t6) goto 14 else goto 17
+     # live vars:
+ 14: label L5
+     # live vars:
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+ 17: label L6
+     # live vars: $t0, $t1
+ 18: label L7
+     # live vars: $t0, $t1
+ 19: $t12 := 1
+     # live vars: $t0, $t1, $t12
+ 20: $t11 := +($t1, $t12)
+     # live vars: $t0, $t11
+ 21: $t1 := move($t11)
+     # live vars: $t0, $t1
+ 22: goto 25
+     # live vars:
+ 23: label L3
+     # live vars:
+ 24: goto 27
+     # live vars: $t0, $t1
+ 25: label L4
+     # live vars: $t0, $t1
+ 26: goto 2
+     # live vars:
+ 27: label L1
+     # live vars:
+ 28: $t14 := copy($t0)
+     # live vars:
+ 29: $t13 := move($t14)
+     # live vars:
+ 30: $t15 := move($t0)
+     # live vars:
+ 31: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: vector<u8>
+     var $t3: vector<u8>
+     var $t4: vector<u8>
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t1
+  1: vectors::loops_with_break_no_inline($t1)
+     # live vars:
+  2: $t3 := copy($t0)
+     # live vars:
+  3: $t2 := move($t3)
+     # live vars:
+  4: $t4 := move($t0)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: vector<u8>
+     var $t17: &vector<u8>
+     var $t18: &vector<u8>
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t1 := move($t2)
+     # live vars: $t1
+  2: $t4 := 0
+     # live vars: $t1, $t4
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+  4: label L0
+     # live vars: $t1, $t3
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
+     # live vars: $t1, $t3, $t6
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+  8: if ($t5) goto 9 else goto 26
+     # live vars: $t1, $t3
+  9: label L2
+     # live vars: $t1, $t3
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
+     # live vars: $t1, $t3, $t9
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := ==($t8, $t10)
+     # live vars: $t1, $t3, $t7
+ 15: if ($t7) goto 16 else goto 18
+     # live vars: $t1, $t3
+ 16: label L5
+     # live vars: $t1, $t3
+ 17: goto 21
+     # live vars:
+ 18: label L6
+     # live vars:
+ 19: $t11 := 3
+     # live vars: $t11
+ 20: abort($t11)
+     # live vars: $t1, $t3
+ 21: label L7
+     # live vars: $t1, $t3
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 24: $t3 := move($t12)
+     # live vars: $t1, $t3
+ 25: goto 28
+     # live vars:
+ 26: label L3
+     # live vars:
+ 27: goto 30
+     # live vars: $t1, $t3
+ 28: label L4
+     # live vars: $t1, $t3
+ 29: goto 4
+     # live vars:
+ 30: label L1
+     # live vars:
+ 31: $t14 := move($t0)
+     # live vars:
+ 32: $t16 := copy($t0)
+     # live vars:
+ 33: $t15 := move($t16)
+     # live vars:
+ 34: return ()
+}
+
+
+[variant baseline]
+fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u8
+     var $t7: &u8
+     var $t8: u8
+     var $t9: u64
+     var $t10: u64
+     var $t11: &vector<u8>
+     var $t12: &vector<u8>
+     # live vars: $t0
+  0: $t2 := 0
+     # live vars: $t0, $t2
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+  2: label L0
+     # live vars: $t0, $t1
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+  4: $t4 := vector::length<u8>($t11)
+     # live vars: $t0, $t1, $t4
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+  7: label L2
+     # live vars: $t0, $t1
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  9: $t7 := vector::borrow<u8>($t12, $t1)
+     # live vars: $t0, $t1, $t7
+ 10: $t6 := read_ref($t7)
+     # live vars: $t0, $t1, $t6
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
+ 12: $t5 := !=($t6, $t8)
+     # live vars: $t0, $t1, $t5
+ 13: if ($t5) goto 14 else goto 17
+     # live vars:
+ 14: label L5
+     # live vars:
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+ 17: label L6
+     # live vars: $t0, $t1
+ 18: label L7
+     # live vars: $t0, $t1
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
+ 21: $t1 := move($t9)
+     # live vars: $t0, $t1
+ 22: goto 25
+     # live vars:
+ 23: label L3
+     # live vars:
+ 24: goto 27
+     # live vars: $t0, $t1
+ 25: label L4
+     # live vars: $t0, $t1
+ 26: goto 2
+     # live vars:
+ 27: label L1
+     # live vars:
+ 28: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_directly() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_flips_directly($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_break_no_inline() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_with_break_without_inline($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_inline_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_flips($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_without_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_without_break_with_inline($t0)
+     # live vars:
+  7: return ()
+}
+
+============ after VisibilityChecker: ================
+
+[variant baseline]
+public fun vectors::guess_flips($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: &vector<u8>
+     var $t17: &vector<u8>
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t1 := move($t2)
+     # live vars: $t1
+  2: $t4 := 0
+     # live vars: $t1, $t4
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+  4: label L0
+     # live vars: $t1, $t3
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+  6: $t6 := vector::length<u8>($t16)
+     # live vars: $t1, $t3, $t6
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+  8: if ($t5) goto 9 else goto 25
+     # live vars: $t1, $t3
+  9: label L2
+     # live vars: $t1, $t3
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
+     # live vars: $t1, $t3, $t9
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := !=($t8, $t10)
+     # live vars: $t1, $t3, $t7
+ 15: if ($t7) goto 16 else goto 19
+     # live vars:
+ 16: label L5
+     # live vars:
+ 17: goto 29
+     # live vars: $t1, $t3
+ 18: goto 20
+     # live vars: $t1, $t3
+ 19: label L6
+     # live vars: $t1, $t3
+ 20: label L7
+     # live vars: $t1, $t3
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
+ 23: $t3 := move($t11)
+     # live vars: $t1, $t3
+ 24: goto 27
+     # live vars:
+ 25: label L3
+     # live vars:
+ 26: goto 29
+     # live vars: $t1, $t3
+ 27: label L4
+     # live vars: $t1, $t3
+ 28: goto 4
+     # live vars:
+ 29: label L1
+     # live vars:
+ 30: $t14 := copy($t0)
+     # live vars:
+ 31: $t13 := move($t14)
+     # live vars:
+ 32: $t15 := move($t0)
+     # live vars:
+ 33: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_flips_directly($t0: vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u8
+     var $t8: &u8
+     var $t9: &vector<u8>
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     # live vars: $t0
+  0: $t2 := 0
+     # live vars: $t0, $t2
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+  2: label L0
+     # live vars: $t0, $t1
+  3: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  4: $t4 := vector::length<u8>($t5)
+     # live vars: $t0, $t1, $t4
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+  7: label L2
+     # live vars: $t0, $t1
+  8: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t9
+  9: $t8 := vector::borrow<u8>($t9, $t1)
+     # live vars: $t0, $t1, $t8
+ 10: $t7 := read_ref($t8)
+     # live vars: $t0, $t1, $t7
+ 11: $t10 := 0
+     # live vars: $t0, $t1, $t7, $t10
+ 12: $t6 := !=($t7, $t10)
+     # live vars: $t0, $t1, $t6
+ 13: if ($t6) goto 14 else goto 17
+     # live vars:
+ 14: label L5
+     # live vars:
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+ 17: label L6
+     # live vars: $t0, $t1
+ 18: label L7
+     # live vars: $t0, $t1
+ 19: $t12 := 1
+     # live vars: $t0, $t1, $t12
+ 20: $t11 := +($t1, $t12)
+     # live vars: $t0, $t11
+ 21: $t1 := move($t11)
+     # live vars: $t0, $t1
+ 22: goto 25
+     # live vars:
+ 23: label L3
+     # live vars:
+ 24: goto 27
+     # live vars: $t0, $t1
+ 25: label L4
+     # live vars: $t0, $t1
+ 26: goto 2
+     # live vars:
+ 27: label L1
+     # live vars:
+ 28: $t14 := copy($t0)
+     # live vars:
+ 29: $t13 := move($t14)
+     # live vars:
+ 30: $t15 := move($t0)
+     # live vars:
+ 31: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: vector<u8>
+     var $t3: vector<u8>
+     var $t4: vector<u8>
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t1
+  1: vectors::loops_with_break_no_inline($t1)
+     # live vars:
+  2: $t3 := copy($t0)
+     # live vars:
+  3: $t2 := move($t3)
+     # live vars:
+  4: $t4 := move($t0)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: vector<u8>
+     var $t17: &vector<u8>
+     var $t18: &vector<u8>
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t1 := move($t2)
+     # live vars: $t1
+  2: $t4 := 0
+     # live vars: $t1, $t4
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+  4: label L0
+     # live vars: $t1, $t3
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
+     # live vars: $t1, $t3, $t6
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+  8: if ($t5) goto 9 else goto 26
+     # live vars: $t1, $t3
+  9: label L2
+     # live vars: $t1, $t3
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
+     # live vars: $t1, $t3, $t9
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := ==($t8, $t10)
+     # live vars: $t1, $t3, $t7
+ 15: if ($t7) goto 16 else goto 18
+     # live vars: $t1, $t3
+ 16: label L5
+     # live vars: $t1, $t3
+ 17: goto 21
+     # live vars:
+ 18: label L6
+     # live vars:
+ 19: $t11 := 3
+     # live vars: $t11
+ 20: abort($t11)
+     # live vars: $t1, $t3
+ 21: label L7
+     # live vars: $t1, $t3
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 24: $t3 := move($t12)
+     # live vars: $t1, $t3
+ 25: goto 28
+     # live vars:
+ 26: label L3
+     # live vars:
+ 27: goto 30
+     # live vars: $t1, $t3
+ 28: label L4
+     # live vars: $t1, $t3
+ 29: goto 4
+     # live vars:
+ 30: label L1
+     # live vars:
+ 31: $t14 := move($t0)
+     # live vars:
+ 32: $t16 := copy($t0)
+     # live vars:
+ 33: $t15 := move($t16)
+     # live vars:
+ 34: return ()
+}
+
+
+[variant baseline]
+fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u8
+     var $t7: &u8
+     var $t8: u8
+     var $t9: u64
+     var $t10: u64
+     var $t11: &vector<u8>
+     var $t12: &vector<u8>
+     # live vars: $t0
+  0: $t2 := 0
+     # live vars: $t0, $t2
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+  2: label L0
+     # live vars: $t0, $t1
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+  4: $t4 := vector::length<u8>($t11)
+     # live vars: $t0, $t1, $t4
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+  7: label L2
+     # live vars: $t0, $t1
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  9: $t7 := vector::borrow<u8>($t12, $t1)
+     # live vars: $t0, $t1, $t7
+ 10: $t6 := read_ref($t7)
+     # live vars: $t0, $t1, $t6
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
+ 12: $t5 := !=($t6, $t8)
+     # live vars: $t0, $t1, $t5
+ 13: if ($t5) goto 14 else goto 17
+     # live vars:
+ 14: label L5
+     # live vars:
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+ 17: label L6
+     # live vars: $t0, $t1
+ 18: label L7
+     # live vars: $t0, $t1
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
+ 21: $t1 := move($t9)
+     # live vars: $t0, $t1
+ 22: goto 25
+     # live vars:
+ 23: label L3
+     # live vars:
+ 24: goto 27
+     # live vars: $t0, $t1
+ 25: label L4
+     # live vars: $t0, $t1
+ 26: goto 2
+     # live vars:
+ 27: label L1
+     # live vars:
+ 28: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_directly() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_flips_directly($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_break_no_inline() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_with_break_without_inline($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_inline_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_flips($t0)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_without_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+  0: $t2 := 0
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+  5: $t0 := move($t1)
+     # live vars: $t0
+  6: vectors::guess_without_break_with_inline($t0)
+     # live vars:
+  7: return ()
+}
+
+============ after MemorySafetyProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: &vector<u8>
+     var $t17: &vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L1}
+     # global_to_label: {}
+     #
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t1, $t4
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  4: label L0
+     # live vars: $t1, $t3
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t16)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t16=L1281}
+     # global_to_label: {}
+     #
+  6: $t6 := vector::length<u8>($t16)
+     # live vars: $t1, $t3, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  8: if ($t5) goto 9 else goto 25
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  9: label L2
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t17)[]}
+     # local_to_label: {$t1=L2560,$t17=L2561}
+     # global_to_label: {}
+     #
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
+     # live vars: $t1, $t3, $t9
+     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t17)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t1=L2560,$t9=L2816,$t17=L2561}
+     # global_to_label: {}
+     #
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 14: $t7 := !=($t8, $t10)
+     # live vars: $t1, $t3, $t7
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 15: if ($t7) goto 16 else goto 19
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 16: label L5
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 17: goto 29
+     # live vars: $t1, $t3
+ 18: goto 20
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 19: label L6
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 20: label L7
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 23: $t3 := move($t11)
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 24: goto 27
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 25: label L3
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 26: goto 29
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 27: label L4
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 28: goto 4
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 29: label L1
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 30: $t14 := copy($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 31: $t13 := move($t14)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 32: $t15 := move($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 33: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_flips_directly($t0: vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u8
+     var $t8: &u8
+     var $t9: &vector<u8>
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: vector<u8>
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t0, $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: label L0
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # graph: {L768=local($t0)[borrow(false) -> L769],L769=local($t5)[]}
+     # local_to_label: {$t0=L768,$t5=L769}
+     # global_to_label: {}
+     #
+  4: $t4 := vector::length<u8>($t5)
+     # live vars: $t0, $t1, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: label L2
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  8: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t9
+     # graph: {L2048=local($t0)[borrow(false) -> L2049],L2049=local($t9)[]}
+     # local_to_label: {$t0=L2048,$t9=L2049}
+     # global_to_label: {}
+     #
+  9: $t8 := vector::borrow<u8>($t9, $t1)
+     # live vars: $t0, $t1, $t8
+     # graph: {L2048=local($t0)[borrow(false) -> L2049],L2049=local($t9)[call(false) -> L2304],L2304=local($t8)[]}
+     # local_to_label: {$t0=L2048,$t8=L2304,$t9=L2049}
+     # global_to_label: {}
+     #
+ 10: $t7 := read_ref($t8)
+     # live vars: $t0, $t1, $t7
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 11: $t10 := 0
+     # live vars: $t0, $t1, $t7, $t10
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 12: $t6 := !=($t7, $t10)
+     # live vars: $t0, $t1, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 13: if ($t6) goto 14 else goto 17
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 14: label L5
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 17: label L6
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 18: label L7
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 19: $t12 := 1
+     # live vars: $t0, $t1, $t12
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 20: $t11 := +($t1, $t12)
+     # live vars: $t0, $t11
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 21: $t1 := move($t11)
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 22: goto 25
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 23: label L3
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 24: goto 27
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 25: label L4
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 26: goto 2
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 27: label L1
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 28: $t14 := copy($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 29: $t13 := move($t14)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 30: $t15 := move($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 31: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: vector<u8>
+     var $t3: vector<u8>
+     var $t4: vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t1 := borrow_local($t0)
+     # live vars: $t1
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L1}
+     # global_to_label: {}
+     #
+  1: vectors::loops_with_break_no_inline($t1)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t3 := copy($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t2 := move($t3)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t4 := move($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
+     var $t1: &vector<u8>
+     var $t2: &vector<u8>
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: u8
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: vector<u8>
+     var $t15: vector<u8>
+     var $t16: vector<u8>
+     var $t17: &vector<u8>
+     var $t18: &vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[]}
+     # local_to_label: {$t0=L0,$t2=L1}
+     # global_to_label: {}
+     #
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t1, $t4
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  4: label L0
+     # live vars: $t1, $t3
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
+     # global_to_label: {}
+     #
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t17)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L1281}
+     # global_to_label: {}
+     #
+  6: $t6 := vector::length<u8>($t17)
+     # live vars: $t1, $t3, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: $t5 := <($t3, $t6)
+     # live vars: $t1, $t3, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  8: if ($t5) goto 9 else goto 26
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  9: label L2
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t18)[]}
+     # local_to_label: {$t1=L2560,$t18=L2561}
+     # global_to_label: {}
+     #
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
+     # live vars: $t1, $t3, $t9
+     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t18)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t1=L2560,$t9=L2816,$t18=L2561}
+     # global_to_label: {}
+     #
+ 12: $t8 := read_ref($t9)
+     # live vars: $t1, $t3, $t8
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 14: $t7 := ==($t8, $t10)
+     # live vars: $t1, $t3, $t7
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 15: if ($t7) goto 16 else goto 18
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 16: label L5
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 17: goto 21
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 18: label L6
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 19: $t11 := 3
+     # live vars: $t11
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 20: abort($t11)
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 21: label L7
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 24: $t3 := move($t12)
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 25: goto 28
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 26: label L3
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 27: goto 30
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 28: label L4
+     # live vars: $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 29: goto 4
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 30: label L1
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 31: $t14 := move($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 32: $t16 := copy($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 33: $t15 := move($t16)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 34: return ()
+}
+
+
+[variant baseline]
+fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u8
+     var $t7: &u8
+     var $t8: u8
+     var $t9: u64
+     var $t10: u64
+     var $t11: &vector<u8>
+     var $t12: &vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t0, $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: label L0
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+     # graph: {L768=local($t0)[skip -> L769],L769=local($t11)[]}
+     # local_to_label: {$t0=L768,$t11=L769}
+     # global_to_label: {}
+     #
+  4: $t4 := vector::length<u8>($t11)
+     # live vars: $t0, $t1, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t3 := <($t1, $t4)
+     # live vars: $t0, $t1, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: if ($t3) goto 7 else goto 23
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: label L2
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+     # graph: {L2048=local($t0)[skip -> L2049],L2049=local($t12)[]}
+     # local_to_label: {$t0=L2048,$t12=L2049}
+     # global_to_label: {}
+     #
+  9: $t7 := vector::borrow<u8>($t12, $t1)
+     # live vars: $t0, $t1, $t7
+     # graph: {L2048=local($t0)[skip -> L2049],L2049=local($t12)[call(false) -> L2304],L2304=local($t7)[]}
+     # local_to_label: {$t0=L2048,$t7=L2304,$t12=L2049}
+     # global_to_label: {}
+     #
+ 10: $t6 := read_ref($t7)
+     # live vars: $t0, $t1, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 12: $t5 := !=($t6, $t8)
+     # live vars: $t0, $t1, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 13: if ($t5) goto 14 else goto 17
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 14: label L5
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 15: goto 27
+     # live vars: $t0, $t1
+ 16: goto 18
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 17: label L6
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 18: label L7
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 21: $t1 := move($t9)
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 22: goto 25
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 23: label L3
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 24: goto 27
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 25: label L4
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 26: goto 2
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 27: label L1
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 28: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_directly() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t3 := 0
+     # live vars: $t2, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t0 := move($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: vectors::guess_flips_directly($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_break_no_inline() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t3 := 0
+     # live vars: $t2, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t0 := move($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: vectors::guess_with_break_without_inline($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_with_inline_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t3 := 0
+     # live vars: $t2, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t0 := move($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: vectors::guess_flips($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun vectors::test_guess_without_break() {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     var $t2: u8
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 0
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t3 := 0
+     # live vars: $t2, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t4 := 0
+     # live vars: $t2, $t3, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t5 := 0
+     # live vars: $t2, $t3, $t4, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t1 := vector($t2, $t3, $t4, $t5)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t0 := move($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: vectors::guess_without_break_with_inline($t0)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
@@ -167,12 +167,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
-     var $t13: vector<u8>
+     var $t13: u64
      var $t14: vector<u8>
      var $t15: vector<u8>
+     var $t16: vector<u8>
   0: $t2 := borrow_local($t0)
   1: $t1 := infer($t2)
   2: $t4 := 0
@@ -180,31 +181,32 @@ public fun vectors::guess_flips($t0: vector<u8>) {
   4: label L0
   5: $t6 := vector::length<u8>($t1)
   6: $t5 := <($t3, $t6)
-  7: if ($t5) goto 8 else goto 23
+  7: if ($t5) goto 8 else goto 24
   8: label L2
-  9: $t9 := vector::borrow<u8>($t1, $t3)
- 10: $t8 := read_ref($t9)
- 11: $t10 := 0
- 12: $t7 := !=($t8, $t10)
- 13: if ($t7) goto 14 else goto 17
- 14: label L5
- 15: goto 27
- 16: goto 18
- 17: label L6
- 18: label L7
- 19: $t12 := 1
- 20: $t11 := +($t3, $t12)
- 21: $t3 := infer($t11)
- 22: goto 25
- 23: label L3
- 24: goto 27
- 25: label L4
- 26: goto 4
- 27: label L1
- 28: $t14 := copy($t0)
- 29: $t13 := infer($t14)
- 30: $t15 := infer($t0)
- 31: return ()
+  9: $t10 := infer($t1)
+ 10: $t9 := vector::borrow<u8>($t10, $t3)
+ 11: $t8 := read_ref($t9)
+ 12: $t11 := 0
+ 13: $t7 := !=($t8, $t11)
+ 14: if ($t7) goto 15 else goto 18
+ 15: label L5
+ 16: goto 28
+ 17: goto 19
+ 18: label L6
+ 19: label L7
+ 20: $t13 := 1
+ 21: $t12 := +($t3, $t13)
+ 22: $t3 := infer($t12)
+ 23: goto 26
+ 24: label L3
+ 25: goto 28
+ 26: label L4
+ 27: goto 4
+ 28: label L1
+ 29: $t15 := copy($t0)
+ 30: $t14 := infer($t15)
+ 31: $t16 := infer($t0)
+ 32: return ()
 }
 
 
@@ -286,13 +288,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
      var $t13: u64
-     var $t14: vector<u8>
+     var $t14: u64
      var $t15: vector<u8>
      var $t16: vector<u8>
+     var $t17: vector<u8>
   0: $t2 := borrow_local($t0)
   1: $t1 := infer($t2)
   2: $t4 := 0
@@ -300,32 +303,33 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
   4: label L0
   5: $t6 := vector::length<u8>($t1)
   6: $t5 := <($t3, $t6)
-  7: if ($t5) goto 8 else goto 24
+  7: if ($t5) goto 8 else goto 25
   8: label L2
-  9: $t9 := vector::borrow<u8>($t1, $t3)
- 10: $t8 := read_ref($t9)
- 11: $t10 := 0
- 12: $t7 := ==($t8, $t10)
- 13: if ($t7) goto 14 else goto 16
- 14: label L5
- 15: goto 19
- 16: label L6
- 17: $t11 := 3
- 18: abort($t11)
- 19: label L7
- 20: $t13 := 1
- 21: $t12 := +($t3, $t13)
- 22: $t3 := infer($t12)
- 23: goto 26
- 24: label L3
- 25: goto 28
- 26: label L4
- 27: goto 4
- 28: label L1
- 29: $t14 := infer($t0)
- 30: $t16 := copy($t0)
- 31: $t15 := infer($t16)
- 32: return ()
+  9: $t10 := infer($t1)
+ 10: $t9 := vector::borrow<u8>($t10, $t3)
+ 11: $t8 := read_ref($t9)
+ 12: $t11 := 0
+ 13: $t7 := ==($t8, $t11)
+ 14: if ($t7) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t12 := 3
+ 19: abort($t12)
+ 20: label L7
+ 21: $t14 := 1
+ 22: $t13 := +($t3, $t14)
+ 23: $t3 := infer($t13)
+ 24: goto 27
+ 25: label L3
+ 26: goto 29
+ 27: label L4
+ 28: goto 4
+ 29: label L1
+ 30: $t15 := infer($t0)
+ 31: $t17 := copy($t0)
+ 32: $t16 := infer($t17)
+ 33: return ()
 }
 
 
@@ -338,36 +342,38 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: u8
-     var $t9: u64
+     var $t8: &vector<u8>
+     var $t9: u8
      var $t10: u64
+     var $t11: u64
   0: $t2 := 0
   1: $t1 := infer($t2)
   2: label L0
   3: $t4 := vector::length<u8>($t0)
   4: $t3 := <($t1, $t4)
-  5: if ($t3) goto 6 else goto 21
+  5: if ($t3) goto 6 else goto 22
   6: label L2
-  7: $t7 := vector::borrow<u8>($t0, $t1)
-  8: $t6 := read_ref($t7)
-  9: $t8 := 0
- 10: $t5 := !=($t6, $t8)
- 11: if ($t5) goto 12 else goto 15
- 12: label L5
- 13: goto 25
- 14: goto 16
- 15: label L6
- 16: label L7
- 17: $t10 := 1
- 18: $t9 := +($t1, $t10)
- 19: $t1 := infer($t9)
- 20: goto 23
- 21: label L3
- 22: goto 25
- 23: label L4
- 24: goto 2
- 25: label L1
- 26: return ()
+  7: $t8 := infer($t0)
+  8: $t7 := vector::borrow<u8>($t8, $t1)
+  9: $t6 := read_ref($t7)
+ 10: $t9 := 0
+ 11: $t5 := !=($t6, $t9)
+ 12: if ($t5) goto 13 else goto 16
+ 13: label L5
+ 14: goto 26
+ 15: goto 17
+ 16: label L6
+ 17: label L7
+ 18: $t11 := 1
+ 19: $t10 := +($t1, $t11)
+ 20: $t1 := infer($t10)
+ 21: goto 24
+ 22: label L3
+ 23: goto 26
+ 24: label L4
+ 25: goto 2
+ 26: label L1
+ 27: return ()
 }
 
 
@@ -459,28 +465,28 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
-     var $t13: vector<u8>
+     var $t13: u64
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: &vector<u8>
+     var $t16: vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
      # live vars: $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
   2: $t4 := 0
      # live vars: $t1, $t4
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t16 := copy($t1)
-     # live vars: $t1, $t3, $t16
-  6: $t6 := vector::length<u8>($t16)
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -488,15 +494,15 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
- 11: $t9 := vector::borrow<u8>($t17, $t3)
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
- 14: $t7 := !=($t8, $t10)
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+ 14: $t7 := !=($t8, $t11)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 19
      # live vars:
@@ -510,11 +516,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
  20: label L7
      # live vars: $t1, $t3
- 21: $t12 := 1
-     # live vars: $t1, $t3, $t12
- 22: $t11 := +($t3, $t12)
-     # live vars: $t1, $t11
- 23: $t3 := move($t11)
+ 21: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 22: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 23: $t3 := copy($t12)
      # live vars: $t1, $t3
  24: goto 27
      # live vars:
@@ -528,11 +534,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars:
  29: label L1
      # live vars:
- 30: $t14 := copy($t0)
+ 30: $t15 := copy($t0)
      # live vars:
- 31: $t13 := move($t14)
+ 31: $t14 := copy($t15)
      # live vars:
- 32: $t15 := move($t0)
+ 32: $t16 := copy($t0)
      # live vars:
  33: return ()
 }
@@ -558,7 +564,7 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars: $t0
   0: $t2 := 0
      # live vars: $t0, $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
@@ -598,7 +604,7 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars: $t0, $t1, $t12
  20: $t11 := +($t1, $t12)
      # live vars: $t0, $t11
- 21: $t1 := move($t11)
+ 21: $t1 := copy($t11)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -614,9 +620,9 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars:
  28: $t14 := copy($t0)
      # live vars:
- 29: $t13 := move($t14)
+ 29: $t13 := copy($t14)
      # live vars:
- 30: $t15 := move($t0)
+ 30: $t15 := copy($t0)
      # live vars:
  31: return ()
 }
@@ -635,9 +641,9 @@ public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
      # live vars:
   2: $t3 := copy($t0)
      # live vars:
-  3: $t2 := move($t3)
+  3: $t2 := copy($t3)
      # live vars:
-  4: $t4 := move($t0)
+  4: $t4 := copy($t0)
      # live vars:
   5: return ()
 }
@@ -654,29 +660,29 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
      var $t13: u64
-     var $t14: vector<u8>
+     var $t14: u64
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: &vector<u8>
+     var $t17: vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
      # live vars: $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
   2: $t4 := 0
      # live vars: $t1, $t4
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-  6: $t6 := vector::length<u8>($t17)
+  5: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+  6: $t6 := vector::length<u8>($t18)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -684,15 +690,15 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
- 11: $t9 := vector::borrow<u8>($t18, $t3)
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
- 14: $t7 := ==($t8, $t10)
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+ 14: $t7 := ==($t8, $t11)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 18
      # live vars: $t1, $t3
@@ -702,17 +708,17 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  18: label L6
      # live vars:
- 19: $t11 := 3
-     # live vars: $t11
- 20: abort($t11)
+ 19: $t12 := 3
+     # live vars: $t12
+ 20: abort($t12)
      # live vars: $t1, $t3
  21: label L7
      # live vars: $t1, $t3
- 22: $t13 := 1
-     # live vars: $t1, $t3, $t13
- 23: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
- 24: $t3 := move($t12)
+ 22: $t14 := 1
+     # live vars: $t1, $t3, $t14
+ 23: $t13 := +($t3, $t14)
+     # live vars: $t1, $t13
+ 24: $t3 := copy($t13)
      # live vars: $t1, $t3
  25: goto 28
      # live vars:
@@ -726,11 +732,11 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  30: label L1
      # live vars:
- 31: $t14 := move($t0)
+ 31: $t15 := copy($t0)
      # live vars:
- 32: $t16 := copy($t0)
+ 32: $t17 := copy($t0)
      # live vars:
- 33: $t15 := move($t16)
+ 33: $t16 := copy($t17)
      # live vars:
  34: return ()
 }
@@ -745,21 +751,21 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: u8
-     var $t9: u64
+     var $t8: &vector<u8>
+     var $t9: u8
      var $t10: u64
-     var $t11: &vector<u8>
+     var $t11: u64
      var $t12: &vector<u8>
      # live vars: $t0
   0: $t2 := 0
      # live vars: $t0, $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
-  3: $t11 := copy($t0)
-     # live vars: $t0, $t1, $t11
-  4: $t4 := vector::length<u8>($t11)
+  3: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  4: $t4 := vector::length<u8>($t12)
      # live vars: $t0, $t1, $t4
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
@@ -767,15 +773,15 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   7: label L2
      # live vars: $t0, $t1
-  8: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-  9: $t7 := vector::borrow<u8>($t12, $t1)
+  8: $t8 := copy($t0)
+     # live vars: $t0, $t1, $t8
+  9: $t7 := vector::borrow<u8>($t8, $t1)
      # live vars: $t0, $t1, $t7
  10: $t6 := read_ref($t7)
      # live vars: $t0, $t1, $t6
- 11: $t8 := 0
-     # live vars: $t0, $t1, $t6, $t8
- 12: $t5 := !=($t6, $t8)
+ 11: $t9 := 0
+     # live vars: $t0, $t1, $t6, $t9
+ 12: $t5 := !=($t6, $t9)
      # live vars: $t0, $t1, $t5
  13: if ($t5) goto 14 else goto 17
      # live vars:
@@ -789,11 +795,11 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
  18: label L7
      # live vars: $t0, $t1
- 19: $t10 := 1
-     # live vars: $t0, $t1, $t10
- 20: $t9 := +($t1, $t10)
-     # live vars: $t0, $t9
- 21: $t1 := move($t9)
+ 19: $t11 := 1
+     # live vars: $t0, $t1, $t11
+ 20: $t10 := +($t1, $t11)
+     # live vars: $t0, $t10
+ 21: $t1 := copy($t10)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -830,7 +836,7 @@ fun vectors::test_guess_directly() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_flips_directly($t0)
      # live vars:
@@ -857,7 +863,7 @@ fun vectors::test_guess_with_break_no_inline() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_with_break_without_inline($t0)
      # live vars:
@@ -884,7 +890,7 @@ fun vectors::test_guess_with_inline_break() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_flips($t0)
      # live vars:
@@ -911,7 +917,7 @@ fun vectors::test_guess_without_break() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_without_break_with_inline($t0)
      # live vars:
@@ -931,28 +937,28 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
-     var $t13: vector<u8>
+     var $t13: u64
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: &vector<u8>
+     var $t16: vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
      # live vars: $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
   2: $t4 := 0
      # live vars: $t1, $t4
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t16 := copy($t1)
-     # live vars: $t1, $t3, $t16
-  6: $t6 := vector::length<u8>($t16)
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -960,15 +966,15 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
- 11: $t9 := vector::borrow<u8>($t17, $t3)
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
- 14: $t7 := !=($t8, $t10)
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+ 14: $t7 := !=($t8, $t11)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 19
      # live vars:
@@ -982,11 +988,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
  20: label L7
      # live vars: $t1, $t3
- 21: $t12 := 1
-     # live vars: $t1, $t3, $t12
- 22: $t11 := +($t3, $t12)
-     # live vars: $t1, $t11
- 23: $t3 := move($t11)
+ 21: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 22: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 23: $t3 := copy($t12)
      # live vars: $t1, $t3
  24: goto 27
      # live vars:
@@ -1000,11 +1006,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars:
  29: label L1
      # live vars:
- 30: $t14 := copy($t0)
+ 30: $t15 := copy($t0)
      # live vars:
- 31: $t13 := move($t14)
+ 31: $t14 := copy($t15)
      # live vars:
- 32: $t15 := move($t0)
+ 32: $t16 := copy($t0)
      # live vars:
  33: return ()
 }
@@ -1030,7 +1036,7 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars: $t0
   0: $t2 := 0
      # live vars: $t0, $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
@@ -1070,7 +1076,7 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars: $t0, $t1, $t12
  20: $t11 := +($t1, $t12)
      # live vars: $t0, $t11
- 21: $t1 := move($t11)
+ 21: $t1 := copy($t11)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -1086,9 +1092,9 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars:
  28: $t14 := copy($t0)
      # live vars:
- 29: $t13 := move($t14)
+ 29: $t13 := copy($t14)
      # live vars:
- 30: $t15 := move($t0)
+ 30: $t15 := copy($t0)
      # live vars:
  31: return ()
 }
@@ -1107,9 +1113,9 @@ public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
      # live vars:
   2: $t3 := copy($t0)
      # live vars:
-  3: $t2 := move($t3)
+  3: $t2 := copy($t3)
      # live vars:
-  4: $t4 := move($t0)
+  4: $t4 := copy($t0)
      # live vars:
   5: return ()
 }
@@ -1126,29 +1132,29 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
      var $t13: u64
-     var $t14: vector<u8>
+     var $t14: u64
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: &vector<u8>
+     var $t17: vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
      # live vars: $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
   2: $t4 := 0
      # live vars: $t1, $t4
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-  6: $t6 := vector::length<u8>($t17)
+  5: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+  6: $t6 := vector::length<u8>($t18)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -1156,15 +1162,15 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
- 11: $t9 := vector::borrow<u8>($t18, $t3)
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
- 14: $t7 := ==($t8, $t10)
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+ 14: $t7 := ==($t8, $t11)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 18
      # live vars: $t1, $t3
@@ -1174,17 +1180,17 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  18: label L6
      # live vars:
- 19: $t11 := 3
-     # live vars: $t11
- 20: abort($t11)
+ 19: $t12 := 3
+     # live vars: $t12
+ 20: abort($t12)
      # live vars: $t1, $t3
  21: label L7
      # live vars: $t1, $t3
- 22: $t13 := 1
-     # live vars: $t1, $t3, $t13
- 23: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
- 24: $t3 := move($t12)
+ 22: $t14 := 1
+     # live vars: $t1, $t3, $t14
+ 23: $t13 := +($t3, $t14)
+     # live vars: $t1, $t13
+ 24: $t3 := copy($t13)
      # live vars: $t1, $t3
  25: goto 28
      # live vars:
@@ -1198,11 +1204,11 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  30: label L1
      # live vars:
- 31: $t14 := move($t0)
+ 31: $t15 := copy($t0)
      # live vars:
- 32: $t16 := copy($t0)
+ 32: $t17 := copy($t0)
      # live vars:
- 33: $t15 := move($t16)
+ 33: $t16 := copy($t17)
      # live vars:
  34: return ()
 }
@@ -1217,21 +1223,21 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: u8
-     var $t9: u64
+     var $t8: &vector<u8>
+     var $t9: u8
      var $t10: u64
-     var $t11: &vector<u8>
+     var $t11: u64
      var $t12: &vector<u8>
      # live vars: $t0
   0: $t2 := 0
      # live vars: $t0, $t2
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
-  3: $t11 := copy($t0)
-     # live vars: $t0, $t1, $t11
-  4: $t4 := vector::length<u8>($t11)
+  3: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  4: $t4 := vector::length<u8>($t12)
      # live vars: $t0, $t1, $t4
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
@@ -1239,15 +1245,15 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   7: label L2
      # live vars: $t0, $t1
-  8: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-  9: $t7 := vector::borrow<u8>($t12, $t1)
+  8: $t8 := copy($t0)
+     # live vars: $t0, $t1, $t8
+  9: $t7 := vector::borrow<u8>($t8, $t1)
      # live vars: $t0, $t1, $t7
  10: $t6 := read_ref($t7)
      # live vars: $t0, $t1, $t6
- 11: $t8 := 0
-     # live vars: $t0, $t1, $t6, $t8
- 12: $t5 := !=($t6, $t8)
+ 11: $t9 := 0
+     # live vars: $t0, $t1, $t6, $t9
+ 12: $t5 := !=($t6, $t9)
      # live vars: $t0, $t1, $t5
  13: if ($t5) goto 14 else goto 17
      # live vars:
@@ -1261,11 +1267,11 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
  18: label L7
      # live vars: $t0, $t1
- 19: $t10 := 1
-     # live vars: $t0, $t1, $t10
- 20: $t9 := +($t1, $t10)
-     # live vars: $t0, $t9
- 21: $t1 := move($t9)
+ 19: $t11 := 1
+     # live vars: $t0, $t1, $t11
+ 20: $t10 := +($t1, $t11)
+     # live vars: $t0, $t10
+ 21: $t1 := copy($t10)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -1302,7 +1308,7 @@ fun vectors::test_guess_directly() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_flips_directly($t0)
      # live vars:
@@ -1329,7 +1335,7 @@ fun vectors::test_guess_with_break_no_inline() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_with_break_without_inline($t0)
      # live vars:
@@ -1356,7 +1362,7 @@ fun vectors::test_guess_with_inline_break() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_flips($t0)
      # live vars:
@@ -1383,7 +1389,7 @@ fun vectors::test_guess_without_break() {
      # live vars: $t2, $t3, $t4, $t5
   4: $t1 := vector($t2, $t3, $t4, $t5)
      # live vars: $t1
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
   6: vectors::guess_without_break_with_inline($t0)
      # live vars:
@@ -1403,13 +1409,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
-     var $t13: vector<u8>
+     var $t13: u64
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: &vector<u8>
+     var $t16: vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -1422,7 +1428,7 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t2=L1}
      # global_to_label: {}
      #
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1434,7 +1440,7 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1446,70 +1452,70 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  5: $t16 := copy($t1)
-     # live vars: $t1, $t3, $t16
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t16)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t16=L1281}
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t17)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L1281}
      # global_to_label: {}
      #
-  6: $t6 := vector::length<u8>($t16)
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   8: if ($t5) goto 9 else goto 25
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   9: label L2
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 10: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t17)[]}
-     # local_to_label: {$t1=L2560,$t17=L2561}
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t10=L2561}
      # global_to_label: {}
      #
- 11: $t9 := vector::borrow<u8>($t17, $t3)
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
-     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t17)[call(false) -> L2816],L2816=local($t9)[]}
-     # local_to_label: {$t1=L2560,$t9=L2816,$t17=L2561}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t10=L2561}
      # global_to_label: {}
      #
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
-     # graph: {}
-     # local_to_label: {}
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 14: $t7 := !=($t8, $t10)
+ 14: $t7 := !=($t8, $t11)
      # live vars: $t1, $t3, $t7
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  15: if ($t7) goto 16 else goto 19
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  16: label L5
@@ -1522,44 +1528,44 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
  18: goto 20
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  19: label L6
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  20: label L7
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 21: $t12 := 1
-     # live vars: $t1, $t3, $t12
-     # graph: {}
-     # local_to_label: {}
+ 21: $t13 := 1
+     # live vars: $t1, $t3, $t13
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 22: $t11 := +($t3, $t12)
-     # live vars: $t1, $t11
-     # graph: {}
-     # local_to_label: {}
+ 22: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 23: $t3 := move($t11)
+ 23: $t3 := copy($t12)
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  24: goto 27
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  25: label L3
@@ -1570,14 +1576,14 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      #
  26: goto 29
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  27: label L4
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  28: goto 4
@@ -1592,19 +1598,19 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 30: $t14 := copy($t0)
+ 30: $t15 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 31: $t13 := move($t14)
+ 31: $t14 := copy($t15)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 32: $t15 := move($t0)
+ 32: $t16 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -1642,16 +1648,16 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   2: label L0
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   3: $t5 := borrow_local($t0)
@@ -1662,62 +1668,62 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      #
   4: $t4 := vector::length<u8>($t5)
      # live vars: $t0, $t1, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   6: if ($t3) goto 7 else goto 23
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   7: label L2
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   8: $t9 := borrow_local($t0)
      # live vars: $t0, $t1, $t9
-     # graph: {L2048=local($t0)[borrow(false) -> L2049],L2049=local($t9)[]}
-     # local_to_label: {$t0=L2048,$t9=L2049}
+     # graph: {L768=local($t0)[borrow(false) -> L2049],L2049=local($t9)[]}
+     # local_to_label: {$t0=L768,$t9=L2049}
      # global_to_label: {}
      #
   9: $t8 := vector::borrow<u8>($t9, $t1)
      # live vars: $t0, $t1, $t8
-     # graph: {L2048=local($t0)[borrow(false) -> L2049],L2049=local($t9)[call(false) -> L2304],L2304=local($t8)[]}
-     # local_to_label: {$t0=L2048,$t8=L2304,$t9=L2049}
+     # graph: {L768=local($t0)[borrow(false) -> L2049],L2049=local($t9)[call(false) -> L2304],L2304=local($t8)[]}
+     # local_to_label: {$t0=L768,$t8=L2304,$t9=L2049}
      # global_to_label: {}
      #
  10: $t7 := read_ref($t8)
      # live vars: $t0, $t1, $t7
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  11: $t10 := 0
      # live vars: $t0, $t1, $t7, $t10
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  12: $t6 := !=($t7, $t10)
      # live vars: $t0, $t1, $t6
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  13: if ($t6) goto 14 else goto 17
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  14: label L5
@@ -1730,44 +1736,44 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # live vars: $t0, $t1
  16: goto 18
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  17: label L6
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  18: label L7
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  19: $t12 := 1
      # live vars: $t0, $t1, $t12
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  20: $t11 := +($t1, $t12)
      # live vars: $t0, $t11
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 21: $t1 := move($t11)
+ 21: $t1 := copy($t11)
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  22: goto 25
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  23: label L3
@@ -1778,14 +1784,14 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      #
  24: goto 27
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  25: label L4
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  26: goto 2
@@ -1806,13 +1812,13 @@ public fun vectors::guess_flips_directly($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 29: $t13 := move($t14)
+ 29: $t13 := copy($t14)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 30: $t15 := move($t0)
+ 30: $t15 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -1851,13 +1857,13 @@ public fun vectors::guess_with_break_without_inline($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
-  3: $t2 := move($t3)
+  3: $t2 := copy($t3)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
-  4: $t4 := move($t0)
+  4: $t4 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -1878,14 +1884,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: u8
-     var $t11: u64
+     var $t10: &vector<u8>
+     var $t11: u8
      var $t12: u64
      var $t13: u64
-     var $t14: vector<u8>
+     var $t14: u64
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: &vector<u8>
+     var $t17: vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -1898,7 +1904,7 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t2=L1}
      # global_to_label: {}
      #
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t1
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1910,7 +1916,7 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t1, $t3
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1922,82 +1928,82 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t17)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L1281}
+  5: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t18)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t18=L1281}
      # global_to_label: {}
      #
-  6: $t6 := vector::length<u8>($t17)
+  6: $t6 := vector::length<u8>($t18)
      # live vars: $t1, $t3, $t6
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   8: if ($t5) goto 9 else goto 26
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
   9: label L2
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 10: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
-     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t18)[]}
-     # local_to_label: {$t1=L2560,$t18=L2561}
+ 10: $t10 := copy($t1)
+     # live vars: $t1, $t3, $t10
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t10=L2561}
      # global_to_label: {}
      #
- 11: $t9 := vector::borrow<u8>($t18, $t3)
+ 11: $t9 := vector::borrow<u8>($t10, $t3)
      # live vars: $t1, $t3, $t9
-     # graph: {L2560=local($t1)[skip -> L2561],L2561=local($t18)[call(false) -> L2816],L2816=local($t9)[]}
-     # local_to_label: {$t1=L2560,$t9=L2816,$t18=L2561}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t10=L2561}
      # global_to_label: {}
      #
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 13: $t10 := 0
-     # live vars: $t1, $t3, $t8, $t10
-     # graph: {}
-     # local_to_label: {}
+ 13: $t11 := 0
+     # live vars: $t1, $t3, $t8, $t11
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 14: $t7 := ==($t8, $t10)
+ 14: $t7 := ==($t8, $t11)
      # live vars: $t1, $t3, $t7
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  15: if ($t7) goto 16 else goto 18
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  16: label L5
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  17: goto 21
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  18: label L6
@@ -2006,46 +2012,46 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 19: $t11 := 3
-     # live vars: $t11
+ 19: $t12 := 3
+     # live vars: $t12
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 20: abort($t11)
+ 20: abort($t12)
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  21: label L7
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 22: $t13 := 1
-     # live vars: $t1, $t3, $t13
-     # graph: {}
-     # local_to_label: {}
+ 22: $t14 := 1
+     # live vars: $t1, $t3, $t14
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 23: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
-     # graph: {}
-     # local_to_label: {}
+ 23: $t13 := +($t3, $t14)
+     # live vars: $t1, $t13
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 24: $t3 := move($t12)
+ 24: $t3 := copy($t13)
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  25: goto 28
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  26: label L3
@@ -2056,14 +2062,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      #
  27: goto 30
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  28: label L4
      # live vars: $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
  29: goto 4
@@ -2078,19 +2084,19 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 31: $t14 := move($t0)
+ 31: $t15 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 32: $t16 := copy($t0)
+ 32: $t17 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 33: $t15 := move($t16)
+ 33: $t16 := copy($t17)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -2109,10 +2115,10 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: u8
-     var $t9: u64
+     var $t8: &vector<u8>
+     var $t9: u8
      var $t10: u64
-     var $t11: &vector<u8>
+     var $t11: u64
      var $t12: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -2125,82 +2131,82 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
-  1: $t1 := move($t2)
+  1: $t1 := copy($t2)
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   2: label L0
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
-  3: $t11 := copy($t0)
-     # live vars: $t0, $t1, $t11
-     # graph: {L768=local($t0)[skip -> L769],L769=local($t11)[]}
-     # local_to_label: {$t0=L768,$t11=L769}
+  3: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+     # graph: {L768=local($t0)[skip -> L769],L769=local($t12)[]}
+     # local_to_label: {$t0=L768,$t12=L769}
      # global_to_label: {}
      #
-  4: $t4 := vector::length<u8>($t11)
+  4: $t4 := vector::length<u8>($t12)
      # live vars: $t0, $t1, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   6: if ($t3) goto 7 else goto 23
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
   7: label L2
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
-  8: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-     # graph: {L2048=local($t0)[skip -> L2049],L2049=local($t12)[]}
-     # local_to_label: {$t0=L2048,$t12=L2049}
+  8: $t8 := copy($t0)
+     # live vars: $t0, $t1, $t8
+     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t8)[]}
+     # local_to_label: {$t0=L768,$t8=L2049}
      # global_to_label: {}
      #
-  9: $t7 := vector::borrow<u8>($t12, $t1)
+  9: $t7 := vector::borrow<u8>($t8, $t1)
      # live vars: $t0, $t1, $t7
-     # graph: {L2048=local($t0)[skip -> L2049],L2049=local($t12)[call(false) -> L2304],L2304=local($t7)[]}
-     # local_to_label: {$t0=L2048,$t7=L2304,$t12=L2049}
+     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t8)[call(false) -> L2304],L2304=local($t7)[]}
+     # local_to_label: {$t0=L768,$t7=L2304,$t8=L2049}
      # global_to_label: {}
      #
  10: $t6 := read_ref($t7)
      # live vars: $t0, $t1, $t6
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 11: $t8 := 0
-     # live vars: $t0, $t1, $t6, $t8
-     # graph: {}
-     # local_to_label: {}
+ 11: $t9 := 0
+     # live vars: $t0, $t1, $t6, $t9
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 12: $t5 := !=($t6, $t8)
+ 12: $t5 := !=($t6, $t9)
      # live vars: $t0, $t1, $t5
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  13: if ($t5) goto 14 else goto 17
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  14: label L5
@@ -2213,44 +2219,44 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
  16: goto 18
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  17: label L6
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  18: label L7
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 19: $t10 := 1
-     # live vars: $t0, $t1, $t10
-     # graph: {}
-     # local_to_label: {}
+ 19: $t11 := 1
+     # live vars: $t0, $t1, $t11
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 20: $t9 := +($t1, $t10)
-     # live vars: $t0, $t9
-     # graph: {}
-     # local_to_label: {}
+ 20: $t10 := +($t1, $t11)
+     # live vars: $t0, $t10
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 21: $t1 := move($t9)
+ 21: $t1 := copy($t10)
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  22: goto 25
      # live vars:
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  23: label L3
@@ -2261,14 +2267,14 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      #
  24: goto 27
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  25: label L4
      # live vars: $t0, $t1
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L768=local($t0)[]}
+     # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
  26: goto 2
@@ -2330,7 +2336,7 @@ fun vectors::test_guess_directly() {
      # local_to_label: {}
      # global_to_label: {}
      #
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
@@ -2389,7 +2395,7 @@ fun vectors::test_guess_with_break_no_inline() {
      # local_to_label: {}
      # global_to_label: {}
      #
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
@@ -2448,7 +2454,7 @@ fun vectors::test_guess_with_inline_break() {
      # local_to_label: {}
      # global_to_label: {}
      #
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
@@ -2507,7 +2513,7 @@ fun vectors::test_guess_without_break() {
      # local_to_label: {}
      # global_to_label: {}
      #
-  5: $t0 := move($t1)
+  5: $t0 := copy($t1)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.move
@@ -1,0 +1,99 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+    public entry fun guess_flips(flips: vector<u8>) {
+        loops_with_break(&flips);
+        let _v = copy flips; // this is ok
+
+        // this will fail, a UNKNOWN_INVARIANT_VIOLATION_ERROR (code 2000)
+        let _v2 =  flips;
+    }
+
+    // no function call
+    public entry fun guess_flips_directly(flips: vector<u8>) {
+        let i = 0;
+        while (i < vector::length(&flips)) {
+            if (*vector::borrow(&flips, i) != 0) {
+                break
+            };
+            i = i + 1;
+        };
+        let _v = copy flips; // this is ok
+        let _v2 =  flips; // this is ok
+    }
+
+    // call function, no inline, with `break`
+    public entry fun guess_with_break_without_inline(flips: vector<u8>) {
+        loops_with_break_no_inline(&flips);
+        let _v = copy flips; // this is ok
+        let _v2 =  flips; // this is ok
+    }
+
+    // call `inline` function, without `break`
+    public entry fun guess_without_break_with_inline(flips: vector<u8>) {
+        loops_without_break(&flips);
+        let _v = flips; // this is ok
+        let _v2 = copy flips; // this is ok
+    }
+
+
+    inline fun loops_with_break(flips: &vector<u8>) {
+        let i = 0;
+        while (i < vector::length(flips)) {
+            if (*vector::borrow(flips, i) != 0) {
+                break
+            };
+            i = i + 1;
+        };
+    }
+
+    fun loops_with_break_no_inline(flips: &vector<u8>) {
+        let i = 0;
+        while (i < vector::length(flips)) {
+            if (*vector::borrow(flips, i) != 0) {
+                break
+            };
+            i = i + 1;
+        };
+    }
+
+    inline fun loops_without_break(flips: &vector<u8>) {
+        let i = 0;
+        while (i < vector::length(flips)) {
+            assert!(*vector::borrow(flips, i) == 0, 3);
+            i = i + 1;
+        };
+    }
+
+    // #[test]
+    fun test_guess_with_inline_break() {
+        let flips = vector[0, 0, 0,0];
+        guess_flips(flips);
+    }
+
+    // #[test]
+    fun test_guess_directly() {
+        let flips = vector[0, 0, 0,0];
+        guess_flips_directly(flips);
+    }
+
+    // #[test]
+    fun test_guess_with_break_no_inline() {
+        let flips = vector[0, 0, 0,0];
+        guess_with_break_without_inline(flips);
+    }
+
+    // #[test]
+    fun test_guess_without_break() {
+        let flips = vector[0, 0, 0,0];
+        guess_without_break_with_inline(flips);
+    }
+}
+
+//#run 0xcafe::vectors::test_guess_with_inline_break
+
+//#run 0xcafe::vectors::test_guess_directly
+
+//#run 0xcafe::vectors::test_guess_with_break_no_inline
+
+//#run 0xcafe::vectors::test_guess_without_break

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
@@ -1,0 +1,664 @@
+// ---- Model Dump
+module 0xcafe::vectors {
+    use std::vector;
+    public entry fun guess_flips_break2(flips: vector<u8>): u64 {
+        {
+          let i: u64 = 0;
+          {
+            let flipsref5: &vector<u8> = Borrow(Immutable)(flips);
+            loop {
+              if Lt<u64>(i, vector::length<u8>(flipsref5)) {
+                if Neq<u8>(Deref(vector::borrow<u8>(flipsref5, i)), 0) {
+                  break
+                } else {
+                  Tuple()
+                };
+                i: u64 = Add<u64>(i, 1);
+                if Eq<u8>(Deref(vector::borrow<u8>(flipsref5, i)), 5) {
+                  break
+                } else {
+                  Tuple()
+                };
+                Tuple()
+              } else {
+                break
+              }
+            };
+            {
+              let _v: vector<u8> = Copy(flips);
+              {
+                let _v2: vector<u8> = flips;
+                {
+                  let x: &vector<u8> = flipsref5;
+                  vector::length<u8>(x)
+                }
+              }
+            }
+          }
+        }
+    }
+    spec fun $guess_flips_break2(flips: vector<u8>): u64;
+} // end 0xcafe::vectors
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: u8
+     var $t12: u64
+     var $t13: u64
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
+     var $t20: vector<u8>
+     var $t21: &vector<u8>
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := borrow_local($t0)
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := vector::length<u8>($t4)
+  6: $t6 := <($t2, $t7)
+  7: if ($t6) goto 8 else goto 33
+  8: label L2
+  9: $t10 := vector::borrow<u8>($t4, $t2)
+ 10: $t9 := read_ref($t10)
+ 11: $t11 := 0
+ 12: $t8 := !=($t9, $t11)
+ 13: if ($t8) goto 14 else goto 17
+ 14: label L5
+ 15: goto 37
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t13 := 1
+ 20: $t12 := +($t2, $t13)
+ 21: $t2 := infer($t12)
+ 22: $t16 := vector::borrow<u8>($t4, $t2)
+ 23: $t15 := read_ref($t16)
+ 24: $t17 := 5
+ 25: $t14 := ==($t15, $t17)
+ 26: if ($t14) goto 27 else goto 30
+ 27: label L8
+ 28: goto 37
+ 29: goto 31
+ 30: label L9
+ 31: label L10
+ 32: goto 35
+ 33: label L3
+ 34: goto 37
+ 35: label L4
+ 36: goto 4
+ 37: label L1
+ 38: $t19 := copy($t0)
+ 39: $t18 := infer($t19)
+ 40: $t20 := infer($t0)
+ 41: $t21 := infer($t4)
+ 42: $t1 := vector::length<u8>($t21)
+ 43: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: u8
+     var $t12: u64
+     var $t13: u64
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
+     var $t20: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
+     var $t23: &vector<u8>
+     var $t24: &vector<u8>
+     # live vars: $t0
+  0: $t3 := 0
+     # live vars: $t0, $t3
+  1: $t2 := move($t3)
+     # live vars: $t0, $t2
+  2: $t5 := borrow_local($t0)
+     # live vars: $t2, $t5
+  3: $t4 := move($t5)
+     # live vars: $t2, $t4
+  4: label L0
+     # live vars: $t2, $t4
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+  6: $t7 := vector::length<u8>($t22)
+     # live vars: $t2, $t4, $t7
+  7: $t6 := <($t2, $t7)
+     # live vars: $t2, $t4, $t6
+  8: if ($t6) goto 9 else goto 36
+     # live vars: $t2, $t4
+  9: label L2
+     # live vars: $t2, $t4
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
+     # live vars: $t2, $t4, $t10
+ 12: $t9 := read_ref($t10)
+     # live vars: $t2, $t4, $t9
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+ 14: $t8 := !=($t9, $t11)
+     # live vars: $t2, $t4, $t8
+ 15: if ($t8) goto 16 else goto 19
+     # live vars: $t4
+ 16: label L5
+     # live vars: $t4
+ 17: goto 40
+     # live vars: $t2, $t4
+ 18: goto 20
+     # live vars: $t2, $t4
+ 19: label L6
+     # live vars: $t2, $t4
+ 20: label L7
+     # live vars: $t2, $t4
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+ 23: $t2 := move($t12)
+     # live vars: $t2, $t4
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
+     # live vars: $t2, $t4, $t16
+ 26: $t15 := read_ref($t16)
+     # live vars: $t2, $t4, $t15
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+ 29: if ($t14) goto 30 else goto 33
+     # live vars: $t4
+ 30: label L8
+     # live vars: $t4
+ 31: goto 40
+     # live vars: $t2, $t4
+ 32: goto 34
+     # live vars: $t2, $t4
+ 33: label L9
+     # live vars: $t2, $t4
+ 34: label L10
+     # live vars: $t2, $t4
+ 35: goto 38
+     # live vars: $t4
+ 36: label L3
+     # live vars: $t4
+ 37: goto 40
+     # live vars: $t2, $t4
+ 38: label L4
+     # live vars: $t2, $t4
+ 39: goto 4
+     # live vars: $t4
+ 40: label L1
+     # live vars: $t4
+ 41: $t19 := copy($t0)
+     # live vars: $t4
+ 42: $t18 := move($t19)
+     # live vars: $t4
+ 43: $t20 := move($t0)
+     # live vars: $t4
+ 44: $t21 := move($t4)
+     # live vars: $t21
+ 45: $t1 := vector::length<u8>($t21)
+     # live vars: $t1
+ 46: return $t1
+}
+
+============ after VisibilityChecker: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: u8
+     var $t12: u64
+     var $t13: u64
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
+     var $t20: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
+     var $t23: &vector<u8>
+     var $t24: &vector<u8>
+     # live vars: $t0
+  0: $t3 := 0
+     # live vars: $t0, $t3
+  1: $t2 := move($t3)
+     # live vars: $t0, $t2
+  2: $t5 := borrow_local($t0)
+     # live vars: $t2, $t5
+  3: $t4 := move($t5)
+     # live vars: $t2, $t4
+  4: label L0
+     # live vars: $t2, $t4
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+  6: $t7 := vector::length<u8>($t22)
+     # live vars: $t2, $t4, $t7
+  7: $t6 := <($t2, $t7)
+     # live vars: $t2, $t4, $t6
+  8: if ($t6) goto 9 else goto 36
+     # live vars: $t2, $t4
+  9: label L2
+     # live vars: $t2, $t4
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
+     # live vars: $t2, $t4, $t10
+ 12: $t9 := read_ref($t10)
+     # live vars: $t2, $t4, $t9
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+ 14: $t8 := !=($t9, $t11)
+     # live vars: $t2, $t4, $t8
+ 15: if ($t8) goto 16 else goto 19
+     # live vars: $t4
+ 16: label L5
+     # live vars: $t4
+ 17: goto 40
+     # live vars: $t2, $t4
+ 18: goto 20
+     # live vars: $t2, $t4
+ 19: label L6
+     # live vars: $t2, $t4
+ 20: label L7
+     # live vars: $t2, $t4
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+ 23: $t2 := move($t12)
+     # live vars: $t2, $t4
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
+     # live vars: $t2, $t4, $t16
+ 26: $t15 := read_ref($t16)
+     # live vars: $t2, $t4, $t15
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+ 29: if ($t14) goto 30 else goto 33
+     # live vars: $t4
+ 30: label L8
+     # live vars: $t4
+ 31: goto 40
+     # live vars: $t2, $t4
+ 32: goto 34
+     # live vars: $t2, $t4
+ 33: label L9
+     # live vars: $t2, $t4
+ 34: label L10
+     # live vars: $t2, $t4
+ 35: goto 38
+     # live vars: $t4
+ 36: label L3
+     # live vars: $t4
+ 37: goto 40
+     # live vars: $t2, $t4
+ 38: label L4
+     # live vars: $t2, $t4
+ 39: goto 4
+     # live vars: $t4
+ 40: label L1
+     # live vars: $t4
+ 41: $t19 := copy($t0)
+     # live vars: $t4
+ 42: $t18 := move($t19)
+     # live vars: $t4
+ 43: $t20 := move($t0)
+     # live vars: $t4
+ 44: $t21 := move($t4)
+     # live vars: $t21
+ 45: $t1 := vector::length<u8>($t21)
+     # live vars: $t1
+ 46: return $t1
+}
+
+============ after MemorySafetyProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: u8
+     var $t12: u64
+     var $t13: u64
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
+     var $t20: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
+     var $t23: &vector<u8>
+     var $t24: &vector<u8>
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t3 := 0
+     # live vars: $t0, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t2 := move($t3)
+     # live vars: $t0, $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t5 := borrow_local($t0)
+     # live vars: $t2, $t5
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[]}
+     # local_to_label: {$t0=L512,$t5=L513}
+     # global_to_label: {}
+     #
+  3: $t4 := move($t5)
+     # live vars: $t2, $t4
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+  4: label L0
+     # live vars: $t2, $t4
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L1281],L1281=local($t22)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t22=L1281}
+     # global_to_label: {}
+     #
+  6: $t7 := vector::length<u8>($t22)
+     # live vars: $t2, $t4, $t7
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: $t6 := <($t2, $t7)
+     # live vars: $t2, $t4, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  8: if ($t6) goto 9 else goto 36
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  9: label L2
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+     # graph: {L2560=local($t4)[skip -> L2561],L2561=local($t23)[]}
+     # local_to_label: {$t4=L2560,$t23=L2561}
+     # global_to_label: {}
+     #
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
+     # live vars: $t2, $t4, $t10
+     # graph: {L2560=local($t4)[skip -> L2561],L2561=local($t23)[call(false) -> L2816],L2816=local($t10)[]}
+     # local_to_label: {$t4=L2560,$t10=L2816,$t23=L2561}
+     # global_to_label: {}
+     #
+ 12: $t9 := read_ref($t10)
+     # live vars: $t2, $t4, $t9
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 14: $t8 := !=($t9, $t11)
+     # live vars: $t2, $t4, $t8
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 15: if ($t8) goto 16 else goto 19
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 16: label L5
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 17: goto 40
+     # live vars: $t2, $t4
+ 18: goto 20
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 19: label L6
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 20: label L7
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 23: $t2 := move($t12)
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+     # graph: {L6144=local($t4)[skip -> L6145],L6145=local($t24)[]}
+     # local_to_label: {$t4=L6144,$t24=L6145}
+     # global_to_label: {}
+     #
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
+     # live vars: $t2, $t4, $t16
+     # graph: {L6144=local($t4)[skip -> L6145],L6145=local($t24)[call(false) -> L6400],L6400=local($t16)[]}
+     # local_to_label: {$t4=L6144,$t16=L6400,$t24=L6145}
+     # global_to_label: {}
+     #
+ 26: $t15 := read_ref($t16)
+     # live vars: $t2, $t4, $t15
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 29: if ($t14) goto 30 else goto 33
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 30: label L8
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 31: goto 40
+     # live vars: $t2, $t4
+ 32: goto 34
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 33: label L9
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 34: label L10
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 35: goto 38
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 36: label L3
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 37: goto 40
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 38: label L4
+     # live vars: $t2, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 39: goto 4
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 40: label L1
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 41: $t19 := copy($t0)
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 42: $t18 := move($t19)
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 43: $t20 := move($t0)
+     # live vars: $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 44: $t21 := move($t4)
+     # live vars: $t21
+     # graph: {L11264=local($t4)[skip -> L11265],L11265=local($t21)[]}
+     # local_to_label: {$t4=L11264,$t21=L11265}
+     # global_to_label: {}
+     #
+ 45: $t1 := vector::length<u8>($t21)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 46: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
@@ -54,17 +54,19 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: u8
-     var $t12: u64
+     var $t11: &vector<u8>
+     var $t12: u8
      var $t13: u64
-     var $t14: bool
-     var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
      var $t20: vector<u8>
-     var $t21: &vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
+     var $t23: &vector<u8>
   0: $t3 := 0
   1: $t2 := infer($t3)
   2: $t5 := borrow_local($t0)
@@ -72,43 +74,45 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
   4: label L0
   5: $t7 := vector::length<u8>($t4)
   6: $t6 := <($t2, $t7)
-  7: if ($t6) goto 8 else goto 33
+  7: if ($t6) goto 8 else goto 35
   8: label L2
-  9: $t10 := vector::borrow<u8>($t4, $t2)
- 10: $t9 := read_ref($t10)
- 11: $t11 := 0
- 12: $t8 := !=($t9, $t11)
- 13: if ($t8) goto 14 else goto 17
- 14: label L5
- 15: goto 37
- 16: goto 18
- 17: label L6
- 18: label L7
- 19: $t13 := 1
- 20: $t12 := +($t2, $t13)
- 21: $t2 := infer($t12)
- 22: $t16 := vector::borrow<u8>($t4, $t2)
- 23: $t15 := read_ref($t16)
- 24: $t17 := 5
- 25: $t14 := ==($t15, $t17)
- 26: if ($t14) goto 27 else goto 30
- 27: label L8
- 28: goto 37
- 29: goto 31
- 30: label L9
- 31: label L10
- 32: goto 35
- 33: label L3
+  9: $t11 := infer($t4)
+ 10: $t10 := vector::borrow<u8>($t11, $t2)
+ 11: $t9 := read_ref($t10)
+ 12: $t12 := 0
+ 13: $t8 := !=($t9, $t12)
+ 14: if ($t8) goto 15 else goto 18
+ 15: label L5
+ 16: goto 39
+ 17: goto 19
+ 18: label L6
+ 19: label L7
+ 20: $t14 := 1
+ 21: $t13 := +($t2, $t14)
+ 22: $t2 := infer($t13)
+ 23: $t18 := infer($t4)
+ 24: $t17 := vector::borrow<u8>($t18, $t2)
+ 25: $t16 := read_ref($t17)
+ 26: $t19 := 5
+ 27: $t15 := ==($t16, $t19)
+ 28: if ($t15) goto 29 else goto 32
+ 29: label L8
+ 30: goto 39
+ 31: goto 33
+ 32: label L9
+ 33: label L10
  34: goto 37
- 35: label L4
- 36: goto 4
- 37: label L1
- 38: $t19 := copy($t0)
- 39: $t18 := infer($t19)
- 40: $t20 := infer($t0)
- 41: $t21 := infer($t4)
- 42: $t1 := vector::length<u8>($t21)
- 43: return $t1
+ 35: label L3
+ 36: goto 39
+ 37: label L4
+ 38: goto 4
+ 39: label L1
+ 40: $t21 := copy($t0)
+ 41: $t20 := infer($t21)
+ 42: $t22 := infer($t0)
+ 43: $t23 := infer($t4)
+ 44: $t1 := vector::length<u8>($t23)
+ 45: return $t1
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -125,34 +129,34 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: u8
-     var $t12: u64
+     var $t11: &vector<u8>
+     var $t12: u8
      var $t13: u64
-     var $t14: bool
-     var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
      var $t20: vector<u8>
-     var $t21: &vector<u8>
-     var $t22: &vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
   0: $t3 := 0
      # live vars: $t0, $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t0, $t2
   2: $t5 := borrow_local($t0)
      # live vars: $t2, $t5
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2, $t4
   4: label L0
      # live vars: $t2, $t4
-  5: $t22 := copy($t4)
-     # live vars: $t2, $t4, $t22
-  6: $t7 := vector::length<u8>($t22)
+  5: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+  6: $t7 := vector::length<u8>($t24)
      # live vars: $t2, $t4, $t7
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
@@ -160,15 +164,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   9: label L2
      # live vars: $t2, $t4
- 10: $t23 := copy($t4)
-     # live vars: $t2, $t4, $t23
- 11: $t10 := vector::borrow<u8>($t23, $t2)
+ 10: $t11 := copy($t4)
+     # live vars: $t2, $t4, $t11
+ 11: $t10 := vector::borrow<u8>($t11, $t2)
      # live vars: $t2, $t4, $t10
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
- 13: $t11 := 0
-     # live vars: $t2, $t4, $t9, $t11
- 14: $t8 := !=($t9, $t11)
+ 13: $t12 := 0
+     # live vars: $t2, $t4, $t9, $t12
+ 14: $t8 := !=($t9, $t12)
      # live vars: $t2, $t4, $t8
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
@@ -182,23 +186,23 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
  20: label L7
      # live vars: $t2, $t4
- 21: $t13 := 1
-     # live vars: $t2, $t4, $t13
- 22: $t12 := +($t2, $t13)
-     # live vars: $t4, $t12
- 23: $t2 := move($t12)
-     # live vars: $t2, $t4
- 24: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
- 25: $t16 := vector::borrow<u8>($t24, $t2)
-     # live vars: $t2, $t4, $t16
- 26: $t15 := read_ref($t16)
-     # live vars: $t2, $t4, $t15
- 27: $t17 := 5
-     # live vars: $t2, $t4, $t15, $t17
- 28: $t14 := ==($t15, $t17)
+ 21: $t14 := 1
      # live vars: $t2, $t4, $t14
- 29: if ($t14) goto 30 else goto 33
+ 22: $t13 := +($t2, $t14)
+     # live vars: $t4, $t13
+ 23: $t2 := copy($t13)
+     # live vars: $t2, $t4
+ 24: $t18 := copy($t4)
+     # live vars: $t2, $t4, $t18
+ 25: $t17 := vector::borrow<u8>($t18, $t2)
+     # live vars: $t2, $t4, $t17
+ 26: $t16 := read_ref($t17)
+     # live vars: $t2, $t4, $t16
+ 27: $t19 := 5
+     # live vars: $t2, $t4, $t16, $t19
+ 28: $t15 := ==($t16, $t19)
+     # live vars: $t2, $t4, $t15
+ 29: if ($t15) goto 30 else goto 33
      # live vars: $t4
  30: label L8
      # live vars: $t4
@@ -222,15 +226,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t4
  40: label L1
      # live vars: $t4
- 41: $t19 := copy($t0)
+ 41: $t21 := copy($t0)
      # live vars: $t4
- 42: $t18 := move($t19)
+ 42: $t20 := copy($t21)
      # live vars: $t4
- 43: $t20 := move($t0)
+ 43: $t22 := copy($t0)
      # live vars: $t4
- 44: $t21 := move($t4)
-     # live vars: $t21
- 45: $t1 := vector::length<u8>($t21)
+ 44: $t23 := copy($t4)
+     # live vars: $t23
+ 45: $t1 := vector::length<u8>($t23)
      # live vars: $t1
  46: return $t1
 }
@@ -249,34 +253,34 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: u8
-     var $t12: u64
+     var $t11: &vector<u8>
+     var $t12: u8
      var $t13: u64
-     var $t14: bool
-     var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
      var $t20: vector<u8>
-     var $t21: &vector<u8>
-     var $t22: &vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
   0: $t3 := 0
      # live vars: $t0, $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t0, $t2
   2: $t5 := borrow_local($t0)
      # live vars: $t2, $t5
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2, $t4
   4: label L0
      # live vars: $t2, $t4
-  5: $t22 := copy($t4)
-     # live vars: $t2, $t4, $t22
-  6: $t7 := vector::length<u8>($t22)
+  5: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+  6: $t7 := vector::length<u8>($t24)
      # live vars: $t2, $t4, $t7
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
@@ -284,15 +288,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   9: label L2
      # live vars: $t2, $t4
- 10: $t23 := copy($t4)
-     # live vars: $t2, $t4, $t23
- 11: $t10 := vector::borrow<u8>($t23, $t2)
+ 10: $t11 := copy($t4)
+     # live vars: $t2, $t4, $t11
+ 11: $t10 := vector::borrow<u8>($t11, $t2)
      # live vars: $t2, $t4, $t10
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
- 13: $t11 := 0
-     # live vars: $t2, $t4, $t9, $t11
- 14: $t8 := !=($t9, $t11)
+ 13: $t12 := 0
+     # live vars: $t2, $t4, $t9, $t12
+ 14: $t8 := !=($t9, $t12)
      # live vars: $t2, $t4, $t8
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
@@ -306,23 +310,23 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
  20: label L7
      # live vars: $t2, $t4
- 21: $t13 := 1
-     # live vars: $t2, $t4, $t13
- 22: $t12 := +($t2, $t13)
-     # live vars: $t4, $t12
- 23: $t2 := move($t12)
-     # live vars: $t2, $t4
- 24: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
- 25: $t16 := vector::borrow<u8>($t24, $t2)
-     # live vars: $t2, $t4, $t16
- 26: $t15 := read_ref($t16)
-     # live vars: $t2, $t4, $t15
- 27: $t17 := 5
-     # live vars: $t2, $t4, $t15, $t17
- 28: $t14 := ==($t15, $t17)
+ 21: $t14 := 1
      # live vars: $t2, $t4, $t14
- 29: if ($t14) goto 30 else goto 33
+ 22: $t13 := +($t2, $t14)
+     # live vars: $t4, $t13
+ 23: $t2 := copy($t13)
+     # live vars: $t2, $t4
+ 24: $t18 := copy($t4)
+     # live vars: $t2, $t4, $t18
+ 25: $t17 := vector::borrow<u8>($t18, $t2)
+     # live vars: $t2, $t4, $t17
+ 26: $t16 := read_ref($t17)
+     # live vars: $t2, $t4, $t16
+ 27: $t19 := 5
+     # live vars: $t2, $t4, $t16, $t19
+ 28: $t15 := ==($t16, $t19)
+     # live vars: $t2, $t4, $t15
+ 29: if ($t15) goto 30 else goto 33
      # live vars: $t4
  30: label L8
      # live vars: $t4
@@ -346,15 +350,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t4
  40: label L1
      # live vars: $t4
- 41: $t19 := copy($t0)
+ 41: $t21 := copy($t0)
      # live vars: $t4
- 42: $t18 := move($t19)
+ 42: $t20 := copy($t21)
      # live vars: $t4
- 43: $t20 := move($t0)
+ 43: $t22 := copy($t0)
      # live vars: $t4
- 44: $t21 := move($t4)
-     # live vars: $t21
- 45: $t1 := vector::length<u8>($t21)
+ 44: $t23 := copy($t4)
+     # live vars: $t23
+ 45: $t1 := vector::length<u8>($t23)
      # live vars: $t1
  46: return $t1
 }
@@ -373,18 +377,18 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: u8
-     var $t12: u64
+     var $t11: &vector<u8>
+     var $t12: u8
      var $t13: u64
-     var $t14: bool
-     var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
      var $t20: vector<u8>
-     var $t21: &vector<u8>
-     var $t22: &vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
@@ -398,7 +402,7 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {}
      # global_to_label: {}
      #
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t0, $t2
      # graph: {}
      # local_to_label: {}
@@ -410,7 +414,7 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t5=L513}
      # global_to_label: {}
      #
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t2, $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
@@ -422,239 +426,239 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
-  5: $t22 := copy($t4)
-     # live vars: $t2, $t4, $t22
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L1281],L1281=local($t22)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t22=L1281}
+  5: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L1281],L1281=local($t24)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t24=L1281}
      # global_to_label: {}
      #
-  6: $t7 := vector::length<u8>($t22)
+  6: $t7 := vector::length<u8>($t24)
      # live vars: $t2, $t4, $t7
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
   8: if ($t6) goto 9 else goto 36
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
   9: label L2
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 10: $t23 := copy($t4)
-     # live vars: $t2, $t4, $t23
-     # graph: {L2560=local($t4)[skip -> L2561],L2561=local($t23)[]}
-     # local_to_label: {$t4=L2560,$t23=L2561}
+ 10: $t11 := copy($t4)
+     # live vars: $t2, $t4, $t11
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t11)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t11=L2561}
      # global_to_label: {}
      #
- 11: $t10 := vector::borrow<u8>($t23, $t2)
+ 11: $t10 := vector::borrow<u8>($t11, $t2)
      # live vars: $t2, $t4, $t10
-     # graph: {L2560=local($t4)[skip -> L2561],L2561=local($t23)[call(false) -> L2816],L2816=local($t10)[]}
-     # local_to_label: {$t4=L2560,$t10=L2816,$t23=L2561}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t11)[call(false) -> L2816],L2816=local($t10)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t10=L2816,$t11=L2561}
      # global_to_label: {}
      #
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 13: $t11 := 0
-     # live vars: $t2, $t4, $t9, $t11
-     # graph: {}
-     # local_to_label: {}
+ 13: $t12 := 0
+     # live vars: $t2, $t4, $t9, $t12
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 14: $t8 := !=($t9, $t11)
+ 14: $t8 := !=($t9, $t12)
      # live vars: $t2, $t4, $t8
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  16: label L5
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  17: goto 40
      # live vars: $t2, $t4
  18: goto 20
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  19: label L6
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  20: label L7
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 21: $t13 := 1
-     # live vars: $t2, $t4, $t13
-     # graph: {}
-     # local_to_label: {}
-     # global_to_label: {}
-     #
- 22: $t12 := +($t2, $t13)
-     # live vars: $t4, $t12
-     # graph: {}
-     # local_to_label: {}
-     # global_to_label: {}
-     #
- 23: $t2 := move($t12)
-     # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
-     # global_to_label: {}
-     #
- 24: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
-     # graph: {L6144=local($t4)[skip -> L6145],L6145=local($t24)[]}
-     # local_to_label: {$t4=L6144,$t24=L6145}
-     # global_to_label: {}
-     #
- 25: $t16 := vector::borrow<u8>($t24, $t2)
-     # live vars: $t2, $t4, $t16
-     # graph: {L6144=local($t4)[skip -> L6145],L6145=local($t24)[call(false) -> L6400],L6400=local($t16)[]}
-     # local_to_label: {$t4=L6144,$t16=L6400,$t24=L6145}
-     # global_to_label: {}
-     #
- 26: $t15 := read_ref($t16)
-     # live vars: $t2, $t4, $t15
-     # graph: {}
-     # local_to_label: {}
-     # global_to_label: {}
-     #
- 27: $t17 := 5
-     # live vars: $t2, $t4, $t15, $t17
-     # graph: {}
-     # local_to_label: {}
-     # global_to_label: {}
-     #
- 28: $t14 := ==($t15, $t17)
+ 21: $t14 := 1
      # live vars: $t2, $t4, $t14
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 29: if ($t14) goto 30 else goto 33
+ 22: $t13 := +($t2, $t14)
+     # live vars: $t4, $t13
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 23: $t2 := copy($t13)
+     # live vars: $t2, $t4
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 24: $t18 := copy($t4)
+     # live vars: $t2, $t4, $t18
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t18)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t18=L6145}
+     # global_to_label: {}
+     #
+ 25: $t17 := vector::borrow<u8>($t18, $t2)
+     # live vars: $t2, $t4, $t17
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t18)[call(false) -> L6400],L6400=local($t17)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t17=L6400,$t18=L6145}
+     # global_to_label: {}
+     #
+ 26: $t16 := read_ref($t17)
+     # live vars: $t2, $t4, $t16
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 27: $t19 := 5
+     # live vars: $t2, $t4, $t16, $t19
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 28: $t15 := ==($t16, $t19)
+     # live vars: $t2, $t4, $t15
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 29: if ($t15) goto 30 else goto 33
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  30: label L8
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  31: goto 40
      # live vars: $t2, $t4
  32: goto 34
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  33: label L9
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  34: label L10
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  35: goto 38
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  36: label L3
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  37: goto 40
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  38: label L4
      # live vars: $t2, $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  39: goto 4
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
  40: label L1
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 41: $t19 := copy($t0)
+ 41: $t21 := copy($t0)
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 42: $t18 := move($t19)
+ 42: $t20 := copy($t21)
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 43: $t20 := move($t0)
+ 43: $t22 := copy($t0)
      # live vars: $t4
-     # graph: {}
-     # local_to_label: {}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 44: $t21 := move($t4)
-     # live vars: $t21
-     # graph: {L11264=local($t4)[skip -> L11265],L11265=local($t21)[]}
-     # local_to_label: {$t4=L11264,$t21=L11265}
+ 44: $t23 := copy($t4)
+     # live vars: $t23
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L11265],L11265=local($t23)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t23=L11265}
      # global_to_label: {}
      #
- 45: $t1 := vector::length<u8>($t21)
+ 45: $t1 := vector::length<u8>($t23)
      # live vars: $t1
      # graph: {}
      # local_to_label: {}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.move
@@ -1,0 +1,25 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    // multi-break
+    public entry fun guess_flips_break2(flips: vector<u8>) : u64 {
+        let i = 0;
+        let flipsref5 = &flips;
+        while (i < vector::length(flipsref5)) {
+            if (*vector::borrow(flipsref5, i) != 0) {
+                break
+            };
+            i = i + 1;
+            if (*vector::borrow(flipsref5, i) == 5) {
+                break
+            };
+        };
+        let _v = copy flips; // this is ok
+        // this used to fail with an UNKNOWN_INVARIANT_VIOLATION_ERROR (code 2000)
+        let _v2 =  flips;
+	let x = flipsref5;
+	vector::length(x)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -98,7 +98,7 @@ fun borrow::field($t0: &borrow::S): u64 {
      # live vars: $t0
   0: $t3 := borrow_field<borrow::S>.f($t0)
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t1 := read_ref($t2)
      # live vars: $t1
@@ -116,11 +116,11 @@ fun borrow::local($t0: u64): u64 {
      # live vars:
   0: $t3 := 33
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t5 := borrow_local($t2)
      # live vars: $t5
-  3: $t4 := move($t5)
+  3: $t4 := copy($t5)
      # live vars: $t4
   4: $t1 := read_ref($t4)
      # live vars: $t1
@@ -136,7 +136,7 @@ fun borrow::param($t0: u64): u64 {
      # live vars: $t0
   0: $t3 := borrow_local($t0)
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t1 := read_ref($t2)
      # live vars: $t1
@@ -180,7 +180,7 @@ fun borrow::mut_local($t0: u64): u64 {
      # live vars:
   0: $t3 := 33
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t5 := borrow_local($t2)
      # live vars: $t5

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -87,39 +87,39 @@ fun constant::test_constans() {
      # live vars:
   0: $t1 := true
      # live vars:
-  1: $t0 := move($t1)
+  1: $t0 := copy($t1)
      # live vars:
   2: $t3 := false
      # live vars:
-  3: $t2 := move($t3)
+  3: $t2 := copy($t3)
      # live vars:
   4: $t5 := 1
      # live vars:
-  5: $t4 := move($t5)
+  5: $t4 := copy($t5)
      # live vars:
   6: $t7 := 7086
      # live vars:
-  7: $t6 := move($t7)
+  7: $t6 := copy($t7)
      # live vars:
   8: $t9 := 14593408
      # live vars:
-  9: $t8 := move($t9)
+  9: $t8 := copy($t9)
      # live vars:
  10: $t11 := 51966
      # live vars:
- 11: $t10 := move($t11)
+ 11: $t10 := copy($t11)
      # live vars:
  12: $t13 := 3735928559
      # live vars:
- 13: $t12 := move($t13)
+ 13: $t12 := copy($t13)
      # live vars:
  14: $t15 := 301490978409967
      # live vars:
- 15: $t14 := move($t15)
+ 15: $t14 := copy($t15)
      # live vars:
  16: $t17 := 0x42
      # live vars:
- 17: $t16 := move($t17)
+ 17: $t16 := copy($t17)
      # live vars:
  18: $t20 := 1
      # live vars: $t20
@@ -129,11 +129,11 @@ fun constant::test_constans() {
      # live vars: $t20, $t21, $t22
  21: $t19 := vector($t20, $t21, $t22)
      # live vars:
- 22: $t18 := move($t19)
+ 22: $t18 := copy($t19)
      # live vars:
  23: $t24 := [72, 101, 108, 108, 111, 33, 10]
      # live vars:
- 24: $t23 := move($t24)
+ 24: $t23 := copy($t24)
      # live vars:
  25: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -169,7 +169,7 @@ fun fields::write_local_direct(): fields::S {
      # live vars: $t3, $t4
   3: $t2 := pack fields::S($t3, $t4)
      # live vars: $t2
-  4: $t1 := move($t2)
+  4: $t1 := copy($t2)
      # live vars: $t1
   5: $t6 := 42
      # live vars: $t1, $t6
@@ -181,7 +181,7 @@ fun fields::write_local_direct(): fields::S {
      # live vars: $t1, $t6, $t7
   9: write_ref($t7, $t6)
      # live vars: $t1
- 10: $t0 := move($t1)
+ 10: $t0 := copy($t1)
      # live vars: $t0
  11: return $t0
 }
@@ -209,7 +209,7 @@ fun fields::write_local_via_ref(): fields::S {
      # live vars: $t3, $t4
   3: $t2 := pack fields::S($t3, $t4)
      # live vars: $t2
-  4: $t1 := move($t2)
+  4: $t1 := copy($t2)
      # live vars: $t1
   5: $t7 := borrow_local($t1)
      # live vars: $t1, $t7
@@ -223,7 +223,7 @@ fun fields::write_local_via_ref(): fields::S {
      # live vars: $t1, $t8, $t9
  10: write_ref($t9, $t8)
      # live vars: $t1
- 11: $t0 := move($t1)
+ 11: $t0 := copy($t1)
      # live vars: $t0
  12: return $t0
 }
@@ -265,7 +265,7 @@ fun fields::write_val($t0: fields::S): fields::S {
      # live vars: $t0, $t2, $t3
   4: write_ref($t3, $t2)
      # live vars: $t0
-  5: $t1 := move($t0)
+  5: $t1 := copy($t0)
      # live vars: $t1
   6: return $t1
 }
@@ -312,7 +312,7 @@ B0:
 	7: MutBorrowField[0](S.g: T)
 	8: MutBorrowField[1](T.h: u64)
 	9: WriteRef
-	10: MoveLoc[0](loc0: S)
+	10: CopyLoc[0](loc0: S)
 	11: StLoc[1](loc1: S)
 	12: MoveLoc[1](loc1: S)
 	13: Ret
@@ -334,7 +334,7 @@ B0:
 	9: MutBorrowField[0](S.g: T)
 	10: MutBorrowField[1](T.h: u64)
 	11: WriteRef
-	12: MoveLoc[0](loc0: S)
+	12: CopyLoc[0](loc0: S)
 	13: StLoc[2](loc2: S)
 	14: MoveLoc[2](loc2: S)
 	15: Ret
@@ -355,7 +355,7 @@ B0:
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
-	5: MoveLoc[0](Arg0: S)
+	5: CopyLoc[0](Arg0: S)
 	6: StLoc[1](loc0: S)
 	7: MoveLoc[1](loc0: S)
 	8: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -31,7 +31,7 @@ fun Test::foo($t0: u64): u64 {
 fun Test::identity<#0>($t0: #0): #0 {
      var $t1: #0
      # live vars: $t0
-  0: $t1 := move($t0)
+  0: $t1 := copy($t0)
      # live vars: $t1
   1: return $t1
 }
@@ -50,7 +50,7 @@ B0:
 }
 identity<Ty0>(Arg0: Ty0): Ty0 {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: CopyLoc[0](Arg0: Ty0)
 	1: StLoc[1](loc0: Ty0)
 	2: MoveLoc[1](loc0: Ty0)
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -85,7 +85,7 @@ fun globals::read($t0: address): u64 {
      # live vars: $t0
   0: $t3 := borrow_global<globals::R>($t0)
      # live vars: $t3
-  1: $t2 := move($t3)
+  1: $t2 := copy($t3)
      # live vars: $t2
   2: $t4 := borrow_field<globals::R>.f($t2)
      # live vars: $t4

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -155,7 +155,7 @@ fun loops::nested_loop($t0: u64): u64 {
      # live vars: $t0, $t7
  11: $t6 := -($t0, $t7)
      # live vars: $t6
- 12: $t0 := move($t6)
+ 12: $t0 := copy($t6)
      # live vars: $t0
  13: goto 19
      # live vars: $t0
@@ -175,7 +175,7 @@ fun loops::nested_loop($t0: u64): u64 {
      # live vars: $t0, $t9
  21: $t8 := -($t0, $t9)
      # live vars: $t8
- 22: $t0 := move($t8)
+ 22: $t0 := copy($t8)
      # live vars: $t0
  23: goto 0
      # live vars: $t0
@@ -191,7 +191,7 @@ fun loops::nested_loop($t0: u64): u64 {
      # live vars: $t0
  29: label L1
      # live vars: $t0
- 30: $t1 := move($t0)
+ 30: $t1 := copy($t0)
      # live vars: $t1
  31: return $t1
 }
@@ -219,7 +219,7 @@ fun loops::while_loop($t0: u64): u64 {
      # live vars: $t0, $t5
   6: $t4 := -($t0, $t5)
      # live vars: $t4
-  7: $t0 := move($t4)
+  7: $t0 := copy($t4)
      # live vars: $t0
   8: goto 11
      # live vars: $t0
@@ -233,7 +233,7 @@ fun loops::while_loop($t0: u64): u64 {
      # live vars: $t0
  13: label L1
      # live vars: $t0
- 14: $t1 := move($t0)
+ 14: $t1 := copy($t0)
      # live vars: $t1
  15: return $t1
 }
@@ -297,7 +297,7 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
      # live vars: $t0, $t9
  22: $t8 := -($t0, $t9)
      # live vars: $t8
- 23: $t0 := move($t8)
+ 23: $t0 := copy($t8)
      # live vars: $t0
  24: goto 27
      # live vars: $t0
@@ -311,7 +311,7 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
      # live vars: $t0
  29: label L1
      # live vars: $t0
- 30: $t1 := move($t0)
+ 30: $t1 := copy($t0)
      # live vars: $t1
  31: return $t1
 }
@@ -370,7 +370,7 @@ B8:
 B9:
 	31: Branch(0)
 B10:
-	32: MoveLoc[0](Arg0: u64)
+	32: CopyLoc[0](Arg0: u64)
 	33: StLoc[5](loc4: u64)
 	34: MoveLoc[5](loc4: u64)
 	35: Ret
@@ -398,7 +398,7 @@ B2:
 B3:
 	14: Branch(0)
 B4:
-	15: MoveLoc[0](Arg0: u64)
+	15: CopyLoc[0](Arg0: u64)
 	16: StLoc[3](loc2: u64)
 	17: MoveLoc[3](loc2: u64)
 	18: Ret
@@ -450,7 +450,7 @@ B8:
 B9:
 	30: Branch(0)
 B10:
-	31: MoveLoc[0](Arg0: u64)
+	31: CopyLoc[0](Arg0: u64)
 	32: StLoc[5](loc4: u64)
 	33: MoveLoc[5](loc4: u64)
 	34: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
@@ -81,9 +81,9 @@ fun pack_unpack::pack2($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t4: u8
      var $t5: u8
      # live vars: $t0, $t1, $t2
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t2, $t4
-  1: $t5 := move($t1)
+  1: $t5 := copy($t1)
      # live vars: $t2, $t4, $t5
   2: $t3 := pack pack_unpack::S($t4, $t2, $t5)
      # live vars: $t3
@@ -96,7 +96,7 @@ fun pack_unpack::pack3($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      # live vars: $t0, $t1, $t2
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t2, $t4
   1: $t3 := pack pack_unpack::S($t1, $t4, $t2)
      # live vars: $t3
@@ -110,9 +110,9 @@ fun pack_unpack::pack4($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t4: u8
      var $t5: u8
      # live vars: $t0, $t1, $t2
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t2, $t4
-  1: $t5 := move($t1)
+  1: $t5 := copy($t1)
      # live vars: $t2, $t4, $t5
   2: $t3 := pack pack_unpack::S($t2, $t4, $t5)
      # live vars: $t3
@@ -125,7 +125,7 @@ fun pack_unpack::pack5($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t3: pack_unpack::S
      var $t4: u8
      # live vars: $t0, $t1, $t2
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t2, $t4
   1: $t3 := pack pack_unpack::S($t1, $t2, $t4)
      # live vars: $t3
@@ -139,9 +139,9 @@ fun pack_unpack::pack6($t0: u8, $t1: u8, $t2: u8): pack_unpack::S {
      var $t4: u8
      var $t5: u8
      # live vars: $t0, $t1, $t2
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t2, $t4
-  1: $t5 := move($t1)
+  1: $t5 := copy($t1)
      # live vars: $t2, $t4, $t5
   2: $t3 := pack pack_unpack::S($t2, $t5, $t4)
      # live vars: $t3
@@ -168,9 +168,9 @@ B0:
 }
 pack2(Arg0: u8, Arg1: u8, Arg2: u8): S {
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: CopyLoc[0](Arg0: u8)
 	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	2: CopyLoc[1](Arg1: u8)
 	3: StLoc[4](loc1: u8)
 	4: MoveLoc[3](loc0: u8)
 	5: MoveLoc[2](Arg2: u8)
@@ -180,7 +180,7 @@ B0:
 }
 pack3(Arg0: u8, Arg1: u8, Arg2: u8): S {
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: CopyLoc[0](Arg0: u8)
 	1: StLoc[3](loc0: u8)
 	2: MoveLoc[1](Arg1: u8)
 	3: MoveLoc[3](loc0: u8)
@@ -190,9 +190,9 @@ B0:
 }
 pack4(Arg0: u8, Arg1: u8, Arg2: u8): S {
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: CopyLoc[0](Arg0: u8)
 	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	2: CopyLoc[1](Arg1: u8)
 	3: StLoc[4](loc1: u8)
 	4: MoveLoc[2](Arg2: u8)
 	5: MoveLoc[3](loc0: u8)
@@ -202,7 +202,7 @@ B0:
 }
 pack5(Arg0: u8, Arg1: u8, Arg2: u8): S {
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: CopyLoc[0](Arg0: u8)
 	1: StLoc[3](loc0: u8)
 	2: MoveLoc[1](Arg1: u8)
 	3: MoveLoc[2](Arg2: u8)
@@ -212,9 +212,9 @@ B0:
 }
 pack6(Arg0: u8, Arg1: u8, Arg2: u8): S {
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: CopyLoc[0](Arg0: u8)
 	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	2: CopyLoc[1](Arg1: u8)
 	3: StLoc[4](loc1: u8)
 	4: MoveLoc[2](Arg2: u8)
 	5: MoveLoc[4](loc1: u8)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -51,9 +51,9 @@ fun pack_unpack::unpack($t0: pack_unpack::S): (u64, u64) {
      # live vars: $t3, $t5
   1: $t4 := unpack pack_unpack::T($t5)
      # live vars: $t3, $t4
-  2: $t1 := move($t3)
+  2: $t1 := copy($t3)
      # live vars: $t1, $t4
-  3: $t2 := move($t4)
+  3: $t2 := copy($t4)
      # live vars: $t1, $t2
   4: return ($t1, $t2)
 }
@@ -90,9 +90,9 @@ B0:
 	2: Unpack[0](T)
 	3: StLoc[1](loc0: u64)
 	4: StLoc[2](loc1: u64)
-	5: MoveLoc[2](loc1: u64)
+	5: CopyLoc[2](loc1: u64)
 	6: StLoc[3](loc2: u64)
-	7: MoveLoc[1](loc0: u64)
+	7: CopyLoc[1](loc0: u64)
 	8: StLoc[4](loc3: u64)
 	9: MoveLoc[3](loc2: u64)
 	10: MoveLoc[4](loc3: u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -105,25 +105,25 @@ public fun m::foo<#0>($t0: m::E<#0>, $t1: &mut #0) {
      var $t10: u64
      var $t11: u64
      # live vars: $t0, $t1
-  0: $t4 := move($t0)
+  0: $t4 := copy($t0)
      # live vars: $t1, $t4
   1: $t5 := unpack m::E<#0>($t4)
      # live vars: $t1, $t5
-  2: $t6 := move($t5)
+  2: $t6 := copy($t5)
      # live vars: $t1, $t6
   3: $t3 := pack m::E<#0>($t6)
      # live vars: $t1, $t3
-  4: $t2 := move($t3)
+  4: $t2 := copy($t3)
      # live vars: $t1, $t2
-  5: $t7 := move($t2)
+  5: $t7 := copy($t2)
      # live vars: $t1, $t7
-  6: $t8 := move($t7)
+  6: $t8 := copy($t7)
      # live vars: $t1, $t8
   7: $t9 := unpack m::E<#0>($t8)
      # live vars: $t1, $t9
   8: $t11 := 3
      # live vars: $t1, $t9
-  9: $t10 := move($t11)
+  9: $t10 := copy($t11)
      # live vars: $t1, $t9
  10: write_ref($t1, $t9)
      # live vars:
@@ -179,7 +179,7 @@ L1:	loc3: E<Ty0>
 L2:	loc4: E<Ty0>
 L3:	loc5: u64
 B0:
-	0: MoveLoc[0](Arg0: E<Ty0>)
+	0: CopyLoc[0](Arg0: E<Ty0>)
 	1: StLoc[2](loc0: E<Ty0>)
 	2: MoveLoc[2](loc0: E<Ty0>)
 	3: UnpackGeneric[1](E<Ty0>)
@@ -187,9 +187,9 @@ B0:
 	5: MoveLoc[3](loc1: Ty0)
 	6: PackGeneric[1](E<Ty0>)
 	7: StLoc[4](loc2: E<Ty0>)
-	8: MoveLoc[4](loc2: E<Ty0>)
+	8: CopyLoc[4](loc2: E<Ty0>)
 	9: StLoc[5](loc3: E<Ty0>)
-	10: MoveLoc[5](loc3: E<Ty0>)
+	10: CopyLoc[5](loc3: E<Ty0>)
 	11: StLoc[6](loc4: E<Ty0>)
 	12: MoveLoc[6](loc4: E<Ty0>)
 	13: UnpackGeneric[1](E<Ty0>)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -158,7 +158,7 @@ public fun vector::remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
      # live vars: $t0, $t1, $t5
   2: $t4 := vector::length<#0>($t5)
      # live vars: $t0, $t1, $t4
-  3: $t3 := move($t4)
+  3: $t3 := copy($t4)
      # live vars: $t0, $t1, $t3
   4: $t6 := >=($t1, $t3)
      # live vars: $t0, $t1, $t3, $t6
@@ -180,7 +180,7 @@ public fun vector::remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
      # live vars: $t0, $t1, $t3, $t9
  13: $t8 := -($t3, $t9)
      # live vars: $t0, $t1, $t8
- 14: $t3 := move($t8)
+ 14: $t3 := copy($t8)
      # live vars: $t0, $t1, $t3
  15: label L3
      # live vars: $t0, $t1, $t3
@@ -198,7 +198,7 @@ public fun vector::remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
      # live vars: $t0, $t1, $t3, $t11, $t12, $t15
  22: $t14 := +($t1, $t15)
      # live vars: $t0, $t3, $t11, $t12, $t14
- 23: $t1 := move($t14)
+ 23: $t1 := copy($t14)
      # live vars: $t0, $t1, $t3, $t11, $t12
  24: $t13 := copy($t1)
      # live vars: $t0, $t1, $t3, $t11, $t12, $t13
@@ -270,17 +270,17 @@ fun vector::test_fold() {
      # live vars: $t2
   1: $t1 := vector($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
-  3: $t5 := move($t0)
+  3: $t5 := copy($t0)
      # live vars: $t5
   4: $t7 := 0
      # live vars: $t5, $t7
-  5: $t6 := move($t7)
+  5: $t6 := copy($t7)
      # live vars: $t5, $t6
-  6: $t8 := move($t6)
+  6: $t8 := copy($t6)
      # live vars: $t5, $t8
-  7: $t9 := move($t5)
+  7: $t9 := copy($t5)
      # live vars: $t8, $t9
   8: $t10 := borrow_local($t9)
      # live vars: $t8, $t9, $t10
@@ -302,13 +302,13 @@ fun vector::test_fold() {
      # live vars: $t9, $t16
  17: $t15 := vector::pop_back<u64>($t16)
      # live vars: $t9
- 18: $t14 := move($t15)
+ 18: $t14 := copy($t15)
      # live vars: $t9
- 19: $t17 := move($t14)
+ 19: $t17 := copy($t14)
      # live vars: $t9
  20: $t18 := 0
      # live vars: $t9, $t18
- 21: $t8 := move($t18)
+ 21: $t8 := copy($t18)
      # live vars: $t8, $t9
  22: goto 25
      # live vars: $t8
@@ -322,9 +322,9 @@ fun vector::test_fold() {
      # live vars: $t8
  27: label L1
      # live vars: $t8
- 28: $t4 := move($t8)
+ 28: $t4 := copy($t8)
      # live vars: $t4
- 29: $t3 := move($t4)
+ 29: $t3 := copy($t4)
      # live vars: $t3
  30: $t20 := 0
      # live vars: $t3, $t20
@@ -440,13 +440,13 @@ B0:
 	0: LdU64(1)
 	1: VecPack(5, 1)
 	2: StLoc[0](loc0: vector<u64>)
-	3: MoveLoc[0](loc0: vector<u64>)
+	3: CopyLoc[0](loc0: vector<u64>)
 	4: StLoc[1](loc1: vector<u64>)
 	5: LdU64(0)
 	6: StLoc[2](loc2: u64)
-	7: MoveLoc[2](loc2: u64)
+	7: CopyLoc[2](loc2: u64)
 	8: StLoc[3](loc3: u64)
-	9: MoveLoc[1](loc1: vector<u64>)
+	9: CopyLoc[1](loc1: vector<u64>)
 	10: StLoc[4](loc4: vector<u64>)
 	11: MutBorrowLoc[4](loc4: vector<u64>)
 	12: Call 1vector::reverse<u64>(&mut vector<u64>)
@@ -459,7 +459,7 @@ B2:
 	17: MutBorrowLoc[4](loc4: vector<u64>)
 	18: VecPopBack(5)
 	19: StLoc[5](loc5: u64)
-	20: MoveLoc[5](loc5: u64)
+	20: CopyLoc[5](loc5: u64)
 	21: StLoc[6](loc6: u64)
 	22: LdU64(0)
 	23: StLoc[3](loc3: u64)
@@ -469,9 +469,9 @@ B3:
 B4:
 	26: Branch(13)
 B5:
-	27: MoveLoc[3](loc3: u64)
+	27: CopyLoc[3](loc3: u64)
 	28: StLoc[7](loc7: u64)
-	29: MoveLoc[7](loc7: u64)
+	29: CopyLoc[7](loc7: u64)
 	30: StLoc[8](loc8: u64)
 	31: LdU64(0)
 	32: StLoc[9](loc9: u64)

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
@@ -1,0 +1,198 @@
+============ initial bytecode ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: &vector<u8>
+     var $t12: u8
+     var $t13: u64
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
+     var $t23: &vector<u8>
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := borrow_local($t0)
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := vector::length<u8>($t4)
+  6: $t6 := <($t2, $t7)
+  7: if ($t6) goto 8 else goto 35
+  8: label L2
+  9: $t11 := infer($t4)
+ 10: $t10 := vector::borrow<u8>($t11, $t2)
+ 11: $t9 := read_ref($t10)
+ 12: $t12 := 0
+ 13: $t8 := !=($t9, $t12)
+ 14: if ($t8) goto 15 else goto 18
+ 15: label L5
+ 16: goto 39
+ 17: goto 19
+ 18: label L6
+ 19: label L7
+ 20: $t14 := 1
+ 21: $t13 := +($t2, $t14)
+ 22: $t2 := infer($t13)
+ 23: $t18 := infer($t4)
+ 24: $t17 := vector::borrow<u8>($t18, $t2)
+ 25: $t16 := read_ref($t17)
+ 26: $t19 := 5
+ 27: $t15 := ==($t16, $t19)
+ 28: if ($t15) goto 29 else goto 32
+ 29: label L8
+ 30: goto 39
+ 31: goto 33
+ 32: label L9
+ 33: label L10
+ 34: goto 37
+ 35: label L3
+ 36: goto 39
+ 37: label L4
+ 38: goto 4
+ 39: label L1
+ 40: $t21 := copy($t0)
+ 41: $t20 := infer($t21)
+ 42: $t22 := infer($t0)
+ 43: $t23 := infer($t4)
+ 44: $t1 := vector::length<u8>($t23)
+ 45: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &vector<u8>
+     var $t5: &vector<u8>
+     var $t6: bool
+     var $t7: u64
+     var $t8: bool
+     var $t9: u8
+     var $t10: &u8
+     var $t11: &vector<u8>
+     var $t12: u8
+     var $t13: u64
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: vector<u8>
+     var $t23: &vector<u8>
+     var $t24: &vector<u8>
+     # live vars: $t0
+  0: $t3 := 0
+     # live vars: $t0, $t3
+  1: $t2 := copy($t3)
+     # live vars: $t0, $t2
+  2: $t5 := borrow_local($t0)
+     # live vars: $t2, $t5
+  3: $t4 := copy($t5)
+     # live vars: $t2, $t4
+  4: label L0
+     # live vars: $t2, $t4
+  5: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+  6: $t7 := vector::length<u8>($t24)
+     # live vars: $t2, $t4, $t7
+  7: $t6 := <($t2, $t7)
+     # live vars: $t2, $t4, $t6
+  8: if ($t6) goto 9 else goto 36
+     # live vars: $t2, $t4
+  9: label L2
+     # live vars: $t2, $t4
+ 10: $t11 := copy($t4)
+     # live vars: $t2, $t4, $t11
+ 11: $t10 := vector::borrow<u8>($t11, $t2)
+     # live vars: $t2, $t4, $t10
+ 12: $t9 := read_ref($t10)
+     # live vars: $t2, $t4, $t9
+ 13: $t12 := 0
+     # live vars: $t2, $t4, $t9, $t12
+ 14: $t8 := !=($t9, $t12)
+     # live vars: $t2, $t4, $t8
+ 15: if ($t8) goto 16 else goto 19
+     # live vars: $t4
+ 16: label L5
+     # live vars: $t4
+ 17: goto 40
+     # live vars: $t2, $t4
+ 18: goto 20
+     # live vars: $t2, $t4
+ 19: label L6
+     # live vars: $t2, $t4
+ 20: label L7
+     # live vars: $t2, $t4
+ 21: $t14 := 1
+     # live vars: $t2, $t4, $t14
+ 22: $t13 := +($t2, $t14)
+     # live vars: $t4, $t13
+ 23: $t2 := copy($t13)
+     # live vars: $t2, $t4
+ 24: $t18 := copy($t4)
+     # live vars: $t2, $t4, $t18
+ 25: $t17 := vector::borrow<u8>($t18, $t2)
+     # live vars: $t2, $t4, $t17
+ 26: $t16 := read_ref($t17)
+     # live vars: $t2, $t4, $t16
+ 27: $t19 := 5
+     # live vars: $t2, $t4, $t16, $t19
+ 28: $t15 := ==($t16, $t19)
+     # live vars: $t2, $t4, $t15
+ 29: if ($t15) goto 30 else goto 33
+     # live vars: $t4
+ 30: label L8
+     # live vars: $t4
+ 31: goto 40
+     # live vars: $t2, $t4
+ 32: goto 34
+     # live vars: $t2, $t4
+ 33: label L9
+     # live vars: $t2, $t4
+ 34: label L10
+     # live vars: $t2, $t4
+ 35: goto 38
+     # live vars: $t4
+ 36: label L3
+     # live vars: $t4
+ 37: goto 40
+     # live vars: $t2, $t4
+ 38: label L4
+     # live vars: $t2, $t4
+ 39: goto 4
+     # live vars: $t4
+ 40: label L1
+     # live vars: $t4
+ 41: $t21 := copy($t0)
+     # live vars: $t4
+ 42: $t20 := copy($t21)
+     # live vars: $t4
+ 43: $t22 := copy($t0)
+     # live vars: $t4
+ 44: $t23 := copy($t4)
+     # live vars: $t23
+ 45: $t1 := vector::length<u8>($t23)
+     # live vars: $t1
+ 46: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.move
@@ -1,0 +1,25 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    // multi-break
+    public entry fun guess_flips_break2(flips: vector<u8>) : u64 {
+        let i = 0;
+        let flipsref5 = &flips;
+        while (i < vector::length(flipsref5)) {
+            if (*vector::borrow(flipsref5, i) != 0) {
+                break
+            };
+            i = i + 1;
+            if (*vector::borrow(flipsref5, i) == 5) {
+                break
+            };
+        };
+        let _v = copy flips; // this is ok
+        // this used to fail with an UNKNOWN_INVARIANT_VIOLATION_ERROR (code 2000)
+        let _v2 =  flips;
+	let x = flipsref5;
+	vector::length(x)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/live-var/explicit_move.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/explicit_move.exp
@@ -66,11 +66,11 @@ fun m::f1_fail() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := move($t0)
      # live vars: $t0, $t4
-  4: $t3 := move($t4)
+  4: $t3 := copy($t4)
      # live vars: $t0, $t3
   5: m::some($t3)
      # live vars: $t0
@@ -93,11 +93,11 @@ fun m::f1_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := move($t0)
      # live vars: $t4
-  4: $t3 := move($t4)
+  4: $t3 := copy($t4)
      # live vars: $t3
   5: $t5 := copy($t3)
      # live vars: $t3, $t5

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
@@ -105,7 +105,7 @@ fun m::f1_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t3 := copy($t0)
      # live vars: $t0, $t3
@@ -128,7 +128,7 @@ fun m::f2_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t3 := copy($t0)
      # live vars: $t0, $t3
@@ -149,7 +149,7 @@ fun m::f3_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t3 := copy($t0)
      # live vars: $t0, $t3
@@ -173,11 +173,11 @@ fun m::f4_fail() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := move($t0)
      # live vars: $t0, $t4
-  4: $t3 := move($t4)
+  4: $t3 := copy($t4)
      # live vars: $t0, $t3
   5: m::some($t0)
      # live vars: $t3
@@ -191,7 +191,7 @@ fun m::f4_fail() {
 fun m::id($t0: m::R): m::R {
      var $t1: m::R
      # live vars: $t0
-  0: $t1 := move($t0)
+  0: $t1 := copy($t0)
      # live vars: $t1
   1: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -187,7 +187,7 @@ fun m::foo(): u64 {
      # live vars: $t3, $t4, $t5
   3: $t2 := vector($t3, $t4, $t5)
      # live vars: $t2
-  4: $t1 := move($t2)
+  4: $t1 := copy($t2)
      # live vars: $t1
   5: $t7 := borrow_local($t1)
      # live vars: $t7
@@ -197,7 +197,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9
   8: $t11 := 0
      # live vars: $t6, $t9, $t11
-  9: $t10 := move($t11)
+  9: $t10 := copy($t11)
      # live vars: $t6, $t9, $t10
  10: $t44 := copy($t9)
      # live vars: $t6, $t9, $t10, $t44
@@ -205,7 +205,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t14
  12: $t13 := vector::length<u64>($t14)
      # live vars: $t6, $t9, $t10, $t13
- 13: $t12 := move($t13)
+ 13: $t12 := copy($t13)
      # live vars: $t6, $t9, $t10, $t12
  14: label L0
      # live vars: $t6, $t9, $t10, $t12
@@ -221,7 +221,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t20
  20: $t19 := vector::borrow<u64>($t20, $t10)
      # live vars: $t6, $t9, $t10, $t12, $t19
- 21: $t18 := move($t19)
+ 21: $t18 := copy($t19)
      # live vars: $t6, $t9, $t10, $t12, $t18
  22: $t21 := read_ref($t18)
      # live vars: $t6, $t9, $t10, $t12, $t21
@@ -247,7 +247,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t24
  33: $t23 := +($t10, $t24)
      # live vars: $t6, $t9, $t12, $t23
- 34: $t10 := move($t23)
+ 34: $t10 := copy($t23)
      # live vars: $t6, $t9, $t10, $t12
  35: goto 38
      # live vars: $t6, $t9, $t10, $t12
@@ -267,7 +267,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25, $t27
  43: $t26 := +($t10, $t27)
      # live vars: $t6, $t9, $t12, $t25, $t26
- 44: $t10 := move($t26)
+ 44: $t10 := copy($t26)
      # live vars: $t6, $t9, $t10, $t12, $t25
  45: label L8
      # live vars: $t6, $t9, $t10, $t12, $t25
@@ -283,7 +283,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25, $t32
  51: $t31 := vector::borrow<u64>($t32, $t10)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t31
- 52: $t30 := move($t31)
+ 52: $t30 := copy($t31)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t30
  53: $t33 := read_ref($t30)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t33
@@ -305,7 +305,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25, $t38
  62: $t37 := +($t25, $t38)
      # live vars: $t6, $t9, $t10, $t12, $t37
- 63: $t25 := move($t37)
+ 63: $t25 := copy($t37)
      # live vars: $t6, $t9, $t10, $t12, $t25
  64: goto 66
      # live vars: $t6, $t9, $t10, $t12, $t25
@@ -317,7 +317,7 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25, $t40
  68: $t39 := +($t10, $t40)
      # live vars: $t6, $t9, $t12, $t25, $t39
- 69: $t10 := move($t39)
+ 69: $t10 := copy($t39)
      # live vars: $t6, $t9, $t10, $t12, $t25
  70: goto 73
      # live vars: $t6
@@ -331,7 +331,7 @@ fun m::foo(): u64 {
      # live vars: $t6
  75: label L9
      # live vars: $t6
- 76: $t8 := move($t25)
+ 76: $t8 := copy($t25)
      # live vars: $t6
  77: $t42 := freeze_ref($t6)
      # live vars: $t42

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
@@ -179,7 +179,7 @@ fun m::f1_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t4
@@ -210,7 +210,7 @@ fun m::f1a_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t4
@@ -245,7 +245,7 @@ fun m::f1b_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t4
@@ -278,7 +278,7 @@ fun m::f2_fail() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t4
@@ -305,7 +305,7 @@ fun m::f3_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t0, $t4
@@ -336,7 +336,7 @@ fun m::f4_ok() {
      # live vars: $t2
   1: $t1 := pack m::R($t2)
      # live vars: $t1
-  2: $t0 := move($t1)
+  2: $t0 := copy($t1)
      # live vars: $t0
   3: $t4 := borrow_local($t0)
      # live vars: $t4
@@ -365,7 +365,7 @@ fun m::f5_fail($t0: bool) {
      # live vars: $t0, $t3
   1: $t2 := pack m::R($t3)
      # live vars: $t0, $t2
-  2: $t1 := move($t2)
+  2: $t1 := copy($t2)
      # live vars: $t0, $t1
   3: $t5 := borrow_local($t1)
      # live vars: $t0, $t5

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
@@ -1,9 +1,0 @@
-
-Diagnostics:
-error: cannot move local `x` which is still borrowed
-  ┌─ tests/reference-safety/v1-tests/borrowed_before_last_usage.move:5:9
-  │
-4 │     let r = &x;
-  │             -- previous local borrow
-5 │     let y = x;
-  │         ^ moved here

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -81,7 +81,29 @@ impl TestConfig {
         let path = path.to_string_lossy();
         let verbose = cfg!(feature = "verbose-debug-print");
         let mut pipeline = FunctionTargetPipeline::default();
-        if path.contains("/folding/") || path.contains("/inlining/") {
+        if path.contains("/inlining/bug_") {
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(VisibilityChecker {}));
+            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
+            Self {
+                type_check_only: false,
+                dump_ast: true,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: true,
+            }
+        } else if path.contains("/inlining/") {
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(VisibilityChecker {}));
+            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
+            Self {
+                type_check_only: false,
+                dump_ast: true,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: verbose,
+            }
+        } else if path.contains("/folding/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(VisibilityChecker {}));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
@@ -101,7 +123,7 @@ impl TestConfig {
                 dump_ast: true,
                 pipeline,
                 generate_file_format: false,
-                dump_annotated_targets: false,
+                dump_annotated_targets: verbose,
             }
         } else if path.contains("/checking/") {
             Self {
@@ -109,7 +131,7 @@ impl TestConfig {
                 dump_ast: true,
                 pipeline,
                 generate_file_format: false,
-                dump_annotated_targets: false,
+                dump_annotated_targets: verbose,
             }
         } else if path.contains("/bytecode-generator/") {
             Self {
@@ -135,7 +157,7 @@ impl TestConfig {
                 dump_ast: false,
                 pipeline,
                 generate_file_format: false,
-                dump_annotated_targets: false,
+                dump_annotated_targets: verbose,
             }
         } else if path.contains("/live-var/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -84,12 +84,13 @@ impl TestConfig {
         if path.contains("/folding/") || path.contains("/inlining/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(VisibilityChecker {}));
+            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             Self {
                 type_check_only: false,
                 dump_ast: true,
                 pipeline,
                 generate_file_format: false,
-                dump_annotated_targets: false,
+                dump_annotated_targets: verbose,
             }
         } else if path.contains("/unit_test/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -92,18 +92,7 @@ impl TestConfig {
                 generate_file_format: false,
                 dump_annotated_targets: true,
             }
-        } else if path.contains("/inlining/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(VisibilityChecker {}));
-            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
-            Self {
-                type_check_only: false,
-                dump_ast: true,
-                pipeline,
-                generate_file_format: false,
-                dump_annotated_targets: verbose,
-            }
-        } else if path.contains("/folding/") {
+        } else if path.contains("/inlining/") || path.contains("/folding/") {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(VisibilityChecker {}));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -592,7 +592,7 @@ B3:
 B4:
 	29: Branch(9)
 B5:
-	30: MoveLoc[1](loc0: vector<u64>)
+	30: CopyLoc[1](loc0: vector<u64>)
 	31: StLoc[7](loc6: vector<u64>)
 	32: MoveLoc[7](loc6: vector<u64>)
 	33: Ret

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.exp
@@ -1,0 +1,25 @@
+comparison between v1 and v2 failed:
+= processed 1 task
+= 
+= task 0 'publish'. lines 1-14:
+- Error: error[E07006]: ambiguous usage of variable
+-   ┌─ TEMPFILE:9:19
++ Error: compilation errors:
++  error: cannot move local `flips` which is still borrowed
++   ┌─ TEMPFILE:9:13
+=   │
+= 6 │         let flipsref5 = &flips;
+-   │                         ------ It is still being borrowed by this reference
++   │                         ------ previous local borrow
+=   ·
+= 9 │         let _v2 = flips;
+-   │                   ^^^^^
+-   │                   │
+-   │                   Ambiguous usage of variable 'flips'
+-   │                   Try an explicit annotation, e.g. 'move flips' or 'copy flips'
+-   │
+-   = Ambiguous inference of 'move' or 'copy' for a borrowed variable's last usage: A 'move' would invalidate the borrowing reference, but a 'copy' might not be the expected implicit behavior since this the last direct usage of the variable.
++   │             ^^^ moved here
+= 
+= 
+= 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.exp
@@ -4,22 +4,17 @@ comparison between v1 and v2 failed:
 = task 0 'publish'. lines 1-14:
 - Error: error[E07006]: ambiguous usage of variable
 -   ┌─ TEMPFILE:9:19
-+ Error: compilation errors:
-+  error: cannot move local `flips` which is still borrowed
-+   ┌─ TEMPFILE:9:13
-=   │
-= 6 │         let flipsref5 = &flips;
+-   │
+- 6 │         let flipsref5 = &flips;
 -   │                         ------ It is still being borrowed by this reference
-+   │                         ------ previous local borrow
-=   ·
-= 9 │         let _v2 = flips;
+-   ·
+- 9 │         let _v2 = flips;
 -   │                   ^^^^^
 -   │                   │
 -   │                   Ambiguous usage of variable 'flips'
 -   │                   Try an explicit annotation, e.g. 'move flips' or 'copy flips'
 -   │
 -   = Ambiguous inference of 'move' or 'copy' for a borrowed variable's last usage: A 'move' would invalidate the borrowing reference, but a 'copy' might not be the expected implicit behavior since this the last direct usage of the variable.
-+   │             ^^^ moved here
 = 
 = 
 = 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.move
@@ -1,0 +1,14 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    // multi-break
+    public entry fun guess_flips_break2(flips: vector<u8>) : u64 {
+        let flipsref5 = &flips;
+        let _v = copy flips; // this is ok
+        // the following stresses live var analysis.
+        let _v2 = flips;
+	let x = flipsref5;
+	vector::length(x)
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717.exp
@@ -3,7 +3,7 @@ comparison between v1 and v2 failed:
 = 
 = task 0 'publish'. lines 1-91:
 + Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
-+     major_status: MOVELOC_UNAVAILABLE_ERROR,
++     major_status: MOVELOC_EXISTS_BORROW_ERROR,
 +     sub_status: None,
 +     location: 0xcafe::vectors,
 +     indices: redacted,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717.exp
@@ -1,48 +1,506 @@
-comparison between v1 and v2 failed:
-= processed 5 tasks
-= 
-= task 0 'publish'. lines 1-91:
-+ Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
-+     major_status: MOVELOC_EXISTS_BORROW_ERROR,
-+     sub_status: None,
-+     location: 0xcafe::vectors,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 1 'run'. lines 93-93:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 2 'run'. lines 95-95:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 3 'run'. lines 97-97:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-+ 
-+ task 4 'run'. lines 99-99:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-+ 
+processed 5 tasks
+
+task 0 'publish'. lines 1-91:
+
+
+
+==> Compiler v2 delivered same results!
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module cafe.vectors {
+
+
+entry public guess_flips(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: StLoc[1](loc0: &vector<u8>)
+	2: LdU64(0)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(4)
+	7: Lt
+	8: BrFalse(30)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(4)
+	13: ReadRef
+	14: LdU8(0)
+	15: Neq
+	16: BrFalse(20)
+B4:
+	17: MoveLoc[1](loc0: &vector<u8>)
+	18: Pop
+	19: Branch(25)
+B5:
+	20: MoveLoc[2](loc1: u64)
+	21: LdU64(1)
+	22: Add
+	23: StLoc[2](loc1: u64)
+	24: Branch(4)
+B6:
+	25: CopyLoc[0](Arg0: vector<u8>)
+	26: Pop
+	27: MoveLoc[0](Arg0: vector<u8>)
+	28: Pop
+	29: Ret
+B7:
+	30: MoveLoc[1](loc0: &vector<u8>)
+	31: Pop
+	32: Branch(25)
+}
+entry public guess_flips_directly(Arg0: vector<u8>) {
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+B1:
+	2: CopyLoc[1](loc0: u64)
+	3: ImmBorrowLoc[0](Arg0: vector<u8>)
+	4: VecLen(4)
+	5: Lt
+	6: BrFalse(26)
+B2:
+	7: Branch(8)
+B3:
+	8: ImmBorrowLoc[0](Arg0: vector<u8>)
+	9: CopyLoc[1](loc0: u64)
+	10: VecImmBorrow(4)
+	11: ReadRef
+	12: LdU8(0)
+	13: Neq
+	14: BrFalse(16)
+B4:
+	15: Branch(21)
+B5:
+	16: MoveLoc[1](loc0: u64)
+	17: LdU64(1)
+	18: Add
+	19: StLoc[1](loc0: u64)
+	20: Branch(2)
+B6:
+	21: CopyLoc[0](Arg0: vector<u8>)
+	22: Pop
+	23: MoveLoc[0](Arg0: vector<u8>)
+	24: Pop
+	25: Ret
+B7:
+	26: Branch(21)
+}
+entry public guess_with_break_without_inline(Arg0: vector<u8>) {
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: Call loops_with_break_no_inline(&vector<u8>)
+	2: CopyLoc[0](Arg0: vector<u8>)
+	3: Pop
+	4: MoveLoc[0](Arg0: vector<u8>)
+	5: Pop
+	6: Ret
+}
+entry public guess_without_break_with_inline(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: StLoc[1](loc0: &vector<u8>)
+	2: LdU64(0)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(4)
+	7: Lt
+	8: BrFalse(27)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(4)
+	13: ReadRef
+	14: LdU8(0)
+	15: Eq
+	16: BrFalse(18)
+B4:
+	17: Branch(22)
+B5:
+	18: MoveLoc[1](loc0: &vector<u8>)
+	19: Pop
+	20: LdU64(3)
+	21: Abort
+B6:
+	22: MoveLoc[2](loc1: u64)
+	23: LdU64(1)
+	24: Add
+	25: StLoc[2](loc1: u64)
+	26: Branch(4)
+B7:
+	27: MoveLoc[1](loc0: &vector<u8>)
+	28: Pop
+	29: CopyLoc[0](Arg0: vector<u8>)
+	30: Pop
+	31: CopyLoc[0](Arg0: vector<u8>)
+	32: Pop
+	33: Ret
+}
+loops_with_break_no_inline(Arg0: &vector<u8>) {
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+B1:
+	2: CopyLoc[1](loc0: u64)
+	3: CopyLoc[0](Arg0: &vector<u8>)
+	4: VecLen(4)
+	5: Lt
+	6: BrFalse(24)
+B2:
+	7: Branch(8)
+B3:
+	8: CopyLoc[0](Arg0: &vector<u8>)
+	9: CopyLoc[1](loc0: u64)
+	10: VecImmBorrow(4)
+	11: ReadRef
+	12: LdU8(0)
+	13: Neq
+	14: BrFalse(18)
+B4:
+	15: MoveLoc[0](Arg0: &vector<u8>)
+	16: Pop
+	17: Branch(23)
+B5:
+	18: MoveLoc[1](loc0: u64)
+	19: LdU64(1)
+	20: Add
+	21: StLoc[1](loc0: u64)
+	22: Branch(2)
+B6:
+	23: Ret
+B7:
+	24: MoveLoc[0](Arg0: &vector<u8>)
+	25: Pop
+	26: Branch(23)
+}
+test_guess_directly() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_directly(vector<u8>)
+	2: Ret
+}
+test_guess_with_break_no_inline() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_with_break_without_inline(vector<u8>)
+	2: Ret
+}
+test_guess_with_inline_break() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips(vector<u8>)
+	2: Ret
+}
+test_guess_without_break() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_without_break_with_inline(vector<u8>)
+	2: Ret
+}
+}
+== END Bytecode ==
+}
+
+>>> V2 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v7
+module cafe.vectors {
+
+
+entry public guess_flips(Arg0: vector<u8>) {
+L0:	loc1: u64
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: StLoc[1](loc0: &vector<u8>)
+	2: LdU64(0)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: CopyLoc[1](loc0: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(2)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[2](loc1: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(31)
+B2:
+	13: CopyLoc[1](loc0: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[2](loc1: u64)
+	17: VecImmBorrow(2)
+	18: ReadRef
+	19: LdU8(0)
+	20: Neq
+	21: BrFalse(24)
+B3:
+	22: Branch(33)
+B4:
+	23: Branch(24)
+B5:
+	24: LdU64(1)
+	25: StLoc[6](loc5: u64)
+	26: MoveLoc[2](loc1: u64)
+	27: MoveLoc[6](loc5: u64)
+	28: Add
+	29: StLoc[2](loc1: u64)
+	30: Branch(32)
+B6:
+	31: Branch(33)
+B7:
+	32: Branch(4)
+B8:
+	33: CopyLoc[0](Arg0: vector<u8>)
+	34: StLoc[7](loc6: vector<u8>)
+	35: CopyLoc[7](loc6: vector<u8>)
+	36: StLoc[8](loc7: vector<u8>)
+	37: CopyLoc[0](Arg0: vector<u8>)
+	38: StLoc[9](loc8: vector<u8>)
+	39: Ret
+}
+entry public guess_flips_directly(Arg0: vector<u8>) {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: vector<u8>
+L3:	loc4: vector<u8>
+L4:	loc5: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+B1:
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: VecLen(2)
+	4: StLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: u64)
+	6: MoveLoc[2](loc1: u64)
+	7: Lt
+	8: BrFalse(25)
+B2:
+	9: ImmBorrowLoc[0](Arg0: vector<u8>)
+	10: CopyLoc[1](loc0: u64)
+	11: VecImmBorrow(2)
+	12: ReadRef
+	13: LdU8(0)
+	14: Neq
+	15: BrFalse(18)
+B3:
+	16: Branch(27)
+B4:
+	17: Branch(18)
+B5:
+	18: LdU64(1)
+	19: StLoc[3](loc2: u64)
+	20: MoveLoc[1](loc0: u64)
+	21: MoveLoc[3](loc2: u64)
+	22: Add
+	23: StLoc[1](loc0: u64)
+	24: Branch(26)
+B6:
+	25: Branch(27)
+B7:
+	26: Branch(2)
+B8:
+	27: CopyLoc[0](Arg0: vector<u8>)
+	28: StLoc[4](loc3: vector<u8>)
+	29: CopyLoc[4](loc3: vector<u8>)
+	30: StLoc[5](loc4: vector<u8>)
+	31: CopyLoc[0](Arg0: vector<u8>)
+	32: StLoc[6](loc5: vector<u8>)
+	33: Ret
+}
+entry public guess_with_break_without_inline(Arg0: vector<u8>) {
+L0:	loc1: vector<u8>
+L1:	loc2: vector<u8>
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: Call loops_with_break_no_inline(&vector<u8>)
+	2: CopyLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: vector<u8>)
+	4: CopyLoc[1](loc0: vector<u8>)
+	5: StLoc[2](loc1: vector<u8>)
+	6: CopyLoc[0](Arg0: vector<u8>)
+	7: StLoc[3](loc2: vector<u8>)
+	8: Ret
+}
+entry public guess_without_break_with_inline(Arg0: vector<u8>) {
+L0:	loc1: u64
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+B0:
+	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	1: StLoc[1](loc0: &vector<u8>)
+	2: LdU64(0)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: CopyLoc[1](loc0: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(2)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[2](loc1: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(32)
+B2:
+	13: CopyLoc[1](loc0: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[2](loc1: u64)
+	17: VecImmBorrow(2)
+	18: ReadRef
+	19: LdU8(0)
+	20: Eq
+	21: BrFalse(23)
+B3:
+	22: Branch(25)
+B4:
+	23: LdU64(3)
+	24: Abort
+B5:
+	25: LdU64(1)
+	26: StLoc[6](loc5: u64)
+	27: MoveLoc[2](loc1: u64)
+	28: MoveLoc[6](loc5: u64)
+	29: Add
+	30: StLoc[2](loc1: u64)
+	31: Branch(33)
+B6:
+	32: Branch(34)
+B7:
+	33: Branch(4)
+B8:
+	34: CopyLoc[0](Arg0: vector<u8>)
+	35: StLoc[7](loc6: vector<u8>)
+	36: CopyLoc[0](Arg0: vector<u8>)
+	37: StLoc[8](loc7: vector<u8>)
+	38: CopyLoc[8](loc7: vector<u8>)
+	39: StLoc[9](loc8: vector<u8>)
+	40: Ret
+}
+loops_with_break_no_inline(Arg0: &vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: u64
+L2:	loc3: &vector<u8>
+L3:	loc4: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+B1:
+	2: CopyLoc[0](Arg0: &vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+	4: MoveLoc[2](loc1: &vector<u8>)
+	5: VecLen(2)
+	6: StLoc[3](loc2: u64)
+	7: CopyLoc[1](loc0: u64)
+	8: MoveLoc[3](loc2: u64)
+	9: Lt
+	10: BrFalse(29)
+B2:
+	11: CopyLoc[0](Arg0: &vector<u8>)
+	12: StLoc[4](loc3: &vector<u8>)
+	13: MoveLoc[4](loc3: &vector<u8>)
+	14: CopyLoc[1](loc0: u64)
+	15: VecImmBorrow(2)
+	16: ReadRef
+	17: LdU8(0)
+	18: Neq
+	19: BrFalse(22)
+B3:
+	20: Branch(31)
+B4:
+	21: Branch(22)
+B5:
+	22: LdU64(1)
+	23: StLoc[5](loc4: u64)
+	24: MoveLoc[1](loc0: u64)
+	25: MoveLoc[5](loc4: u64)
+	26: Add
+	27: StLoc[1](loc0: u64)
+	28: Branch(30)
+B6:
+	29: Branch(31)
+B7:
+	30: Branch(2)
+B8:
+	31: Ret
+}
+test_guess_directly() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(2, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_directly(vector<u8>)
+	8: Ret
+}
+test_guess_with_break_no_inline() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(2, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_with_break_without_inline(vector<u8>)
+	8: Ret
+}
+test_guess_with_inline_break() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(2, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips(vector<u8>)
+	8: Ret
+}
+test_guess_without_break() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(2, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_without_break_with_inline(vector<u8>)
+	8: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717_looponly.exp
@@ -1,48 +1,728 @@
-comparison between v1 and v2 failed:
-= processed 5 tasks
-= 
-= task 0 'publish'. lines 1-130:
-+ Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
-+     major_status: MOVELOC_EXISTS_BORROW_ERROR,
-+     sub_status: None,
-+     location: 0xcafe::vectors,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 1 'run'. lines 132-132:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 2 'run'. lines 134-134:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
-+ task 3 'run'. lines 136-136:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-+ 
-+ task 4 'run'. lines 138-138:
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-+ 
+processed 5 tasks
+
+task 0 'publish'. lines 1-130:
+
+
+
+==> Compiler v2 delivered same results!
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module cafe.vectors {
+
+
+entry public entry_test_guess_flips_abort() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_abort(vector<u8>)
+	2: Ret
+}
+entry public entry_test_guess_flips_break() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_break(vector<u8>)
+	2: Ret
+}
+entry public entry_test_guess_flips_break2() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_break2(vector<u8>)
+	2: Ret
+}
+entry public entry_test_guess_flips_continue() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_continue(vector<u8>)
+	2: Ret
+}
+entry public entry_test_guess_flips_nocheck() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_nocheck(vector<u8>)
+	2: Ret
+}
+entry public guess_flips_abort(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[2](loc1: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(3)
+	7: Lt
+	8: BrFalse(27)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(3)
+	13: ReadRef
+	14: LdU8(0)
+	15: Eq
+	16: BrFalse(18)
+B4:
+	17: Branch(22)
+B5:
+	18: MoveLoc[1](loc0: &vector<u8>)
+	19: Pop
+	20: LdU64(3)
+	21: Abort
+B6:
+	22: MoveLoc[2](loc1: u64)
+	23: LdU64(1)
+	24: Add
+	25: StLoc[2](loc1: u64)
+	26: Branch(4)
+B7:
+	27: MoveLoc[1](loc0: &vector<u8>)
+	28: Pop
+	29: CopyLoc[0](Arg0: vector<u8>)
+	30: Pop
+	31: MoveLoc[0](Arg0: vector<u8>)
+	32: Pop
+	33: Ret
+}
+entry public guess_flips_break(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[2](loc1: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(3)
+	7: Lt
+	8: BrFalse(30)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(3)
+	13: ReadRef
+	14: LdU8(0)
+	15: Neq
+	16: BrFalse(20)
+B4:
+	17: MoveLoc[1](loc0: &vector<u8>)
+	18: Pop
+	19: Branch(25)
+B5:
+	20: MoveLoc[2](loc1: u64)
+	21: LdU64(1)
+	22: Add
+	23: StLoc[2](loc1: u64)
+	24: Branch(4)
+B6:
+	25: CopyLoc[0](Arg0: vector<u8>)
+	26: Pop
+	27: MoveLoc[0](Arg0: vector<u8>)
+	28: Pop
+	29: Ret
+B7:
+	30: MoveLoc[1](loc0: &vector<u8>)
+	31: Pop
+	32: Branch(25)
+}
+entry public guess_flips_break2(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[2](loc1: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(3)
+	7: Lt
+	8: BrFalse(40)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(3)
+	13: ReadRef
+	14: LdU8(0)
+	15: Neq
+	16: BrFalse(20)
+B4:
+	17: MoveLoc[1](loc0: &vector<u8>)
+	18: Pop
+	19: Branch(35)
+B5:
+	20: MoveLoc[2](loc1: u64)
+	21: LdU64(1)
+	22: Add
+	23: StLoc[2](loc1: u64)
+	24: CopyLoc[1](loc0: &vector<u8>)
+	25: CopyLoc[2](loc1: u64)
+	26: VecImmBorrow(3)
+	27: ReadRef
+	28: LdU8(5)
+	29: Eq
+	30: BrFalse(34)
+B6:
+	31: MoveLoc[1](loc0: &vector<u8>)
+	32: Pop
+	33: Branch(35)
+B7:
+	34: Branch(4)
+B8:
+	35: CopyLoc[0](Arg0: vector<u8>)
+	36: Pop
+	37: MoveLoc[0](Arg0: vector<u8>)
+	38: Pop
+	39: Ret
+B9:
+	40: MoveLoc[1](loc0: &vector<u8>)
+	41: Pop
+	42: Branch(35)
+}
+entry public guess_flips_continue(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[2](loc1: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(3)
+	7: Lt
+	8: BrFalse(23)
+B2:
+	9: Branch(10)
+B3:
+	10: CopyLoc[1](loc0: &vector<u8>)
+	11: CopyLoc[2](loc1: u64)
+	12: VecImmBorrow(3)
+	13: ReadRef
+	14: LdU8(0)
+	15: Neq
+	16: BrFalse(18)
+B4:
+	17: Branch(4)
+B5:
+	18: MoveLoc[2](loc1: u64)
+	19: LdU64(1)
+	20: Add
+	21: StLoc[2](loc1: u64)
+	22: Branch(4)
+B6:
+	23: MoveLoc[1](loc0: &vector<u8>)
+	24: Pop
+	25: CopyLoc[0](Arg0: vector<u8>)
+	26: Pop
+	27: MoveLoc[0](Arg0: vector<u8>)
+	28: Pop
+	29: Ret
+}
+entry public guess_flips_nocheck(Arg0: vector<u8>) {
+L0:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[2](loc1: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[1](loc0: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &vector<u8>)
+	6: VecLen(3)
+	7: Lt
+	8: BrFalse(15)
+B2:
+	9: Branch(10)
+B3:
+	10: MoveLoc[2](loc1: u64)
+	11: LdU64(1)
+	12: Add
+	13: StLoc[2](loc1: u64)
+	14: Branch(4)
+B4:
+	15: MoveLoc[1](loc0: &vector<u8>)
+	16: Pop
+	17: CopyLoc[0](Arg0: vector<u8>)
+	18: Pop
+	19: MoveLoc[0](Arg0: vector<u8>)
+	20: Pop
+	21: Ret
+}
+test_guess_flips_abort() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_abort(vector<u8>)
+	2: Ret
+}
+test_guess_flips_break() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_break(vector<u8>)
+	2: Ret
+}
+test_guess_flips_break2() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_break2(vector<u8>)
+	2: Ret
+}
+test_guess_flips_continue() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_continue(vector<u8>)
+	2: Ret
+}
+test_guess_flips_nocheck() {
+B0:
+	0: LdConst[0](Vector(U8): [4, 0, 0, 0, 0])
+	1: Call guess_flips_nocheck(vector<u8>)
+	2: Ret
+}
+}
+== END Bytecode ==
+}
+
+>>> V2 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v7
+module cafe.vectors {
+
+
+entry public entry_test_guess_flips_abort() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_abort(vector<u8>)
+	8: Ret
+}
+entry public entry_test_guess_flips_break() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_break(vector<u8>)
+	8: Ret
+}
+entry public entry_test_guess_flips_break2() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_break2(vector<u8>)
+	8: Ret
+}
+entry public entry_test_guess_flips_continue() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_continue(vector<u8>)
+	8: Ret
+}
+entry public entry_test_guess_flips_nocheck() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_nocheck(vector<u8>)
+	8: Ret
+}
+entry public guess_flips_abort(Arg0: vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(1)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[1](loc0: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(32)
+B2:
+	13: CopyLoc[2](loc1: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[1](loc0: u64)
+	17: VecImmBorrow(1)
+	18: ReadRef
+	19: LdU8(0)
+	20: Eq
+	21: BrFalse(23)
+B3:
+	22: Branch(25)
+B4:
+	23: LdU64(3)
+	24: Abort
+B5:
+	25: LdU64(1)
+	26: StLoc[6](loc5: u64)
+	27: MoveLoc[1](loc0: u64)
+	28: MoveLoc[6](loc5: u64)
+	29: Add
+	30: StLoc[1](loc0: u64)
+	31: Branch(33)
+B6:
+	32: Branch(34)
+B7:
+	33: Branch(4)
+B8:
+	34: CopyLoc[0](Arg0: vector<u8>)
+	35: StLoc[7](loc6: vector<u8>)
+	36: CopyLoc[7](loc6: vector<u8>)
+	37: StLoc[8](loc7: vector<u8>)
+	38: CopyLoc[0](Arg0: vector<u8>)
+	39: StLoc[9](loc8: vector<u8>)
+	40: Ret
+}
+entry public guess_flips_break(Arg0: vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(1)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[1](loc0: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(31)
+B2:
+	13: CopyLoc[2](loc1: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[1](loc0: u64)
+	17: VecImmBorrow(1)
+	18: ReadRef
+	19: LdU8(0)
+	20: Neq
+	21: BrFalse(24)
+B3:
+	22: Branch(33)
+B4:
+	23: Branch(24)
+B5:
+	24: LdU64(1)
+	25: StLoc[6](loc5: u64)
+	26: MoveLoc[1](loc0: u64)
+	27: MoveLoc[6](loc5: u64)
+	28: Add
+	29: StLoc[1](loc0: u64)
+	30: Branch(32)
+B6:
+	31: Branch(33)
+B7:
+	32: Branch(4)
+B8:
+	33: CopyLoc[0](Arg0: vector<u8>)
+	34: StLoc[7](loc6: vector<u8>)
+	35: CopyLoc[7](loc6: vector<u8>)
+	36: StLoc[8](loc7: vector<u8>)
+	37: CopyLoc[0](Arg0: vector<u8>)
+	38: StLoc[9](loc8: vector<u8>)
+	39: Ret
+}
+entry public guess_flips_break2(Arg0: vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: &vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+L8:	loc9: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(1)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[1](loc0: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(42)
+B2:
+	13: CopyLoc[2](loc1: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[1](loc0: u64)
+	17: VecImmBorrow(1)
+	18: ReadRef
+	19: LdU8(0)
+	20: Neq
+	21: BrFalse(24)
+B3:
+	22: Branch(44)
+B4:
+	23: Branch(24)
+B5:
+	24: LdU64(1)
+	25: StLoc[6](loc5: u64)
+	26: MoveLoc[1](loc0: u64)
+	27: MoveLoc[6](loc5: u64)
+	28: Add
+	29: StLoc[1](loc0: u64)
+	30: CopyLoc[2](loc1: &vector<u8>)
+	31: StLoc[7](loc6: &vector<u8>)
+	32: MoveLoc[7](loc6: &vector<u8>)
+	33: CopyLoc[1](loc0: u64)
+	34: VecImmBorrow(1)
+	35: ReadRef
+	36: LdU8(5)
+	37: Eq
+	38: BrFalse(41)
+B6:
+	39: Branch(44)
+B7:
+	40: Branch(41)
+B8:
+	41: Branch(43)
+B9:
+	42: Branch(44)
+B10:
+	43: Branch(4)
+B11:
+	44: CopyLoc[0](Arg0: vector<u8>)
+	45: StLoc[8](loc7: vector<u8>)
+	46: CopyLoc[8](loc7: vector<u8>)
+	47: StLoc[9](loc8: vector<u8>)
+	48: CopyLoc[0](Arg0: vector<u8>)
+	49: StLoc[10](loc9: vector<u8>)
+	50: Ret
+}
+entry public guess_flips_continue(Arg0: vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: &vector<u8>
+L4:	loc5: u64
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+L7:	loc8: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(1)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[1](loc0: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(31)
+B2:
+	13: CopyLoc[2](loc1: &vector<u8>)
+	14: StLoc[5](loc4: &vector<u8>)
+	15: MoveLoc[5](loc4: &vector<u8>)
+	16: CopyLoc[1](loc0: u64)
+	17: VecImmBorrow(1)
+	18: ReadRef
+	19: LdU8(0)
+	20: Neq
+	21: BrFalse(24)
+B3:
+	22: Branch(4)
+B4:
+	23: Branch(24)
+B5:
+	24: LdU64(1)
+	25: StLoc[6](loc5: u64)
+	26: MoveLoc[1](loc0: u64)
+	27: MoveLoc[6](loc5: u64)
+	28: Add
+	29: StLoc[1](loc0: u64)
+	30: Branch(32)
+B6:
+	31: Branch(33)
+B7:
+	32: Branch(4)
+B8:
+	33: CopyLoc[0](Arg0: vector<u8>)
+	34: StLoc[7](loc6: vector<u8>)
+	35: CopyLoc[7](loc6: vector<u8>)
+	36: StLoc[8](loc7: vector<u8>)
+	37: CopyLoc[0](Arg0: vector<u8>)
+	38: StLoc[9](loc8: vector<u8>)
+	39: Ret
+}
+entry public guess_flips_nocheck(Arg0: vector<u8>) {
+L0:	loc1: &vector<u8>
+L1:	loc2: &vector<u8>
+L2:	loc3: u64
+L3:	loc4: u64
+L4:	loc5: vector<u8>
+L5:	loc6: vector<u8>
+L6:	loc7: vector<u8>
+B0:
+	0: LdU64(0)
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[0](Arg0: vector<u8>)
+	3: StLoc[2](loc1: &vector<u8>)
+B1:
+	4: CopyLoc[2](loc1: &vector<u8>)
+	5: StLoc[3](loc2: &vector<u8>)
+	6: MoveLoc[3](loc2: &vector<u8>)
+	7: VecLen(1)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[1](loc0: u64)
+	10: MoveLoc[4](loc3: u64)
+	11: Lt
+	12: BrFalse(20)
+B2:
+	13: LdU64(1)
+	14: StLoc[5](loc4: u64)
+	15: MoveLoc[1](loc0: u64)
+	16: MoveLoc[5](loc4: u64)
+	17: Add
+	18: StLoc[1](loc0: u64)
+	19: Branch(21)
+B3:
+	20: Branch(22)
+B4:
+	21: Branch(4)
+B5:
+	22: CopyLoc[0](Arg0: vector<u8>)
+	23: StLoc[6](loc5: vector<u8>)
+	24: CopyLoc[6](loc5: vector<u8>)
+	25: StLoc[7](loc6: vector<u8>)
+	26: CopyLoc[0](Arg0: vector<u8>)
+	27: StLoc[8](loc7: vector<u8>)
+	28: Ret
+}
+test_guess_flips_abort() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_abort(vector<u8>)
+	8: Ret
+}
+test_guess_flips_break() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_break(vector<u8>)
+	8: Ret
+}
+test_guess_flips_break2() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_break2(vector<u8>)
+	8: Ret
+}
+test_guess_flips_continue() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_continue(vector<u8>)
+	8: Ret
+}
+test_guess_flips_nocheck() {
+L0:	loc0: vector<u8>
+B0:
+	0: LdU8(0)
+	1: LdU8(0)
+	2: LdU8(0)
+	3: LdU8(0)
+	4: VecPack(1, 4)
+	5: StLoc[0](loc0: vector<u8>)
+	6: MoveLoc[0](loc0: vector<u8>)
+	7: Call guess_flips_nocheck(vector<u8>)
+	8: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_9717_looponly.exp
@@ -3,7 +3,7 @@ comparison between v1 and v2 failed:
 = 
 = task 0 'publish'. lines 1-130:
 + Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
-+     major_status: MOVELOC_UNAVAILABLE_ERROR,
++     major_status: MOVELOC_EXISTS_BORROW_ERROR,
 +     sub_status: None,
 +     location: 0xcafe::vectors,
 +     indices: redacted,

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -230,7 +230,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             Err(vm_error) => Err(anyhow!(
                 "Unable to publish module '{}'. Got VMError: {}",
                 module.self_id(),
-                vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
+                vm_error.format_test_output(
+                    move_test_debug() || verbose,
+                    !move_test_debug() && self.comparison_mode
+                )
             )),
         }
     }
@@ -274,7 +277,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Script execution failed with VMError: {}",
-                    vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
+                    vm_error.format_test_output(
+                        move_test_debug() || verbose,
+                        !move_test_debug() && self.comparison_mode
+                    )
                 )
             })?;
         Ok((None, serialized_return_values))
@@ -319,7 +325,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .map_err(|vm_error| {
                 anyhow!(
                     "Function execution failed with VMError: {}",
-                    vm_error.format_test_output(move_test_debug() || verbose, self.comparison_mode)
+                    vm_error.format_test_output(
+                        move_test_debug() || verbose,
+                        !move_test_debug() && self.comparison_mode
+                    )
                 )
             })?;
         Ok((None, serialized_return_values))


### PR DESCRIPTION
### Description

Solve Issue #11139 by reducing it to new Issue #11223.
- In `file_format_generator/function_generator.rs`, only turn an assignment into a `Move` if its requested;
  inference should be handled earlier, in LiveVarAnalysis.
- In `livevar_analysis_processor`, only resolve mutable references to a `Move` for now, to skirt
  incomplete handling of references in LiveVarAnalysis (delegated to  #11223).  This is a heavy-handed
  hack that should be undone when #11223 is fixed.
- added a new test bug_11223.move which illustrates the underlying issue without VM bugs, if the hack
  is disabled.

Test case `bug_9717.move`and `bug_9717_looponly.move` were yielding VM errors with move-compiler-v2.
These relate to moving values that have references to them on the stack/in temporaries, and is arguably a VM bug.
New test case `bug_11223.move` illustrates the underlying problem without questions of being a VM bug.

Interesting issues:
- Test case `move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.move` no longer
  yields an error, which is correct, since a `Copy` is the only legal operation at the "ambigious" assignment.
- Various other tests outputs that show bytecode change, due to increased use of `copy` instead of `move`.

Left in some extra instrumentation for debugging compiler issues:
- Skip v1 comparisons in transactional tests if `MOVE_TEST_DEBUG` is enabled.
- dump annotated targets for inline tests if `verbose` feature is enabled.

Added some more output from compiler when debug flag is enabled, and disable V1 comparisons in 

### Test Plan
New tests added to illustrate problem more conclusively.
