### PR TITLE
[Gas estimate][metrics] Add metrics for gas estimation, and call it periodically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "aptos-framework",
  "aptos-gas-meter",
  "aptos-gas-schedule",
+ "aptos-global-constants",
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,6 +21,7 @@ aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-framework =  { workspace = true }
 aptos-gas-schedule = { workspace = true }
+aptos-global-constants = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -63,7 +63,7 @@ pub struct Context {
     chain_id: ChainId,
     pub db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
-    pub node_config: NodeConfig,
+    pub node_config: Arc<NodeConfig>,
     gas_schedule_cache: Arc<RwLock<GasScheduleCache>>,
     gas_estimation_cache: Arc<RwLock<GasEstimationCache>>,
     gas_limit_cache: Arc<RwLock<GasLimitCache>>,
@@ -86,7 +86,7 @@ impl Context {
             chain_id,
             db,
             mp_sender,
-            node_config,
+            node_config: Arc::new(node_config),
             gas_schedule_cache: Arc::new(RwLock::new(GasScheduleCache {
                 last_updated_epoch: None,
                 gas_schedule_params: None,

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -2,11 +2,16 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_global_constants::DEFAULT_BUCKETS;
 use aptos_metrics_core::{
     exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
     IntCounterVec,
 };
 use once_cell::sync::Lazy;
+
+pub const GAS_ESTIMATE_DEPRIORITIZED: &str = "deprioritized";
+pub const GAS_ESTIMATE_CURRENT: &str = "current";
+pub const GAS_ESTIMATE_PRIORITIZED: &str = "prioritized";
 
 /// In addition to DEFAULT_BUCKETS, add histogram buckets that are < 5ms:
 /// 0.0001, 0.00025, 0.0005, 0.001, 0.0025
@@ -59,6 +64,16 @@ pub static REQUEST_SOURCE_CLIENT: Lazy<IntCounterVec> = Lazy::new(|| {
         "aptos_api_request_source_client",
         "API requests grouped by source (e.g. which SDK, unknown, etc), operation_id, and status",
         &["request_source_client", "operation_id", "status"]
+    )
+    .unwrap()
+});
+
+pub static GAS_ESTIMATE: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_api_gas_estimate",
+        "API gas estimate returned as part of API calls",
+        &["level"],
+        DEFAULT_BUCKETS.iter().map(|x| *x as f64).collect(),
     )
     .unwrap()
 });

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -565,7 +565,7 @@ impl TransactionsApi {
         api_spawn_blocking(move || api.get_signing_message(&accept_type, data.0)).await
     }
 
-    fn log_gas_estimation(gas_estimation: &GasEstimation) {
+    pub fn log_gas_estimation(gas_estimation: &GasEstimation) {
         metrics::GAS_ESTIMATE
             .with_label_values(&[metrics::GAS_ESTIMATE_CURRENT])
             .observe(gas_estimation.gas_estimate as f64);

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -72,6 +72,8 @@ pub struct ApiConfig {
     pub runtime_worker_multiplier: usize,
     /// Configs for computing unit gas price estimation
     pub gas_estimation: GasEstimationConfig,
+    /// Periodically call gas estimation
+    pub periodic_gas_estimation_ms: Option<u64>,
 }
 
 const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -116,6 +118,7 @@ impl Default for ApiConfig {
             max_runtime_workers: None,
             runtime_worker_multiplier: 2,
             gas_estimation: GasEstimationConfig::default(),
+            periodic_gas_estimation_ms: Some(30_000),
         }
     }
 }


### PR DESCRIPTION
### Description

The metrics give direct observability of what gas estimations are actually being returned.

Calling it periodically helps understand the gas estimation even in environments (forge, previewnet) where the estimation is not called.

### Test Plan

Run forge, observe the metrics.
