### PR TITLE
[storage] support localFs with gzip

### DIFF
--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -90,6 +90,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
+      - name: Install Gfuse
+        run: |
+          export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+          echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install gcsfuse
+      - name: Mount GCS bucket
+        run: |
+          mkdir -p /tmp/gcs
+          sudo gcsfuse --foreground --implicit-dirs --only-dir ${{ inputs.SUB_DIR }} ${{ inputs.BUCKET }} /tmp/gcs
+          ls -l /tmp/gcs
 
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "aptos-temppath",
  "aptos-types",
  "aptos-vm",
+ "async-compression 0.4.5",
  "async-trait",
  "bcs 0.1.4",
  "bytes",
@@ -4530,6 +4531,19 @@ name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -12708,7 +12722,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "async-compression",
+ "async-compression 0.3.15",
  "base64 0.13.0",
  "bytes",
  "cookie 0.16.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,6 +448,7 @@ async-mutex = "1.4.0"
 async-recursion = "1.0.5"
 async-stream = "0.3"
 async-trait = "0.1.53"
+async-compression = { version = "0.4.5", features = ["tokio"] }
 axum = "0.5.16"
 base64 = "0.13.0"
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -32,6 +32,7 @@ aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 async-trait = { workspace = true }
+async-compression = { workspace = true, features = ["gzip"] }
 bcs = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -33,7 +33,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 #[derive(Parser, Clone, Debug, Serialize, Deserialize)]
 pub struct CommandAdapterOpt {
     #[clap(
-        long = "config",
+        long = "command_adapter_config",
         help = "Config file for the command adapter backup store."
     )]
     config: PathBuf,

--- a/testsuite/replay_verify.py
+++ b/testsuite/replay_verify.py
@@ -139,8 +139,9 @@ def replay_verify_partition(
             "--end-version",
             str(end),
             "--lazy-quit",
-            "--command-adapter-config",
-            backup_config_template_path,
+            "--local-fs-dir",
+            "/tmp/gcs",
+            "--compressed"
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,  # redirect stderr to stdout

--- a/testsuite/replay_verify_run_local.py
+++ b/testsuite/replay_verify_run_local.py
@@ -46,5 +46,5 @@ def local_setup():
 if __name__ == "__main__":
     local_setup()
     replay_verify.main(
-        runner_no=None, runner_cnt=None, start_version=291217350, end_version=292975771
+        runner_no=None, runner_cnt=None, start_version=250000000, end_version=350000000
     )


### PR DESCRIPTION
### Description
we can read and write zipped file to local Fs

one scenario is that we can directly use gfuse to mount a google bucket and read the zipped files as local files 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
new command works 
cargo run --release -p aptos-debugger aptos-db replay-verify --txns-to-skip 46874937 151020059 409163615 409163669 409163708 409163774 409163845 409163955 409164059 409164191 414625832 --target-db-dir /mnt/data/tmp_replay_verify_gfuse --local-fs-dir /mnt/data/gcs/e1 --compressed --start-version 280000000 --end-version 290000000

old command using command-adapter-config also works 


