### PR TITLE
Fix move-compiler-transactional-tests to also inline functions from pre-compiled-library. (#11264)

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
@@ -35,3 +35,654 @@ module 0xcafe::vectors {
     }
     spec fun $test_for_each_mut();
 } // end 0xcafe::vectors
+
+============ initial bytecode ================
+
+[variant baseline]
+fun vectors::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: vector<u64>
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut vector<u64>
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: &vector<u64>
+     var $t14: &mut u64
+     var $t15: &mut u64
+     var $t16: &mut vector<u64>
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: bool
+     var $t22: vector<u64>
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t4 := 3
+  3: $t1 := vector($t2, $t3, $t4)
+  4: $t0 := infer($t1)
+  5: $t6 := 2
+  6: $t5 := infer($t6)
+  7: $t8 := borrow_local($t0)
+  8: $t7 := infer($t8)
+  9: $t10 := 0
+ 10: $t9 := infer($t10)
+ 11: label L0
+ 12: $t13 := freeze_ref($t7)
+ 13: $t12 := vector::length<u64>($t13)
+ 14: $t11 := <($t9, $t12)
+ 15: if ($t11) goto 16 else goto 28
+ 16: label L2
+ 17: $t16 := infer($t7)
+ 18: $t15 := vector::borrow_mut<u64>($t16, $t9)
+ 19: $t14 := infer($t15)
+ 20: write_ref($t14, $t5)
+ 21: $t18 := 1
+ 22: $t17 := +($t5, $t18)
+ 23: $t5 := infer($t17)
+ 24: $t20 := 1
+ 25: $t19 := +($t9, $t20)
+ 26: $t9 := infer($t19)
+ 27: goto 30
+ 28: label L3
+ 29: goto 32
+ 30: label L4
+ 31: goto 11
+ 32: label L1
+ 33: $t23 := 2
+ 34: $t24 := 3
+ 35: $t25 := 4
+ 36: $t22 := vector($t23, $t24, $t25)
+ 37: $t21 := ==($t0, $t22)
+ 38: if ($t21) goto 39 else goto 41
+ 39: label L5
+ 40: goto 44
+ 41: label L6
+ 42: $t26 := 0
+ 43: abort($t26)
+ 44: label L7
+ 45: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun vectors::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: vector<u64>
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut vector<u64>
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: &vector<u64>
+     var $t14: &mut u64
+     var $t15: &mut u64
+     var $t16: &mut vector<u64>
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: bool
+     var $t22: vector<u64>
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<u64>
+     # live vars:
+  0: $t2 := 1
+     # live vars: $t2
+  1: $t3 := 2
+     # live vars: $t2, $t3
+  2: $t4 := 3
+     # live vars: $t2, $t3, $t4
+  3: $t1 := vector($t2, $t3, $t4)
+     # live vars: $t1
+  4: $t0 := copy($t1)
+     # live vars: $t0
+  5: $t6 := 2
+     # live vars: $t0, $t6
+  6: $t5 := copy($t6)
+     # live vars: $t0, $t5
+  7: $t8 := borrow_local($t0)
+     # live vars: $t0, $t5, $t8
+  8: $t7 := move($t8)
+     # live vars: $t0, $t5, $t7
+  9: $t10 := 0
+     # live vars: $t0, $t5, $t7, $t10
+ 10: $t9 := copy($t10)
+     # live vars: $t0, $t5, $t7, $t9
+ 11: label L0
+     # live vars: $t0, $t5, $t7, $t9
+ 12: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+ 13: $t13 := freeze_ref($t27)
+     # live vars: $t0, $t5, $t7, $t9, $t13
+ 14: $t12 := vector::length<u64>($t13)
+     # live vars: $t0, $t5, $t7, $t9, $t12
+ 15: $t11 := <($t9, $t12)
+     # live vars: $t0, $t5, $t7, $t9, $t11
+ 16: if ($t11) goto 17 else goto 29
+     # live vars: $t0, $t5, $t7, $t9
+ 17: label L2
+     # live vars: $t0, $t5, $t7, $t9
+ 18: $t16 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t16
+ 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+     # live vars: $t0, $t5, $t7, $t9, $t15
+ 20: $t14 := move($t15)
+     # live vars: $t0, $t5, $t7, $t9, $t14
+ 21: write_ref($t14, $t5)
+     # live vars: $t0, $t5, $t7, $t9
+ 22: $t18 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t18
+ 23: $t17 := +($t5, $t18)
+     # live vars: $t0, $t7, $t9, $t17
+ 24: $t5 := copy($t17)
+     # live vars: $t0, $t5, $t7, $t9
+ 25: $t20 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t20
+ 26: $t19 := +($t9, $t20)
+     # live vars: $t0, $t5, $t7, $t19
+ 27: $t9 := copy($t19)
+     # live vars: $t0, $t5, $t7, $t9
+ 28: goto 31
+     # live vars: $t0
+ 29: label L3
+     # live vars: $t0
+ 30: goto 33
+     # live vars: $t0, $t5, $t7, $t9
+ 31: label L4
+     # live vars: $t0, $t5, $t7, $t9
+ 32: goto 11
+     # live vars: $t0
+ 33: label L1
+     # live vars: $t0
+ 34: $t23 := 2
+     # live vars: $t0, $t23
+ 35: $t24 := 3
+     # live vars: $t0, $t23, $t24
+ 36: $t25 := 4
+     # live vars: $t0, $t23, $t24, $t25
+ 37: $t22 := vector($t23, $t24, $t25)
+     # live vars: $t0, $t22
+ 38: $t21 := ==($t0, $t22)
+     # live vars: $t21
+ 39: if ($t21) goto 40 else goto 42
+     # live vars:
+ 40: label L5
+     # live vars:
+ 41: goto 45
+     # live vars:
+ 42: label L6
+     # live vars:
+ 43: $t26 := 0
+     # live vars: $t26
+ 44: abort($t26)
+     # live vars:
+ 45: label L7
+     # live vars:
+ 46: return ()
+}
+
+============ after VisibilityChecker: ================
+
+[variant baseline]
+fun vectors::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: vector<u64>
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut vector<u64>
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: &vector<u64>
+     var $t14: &mut u64
+     var $t15: &mut u64
+     var $t16: &mut vector<u64>
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: bool
+     var $t22: vector<u64>
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<u64>
+     # live vars:
+  0: $t2 := 1
+     # live vars: $t2
+  1: $t3 := 2
+     # live vars: $t2, $t3
+  2: $t4 := 3
+     # live vars: $t2, $t3, $t4
+  3: $t1 := vector($t2, $t3, $t4)
+     # live vars: $t1
+  4: $t0 := copy($t1)
+     # live vars: $t0
+  5: $t6 := 2
+     # live vars: $t0, $t6
+  6: $t5 := copy($t6)
+     # live vars: $t0, $t5
+  7: $t8 := borrow_local($t0)
+     # live vars: $t0, $t5, $t8
+  8: $t7 := move($t8)
+     # live vars: $t0, $t5, $t7
+  9: $t10 := 0
+     # live vars: $t0, $t5, $t7, $t10
+ 10: $t9 := copy($t10)
+     # live vars: $t0, $t5, $t7, $t9
+ 11: label L0
+     # live vars: $t0, $t5, $t7, $t9
+ 12: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+ 13: $t13 := freeze_ref($t27)
+     # live vars: $t0, $t5, $t7, $t9, $t13
+ 14: $t12 := vector::length<u64>($t13)
+     # live vars: $t0, $t5, $t7, $t9, $t12
+ 15: $t11 := <($t9, $t12)
+     # live vars: $t0, $t5, $t7, $t9, $t11
+ 16: if ($t11) goto 17 else goto 29
+     # live vars: $t0, $t5, $t7, $t9
+ 17: label L2
+     # live vars: $t0, $t5, $t7, $t9
+ 18: $t16 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t16
+ 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+     # live vars: $t0, $t5, $t7, $t9, $t15
+ 20: $t14 := move($t15)
+     # live vars: $t0, $t5, $t7, $t9, $t14
+ 21: write_ref($t14, $t5)
+     # live vars: $t0, $t5, $t7, $t9
+ 22: $t18 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t18
+ 23: $t17 := +($t5, $t18)
+     # live vars: $t0, $t7, $t9, $t17
+ 24: $t5 := copy($t17)
+     # live vars: $t0, $t5, $t7, $t9
+ 25: $t20 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t20
+ 26: $t19 := +($t9, $t20)
+     # live vars: $t0, $t5, $t7, $t19
+ 27: $t9 := copy($t19)
+     # live vars: $t0, $t5, $t7, $t9
+ 28: goto 31
+     # live vars: $t0
+ 29: label L3
+     # live vars: $t0
+ 30: goto 33
+     # live vars: $t0, $t5, $t7, $t9
+ 31: label L4
+     # live vars: $t0, $t5, $t7, $t9
+ 32: goto 11
+     # live vars: $t0
+ 33: label L1
+     # live vars: $t0
+ 34: $t23 := 2
+     # live vars: $t0, $t23
+ 35: $t24 := 3
+     # live vars: $t0, $t23, $t24
+ 36: $t25 := 4
+     # live vars: $t0, $t23, $t24, $t25
+ 37: $t22 := vector($t23, $t24, $t25)
+     # live vars: $t0, $t22
+ 38: $t21 := ==($t0, $t22)
+     # live vars: $t21
+ 39: if ($t21) goto 40 else goto 42
+     # live vars:
+ 40: label L5
+     # live vars:
+ 41: goto 45
+     # live vars:
+ 42: label L6
+     # live vars:
+ 43: $t26 := 0
+     # live vars: $t26
+ 44: abort($t26)
+     # live vars:
+ 45: label L7
+     # live vars:
+ 46: return ()
+}
+
+============ after MemorySafetyProcessor: ================
+
+[variant baseline]
+fun vectors::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: vector<u64>
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut vector<u64>
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: &vector<u64>
+     var $t14: &mut u64
+     var $t15: &mut u64
+     var $t16: &mut vector<u64>
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: bool
+     var $t22: vector<u64>
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: &mut vector<u64>
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  2: $t4 := 3
+     # live vars: $t2, $t3, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  3: $t1 := vector($t2, $t3, $t4)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  4: $t0 := copy($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  5: $t6 := 2
+     # live vars: $t0, $t6
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  6: $t5 := copy($t6)
+     # live vars: $t0, $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  7: $t8 := borrow_local($t0)
+     # live vars: $t0, $t5, $t8
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[]}
+     # local_to_label: {$t0=L1792,$t8=L1793}
+     # global_to_label: {}
+     #
+  8: $t7 := move($t8)
+     # live vars: $t0, $t5, $t7
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+  9: $t10 := 0
+     # live vars: $t0, $t5, $t7, $t10
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 10: $t9 := copy($t10)
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 11: label L0
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 12: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t27)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t27=L3073}
+     # global_to_label: {}
+     #
+ 13: $t13 := freeze_ref($t27)
+     # live vars: $t0, $t5, $t7, $t9, $t13
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t27)[call(false) -> L3328],L3328=local($t13)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t13=L3328,$t27=L3073}
+     # global_to_label: {}
+     #
+ 14: $t12 := vector::length<u64>($t13)
+     # live vars: $t0, $t5, $t7, $t9, $t12
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 15: $t11 := <($t9, $t12)
+     # live vars: $t0, $t5, $t7, $t9, $t11
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 16: if ($t11) goto 17 else goto 29
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 17: label L2
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 18: $t16 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t16
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t16=L4609}
+     # global_to_label: {}
+     #
+ 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+     # live vars: $t0, $t5, $t7, $t9, $t15
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[call(true) -> L4864],L4864=local($t15)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t15=L4864,$t16=L4609}
+     # global_to_label: {}
+     #
+ 20: $t14 := move($t15)
+     # live vars: $t0, $t5, $t7, $t9, $t14
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[call(true) -> L4864],L4864=local($t15)[skip -> L5121],L5121=local($t14)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t14=L5121,$t15=L4864,$t16=L4609}
+     # global_to_label: {}
+     #
+ 21: write_ref($t14, $t5)
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 22: $t18 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t18
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 23: $t17 := +($t5, $t18)
+     # live vars: $t0, $t7, $t9, $t17
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 24: $t5 := copy($t17)
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 25: $t20 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t20
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 26: $t19 := +($t9, $t20)
+     # live vars: $t0, $t5, $t7, $t19
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 27: $t9 := copy($t19)
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 28: goto 31
+     # live vars: $t0
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 29: label L3
+     # live vars: $t0
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 30: goto 33
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 31: label L4
+     # live vars: $t0, $t5, $t7, $t9
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
+     # global_to_label: {}
+     #
+ 32: goto 11
+     # live vars: $t0
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 33: label L1
+     # live vars: $t0
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 34: $t23 := 2
+     # live vars: $t0, $t23
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 35: $t24 := 3
+     # live vars: $t0, $t23, $t24
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 36: $t25 := 4
+     # live vars: $t0, $t23, $t24, $t25
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 37: $t22 := vector($t23, $t24, $t25)
+     # live vars: $t0, $t22
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 38: $t21 := ==($t0, $t22)
+     # live vars: $t21
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 39: if ($t21) goto 40 else goto 42
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 40: label L5
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 41: goto 45
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 42: label L6
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 43: $t26 := 0
+     # live vars: $t26
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 44: abort($t26)
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 45: label L7
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+ 46: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
@@ -1,0 +1,37 @@
+// ---- Model Dump
+module 0xcafe::vectors {
+    use std::vector;
+    private fun test_for_each_mut() {
+        {
+          let v: vector<u64> = Vector<u64>(1, 2, 3);
+          {
+            let s: u64 = 2;
+            {
+              let (v: &mut vector<u64>) = Tuple(Borrow(Mutable)(v));
+              {
+                let i: u64 = 0;
+                loop {
+                  if Lt<u64>(i, vector::length<u64>(v)) {
+                    {
+                      let (e: &mut u64) = Tuple(vector::borrow_mut<u64>(v, i));
+                      e = s;
+                      s: u64 = Add<u64>(s, 1)
+                    };
+                    i: u64 = Add<u64>(i, 1)
+                  } else {
+                    break
+                  }
+                }
+              }
+            };
+            if Eq<vector<u64>>(v, Vector<u64>(2, 3, 4)) {
+              Tuple()
+            } else {
+              Abort(0)
+            };
+            Tuple()
+          }
+        }
+    }
+    spec fun $test_for_each_mut();
+} // end 0xcafe::vectors

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.move
@@ -1,0 +1,11 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    fun test_for_each_mut() {
+	let v = vector[1, 2, 3];
+	let s = 2;
+	vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+	assert!(v == vector[2, 3, 4], 0);
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.exp
@@ -1,0 +1,123 @@
+comparison between v1 and v2 failed:
+= processed 2 tasks
+= 
+= task 0 'print-bytecode'. lines 1-11:
+- Error: warning[W09003]: unused assignment
+-   ┌─ TEMPFILE:6:6
+-   │
+- 6 │     let s = 2;
+-   │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
++ // Move bytecode v7
++ module cafe.vectors {
+= 
+- error[E14004]: lambda parameter only permitted as parameter to inlined function
+-   ┌─ TEMPFILE:7:31
+-   │
+- 7 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+-   │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
+= 
++ test_for_each_mut() {
++ L0:	loc0: vector<u64>
++ L1:	loc1: u64
++ L2:	loc2: &mut vector<u64>
++ L3:	loc3: u64
++ L4:	loc4: &mut vector<u64>
++ L5:	loc5: u64
++ L6:	loc6: &mut vector<u64>
++ L7:	loc7: &mut u64
++ L8:	loc8: u64
++ L9:	loc9: u64
++ L10:	loc10: vector<u64>
++ B0:
++ 	0: LdU64(1)
++ 	1: LdU64(2)
++ 	2: LdU64(3)
++ 	3: VecPack(1, 3)
++ 	4: StLoc[0](loc0: vector<u64>)
++ 	5: LdU64(2)
++ 	6: StLoc[1](loc1: u64)
++ 	7: MutBorrowLoc[0](loc0: vector<u64>)
++ 	8: StLoc[2](loc2: &mut vector<u64>)
++ 	9: LdU64(0)
++ 	10: StLoc[3](loc3: u64)
++ B1:
++ 	11: CopyLoc[2](loc2: &mut vector<u64>)
++ 	12: StLoc[4](loc4: &mut vector<u64>)
++ 	13: MoveLoc[4](loc4: &mut vector<u64>)
++ 	14: FreezeRef
++ 	15: VecLen(1)
++ 	16: StLoc[5](loc5: u64)
++ 	17: CopyLoc[3](loc3: u64)
++ 	18: MoveLoc[5](loc5: u64)
++ 	19: Lt
++ 	20: BrFalse(43)
++ B2:
++ 	21: CopyLoc[2](loc2: &mut vector<u64>)
++ 	22: StLoc[6](loc6: &mut vector<u64>)
++ 	23: MoveLoc[6](loc6: &mut vector<u64>)
++ 	24: CopyLoc[3](loc3: u64)
++ 	25: VecMutBorrow(1)
++ 	26: StLoc[7](loc7: &mut u64)
++ 	27: CopyLoc[1](loc1: u64)
++ 	28: MoveLoc[7](loc7: &mut u64)
++ 	29: WriteRef
++ 	30: LdU64(1)
++ 	31: StLoc[8](loc8: u64)
++ 	32: MoveLoc[1](loc1: u64)
++ 	33: MoveLoc[8](loc8: u64)
++ 	34: Add
++ 	35: StLoc[1](loc1: u64)
++ 	36: LdU64(1)
++ 	37: StLoc[9](loc9: u64)
++ 	38: MoveLoc[3](loc3: u64)
++ 	39: MoveLoc[9](loc9: u64)
++ 	40: Add
++ 	41: StLoc[3](loc3: u64)
++ 	42: Branch(44)
++ B3:
++ 	43: Branch(45)
++ B4:
++ 	44: Branch(11)
++ B5:
++ 	45: LdU64(2)
++ 	46: LdU64(3)
++ 	47: LdU64(4)
++ 	48: VecPack(1, 3)
++ 	49: StLoc[10](loc10: vector<u64>)
++ 	50: MoveLoc[0](loc0: vector<u64>)
++ 	51: MoveLoc[10](loc10: vector<u64>)
++ 	52: Eq
++ 	53: BrFalse(55)
++ B6:
++ 	54: Branch(57)
++ B7:
++ 	55: LdU64(0)
++ 	56: Abort
++ B8:
++ 	57: Ret
++ }
++ }
+= 
+- 
+= task 1 'publish'. lines 13-23:
+- Error: warning[W09003]: unused assignment
+-    ┌─ TEMPFILE:18:6
+-    │
+- 18 │     let s = 2;
+-    │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
++ Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
++     major_status: MOVELOC_EXISTS_BORROW_ERROR,
++     sub_status: None,
++     location: 0xcafe::vectors,
++     indices: redacted,
++     offsets: redacted,
++ }
+= 
+- error[E14004]: lambda parameter only permitted as parameter to inlined function
+-    ┌─ TEMPFILE:19:31
+-    │
+- 19 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
+- 
+- 
+- 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.exp
@@ -2,33 +2,35 @@ comparison between v1 and v2 failed:
 = processed 2 tasks
 = 
 = task 0 'print-bytecode'. lines 1-11:
