### PR TITLE
[framework] Remove move warnings from framework

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -43,7 +43,6 @@ spec aptos_framework::object {
     }
 
     spec create_sticky_object(owner_address: address): ConstructorRef {
-        use std::features;
         pragma aborts_if_is_partial;
 
         let unique_address = transaction_context::spec_generate_unique_address();

--- a/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
@@ -8,7 +8,6 @@
 /// * Metadata property type
 module aptos_token_objects::aptos_token {
     use std::error;
-    use std::features;
     use std::option::{Self, Option};
     use std::string::String;
     use std::signer;


### PR DESCRIPTION
### Description
Looks like some imports weren't cleaned up when the feature flags were removed.  These show up whenever you compile against main with the compiler.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
