### PR TITLE
[txn-emitter] option to use an api key

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -75,6 +75,11 @@ pub struct ClusterArgs {
 
     #[clap(flatten)]
     pub coin_source_args: CoinSourceArgs,
+
+    /// Key to use for ratelimiting purposes with the node API. This value will be used
+    /// as `Authorization: Bearer <key>`.
+    #[clap(long, env)]
+    pub node_api_key: Option<String>,
 }
 
 impl ClusterArgs {

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -152,6 +152,21 @@ impl Cluster {
             urls.push(url);
         }
 
+        // some sanity check around the URL and whether we expect an API key or not
+        // just print it out for now rather than enforcing, since this is subject to change
+        for url in &urls {
+            if url.host_str().unwrap().starts_with("api.") {
+                if args.node_api_key.is_none() {
+                    println!("URL {} starts with api.* but no API key was provided. Hint: generate one at https://developers.aptoslabs.com", url);
+                }
+            } else if args.node_api_key.is_some() {
+                println!(
+                    "URL {} does not start with api.* but an API key was provided. You may not need it.",
+                    url
+                );
+            }
+        }
+
         let (coin_source_key, is_root) = args.coin_source_args.get_private_key()?;
 
         let cluster = Cluster::from_host_port(

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -38,6 +38,7 @@ impl Cluster {
         coin_source_key: Ed25519PrivateKey,
         coin_source_is_root: bool,
         chain_id: ChainId,
+        api_key: Option<String>,
     ) -> Result<Self> {
         let num_peers = peers.len();
 
@@ -54,6 +55,7 @@ impl Cluster {
                 ), /* short_hash */
                 url.clone(),
                 None,
+                api_key.clone(),
             );
             futures.push(async move {
                 let result = instance.rest_client().get_ledger_information().await;
@@ -152,9 +154,15 @@ impl Cluster {
 
         let (coin_source_key, is_root) = args.coin_source_args.get_private_key()?;
 
-        let cluster = Cluster::from_host_port(urls, coin_source_key, is_root, args.chain_id)
-            .await
-            .map_err(|e| format_err!("failed to create a cluster from host and port: {:?}", e))?;
+        let cluster = Cluster::from_host_port(
+            urls,
+            coin_source_key,
+            is_root,
+            args.chain_id,
+            args.node_api_key.clone(),
+        )
+        .await
+        .map_err(|e| format_err!("failed to create a cluster from host and port: {:?}", e))?;
 
         Ok(cluster)
     }

--- a/crates/transaction-emitter-lib/src/instance.rs
+++ b/crates/transaction-emitter-lib/src/instance.rs
@@ -1,23 +1,33 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_rest_client::Client as RestClient;
+use aptos_rest_client::{aptos_api_types, AptosBaseUrl, Client as RestClient};
 use reqwest::Url;
 use std::fmt;
+
+// Custom header value to identify the client
+const X_APTOS_CLIENT_VALUE: &str = "aptos-transaction-emitter";
 
 #[derive(Clone)]
 pub struct Instance {
     peer_name: String,
     url: Url,
     inspection_service_port: Option<u32>,
+    api_key: Option<String>,
 }
 
 impl Instance {
-    pub fn new(peer_name: String, url: Url, inspection_service_port: Option<u32>) -> Instance {
+    pub fn new(
+        peer_name: String,
+        url: Url,
+        inspection_service_port: Option<u32>,
+        api_key: Option<String>,
+    ) -> Instance {
         Instance {
             peer_name,
             url,
             inspection_service_port,
+            api_key,
         }
     }
 
@@ -34,7 +44,20 @@ impl Instance {
     }
 
     pub fn rest_client(&self) -> RestClient {
-        RestClient::new(self.api_url())
+        let client = RestClient::builder(AptosBaseUrl::Custom(self.api_url()))
+            .header(aptos_api_types::X_APTOS_CLIENT, X_APTOS_CLIENT_VALUE)
+            .expect("Failed to initialize REST Client instance");
+
+        // add the API key if it is provided
+        let client = if let Some(api_key) = &self.api_key {
+            client.api_key(api_key)
+        } else {
+            Ok(client)
+        };
+
+        client
+            .expect("Failed to build REST Client instance")
+            .build()
     }
 }
 

--- a/ecosystem/node-checker/src/checker/tps.rs
+++ b/ecosystem/node-checker/src/checker/tps.rs
@@ -128,6 +128,7 @@ impl Checker for TpsChecker {
             targets_file: None,
             coin_source_args: self.config.coin_source_args.clone(),
             chain_id,
+            node_api_key: None,
         };
         let cluster = Cluster::try_from_cluster_args(&cluster_config)
             .await


### PR DESCRIPTION
### Description

Option to use an API key for the txn-emitter's underlying REST client, so we can route traffic through the API gateway

### Test Plan

Run the txn emitter with the new `--node-api-key` argument, after creating a new API key

```
cargo run -p aptos-transaction-emitter --release -- emit-tx -t https://fullnode.devnet.aptoslabs.com --coin-source-key ${DEVNET_APT_KEY} --chain-id ${CHAIN_ID} ...--node-api-key <MY_KEY>
```

<!-- Please provide us with clear details for verifying that your changes work. -->
