### PR TITLE
Make block executor include StateCheckpoint on block limit reached as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11051,11 +11051,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -11083,9 +11083,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1029,8 +1029,14 @@ impl Context {
                     } else if let Some(full_block_gas_used) =
                         block_config.block_gas_limit_type.block_gas_limit()
                     {
-                        prices_and_used.iter().map(|(_, used)| *used).sum::<u64>()
-                            >= full_block_gas_used
+                        // be pesimistic for conflicts, as such information is not onchain
+                        let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
+                        let max_conflict_multiplier = block_config
+                            .block_gas_limit_type
+                            .conflict_penalty_window()
+                            .unwrap_or(1)
+                            as u64;
+                        gas_used * max_conflict_multiplier >= full_block_gas_used
                     } else {
                         false
                     };

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -460,7 +460,6 @@ impl VMChangeSet {
             .collect::<anyhow::Result<BTreeMap<StateKey, WriteOp>, VMStatus>>()?;
         self.aggregator_v1_write_set
             .extend(materialized_aggregator_delta_set);
-
         Ok(())
     }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -15,7 +15,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     errors::Error, executor::BlockExecutor,
     task::TransactionOutput as BlockExecutorTransactionOutput,
-    txn_commit_hook::TransactionCommitHook,
+    txn_commit_hook::TransactionCommitHook, types::InputOutputKey,
 };
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
@@ -36,7 +36,10 @@ use aptos_vm_types::{abstract_write_op::AbstractResourceWriteOp, output::VMOutpu
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -315,6 +318,61 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .as_ref()
             .expect("Output to be set to get fee statement")
             .fee_statement()
+    }
+
+    fn output_approx_size(&self) -> u64 {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut size = 0;
+        for (state_key, write_size) in change_set.write_set_size_iter() {
+            size += state_key.size() as u64 + write_size.write_len().unwrap_or(0);
+        }
+
+        for (event, _) in change_set.events() {
+            size += event.size() as u64;
+        }
+
+        size
+    }
+
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag, DelayedFieldID>> {
+        let vm_output = self.vm_output.lock();
+        let change_set = vm_output
+            .as_ref()
+            .expect("Output to be set to get write summary")
+            .change_set();
+
+        let mut writes = HashSet::new();
+
+        for (state_key, write) in change_set.resource_write_set() {
+            match write {
+                AbstractResourceWriteOp::Write(_)
+                | AbstractResourceWriteOp::WriteWithDelayedFields(_) => {
+                    writes.insert(InputOutputKey::Resource(state_key.clone()));
+                },
+                AbstractResourceWriteOp::WriteResourceGroup(write) => {
+                    for tag in write.inner_ops().keys() {
+                        writes.insert(InputOutputKey::Group(state_key.clone(), tag.clone()));
+                    }
+                },
+                AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)
+                | AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_) => {
+                    // No conflicts on resources from in-place delayed field changes.
+                    // Delayed fields conflicts themselves are handled via
+                    // delayed_field_change_set below.
+                },
+            }
+        }
+
+        for identifier in change_set.delayed_field_change_set().keys() {
+            writes.insert(InputOutputKey::DelayedField(*identifier));
+        }
+
+        writes
     }
 }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -58,6 +58,13 @@ impl AptosTransactionOutput {
         }
     }
 
+    pub(crate) fn new_from_committed_output(output: TransactionOutput) -> Self {
+        Self {
+            vm_output: Mutex::new(None),
+            committed_output: OnceCell::from(output),
+        }
+    }
+
     pub(crate) fn committed_output(&self) -> &TransactionOutput {
         self.committed_output.get().unwrap()
     }
@@ -67,12 +74,13 @@ impl AptosTransactionOutput {
             Some(output) => output,
             // TODO: revisit whether we should always get it via committed, or o.w. create a
             // dedicated API without creating empty data structures.
+            // This is currently used because we do not commit skip_output() transactions.
             None => self
                 .vm_output
                 .lock()
                 .take()
                 .expect("Output must be set")
-                .into_transaction_output_with_materialized_write_set(vec![], vec![], vec![])
+                .into_transaction_output()
                 .expect("Transaction output is not alerady materialized"),
         }
     }

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -5,12 +5,18 @@
 use crate::{
     aptos_vm::AptosVM, block_executor::AptosTransactionOutput, data_cache::AsMoveResolver,
 };
+use aptos_aggregator::types::code_invariant_error;
 use aptos_block_executor::task::{ExecutionStatus, ExecutorTask};
 use aptos_logger::{enabled, Level};
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_state_view::StateView;
-use aptos_types::transaction::{
-    signature_verified_transaction::SignatureVerifiedTransaction, Transaction, WriteSetPayload,
+use aptos_types::{
+    aggregator::PanicError,
+    transaction::{
+        signature_verified_transaction::SignatureVerifiedTransaction, Transaction,
+        TransactionOutput, TransactionStatus, WriteSetPayload,
+    },
+    write_set::WriteSet,
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use aptos_vm_types::resolver::{ExecutorView, ResourceGroupView};
@@ -113,6 +119,39 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
                     ExecutionStatus::Abort(err)
                 }
             },
+        }
+    }
+
+    fn execute_skipped_checkpoint(
+        txn: &Self::Txn,
+        output: &mut Self::Output,
+    ) -> Result<(), PanicError> {
+        if txn.is_valid() {
+            match txn.expect_valid() {
+                Transaction::StateCheckpoint(_) => {
+                    aptos_block_executor::task::TransactionOutput::set_txn_output_for_non_dynamic_change_set(output);
+                    let committed_output = output.committed_output();
+                    if !committed_output.status().is_retry() {
+                        return Err(code_invariant_error(format!(
+                            "Block limit cannot be reached on StateCheckpoint transaction, as it is free and empty. {:?}",
+                            committed_output,
+                        )));
+                    }
+
+                    let events = vec![];
+                    let status = TransactionStatus::Keep(aptos_types::transaction::ExecutionStatus::Success);
+                    *output = AptosTransactionOutput::new_from_committed_output(TransactionOutput::new(WriteSet::default(), events, 0, status));
+                    Ok(())
+                },
+                valid_txn => {
+                    Err(code_invariant_error(format!(
+                        "Last transaction in a block where limit is reached is not StateCheckpoint, but: {}",
+                        valid_txn.type_name()
+                    )))
+                },
+            }
+        } else {
+            Err(code_invariant_error("When block limit is used, last transaction (should be StateCheckpoint or genesis) must not be invalid"))
         }
     }
 

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use anyhow::bail;
 use aptos_aggregator::{
     delta_math::DeltaHistory,
@@ -335,8 +336,6 @@ impl<T: Transaction> CapturedReads<T> {
         &'a self,
         skip: &'a HashSet<T::Key>,
     ) -> impl Iterator<Item = (&T::Key, &GroupRead<T>)> {
-        // TODO[agg_v2](optimize) - We could potentially filter out inner_reads
-        // to only contain those that have Some(layout)
         self.group_reads.iter().filter(|(key, group_read)| {
             !skip.contains(key)
                 && group_read
@@ -662,12 +661,79 @@ impl<T: Transaction> CapturedReads<T> {
         Ok(true)
     }
 
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for (key, read) in &self.data_reads {
+            if let DataRead::Versioned(_, _, _) = read {
+                ret.insert(InputOutputKey::Resource(key.clone()));
+            }
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for (tag, read) in &group_reads.inner_reads {
+                if let DataRead::Versioned(_, _, _) = read {
+                    ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+                }
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, read) in &self.delayed_field_reads {
+            if let DelayedFieldRead::Value { .. } = read {
+                ret.insert(InputOutputKey::DelayedField(*key));
+            }
+        }
+
+        ret
+    }
+
     pub(crate) fn mark_failure(&mut self) {
         self.speculative_failure = true;
     }
 
     pub(crate) fn mark_incorrect_use(&mut self) {
         self.incorrect_use = true;
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default(bound = "", new = "true"))]
+pub(crate) struct UnsyncReadSet<T: Transaction> {
+    pub(crate) resource_reads: HashSet<T::Key>,
+    pub(crate) module_reads: HashSet<T::Key>,
+    pub(crate) group_reads: HashMap<T::Key, HashSet<T::Tag>>,
+    pub(crate) delayed_field_reads: HashSet<T::Identifier>,
+}
+
+impl<T: Transaction> UnsyncReadSet<T> {
+    pub(crate) fn get_read_summary(
+        &self,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        let mut ret = HashSet::new();
+        for key in &self.resource_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for (key, group_reads) in &self.group_reads {
+            for tag in group_reads {
+                ret.insert(InputOutputKey::Group(key.clone(), tag.clone()));
+            }
+        }
+
+        for key in &self.module_reads {
+            ret.insert(InputOutputKey::Resource(key.clone()));
+        }
+
+        for key in &self.delayed_field_reads {
+            ret.insert(InputOutputKey::DelayedField(*key));
+        }
+
+        ret
     }
 }
 

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -26,34 +26,6 @@ impl Mode {
     pub const SEQUENTIAL: &'static str = "sequential";
 }
 
-/// Record the block gas during parallel execution.
-fn observe_parallel_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during parallel execution.
-fn observe_parallel_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::PARALLEL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the block gas during sequential execution.
-fn observe_sequential_execution_block_gas(cost: u64, gas_type: &'static str) {
-    BLOCK_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
-/// Record the txn gas during sequential execution.
-fn observe_sequential_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    TXN_GAS
-        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
-        .observe(cost as f64);
-}
-
 /// Count of times the module publishing fallback was triggered in parallel execution.
 pub static MODULE_PUBLISHING_FALLBACK_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -77,6 +49,16 @@ pub static EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| 
     register_int_counter_vec!(
         "aptos_execution_gas_limit_count",
         "Count of times the BlockSTM is early halted due to exceeding the per-block gas limit",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+/// Count of times the BlockSTM is early halted due to exceeding the per-block output size limit.
+pub static EXCEED_PER_BLOCK_OUTPUT_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_execution_output_limit_count",
+        "Count of times the BlockSTM is early halted due to exceeding the per-block output size limit",
         &["mode"]
     )
     .unwrap()
@@ -166,6 +148,25 @@ pub static BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static EFFECTIVE_BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_effective_block_gas",
+        "Histogram for different effective block gas costs - used for evaluating block gas limit. \
+        This can be different from actual gas consumed in a block, due to applied adjustements",
+        &["mode"]
+    )
+    .unwrap()
+});
+
+pub static APPROX_BLOCK_OUTPUT_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_execution_approx_block_output_size",
+        "Historgram for different approx block output sizes - used for evaluting block ouptut limit.",
+        &["mode"]
+    )
+    .unwrap()
+});
+
 pub static TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_execution_txn_gas",