-- Error: warning[W09003]: unused assignment
--   ┌─ TEMPFILE:6:6
--   │
-- 6 │     let s = 2;
--   │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
+- // Move bytecode v6
 + // Move bytecode v7
-+ module cafe.vectors {
+= module cafe.vectors {
 = 
-- error[E14004]: lambda parameter only permitted as parameter to inlined function
--   ┌─ TEMPFILE:7:31
--   │
-- 7 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
--   │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
 = 
-+ test_for_each_mut() {
+= test_for_each_mut() {
+- L0:	loc0: &mut u64
 + L0:	loc0: vector<u64>
-+ L1:	loc1: u64
+= L1:	loc1: u64
+- L2:	loc2: u64
+- L3:	loc3: vector<u64>
 + L2:	loc2: &mut vector<u64>
 + L3:	loc3: u64
-+ L4:	loc4: &mut vector<u64>
+= L4:	loc4: &mut vector<u64>
 + L5:	loc5: u64
 + L6:	loc6: &mut vector<u64>
 + L7:	loc7: &mut u64
 + L8:	loc8: u64
 + L9:	loc9: u64
 + L10:	loc10: vector<u64>
-+ B0:
+= B0:
+- 	0: LdConst[0](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+- 	1: StLoc[3](loc3: vector<u64>)
+- 	2: LdU64(2)
+- 	3: StLoc[2](loc2: u64)
+- 	4: MutBorrowLoc[3](loc3: vector<u64>)
+- 	5: StLoc[4](loc4: &mut vector<u64>)
+- 	6: LdU64(0)
+- 	7: StLoc[1](loc1: u64)
 + 	0: LdU64(1)
 + 	1: LdU64(2)
 + 	2: LdU64(3)
@@ -40,7 +42,13 @@ comparison between v1 and v2 failed:
 + 	8: StLoc[2](loc2: &mut vector<u64>)
 + 	9: LdU64(0)
 + 	10: StLoc[3](loc3: u64)
-+ B1:
+= B1:
+- 	8: CopyLoc[1](loc1: u64)
+- 	9: CopyLoc[4](loc4: &mut vector<u64>)
+- 	10: FreezeRef
+- 	11: VecLen(2)
+- 	12: Lt
+- 	13: BrFalse(31)
 + 	11: CopyLoc[2](loc2: &mut vector<u64>)
 + 	12: StLoc[4](loc4: &mut vector<u64>)
 + 	13: MoveLoc[4](loc4: &mut vector<u64>)
@@ -51,7 +59,8 @@ comparison between v1 and v2 failed:
 + 	18: MoveLoc[5](loc5: u64)
 + 	19: Lt
 + 	20: BrFalse(43)
-+ B2:
+= B2:
+- 	14: Branch(15)
 + 	21: CopyLoc[2](loc2: &mut vector<u64>)
 + 	22: StLoc[6](loc6: &mut vector<u64>)
 + 	23: MoveLoc[6](loc6: &mut vector<u64>)
@@ -74,11 +83,34 @@ comparison between v1 and v2 failed:
 + 	40: Add
 + 	41: StLoc[3](loc3: u64)
 + 	42: Branch(44)
-+ B3:
+= B3:
+- 	15: CopyLoc[4](loc4: &mut vector<u64>)
+- 	16: CopyLoc[1](loc1: u64)
+- 	17: VecMutBorrow(2)
+- 	18: StLoc[0](loc0: &mut u64)
+- 	19: CopyLoc[2](loc2: u64)
+- 	20: MoveLoc[0](loc0: &mut u64)
+- 	21: WriteRef
+- 	22: MoveLoc[2](loc2: u64)
+- 	23: LdU64(1)
+- 	24: Add
+- 	25: StLoc[2](loc2: u64)
+- 	26: MoveLoc[1](loc1: u64)
+- 	27: LdU64(1)
+- 	28: Add
+- 	29: StLoc[1](loc1: u64)
+- 	30: Branch(8)
 + 	43: Branch(45)
-+ B4:
+= B4:
+- 	31: MoveLoc[4](loc4: &mut vector<u64>)
+- 	32: Pop
+- 	33: MoveLoc[3](loc3: vector<u64>)
+- 	34: LdConst[1](Vector(U64): [3, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0])
+- 	35: Eq
+- 	36: BrFalse(38)
 + 	44: Branch(11)
-+ B5:
+= B5:
+- 	37: Branch(40)
 + 	45: LdU64(2)
 + 	46: LdU64(3)
 + 	47: LdU64(4)
@@ -88,23 +120,20 @@ comparison between v1 and v2 failed:
 + 	51: MoveLoc[10](loc10: vector<u64>)
 + 	52: Eq
 + 	53: BrFalse(55)
-+ B6:
+= B6:
+- 	38: LdU64(0)
+- 	39: Abort
 + 	54: Branch(57)
-+ B7:
+= B7:
+- 	40: Ret
 + 	55: LdU64(0)
 + 	56: Abort
 + B8:
 + 	57: Ret
-+ }
-+ }
+= }
+= }
 = 
-- 
 = task 1 'publish'. lines 13-23:
-- Error: warning[W09003]: unused assignment
--    ┌─ TEMPFILE:18:6
--    │
-- 18 │     let s = 2;
--    │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
 + Error: Unable to publish module '000000000000000000000000000000000000000000000000000000000000cafe::vectors'. Got VMError: {
 +     major_status: MOVELOC_EXISTS_BORROW_ERROR,
 +     sub_status: None,
@@ -113,11 +142,5 @@ comparison between v1 and v2 failed:
 +     offsets: redacted,
 + }
 = 
-- error[E14004]: lambda parameter only permitted as parameter to inlined function
--    ┌─ TEMPFILE:19:31
--    │
-- 19 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
--    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
-- 
 - 
 - 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11112.move
@@ -1,0 +1,23 @@
+//#print-bytecode --input=module
+module 0xcafe::vectors {
+    use std::vector;
+
+    fun test_for_each_mut() {
+	let v = vector[1, 2, 3];
+	let s = 2;
+	vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+	assert!(v == vector[2, 3, 4], 0);
+    }
+}
+
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    fun test_for_each_mut() {
+	let v = vector[1, 2, 3];
+	let s = 2;
+	vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+	assert!(v == vector[2, 3, 4], 0);
+    }
+}

