### PR TITLE
[compiler-v2] Fixes a bug in borrow graph shrinking

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -52,6 +52,18 @@ pub struct LiveVarInfoAtCodeOffset {
     pub after: BTreeMap<TempIndex, LiveVarInfo>,
 }
 
+impl LiveVarInfoAtCodeOffset {
+    /// Creates a set of the temporaries alive before this program point.
+    pub fn before_set(&self) -> BTreeSet<TempIndex> {
+        self.before.keys().cloned().collect()
+    }
+
+    /// Creates a set of the temporaries alive after this program point.
+    pub fn after_set(&self) -> BTreeSet<TempIndex> {
+        self.after.keys().cloned().collect()
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
 pub struct LiveVarInfo {
     /// The usage of a given temporary after this program point, inclusive of locations where

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -67,7 +67,7 @@ impl LiveVarInfoAtCodeOffset {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
 pub struct LiveVarInfo {
     /// The usage of a given temporary after this program point, inclusive of locations where
-    /// the usage happens.
+    /// the usage happens. This set contains at least one element.
     pub usages: BTreeSet<Loc>,
 }
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.move
@@ -1,0 +1,11 @@
+module 0x42::m {
+    use 0x1::vector;
+
+    struct S has copy, drop { f: vector<u64> }
+
+    // The compiler should detect that the returned reference is derived from input parameters.
+    fun f(r1: &S, r2: &u64): &u64 {
+        let vec = &r1.f;
+        if (vector::is_empty(vec)) r2 else vector::borrow(vec, 0)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -37,6 +37,8 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:86:9
    │
+83 │         let c; if (cond) c = &inner.f1 else c = &other.s1.f2;
+   │                              --------- previous field borrow
 84 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 85 │         *c;
@@ -57,6 +59,11 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:95:9
    │
+92 │         let c; if (cond) c = id(&inner.f1) else c = &other.s1.f2;
+   │                              -------------
+   │                              │  │
+   │                              │  previous field borrow
+   │                              used by call result
 93 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 94 │         *c;
@@ -127,6 +134,8 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:34:9
    │
+31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
+   │                              ------------------ previous call result
 32 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 33 │         *c;
@@ -147,6 +156,11 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:43:9
    │
+40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
+   │                              ----------------------
+   │                              │  │
+   │                              │  previous call result
+   │                              used by call result
 41 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 42 │         *c;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
@@ -159,6 +159,8 @@ error: cannot mutable borrow local since other references exists
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:49:9
    │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
    │                  ------------- previous mutable field borrow
 48 │         *c;
@@ -168,10 +170,21 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot dereference local which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:49:9
    │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
 47 │         let f1 = &mut inner.f1;
    │                  ------------- previous mutable field borrow
 48 │         *c;
 49 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:51:9
+   │
+46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+51 │         *inner;
    │         ^^^^^^ dereferenced here
 
 error: cannot mutable borrow local `outer` since other references exists
@@ -201,8 +214,28 @@ error: cannot immutable borrow local since other mutable references exist
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:27:9
    │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
 25 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 26 │         *c;
 27 │         *inner;
    │         ^^^^^^ copied here
+
+error: cannot dereference local which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:27:9
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+27 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:29:9
+   │
+24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
+   │                              ------------------ previous mutable call result
+   ·
+29 │         *inner;
+   │         ^^^^^^ dereferenced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field.exp
@@ -11,6 +11,8 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:34:9
    │
+31 │         let c = &inner.f1;
+   │                 --------- previous field borrow
 32 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 33 │         *c;
@@ -31,6 +33,11 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_field.move:43:9
    │
+40 │         let c = id(&inner.f1);
+   │                 -------------
+   │                 │  │
+   │                 │  previous field borrow
+   │                 used by call result
 41 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 42 │         *c;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full.exp
@@ -11,6 +11,8 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full.move:34:9
    │
+31 │         let c = freeze(inner);
+   │                 ------------- previous call result
 32 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 33 │         *c;
@@ -31,6 +33,11 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full.move:43:9
    │
+40 │         let c = id(freeze(inner));
+   │                 -----------------
+   │                 │  │
+   │                 │  previous call result
+   │                 used by call result
 41 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 42 │         *c;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
@@ -36,11 +36,31 @@ error: cannot immutable borrow local since other mutable references exist
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:25:9
    │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
 23 │         let f1 = &inner.f1;
    │                  --------- previous field borrow
 24 │         *c;
 25 │         *inner;
    │         ^^^^^^ copied here
+
+error: cannot dereference local which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:25:9
+   │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+25 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:27:9
+   │
+22 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+27 │         *inner;
+   │         ^^^^^^ dereferenced here
 
 error: cannot copy mutable reference in local `c` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:33:9
@@ -95,6 +115,8 @@ error: cannot mutable borrow local since other references exists
 error: cannot copy mutable reference in local `inner` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:43:9
    │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
    │                  ------------- previous mutable field borrow
 42 │         *c;
@@ -104,8 +126,19 @@ error: cannot copy mutable reference in local `inner` which is still borrowed
 error: cannot dereference local which is still mutable borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:43:9
    │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
 41 │         let f1 = &mut inner.f1;
    │                  ------------- previous mutable field borrow
 42 │         *c;
 43 │         *inner;
+   │         ^^^^^^ dereferenced here
+
+error: cannot dereference local `inner` which is still mutable borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:45:9
+   │
+40 │         let c = id_mut(inner);
+   │                 ------------- previous mutable call result
+   ·
+45 │         *inner;
    │         ^^^^^^ dereferenced here

--- a/third_party/move/move-model/bytecode/src/dataflow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/dataflow_analysis.rs
@@ -64,6 +64,21 @@ pub trait DataflowAnalysis: TransferFunctions {
         instrs: &[Bytecode],
         cfg: &StacklessControlFlowGraph,
     ) -> StateMap<Self::State> {
+        self.analyze_function_with_debug_print(initial_state, instrs, cfg, None)
+    }
+
+    fn analyze_function_with_debug_print(
+        &self,
+        initial_state: Self::State,
+        instrs: &[Bytecode],
+        cfg: &StacklessControlFlowGraph,
+        debug_printer: Option<&dyn Fn(&Self::State) -> String>,
+    ) -> StateMap<Self::State> {
+        let debug_print_state = |block_id: BlockId, prefix: &str, state: &Self::State| {
+            if let Some(p) = &debug_printer {
+                eprintln!("B{} {}: {}", block_id, prefix, p(state))
+            }
+        };
         let mut state_map: StateMap<Self::State> = StateMap::new();
         let mut work_list = VecDeque::new();
         work_list.push_back(cfg.entry_block());
@@ -73,13 +88,16 @@ pub trait DataflowAnalysis: TransferFunctions {
         });
         while let Some(block_id) = work_list.pop_front() {
             let pre = state_map.get(&block_id).expect("basic block").pre.clone();
+            debug_print_state(block_id, "pre", &pre);
             let post = self.execute_block(block_id, pre, instrs, cfg);
-
+            debug_print_state(block_id, "post", &post);
             // propagate postcondition of this block to successor blocks
             for next_block_id in cfg.successors(block_id) {
                 match state_map.get_mut(next_block_id) {
                     Some(next_block_res) => {
+                        debug_print_state(*next_block_id, "pre join", &next_block_res.pre);
                         let join_result = next_block_res.pre.join(&post);
+                        debug_print_state(*next_block_id, "post join", &next_block_res.pre);
                         match join_result {
                             JoinResult::Unchanged => {
                                 // Pre is the same after join. Reanalyzing this block would produce


### PR DESCRIPTION
Closes #11221.

When a temporary goes out of scope, nodes related to that temporary are removed from the graph, provided they are not borrowed. This process recursively continues, visiting nodes representing other temporaries, cleaning up large parts of the graph. There was a significant bug in this cleanup, namely ignoring whether a node and a related temporary are also referenced from the outside. This is for example the case if the temporary is used later in the program. It appears this bug only hits if different control flows contribute to the graph, as is in the test case `return_borrowed.move`.

Notice the better error messages in other .exp files come from that previously parts of the graph have been removed. Its the same errors, only with more secondary info from the corrected borrow graph.
