### PR TITLE
[compiler] Clean up Move-Model AST visitors and exp_rewriter interfaces

### DIFF
--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -755,15 +755,15 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
     /// Also check for Break or Continue inside a lambda and not inside a loop.
     fn check_for_return_break_continue_in_lambda(env: &GlobalEnv, lambda_body: &Exp) {
         let mut in_loop = 0;
-        lambda_body.visit_pre_post(&mut |up, e| {
+        lambda_body.visit_pre_post(&mut |post, e| {
             match e {
-                ExpData::Loop(..) if !up => {
+                ExpData::Loop(..) if !post => {
                     in_loop += 1;
                 },
-                ExpData::Loop(..) if up => {
+                ExpData::Loop(..) if post => {
                     in_loop -= 1;
                 },
-                ExpData::Return(node_id, _) if !up => {
+                ExpData::Return(node_id, _) if !post => {
                     let node_loc = env.get_node_loc(*node_id);
                     env.error(
                         &node_loc,
@@ -771,7 +771,7 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                          (lambda expressions)",
                     )
                 },
-                ExpData::LoopCont(node_id, is_continue) if !up && in_loop == 0 => {
+                ExpData::LoopCont(node_id, is_continue) if !post && in_loop == 0 => {
                     let node_loc = env.get_node_loc(*node_id);
                     env.error(
                         &node_loc,

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -755,7 +755,7 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
     /// Also check for Break or Continue inside a lambda and not inside a loop.
     fn check_for_return_break_continue_in_lambda(env: &GlobalEnv, lambda_body: &Exp) {
         let mut in_loop = 0;
-        let _ = lambda_body.visit_pre_post(&mut |up, e| {
+        lambda_body.visit_pre_post(&mut |up, e| {
             match e {
                 ExpData::Loop(..) if !up => {
                     in_loop += 1;
@@ -784,7 +784,7 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                 },
                 _ => {},
             }
-            Ok(())
+            true // keep going
         });
     }
 

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -668,10 +668,8 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
         for arg_exp in non_lambda_function_args {
             env.error(
                 &env.get_node_loc(arg_exp.as_ref().node_id()),
-                concat!(
-                    "Currently, a function-typed parameter to an inline function",
-                    " must be a literal lambda expression",
-                ),
+                "Currently, a function-typed parameter to an inline function \
+                 must be a literal lambda expression",
             );
         }
 
@@ -769,10 +767,8 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                     let node_loc = env.get_node_loc(*node_id);
                     env.error(
                         &node_loc,
-                        concat!(
-                            "Return not currently supported in function-typed arguments",
-                            " (lambda expressions)"
-                        ),
+                        "Return not currently supported in function-typed arguments \
+                         (lambda expressions)",
                     )
                 },
                 ExpData::LoopCont(node_id, is_continue) if !up && in_loop == 0 => {
@@ -780,10 +776,8 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                     env.error(
                         &node_loc,
                         &format!(
-                            concat!(
-                                "{} outside of a loop not supported in function-typed arguments",
-                                " (lambda expressions)"
-                            ),
+                            "{} outside of a loop not supported in function-typed arguments \
+                             (lambda expressions)",
                             if *is_continue { "Continue" } else { "Break" }
                         ),
                     )
@@ -1011,7 +1005,7 @@ impl<'env, 'rewriter> ExpRewriterFunctions for InlinedRewriter<'env, 'rewriter> 
                 let node_loc = self.env.get_node_loc(*node_id);
                 self.env.error(
                     &node_loc,
-                    concat!("Return not currently supported in inline functions"),
+                    "Return not currently supported in inline functions",
                 );
                 false
             },
@@ -1093,10 +1087,8 @@ impl<'env, 'rewriter> ExpRewriterFunctions for InlinedRewriter<'env, 'rewriter> 
                 Severity::Bug,
                 &loc,
                 &format!(
-                    concat!(
-                        "Temporary with invalid index `{}` during inlining",
-                        " of function with `{}` parameters"
-                    ),
+                    "Temporary with invalid index `{}` during inlining \
+                     of function with `{}` parameters",
                     idx,
                     self.inlined_formal_params.len()
                 ),

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -622,6 +622,7 @@ impl ExpData {
         let mut ids = vec![];
         self.visit(&mut |e| {
             ids.push(e.node_id());
+            Ok(())
         });
         ids
     }
@@ -651,8 +652,9 @@ impl ExpData {
                     }
                 }
             }
+            Ok(())
         };
-        self.visit_pre_post(&mut visitor);
+        let _ = self.visit_pre_post(&mut visitor);
         vars
     }
 
@@ -704,8 +706,9 @@ impl ExpData {
                     }
                 }
             }
+            Ok(())
         };
-        self.visit_pre_post(&mut visitor);
+        let _ = self.visit_pre_post(&mut visitor);
     }
 
     /// Returns just the free local variables in this expression.
@@ -746,6 +749,7 @@ impl ExpData {
                 },
                 _ => {},
             }
+            Ok(())
         };
         self.visit(&mut visitor);
         result
@@ -760,6 +764,7 @@ impl ExpData {
                     temps.push((*idx, env.get_node_type(*id)));
                 }
             }
+            Ok(())
         };
         self.visit(&mut visitor);
         temps
@@ -772,6 +777,7 @@ impl ExpData {
             if let ExpData::Call(_, Operation::MoveFunction(mid, fid), _) = e {
                 called.insert(mid.qualified(*fid));
             }
+            Ok(())
         };
         self.visit(&mut visitor);
         called
@@ -787,22 +793,27 @@ impl ExpData {
                     .or_default()
                     .insert(*node_id);
             }
+            Ok(())
         };
         self.visit(&mut visitor);
         called
     }
 
     pub fn has_exit(&self) -> bool {
-        // TODO: we currently cannot break out of a visitor, so we maintain a state when we
-        // are inside a loop.
-        let mut in_loop = false;
+        let mut loop_count = 0; // Count internal nested loops.
         let mut has_exit = false;
-        let mut visitor = |post: bool, e: &ExpData| match e {
-            ExpData::Loop(_, _) => in_loop = !post,
-            ExpData::LoopCont(_, _) if !in_loop => has_exit = true,
-            _ => {},
+        let mut visitor = |up: bool, e: &ExpData| {
+            match e {
+                ExpData::Loop(_, _) => loop_count += if up { -1 } else { 1 },
+                ExpData::LoopCont(_, _) if loop_count == 0 => {
+                    has_exit = true;
+                    return Err(()); // found an exit, exit visit early
+                },
+                _ => {},
+            }
+            Ok(())
         };
-        self.visit_pre_post(&mut visitor);
+        let _ = self.visit_pre_post(&mut visitor);
         has_exit
     }
 
@@ -813,39 +824,45 @@ impl ExpData {
     /// but is not documented as such in the book
     pub fn is_valid_for_constant(&self, env: &GlobalEnv, reasons: &mut Vec<(Loc, String)>) -> bool {
         let mut valid = true;
-        let mut visitor = |e: &ExpData| match e {
-            ExpData::Value(..) | ExpData::Invalid(_) | ExpData::Sequence(_, _) => {},
-            ExpData::Call(id, oper, _args) => {
-                // Note that _args are visited separately.  No need to check them here.
-                if !oper.is_builtin_op() {
+        let mut visitor = |e: &ExpData| {
+            match e {
+                ExpData::Value(..) | ExpData::Invalid(_) | ExpData::Sequence(_, _) => {},
+                ExpData::Call(id, oper, _args) => {
+                    // Note that _args are visited separately.  No need to check them here.
+                    if !oper.is_builtin_op() {
+                        reasons.push((
+                            env.get_node_loc(*id),
+                            "Invalid call or operation in constant".to_owned(),
+                        ));
+                        valid = false;
+                    }
+                },
+                _ => {
+                    let id = e.node_id();
                     reasons.push((
-                        env.get_node_loc(*id),
-                        "Invalid call or operation in constant".to_owned(),
+                        env.get_node_loc(id),
+                        "Invalid statement or expression in constant".to_owned(),
                     ));
                     valid = false;
-                }
-            },
-            _ => {
-                let id = e.node_id();
-                reasons.push((
-                    env.get_node_loc(id),
-                    "Invalid statement or expression in constant".to_owned(),
-                ));
-                valid = false
-            },
+                },
+            }
+            Ok(()) // always keep going
         };
         self.visit_top_down(&mut visitor);
         valid
     }
 
     /// Visits expression, calling visitor on each sub-expression, depth first.
+    /// `visitor` returns false to indicate that visit should stop early.
     pub fn visit<F>(&self, visitor: &mut F)
     where
-        F: FnMut(&ExpData),
+        F: FnMut(&ExpData) -> Result<(), ()>,
     {
-        self.visit_pre_post(&mut |up, e| {
+        let _ = self.visit_pre_post(&mut |up, e| {
             if up {
-                visitor(e);
+                visitor(e)
+            } else {
+                Ok(())
             }
         });
     }
@@ -853,11 +870,13 @@ impl ExpData {
     /// Visits expression, calling visitor parent expression, then subexpressions, depth first.
     pub fn visit_top_down<F>(&self, visitor: &mut F)
     where
-        F: FnMut(&ExpData),
+        F: FnMut(&ExpData) -> Result<(), ()>,
     {
-        self.visit_pre_post(&mut |up, e| {
+        let _ = self.visit_pre_post(&mut |up, e| {
             if !up {
-                visitor(e);
+                visitor(e)
+            } else {
+                Ok(())
             }
         });
     }
@@ -868,10 +887,11 @@ impl ExpData {
     {
         let mut found = false;
         self.visit(&mut |e| {
-            if !found {
-                // This still continues to visit after a match is found, may want to
-                // optimize if it becomes an issue.
-                found = predicate(e)
+            if predicate(e) {
+                found = true;
+                Err(()) // shortcut, stop visiting
+            } else {
+                Ok(()) // keep going
             }
         });
         found
@@ -881,92 +901,96 @@ impl ExpData {
     /// be called before descending into expression, and `visitor(true, ..)` after. Notice
     /// we use one function instead of two so a lambda can be passed which encapsulates mutable
     /// references.
-    pub fn visit_pre_post<F>(&self, visitor: &mut F)
+    /// - `visitor` returns `Err(())`` to indicate that visit should stop early.
+    /// - `visit_pre_post` returns `false` if visitor returned `false`.
+    pub fn visit_pre_post<F>(&self, visitor: &mut F) -> Result<(), ()>
     where
-        F: FnMut(bool, &ExpData),
+        F: FnMut(bool, &ExpData) -> Result<(), ()>,
     {
         use ExpData::*;
-        visitor(false, self);
+        visitor(false, self)?;
         match self {
             Call(_, _, args) => {
                 for exp in args {
-                    exp.visit_pre_post(visitor);
+                    exp.visit_pre_post(visitor)?;
                 }
             },
             Invoke(_, target, args) => {
-                target.visit_pre_post(visitor);
+                target.visit_pre_post(visitor)?;
                 for exp in args {
-                    exp.visit_pre_post(visitor);
+                    exp.visit_pre_post(visitor)?
                 }
             },
-            Lambda(_, _, body) => body.visit_pre_post(visitor),
+            Lambda(_, _, body) => body.visit_pre_post(visitor)?,
             Quant(_, _, ranges, triggers, condition, body) => {
                 for (_, range) in ranges {
-                    range.visit_pre_post(visitor);
+                    range.visit_pre_post(visitor)?;
                 }
                 for trigger in triggers {
                     for e in trigger {
-                        e.visit_pre_post(visitor);
+                        e.visit_pre_post(visitor)?;
                     }
                 }
                 if let Some(exp) = condition {
-                    exp.visit_pre_post(visitor);
+                    exp.visit_pre_post(visitor)?;
                 }
-                body.visit_pre_post(visitor);
+                body.visit_pre_post(visitor)?;
             },
             Block(_, _, binding, body) => {
                 if let Some(exp) = binding {
-                    exp.visit_pre_post(visitor)
+                    exp.visit_pre_post(visitor)?;
                 }
-                body.visit_pre_post(visitor)
+                body.visit_pre_post(visitor)?;
             },
             IfElse(_, c, t, e) => {
-                c.visit_pre_post(visitor);
-                t.visit_pre_post(visitor);
-                e.visit_pre_post(visitor);
+                c.visit_pre_post(visitor)?;
+                t.visit_pre_post(visitor)?;
+                e.visit_pre_post(visitor)?;
             },
-            Loop(_, e) => e.visit_pre_post(visitor),
-            Return(_, e) => e.visit_pre_post(visitor),
+            Loop(_, e) => e.visit_pre_post(visitor)?,
+            Return(_, e) => e.visit_pre_post(visitor)?,
             Sequence(_, es) => {
                 for e in es {
-                    e.visit_pre_post(visitor)
+                    e.visit_pre_post(visitor)?;
                 }
             },
-            Assign(_, _, e) => e.visit_pre_post(visitor),
+            Assign(_, _, e) => e.visit_pre_post(visitor)?,
             Mutate(_, lhs, rhs) => {
-                lhs.visit_pre_post(visitor);
-                rhs.visit_pre_post(visitor);
+                lhs.visit_pre_post(visitor)?;
+                rhs.visit_pre_post(visitor)?;
             },
-            SpecBlock(_, spec) => Self::visit_pre_post_spec(spec, visitor),
+            SpecBlock(_, spec) => Self::visit_pre_post_spec(spec, visitor)?,
             // Explicitly list all enum variants
             LoopCont(..) | Value(..) | LocalVar(..) | Temporary(..) | Invalid(..) => {},
         }
-        visitor(true, self);
+        visitor(true, self)
     }
 
-    fn visit_pre_post_spec<F>(spec: &Spec, visitor: &mut F)
+    fn visit_pre_post_spec<F>(spec: &Spec, visitor: &mut F) -> Result<(), ()>
     where
-        F: FnMut(bool, &ExpData),
+        F: FnMut(bool, &ExpData) -> Result<(), ()>,
     {
         for cond in &spec.conditions {
-            Self::visit_pre_post_cond(cond, visitor)
+            Self::visit_pre_post_cond(cond, visitor)?
         }
         for impl_spec in spec.on_impl.values() {
-            Self::visit_pre_post_spec(impl_spec, visitor)
+            Self::visit_pre_post_spec(impl_spec, visitor)?
         }
         for cond in spec.update_map.values() {
-            Self::visit_pre_post_cond(cond, visitor)
+            Self::visit_pre_post_cond(cond, visitor)?
         }
+        Ok(())
     }
 
-    fn visit_pre_post_cond<F>(cond: &Condition, visitor: &mut F)
+    fn visit_pre_post_cond<F>(cond: &Condition, visitor: &mut F) -> Result<(), ()>
     where
-        F: FnMut(bool, &ExpData),
+        F: FnMut(bool, &ExpData) -> Result<(), ()>,
     {
-        cond.exp.visit_pre_post(visitor);
+        cond.exp.visit_pre_post(visitor)?;
         for exp in &cond.additional_exps {
-            exp.visit_pre_post(visitor);
+            exp.visit_pre_post(visitor)?
         }
+        Ok(())
     }
 
     /// Rewrites this expression and sub-expression based on the rewriter function. The function
@@ -992,7 +1016,7 @@ impl ExpData {
         pattern_rewriter: &mut G,
     ) -> Exp
     where
-        F: FnMut(Exp) -> Result<Exp, Exp>,
+        F: FnMut(Exp) -> RewriteResult,
         G: FnMut(&Pattern, bool) -> Option<Pattern>,
     {
         ExpRewriter {
@@ -1098,6 +1122,7 @@ impl ExpData {
                     _ => {},
                 }
             }
+            Ok(()) // keep going.
         });
     }
 
@@ -1139,6 +1164,7 @@ impl ExpData {
                     _ => {},
                 }
             }
+            Ok(()) // keep going.
         });
     }
 
@@ -1154,6 +1180,7 @@ impl ExpData {
                     _ => {},
                 }
             }
+            Ok(()) // keep going.
         });
     }
 
@@ -1170,6 +1197,7 @@ impl ExpData {
                     _ => {},
                 }
             }
+            Ok(()) // keep going.
         });
     }
 