@@ -185,100 +186,67 @@ pub static BLOCK_COMMITTED_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) fn update_parallel_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_parallel_execution_block_gas(accumulated_fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_parallel_execution_block_gas(accumulated_fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_parallel_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
+fn observe_gas(counter: &Lazy<HistogramVec>, mode_str: &str, fee_statement: &FeeStatement) {
+    counter
+        .with_label_values(&[mode_str, GasType::TOTAL_GAS])
+        .observe(fee_statement.gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::EXECUTION_GAS])
+        .observe(fee_statement.execution_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::IO_GAS])
+        .observe(fee_statement.io_gas_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::NON_STORAGE_GAS])
+        .observe((fee_statement.execution_gas_used() + fee_statement.io_gas_used()) as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE])
+        .observe(fee_statement.storage_fee_used() as f64);
+
+    counter
+        .with_label_values(&[mode_str, GasType::STORAGE_FEE_REFUND])
+        .observe(fee_statement.storage_fee_refund() as f64);
 }
 
-pub(crate) fn update_parallel_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>) {
+pub(crate) fn update_block_gas_counters(
+    accumulated_fee_statement: &FeeStatement,
+    accumulated_effective_gas: u64,
+    accumulated_approx_output_size: u64,
+    num_committed: usize,
+    is_parallel: bool,
+) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
+    observe_gas(&BLOCK_GAS, mode_str, accumulated_fee_statement);
+    BLOCK_COMMITTED_TXNS
+        .with_label_values(&[mode_str])
+        .observe(num_committed as f64);
+
+    EFFECTIVE_BLOCK_GAS
+        .with_label_values(&[mode_str])
+        .observe(accumulated_effective_gas as f64);
+
+    APPROX_BLOCK_OUTPUT_SIZE
+        .with_label_values(&[mode_str])
+        .observe(accumulated_approx_output_size as f64);
+}
+
+pub(crate) fn update_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>, is_parallel: bool) {
+    let mode_str = if is_parallel {
+        Mode::PARALLEL
+    } else {
+        Mode::SEQUENTIAL
+    };
+
     for fee_statement in txn_fee_statements {
-        observe_parallel_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-        observe_parallel_execution_txn_gas(
-            fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        observe_parallel_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-        observe_parallel_execution_txn_gas(
-            fee_statement.storage_fee_refund(),
-            GasType::STORAGE_FEE_REFUND,
-        );
+        observe_gas(&TXN_GAS, mode_str, fee_statement);
     }
-}
-
-pub(crate) fn update_sequential_block_gas_counters(
-    accumulated_fee_statement: &FeeStatement,
-    num_committed: usize,
-) {
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.gas_used(),
-        GasType::TOTAL_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.io_gas_used(),
-        GasType::IO_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.execution_gas_used() + accumulated_fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_used(),
-        GasType::STORAGE_FEE,
-    );
-    observe_sequential_execution_block_gas(
-        accumulated_fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
-    BLOCK_COMMITTED_TXNS
-        .with_label_values(&[Mode::PARALLEL])
-        .observe(num_committed as f64);
-}
-
-pub(crate) fn update_sequential_txn_gas_counters(fee_statement: &FeeStatement) {
-    observe_sequential_execution_txn_gas(fee_statement.gas_used(), GasType::TOTAL_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used(),
-        GasType::EXECUTION_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.io_gas_used(), GasType::IO_GAS);
-    observe_sequential_execution_txn_gas(
-        fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-        GasType::NON_STORAGE_GAS,
-    );
-    observe_sequential_execution_txn_gas(fee_statement.storage_fee_used(), GasType::STORAGE_FEE);
-    observe_sequential_execution_txn_gas(
-        fee_statement.storage_fee_refund(),
-        GasType::STORAGE_FEE_REFUND,
-    );
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -10,10 +10,12 @@ use crate::{
     },
     errors::*,
     explicit_sync_wrapper::ExplicitSyncWrapper,
+    limit_processor::BlockGasLimitProcessor,
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     task::{ExecutionStatus, ExecutorTask, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::{KeyKind, TxnLastInputOutput},
+    types::ReadWriteSummary,
     view::{LatestView, ParallelState, SequentialState, ViewState},
 };
 use aptos_aggregator::{
@@ -35,7 +37,7 @@ use aptos_types::{
     block_executor::config::BlockExecutorConfig,
     contract_event::TransactionEvent,
     executable::Executable,
-    fee_statement::FeeStatement,
+    on_chain_config::BlockGasLimitType,
     transaction::BlockExecutableTransaction as Transaction,
     write_set::{TransactionWrite, WriteOp},
 };
@@ -57,9 +59,8 @@ use std::{
 pub struct BlockExecutor<T, E, S, L, X> {
     // Number of active concurrent tasks, corresponding to the maximum number of rayon
     // threads that may be concurrently participating in parallel execution.
-    concurrency_level: usize,
+    config: BlockExecutorConfig,
     executor_thread_pool: Arc<ThreadPool>,
-    maybe_block_gas_limit: Option<u64>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<(T, E, S, L, X)>,
 }
@@ -85,9 +86,8 @@ where
             config.local.concurrency_level
         );
         Self {
-            concurrency_level: config.local.concurrency_level,
+            config,
             executor_thread_pool,
-            maybe_block_gas_limit: config.onchain.block_gas_limit_type.block_gas_limit(),
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -118,7 +118,7 @@ where
             .delayed_field_keys(idx_to_execute)
             .map_or(HashSet::new(), |keys| keys.collect());
 
-        let mut read_set = sync_view.take_reads();
+        let mut read_set = sync_view.take_parallel_reads();
 
         // For tracking whether the recent execution wrote outside of the previous write/delta set.
         let mut updates_outside = false;
@@ -404,6 +404,19 @@ where
         Ok(execution_still_valid)
     }
 
+    fn get_txn_read_write_summary(
+        txn_idx: TxnIndex,
+        last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
+    ) -> ReadWriteSummary<T> {
+        let read_set = last_input_output
+            .read_set(txn_idx)
+            .expect("Read set must be recorded");
+
+        let reads = read_set.get_read_summary();
+        let writes = last_input_output.get_write_summary(txn_idx);
+        ReadWriteSummary::new(reads, writes)
+    }
+
     /// This method may be executed by different threads / workers, but is guaranteed to be executed
     /// non-concurrently by the scheduling in parallel executor. This allows to perform light logic
     /// related to committing a transaction in a simple way and without excessive synchronization
@@ -414,14 +427,13 @@ where
     /// way, the materialization can be almost embarassingly parallelizable.
     fn prepare_and_queue_commit_ready_txns(
         &self,
-        maybe_block_gas_limit: Option<u64>,
+        block_gas_limit_type: &BlockGasLimitType,
         scheduler: &Scheduler,
         versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         scheduler_task: &mut SchedulerTask,
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         shared_commit_state: &ExplicitSyncWrapper<(
-            FeeStatement,
-            Vec<FeeStatement>,
+            BlockGasLimitProcessor<T>,
             Option<Error<E::Error>>,
         )>,
         base_view: &S,
@@ -431,30 +443,7 @@ where
         block: &[T],
     ) -> ::std::result::Result<(), PanicOr<IntentionalFallbackToSequential>> {
         let mut shared_commit_state_guard = shared_commit_state.acquire();
-        let (accumulated_fee_statement, txn_fee_statements, shared_maybe_error) =
-            shared_commit_state_guard.dereference_mut();
-
-        let update_counters_and_log_info =
-            |txn_idx: u32,
-             accumulated_fee_statement: &mut FeeStatement,
-             txn_fee_statements: &mut Vec<FeeStatement>| {
-                counters::update_parallel_block_gas_counters(
-                    accumulated_fee_statement,
-                    (txn_idx + 1) as usize,
-                );
-                counters::update_parallel_txn_gas_counters(txn_fee_statements);
-
-                let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                    + accumulated_fee_statement.io_gas_used();
-                info!(
-                    "[BlockSTM]: Parallel execution completed. {} out of {} txns committed. \
-		         accumulated_non_storage_gas = {}, limit = {:?}",
-                    txn_idx + 1,
-                    scheduler.num_txns(),
-                    accumulated_non_storage_gas,
-                    maybe_block_gas_limit,
-                );
-            };
+        let (accumulator, shared_maybe_error) = shared_commit_state_guard.dereference_mut();
 
         while let Some((txn_idx, incarnation)) = scheduler.try_commit() {
             if !Self::validate_commit_ready(txn_idx, versioned_cache, last_input_output)? {
@@ -502,30 +491,28 @@ where
             }
 
             if let Some(fee_statement) = last_input_output.fee_statement(txn_idx) {
+                let approx_output_size = if block_gas_limit_type.block_output_limit().is_some() {
+                    last_input_output.output_approx_size(txn_idx)
+                } else {
+                    None
+                };
+                let txn_read_write_summary =
+                    if block_gas_limit_type.conflict_penalty_window().is_some() {
+                        Some(Self::get_txn_read_write_summary(txn_idx, last_input_output))
+                    } else {
+                        None
+                    };
+
                 // For committed txns with Success status, calculate the accumulated gas costs.
-                accumulated_fee_statement.add_fee_statement(&fee_statement);
-                txn_fee_statements.push(fee_statement);
+                accumulator.accumulate_fee_statement(
+                    fee_statement,
+                    txn_read_write_summary,
+                    approx_output_size,
+                );
 
-                if let Some(per_block_gas_limit) = maybe_block_gas_limit {
-                    // When the accumulated execution and io gas of the committed txns exceeds
-                    // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage gas does not count towards
-                    // the per block gas limit, as we measure execution related cost here.
-                    let accumulated_non_storage_gas = accumulated_fee_statement
-                        .execution_gas_used()
-                        + accumulated_fee_statement.io_gas_used();
-                    if accumulated_non_storage_gas >= per_block_gas_limit {
-                        counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
-                            .with_label_values(&[counters::Mode::PARALLEL])
-                            .inc();
-                        info!(
-                            "[BlockSTM]: Parallel execution early halted due to \
-                             accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}",
-                            accumulated_non_storage_gas, per_block_gas_limit,
-                        );
-
-                        // Set the execution output status to be SkipRest, to skip the rest of the txns.
-                        last_input_output.update_to_skip_rest(txn_idx);
-                    }
+                if accumulator.should_end_block_parallel() {
+                    // Set the execution output status to be SkipRest, to skip the rest of the txns.
+                    last_input_output.update_to_skip_rest(txn_idx);
                 }
             }
 
@@ -620,10 +607,9 @@ where
                         "Block execution was aborted due to {:?}",
                         shared_maybe_error.as_ref().unwrap()
                     );
-                    update_counters_and_log_info(
-                        txn_idx,
-                        accumulated_fee_statement,
-                        txn_fee_statements,
+                    accumulator.finish_parallel_update_counters_and_log_info(
+                        txn_idx + 1,
+                        scheduler.num_txns(),
                     );
                 } // else it's already halted
                 break;
@@ -642,10 +628,9 @@ where
                 }
 
                 if scheduler.halt() {
-                    update_counters_and_log_info(
-                        txn_idx,
-                        accumulated_fee_statement,
-                        txn_fee_statements,
+                    accumulator.finish_parallel_update_counters_and_log_info(
+                        txn_idx + 1,
+                        scheduler.num_txns(),
                     );
                 }
                 break;
@@ -961,8 +946,7 @@ where
         start_shared_counter: u32,
         shared_counter: &AtomicU32,
         shared_commit_state: &ExplicitSyncWrapper<(
-            FeeStatement,
-            Vec<FeeStatement>,
+            BlockGasLimitProcessor<T>,
             Option<Error<E::Error>>,
         )>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
@@ -996,7 +980,7 @@ where
             // Priorotize committing validated transactions
             while scheduler.should_coordinate_commits() {
                 self.prepare_and_queue_commit_ready_txns(
-                    self.maybe_block_gas_limit,
+                    &self.config.onchain.block_gas_limit_type,
                     scheduler,
                     versioned_cache,
                     &mut scheduler_task,
@@ -1078,7 +1062,10 @@ where
         // will only have a coordinator role but no workers for rolling commit.
         // Need to special case no roles (commit hook by thread itself) to run
         // w. concurrency_level = 1 for some reason.
-        assert!(self.concurrency_level > 1, "Must use sequential execution");
+        assert!(
+            self.config.local.concurrency_level > 1,
+            "Must use sequential execution"
+        );
 
         let versioned_cache = MVHashMap::new();
         let start_shared_counter = gen_id_start_value(false);
@@ -1091,8 +1078,7 @@ where
         let num_txns = signature_verified_block.len();
 
         let shared_commit_state = ExplicitSyncWrapper::new((
-            FeeStatement::zero(),
-            Vec::<FeeStatement>::with_capacity(num_txns),
+            BlockGasLimitProcessor::new(self.config.onchain.block_gas_limit_type.clone(), num_txns),
             None,
         ));
 
@@ -1111,7 +1097,7 @@ where
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
         self.executor_thread_pool.scope(|s| {
-            for _ in 0..self.concurrency_level {
+            for _ in 0..self.config.local.concurrency_level {
                 s.spawn(|_| {
                     if let Err(e) = self.worker_loop(
                         &executor_initial_arguments,
@@ -1127,7 +1113,7 @@ where
                     ) {
                         if scheduler.halt() {
                             let mut shared_commit_state_guard = shared_commit_state.acquire();
-                            let (_, _, maybe_error) = shared_commit_state_guard.dereference_mut();
+                            let (_, maybe_error) = shared_commit_state_guard.dereference_mut();
                             *maybe_error = Some(Error::FallbackToSequential(e));
                         }
                     }
@@ -1137,7 +1123,7 @@ where
         drop(timer);
         // Explicit async drops.
         DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
-        let (_, _, maybe_error) = shared_commit_state.into_inner();
+        let (_, maybe_error) = shared_commit_state.into_inner();
         match maybe_error {
             Some(err) => Err(err),
             None => Ok(final_results.into_inner()),
@@ -1238,7 +1224,10 @@ where
         let counter = RefCell::new(start_counter);
         let unsync_map = UnsyncMap::new();
         let mut ret = Vec::with_capacity(num_txns);
-        let mut accumulated_fee_statement = FeeStatement::zero();
+        let mut accumulator = BlockGasLimitProcessor::<T>::new(
+            self.config.onchain.block_gas_limit_type.clone(),
+            num_txns,
+        );
 
         for (idx, txn) in signature_verified_block.iter().enumerate() {
             let latest_view = LatestView::<T, S, X>::new(
@@ -1256,17 +1245,47 @@ where
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
                 ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                    // Calculating the accumulated gas costs of the committed txns.
+                    let fee_statement = output.fee_statement();
+
+                    let approx_output_size = if self
+                        .config
+                        .onchain
+                        .block_gas_limit_type
+                        .block_output_limit()
+                        .is_some()
+                    {
+                        Some(output.output_approx_size())
+                    } else {
+                        None
+                    };
+
+                    let read_write_summary = if self
+                        .config
+                        .onchain
+                        .block_gas_limit_type
+                        .conflict_penalty_window()
+                        .is_some()
+                    {
+                        Some(ReadWriteSummary::new(
+                            latest_view.take_sequential_reads().get_read_summary(),
+                            output.get_write_summary(),
+                        ))
+                    } else {
+                        None
+                    };
+                    accumulator.accumulate_fee_statement(
+                        fee_statement,
+                        read_write_summary,
+                        approx_output_size,
+                    );
+
                     output.materialize_agg_v1(&latest_view);
                     assert_eq!(
                         output.aggregator_v1_delta_set().len(),
                         0,
                         "Sequential execution must materialize deltas"
                     );
-
-                    // Calculating the accumulated gas costs of the committed txns.
-                    let fee_statement = output.fee_statement();
-                    accumulated_fee_statement.add_fee_statement(&fee_statement);
-                    counters::update_sequential_txn_gas_counters(&fee_statement);
 
                     // Apply the writes.
                     // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
@@ -1400,41 +1419,14 @@ where
                 break;
             }
 
-            if let Some(per_block_gas_limit) = self.maybe_block_gas_limit {
-                // When the accumulated gas of the committed txns
-                // exceeds per_block_gas_limit, halt sequential execution.
-                let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                    + accumulated_fee_statement.io_gas_used();
-                if accumulated_non_storage_gas >= per_block_gas_limit {
-                    counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
-                        .with_label_values(&[counters::Mode::SEQUENTIAL])
-                        .inc();
-                    info!(
-                        "[Execution]: Sequential execution early halted due to \
-                        accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed.",
-                        accumulated_non_storage_gas,
-                        per_block_gas_limit,
-                        ret.len()
-                    );
-                    break;
-                }
+            if accumulator.should_end_block_sequential() {
+                break;
             }
         }
 
-        if ret.len() == num_txns {
-            let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
-                + accumulated_fee_statement.io_gas_used();
-            info!(
-                "[Execution]: Sequential execution completed. \
-		 {} out of {} txns committed. accumulated_non_storage_gas = {}, limit = {:?}",
-                ret.len(),
-                num_txns,
-                accumulated_non_storage_gas,
-                self.maybe_block_gas_limit,
-            );
-        }
+        accumulator
+            .finish_sequential_update_counters_and_log_info(ret.len() as u32, num_txns as u32);
 
-        counters::update_sequential_block_gas_counters(&accumulated_fee_statement, ret.len());
         ret.resize_with(num_txns, E::Output::skip_output);
         Ok(ret)
     }
@@ -1448,7 +1440,9 @@ where
         let dynamic_change_set_optimizations_enabled = signature_verified_block.len() != 1
             || E::is_transaction_dynamic_change_set_capable(&signature_verified_block[0]);
 
-        let mut ret = if self.concurrency_level > 1 && dynamic_change_set_optimizations_enabled {
+        let mut ret = if self.config.local.concurrency_level > 1
+            && dynamic_change_set_optimizations_enabled
+        {
             self.execute_transactions_parallel(
                 executor_arguments,
                 signature_verified_block,
@@ -1465,7 +1459,7 @@ where
 
         // Sequential execution fallback
         // Only worth doing if we did parallel before, i.e. if we did a different pass.
-        if self.concurrency_level > 1 {
+        if self.config.local.concurrency_level > 1 {
             if let Err(Error::FallbackToSequential(e)) = &ret {
                 match e {
                     PanicOr::Or(IntentionalFallbackToSequential::ModulePathReadWrite) => {

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -144,12 +144,14 @@ pub mod counters;
 pub mod errors;
 pub mod executor;
 pub mod explicit_sync_wrapper;
+mod limit_processor;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 mod scheduler;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;
+pub mod types;
 #[cfg(test)]
 mod unit_tests;
 pub mod view;

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -1,0 +1,206 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{counters, types::ReadWriteSummary};
+use aptos_logger::info;
+use aptos_types::{
+    fee_statement::FeeStatement, on_chain_config::BlockGasLimitType,
+    transaction::BlockExecutableTransaction as Transaction,
+};
+use claims::assert_le;
+
+pub struct BlockGasLimitProcessor<T: Transaction> {
+    block_gas_limit_type: BlockGasLimitType,
+    accumulated_effective_block_gas: u64,
+    accumulated_approx_output_size: u64,
+    accumulated_fee_statement: FeeStatement,
+    txn_fee_statements: Vec<FeeStatement>,
+    txn_read_write_summaries: Vec<ReadWriteSummary<T>>,
+}
+
+impl<T: Transaction> BlockGasLimitProcessor<T> {
+    pub fn new(block_gas_limit_type: BlockGasLimitType, init_size: usize) -> Self {
+        Self {
+            block_gas_limit_type,
+            accumulated_effective_block_gas: 0,
+            accumulated_approx_output_size: 0,
+            accumulated_fee_statement: FeeStatement::zero(),
+            txn_fee_statements: Vec::with_capacity(init_size),
+            txn_read_write_summaries: Vec::with_capacity(init_size),
+        }
+    }
+
+    pub(crate) fn accumulate_fee_statement(
+        &mut self,
+        fee_statement: FeeStatement,
+        txn_read_write_summary: Option<ReadWriteSummary<T>>,
+        approx_output_size: Option<u64>,
+    ) {
+        self.accumulated_fee_statement
+            .add_fee_statement(&fee_statement);
+        self.txn_fee_statements.push(fee_statement);
+
+        let conflict_multiplier = if let Some(conflict_overlap_length) =
+            self.block_gas_limit_type.conflict_penalty_window()
+        {
+            self.txn_read_write_summaries.push(
+                if self
+                    .block_gas_limit_type
+                    .use_granular_resource_group_conflicts()
+                {
+                    txn_read_write_summary.unwrap()
+                } else {
+                    txn_read_write_summary
+                        .unwrap()
+                        .collapse_resource_group_conflicts()
+                },
+            );
+            self.compute_conflict_multiplier(conflict_overlap_length as usize)
+        } else {
+            1
+        };
+
+        // println!("[{}] Multiplier {}, with read/write summary: {:?}", self.txn_fee_statements.len() - 1, conflict_multiplier, self.txn_read_write_summaries.last());
+
+        // When the accumulated execution and io gas of the committed txns exceeds
+        // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage fee does not count towards
+        // the per block gas limit, as we measure execution related cost here.
+        self.accumulated_effective_block_gas += conflict_multiplier
+            * (fee_statement.execution_gas_used()
+                * self
+                    .block_gas_limit_type
+                    .execution_gas_effective_multiplier()
+                + fee_statement.io_gas_used()
+                    * self.block_gas_limit_type.io_gas_effective_multiplier());
+
+        self.accumulated_approx_output_size += approx_output_size.unwrap_or(0);
+    }
+
+    fn should_end_block(&self, is_parallel: bool) -> bool {
+        let mode = if is_parallel {
+            counters::Mode::PARALLEL
+        } else {
+            counters::Mode::SEQUENTIAL
+        };
+        if let Some(per_block_gas_limit) = self.block_gas_limit_type.block_gas_limit() {
+            // When the accumulated block gas of the committed txns exceeds
+            // PER_BLOCK_GAS_LIMIT, early halt BlockSTM.
+            let accumulated_block_gas = self.get_effective_accumulated_block_gas();
+            if accumulated_block_gas >= per_block_gas_limit {
+                counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                    .with_label_values(&[mode])
+                    .inc();
+                info!(
+                    "[BlockSTM]: execution (is_parallel = {}) early halted due to \
+                    accumulated_block_gas {} >= PER_BLOCK_GAS_LIMIT {}",
+                    is_parallel, accumulated_block_gas, per_block_gas_limit,
+                );
+
+                return true;
+            }
+        }
+
+        if let Some(per_block_output_limit) = self.block_gas_limit_type.block_output_limit() {
+            let accumulated_output = self.get_accumulated_approx_output_size();
+            if accumulated_output >= per_block_output_limit {
+                counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                    .with_label_values(&[mode])
+                    .inc();
+                info!(
+                    "[BlockSTM]: execution (is_parallel = {}) early halted due to \
+                    accumulated_output {} >= PER_BLOCK_OUTPUT_LIMIT {}",
+                    is_parallel, accumulated_output, per_block_output_limit,
+                );
+
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub(crate) fn should_end_block_parallel(&self) -> bool {
+        self.should_end_block(true)
+    }
+
+    pub(crate) fn should_end_block_sequential(&self) -> bool {
+        self.should_end_block(false)
+    }
+
+    fn get_effective_accumulated_block_gas(&self) -> u64 {
+        self.accumulated_effective_block_gas
+    }
+
+    fn get_accumulated_approx_output_size(&self) -> u64 {
+        self.accumulated_approx_output_size
+    }
+
+    fn compute_conflict_multiplier(&self, conflict_overlap_length: usize) -> u64 {
+        let start = self
+            .txn_read_write_summaries
+            .len()
+            .saturating_sub(conflict_overlap_length);
+        let end = self.txn_read_write_summaries.len() - 1;
+
+        let mut conflict_count = 0;
+        let current = &self.txn_read_write_summaries[end];
+        for prev in &self.txn_read_write_summaries[start..end] {
+            if current.conflicts_with_previous(prev) {
+                conflict_count += 1;
+            }
+        }
+        assert_le!(conflict_count + 1, conflict_overlap_length);
+        (conflict_count + 1) as u64
+    }
+
+    fn finish_update_counters_and_log_info(
+        &self,
+        is_parallel: bool,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        let accumulated_effective_block_gas = self.get_effective_accumulated_block_gas();
+        let accumulated_approx_output_size = self.get_accumulated_approx_output_size();
+
+        counters::update_block_gas_counters(
+            &self.accumulated_fee_statement,
+            accumulated_effective_block_gas,
+            accumulated_approx_output_size,
+            num_committed as usize,
+            is_parallel,
+        );
+        counters::update_txn_gas_counters(&self.txn_fee_statements, is_parallel);
+
+        info!(
+            "[BlockSTM]: {} execution completed. {} out of {} txns committed. \
+            accumulated_effective_block_gas = {}, limit = {:?}",
+            if is_parallel {
+                "Parallel"
+            } else {
+                "Sequential"
+            },
+            num_committed,
+            num_total,
+            accumulated_effective_block_gas,
+            self.block_gas_limit_type,
+        );
+    }
+
+    pub(crate) fn finish_parallel_update_counters_and_log_info(
+        &self,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        self.finish_update_counters_and_log_info(true, num_committed, num_total)
+    }
+
+    pub(crate) fn finish_sequential_update_counters_and_log_info(
+        &self,
+        num_committed: u32,
+        num_total: u32,
+    ) {
+        self.finish_update_counters_and_log_info(false, num_committed, num_total)
+    }
+}
+
+// TODO: add tests for accumulate_fee_statement / compute_conflict_multiplier for different BlockGasLimitType configs

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -17,6 +17,7 @@ use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
+    aggregator::PanicError,
     contract_event::TransactionEvent,
     executable::ModulePath,
     fee_statement::FeeStatement,
@@ -963,6 +964,14 @@ where
             MockTransaction::SkipRest => ExecutionStatus::SkipRest(MockOutput::skip_output()),
             MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
+    }
+
+    fn execute_skipped_checkpoint(
+        _txn: &Self::Txn,
+        _output: &mut Self::Output,
+    ) -> Result<(), PanicError> {
+        // no distinction of whether it is skip_output or not
+        Ok(())
     }
 
     fn is_transaction_dynamic_change_set_capable(_txn: &Self::Txn) -> bool {

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1132,6 +1132,23 @@ where
             0,
         )
     }
+
+    fn output_approx_size(&self) -> u64 {
+        // TODO add block output limit testing
+        0
+    }
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        crate::types::InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    > {
+        HashSet::new()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,8 +8,8 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    fee_statement::FeeStatement, transaction::BlockExecutableTransaction as Transaction,
-    write_set::WriteOp,
+    aggregator::PanicError, fee_statement::FeeStatement,
+    transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
@@ -82,6 +82,11 @@ pub trait ExecutorTask: Sync {
         txn: &Self::Txn,
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
+
+    fn execute_skipped_checkpoint(
+        txn: &Self::Txn,
+        output: &mut Self::Output,
+    ) -> Result<(), PanicError>;
 
     fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool;
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::types::InputOutputKey;
 use aptos_aggregator::{
     delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
 };
@@ -12,7 +13,11 @@ use aptos_types::{
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
 use move_core_types::value::MoveTypeLayout;
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Debug,
+    sync::Arc,
+};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -182,4 +187,16 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     /// Return the fee statement of the transaction.
     fn fee_statement(&self) -> FeeStatement;
+
+    fn output_approx_size(&self) -> u64;
+
+    fn get_write_summary(
+        &self,
+    ) -> HashSet<
+        InputOutputKey<
+            <Self::Txn as Transaction>::Key,
+            <Self::Txn as Transaction>::Tag,
+            <Self::Txn as Transaction>::Identifier,
+        >,
+    >;
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -6,6 +6,7 @@ use crate::{
     errors::{Error, IntentionalFallbackToSequential},
     explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
+    types::InputOutputKey,
 };
 use aptos_aggregator::types::PanicOr;
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
@@ -18,7 +19,7 @@ use crossbeam::utils::CachePadded;
 use dashmap::DashSet;
 use move_core_types::value::MoveTypeLayout;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     iter::{empty, Iterator},
     sync::{
@@ -173,6 +174,19 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 Some(output.fee_statement())
+            },
+            _ => None,
+        }
+    }
+
+    pub(crate) fn output_approx_size(&self, txn_idx: TxnIndex) -> Option<u64> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("[BlockSTM]: Execution output must be recorded after execution")
+            .output_status
+        {
+            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                Some(output.output_approx_size())
             },
             _ => None,
         }
@@ -418,6 +432,23 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {},
         };
+    }
+
+    pub(crate) fn get_write_summary(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
+        match &self.outputs[txn_idx as usize]
+            .load_full()
+            .expect("Output must exist")
+            .output_status
+        {
+            ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
+            ExecutionStatus::Abort(_)
+            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
+            | ExecutionStatus::SpeculativeExecutionAbortError(_)
+            | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => HashSet::new(),
+        }
     }
 
     // Must be executed after parallel execution is done, grabs outputs. Will panic if

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -1,0 +1,56 @@
+// Copyright © Aptos Foundation
+
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::{collections::HashSet, fmt};
+
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum InputOutputKey<K, T, I> {
+    Resource(K),
+    Group(K, T),
+    DelayedField(I),
+}
+
+pub struct ReadWriteSummary<T: Transaction> {
+    reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+}
+
+impl<T: Transaction> ReadWriteSummary<T> {
+    pub fn new(
+        reads: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+        writes: HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>>,
+    ) -> Self {
+        Self { reads, writes }
+    }
+
+    pub fn conflicts_with_previous(&self, previous: &Self) -> bool {
+        !self.reads.is_disjoint(&previous.writes)
+    }
+
+    pub fn collapse_resource_group_conflicts(self) -> Self {
+        let collapse = |k: InputOutputKey<T::Key, T::Tag, T::Identifier>| match k {
+            InputOutputKey::Resource(k) => InputOutputKey::Resource(k),
+            InputOutputKey::Group(k, _) => InputOutputKey::Resource(k),
+            InputOutputKey::DelayedField(id) => InputOutputKey::DelayedField(id),
+        };
+        Self {
+            reads: self.reads.into_iter().map(collapse).collect(),
+            writes: self.writes.into_iter().map(collapse).collect(),
+        }
+    }
+}
+
+impl<T: Transaction> fmt::Debug for ReadWriteSummary<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "ReadWriteSummary")?;
+        writeln!(f, "reads:")?;
+        for read in &self.reads {
+            writeln!(f, "    {:?}", read)?;
+        }
+        writeln!(f, "writes:")?;
+        for write in &self.writes {
+            writeln!(f, "    {:?}", write)?;
+        }
+        Ok(())
+    }
+}

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -40,8 +40,8 @@ use aptos_types::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     on_chain_config::{
-        BlockGasLimitType, FeatureFlag, Features, OnChainConfig, TimedFeatureOverride,
-        TimedFeaturesBuilder, ValidatorSet, Version,
+        FeatureFlag, Features, OnChainConfig, TimedFeatureOverride, TimedFeaturesBuilder,
+        ValidatorSet, Version,
     },
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -516,10 +516,8 @@ impl FakeExecutor {
             }
         });
 
-        let onchain_config = BlockExecutorConfigFromOnchain {
-            // TODO fetch values from state?
-            block_gas_limit_type: BlockGasLimitType::Limit(30000),
-        };
+        // TODO fetch values from state?
+        let onchain_config = BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
         let sequential_output = if mode != ExecutorMode::ParallelOnly {
             Some(AptosVM::execute_block(

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -444,8 +444,14 @@ impl FakeExecutor {
             txn_block
                 .into_iter()
                 .map(Transaction::UserTransaction)
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect(),
         )
+        .map(|mut results| {
+            let result = results.pop().unwrap();
+            println!("Execution result for StateCheckpoint: {:?}", result);
+            results
+        })
     }
 
     /// Executes the transaction as a singleton block and applies the resulting write set to the

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -122,14 +122,12 @@ impl ExecutionPipeline {
         }
         let validator_txns = block.validator_txns().cloned().unwrap_or_default();
         let input_txns = input_txns.unwrap();
-        let is_block_gas_limit = block_executor_onchain_config.has_any_block_gas_limit();
         tokio::task::spawn_blocking(move || {
             let txns_to_execute = Block::transactions_to_execute_for_metadata(
                 block.id(),
                 validator_txns,
                 input_txns.clone(),
                 metadata,
-                is_block_gas_limit,
             );
             let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
                 SIG_VERIFY_POOL.install(|| {

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -64,7 +64,6 @@ impl TxnNotifier for DummyTxnNotifier {
         &self,
         _txns: Vec<SignedTransaction>,
         _compute_results: &StateComputeResult,
-        _block_gas_limit_enabled: bool,
     ) -> anyhow::Result<(), MempoolError> {
         Ok(())
     }

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,12 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_temppath::TempPath;
 use rand::{rngs::StdRng, SeedableRng};
 
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
+    test_config_with_custom_onchain(None)
+}
+
+pub fn test_config_with_custom_onchain(
+    init_genesis_config: Option<InitGenesisConfigFn>,
+) -> (NodeConfig, Ed25519PrivateKey) {
     let path = TempPath::new();
     path.create_as_dir().unwrap();
     let (root_key, _genesis, _genesis_waypoint, validators) = crate::builder::Builder::new(
@@ -14,6 +21,7 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         aptos_cached_packages::head_release_bundle().clone(),
     )
     .unwrap()
+    .with_init_genesis_config(init_genesis_config)
     .build(StdRng::from_seed([0; 32]))
     .unwrap();
     let (

--- a/execution/executor-benchmark/src/db_reliable_submitter.rs
+++ b/execution/executor-benchmark/src/db_reliable_submitter.rs
@@ -2,10 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    db_access::{CoinStore, DbAccessUtil},
-    transaction_executor::BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-};
+use crate::db_access::{CoinStore, DbAccessUtil};
 use anyhow::{Context, Result};
 use aptos_crypto::HashValue;
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
@@ -58,10 +55,7 @@ impl ReliableTransactionSubmitter for DbReliableTransactionSubmitter {
         self.block_sender.send(
             txns.iter()
                 .map(|t| Transaction::UserTransaction(t.clone()))
-                .chain(
-                    (!BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit())
-                        .then_some(Transaction::StateCheckpoint(HashValue::random())),
-                )
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect(),
         )?;
 

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -181,6 +181,11 @@ where
                     executed
                 );
                 info!(
+                    "Overall execution effectiveGPS: {} gas/s (over {} txns)",
+                    delta_gas.effective_block_gas / elapsed,
+                    executed
+                );
+                info!(
                     "Overall execution ioGPS: {} gas/s (over {} txns)",
                     delta_gas.io_gas / elapsed,
                     executed
@@ -194,6 +199,10 @@ where
                     "Overall execution GPT: {} gas/txn (over {} txns)",
                     delta_gas.gas / (delta_gas.gas_count as f64).max(1.0),
                     executed
+                );
+                info!(
+                    "Overall execution approx_output: {} bytes/s",
+                    delta_gas.approx_block_output / elapsed
                 );
                 info!(
                     "Overall execution output: {} bytes/s",

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -69,12 +69,7 @@ where
             )
             .unwrap();
 
-        let diff = if BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-            1
-        } else {
-            0
-        };
-        assert_eq!(output.txn_statuses().len(), num_txns + diff);
+        assert_eq!(output.txn_statuses().len(), num_txns);
 
         let msg = LedgerUpdateMessage {
             current_block_start_time,

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -16,11 +16,7 @@ use std::{
 };
 
 pub const BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-    block_gas_limit_type:
-        // present, but large to not limit blocks
-        aptos_types::on_chain_config::BlockGasLimitType::Limit(1_000_000_000),
-};
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 pub struct TransactionExecutor<V> {
     num_blocks_processed: usize,

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -5,7 +5,6 @@
 use crate::{
     account_generator::{AccountCache, AccountGenerator},
     metrics::{NUM_TXNS, TIMER},
-    transaction_executor::BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue};
 use aptos_logger::info;
@@ -374,10 +373,7 @@ impl TransactionGenerator {
                     );
                     Transaction::UserTransaction(txn)
                 })
-                .chain(
-                    (!BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit())
-                        .then_some(Transaction::StateCheckpoint(HashValue::random())),
-                )
+                .chain(Some(Transaction::StateCheckpoint(HashValue::random())))
                 .collect();
             bar.inc(transactions.len() as u64 - 1);
             if let Some(sender) = &self.block_sender {
@@ -672,10 +668,7 @@ impl TransactionGenerator {
         for i in 0..block_size {
             transactions.push(transactions_by_index.get(&i).unwrap().clone());
         }
-
-        if !BENCHMARKS_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-            transactions.push(Transaction::StateCheckpoint(HashValue::random()));
-        }
+        transactions.push(Transaction::StateCheckpoint(HashValue::random()));
 
         NUM_TXNS
             .with_label_values(&["generation_done"])

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -173,7 +173,7 @@ pub fn test_execution_with_storage_impl_inner(
             txn_factory.transfer(account3.address(), 10 * B),
         )));
     }
-    let block3 = block(block3, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG); // append state checkpoint txn
+    let block3 = block(block3); // append state checkpoint txn
 
     let output1 = executor
         .execute_block(
@@ -449,16 +449,9 @@ pub fn test_execution_with_storage_impl_inner(
     })
     .unwrap();
 
-    // With block gas limit, StateCheckpoint txn is inserted to block after execution.
-    let diff = if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-        0
-    } else {
-        1
-    };
-
     let transaction_list_with_proof = db
         .reader
-        .get_transactions(14, 15 + diff, current_version, false)
+        .get_transactions(14, 16, current_version, false)
         .unwrap();
     let expected_txns: Vec<Transaction> = block3.iter().map(|t| t.expect_valid().clone()).collect();
     verify_transactions(&transaction_list_with_proof, &expected_txns).unwrap();

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -20,13 +20,17 @@ pub struct TransactionsByStatus {
 
 impl TransactionsByStatus {
     pub fn new(
-        status: Vec<TransactionStatus>,
         to_keep: TransactionsWithParsedOutput,
         to_discard: TransactionsWithParsedOutput,
         to_retry: TransactionsWithParsedOutput,
     ) -> Self {
         Self {
-            statuses: status,
+            statuses: to_keep
+                .iter()
+                .chain(to_discard.iter())
+                .chain(to_retry.iter())
+                .map(|(_, o)| o.status().clone())
+                .collect(),
             to_keep,
             to_discard,
             to_retry,

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -252,12 +252,9 @@ where
                     .with_label_values(&["state_checkpoint"])
                     .start_timer();
 
-                THREAD_MANAGER.get_exe_cpu_pool().install(|| {
-                    chunk_output.into_state_checkpoint_output(
-                        parent_output.state(),
-                        onchain_config.has_any_block_gas_limit().then_some(block_id),
-                    )
-                })?
+                THREAD_MANAGER
+                    .get_exe_cpu_pool()
+                    .install(|| chunk_output.into_state_checkpoint_output(parent_output.state()))?
             };
 
         let _ = self.block_tree.add_block(

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -285,7 +285,6 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             ApplyChunkOutput::calculate_state_checkpoint(
                 chunk_output,
                 &self.commit_queue.lock().latest_state(),
-                None, // append_state_checkpoint_to_block
                 Some(known_state_checkpoints),
                 false, // is_block
             )?;
@@ -370,7 +369,6 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             ApplyChunkOutput::calculate_state_checkpoint(
                 chunk_output,
                 &self.commit_queue.lock().latest_state(),
-                None, // append_state_checkpoint_to_block
                 Some(known_state_checkpoints),
                 false, // is_block
             )?
@@ -754,7 +752,6 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
                     .map(|txn_info| txn_info.state_checkpoint_hash())
                     .collect(),
             ),
-            None,
         )?;
         ensure_no_discard(to_discard)?;
         ensure_no_retry(to_retry)?;

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -135,23 +135,16 @@ impl ChunkOutput {
         self,
         base_view: &ExecutedTrees,
         known_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
-        append_state_checkpoint_to_block: Option<HashValue>,
     ) -> Result<(ExecutedChunk, Vec<Transaction>, Vec<Transaction>)> {
         fail_point!("executor::apply_to_ledger", |_| {
             Err(anyhow::anyhow!("Injected error in apply_to_ledger."))
         });
-        ApplyChunkOutput::apply_chunk(
-            self,
-            base_view,
-            known_state_checkpoint_hashes,
-            append_state_checkpoint_to_block,
-        )
+        ApplyChunkOutput::apply_chunk(self, base_view, known_state_checkpoint_hashes)
     }
 
     pub fn into_state_checkpoint_output(
         self,
         parent_state: &StateDelta,
-        append_state_checkpoint_to_block: Option<HashValue>,
     ) -> Result<(StateDelta, Option<EpochState>, StateCheckpointOutput)> {
         fail_point!("executor::into_state_checkpoint_output", |_| {
             Err(anyhow::anyhow!(
@@ -164,7 +157,6 @@ impl ChunkOutput {
         ApplyChunkOutput::calculate_state_checkpoint(
             self,
             parent_state,
-            append_state_checkpoint_to_block,
             None,
             /*is_block=*/ true,
         )

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -152,7 +152,7 @@ pub fn calculate_genesis<V: VMExecutor>(
         base_state_view,
         BlockExecutorConfigFromOnchain::new_no_block_limit(),
     )?
-    .apply_to_ledger(&executed_trees, None, None)?;
+    .apply_to_ledger(&executed_trees, None)?;
     ensure!(
         !output.transactions_to_commit().is_empty(),
         "Genesis txn execution failed."

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -235,7 +235,7 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
             .collect::<Vec<_>>();
         let output = executor
             .execute_block(
-                (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+                (block_id, block(txns)).into(),
                 parent_block_id,
                 TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
             )
@@ -285,7 +285,7 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
             .map(|_| encode_mint_transaction(tests::gen_address(rng.gen::<u64>()), 100))
             .collect::<Vec<_>>();
         let output = executor
-            .execute_block((block_id, block(txns, None)).into(), parent_block_id, None)
+            .execute_block((block_id, block(txns)).into(), parent_block_id, None)
             .unwrap();
         let ledger_info = tests::gen_ledger_info(6, output.root_hash(), block_id, 1);
         executor.commit_blocks(vec![block_id], ledger_info).unwrap();

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -54,7 +54,7 @@ fn execute_and_commit_block(
 
     let output = executor
         .execute_block(
-            (id, block(vec![txn], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+            (id, block(vec![txn])).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -153,11 +153,7 @@ fn test_executor_status() {
 
     let output = executor
         .execute_block(
-            (
-                block_id,
-                block(vec![txn0, txn1, txn2], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-            )
-                .into(),
+            (block_id, block(vec![txn0, txn1, txn2])).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -187,11 +183,7 @@ fn test_executor_status_consensus_only() {
 
     let output = executor
         .execute_block(
-            (
-                block_id,
-                block(vec![txn0, txn1, txn2], TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-            )
-                .into(),
+            (block_id, block(vec![txn0, txn1, txn2])).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -221,7 +213,7 @@ fn test_executor_one_block() {
         .collect::<Vec<_>>();
     let output = executor
         .execute_block(
-            (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+            (block_id, block(txns)).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -267,22 +259,14 @@ fn test_executor_two_blocks_with_failed_txns() {
         .collect::<Vec<_>>();
     let _output1 = executor
         .execute_block(
-            (
-                block1_id,
-                block(block1_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-            )
-                .into(),
+            (block1_id, block(block1_txns)).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
     let output2 = executor
         .execute_block(
-            (
-                block2_id,
-                block(block2_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-            )
-                .into(),
+            (block2_id, block(block2_txns)).into(),
             block1_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -304,11 +288,7 @@ fn test_executor_commit_twice() {
     let block1_id = gen_block_id(1);
     let output1 = executor
         .execute_block(
-            (
-                block1_id,
-                block(block1_txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-            )
-                .into(),
+            (block1_id, block(block1_txns)).into(),
             parent_block_id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
@@ -338,11 +318,7 @@ fn test_executor_execute_same_block_multiple_times() {
     for _i in 0..100 {
         let output = executor
             .execute_block(
-                (
-                    block_id,
-                    block(txns.clone(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG),
-                )
-                    .into(),
+                (block_id, block(txns.clone())).into(),
                 parent_block_id,
                 TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
             )
@@ -351,20 +327,6 @@ fn test_executor_execute_same_block_multiple_times() {
     }
     responses.dedup();
     assert_eq!(responses.len(), 1);
-}
-
-fn ledger_version_from_block_size(
-    block_size: usize,
-    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
-) -> usize {
-    // With block gas limit, StateCheckpoint txn is inserted to block after execution.
-    // So the ledger_info version needs to block_size + 1 with block gas limit.
-    block_size
-        + if block_executor_onchain_config.has_any_block_gas_limit() {
-            1
-        } else {
-            0
-        }
 }
 
 /// Generates a list of `TransactionListWithProof`s according to the given ranges.
@@ -390,9 +352,8 @@ fn create_transaction_chunks(
         let txn = encode_mint_transaction(gen_address(i), 100);
         txns.push(txn.into());
     }
-    if !TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-        txns.push(Transaction::StateCheckpoint(HashValue::random()).into());
-    }
+    txns.push(Transaction::StateCheckpoint(HashValue::random()).into());
+
     let id = gen_block_id(1);
 
     let output = executor
@@ -403,8 +364,7 @@ fn create_transaction_chunks(
         )
         .unwrap();
 
-    let ledger_version =
-        ledger_version_from_block_size(txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64;
+    let ledger_version = txns.len() as u64;
     let ledger_info = gen_ledger_info(ledger_version, output.root_hash(), id, 1);
     executor
         .commit_blocks(vec![id], ledger_info.clone())
@@ -444,7 +404,7 @@ fn test_noop_block_after_reconfiguration() {
         )
         .unwrap();
     parent_block_id = first_block_id;
-    let second_block = TestBlock::new(10, 10, gen_block_id(2), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+    let second_block = TestBlock::new(10, 10, gen_block_id(2));
     let output2 = executor
         .execute_block(
             (second_block.id, second_block.txns).into(),
@@ -519,9 +479,7 @@ fn apply_transaction_by_writeset(
     let chunk_output =
         ChunkOutput::by_transaction_output(transactions_and_outputs, state_view).unwrap();
 
-    let (executed, _, _) = chunk_output
-        .apply_to_ledger(&ledger_view, None, None)
-        .unwrap();
+    let (executed, _, _) = chunk_output.apply_to_ledger(&ledger_view, None).unwrap();
     let ExecutedChunk {
         result_state,
         ledger_info,
@@ -642,21 +600,11 @@ fn test_reconfig_suffix_empty_blocks() {
         db: _,
         executor,
     } = TestExecutor::new();
-    let block_a = TestBlock::new(
-        10000,
-        1,
-        gen_block_id(1),
-        TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-    );
+    let block_a = TestBlock::new(10000, 1, gen_block_id(1));
     // add block gas limit to be consistent with block executor that will add state checkpoint txn
-    let mut block_b = TestBlock::new(
-        10000,
-        1,
-        gen_block_id(2),
-        BlockExecutorConfigFromOnchain::new_maybe_block_limit(Some(0)),
-    );
-    let block_c = TestBlock::new(1, 1, gen_block_id(3), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
-    let block_d = TestBlock::new(1, 1, gen_block_id(4), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+    let mut block_b = TestBlock::new(10000, 1, gen_block_id(2));
+    let block_c = TestBlock::new(1, 1, gen_block_id(3));
+    let block_d = TestBlock::new(1, 1, gen_block_id(4));
     block_b
         .txns
         .push(encode_reconfiguration_transaction().into());
@@ -706,12 +654,7 @@ struct TestBlock {
 }
 
 impl TestBlock {
-    fn new(
-        num_user_txns: u64,
-        amount: u32,
-        id: HashValue,
-        block_executor_onchain_config: BlockExecutorConfigFromOnchain,
-    ) -> Self {
+    fn new(num_user_txns: u64, amount: u32, id: HashValue) -> Self {
         let txns = if num_user_txns == 0 {
             Vec::new()
         } else {
@@ -719,7 +662,6 @@ impl TestBlock {
                 (0..num_user_txns)
                     .map(|index| encode_mint_transaction(gen_address(index), u64::from(amount)))
                     .collect(),
-                block_executor_onchain_config,
             )
         };
         TestBlock { txns, id }
@@ -753,7 +695,7 @@ fn run_transactions_naive(
             block_executor_onchain_config.clone(),
         )
         .unwrap();
-        let (executed, _, _) = out.apply_to_ledger(&ledger_view, None, None).unwrap();
+        let (executed, _, _) = out.apply_to_ledger(&ledger_view, None).unwrap();
         let next_ledger_view = executed.result_view();
         let ExecutedChunk {
             result_state,
@@ -802,7 +744,7 @@ proptest! {
             let executor = TestExecutor::new();
 
             let block_id = gen_block_id(1);
-            let mut block = TestBlock::new(num_user_txns, 10, block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+            let mut block = TestBlock::new(num_user_txns, 10, block_id);
             let num_txns = block.txns.len() as LeafCount;
             block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction().into();
 
@@ -831,7 +773,7 @@ proptest! {
             ).unwrap();
             prop_assert!(retry_output.compute_status().iter().all(|s| matches!(*s, TransactionStatus::Keep(_))));
 
-            let ledger_version = ledger_version_from_block_size(num_txns as usize, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64;
+            let ledger_version = num_txns;
 
             // commit
             let ledger_info = gen_ledger_info(ledger_version, retry_output.root_hash(), retry_block_id, 12345 /* timestamp */);
@@ -863,8 +805,8 @@ proptest! {
     fn test_executor_restart(a_size in 1..30u64, b_size in 1..30u64, amount in any::<u32>()) {
         let TestExecutor { _path, db, executor } = TestExecutor::new();
 
-        let block_a = TestBlock::new(a_size, amount, gen_block_id(1), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
-        let block_b = TestBlock::new(b_size, amount, gen_block_id(2), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
+        let block_a = TestBlock::new(a_size, amount, gen_block_id(1));
+        let block_b = TestBlock::new(b_size, amount, gen_block_id(2));
 
         let mut parent_block_id;
         let mut root_hash;
@@ -876,7 +818,7 @@ proptest! {
                 (block_a.id, block_a.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
             ).unwrap();
             root_hash = output_a.root_hash();
-            let ledger_info = gen_ledger_info(ledger_version_from_block_size(block_a.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) as u64, root_hash, block_a.id, 1);
+            let ledger_info = gen_ledger_info(block_a.txns.len() as u64, root_hash, block_a.id, 1);
             executor.commit_blocks(vec![block_a.id], ledger_info).unwrap();
             parent_block_id = block_a.id;
             drop(executor);
@@ -888,7 +830,7 @@ proptest! {
             let output_b = executor.execute_block((block_b.id, block_b.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG).unwrap();
             root_hash = output_b.root_hash();
             let ledger_info = gen_ledger_info(
-                (ledger_version_from_block_size(block_a.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG) + ledger_version_from_block_size(block_b.txns.len(), TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)) as u64,
+                (block_a.txns.len() + block_b.txns.len()) as u64,
                 root_hash,
                 block_b.id,
                 2,
@@ -899,13 +841,7 @@ proptest! {
         let expected_root_hash = run_transactions_naive({
             let mut txns = vec![];
             txns.extend(block_a.txns.iter().cloned());
-            if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-                txns.push(Transaction::StateCheckpoint(block_a.id).into());
-            }
             txns.extend(block_b.txns.iter().cloned());
-            if TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG.has_any_block_gas_limit() {
-                txns.push(Transaction::StateCheckpoint(block_b.id).into());
-            }
             txns
         }, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG);
         prop_assert_eq!(root_hash, expected_root_hash);

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -89,7 +89,7 @@ fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter, signer: &Vali
     let executor = BlockExecutor::<AptosVM>::new(db.clone());
     let output = executor
         .execute_block(
-            (block_id, block(txns, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG)).into(),
+            (block_id, block(txns)).into(),
             executor.committed_block_id(),
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -224,6 +224,7 @@ def execute_command(command):
 class RunResults:
     tps: float
     gps: float
+    effective_gps: float
     io_gps: float
     execution_gps: float
     gpt: float
@@ -253,6 +254,9 @@ def extract_run_results(
     if execution_only:
         tps = float(re.findall(r"Overall execution TPS: (\d+\.?\d*) txn/s", output)[-1])
         gps = float(re.findall(r"Overall execution GPS: (\d+\.?\d*) gas/s", output)[-1])
+        effective_gps = float(
+            re.findall(r"Overall execution effectiveGPS: (\d+\.?\d*) gas/s", output)[-1]
+        )
         io_gps = float(
             re.findall(r"Overall execution ioGPS: (\d+\.?\d*) gas/s", output)[-1]
         )
@@ -275,6 +279,7 @@ def extract_run_results(
             )
         )
         gps = 0
+        effective_gps = 0
         io_gps = 0
         execution_gps = 0
         gpt = 0
@@ -282,6 +287,9 @@ def extract_run_results(
     else:
         tps = float(get_only(re.findall(r"Overall TPS: (\d+\.?\d*) txn/s", output)))
         gps = float(get_only(re.findall(r"Overall GPS: (\d+\.?\d*) gas/s", output)))
+        effective_gps = float(
+            get_only(re.findall(r"Overall effectiveGPS: (\d+\.?\d*) gas/s", output))
+        )
         io_gps = float(
             get_only(re.findall(r"Overall ioGPS: (\d+\.?\d*) gas/s", output))
         )
@@ -313,6 +321,7 @@ def extract_run_results(
     return RunResults(
         tps=tps,
         gps=gps,
+        effective_gps=effective_gps,
         io_gps=io_gps,
         execution_gps=execution_gps,
         gpt=gpt,
@@ -353,6 +362,7 @@ def print_table(
                 "vm/exe",
                 "commit/total",
                 "g/s",
+                "eff g/s",
                 "io g/s",
                 "exe g/s",
                 "g/t",
@@ -386,6 +396,7 @@ def print_table(
             row.append(round(result.single_node_result.fraction_of_execution_in_vm, 3))
             row.append(round(result.single_node_result.fraction_in_commit, 3))
             row.append(int(round(result.single_node_result.gps)))
+            row.append(int(round(result.single_node_result.effective_gps)))
             row.append(int(round(result.single_node_result.io_gps)))
             row.append(int(round(result.single_node_result.execution_gps)))
             row.append(int(round(result.single_node_result.gpt)))
@@ -402,7 +413,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     execute_command(f"cargo build {BUILD_FLAG} --package aptos-executor-benchmark")
 
     print(f"Warmup - creating DB with {NUM_ACCOUNTS} accounts")
-    create_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
+    create_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
     results = []
@@ -459,14 +470,14 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         number_of_threads_results = {}
 
         for execution_threads in EXECUTION_ONLY_NUMBER_OF_THREADS:
-            test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
+            test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
             output = execute_command(test_db_command)
 
             number_of_threads_results[execution_threads] = extract_run_results(
                 output, execution_only=True
             )
 
-        test_db_command = f"{BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
+        test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {NUMBER_OF_EXECUTION_THREADS} {common_command_suffix} --blocks {NUM_BLOCKS}"
         output = execute_command(test_db_command)
 
         single_node_result = extract_run_results(output, execution_only=False)

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -33,6 +33,22 @@ impl BlockExecutorConfigFromOnchain {
     pub fn has_any_block_gas_limit(&self) -> bool {
         self.block_gas_limit_type.block_gas_limit().is_some()
     }
+
+    pub const fn on_but_large_for_test() -> Self {
+        Self {
+            block_gas_limit_type:
+                // present, so code is excercised, but large to not limit blocks
+                BlockGasLimitType::ComplexLimitV1 {
+                    effective_block_gas_limit: 1_000_000_000,
+                    execution_gas_effective_multiplier: 1,
+                    io_gas_effective_multiplier: 1,
+                    block_output_limit: Some(1_000_000_000_000),
+                    conflict_penalty_window: 8,
+                    add_block_limit_outcome_onchain: false,
+                    use_granular_resource_group_conflicts: false,
+                },
+        }
+    }
 }
 
 /// Configuration for the BlockExecutor.

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -30,10 +30,6 @@ impl BlockExecutorConfigFromOnchain {
         }
     }
 
-    pub fn has_any_block_gas_limit(&self) -> bool {
-        self.block_gas_limit_type.block_gas_limit().is_some()
-    }
-
     pub const fn on_but_large_for_test() -> Self {
         Self {
             block_gas_limit_type:

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -17,6 +17,7 @@ pub enum OnChainExecutionConfig {
     /// to previous behavior (before OnChainExecutionConfig was registered) in case of Missing.
     Missing,
     // Reminder: Add V4 and future versions here, after Missing (order matters for enums).
+    V4(ExecutionConfigV4),
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -28,6 +29,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type.clone(),
         }
     }
 
@@ -42,6 +44,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config
                 .block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+            OnChainExecutionConfig::V4(config) => config.block_gas_limit_type.clone(),
         }
     }
 
@@ -59,15 +62,24 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V1(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.transaction_deduper_type.clone(),
         }
     }
 
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+        OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            block_gas_limit: Some(35000),
+            block_gas_limit_type: BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit: 35000,
+                execution_gas_effective_multiplier: 1,
+                io_gas_effective_multiplier: 1,
+                block_output_limit: None,
+                conflict_penalty_window: 1,
+                add_block_limit_outcome_onchain: false,
+                use_granular_resource_group_conflicts: false,
+            },
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         })
     }
@@ -115,6 +127,13 @@ pub struct ExecutionConfigV3 {
     pub transaction_deduper_type: TransactionDeduperType,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV4 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+    pub block_gas_limit_type: BlockGasLimitType,
+    pub transaction_deduper_type: TransactionDeduperType,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionShufflerType {
@@ -134,6 +153,30 @@ pub enum TransactionDeduperType {
 pub enum BlockGasLimitType {
     NoLimit,
     Limit(u64),
+    /// Provides two separate block limits:
+    /// 1. effective_block_gas_limit
+    /// 2. block_output_limit
+    ComplexLimitV1 {
+        /// Formula for effective block gas limit:
+        /// effective_block_gas_limit <
+        /// (execution_gas_effective_multiplier * execution_gas_used +
+        ///  io_gas_effective_multiplier * io_gas_used
+        /// ) * (1 + num conflicts in conflict_penalty_window)
+        effective_block_gas_limit: u64,
+        execution_gas_effective_multiplier: u64,
+        io_gas_effective_multiplier: u64,
+        conflict_penalty_window: u32,
+        /// Block limit on the total (approximate) txn output size in bytes.
+        block_output_limit: Option<u64>,
+
+        add_block_limit_outcome_onchain: bool,
+
+        // If true we look at granular resource group conflicts (i.e. if same Tag
+        // within a resource group has a conflict)
+        // If false, we treat any conclicts inside of resource groups (even across
+        // non-overlapping tags) as conflicts).
+        use_granular_resource_group_conflicts: bool,
+    },
 }
 
 impl BlockGasLimitType {
@@ -141,6 +184,81 @@ impl BlockGasLimitType {
         match self {
             BlockGasLimitType::NoLimit => None,
             BlockGasLimitType::Limit(limit) => Some(*limit),
+            BlockGasLimitType::ComplexLimitV1 {
+                effective_block_gas_limit,
+                ..
+            } => Some(*effective_block_gas_limit),
+        }
+    }
+
+    pub fn execution_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                execution_gas_effective_multiplier,
+                ..
+            } => *execution_gas_effective_multiplier,
+        }
+    }
+
+    pub fn io_gas_effective_multiplier(&self) -> u64 {
+        match self {
+            BlockGasLimitType::NoLimit => 1,
+            BlockGasLimitType::Limit(_) => 1,
+            BlockGasLimitType::ComplexLimitV1 {
+                io_gas_effective_multiplier,
+                ..
+            } => *io_gas_effective_multiplier,
+        }
+    }
+
+    pub fn block_output_limit(&self) -> Option<u64> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                block_output_limit, ..
+            } => *block_output_limit,
+        }
+    }
+
+    pub fn conflict_penalty_window(&self) -> Option<u32> {
+        match self {
+            BlockGasLimitType::NoLimit => None,
+            BlockGasLimitType::Limit(_) => None,
+            BlockGasLimitType::ComplexLimitV1 {
+                conflict_penalty_window,
+                ..
+            } => {
+                if *conflict_penalty_window > 1 {
+                    Some(*conflict_penalty_window)
+                } else {
+                    None
+                }
+            },
+        }
+    }
+
+    pub fn add_block_limit_outcome_onchain(&self) -> bool {
+        match self {
+            BlockGasLimitType::NoLimit => false,
+            BlockGasLimitType::Limit(_) => false,
+            BlockGasLimitType::ComplexLimitV1 {
+                add_block_limit_outcome_onchain,
+                ..
+            } => *add_block_limit_outcome_onchain,
+        }
+    }
+
+    pub fn use_granular_resource_group_conflicts(&self) -> bool {
+        match self {
+            BlockGasLimitType::NoLimit => false,
+            BlockGasLimitType::Limit(_) => false,
+            BlockGasLimitType::ComplexLimitV1 {
+                use_granular_resource_group_conflicts,
+                ..
+            } => *use_granular_resource_group_conflicts,
         }
     }
 }

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -6,7 +6,6 @@ use crate::{
     account_address::AccountAddress,
     block_executor::config::BlockExecutorConfigFromOnchain,
     chain_id::ChainId,
-    on_chain_config::BlockGasLimitType,
     transaction::{
         authenticator::AccountAuthenticator,
         signature_verified_transaction::{
@@ -23,9 +22,7 @@ const TEST_GAS_PRICE: u64 = 100;
 
 // The block executor onchain config (gas limit parameters) for executor tests
 pub const TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG: BlockExecutorConfigFromOnchain =
-    BlockExecutorConfigFromOnchain {
-        block_gas_limit_type: BlockGasLimitType::Limit(1000),
-    };
+    BlockExecutorConfigFromOnchain::on_but_large_for_test();
 
 static EMPTY_SCRIPT: &[u8] = include_bytes!("empty_script.mv");
 

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -248,12 +248,7 @@ pub fn get_test_txn_with_chain_id(
     SignedTransaction::new(raw_txn, public_key, signature)
 }
 
-pub fn block(
-    mut user_txns: Vec<Transaction>,
-    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
-) -> Vec<SignatureVerifiedTransaction> {
-    if !block_executor_onchain_config.has_any_block_gas_limit() {
-        user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
-    }
+pub fn block(mut user_txns: Vec<Transaction>) -> Vec<SignatureVerifiedTransaction> {
+    user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
     into_signature_verified_block(user_txns)
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1836,6 +1836,16 @@ impl Transaction {
             Transaction::ValidatorTransaction(_) => String::from("validator_transaction"),
         }
     }
+
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Transaction::UserTransaction(_) => "user_transaction",
+            Transaction::GenesisTransaction(_) => "genesis_transaction",
+            Transaction::BlockMetadata(_) => "block_metadata",
+            Transaction::StateCheckpoint(_) => "state_checkpoint",
+            Transaction::ValidatorTransaction(_) => "validator_transaction",
+        }
+    }
 }
 
 impl TryFrom<Transaction> for SignedTransaction {


### PR DESCRIPTION
Cleanup StateCheckpoint handling when block gas limit is used.

instead of needing to special handle it everywhere, and adding it back outside of BlockExecutor,
we just make BlockExecutor keep it at the end of the block.


### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
