### PR TITLE
[Compiler-v2] Fix a bug related to vector constants

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/folding_vector.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/folding_vector.exp
@@ -1,3 +1,3 @@
-processed 1 task
+processed 2 tasks
 
 ==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/folding_vector.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/folding_vector.move
@@ -8,4 +8,11 @@ module 0x42::M {
     const E0: bool = vector<u8>[] == vector[];
     const E1: bool = vector[0] == vector[1, 100];
 
+    const E3: vector<vector<u8>> = vector[vector[1], vector[2]];
+
+    fun foo() {
+        assert!(vector[vector[1], vector[2]] == E3, 0);
+    }
 }
+
+//#run 0x42::M::foo

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -368,6 +368,15 @@ impl Type {
         matches!(self, Type::Vector(..))
     }
 
+    /// Get the element type of a vector
+    pub fn get_vector_element_type(&self) -> Option<Type> {
+        if let Type::Vector(e) = self {
+            Some(e.as_ref().clone())
+        } else {
+            None
+        }
+    }
+
     /// Determines whether this is a struct, or a vector of structs, or a reference to any of
     /// those.
     pub fn is_struct_or_vector_of_struct(&self) -> bool {


### PR DESCRIPTION
### Description

This PR fixes the bug that the compiler V2 does not correctly handle the type of vector constants when generating the stackless bytecode. A new test is added to the test case `folding_vector` to validate the fix.