@@ -1418,7 +1446,7 @@ impl<'a> fmt::Display for EnvDisplay<'a, Value> {
 
 impl Operation {
     /// Determines whether this operation depends on global memory
-    pub fn uses_memory<F>(&self, check_pure: &F) -> bool
+    pub fn uses_no_memory<F>(&self, check_pure: &F) -> bool
     where
         F: Fn(ModuleId, SpecFunId) -> bool,
     {
@@ -1476,7 +1504,7 @@ impl Operation {
 
 impl ExpData {
     /// Determines whether this expression depends on global memory
-    pub fn uses_memory<F>(&self, check_pure: &F) -> bool
+    pub fn uses_no_memory<F>(&self, check_pure: &F) -> bool
     where
         F: Fn(ModuleId, SpecFunId) -> bool,
     {
@@ -1484,7 +1512,14 @@ impl ExpData {
         let mut no_use = true;
         self.visit(&mut |exp: &ExpData| {
             if let Call(_, oper, _) = exp {
-                no_use = no_use && oper.uses_memory(check_pure);
+                if !oper.uses_no_memory(check_pure) {
+                    no_use = false;
+                    Err(()) // we're done, stop visiting
+                } else {
+                    Ok(()) // keep looking
+                }
+            } else {
+                Ok(()) // keep looking
             }
         });
         no_use
@@ -1503,6 +1538,7 @@ impl ExpData {
                 Temporary(id, _) => {
                     if env.get_node_type(*id).is_mutable_reference() {
                         is_pure = false;
+                        return Err(()); // done visiting
                     }
                 },
                 Call(_, oper, _) => match oper {
@@ -1512,12 +1548,14 @@ impl ExpData {
                         let fun = module.get_spec_fun(*fid);
                         if !fun.used_memory.is_empty() {
                             is_pure = false;
+                            return Err(()); // done visiting
                         }
                     },
                     _ => {},
                 },
                 _ => {},
             }
+            Ok(()) // keep going
         };
         self.visit(&mut visitor);
         is_pure

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -561,8 +561,8 @@ impl From<Exp> for ExpData {
 
 /// Rewrite result
 pub enum RewriteResult {
-    Rewritten(Exp), // was OK
-    Unchanged(Exp), // was Error
+    Rewritten(Exp),
+    Unchanged(Exp),
 }
 
 impl ExpData {

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1246,7 +1246,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let body = self.translate_exp(body, &Type::unit());
                 // See the Move book for below treatment: if the loop has no exit, the type
                 // is arbitrary, otherwise `()`.
-                let loop_type = if body.has_exit() {
+                let loop_type = if body.has_loop_exit() {
                     self.check_type(&loc, &Type::unit(), expected_type, "")
                 } else {
                     expected_type.clone()

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -5,7 +5,7 @@
 use crate::{
     ast::{
         AccessSpecifier, Address, AddressSpecifier, Exp, ExpData, ModuleName, Operation, Pattern,
-        QualifiedSymbol, QuantKind, ResourceSpecifier, Spec, TempIndex, Value,
+        QualifiedSymbol, QuantKind, ResourceSpecifier, RewriteResult, Spec, TempIndex, Value,
     },
     builder::{
         model_builder::{AnyFunEntry, ConstEntry, EntryVisibility, LocalVarEntry, StructEntry},
@@ -1509,7 +1509,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                                     self.bug(&loc, "unresolved spec anchor");
                                     Spec::default()
                                 };
-                                Ok(ExpData::SpecBlock(id, spec).into_exp())
+                                RewriteResult::Rewritten(ExpData::SpecBlock(id, spec).into_exp())
                             },
                             ExpPlaceholder::FieldSelectInfo {
                                 struct_ty,
@@ -1521,23 +1521,31 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                                     .specialize_with_defaults(struct_ty)
                                     .skip_reference()
                                 {
-                                    Ok(ExpData::Call(
-                                        id,
-                                        Operation::Select(*mid, *sid, FieldId::new(*field_name)),
-                                        args,
+                                    RewriteResult::Rewritten(
+                                        ExpData::Call(
+                                            id,
+                                            Operation::Select(
+                                                *mid,
+                                                *sid,
+                                                FieldId::new(*field_name),
+                                            ),
+                                            args,
+                                        )
+                                        .into_exp(),
                                     )
-                                    .into_exp())
                                 } else {
-                                    Ok(self.new_error_exp().into_exp())
+                                    RewriteResult::Rewritten(self.new_error_exp().into_exp())
                                 }
                             },
                         }
                     } else {
                         // Reconstruct expression and return for traversal
-                        Err(ExpData::Call(id, Operation::NoOp, args).into_exp())
+                        RewriteResult::Unchanged(
+                            ExpData::Call(id, Operation::NoOp, args).into_exp(),
+                        )
                     }
                 } else {
-                    Err(exp_data.into_exp())
+                    RewriteResult::Unchanged(exp_data.into_exp())
                 }
             },
             &mut |pat, _entering_scope| match pat {

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1482,7 +1482,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             &mut |e| {
                 if self.placeholder_map.is_empty() {
                     // Shortcut case of no placeholders
-                    return Err(e);
+                    return RewriteResult::Unchanged(e);
                 }
                 let exp_data: ExpData = e.into();
                 if let ExpData::Call(id, Operation::NoOp, args) = exp_data {

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1453,20 +1453,20 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     // This is calling a function from another module we already have
                     // translated. In this case, the impurity has already been propagated
                     // in translate_call.
-                    Ok(())
+                    true
                 } else {
                     // This is calling a function from the module we are currently translating.
                     // Need to recursively ensure we have propagated impurity because of
                     // arbitrary call graphs, including cyclic.
                     if !self.propagate_function_impurity(visited, *fid) {
                         is_pure = false;
-                        Err(()) // Short-curcuit the visit; this function is not pure
+                        false // Short-curcuit the visit; this function is not pure
                     } else {
-                        Ok(())
+                        true
                     }
                 }
             } else {
-                Ok(())
+                true
             }
         });
         if is_pure {
@@ -2076,7 +2076,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     );
                     ok = false;
                 }
-                Ok(()) // continue visit
+                true // continue visit, note all problematic subexprs
             };
             cond.exp.visit(&mut visitor);
         } else if let FunctionCode(name, _) | FunctionCodeV2(name, _) = context {
@@ -2108,7 +2108,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         },
                     };
                 }
-                Ok(()) // continue visit
+                true // continue visit, note all problematic subexprs
             };
             cond.exp.visit(&mut visitor);
         }
