### PR TITLE
Turn off v1 comparison in v2 transactional tests if MOVE_TEST_DEBUG is enabled 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9912,7 +9912,9 @@ name = "move-compiler-v2-transactional-tests"
 version = "0.1.0"
 dependencies = [
  "datatest-stable",
+ "move-command-line-common",
  "move-transactional-test-runner",
+ "once_cell",
 ]
 
 [[package]]

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -1218,7 +1218,6 @@ mod tests {
             (9, BTreeSet::new()),
         ]);
         let result = postorder(&entries, &call_graph);
-        // eprintln!("result is {:#?}", &result);
         assert!(
             result == vec![8, 7, 5, 6, 4, 3, 2, 1]
                 || result == vec![8, 7, 6, 5, 4, 3, 2, 1]

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -1218,7 +1218,7 @@ mod tests {
             (9, BTreeSet::new()),
         ]);
         let result = postorder(&entries, &call_graph);
-        eprintln!("result is {:#?}", &result);
+        // eprintln!("result is {:#?}", &result);
         assert!(
             result == vec![8, 7, 5, 6, 4, 3, 2, 1]
                 || result == vec![8, 7, 6, 5, 4, 3, 2, 1]

--- a/third_party/move/move-compiler-v2/transactional-tests/Cargo.toml
+++ b/third_party/move/move-compiler-v2/transactional-tests/Cargo.toml
@@ -6,6 +6,10 @@ publish = false
 edition = "2021"
 license = "Apache-2.0"
 
+[dependencies]
+move-command-line-common = { path = "../../move-command-line-common" }
+once_cell = "1.7.2"
+
 [dev-dependencies]
 datatest-stable = "0.1.1"
 move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -4,7 +4,9 @@
 
 pub const TEST_DIR: &str = "tests";
 
+use move_command_line_common::env::read_bool_env_var;
 use move_transactional_test_runner::{vm_test_harness, vm_test_harness::TestRunConfig};
+use once_cell::sync::Lazy;
 use std::path::Path;
 
 datatest_stable::harness!(run, TEST_DIR, r".*\.move$");
@@ -12,9 +14,14 @@ datatest_stable::harness!(run, TEST_DIR, r".*\.move$");
 /// Tests containing this string in their path will skip v1-v2 comparison
 const SKIP_V1_COMPARISON_PATH: &str = "/no-v1-comparison/";
 
+fn move_test_debug() -> bool {
+    static MOVE_TEST_DEBUG: Lazy<bool> = Lazy::new(|| read_bool_env_var("MOVE_TEST_DEBUG"));
+    *MOVE_TEST_DEBUG
+}
+
 fn run(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let p = path.to_str().unwrap_or_default();
-    let test_config = if p.contains(SKIP_V1_COMPARISON_PATH) {
+    let test_config = if p.contains(SKIP_V1_COMPARISON_PATH) || move_test_debug() {
         TestRunConfig::CompilerV2
     } else {
         TestRunConfig::ComparisonV1V2


### PR DESCRIPTION
### Description

Tweak V2 transactional tests to not compile V1 and run comparisons if `MOVE_TEST_DEBUG` is enabled, making debugging easier..

### Test Plan
Run tests with and without `MOVE_TEST_DEBUG=1`.