--- a/third_party/move/move-compiler/src/command_line/compiler.rs
+++ b/third_party/move/move-compiler/src/command_line/compiler.rs
@@ -837,7 +837,7 @@ fn run(
             )
         },
         PassResult::Typing(mut tprog) => {
-            inlining::translate::run_inlining(compilation_env, &mut tprog);
+            inlining::translate::run_inlining(compilation_env, pre_compiled_lib, &mut tprog);
             compilation_env.check_diags_at_or_above_severity(Severity::BlockingError)?;
             if compilation_env.flags().debug() {
                 eprintln!(

--- a/third_party/move/move-compiler/src/inlining/translate.rs
+++ b/third_party/move/move-compiler/src/inlining/translate.rs
@@ -25,8 +25,10 @@ use crate::{
 };
 use move_ir_types::location::{sp, Loc};
 use move_symbol_pool::Symbol;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::fmt;
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt,
+};
 
 /// A globally unique function name
 type GlobalFunctionName = (ModuleIdent_, Symbol);

--- a/third_party/move/move-compiler/tests/move_check/inlining/bug_11112.move
+++ b/third_party/move/move-compiler/tests/move_check/inlining/bug_11112.move
@@ -1,0 +1,11 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    fun test_for_each_mut() {
+	let v = vector[1, 2, 3];
+	let s = 2;
+	vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+	assert!(v == vector[2, 3, 4], 0);
+    }
+}

--- a/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.exp
@@ -1,0 +1,16 @@
+processed 1 task
+
+task 0 'publish'. lines 1-11:
+Error: warning[W09003]: unused assignment
+  ┌─ TEMPFILE:6:6
+  │
+6 │     let s = 2;
+  │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
+
+error[E14004]: lambda parameter only permitted as parameter to inlined function
+  ┌─ TEMPFILE:7:31
+  │
+7 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+  │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
+
+

--- a/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.exp
@@ -1,16 +1,71 @@
 processed 1 task
 
 task 0 'publish'. lines 1-11:
-Error: warning[W09003]: unused assignment
-  ┌─ TEMPFILE:6:6
-  │
-6 │     let s = 2;
-  │         ^ Unused assignment or binding for local 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
-
-error[E14004]: lambda parameter only permitted as parameter to inlined function
-  ┌─ TEMPFILE:7:31
-  │
-7 │     vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
-  │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected lambda
 
 
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module cafe.vectors {
+
+
+test_for_each_mut() {
+L0:	loc0: &mut u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: vector<u64>
+L4:	loc4: &mut vector<u64>
+B0:
+	0: LdConst[0](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[3](loc3: vector<u64>)
+	2: LdU64(2)
+	3: StLoc[2](loc2: u64)
+	4: MutBorrowLoc[3](loc3: vector<u64>)
+	5: StLoc[4](loc4: &mut vector<u64>)
+	6: LdU64(0)
+	7: StLoc[1](loc1: u64)
+B1:
+	8: CopyLoc[1](loc1: u64)
+	9: CopyLoc[4](loc4: &mut vector<u64>)
+	10: FreezeRef
+	11: VecLen(2)
+	12: Lt
+	13: BrFalse(31)
+B2:
+	14: Branch(15)
+B3:
+	15: CopyLoc[4](loc4: &mut vector<u64>)
+	16: CopyLoc[1](loc1: u64)
+	17: VecMutBorrow(2)
+	18: StLoc[0](loc0: &mut u64)
+	19: CopyLoc[2](loc2: u64)
+	20: MoveLoc[0](loc0: &mut u64)
+	21: WriteRef
+	22: MoveLoc[2](loc2: u64)
+	23: LdU64(1)
+	24: Add
+	25: StLoc[2](loc2: u64)
+	26: MoveLoc[1](loc1: u64)
+	27: LdU64(1)
+	28: Add
+	29: StLoc[1](loc1: u64)
+	30: Branch(8)
+B4:
+	31: MoveLoc[4](loc4: &mut vector<u64>)
+	32: Pop
+	33: MoveLoc[3](loc3: vector<u64>)
+	34: LdConst[1](Vector(U64): [3, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0])
+	35: Eq
+	36: BrFalse(38)
+B5:
+	37: Branch(40)
+B6:
+	38: LdU64(0)
+	39: Abort
+B7:
+	40: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/inlining/bug_11112.move
@@ -1,0 +1,11 @@
+//#publish --print-bytecode
+module 0xcafe::vectors {
+    use std::vector;
+
+    fun test_for_each_mut() {
+	let v = vector[1, 2, 3];
+	let s = 2;
+	vector::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+	assert!(v == vector[2, 3, 4], 0);
+    }
+}


### PR DESCRIPTION
### Description

Fix move-compiler-transactional-tests to also inline functions from pre-compiled-library.

- Added a new test bug_11112.move showing the problem in both v1 and v2 (because it also compares with v1 output).

- Provided `pre_compiled_lib` to inlining pass in move-compiler (V1) for transactional tests, and also collect inline
functions from that library in inlining pass.  This could probably be made more efficient, but as V1 is on its way out,
that'll do for now.

Fixes Issue #11264 

### Test Plan
The new test illustrated the problem, now shows it is fixed.

This change only affects move-compiler-transactional-tests (and move-compiler-v2-transactional-tests due to its
output comparison with V1), so running all transactional tests should be sufficient.

