### PR TITLE
trivial: split out StoragePricing

### DIFF
--- a/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
+++ b/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
@@ -6,7 +6,7 @@ use aptos_gas_algebra::{
 };
 use aptos_gas_meter::GasAlgebra;
 use aptos_gas_schedule::VMGasParameters;
-use aptos_vm_types::storage::StorageGasParameters;
+use aptos_vm_types::storage::io_pricing::IoPricing;
 use move_binary_format::errors::PartialVMResult;
 use std::sync::{Arc, Mutex};
 
@@ -29,8 +29,8 @@ impl<A: GasAlgebra> GasAlgebra for CalibrationAlgebra<A> {
         self.base.vm_gas_params()
     }
 
-    fn storage_gas_params(&self) -> &StorageGasParameters {
-        self.base.storage_gas_params()
+    fn io_pricing(&self) -> &IoPricing {
+        self.base.io_pricing()
     }
 
     fn balance_internal(&self) -> InternalGas {

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -29,7 +29,9 @@ use aptos_vm::{
     AptosVM, VMExecutor,
 };
 use aptos_vm_logging::log_schema::AdapterLogSchema;
-use aptos_vm_types::{change_set::VMChangeSet, output::VMOutput, storage::ChangeSetConfigs};
+use aptos_vm_types::{
+    change_set::VMChangeSet, output::VMOutput, storage::change_set_configs::ChangeSetConfigs,
+};
 use move_binary_format::errors::VMResult;
 use std::{path::Path, sync::Arc};
 

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -5,7 +5,7 @@ use crate::traits::GasAlgebra;
 use aptos_gas_algebra::{Fee, FeePerGasUnit, Gas, GasExpression, Octa};
 use aptos_gas_schedule::VMGasParameters;
 use aptos_logger::error;
-use aptos_vm_types::storage::StorageGasParameters;
+use aptos_vm_types::storage::{io_pricing::IoPricing, StorageGasParameters};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     gas_algebra::{InternalGas, InternalGasUnit},
@@ -83,8 +83,8 @@ impl GasAlgebra for StandardGasAlgebra {
         &self.vm_gas_params
     }
 
-    fn storage_gas_params(&self) -> &StorageGasParameters {
-        &self.storage_gas_params
+    fn io_pricing(&self) -> &IoPricing {
+        &self.storage_gas_params.io_pricing
     }
 
     fn balance_internal(&self) -> InternalGas {

--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -161,8 +161,7 @@ where
             return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message("in legacy versions, number of bytes loaded must be zero when the resource does not exist ".to_string()));
         }
         let cost = self
-            .storage_gas_params()
-            .pricing
+            .io_pricing()
             .calculate_read_gas(val.is_some(), bytes_loaded);
         self.algebra.charge_io(cost)
     }
@@ -489,10 +488,7 @@ where
     }
 
     fn charge_io_gas_for_write(&mut self, key: &StateKey, op_size: &WriteOpSize) -> VMResult<()> {
-        let cost = self
-            .storage_gas_params()
-            .pricing
-            .io_gas_per_write(key, op_size);
+        let cost = self.io_pricing().io_gas_per_write(key, op_size);
 
         self.algebra
             .charge_io(cost)

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -8,7 +8,7 @@ use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValueMetadata},
     write_set::WriteOpSize,
 };
-use aptos_vm_types::{change_set::VMChangeSet, storage::StorageGasParameters};
+use aptos_vm_types::{change_set::VMChangeSet, storage::io_pricing::IoPricing};
 use move_binary_format::errors::{Location, PartialVMResult, VMResult};
 use move_core_types::gas_algebra::{InternalGas, InternalGasUnit, NumBytes};
 use move_vm_types::gas::GasMeter as MoveGasMeter;
