### PR TITLE
remove accidental println

### DIFF
--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -65,15 +65,6 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         // When the accumulated execution and io gas of the committed txns exceeds
         // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage fee does not count towards
         // the per block gas limit, as we measure execution related cost here.
-        println!(
-            "{} * ({} * {} + {} * {})",
-            conflict_multiplier,
-            fee_statement.execution_gas_used(),
-            self.block_gas_limit_type
-                .execution_gas_effective_multiplier(),
-            fee_statement.io_gas_used(),
-            self.block_gas_limit_type.io_gas_effective_multiplier()
-        );
         self.accumulated_effective_block_gas += conflict_multiplier
             * (fee_statement.execution_gas_used()
                 * self


### PR DESCRIPTION
seems like squash didn't squash my last update to the PR

remove unnecessary println


### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