@@ -3537,7 +3537,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 },
                 _ => {},
             }
-            Ok(())
+            true // continue visit, note all problematic subexprs
         });
         (used_memory, callees)
     }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -609,15 +609,14 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                             && cont.span().start() >= loc.span().start()
                             && cont.span().end() <= loc.span().end()
                     };
-                    let _ = arg.visit_pre_post(&mut |up: bool, e: &ExpData| {
+                    arg.visit_top_down(&mut |e: &ExpData| {
                         let sub_loc = self.builder.global_env().get_node_loc(e.node_id());
-                        if !up
-                            && !loc_contained(&loc, &sub_loc)
+                        if !loc_contained(&loc, &sub_loc)
                             && !labels.iter().any(|(l, _)| loc_contained(l, &sub_loc))
                         {
                             labels.push((sub_loc, "substituted sub-expression".to_owned()))
                         }
-                        Ok(()) // continue visit
+                        true // continue visit
                     });
                     self.builder.global_env().diag_with_labels(
                         Severity::Error,

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -7,8 +7,8 @@
 
 use crate::{
     ast::{
-        Condition, ConditionKind, Exp, ExpData, GlobalInvariant, MemoryLabel, Operation, Spec,
-        TempIndex, TraceKind,
+        Condition, ConditionKind, Exp, ExpData, GlobalInvariant, MemoryLabel, Operation,
+        RewriteResult, Spec, TempIndex, TraceKind,
     },
     exp_generator::ExpGenerator,
     exp_rewriter::ExpRewriterFunctions,
@@ -524,10 +524,10 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             if trace_this {
                 let l = self.builder.global_env().get_node_loc(e.node_id());
                 let traced = self.auto_trace_exp(&l, e, TraceKind::SubAuto);
-                Ok(traced)
+                RewriteResult::Rewritten(traced)
             } else {
                 // descent
-                Err(e)
+                RewriteResult::Unchanged(e)
             }
         })
     }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -609,7 +609,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                             && cont.span().start() >= loc.span().start()
                             && cont.span().end() <= loc.span().end()
                     };