@@ -24,7 +24,7 @@ pub trait GasAlgebra {
     fn vm_gas_params(&self) -> &VMGasParameters;
 
     /// Returns the struct containing the storage-specific gas parameters.
-    fn storage_gas_params(&self) -> &StorageGasParameters;
+    fn io_pricing(&self) -> &IoPricing;
 
     /// Returns the current balance, measured in internal gas units.
     fn balance_internal(&self) -> InternalGas;
@@ -212,8 +212,8 @@ pub trait AptosGasMeter: MoveGasMeter {
     }
 
     // Returns a reference to the struct containing all storage gas parameters.
-    fn storage_gas_params(&self) -> &StorageGasParameters {
-        self.algebra().storage_gas_params()
+    fn io_pricing(&self) -> &IoPricing {
+        self.algebra().io_pricing()
     }
 
     /// Returns the remaining balance, measured in (external) gas units.

--- a/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
+++ b/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
@@ -1,0 +1,124 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{change_set::VMChangeSet, check_change_set::CheckChangeSet};
+use aptos_gas_schedule::AptosGasParameters;
+use move_core_types::vm_status::{err_msg, StatusCode, VMStatus};
+
+#[derive(Clone, Debug)]
+pub struct ChangeSetConfigs {
+    gas_feature_version: u64,
+    max_bytes_per_write_op: u64,
+    max_bytes_all_write_ops_per_transaction: u64,
+    max_bytes_per_event: u64,
+    max_bytes_all_events_per_transaction: u64,
+    max_write_ops_per_transaction: u64,
+}
+
+impl ChangeSetConfigs {
+    pub fn unlimited_at_gas_feature_version(gas_feature_version: u64) -> Self {
+        Self::new_impl(
+            gas_feature_version,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+        )
+    }
+
+    pub fn new(feature_version: u64, gas_params: &AptosGasParameters) -> Self {
+        if feature_version >= 5 {
+            Self::from_gas_params(feature_version, gas_params)
+        } else if feature_version >= 3 {
+            Self::for_feature_version_3()
+        } else {
+            Self::unlimited_at_gas_feature_version(feature_version)
+        }
+    }
+
+    fn new_impl(
+        gas_feature_version: u64,
+        max_bytes_per_write_op: u64,
+        max_bytes_all_write_ops_per_transaction: u64,
+        max_bytes_per_event: u64,
+        max_bytes_all_events_per_transaction: u64,
+        max_write_ops_per_transaction: u64,
+    ) -> Self {
+        Self {
+            gas_feature_version,
+            max_bytes_per_write_op,
+            max_bytes_all_write_ops_per_transaction,
+            max_bytes_per_event,
+            max_bytes_all_events_per_transaction,
+            max_write_ops_per_transaction,
+        }
+    }
+
+    pub fn legacy_resource_creation_as_modification(&self) -> bool {
+        // Bug fixed at gas_feature_version 3 where (non-group) resource creation was converted to
+        // modification.
+        // Modules and table items were not affected (https://github.com/aptos-labs/aptos-core/pull/4722/commits/7c5e52297e8d1a6eac67a68a804ab1ca2a0b0f37).
+        // Resource groups and state values with metadata were not affected because they were
+        // introduced later than feature_version 3 on all networks.
+        self.gas_feature_version < 3
+    }
+
+    fn for_feature_version_3() -> Self {
+        const MB: u64 = 1 << 20;
+
+        Self::new_impl(3, MB, u64::MAX, MB, 10 * MB, u64::MAX)
+    }
+
+    fn from_gas_params(gas_feature_version: u64, gas_params: &AptosGasParameters) -> Self {
+        let params = &gas_params.vm.txn;
+        Self::new_impl(
+            gas_feature_version,
+            params.max_bytes_per_write_op.into(),
+            params.max_bytes_all_write_ops_per_transaction.into(),
+            params.max_bytes_per_event.into(),
+            params.max_bytes_all_events_per_transaction.into(),
+            params.max_write_ops_per_transaction.into(),
+        )
+    }
+}
+
+impl CheckChangeSet for ChangeSetConfigs {
+    fn check_change_set(&self, change_set: &VMChangeSet) -> Result<(), VMStatus> {
+        const ERR: StatusCode = StatusCode::STORAGE_WRITE_LIMIT_REACHED;
+
+        if self.max_write_ops_per_transaction != 0
+            && change_set.num_write_ops() as u64 > self.max_write_ops_per_transaction
+        {
+            return Err(VMStatus::error(ERR, err_msg("Too many write ops.")));
+        }
+
+        let mut write_set_size = 0;
+        for (key, op_size) in change_set.write_set_size_iter() {
+            if let Some(len) = op_size.write_len() {
+                let write_op_size = len + (key.size() as u64);
+                if write_op_size > self.max_bytes_per_write_op {
+                    return Err(VMStatus::error(ERR, None));
+                }
+                write_set_size += write_op_size;
+            }
+            if write_set_size > self.max_bytes_all_write_ops_per_transaction {
+                return Err(VMStatus::error(ERR, None));
+            }
+        }
+
+        let mut total_event_size = 0;
+        for (event, _) in change_set.events() {
+            let size = event.event_data().len() as u64;
+            if size > self.max_bytes_per_event {
+                return Err(VMStatus::error(ERR, None));
+            }
+            total_event_size += size;
+            if total_event_size > self.max_bytes_all_events_per_transaction {
+                return Err(VMStatus::error(ERR, None));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
+++ b/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
@@ -1,27 +1,26 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{change_set::VMChangeSet, check_change_set::CheckChangeSet};
 use aptos_gas_algebra::GasExpression;
 use aptos_gas_schedule::{
-    gas_params::txn::*, AptosGasParameters, VMGasParameters, LATEST_GAS_FEATURE_VERSION,
+    gas_params::txn::{
+        STORAGE_IO_PER_STATE_BYTE_READ, STORAGE_IO_PER_STATE_BYTE_WRITE,
+        STORAGE_IO_PER_STATE_SLOT_READ, STORAGE_IO_PER_STATE_SLOT_WRITE,
+    },
+    AptosGasParameters, VMGasParameters,
 };
 use aptos_types::{
-    on_chain_config::{ConfigStorage, OnChainConfig, StorageGasSchedule},
+    on_chain_config::{ConfigStorage, StorageGasSchedule},
     state_store::state_key::StateKey,
     write_set::WriteOpSize,
 };
 use either::Either;
-use move_core_types::{
-    gas_algebra::{
-        InternalGas, InternalGasPerArg, InternalGasPerByte, InternalGasUnit, NumArgs, NumBytes,
-    },
-    vm_status::{err_msg, StatusCode, VMStatus},
+use move_core_types::gas_algebra::{
+    InternalGas, InternalGasPerArg, InternalGasPerByte, InternalGasUnit, NumArgs, NumBytes,
 };
-use std::fmt::Debug;
 
 #[derive(Clone, Debug)]
-pub struct StoragePricingV1 {
+pub struct IoPricingV1 {
     write_data_per_op: InternalGasPerArg,
     write_data_per_new_item: InternalGasPerArg,
     write_data_per_byte_in_key: InternalGasPerByte,
@@ -31,7 +30,7 @@ pub struct StoragePricingV1 {
     load_data_failure: InternalGas,
 }
 
-impl StoragePricingV1 {
+impl IoPricingV1 {
     fn new(gas_params: &AptosGasParameters) -> Self {
         Self {
             write_data_per_op: gas_params.vm.txn.storage_io_per_state_slot_write,
@@ -45,7 +44,7 @@ impl StoragePricingV1 {
     }
 }
 
-impl StoragePricingV1 {
+impl IoPricingV1 {
     fn calculate_read_gas(&self, loaded: Option<NumBytes>) -> InternalGas {
         self.load_data_base
             + match loaded {
@@ -84,7 +83,7 @@ impl StoragePricingV1 {
 }
 
 #[derive(Clone, Debug)]
-pub struct StoragePricingV2 {
+pub struct IoPricingV2 {
     pub feature_version: u64,
     pub free_write_bytes_quota: NumBytes,
     pub per_item_read: InternalGasPerArg,
@@ -95,7 +94,7 @@ pub struct StoragePricingV2 {
     pub per_byte_write: InternalGasPerByte,
 }
 
-impl StoragePricingV2 {
+impl IoPricingV2 {
     pub fn new_with_storage_curves(
         feature_version: u64,
         storage_gas_schedule: &StorageGasSchedule,
@@ -166,12 +165,12 @@ impl StoragePricingV2 {
 
 // No storage curve. New gas parameter representation.
 #[derive(Debug, Clone)]
-pub struct StoragePricingV3 {
+pub struct IoPricingV3 {
     pub feature_version: u64,
     pub free_write_bytes_quota: NumBytes,
 }
 
-impl StoragePricingV3 {
+impl IoPricingV3 {
     fn calculate_read_gas(
         &self,
         loaded: NumBytes,
@@ -206,31 +205,32 @@ impl StoragePricingV3 {
 }
 
 #[derive(Clone, Debug)]
-pub enum StoragePricing {
-    V1(StoragePricingV1),
-    V2(StoragePricingV2),
-    V3(StoragePricingV3),
+pub enum IoPricing {
+    V1(IoPricingV1),
+    V2(IoPricingV2),
+    V3(IoPricingV3),
 }
 
-impl StoragePricing {
+impl IoPricing {
     pub fn new(
         feature_version: u64,
         gas_params: &AptosGasParameters,
         config_storage: &impl ConfigStorage,
-    ) -> StoragePricing {
-        use StoragePricing::*;
+    ) -> IoPricing {
+        use aptos_types::on_chain_config::OnChainConfig;
+        use IoPricing::*;
 
         match feature_version {
-            0 => V1(StoragePricingV1::new(gas_params)),
+            0 => V1(IoPricingV1::new(gas_params)),
             1..=9 => match StorageGasSchedule::fetch_config(config_storage) {
-                None => V1(StoragePricingV1::new(gas_params)),
-                Some(schedule) => V2(StoragePricingV2::new_with_storage_curves(
+                None => V1(IoPricingV1::new(gas_params)),
+                Some(schedule) => V2(IoPricingV2::new_with_storage_curves(
                     feature_version,
                     &schedule,
                     gas_params,
                 )),
             },
-            10.. => V3(StoragePricingV3 {
+            10.. => V3(IoPricingV3 {
                 feature_version,
                 free_write_bytes_quota: gas_params.vm.txn.free_write_bytes_quota,
             }),
@@ -242,7 +242,7 @@ impl StoragePricing {
         resource_exists: bool,
         bytes_loaded: NumBytes,
     ) -> impl GasExpression<VMGasParameters, Unit = InternalGasUnit> {
-        use StoragePricing::*;
+        use IoPricing::*;
 
         match self {
             V1(v1) => Either::Left(v1.calculate_read_gas(
@@ -264,164 +264,12 @@ impl StoragePricing {
         key: &StateKey,
         op_size: &WriteOpSize,
     ) -> impl GasExpression<VMGasParameters, Unit = InternalGasUnit> {
-        use StoragePricing::*;
+        use IoPricing::*;
 
         match self {
             V1(v1) => Either::Left(v1.io_gas_per_write(key, op_size)),
             V2(v2) => Either::Left(v2.io_gas_per_write(key, op_size)),
             V3(v3) => Either::Right(v3.io_gas_per_write(key, op_size)),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ChangeSetConfigs {
-    gas_feature_version: u64,
-    max_bytes_per_write_op: u64,
-    max_bytes_all_write_ops_per_transaction: u64,
-    max_bytes_per_event: u64,
-    max_bytes_all_events_per_transaction: u64,
-    max_write_ops_per_transaction: u64,
-}
-
-impl ChangeSetConfigs {
-    pub fn unlimited_at_gas_feature_version(gas_feature_version: u64) -> Self {
-        Self::new_impl(
-            gas_feature_version,
-            u64::MAX,
-            u64::MAX,
-            u64::MAX,
-            u64::MAX,
-            u64::MAX,
-        )
-    }
-
-    pub fn new(feature_version: u64, gas_params: &AptosGasParameters) -> Self {
-        if feature_version >= 5 {
-            Self::from_gas_params(feature_version, gas_params)
-        } else if feature_version >= 3 {
-            Self::for_feature_version_3()
-        } else {
-            Self::unlimited_at_gas_feature_version(feature_version)
-        }
-    }
-
-    fn new_impl(
-        gas_feature_version: u64,
-        max_bytes_per_write_op: u64,
-        max_bytes_all_write_ops_per_transaction: u64,
-        max_bytes_per_event: u64,
-        max_bytes_all_events_per_transaction: u64,
-        max_write_ops_per_transaction: u64,
-    ) -> Self {
-        Self {
-            gas_feature_version,
-            max_bytes_per_write_op,
-            max_bytes_all_write_ops_per_transaction,
-            max_bytes_per_event,
-            max_bytes_all_events_per_transaction,
-            max_write_ops_per_transaction,
-        }
-    }
-
-    pub fn legacy_resource_creation_as_modification(&self) -> bool {
-        // Bug fixed at gas_feature_version 3 where (non-group) resource creation was converted to
-        // modification.
-        // Modules and table items were not affected (https://github.com/aptos-labs/aptos-core/pull/4722/commits/7c5e52297e8d1a6eac67a68a804ab1ca2a0b0f37).
-        // Resource groups and state values with metadata were not affected because they were
-        // introduced later than feature_version 3 on all networks.
-        self.gas_feature_version < 3
-    }
-
-    fn for_feature_version_3() -> Self {
-        const MB: u64 = 1 << 20;
-
-        Self::new_impl(3, MB, u64::MAX, MB, 10 * MB, u64::MAX)
-    }
-
-    fn from_gas_params(gas_feature_version: u64, gas_params: &AptosGasParameters) -> Self {
-        let params = &gas_params.vm.txn;
-        Self::new_impl(
-            gas_feature_version,
-            params.max_bytes_per_write_op.into(),
-            params.max_bytes_all_write_ops_per_transaction.into(),
-            params.max_bytes_per_event.into(),
-            params.max_bytes_all_events_per_transaction.into(),
-            params.max_write_ops_per_transaction.into(),
-        )
-    }
-}
-
-impl CheckChangeSet for ChangeSetConfigs {
-    fn check_change_set(&self, change_set: &VMChangeSet) -> Result<(), VMStatus> {
-        const ERR: StatusCode = StatusCode::STORAGE_WRITE_LIMIT_REACHED;
-
-        if self.max_write_ops_per_transaction != 0
-            && change_set.num_write_ops() as u64 > self.max_write_ops_per_transaction
-        {
-            return Err(VMStatus::error(ERR, err_msg("Too many write ops.")));
-        }
-
-        let mut write_set_size = 0;
-        for (key, op_size) in change_set.write_set_size_iter() {
-            if let Some(len) = op_size.write_len() {
-                let write_op_size = len + (key.size() as u64);
-                if write_op_size > self.max_bytes_per_write_op {
-                    return Err(VMStatus::error(ERR, None));
-                }
-                write_set_size += write_op_size;
-            }
-            if write_set_size > self.max_bytes_all_write_ops_per_transaction {
-                return Err(VMStatus::error(ERR, None));
-            }
-        }
-
-        let mut total_event_size = 0;
-        for (event, _) in change_set.events() {
-            let size = event.event_data().len() as u64;
-            if size > self.max_bytes_per_event {
-                return Err(VMStatus::error(ERR, None));
-            }
-            total_event_size += size;
-            if total_event_size > self.max_bytes_all_events_per_transaction {
-                return Err(VMStatus::error(ERR, None));
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct StorageGasParameters {
-    pub pricing: StoragePricing,
-    pub change_set_configs: ChangeSetConfigs,
-}
-
-impl StorageGasParameters {
-    pub fn new(
-        feature_version: u64,
-        gas_params: &AptosGasParameters,
-        config_storage: &impl ConfigStorage,
-    ) -> Self {
-        let pricing = StoragePricing::new(feature_version, gas_params, config_storage);
-        let change_set_configs = ChangeSetConfigs::new(feature_version, gas_params);
-
-        Self {
-            pricing,
-            change_set_configs,
-        }
-    }
-
-    pub fn unlimited(free_write_bytes_quota: NumBytes) -> Self {
-        Self {
-            pricing: StoragePricing::V3(StoragePricingV3 {
-                feature_version: LATEST_GAS_FEATURE_VERSION,
-                free_write_bytes_quota,
-            }),
-            change_set_configs: ChangeSetConfigs::unlimited_at_gas_feature_version(
-                LATEST_GAS_FEATURE_VERSION,
-            ),
         }
     }
 }

--- a/aptos-move/aptos-vm-types/src/storage/mod.rs
+++ b/aptos-move/aptos-vm-types/src/storage/mod.rs
@@ -1,0 +1,48 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::storage::{
+    change_set_configs::ChangeSetConfigs,
+    io_pricing::{IoPricing, IoPricingV3},
+};
+use aptos_gas_schedule::{AptosGasParameters, LATEST_GAS_FEATURE_VERSION};
+use aptos_types::on_chain_config::ConfigStorage;
+use move_core_types::gas_algebra::NumBytes;
+use std::fmt::Debug;
+
+pub mod change_set_configs;
+pub mod io_pricing;
+
+#[derive(Clone, Debug)]
+pub struct StorageGasParameters {
+    pub io_pricing: IoPricing,
+    pub change_set_configs: ChangeSetConfigs,
+}
+
+impl StorageGasParameters {
+    pub fn new(
+        feature_version: u64,
+        gas_params: &AptosGasParameters,
+        config_storage: &impl ConfigStorage,
+    ) -> Self {
+        let io_pricing = IoPricing::new(feature_version, gas_params, config_storage);
+        let change_set_configs = ChangeSetConfigs::new(feature_version, gas_params);
+
+        Self {
+            io_pricing,
+            change_set_configs,
+        }
+    }
+
+    pub fn unlimited(free_write_bytes_quota: NumBytes) -> Self {
+        Self {
+            io_pricing: IoPricing::V3(IoPricingV3 {
+                feature_version: LATEST_GAS_FEATURE_VERSION,
+                free_write_bytes_quota,
+            }),
+            change_set_configs: ChangeSetConfigs::unlimited_at_gas_feature_version(
+                LATEST_GAS_FEATURE_VERSION,
+            ),
+        }
+    }
+}

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -63,7 +63,7 @@ use aptos_vm_types::{
     change_set::VMChangeSet,
     output::VMOutput,
     resolver::{ExecutorView, ResourceGroupView},
-    storage::{ChangeSetConfigs, StorageGasParameters},
+    storage::{change_set_configs::ChangeSetConfigs, StorageGasParameters},
 };
 use claims::assert_err;
 use fail::fail_point;

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -11,7 +11,7 @@ use aptos_types::on_chain_config::{
     ApprovedExecutionHashes, ConfigStorage, GasSchedule, GasScheduleV2, OnChainConfig,
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_log, speculative_warn};
-use aptos_vm_types::storage::{StorageGasParameters, StoragePricing};
+use aptos_vm_types::storage::{io_pricing::IoPricing, StorageGasParameters};
 use move_core_types::{
     gas_algebra::NumArgs,
     language_storage::CORE_CODE_ADDRESS,
@@ -63,7 +63,7 @@ pub(crate) fn get_gas_parameters(
             match gas_feature_version {
                 0..=1 => (),
                 2..=6 => {
-                    if let StoragePricing::V2(pricing) = &storage_gas_params.pricing {
+                    if let IoPricing::V2(pricing) = &storage_gas_params.io_pricing {
                         g.common_load_base_legacy = pricing.per_item_read * NumArgs::new(1);
                         g.common_load_base_new = 0.into();
                         g.common_load_per_byte = pricing.per_byte_read;
@@ -71,7 +71,7 @@ pub(crate) fn get_gas_parameters(
                     }
                 }
                 7..=9 => {
-                    if let StoragePricing::V2(pricing) = &storage_gas_params.pricing {
+                    if let IoPricing::V2(pricing) = &storage_gas_params.io_pricing {
                         g.common_load_base_legacy = 0.into();
                         g.common_load_base_new = pricing.per_item_read * NumArgs::new(1);
                         g.common_load_per_byte = pricing.per_byte_read;

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -34,7 +34,7 @@ use aptos_vm_types::{
         ExecutorView, ResourceGroupSize, ResourceGroupView, StateStorageView, TModuleView,
         TResourceGroupView, TResourceView,
     },
-    storage::ChangeSetConfigs,
+    storage::change_set_configs::ChangeSetConfigs,
 };
 use bytes::Bytes;
 use move_core_types::{

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -18,7 +18,7 @@ use aptos_types::{
     access_path::AccessPath, block_metadata::BlockMetadata, contract_event::ContractEvent,
     on_chain_config::Features, state_store::state_key::StateKey,
 };
-use aptos_vm_types::{change_set::VMChangeSet, storage::ChangeSetConfigs};
+use aptos_vm_types::{change_set::VMChangeSet, storage::change_set_configs::ChangeSetConfigs};
 use bytes::Bytes;
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -62,7 +62,7 @@ use aptos_vm::{
 };
 use aptos_vm_genesis::{generate_genesis_change_set_for_testing_with_count, GenesisOptions};
 use aptos_vm_logging::log_schema::AdapterLogSchema;
-use aptos_vm_types::storage::{ChangeSetConfigs, StorageGasParameters};
+use aptos_vm_types::storage::{change_set_configs::ChangeSetConfigs, StorageGasParameters};
 use bytes::Bytes;
 use move_core_types::{
     account_address::AccountAddress,

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -32,7 +32,7 @@ use aptos_vm::{
     data_cache::AsMoveResolver,
     move_vm_ext::{MoveVmExt, SessionExt, SessionId},
 };
-use aptos_vm_types::storage::ChangeSetConfigs;
+use aptos_vm_types::storage::change_set_configs::ChangeSetConfigs;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -16,7 +16,7 @@ use aptos_vm::{
     data_cache::AsMoveResolver,
     move_vm_ext::{MoveVmExt, SessionExt, SessionId},
 };
-use aptos_vm_types::storage::ChangeSetConfigs;
+use aptos_vm_types::storage::change_set_configs::ChangeSetConfigs;
 use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},


### PR DESCRIPTION
### Description
1. Split the pricing configs (`StoragePricing`) and change set limit configs (`ChangeSetConfigs`) to their own files.
2. Rename `StoragePricing` to `IoPricing`, in preparation to introduce `space_pricing`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
existing coverage
