### PR TITLE
[indexer grpc] Default enable_verbose_logging flag to false in rust config

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
@@ -17,7 +17,7 @@ pub struct IndexerGrpcCacheWorkerConfig {
     pub fullnode_grpc_address: Url,
     pub file_store_config: IndexerGrpcFileStoreConfig,
     pub redis_main_instance_address: RedisUrl,
-    pub enable_verbose_logging: bool,
+    pub enable_verbose_logging: Option<bool>,
 }
 
 impl IndexerGrpcCacheWorkerConfig {
@@ -31,7 +31,7 @@ impl IndexerGrpcCacheWorkerConfig {
             fullnode_grpc_address,
             file_store_config,
             redis_main_instance_address,
-            enable_verbose_logging: enable_verbose_logging.unwrap_or(false),
+            enable_verbose_logging,
         }
     }
 }
@@ -43,7 +43,7 @@ impl RunnableConfig for IndexerGrpcCacheWorkerConfig {
             self.fullnode_grpc_address.clone(),
             self.redis_main_instance_address.clone(),
             self.file_store_config.clone(),
-            self.enable_verbose_logging,
+            self.enable_verbose_logging.unwrap_or(false),
         )
         .await
         .context("Failed to create cache worker")?;

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
@@ -66,7 +66,7 @@ pub struct IndexerGrpcDataServiceConfig {
     pub file_store_config: IndexerGrpcFileStoreConfig,
     /// Redis read replica address.
     pub redis_read_replica_address: RedisUrl,
-    pub enable_verbose_logging: bool,
+    pub enable_verbose_logging: Option<bool>,
 }
 
 impl IndexerGrpcDataServiceConfig {
@@ -89,7 +89,7 @@ impl IndexerGrpcDataServiceConfig {
             disable_auth_check,
             file_store_config,
             redis_read_replica_address,
-            enable_verbose_logging: enable_verbose_logging.unwrap_or(false),
+            enable_verbose_logging,
         }
     }
 
@@ -153,7 +153,7 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
             self.redis_read_replica_address.clone(),
             self.file_store_config.clone(),
             self.data_service_response_channel_size,
-            self.enable_verbose_logging,
+            self.enable_verbose_logging.unwrap_or(false),
         )?;
         let svc = aptos_protos::indexer::v1::raw_data_server::RawDataServer::new(server)
             .send_compressed(CompressionEncoding::Gzip)

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 pub struct IndexerGrpcFileStoreWorkerConfig {
     pub file_store_config: IndexerGrpcFileStoreConfig,
     pub redis_main_instance_address: RedisUrl,
-    pub enable_verbose_logging: bool,
+    pub enable_verbose_logging: Option<bool>,
 }
 
 impl IndexerGrpcFileStoreWorkerConfig {
@@ -27,7 +27,7 @@ impl IndexerGrpcFileStoreWorkerConfig {
         Self {
             file_store_config,
             redis_main_instance_address,
-            enable_verbose_logging: enable_verbose_logging.unwrap_or(false),
+            enable_verbose_logging,
         }
     }
 }
@@ -38,7 +38,7 @@ impl RunnableConfig for IndexerGrpcFileStoreWorkerConfig {
         let mut processor = Processor::new(
             self.redis_main_instance_address.clone(),
             self.file_store_config.clone(),
-            self.enable_verbose_logging,
+            self.enable_verbose_logging.unwrap_or(false),
         )
         .await
         .context("Failed to create processor for file store worker")?;


### PR DESCRIPTION
### Description
Old yaml's that don't have the `enable_verbose_logging` flag set will not work. This PR sets default for the flag if it's not set. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
1. Test without `enable_verbose_logging` flag
2. Test set `enable_verbose_logging` to true
3. Test set `enable_verbose_logging` to false 

[Humio](https://cloud.us.humio.com/k8s/search?live=false&query=k8s.namespace%20%3D%20%22indexer-grpc-devnet%22%0A%7C%20rename(%5B%5Bdata.service_type%2C%20fields.service_type%5D%2C%20%5Bdata.step%2C%20fields.step%5D%5D)%20%2F%2F%20Rename%20the%20fields%20in%20fullnode%0A%7C%20in(fields.service_type%2C%20values%3D%5B%22data_service%22%2C%20%22cache_worker%22%2C%20%22file_worker%22%2C%20%22indexer_fullnode%22%5D)%0A%7C%20fields.step%20%3D%20*%0A%7C%20format(format%3D%22service%3D%25s%2C%20step%3D%25s%22%2C%20field%3D%5Bfields.service_type%2C%20fields.step%5D%2C%20as%3D%22step%22)%0A%7C%20timeChart(series%3Dstep%2C%20function%3Dmax(fields.end_version))&start=5m&tz=America%2FLos_Angeles)