-                    arg.visit_top_down(&mut |e: &ExpData| {
+                    arg.visit_pre_order(&mut |e: &ExpData| {
                         let sub_loc = self.builder.global_env().get_node_loc(e.node_id());
                         if !loc_contained(&loc, &sub_loc)
                             && !labels.iter().any(|(l, _)| loc_contained(l, &sub_loc))

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -609,7 +609,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                             && cont.span().start() >= loc.span().start()
                             && cont.span().end() <= loc.span().end()
                     };
-                    arg.visit_pre_post(&mut |up: bool, e: &ExpData| {
+                    let _ = arg.visit_pre_post(&mut |up: bool, e: &ExpData| {
                         let sub_loc = self.builder.global_env().get_node_loc(e.node_id());
                         if !up
                             && !loc_contained(&loc, &sub_loc)
@@ -617,6 +617,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                         {
                             labels.push((sub_loc, "substituted sub-expression".to_owned()))
                         }
+                        Ok(()) // continue visit
                     });
                     self.builder.global_env().diag_with_labels(
                         Severity::Error,

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -517,6 +517,7 @@ impl<'a> Analyzer<'a> {
                     }
                 }
             }
+            Ok(())
         });
     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -466,7 +466,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn analyze_exp(&mut self, exp: &ExpData) {
-        exp.visit(&mut |e| {
+        exp.visit_post_order(&mut |e| {
             let node_id = e.node_id();
             self.add_type_root(&self.env.get_node_type(node_id));
             for ref ty in self.env.get_node_instantiation(node_id) {

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -517,7 +517,7 @@ impl<'a> Analyzer<'a> {
                     }
                 }
             }
-            Ok(())
+            true // keep going
         });
     }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -474,7 +474,7 @@ impl<'a> NumberOperationAnalysis<'a> {
                 },
                 _ => {},
             }
-            Ok(())
+            true // keep going
         };
         e.visit(visitor);
     }

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -476,7 +476,7 @@ impl<'a> NumberOperationAnalysis<'a> {
             }
             true // keep going
         };
-        e.visit(visitor);
+        e.visit_post_order(visitor);
     }
 
     /// Check whether operations in s conflicting

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -474,6 +474,7 @@ impl<'a> NumberOperationAnalysis<'a> {
                 },
                 _ => {},
             }
+            Ok(())
         };
         e.visit(visitor);
     }


### PR DESCRIPTION
Clean up Move-Model AST visitors and exp_rewriter interfaces

### Description

- don't abuse `Result(Exp, Exp)` in ExpRewriter interfaces, since it's confusing (which one is changed?)
- OTOH, return `Option<()>` from the implementation of `ExpData::visit..` so we can use `None` to more convenient short-cutting with `?`.   Client visitor functions return `bool`, with `true` to continue, and `false` to exit early by short-cutting.
- While we're at it, rename `move_model::ast::ExpData::uses_memory` to `uses_no_memory` to match its semantics (fixing #10725).

### Test Plan
Existing tests.

