### PR TITLE
[Forge] Remove system metrics check for max throughput test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1913,12 +1913,13 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
             SuccessCriteria::new(12000)
                 .add_no_restarts()
                 /* This test runs at high load, so we need more catchup time */
-                .add_wait_for_catchup_s(120), /* Doesn't work without event indices
-                                              .add_chain_progress(StateProgressThreshold {
-                                                  max_no_progress_secs: 10.0,
-                                                  max_round_gap: 4,
-                                              }),
-                                              */
+                .add_wait_for_catchup_s(120),
+            /* Doesn't work without event indices
+                .add_chain_progress(StateProgressThreshold {
+                     max_no_progress_secs: 10.0,
+                     max_round_gap: 4,
+                 }),
+            */
         );
     }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1913,21 +1913,12 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
             SuccessCriteria::new(12000)
                 .add_no_restarts()
                 /* This test runs at high load, so we need more catchup time */
-                .add_wait_for_catchup_s(120)
-                .add_system_metrics_threshold(SystemMetricsThreshold::new(
-                    // Tuned for throughput uses more cores than regular tests,
-                    // as it achieves higher throughput.
-                    // Check that we don't use more than 14 CPU cores for 30% of the time.
-                    MetricsThreshold::new(14.0, 30),
-                    // Check that we don't use more than 10 GB of memory for 30% of the time.
-                    MetricsThreshold::new_gb(10.0, 30),
-                )),
-            /* Doesn't work without event indices
-            .add_chain_progress(StateProgressThreshold {
-                max_no_progress_secs: 10.0,
-                max_round_gap: 4,
-            }),
-            */
+                .add_wait_for_catchup_s(120), /* Doesn't work without event indices
+                                              .add_chain_progress(StateProgressThreshold {
+                                                  max_no_progress_secs: 10.0,
+                                                  max_round_gap: 4,
+                                              }),
+                                              */
         );
     }
 


### PR DESCRIPTION
### Description

CPU metrics check is not needed and flaky for max throughput tests. Removing it. 

### Test Plan

Will run Forge. 