### PR TITLE
[e2e-move-tests] Enable compiler v2 in e2e-move-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,6 +6693,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
  "move-package",
  "move-symbol-pool",

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -34,6 +34,7 @@ claims = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
 move-binary-format = { workspace = true }
+move-command-line-common = { workspace = true }
 move-core-types = { workspace = true }
 move-package = { workspace = true }
 move-symbol-pool = { workspace = true }

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, AptosPackageHooks};
+use crate::{assert_success, build_package, AptosPackageHooks};
 use anyhow::Error;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
@@ -398,7 +398,7 @@ impl MoveHarness {
         options: Option<BuildOptions>,
         patch_metadata: impl FnMut(&mut PackageMetadata),
     ) -> SignedTransaction {
-        let package = BuiltPackage::build(path.to_owned(), options.unwrap_or_default())
+        let package = build_package(path.to_owned(), options.unwrap_or_default())
             .expect("building package must succeed");
         self.create_publish_built_package(account, &package, patch_metadata)
     }
@@ -413,10 +413,7 @@ impl MoveHarness {
             let mut cache = CACHED_BUILT_PACKAGES.lock().unwrap();
 
             Arc::clone(cache.entry(path.to_owned()).or_insert_with(|| {
-                Arc::new(BuiltPackage::build(
-                    path.to_owned(),
-                    BuildOptions::default(),
-                ))
+                Arc::new(build_package(path.to_owned(), BuildOptions::default()))
             }))
         };
         let package_ref = package_arc

--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -9,11 +9,15 @@ pub mod stake;
 pub mod transaction_fee;
 
 use anyhow::bail;
-use aptos_framework::UPGRADE_POLICY_CUSTOM_FIELD;
+use aptos_framework::{BuildOptions, BuiltPackage, UPGRADE_POLICY_CUSTOM_FIELD};
 pub use harness::*;
-use move_package::{package_hooks::PackageHooks, source_package::parsed_manifest::CustomDepInfo};
+use move_command_line_common::{env::read_bool_env_var, testing::ENABLE_V2};
+use move_package::{
+    package_hooks::PackageHooks, source_package::parsed_manifest::CustomDepInfo, CompilerVersion,
+};
 use move_symbol_pool::Symbol;
 pub use stake::*;
+use std::path::PathBuf;
 
 #[cfg(test)]
 mod tests;
@@ -36,4 +40,15 @@ impl PackageHooks for AptosPackageHooks {
     ) -> anyhow::Result<()> {
         bail!("not used")
     }
+}
+
+pub(crate) fn build_package(
+    package_path: PathBuf,
+    options: BuildOptions,
+) -> anyhow::Result<BuiltPackage> {
+    let mut options = options;
+    if read_bool_env_var(ENABLE_V2) {
+        options.compiler_version = Some(CompilerVersion::V2);
+    }
+    BuiltPackage::build(package_path.to_owned(), options)
 }

