### PR TITLE
[indexer grpc] Create env var to toggle logging 

### DIFF
--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::IndexerGrpcConfig;
 use crate::{
     config::{
         node_config_loader::NodeType, utils::get_config_name, AdminServiceConfig, Error,
@@ -99,6 +100,9 @@ impl ConfigOptimizer for NodeConfig {
         let mut optimizers_with_modifications = vec![];
         if IndexerConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(IndexerConfig::get_optimizer_name());
+        }
+        if IndexerGrpcConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(IndexerGrpcConfig::get_optimizer_name());
         }
         if AdminServiceConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(AdminServiceConfig::get_optimizer_name());

--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, Error, NodeConfig,
+    config_optimizer::ConfigOptimizer, config_sanitizer::ConfigSanitizer,
+    node_config_loader::NodeType, Error, NodeConfig,
 };
 use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use serde_yaml::Value;
+use std::{
+    fmt::{Debug, Formatter},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+};
 
 // Useful indexer defaults
 const DEFAULT_PROCESSOR_TASK_COUNT: u16 = 20;
@@ -14,7 +19,7 @@ const DEFAULT_PROCESSOR_BATCH_SIZE: u16 = 1000;
 const DEFAULT_OUTPUT_BATCH_SIZE: u16 = 100;
 pub const DEFAULT_GRPC_STREAM_PORT: u16 = 50051;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct IndexerGrpcConfig {
     pub enabled: bool,
@@ -38,6 +43,23 @@ pub struct IndexerGrpcConfig {
     pub output_batch_size: u16,
 
     pub enable_verbose_logging: bool,
+}
+
+impl Debug for IndexerGrpcConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexerGrpcConfig")
+            .field("enabled", &self.enabled)
+            .field(
+                "use_data_service_interface",
+                &self.use_data_service_interface,
+            )
+            .field("address", &self.address)
+            .field("processor_task_count", &self.processor_task_count)
+            .field("processor_batch_size", &self.processor_batch_size)
+            .field("output_batch_size", &self.output_batch_size)
+            .field("enable_verbose_logging", &self.enable_verbose_logging)
+            .finish()
+    }
 }
 
 // Reminder, #[serde(default)] on IndexerGrpcConfig means that the default values for
@@ -82,6 +104,37 @@ impl ConfigSanitizer for IndexerGrpcConfig {
     }
 }
 
+impl ConfigOptimizer for IndexerGrpcConfig {
+    fn optimize(
+        node_config: &mut NodeConfig,
+        _local_config_yaml: &Value,
+        _node_type: NodeType,
+        _chain_id: Option<ChainId>,
+    ) -> Result<bool, Error> {
+        let indexer_config = &mut node_config.indexer_grpc;
+        // If the indexer is not enabled, there's nothing to do
+        if !indexer_config.enabled {
+            return Ok(false);
+        }
+
+        // TODO: we really shouldn't be overriding the configs if they are
+        // specified in the local node config file. This optimizer should
+        // migrate to the pattern used by other optimizers, but for now, we'll
+        // just keep the legacy behaviour to avoid breaking anything.
+
+        // Override with environment variables if they are set
+        indexer_config.enable_verbose_logging = env_var_or_default(
+            "INDEXER_GRPC_ENABLE_VERBOSE_LOGGING",
+            Some(indexer_config.enable_verbose_logging),
+            None,
+        )
+        .map(|v| v)
+        .unwrap_or(false);
+
+        Ok(true)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,5 +171,25 @@ mod tests {
         // Sanitize the config and verify that it now succeeds
         IndexerGrpcConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
             .unwrap();
+    }
+}
+
+/// Returns the value of the environment variable `env_var`
+/// if it is set, otherwise returns `default`.
+fn env_var_or_default<T: std::str::FromStr>(
+    env_var: &'static str,
+    default: Option<T>,
+    expected_message: Option<String>,
+) -> Option<T> {
+    let partial = std::env::var(env_var).ok().map(|s| s.parse().ok());
+    match default {
+        None => partial.unwrap_or_else(|| {
+            panic!(
+                "{}",
+                expected_message
+                    .unwrap_or_else(|| { format!("Expected env var {} to be set", env_var) })
+            )
+        }),
+        Some(default_value) => partial.unwrap_or(Some(default_value)),
     }
 }

--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -128,7 +128,6 @@ impl ConfigOptimizer for IndexerGrpcConfig {
             Some(indexer_config.enable_verbose_logging),
             None,
         )
-        .map(|v| v)
         .unwrap_or(false);
 
         Ok(true)


### PR DESCRIPTION
### Description
When env is available, it overrides the yaml. Otherwise everything else works as intended.

### Test Plan
enable_verbose_logging: true in yaml, no env
![image](https://github.com/aptos-labs/aptos-core/assets/11738325/635dcbd7-c62a-4ddd-98f2-1414dc9d3f38)

enable_verbose_logging: true in yaml, env set to false
<img width="732" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/11738325/85c4234d-4e43-4169-a9f1-b5b3ca736abf">

enable_verbose_logging: false in yaml or missing, env set to false or missing
<img width="727" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/11738325/410d7a92-149e-4373-be9b-d479a50267c5">
