### PR TITLE
Use bcs::serialized_size(..) instead of bcs::to_bytes(..).len()

### DIFF
--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -469,7 +469,7 @@ fn test_transactions_with_byte_limit(
     // Continue to add transactions to the batch until we hit the byte limit
     loop {
         let transaction = test_transaction(sequence_number);
-        let transaction_bytes = bcs::to_bytes(&transaction).unwrap().len();
+        let transaction_bytes = bcs::serialized_size(&transaction).unwrap();
         if (byte_count + transaction_bytes) < byte_limit {
             transactions.push(transaction);
             byte_count += transaction_bytes;

--- a/state-sync/storage-service/server/src/tests/epoch_ending.rs
+++ b/state-sync/storage-service/server/src/tests/epoch_ending.rs
@@ -272,7 +272,7 @@ async fn get_epoch_ending_ledger_infos_network_limit(network_limit_bytes: u64) {
         // Verify the response adheres to the network limits
         match response.get_data_response().unwrap() {
             DataResponse::EpochEndingLedgerInfos(epoch_change_proof) => {
-                let num_response_bytes = bcs::to_bytes(&response).unwrap().len() as u64;
+                let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
                 let num_ledger_infos = epoch_change_proof.ledger_info_with_sigs.len() as u64;
                 if num_response_bytes > network_limit_bytes {
                     assert_eq!(num_ledger_infos, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/state_values.rs
+++ b/state-sync/storage-service/server/src/tests/state_values.rs
@@ -295,7 +295,7 @@ async fn get_states_with_proof_network_limit(network_limit_bytes: u64) {
         // Verify the response adheres to the network limits
         match response.get_data_response().unwrap() {
             DataResponse::StateValueChunkWithProof(state_value_chunk_with_proof) => {
-                let num_response_bytes = bcs::to_bytes(&response).unwrap().len() as u64;
+                let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
                 let num_state_values = state_value_chunk_with_proof.raw_values.len() as u64;
                 if num_response_bytes > network_limit_bytes {
                     assert_eq!(num_state_values, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transaction_outputs.rs
@@ -245,7 +245,7 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
         // Verify the response is correct
         match response.get_data_response().unwrap() {
             DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
-                let num_response_bytes = bcs::to_bytes(&response).unwrap().len() as u64;
+                let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
                 let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
                 if num_response_bytes > network_limit_bytes {
                     assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/transactions.rs
+++ b/state-sync/storage-service/server/src/tests/transactions.rs
@@ -249,7 +249,7 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
             // Verify the response is correct
             match response.get_data_response().unwrap() {
                 DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                    let num_response_bytes = bcs::to_bytes(&response).unwrap().len() as u64;
+                    let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
                     let num_transactions = transactions_with_proof.transactions.len() as u64;
                     if num_response_bytes > network_limit_bytes {
                         assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
@@ -339,7 +339,7 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
 
                     if let Some(transactions_with_proof) = transactions_with_proof {
                         let num_response_bytes =
-                            bcs::to_bytes(&transactions_with_proof).unwrap().len() as u64;
+                            bcs::serialized_size(&transactions_with_proof).unwrap() as u64;
                         let num_transactions = transactions_with_proof.transactions.len() as u64;
                         if num_response_bytes > network_limit_bytes {
                             assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item
@@ -349,7 +349,7 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
                         }
                     } else if let Some(outputs_with_proof) = outputs_with_proof {
                         let num_response_bytes =
-                            bcs::to_bytes(&outputs_with_proof).unwrap().len() as u64;
+                            bcs::serialized_size(&outputs_with_proof).unwrap() as u64;
                         let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
                         if num_response_bytes > network_limit_bytes {
                             assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -298,10 +298,10 @@ pub fn configure_network_chunk_limit(
 ) -> StorageServiceConfig {
     let max_network_chunk_bytes = if fallback_to_transactions {
         // Network limit is only big enough for the transaction list
-        bcs::to_bytes(&transaction_list_with_proof).unwrap().len() as u64 + 1
+        bcs::serialized_size(&transaction_list_with_proof).unwrap() as u64 + 1
     } else {
         // Network limit is big enough for the output list
-        bcs::to_bytes(&output_list_with_proof).unwrap().len() as u64 + 1
+        bcs::serialized_size(&output_list_with_proof).unwrap() as u64 + 1
     };
     StorageServiceConfig {
         max_network_chunk_bytes,

--- a/storage/backup/backup-cli/src/backup_types/transaction/analysis.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/analysis.rs
@@ -116,7 +116,7 @@ impl TransactionAnalysis {
             GenesisTransaction(_)
             | BlockMetadata(_)
             | StateCheckpoint(_)
-            | ValidatorTransaction(_) => bcs::to_bytes(txn).expect("Txn should serialize").len(),
+            | ValidatorTransaction(_) => bcs::serialized_size(txn).expect("Txn should serialize"),
         }
     }
 }

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -49,7 +49,7 @@ fn end_to_end() {
         .collect::<Vec<_>>();
     let max_chunk_size = txns
         .iter()
-        .map(|t| bcs::to_bytes(t).unwrap().len())
+        .map(|t| bcs::serialized_size(t).unwrap())
         .max()
         .unwrap() // biggest txn
         + 115 // size of a serialized TransactionInfo

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -192,7 +192,7 @@ impl ContractEventV1 {
     }
 
     pub fn size(&self) -> usize {
-        self.key.size() + 8 /* u64 */ + bcs::to_bytes(&self.type_tag).unwrap().len() + self.event_data.len()
+        self.key.size() + 8 /* u64 */ + bcs::serialized_size(&self.type_tag).unwrap() + self.event_data.len()
     }
 }
 
@@ -228,7 +228,7 @@ impl ContractEventV2 {
     }
 
     pub fn size(&self) -> usize {
-        bcs::to_bytes(&self.type_tag).unwrap().len() + self.event_data.len()
+        bcs::serialized_size(&self.type_tag).unwrap() + self.event_data.len()
     }
 
     pub fn type_tag(&self) -> &TypeTag {


### PR DESCRIPTION
It is innefficient to be serializing to bytes (and allocating that memory), 
when we only care about the length of the serialized value.

Let's see if this improves performance a bit, I think we use it to charge txn_size, among other places

