### PR TITLE
[compiler-v2] Fixing a bug with propagation of phantom type parameters

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/objects.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/objects.exp
@@ -1,12 +1,3 @@
-comparison between v1 and v2 failed:
-= processed 3 tasks
-= 
-+ task 2 'run'. lines 103-115:
-+ Error: Script execution failed with VMError: {
-+     major_status: UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP,
-+     sub_status: None,
-+     location: script,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-+ 
+processed 3 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/phantoms.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/phantoms.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/phantoms.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/phantoms.move
@@ -1,0 +1,18 @@
+//# publish
+module 0x42::phantoms {
+
+
+    /// A struct with a phantom parameter. Even if the parameter is not dropable, the struct should still be.
+    struct S<phantom T> has drop {
+        addr: address,
+    }
+
+    struct T {} // no abilities
+
+    public fun test_phantoms() {
+       let _s = S<T>{ addr: @0x12 };
+        // _s is dropped
+    }
+}
+
+//# run 0x42::phantoms::test_phantoms


### PR DESCRIPTION
Closes #11092. In fact abilities are correctly propagated to file format. However, a phantom type parameter was not. This lead to the bytecode verification error `UNSAFE_RET_UNUSED_VALUES_WITHOUT_DROP`  in `objects.move` which is now fixed.

