### PR TITLE
fix consensus config for realistic_env_max_load_test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1782,7 +1782,8 @@ fn realistic_env_max_load_test(
             helm_values["chain"]["epoch_duration_secs"] =
                 (if long_running { 600 } else { 300 }).into();
             helm_values["chain"]["on_chain_consensus_config"] =
-                serde_yaml::to_value(OnChainConsensusConfig::default()).expect("must serialize");
+                serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
+                    .expect("must serialize");
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
                     .expect("must serialize");


### PR DESCRIPTION
### Description

The test should use the `default_for_genesis` version of consensus config (similar to the execution config).
Currently `OnChainConsensusConfig` is primarily used as `default_is_missing`.
