### PR TITLE
[gas] add script for mass-modifying the gas schedule

### DIFF
--- a/aptos-move/aptos-gas-schedule/mass_mod.py
+++ b/aptos-move/aptos-gas-schedule/mass_mod.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# This is a script to perform mass modification of gas entries embedded in the Rust source files.
+#
+# It serves as a temporary solution until we come up with a more appropriate format for storing
+# the gas schedule.
+
+import os, re
+from typing import Callable
+
+root_path = os.path.dirname(os.path.abspath(__file__))
+
+pat = re.compile("\[\s*([a-zA-Z][a-zA-Z0-9_]*)\s*:\s*([a-zA-Z][a-zA-Z0-9_]*)\s*,([^]]*),\s*([0-9][0-9_]*)\s*\,?\s*]", re.MULTILINE | re.DOTALL)
+
+class GasEntry:
+    def __init__(self, name: str, ty: str, on_chain_name: str, val: int):
+        self.name = name
+        self.ty = ty
+        self.on_chain_name = on_chain_name
+        self.val = val
+
+def modify_file(path: str, modify_entry: Callable[[GasEntry], GasEntry]):
+    with open(path, 'r') as file:
+        content = file.read()
+
+    def replace(match):
+        val = int(match.group(4).replace("_", ""))
+        on_chain_name: str = match.group(3).lstrip().rstrip()
+        entry = GasEntry(match.group(1), match.group(2), on_chain_name, val)
+        entry = modify_entry(entry)
+        return "[{}: {}, {}, {}]".format(entry.name, entry.ty, entry.on_chain_name, entry.val)
+
+    updated_content = pat.sub(replace, content)
+
+    with open(path, 'w') as file:
+        file.write(updated_content)
+
+def modify_all_execution(modify_entry: Callable[[GasEntry], GasEntry]):
+    modify_file(root_path + "/src/gas_schedule/instr.rs", modify_entry)
+    modify_file(root_path + "/src/gas_schedule/move_stdlib.rs", modify_entry)
+
+    def wrapper(entry):
+        if entry.name.startswith("event_"):
+            return entry
+        else:
+            return modify_entry(entry)
+    modify_file(root_path + "/src/gas_schedule/aptos_framework.rs", wrapper)
+
+    def wrapper(entry):
+        if entry.name.startswith("common_load_"):
+            return entry
+        else:
+            return modify_entry(entry)
+    modify_file(root_path + "/src/gas_schedule/table.rs", wrapper)
+
+def scale_all_execution(nominator: int, denominator: int):
+    def scale_entry(entry):
+        entry.val = (entry.val * nominator) // denominator
+        return entry
+    modify_all_execution(scale_entry)
+
+def id(entry):
+    return entry
+
+modify_all_execution(id)
+#scale_all_execution(5, 4)

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -18,78 +18,78 @@ crate::gas_schedule::macros::define_gas_parameters!(
 
         // BN254 algebra gas parameters begin.
         // Generated at time 1701559125.5498126 by `scripts/algebra-gas/update_bn254_algebra_gas_params.py` with gas_per_ns=209.10511688369482.
-        [algebra_ark_bn254_fq12_add: InternalGas, { 12.. => "algebra.ark_bn254_fq12_add" }, 4_406],
-        [algebra_ark_bn254_fq12_clone: InternalGas, { 12.. => "algebra.ark_bn254_fq12_clone" }, 4_392],
-        [algebra_ark_bn254_fq12_deser: InternalGas, { 12.. => "algebra.ark_bn254_fq12_deser" }, 129_063],
-        [algebra_ark_bn254_fq12_div: InternalGas, { 12.. => "algebra.ark_bn254_fq12_div" }, 2_813_602],
-        [algebra_ark_bn254_fq12_eq: InternalGas, { 12.. => "algebra.ark_bn254_fq12_eq" }, 12_142],
-        [algebra_ark_bn254_fq12_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fq12_from_u64" }, 14_463],
-        [algebra_ark_bn254_fq12_inv: InternalGas, { 12.. => "algebra.ark_bn254_fq12_inv" }, 2_168_418],
-        [algebra_ark_bn254_fq12_mul: InternalGas, { 12.. => "algebra.ark_bn254_fq12_mul" }, 643_914],
-        [algebra_ark_bn254_fq12_neg: InternalGas, { 12.. => "algebra.ark_bn254_fq12_neg" }, 13_311],
+        [algebra_ark_bn254_fq12_add: InternalGas, { 12.. => "algebra.ark_bn254_fq12_add" }, 4406],
+        [algebra_ark_bn254_fq12_clone: InternalGas, { 12.. => "algebra.ark_bn254_fq12_clone" }, 4392],
+        [algebra_ark_bn254_fq12_deser: InternalGas, { 12.. => "algebra.ark_bn254_fq12_deser" }, 129063],
+        [algebra_ark_bn254_fq12_div: InternalGas, { 12.. => "algebra.ark_bn254_fq12_div" }, 2813602],
+        [algebra_ark_bn254_fq12_eq: InternalGas, { 12.. => "algebra.ark_bn254_fq12_eq" }, 12142],
+        [algebra_ark_bn254_fq12_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fq12_from_u64" }, 14463],
+        [algebra_ark_bn254_fq12_inv: InternalGas, { 12.. => "algebra.ark_bn254_fq12_inv" }, 2168418],
+        [algebra_ark_bn254_fq12_mul: InternalGas, { 12.. => "algebra.ark_bn254_fq12_mul" }, 643914],
+        [algebra_ark_bn254_fq12_neg: InternalGas, { 12.. => "algebra.ark_bn254_fq12_neg" }, 13311],
         [algebra_ark_bn254_fq12_one: InternalGas, { 12.. => "algebra.ark_bn254_fq12_one" }, 209],
-        [algebra_ark_bn254_fq12_pow_u256: InternalGas, { 12.. => "algebra.ark_bn254_fq12_pow_u256" }, 192_871_746],
-        [algebra_ark_bn254_fq12_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fq12_serialize" }, 117_336],
-        [algebra_ark_bn254_fq12_square: InternalGas, { 12.. => "algebra.ark_bn254_fq12_square" }, 468_955],
-        [algebra_ark_bn254_fq12_sub: InternalGas, { 12.. => "algebra.ark_bn254_fq12_sub" }, 30_497],
+        [algebra_ark_bn254_fq12_pow_u256: InternalGas, { 12.. => "algebra.ark_bn254_fq12_pow_u256" }, 192871746],
+        [algebra_ark_bn254_fq12_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fq12_serialize" }, 117336],
+        [algebra_ark_bn254_fq12_square: InternalGas, { 12.. => "algebra.ark_bn254_fq12_square" }, 468955],
+        [algebra_ark_bn254_fq12_sub: InternalGas, { 12.. => "algebra.ark_bn254_fq12_sub" }, 30497],
         [algebra_ark_bn254_fq12_zero: InternalGas, { 12.. => "algebra.ark_bn254_fq12_zero" }, 209],
-        [algebra_ark_bn254_fq_add: InternalGas, { 12.. => "algebra.ark_bn254_fq_add" }, 4_373],
-        [algebra_ark_bn254_fq_clone: InternalGas, { 12.. => "algebra.ark_bn254_fq_clone" }, 4_313],
-        [algebra_ark_bn254_fq_deser: InternalGas, { 12.. => "algebra.ark_bn254_fq_deser" }, 17_588],
-        [algebra_ark_bn254_fq_div: InternalGas, { 12.. => "algebra.ark_bn254_fq_div" }, 1_140_544],
-        [algebra_ark_bn254_fq_eq: InternalGas, { 12.. => "algebra.ark_bn254_fq_eq" }, 4_373],
-        [algebra_ark_bn254_fq_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fq_from_u64" }, 14_137],
-        [algebra_ark_bn254_fq_inv: InternalGas, { 12.. => "algebra.ark_bn254_fq_inv" }, 1_136_577],
-        [algebra_ark_bn254_fq_mul: InternalGas, { 12.. => "algebra.ark_bn254_fq_mul" }, 10_050],
-        [algebra_ark_bn254_fq_neg: InternalGas, { 12.. => "algebra.ark_bn254_fq_neg" }, 4_314],
+        [algebra_ark_bn254_fq_add: InternalGas, { 12.. => "algebra.ark_bn254_fq_add" }, 4373],
+        [algebra_ark_bn254_fq_clone: InternalGas, { 12.. => "algebra.ark_bn254_fq_clone" }, 4313],
+        [algebra_ark_bn254_fq_deser: InternalGas, { 12.. => "algebra.ark_bn254_fq_deser" }, 17588],
+        [algebra_ark_bn254_fq_div: InternalGas, { 12.. => "algebra.ark_bn254_fq_div" }, 1140544],
+        [algebra_ark_bn254_fq_eq: InternalGas, { 12.. => "algebra.ark_bn254_fq_eq" }, 4373],
+        [algebra_ark_bn254_fq_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fq_from_u64" }, 14137],
+        [algebra_ark_bn254_fq_inv: InternalGas, { 12.. => "algebra.ark_bn254_fq_inv" }, 1136577],
+        [algebra_ark_bn254_fq_mul: InternalGas, { 12.. => "algebra.ark_bn254_fq_mul" }, 10050],
+        [algebra_ark_bn254_fq_neg: InternalGas, { 12.. => "algebra.ark_bn254_fq_neg" }, 4314],
         [algebra_ark_bn254_fq_one: InternalGas, { 12.. => "algebra.ark_bn254_fq_one" }, 209],
-        [algebra_ark_bn254_fq_pow_u256: InternalGas, { 12.. => "algebra.ark_bn254_fq_pow_u256" }, 2_081_451],
-        [algebra_ark_bn254_fq_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fq_serialize" }, 25_938],
-        [algebra_ark_bn254_fq_square: InternalGas, { 12.. => "algebra.ark_bn254_fq_square" }, 4_314],
-        [algebra_ark_bn254_fq_sub: InternalGas, { 12.. => "algebra.ark_bn254_fq_sub" }, 6_148],
+        [algebra_ark_bn254_fq_pow_u256: InternalGas, { 12.. => "algebra.ark_bn254_fq_pow_u256" }, 2081451],
+        [algebra_ark_bn254_fq_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fq_serialize" }, 25938],
+        [algebra_ark_bn254_fq_square: InternalGas, { 12.. => "algebra.ark_bn254_fq_square" }, 4314],
+        [algebra_ark_bn254_fq_sub: InternalGas, { 12.. => "algebra.ark_bn254_fq_sub" }, 6148],
         [algebra_ark_bn254_fq_zero: InternalGas, { 12.. => "algebra.ark_bn254_fq_zero" }, 209],
-        [algebra_ark_bn254_fr_add: InternalGas, { 12.. => "algebra.ark_bn254_fr_add" }, 4_377],
-        [algebra_ark_bn254_fr_deser: InternalGas, { 12.. => "algebra.ark_bn254_fr_deser" }, 16_722],
-        [algebra_ark_bn254_fr_div: InternalGas, { 12.. => "algebra.ark_bn254_fr_div" }, 1_217_943],
-        [algebra_ark_bn254_fr_eq: InternalGas, { 12.. => "algebra.ark_bn254_fr_eq" }, 4_396],
-        [algebra_ark_bn254_fr_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fr_from_u64" }, 13_485],
-        [algebra_ark_bn254_fr_inv: InternalGas, { 12.. => "algebra.ark_bn254_fr_inv" }, 1_209_015],
-        [algebra_ark_bn254_fr_mul: InternalGas, { 12.. => "algebra.ark_bn254_fr_mul" }, 9_867],
-        [algebra_ark_bn254_fr_neg: InternalGas, { 12.. => "algebra.ark_bn254_fr_neg" }, 4_314],
+        [algebra_ark_bn254_fr_add: InternalGas, { 12.. => "algebra.ark_bn254_fr_add" }, 4377],
+        [algebra_ark_bn254_fr_deser: InternalGas, { 12.. => "algebra.ark_bn254_fr_deser" }, 16722],
+        [algebra_ark_bn254_fr_div: InternalGas, { 12.. => "algebra.ark_bn254_fr_div" }, 1217943],
+        [algebra_ark_bn254_fr_eq: InternalGas, { 12.. => "algebra.ark_bn254_fr_eq" }, 4396],
+        [algebra_ark_bn254_fr_from_u64: InternalGas, { 12.. => "algebra.ark_bn254_fr_from_u64" }, 13485],
+        [algebra_ark_bn254_fr_inv: InternalGas, { 12.. => "algebra.ark_bn254_fr_inv" }, 1209015],
+        [algebra_ark_bn254_fr_mul: InternalGas, { 12.. => "algebra.ark_bn254_fr_mul" }, 9867],
+        [algebra_ark_bn254_fr_neg: InternalGas, { 12.. => "algebra.ark_bn254_fr_neg" }, 4314],
         [algebra_ark_bn254_fr_one: InternalGas, { 12.. => "algebra.ark_bn254_fr_one" }, 0],
-        [algebra_ark_bn254_fr_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fr_serialize" }, 25_749],
-        [algebra_ark_bn254_fr_square: InternalGas, { 12.. => "algebra.ark_bn254_fr_square" }, 4_311],
-        [algebra_ark_bn254_fr_sub: InternalGas, { 12.. => "algebra.ark_bn254_fr_sub" }, 10_370],
+        [algebra_ark_bn254_fr_serialize: InternalGas, { 12.. => "algebra.ark_bn254_fr_serialize" }, 25749],
+        [algebra_ark_bn254_fr_square: InternalGas, { 12.. => "algebra.ark_bn254_fr_square" }, 4311],
+        [algebra_ark_bn254_fr_sub: InternalGas, { 12.. => "algebra.ark_bn254_fr_sub" }, 10370],
         [algebra_ark_bn254_fr_zero: InternalGas, { 12.. => "algebra.ark_bn254_fr_zero" }, 209],
-        [algebra_ark_bn254_g1_affine_deser_comp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_deser_comp" }, 23_497_333],
-        [algebra_ark_bn254_g1_affine_deser_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_deser_uncomp" }, 21_528_706],
-        [algebra_ark_bn254_g1_affine_serialize_comp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_serialize_comp" }, 44_924],
-        [algebra_ark_bn254_g1_affine_serialize_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_serialize_uncomp" }, 58_820],
-        [algebra_ark_bn254_g1_proj_add: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_add" }, 106_501],
-        [algebra_ark_bn254_g1_proj_double: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_double" }, 63_682],
-        [algebra_ark_bn254_g1_proj_eq: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_eq" }, 53_021],
+        [algebra_ark_bn254_g1_affine_deser_comp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_deser_comp" }, 23497333],
+        [algebra_ark_bn254_g1_affine_deser_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_deser_uncomp" }, 21528706],
+        [algebra_ark_bn254_g1_affine_serialize_comp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_serialize_comp" }, 44924],
+        [algebra_ark_bn254_g1_affine_serialize_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g1_affine_serialize_uncomp" }, 58820],
+        [algebra_ark_bn254_g1_proj_add: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_add" }, 106501],
+        [algebra_ark_bn254_g1_proj_double: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_double" }, 63682],
+        [algebra_ark_bn254_g1_proj_eq: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_eq" }, 53021],
         [algebra_ark_bn254_g1_proj_generator: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_generator" }, 209],
         [algebra_ark_bn254_g1_proj_infinity: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_infinity" }, 209],
         [algebra_ark_bn254_g1_proj_neg: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_neg" }, 209],
-        [algebra_ark_bn254_g1_proj_scalar_mul: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_scalar_mul" }, 26_456_386],
-        [algebra_ark_bn254_g1_proj_sub: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_sub" }, 106_903],
-        [algebra_ark_bn254_g1_proj_to_affine: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_to_affine" }, 6_340],
-        [algebra_ark_bn254_g2_affine_deser_comp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_deser_comp" }, 67_710_223],
-        [algebra_ark_bn254_g2_affine_deser_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_deser_uncomp" }, 60_677_591],
-        [algebra_ark_bn254_g2_affine_serialize_comp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_serialize_comp" }, 69_214],
-        [algebra_ark_bn254_g2_affine_serialize_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_serialize_uncomp" }, 98_505],
-        [algebra_ark_bn254_g2_proj_add: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_add" }, 318_234],
-        [algebra_ark_bn254_g2_proj_double: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_double" }, 158_874],
-        [algebra_ark_bn254_g2_proj_eq: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_eq" }, 141_359],
+        [algebra_ark_bn254_g1_proj_scalar_mul: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_scalar_mul" }, 26456386],
+        [algebra_ark_bn254_g1_proj_sub: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_sub" }, 106903],
+        [algebra_ark_bn254_g1_proj_to_affine: InternalGas, { 12.. => "algebra.ark_bn254_g1_proj_to_affine" }, 6340],
+        [algebra_ark_bn254_g2_affine_deser_comp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_deser_comp" }, 67710223],
+        [algebra_ark_bn254_g2_affine_deser_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_deser_uncomp" }, 60677591],
+        [algebra_ark_bn254_g2_affine_serialize_comp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_serialize_comp" }, 69214],
+        [algebra_ark_bn254_g2_affine_serialize_uncomp: InternalGas, { 12.. => "algebra.ark_bn254_g2_affine_serialize_uncomp" }, 98505],
+        [algebra_ark_bn254_g2_proj_add: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_add" }, 318234],
+        [algebra_ark_bn254_g2_proj_double: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_double" }, 158874],
+        [algebra_ark_bn254_g2_proj_eq: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_eq" }, 141359],
         [algebra_ark_bn254_g2_proj_generator: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_generator" }, 209],
         [algebra_ark_bn254_g2_proj_infinity: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_infinity" }, 209],
         [algebra_ark_bn254_g2_proj_neg: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_neg" }, 209],
-        [algebra_ark_bn254_g2_proj_scalar_mul: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_scalar_mul" }, 76_395_801],
-        [algebra_ark_bn254_g2_proj_sub: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_sub" }, 321_727],
-        [algebra_ark_bn254_g2_proj_to_affine: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_to_affine" }, 1_251_909],
-        [algebra_ark_bn254_multi_pairing_base: InternalGas, { 12.. => "algebra.ark_bn254_multi_pairing_base" }, 127_794_596],
-        [algebra_ark_bn254_multi_pairing_per_pair: InternalGasPerArg, { 12.. => "algebra.ark_bn254_multi_pairing_per_pair" }, 67_624_587],
-        [algebra_ark_bn254_pairing: InternalGas, { 12.. => "algebra.ark_bn254_pairing" }, 209_703_839],
+        [algebra_ark_bn254_g2_proj_scalar_mul: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_scalar_mul" }, 76395801],
+        [algebra_ark_bn254_g2_proj_sub: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_sub" }, 321727],
+        [algebra_ark_bn254_g2_proj_to_affine: InternalGas, { 12.. => "algebra.ark_bn254_g2_proj_to_affine" }, 1251909],
+        [algebra_ark_bn254_multi_pairing_base: InternalGas, { 12.. => "algebra.ark_bn254_multi_pairing_base" }, 127794596],
+        [algebra_ark_bn254_multi_pairing_per_pair: InternalGasPerArg, { 12.. => "algebra.ark_bn254_multi_pairing_per_pair" }, 67624587],
+        [algebra_ark_bn254_pairing: InternalGas, { 12.. => "algebra.ark_bn254_pairing" }, 209703839],
         // BN254 algebra gas parameters end.
 
         // BLS12-381 algebra gas parameters begin.
@@ -242,15 +242,15 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [type_info_chain_id_base: InternalGas, { 4.. => "type_info.chain_id.base" }, 3000],
 
         // Reusing SHA2-512's cost from Ristretto
-        [hash_sha2_512_base: InternalGas, { 4.. => "hash.sha2_512.base" }, 64_800],  // 3_240 * 20
-        [hash_sha2_512_per_byte: InternalGasPerByte, { 4.. => "hash.sha2_512.per_byte" }, 1_200], // 60 * 20
+        [hash_sha2_512_base: InternalGas, { 4.. => "hash.sha2_512.base" }, 64800],  // 3_240 * 20
+        [hash_sha2_512_per_byte: InternalGasPerByte, { 4.. => "hash.sha2_512.per_byte" }, 1200], // 60 * 20
         // Back-of-the-envelope approximation from SHA3-256's costs (4000 base, 45 per-byte)
-        [hash_sha3_512_base: InternalGas, { 4.. => "hash.sha3_512.base" }, 90_000], // 4_500 * 20
-        [hash_sha3_512_per_byte: InternalGasPerByte, { 4.. => "hash.sha3_512.per_byte" }, 1_000], // 50 * 20
+        [hash_sha3_512_base: InternalGas, { 4.. => "hash.sha3_512.base" }, 90000], // 4_500 * 20
+        [hash_sha3_512_per_byte: InternalGasPerByte, { 4.. => "hash.sha3_512.per_byte" }, 1000], // 50 * 20
         // Using SHA2-256's cost
-        [hash_ripemd160_base: InternalGas, { 4.. => "hash.ripemd160.base" }, 60_000], // 3000 * 20
-        [hash_ripemd160_per_byte: InternalGasPerByte, { 4.. => "hash.ripemd160.per_byte" }, 1_000], // 50 * 20
-        [hash_blake2b_256_base: InternalGas, { 6.. => "hash.blake2b_256.base" }, 35_000], // 1750 * 20
+        [hash_ripemd160_base: InternalGas, { 4.. => "hash.ripemd160.base" }, 60000], // 3000 * 20
+        [hash_ripemd160_per_byte: InternalGasPerByte, { 4.. => "hash.ripemd160.per_byte" }, 1000], // 50 * 20
+        [hash_blake2b_256_base: InternalGas, { 6.. => "hash.blake2b_256.base" }, 35000], // 1750 * 20
         [hash_blake2b_256_per_byte: InternalGasPerByte, { 6.. => "hash.blake2b_256.per_byte" }, 300], // 15 * 20
 
         [util_from_bytes_base: InternalGas, "util.from_bytes.base", 6000],
@@ -265,9 +265,9 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [code_request_publish_per_byte: InternalGasPerByte, "code.request_publish.per_byte", 40],
 
         // Note(Gas): These are storage operations so the values should not be multiplied.
-        [event_write_to_event_store_base: InternalGas, "event.write_to_event_store.base", 300_000],
+        [event_write_to_event_store_base: InternalGas, "event.write_to_event_store.base", 300000],
         // TODO(Gas): the on-chain name is wrong...
-        [event_write_to_event_store_per_abstract_value_unit: InternalGasPerAbstractValueUnit, "event.write_to_event_store.per_abstract_memory_unit", 5_000],
+        [event_write_to_event_store_per_abstract_value_unit: InternalGasPerAbstractValueUnit, "event.write_to_event_store.per_abstract_memory_unit", 5000],
 
         [state_storage_get_usage_base_cost: InternalGas, "state_storage.get_usage.base", 10000],
 

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/instr.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/instr.rs
@@ -36,34 +36,17 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [ld_true: InternalGas, "ld_true", 1200],
         [ld_false: InternalGas, "ld_false", 1200],
         [ld_const_base: InternalGas, "ld_const.base", 13000],
-        [
-            ld_const_per_byte: InternalGasPerByte,
-            "ld_const.per_byte",
-            700,
-            LD_CONST_PER_BYTE
-        ],
+        [ld_const_per_byte: InternalGasPerByte, "ld_const.per_byte", 700],
         // borrow
         [imm_borrow_loc: InternalGas, "imm_borrow_loc", 1200],
         [mut_borrow_loc: InternalGas, "mut_borrow_loc", 1200],
         [imm_borrow_field: InternalGas, "imm_borrow_field", 4000],
         [mut_borrow_field: InternalGas, "mut_borrow_field", 4000],
-        [
-            imm_borrow_field_generic: InternalGas,
-            "imm_borrow_field_generic",
-            4000
-        ],
-        [
-            mut_borrow_field_generic: InternalGas,
-            "mut_borrow_field_generic",
-            4000
-        ],
+        [imm_borrow_field_generic: InternalGas, "imm_borrow_field_generic", 4000],
+        [mut_borrow_field_generic: InternalGas, "mut_borrow_field_generic", 4000],
         // locals
         [copy_loc_base: InternalGas, "copy_loc.base", 1600],
-        [
-            copy_loc_per_abs_val_unit: InternalGasPerAbstractValueUnit,
-            "copy_loc.per_abs_val_unit",
-            80
-        ],
+        [copy_loc_per_abs_val_unit: InternalGasPerAbstractValueUnit, "copy_loc.per_abs_val_unit", 80],
         [move_loc_base: InternalGas, "move_loc.base", 2400],
         [st_loc_base: InternalGas, "st_loc.base", 2400],
         // call
@@ -71,41 +54,21 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [call_per_arg: InternalGasPerArg, "call.per_arg", 2000],
         [call_per_local: InternalGasPerArg, { 1.. => "call.per_local" }, 2000],
         [call_generic_base: InternalGas, "call_generic.base", 20000],
-        [
-            call_generic_per_ty_arg: InternalGasPerArg,
-            "call_generic.per_ty_arg",
-            2000
-        ],
-        [
-            call_generic_per_arg: InternalGasPerArg,
-            "call_generic.per_arg",
-            2000
-        ],
+        [call_generic_per_ty_arg: InternalGasPerArg, "call_generic.per_ty_arg", 2000],
+        [call_generic_per_arg: InternalGasPerArg, "call_generic.per_arg", 2000],
         [call_generic_per_local: InternalGasPerArg, { 1.. => "call_generic.per_local" }, 2000],
         // struct
         [pack_base: InternalGas, "pack.base", 4400],
         [pack_per_field: InternalGasPerArg, "pack.per_field", 800],
         [pack_generic_base: InternalGas, "pack_generic.base", 4400],
-        [
-            pack_generic_per_field: InternalGasPerArg,
-            "pack_generic.per_field",
-            800
-        ],
+        [pack_generic_per_field: InternalGasPerArg, "pack_generic.per_field", 800],
         [unpack_base: InternalGas, "unpack.base", 4400],
         [unpack_per_field: InternalGasPerArg, "unpack.per_field", 800],
         [unpack_generic_base: InternalGas, "unpack_generic.base", 4400],
-        [
-            unpack_generic_per_field: InternalGasPerArg,
-            "unpack_generic.per_field",
-            800
-        ],
+        [unpack_generic_per_field: InternalGasPerArg, "unpack_generic.per_field", 800],
         // ref
         [read_ref_base: InternalGas, "read_ref.base", 4000],
-        [
-            read_ref_per_abs_val_unit: InternalGasPerAbstractValueUnit,
-            "read_ref.per_abs_val_unit",
-            80
-        ],
+        [read_ref_per_abs_val_unit: InternalGasPerAbstractValueUnit, "read_ref.per_abs_val_unit", 80],
         [write_ref_base: InternalGas, "write_ref.base", 4000],
         [freeze_ref: InternalGas, "freeze_ref", 200],
         // casting
@@ -137,52 +100,20 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [le: InternalGas, "le", 3200],
         [ge: InternalGas, "ge", 3200],
         [eq_base: InternalGas, "eq.base", 2000],
-        [
-            eq_per_abs_val_unit: InternalGasPerAbstractValueUnit,
-            "eq.per_abs_val_unit",
-            80
-        ],
+        [eq_per_abs_val_unit: InternalGasPerAbstractValueUnit, "eq.per_abs_val_unit", 80],
         [neq_base: InternalGas, "neq.base", 2000],
-        [
-            neq_per_abs_val_unit: InternalGasPerAbstractValueUnit,
-            "neq.per_abs_val_unit",
-            80
-        ],
+        [neq_per_abs_val_unit: InternalGasPerAbstractValueUnit, "neq.per_abs_val_unit", 80],
         // global
-        [
-            imm_borrow_global_base: InternalGas,
-            "imm_borrow_global.base",
-            10000
-        ],
-        [
-            imm_borrow_global_generic_base: InternalGas,
-            "imm_borrow_global_generic.base",
-            10000
-        ],
-        [
-            mut_borrow_global_base: InternalGas,
-            "mut_borrow_global.base",
-            10000
-        ],
-        [
-            mut_borrow_global_generic_base: InternalGas,
-            "mut_borrow_global_generic.base",
-            10000
-        ],
+        [imm_borrow_global_base: InternalGas, "imm_borrow_global.base", 10000],
+        [imm_borrow_global_generic_base: InternalGas, "imm_borrow_global_generic.base", 10000],
+        [mut_borrow_global_base: InternalGas, "mut_borrow_global.base", 10000],
+        [mut_borrow_global_generic_base: InternalGas, "mut_borrow_global_generic.base", 10000],
         [exists_base: InternalGas, "exists.base", 5000],
         [exists_generic_base: InternalGas, "exists_generic.base", 5000],
         [move_from_base: InternalGas, "move_from.base", 7000],
-        [
-            move_from_generic_base: InternalGas,
-            "move_from_generic.base",
-            7000
-        ],
+        [move_from_generic_base: InternalGas, "move_from_generic.base", 7000],
         [move_to_base: InternalGas, "move_to.base", 10000],
-        [
-            move_to_generic_base: InternalGas,
-            "move_to_generic.base",
-            10000
-        ],
+        [move_to_generic_base: InternalGas, "move_to_generic.base", 10000],
         // vec
         [vec_len_base: InternalGas, "vec_len.base", 4400],
         [vec_imm_borrow_base: InternalGas, "vec_imm_borrow.base", 6600],
@@ -191,16 +122,8 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [vec_pop_back_base: InternalGas, "vec_pop_back.base", 5200],
         [vec_swap_base: InternalGas, "vec_swap.base", 6000],
         [vec_pack_base: InternalGas, "vec_pack.base", 12000],
-        [
-            vec_pack_per_elem: InternalGasPerArg,
-            "vec_pack.per_elem",
-            800
-        ],
+        [vec_pack_per_elem: InternalGasPerArg, "vec_pack.per_elem", 800],
         [vec_unpack_base: InternalGas, "vec_unpack.base", 10000],
-        [
-            vec_unpack_per_expected_elem: InternalGasPerArg,
-            "vec_unpack.per_expected_elem",
-            800
-        ],
+        [vec_unpack_per_expected_elem: InternalGasPerArg, "vec_unpack.per_expected_elem", 800],
     ]
 );


### PR DESCRIPTION
This introduces a python script that can be used to mass-modify the gas schedule entries that are embedded in the Rust source files. It is meant to serve as a temporary solution until we come up with a more appropriate format for storing 
the gas schedule.

Notice that I've also included some formatting changes in the PR. These are generated by running the script with an id function. Making these formatting changes now will make it easier for us to spot changes in subsequent gas adjustment PRs.