### PR TITLE
Exclude initialization steps from benchmark measurements

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -41,8 +41,6 @@ mod block_store_test;
 #[path = "sync_manager.rs"]
 pub mod sync_manager;
 
-const MAX_ORDERING_PIPELINE_LATENCY_REDUCTION: Duration = Duration::from_secs(1);
-
 fn update_counters_for_ordered_blocks(ordered_blocks: &[Arc<ExecutedBlock>]) {
     for block in ordered_blocks {
         observe_block(block.block().timestamp_usecs(), BlockStage::ORDERED);


### PR DESCRIPTION
for very low TPS workloads, I noticed that execution throughput was lower than overall, because we were counting initialization (which is around 18 TPS for ~0.1s)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