--- a/aptos-move/e2e-move-tests/src/tests/attributes.rs
+++ b/aptos-move/e2e-move-tests/src/tests/attributes.rs
@@ -1,9 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, assert_vm_status, MoveHarness};
+use crate::{assert_success, assert_vm_status, build_package, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
-use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_framework::BuildOptions;
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{account_address::AccountAddress, on_chain_config::FeatureFlag};
 use move_binary_format::CompiledModule;
@@ -87,7 +87,7 @@ fn test_bad_fun_attribute_in_compiled_module() {
     );
     let path = builder.write_to_temp().unwrap();
 
-    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
+    let package = build_package(path.path().to_path_buf(), BuildOptions::default())
         .expect("building package must succeed");
     let code = package.extract_code();
     // There should only be the above module
@@ -236,7 +236,7 @@ fn build_package_and_insert_attribute(
     builder.add_source("m.move", source);
     let path = builder.write_to_temp().unwrap();
 
-    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
+    let package = build_package(path.path().to_path_buf(), BuildOptions::default())
         .expect("building package must succeed");
     let code = package.extract_code();
     // There should only be one module

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_abort, assert_success, assert_vm_status, tests::common, MoveHarness};
+use crate::{
+    assert_abort, assert_success, assert_vm_status, build_package, tests::common, MoveHarness,
+};
 use aptos_framework::natives::code::{PackageRegistry, UpgradePolicy};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::{
@@ -228,7 +230,7 @@ fn code_publishing_using_resource_account() {
         ),
     );
     let pack_dir = pack.write_to_temp().unwrap();
-    let package = aptos_framework::BuiltPackage::build(
+    let package = build_package(
         pack_dir.path().to_owned(),
         aptos_framework::BuildOptions::default(),
     )

--- a/aptos-move/e2e-move-tests/src/tests/common.rs
+++ b/aptos-move/e2e-move-tests/src/tests/common.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::build_package;
 use std::{collections::BTreeMap, path::PathBuf};
 
 pub fn test_dir_path(s: &str) -> PathBuf {
@@ -20,7 +21,7 @@ pub fn framework_dir_path(s: &str) -> PathBuf {
 pub fn build_scripts(package_folder: &str, package_names: Vec<&str>) -> BTreeMap<String, Vec<u8>> {
     let mut scripts = BTreeMap::new();
     for package_name in package_names {
-        let script = aptos_framework::BuiltPackage::build(
+        let script = build_package(
             test_dir_path(format!("{}/{}", package_folder, package_name).as_str()),
             aptos_framework::BuildOptions::default(),
         )

--- a/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::common, MoveHarness};
-use aptos_framework::{BuildOptions, BuiltPackage, ReleasePackage};
+use crate::{build_package, tests::common, MoveHarness};
+use aptos_framework::{BuildOptions, ReleasePackage};
 use aptos_package_builder::PackageBuilder;
 use aptos_types::account_address::AccountAddress;
 use move_package::compilation::package_layout::CompiledPackageLayout;
@@ -37,7 +37,7 @@ module 0x{}::test {{
     let proposal_dir = proposal.write_to_temp().unwrap();
 
     let upgrade_release = ReleasePackage::new(
-        BuiltPackage::build(upgrade_dir.path().to_path_buf(), BuildOptions::default()).unwrap(),
+        build_package(upgrade_dir.path().to_path_buf(), BuildOptions::default()).unwrap(),
     )
     .unwrap();
 
@@ -52,8 +52,7 @@ module 0x{}::test {{
                 .join("proposal.move"),
         )
         .unwrap();
-    let _ =
-        BuiltPackage::build(proposal_dir.path().to_path_buf(), BuildOptions::default()).unwrap();
+    let _ = build_package(proposal_dir.path().to_path_buf(), BuildOptions::default()).unwrap();
 
     // TODO: maybe execute the proposal.
 }

--- a/aptos-move/e2e-move-tests/src/tests/metadata.rs
+++ b/aptos-move/e2e-move-tests/src/tests/metadata.rs
@@ -1,10 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_vm_status, MoveHarness};
+use crate::{assert_vm_status, build_package, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_framework::{
-    BuildOptions, BuiltPackage, RuntimeModuleMetadata, RuntimeModuleMetadataV1, APTOS_METADATA_KEY,
+    BuildOptions, RuntimeModuleMetadata, RuntimeModuleMetadataV1, APTOS_METADATA_KEY,
     APTOS_METADATA_KEY_V1,
 };
 use aptos_package_builder::PackageBuilder;
@@ -109,7 +109,7 @@ fn test_metadata_with_changes(f: impl Fn() -> Vec<Metadata>) -> TransactionStatu
     );
     let path = builder.write_to_temp().unwrap();
 
-    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
+    let package = build_package(path.path().to_path_buf(), BuildOptions::default())
         .expect("building package must succeed");
     let origin_code = package.extract_code();
     let mut compiled_module = CompiledModule::deserialize(&origin_code[0]).unwrap();

--- a/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, build_package, tests::common, MoveHarness};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
     SigningKey, ValidCryptoMaterialStringExt,
@@ -64,7 +64,7 @@ fn mint_nft_e2e() {
         .insert("source_addr".to_string(), *acc.address());
 
     // build the package from our example code
-    let package = aptos_framework::BuiltPackage::build(
+    let package = build_package(
         common::test_dir_path("../../../move-examples/mint_nft/4-Getting-Production-Ready"),
         build_options,
     )

--- a/aptos-move/e2e-move-tests/src/tests/nft_dao.rs
+++ b/aptos-move/e2e-move-tests/src/tests/nft_dao.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, build_package, tests::common, MoveHarness};
 use aptos_types::account_address::create_resource_address;
 use move_core_types::account_address::AccountAddress;
 
@@ -18,7 +18,7 @@ fn test_nft_dao_txn_arguments() {
         .insert("dao_platform".to_string(), *acc.address());
 
     // build the package from our example code
-    let package = aptos_framework::BuiltPackage::build(
+    let package = build_package(
         common::test_dir_path("../../../move-examples/dao/nft_dao"),
         build_options,
     )

--- a/aptos-move/e2e-move-tests/src/tests/scripts.rs
+++ b/aptos-move/e2e-move-tests/src/tests/scripts.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, build_package, tests::common, MoveHarness};
 use aptos_language_e2e_tests::account::TransactionBuilder;
 use aptos_types::{
     account_address::AccountAddress,
@@ -15,7 +15,7 @@ fn test_script_with_type_parameter() {
 
     let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
 
-    let package = aptos_framework::BuiltPackage::build(
+    let package = build_package(
         common::test_dir_path("script_with_ty_param.data/pack"),
         aptos_framework::BuildOptions::default(),
     )
@@ -60,7 +60,7 @@ fn test_two_to_two_transfer() {
         ..aptos_framework::BuildOptions::default()
     };
 
-    let package = aptos_framework::BuiltPackage::build(
+    let package = build_package(
         common::test_dir_path("../../../move-examples/scripts/two_by_two_transfer"),
         build_options,
     )

--- a/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
+++ b/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
@@ -1,9 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_success, build_package, tests::common, MoveHarness};
 use aptos_cached_packages::aptos_stdlib;
-use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_framework::BuildOptions;
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
@@ -37,7 +37,7 @@ fn exchange_e2e_test() {
     build_options
         .named_addresses
         .insert("resource_account".to_string(), resource_address);
-    let package = BuiltPackage::build(
+    let package = build_package(
         common::test_dir_path("../../../move-examples/resource_account"),
         build_options,
     )


### PR DESCRIPTION
### Description

This PR uses the environment variable `ENABLE_V2` to control whether to use compiler v2 for tests in `e2e-move-tests`.
