### PR TITLE
[rb] support concurrent message verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ name = "aptos-reliable-broadcast"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-bounded-executor",
  "aptos-consensus-types",
  "aptos-enum-conversion-derive",
  "aptos-infallible",

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -34,6 +34,7 @@ use crate::{
     pipeline::buffer_manager::OrderedBlocks,
     state_replication::StateComputer,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{
     aptos_channel::{self, Receiver},
     message_queues::QueueStyle,
@@ -119,7 +120,7 @@ impl ActiveMode {
     async fn run_internal(
         self,
         dag_rpc_rx: &mut Receiver<Author, IncomingDAGRequest>,
-        _bootstrapper: &DagBootstrapper,
+        bootstrapper: &DagBootstrapper,
     ) -> Option<Mode> {
         info!(
             LogSchema::new(LogEvent::ActiveMode)
@@ -148,7 +149,10 @@ impl ActiveMode {
         });
 
         // Run the network handler until it returns with state sync status.
-        let sync_outcome = self.handler.run(dag_rpc_rx, self.buffer).await;
+        let sync_outcome = self
+            .handler
+            .run(dag_rpc_rx, bootstrapper.executor.clone(), self.buffer)
+            .await;
 
         info!(
             LogSchema::new(LogEvent::SyncOutcome),
@@ -324,6 +328,7 @@ pub struct DagBootstrapper {
     ordered_nodes_tx: UnboundedSender<OrderedBlocks>,
     quorum_store_enabled: bool,
     validator_txn_enabled: bool,
+    executor: BoundedExecutor,
 }
 
 impl DagBootstrapper {
@@ -345,6 +350,7 @@ impl DagBootstrapper {
         ordered_nodes_tx: UnboundedSender<OrderedBlocks>,
         quorum_store_enabled: bool,
         validator_txn_enabled: bool,
+        executor: BoundedExecutor,
     ) -> Self {
         Self {
             self_peer,
@@ -363,6 +369,7 @@ impl DagBootstrapper {
             ordered_nodes_tx,
             quorum_store_enabled,
             validator_txn_enabled,
+            executor,
         }
     }
 
@@ -485,6 +492,7 @@ impl DagBootstrapper {
             rb_backoff_policy,
             self.time_service.clone(),
             Duration::from_millis(rb_config.rpc_timeout_ms),
+            self.executor.clone(),
         ));
 
         let BootstrapBaseState {
@@ -655,6 +663,7 @@ pub(super) fn bootstrap_dag_for_test(
         ordered_nodes_tx,
         false,
         true,
+        BoundedExecutor::new(2, Handle::current()),
     );
 
     let (_base_state, handler, fetch_service) = bootstraper.full_bootstrap();
@@ -663,7 +672,9 @@ pub(super) fn bootstrap_dag_for_test(
 
     let dh_handle = tokio::spawn(async move {
         let mut dag_rpc_rx = dag_rpc_rx;
-        handler.run(&mut dag_rpc_rx, Vec::new()).await
+        handler
+            .run(&mut dag_rpc_rx, bootstraper.executor.clone(), Vec::new())
+            .await
     });
     let df_handle = tokio::spawn(fetch_service.start());
 

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -79,8 +79,7 @@ impl StateSyncTrigger {
         Ok(())
     }
 
-    /// This method checks if a state sync is required, and if so,
-    /// notifies the bootstraper, to let the bootstraper can abort this task.
+    /// This method checks if a state sync is required
     pub(super) async fn check(&self, node: CertifiedNodeMessage) -> anyhow::Result<SyncOutcome> {
         let ledger_info_with_sigs = node.ledger_info();
 
@@ -139,9 +138,9 @@ impl StateSyncTrigger {
         }
 
         let dag_reader = self.dag_store.read();
-        // check whether if DAG order round is behind the given ledger info round
+        // check whether if DAG order round is behind the given ledger info committed round
         // (meaning consensus is behind) or
-        // the highest committed anchor round is 2*DAG_WINDOW behind the given ledger info round
+        // the local highest committed anchor round is 2*DAG_WINDOW behind the given ledger info round
         // (meaning execution is behind the DAG window)
 
         // fetch can't work since nodes are garbage collected

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -19,6 +19,7 @@ use aptos_crypto::{
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_enum_conversion_derive::EnumConversion;
+use aptos_infallible::Mutex;
 use aptos_logger::debug;
 use aptos_reliable_broadcast::{BroadcastStatus, RBMessage};
 use aptos_types::{
@@ -533,42 +534,43 @@ impl TryFrom<DAGRpcResult> for Vote {
 
 pub struct SignatureBuilder {
     metadata: NodeMetadata,
-    partial_signatures: PartialSignatures,
+    partial_signatures: Mutex<PartialSignatures>,
     epoch_state: Arc<EpochState>,
 }
 
 impl SignatureBuilder {
-    pub fn new(metadata: NodeMetadata, epoch_state: Arc<EpochState>) -> Self {
-        Self {
+    pub fn new(metadata: NodeMetadata, epoch_state: Arc<EpochState>) -> Arc<Self> {
+        Arc::new(Self {
             metadata,
-            partial_signatures: PartialSignatures::empty(),
+            partial_signatures: Mutex::new(PartialSignatures::empty()),
             epoch_state,
-        }
+        })
     }
 }
 
-impl BroadcastStatus<DAGMessage, DAGRpcResult> for SignatureBuilder {
+impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
     type Ack = Vote;
     type Aggregated = NodeCertificate;
     type Message = Node;
 
-    fn add(&mut self, peer: Author, ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
+    fn add(&self, peer: Author, ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
         ensure!(self.metadata == ack.metadata, "Digest mismatch");
         ack.verify(peer, &self.epoch_state.verifier)?;
         debug!(LogSchema::new(LogEvent::ReceiveVote)
             .remote_peer(peer)
             .round(self.metadata.round()));
-        self.partial_signatures.add_signature(peer, ack.signature);
+        let mut signatures_lock = self.partial_signatures.lock();
+        signatures_lock.add_signature(peer, ack.signature);
         Ok(self
             .epoch_state
             .verifier
-            .check_voting_power(self.partial_signatures.signatures().keys(), true)
+            .check_voting_power(signatures_lock.signatures().keys(), true)
             .ok()
             .map(|_| {
                 let aggregated_signature = self
                     .epoch_state
                     .verifier
-                    .aggregate_signatures(&self.partial_signatures)
+                    .aggregate_signatures(&signatures_lock)
                     .expect("Signature aggregation should succeed");
                 observe_node(self.metadata.timestamp(), NodeStage::CertAggregated);
                 NodeCertificate::new(self.metadata.clone(), aggregated_signature)
@@ -578,15 +580,15 @@ impl BroadcastStatus<DAGMessage, DAGRpcResult> for SignatureBuilder {
 
 pub struct CertificateAckState {
     num_validators: usize,
-    received: HashSet<Author>,
+    received: Mutex<HashSet<Author>>,
 }
 
 impl CertificateAckState {
-    pub fn new(num_validators: usize) -> Self {
-        Self {
+    pub fn new(num_validators: usize) -> Arc<Self> {
+        Arc::new(Self {
             num_validators,
-            received: HashSet::new(),
-        }
+            received: Mutex::new(HashSet::new()),
+        })
     }
 }
 
@@ -615,15 +617,16 @@ impl TryFrom<DAGRpcResult> for CertifiedAck {
     }
 }
 
-impl BroadcastStatus<DAGMessage, DAGRpcResult> for CertificateAckState {
+impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<CertificateAckState> {
     type Ack = CertifiedAck;
     type Aggregated = ();
     type Message = CertifiedNodeMessage;
 
-    fn add(&mut self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
+    fn add(&self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
         debug!(LogSchema::new(LogEvent::ReceiveAck).remote_peer(peer));
-        self.received.insert(peer);
-        if self.received.len() == self.num_validators {
+        let mut received = self.received.lock();
+        received.insert(peer);
+        if received.len() == self.num_validators {
             Ok(Some(()))
         } else {
             Ok(None)

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -601,14 +601,14 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             block_rx,
             reset_rx,
             epoch_state,
+            self.bounded_executor.clone(),
         );
-        let bounded_executor = self.bounded_executor.clone();
 
         tokio::spawn(execution_schedule_phase.start());
         tokio::spawn(execution_wait_phase.start());
         tokio::spawn(signing_phase.start());
         tokio::spawn(persisting_phase.start());
-        tokio::spawn(buffer_manager.start(bounded_executor));
+        tokio::spawn(buffer_manager.start());
 
         (block_tx, reset_tx)
     }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1130,6 +1130,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             block_tx,
             onchain_consensus_config.quorum_store_enabled(),
             onchain_consensus_config.validator_txn_enabled(),
+            self.bounded_executor.clone(),
         );
 
         let (dag_rpc_tx, dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 10, None);

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -121,6 +121,7 @@ pub struct BufferManager {
     end_epoch_timestamp: OnceCell<u64>,
     previous_commit_time: Instant,
     reset_flag: Arc<AtomicBool>,
+    bounded_executor: BoundedExecutor,
 }
 
 impl BufferManager {
@@ -144,6 +145,7 @@ impl BufferManager {
         epoch_state: Arc<EpochState>,
         ongoing_tasks: Arc<AtomicU64>,
         reset_flag: Arc<AtomicBool>,
+        executor: BoundedExecutor,
     ) -> Self {
         let buffer = Buffer::<BufferItem>::new();
 
@@ -171,6 +173,7 @@ impl BufferManager {
                 rb_backoff_policy,
                 TimeService::real(),
                 Duration::from_millis(COMMIT_VOTE_BROADCAST_INTERVAL_MS),
+                executor.clone(),
             ),
             commit_proof_rb_handle: None,
             commit_msg_tx,
@@ -187,6 +190,7 @@ impl BufferManager {
             end_epoch_timestamp: OnceCell::new(),
             previous_commit_time: Instant::now(),
             reset_flag,
+            bounded_executor: executor,
         }
     }
 
@@ -694,12 +698,13 @@ impl BufferManager {
             .set(pending_aggregated as i64);
     }
 
-    pub async fn start(mut self, bounded_executor: BoundedExecutor) {
+    pub async fn start(mut self) {
         info!("Buffer manager starts.");
         let (verified_commit_msg_tx, mut verified_commit_msg_rx) = create_channel();
         let mut interval = tokio::time::interval(Duration::from_millis(LOOP_INTERVAL_MS));
         let mut commit_msg_rx = self.commit_msg_rx.take().expect("commit msg rx must exist");
         let epoch_state = self.epoch_state.clone();
+        let bounded_executor = self.bounded_executor.clone();
         spawn_named!("buffer manager verification", async move {
             while let Some(commit_msg) = commit_msg_rx.next().await {
                 let tx = verified_commit_msg_tx.clone();

--- a/consensus/src/pipeline/decoupled_execution_utils.rs
+++ b/consensus/src/pipeline/decoupled_execution_utils.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     state_replication::StateComputer,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::aptos_channel::Receiver;
 use aptos_consensus_types::common::Author;
 use aptos_types::{account_address::AccountAddress, epoch_state::EpochState};
@@ -34,6 +35,7 @@ pub fn prepare_phases_and_buffer_manager(
     block_rx: UnboundedReceiver<OrderedBlocks>,
     sync_rx: UnboundedReceiver<ResetRequest>,
     epoch_state: Arc<EpochState>,
+    bounded_executor: BoundedExecutor,
 ) -> (
     PipelinePhase<ExecutionSchedulePhase>,
     PipelinePhase<ExecutionWaitPhase>,
@@ -116,6 +118,7 @@ pub fn prepare_phases_and_buffer_manager(
             epoch_state,
             ongoing_tasks,
             reset_flag.clone(),
+            bounded_executor,
         ),
     )
 }

--- a/crates/reliable-broadcast/Cargo.toml
+++ b/crates/reliable-broadcast/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-bounded-executor = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-enum-conversion-derive = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -1,11 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_consensus_types::common::Author;
 use aptos_logger::info;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use async_trait::async_trait;
-use futures::{future::AbortHandle, stream::FuturesUnordered, Future, StreamExt};
+use futures::{
+    stream::{AbortHandle, FuturesUnordered},
+    Future, FutureExt, StreamExt,
+};
 use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
 pub trait RBMessage: Send + Sync + Clone {}
@@ -20,12 +24,12 @@ pub trait RBNetworkSender<Req: RBMessage, Res: RBMessage = Req>: Send + Sync {
     ) -> anyhow::Result<Res>;
 }
 
-pub trait BroadcastStatus<Req: RBMessage, Res: RBMessage = Req> {
+pub trait BroadcastStatus<Req: RBMessage, Res: RBMessage = Req>: Send + Sync + Clone {
     type Ack: Into<Res> + TryFrom<Res> + Clone;
-    type Aggregated;
+    type Aggregated: Send;
     type Message: Into<Req> + TryFrom<Req> + Clone;
 
-    fn add(&mut self, peer: Author, ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>>;
+    fn add(&self, peer: Author, ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>>;
 }
 
 pub struct ReliableBroadcast<Req: RBMessage, TBackoff, Res: RBMessage = Req> {
@@ -34,13 +38,14 @@ pub struct ReliableBroadcast<Req: RBMessage, TBackoff, Res: RBMessage = Req> {
     backoff_policy: TBackoff,
     time_service: TimeService,
     rpc_timeout_duration: Duration,
+    executor: BoundedExecutor,
 }
 
 impl<Req, TBackoff, Res> ReliableBroadcast<Req, TBackoff, Res>
 where
-    Req: RBMessage,
-    TBackoff: Iterator<Item = Duration> + Clone,
-    Res: RBMessage,
+    Req: RBMessage + 'static,
+    TBackoff: Iterator<Item = Duration> + Clone + 'static,
+    Res: RBMessage + 'static,
 {
     pub fn new(
         validators: Vec<Author>,
@@ -48,6 +53,7 @@ where
         backoff_policy: TBackoff,
         time_service: TimeService,
         rpc_timeout_duration: Duration,
+        executor: BoundedExecutor,
     ) -> Self {
         Self {
             validators,
@@ -55,14 +61,15 @@ where
             backoff_policy,
             time_service,
             rpc_timeout_duration,
+            executor,
         }
     }
 
-    pub fn broadcast<S: BroadcastStatus<Req, Res>>(
+    pub fn broadcast<S: BroadcastStatus<Req, Res> + 'static>(
         &self,
         message: S::Message,
-        mut aggregating: S,
-    ) -> impl Future<Output = S::Aggregated>
+        aggregating: S,
+    ) -> impl Future<Output = S::Aggregated> + 'static
     where
         <<S as BroadcastStatus<Req, Res>>::Ack as TryFrom<Res>>::Error: Debug,
     {
@@ -76,8 +83,8 @@ where
             .cloned()
             .map(|author| (author, self.backoff_policy.clone()))
             .collect();
+        let executor = self.executor.clone();
         async move {
-            let mut fut = FuturesUnordered::new();
             let send_message = |receiver, message, sleep_duration: Option<Duration>| {
                 let network_sender = network_sender.clone();
                 let time_service = time_service.clone();
@@ -92,31 +99,53 @@ where
                             .await,
                     )
                 }
+                .boxed()
             };
             let message: Req = message.into();
+            let mut rpc_futures = FuturesUnordered::new();
+            let mut aggregate_futures = FuturesUnordered::new();
             for receiver in receivers {
-                fut.push(send_message(receiver, message.clone(), None));
+                rpc_futures.push(send_message(receiver, message.clone(), None));
             }
-            while let Some((receiver, result)) = fut.next().await {
-                match result.and_then(|msg| msg.try_into().map_err(|e| anyhow::anyhow!("{:?}", e)))
-                {
-                    Ok(ack) => {
-                        if let Ok(Some(aggregated)) = aggregating.add(receiver, ack) {
-                            return aggregated;
+            loop {
+                tokio::select! {
+                    Some((receiver, result)) = rpc_futures.next() => {
+                        let aggregating = aggregating.clone();
+                        let future = executor.spawn(async move {
+                            (
+                                    receiver,
+                                    result
+                                        .and_then(|msg| {
+                                            msg.try_into().map_err(|e| anyhow::anyhow!("{:?}", e))
+                                        })
+                                        .and_then(|ack| aggregating.add(receiver, ack)),
+                            )
+                        }).await;
+                        aggregate_futures.push(future);
+                    },
+                    Some(result) = aggregate_futures.next() => {
+                        let (receiver, result) = result.expect("spawned task must succeed");
+                        match result {
+                            Ok(may_be_aggragated) => {
+                                if let Some(aggregated) = may_be_aggragated {
+                                    return aggregated;
+                                }
+                            },
+                            Err(e) => {
+                                info!(error = ?e, "rpc to {} failed", receiver);
+
+                                let backoff_strategy = backoff_policies
+                                    .get_mut(&receiver)
+                                    .expect("should be present");
+                                let duration = backoff_strategy.next().expect("should produce value");
+                                rpc_futures
+                                    .push(send_message(receiver, message.clone(), Some(duration)));
+                            },
                         }
                     },
-                    Err(e) => {
-                        info!(error = ?e, "rpc to {} failed", receiver);
-
-                        let backoff_strategy = backoff_policies
-                            .get_mut(&receiver)
-                            .expect("should be present");
-                        let duration = backoff_strategy.next().expect("should produce value");
-                        fut.push(send_message(receiver, message.clone(), Some(duration)));
-                    },
+                    else => unreachable!("Should aggregate with all responses")
                 }
             }
-            unreachable!("Should aggregate with all responses");
         }
     }
 }

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -3,6 +3,7 @@
 
 use crate::{BroadcastStatus, RBMessage, RBNetworkSender, ReliableBroadcast};
 use anyhow::bail;
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_consensus_types::common::Author;
 use aptos_enum_conversion_derive::EnumConversion;
 use aptos_infallible::Mutex;
@@ -20,6 +21,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tokio::runtime::Handle;
 use tokio_retry::strategy::FixedInterval;
 
 #[derive(Clone)]
@@ -38,10 +40,10 @@ impl RBMessage for TestRBMessage {}
 
 struct TestBroadcastStatus {
     threshold: usize,
-    received: HashSet<Author>,
+    received: Arc<Mutex<HashSet<Author>>>,
 }
 
-impl<M> BroadcastStatus<M> for TestBroadcastStatus
+impl<M> BroadcastStatus<M> for Arc<TestBroadcastStatus>
 where
     M: RBMessage,
     TestAck: TryFrom<M> + Into<M>,
@@ -51,10 +53,10 @@ where
     type Aggregated = HashSet<Author>;
     type Message = TestMessage;
 
-    fn add(&mut self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
-        self.received.insert(peer);
-        if self.received.len() == self.threshold {
-            Ok(Some(self.received.clone()))
+    fn add(&self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
+        self.received.lock().insert(peer);
+        if self.received.lock().len() == self.threshold {
+            Ok(Some(self.received.lock().clone()))
         } else {
             Ok(None)
         }
@@ -122,12 +124,13 @@ async fn test_reliable_broadcast() {
         FixedInterval::from_millis(10),
         TimeService::real(),
         Duration::from_millis(500),
+        BoundedExecutor::new(2, Handle::current()),
     );
     let message = TestMessage(vec![42; validators.len() - 1]);
-    let aggregating = TestBroadcastStatus {
+    let aggregating = Arc::new(TestBroadcastStatus {
         threshold: validators.len(),
-        received: HashSet::new(),
-    };
+        received: Arc::new(Mutex::new(HashSet::new())),
+    });
     let fut = rb.broadcast(message, aggregating);
     assert_eq!(fut.await, validators.into_iter().collect());
 }
@@ -138,27 +141,29 @@ async fn test_chaining_reliable_broadcast() {
     let validators = validator_verifier.get_ordered_account_addresses();
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
     let sender = Arc::new(TestRBSender::<TestRBMessage>::new(failures));
-    let rb = ReliableBroadcast::new(
+    let rb = Arc::new(ReliableBroadcast::new(
         validators.clone(),
         sender,
         FixedInterval::from_millis(10),
         TimeService::real(),
         Duration::from_millis(500),
-    );
+        BoundedExecutor::new(2, Handle::current()),
+    ));
     let message = TestMessage(vec![42; validators.len()]);
     let expected = validators.iter().cloned().collect();
-    let aggregating = TestBroadcastStatus {
+    let aggregating = Arc::new(TestBroadcastStatus {
         threshold: validators.len(),
-        received: HashSet::new(),
-    };
-    let fut = rb
+        received: Arc::new(Mutex::new(HashSet::new())),
+    });
+    let rb1 = rb.clone();
+    let fut = rb1
         .broadcast(message.clone(), aggregating)
         .then(|aggregated| async move {
             assert_eq!(aggregated, expected);
-            let aggregating = TestBroadcastStatus {
+            let aggregating = Arc::new(TestBroadcastStatus {
                 threshold: validator_verifier.len(),
-                received: HashSet::new(),
-            };
+                received: Arc::new(Mutex::new(HashSet::new())),
+            });
             rb.broadcast(message, aggregating).await
         });
     assert_eq!(fut.await, validators.into_iter().collect());
@@ -170,27 +175,28 @@ async fn test_abort_reliable_broadcast() {
     let validators = validator_verifier.get_ordered_account_addresses();
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
     let sender = Arc::new(TestRBSender::<TestRBMessage>::new(failures));
-    let rb = ReliableBroadcast::new(
+    let rb = Arc::new(ReliableBroadcast::new(
         validators.clone(),
         sender,
         FixedInterval::from_millis(10),
         TimeService::real(),
         Duration::from_millis(500),
-    );
+        BoundedExecutor::new(2, Handle::current()),
+    ));
     let message = TestMessage(vec![42; validators.len()]);
     let (tx, rx) = oneshot::channel();
     let (abort_handle, abort_registration) = AbortHandle::new_pair();
-    let aggregating = TestBroadcastStatus {
+    let aggregating = Arc::new(TestBroadcastStatus {
         threshold: validators.len(),
-        received: HashSet::new(),
-    };
+        received: Arc::new(Mutex::new(HashSet::new())),
+    });
     let fut = Abortable::new(
         rb.broadcast(message.clone(), aggregating)
             .then(|_| async move {
-                let aggregating = TestBroadcastStatus {
+                let aggregating = Arc::new(TestBroadcastStatus {
                     threshold: validators.len(),
-                    received: HashSet::new(),
-                };
+                    received: Arc::new(Mutex::new(HashSet::new())),
+                });
                 let ret = rb.broadcast(message, aggregating).await;
                 tx.send(ret)
             }),


### PR DESCRIPTION
### Description

This PR modifies ReliableBroadcast to process RPC responses concurrently using the `concurrent_map`ping function introduced in #11290. To support concurrency, `BroadcastStatus` trait had to support `Sync + Send + Clone`, so this PR also changes all instances of BroadcastStatus to satisfy the new bounds.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
