### PR TITLE
[dev_setup] Don't install libdw for arch linux

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -714,8 +714,8 @@ function install_lld {
 }
 
 function install_libdw {
-  # Right now, only install libdw for linux
-  if [[ "$(uname)" == "Linux" ]]; then
+  # Right now, only install libdw for linux (not Arch)
+  if [[ "$(uname)" == "Linux" && "$PACKAGE_MANAGER" != "pacman" ]]; then
     install_pkg libdw-dev "$PACKAGE_MANAGER"
   fi
 }


### PR DESCRIPTION
### Description
Fails to install on ArchLinux via pacman with libdw, so I've skipped over it.

### Test Plan
Tested locally on an ArchLinux VM.