### PR TITLE
[indexer grpc] Gate only the expensive part of the logging 

### DIFF
--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -42,7 +42,7 @@ pub struct IndexerGrpcConfig {
     /// Number of transactions returned in a single stream response
     pub output_batch_size: u16,
 
-    pub enable_verbose_logging: bool,
+    pub enable_expensive_logging: bool,
 }
 
 impl Debug for IndexerGrpcConfig {
@@ -57,7 +57,7 @@ impl Debug for IndexerGrpcConfig {
             .field("processor_task_count", &self.processor_task_count)
             .field("processor_batch_size", &self.processor_batch_size)
             .field("output_batch_size", &self.output_batch_size)
-            .field("enable_verbose_logging", &self.enable_verbose_logging)
+            .field("enable_expensive_logging", &self.enable_expensive_logging)
             .finish()
     }
 }
@@ -77,7 +77,7 @@ impl Default for IndexerGrpcConfig {
             processor_task_count: DEFAULT_PROCESSOR_TASK_COUNT,
             processor_batch_size: DEFAULT_PROCESSOR_BATCH_SIZE,
             output_batch_size: DEFAULT_OUTPUT_BATCH_SIZE,
-            enable_verbose_logging: false,
+            enable_expensive_logging: false,
         }
     }
 }
@@ -123,9 +123,9 @@ impl ConfigOptimizer for IndexerGrpcConfig {
         // just keep the legacy behaviour to avoid breaking anything.
 
         // Override with environment variables if they are set
-        indexer_config.enable_verbose_logging = env_var_or_default(
-            "INDEXER_GRPC_ENABLE_VERBOSE_LOGGING",
-            Some(indexer_config.enable_verbose_logging),
+        indexer_config.enable_expensive_logging = env_var_or_default(
+            "INDEXER_GRPC_ENABLE_EXPENSIVE_LOGGING",
+            Some(indexer_config.enable_expensive_logging),
             None,
         )
         .unwrap_or(false);

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -16,7 +16,7 @@ use tonic::{Request, Response, Status};
 
 pub struct FullnodeDataService {
     pub service_context: ServiceContext,
-    pub enable_verbose_logging: bool,
+    pub enable_expensive_logging: bool,
 }
 
 type FullnodeResponseStream =
@@ -50,7 +50,7 @@ impl FullnodeData for FullnodeDataService {
         let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;
-        let enable_verbose_logging = self.enable_verbose_logging;
+        let enable_expensive_logging = self.enable_expensive_logging;
 
         // Some node metadata
         let context = self.service_context.context.clone();
@@ -93,7 +93,9 @@ impl FullnodeData for FullnodeDataService {
             loop {
                 let start_time = std::time::Instant::now();
                 // Processes and sends batch of transactions to client
-                let results = coordinator.process_next_batch(enable_verbose_logging).await;
+                let results = coordinator
+                    .process_next_batch(enable_expensive_logging)
+                    .await;
                 let max_version = match IndexerStreamCoordinator::get_max_batch_version(results) {
                     Ok(max_version) => max_version,
                     Err(e) => {
@@ -102,18 +104,6 @@ impl FullnodeData for FullnodeDataService {
                     },
                 };
                 let highest_known_version = coordinator.highest_known_version;
-
-                log_grpc_step_fullnode(
-                    IndexerGrpcStep::FullnodeProcessedBatch,
-                    enable_verbose_logging,
-                    Some(coordinator.current_version as i64),
-                    Some(max_version as i64),
-                    None,
-                    Some(coordinator.highest_known_version as i64),
-                    None,
-                    Some(start_time.elapsed().as_secs_f64()),
-                    Some(ma.sum() as i64),
-                );
 
                 // send end batch message (each batch) upon success of the entire batch
                 // client can use the start and end version to ensure that there are no gaps
@@ -134,7 +124,6 @@ impl FullnodeData for FullnodeDataService {
 
                             log_grpc_step_fullnode(
                                 IndexerGrpcStep::FullnodeProcessedBatch,
-                                enable_verbose_logging,
                                 Some(coordinator.current_version as i64),
                                 Some(max_version as i64),
                                 None,

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
@@ -23,7 +23,7 @@ type TransactionResponseStream =
 
 pub struct LocalnetDataService {
     pub service_context: ServiceContext,
-    pub enable_verbose_logging: bool,
+    pub enable_expensive_logging: bool,
 }
 
 /// External service on the fullnode is for testing/local development only.
@@ -48,7 +48,7 @@ impl RawData for LocalnetDataService {
         // Creates a channel to send the stream to the client
         let (tx, mut rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
         let (external_service_tx, external_service_rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
-        let enable_verbose_logging = self.enable_verbose_logging;
+        let enable_expensive_logging = self.enable_expensive_logging;
 
         tokio::spawn(async move {
             // Initialize the coordinator that tracks starting version and processes transactions
@@ -64,7 +64,9 @@ impl RawData for LocalnetDataService {
             );
             loop {
                 // Processes and sends batch of transactions to client
-                let results = coordinator.process_next_batch(enable_verbose_logging).await;
+                let results = coordinator
+                    .process_next_batch(enable_expensive_logging)
+                    .await;
                 let max_version = match IndexerStreamCoordinator::get_max_batch_version(results) {
                     Ok(max_version) => max_version,
                     Err(e) => {

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -48,7 +48,7 @@ pub fn bootstrap(
     let processor_task_count = node_config.indexer_grpc.processor_task_count;
     let processor_batch_size = node_config.indexer_grpc.processor_batch_size;
     let output_batch_size = node_config.indexer_grpc.output_batch_size;
-    let enable_verbose_logging = node_config.indexer_grpc.enable_verbose_logging;
+    let enable_expensive_logging = node_config.indexer_grpc.enable_expensive_logging;
 
     runtime.spawn(async move {
         let context = Arc::new(Context::new(chain_id, db, mp_sender, node_config));
@@ -61,11 +61,11 @@ pub fn bootstrap(
         // If we are here, we know indexer grpc is enabled.
         let server = FullnodeDataService {
             service_context: service_context.clone(),
-            enable_verbose_logging,
+            enable_expensive_logging,
         };
         let localnet_data_server = LocalnetDataService {
             service_context,
-            enable_verbose_logging,
+            enable_expensive_logging,
         };
 
         let reflection_service = tonic_reflection::server::Builder::configure()

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
@@ -81,7 +81,7 @@ impl IndexerStreamCoordinator {
     /// 4. Encode protobuf objects (base64)
     pub async fn process_next_batch(
         &mut self,
-        enable_verbose_logging: bool,
+        enable_expensive_logging: bool,
     ) -> Vec<Result<EndVersion, Status>> {
         let ledger_chain_id = self.context.chain_id().id();
         let mut tasks = vec![];
@@ -98,12 +98,23 @@ impl IndexerStreamCoordinator {
                 // Fetch and convert transactions from API
                 let raw_txns =
                     Self::fetch_raw_txns_with_retries(context.clone(), ledger_version, batch).await;
+                let first_raw_transaction = raw_txns.first().unwrap();
+                let last_raw_transaction = raw_txns.last().unwrap();
+                let mut last_transaction_timestamp = None;
+                if enable_expensive_logging {
+                    // Reusing the conversion methods which need a vec, so make a vec of size 1
+                    let api_txn = Self::convert_to_api_txns(context.clone(), vec![
+                        last_raw_transaction.clone(),
+                    ])
+                    .await;
+                    let pb_txn = Self::convert_to_pb_txns(api_txn);
+                    last_transaction_timestamp = pb_txn.first().unwrap().timestamp.clone();
+                }
                 log_grpc_step_fullnode(
                     IndexerGrpcStep::FullnodeFetchedBatch,
-                    enable_verbose_logging,
-                    None,
-                    None,
-                    None,
+                    Some(first_raw_transaction.version as i64),
+                    Some(last_raw_transaction.version as i64),
+                    last_transaction_timestamp.as_ref(),
                     Some(ledger_version as i64),
                     None,
                     Some(batch_start_time.elapsed().as_secs_f64()),
@@ -118,7 +129,6 @@ impl IndexerStreamCoordinator {
 
                 log_grpc_step_fullnode(
                     IndexerGrpcStep::FullnodeDecodedBatch,
-                    enable_verbose_logging,
                     Some(start_transaction.version as i64),
                     Some(end_transaction.version as i64),
                     end_txn_timestamp.as_ref(),
@@ -153,7 +163,6 @@ impl IndexerStreamCoordinator {
 
                 log_grpc_step_fullnode(
                     IndexerGrpcStep::FullnodeSentBatch,
-                    enable_verbose_logging,
                     Some(start_transaction.version as i64),
                     Some(end_transaction.version as i64),
                     end_txn_timestamp.as_ref(),

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -227,7 +227,6 @@ pub fn log_grpc_step(
 
 pub fn log_grpc_step_fullnode(
     step: IndexerGrpcStep,
-    enable_logging: bool,
     start_version: Option<i64>,
     end_version: Option<i64>,
     end_version_timestamp: Option<&Timestamp>,
@@ -260,18 +259,16 @@ pub fn log_grpc_step_fullnode(
             .set(end_txn_timestamp_unixtime);
     }
 
-    if enable_logging {
-        tracing::info!(
-            start_version,
-            end_version,
-            num_transactions,
-            duration_in_secs,
-            highest_known_version,
-            tps,
-            service_type,
-            step = step.get_step(),
-            "{}",
-            step.get_label(),
-        );
-    }
+    tracing::info!(
+        start_version,
+        end_version,
+        num_transactions,
+        duration_in_secs,
+        highest_known_version,
+        tps,
+        service_type,
+        step = step.get_step(),
+        "{}",
+        step.get_label(),
+    );
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -45,8 +45,8 @@ impl IndexerGrpcStep {
             // Fullnode steps
             IndexerGrpcStep::FullnodeFetchedBatch => "1",
             IndexerGrpcStep::FullnodeDecodedBatch => "2",
-            IndexerGrpcStep::FullnodeProcessedBatch => "3",
-            IndexerGrpcStep::FullnodeSentBatch => "4",
+            IndexerGrpcStep::FullnodeSentBatch => "3",
+            IndexerGrpcStep::FullnodeProcessedBatch => "4",
         }
     }
 


### PR DESCRIPTION
### Description
1. rename var to enable_expensive_logging
2. gate the expensive parts of logging
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
1. test with enable_expensive_logging not set or set to false. Step 1 shouldn't show up in metrics 
![Screenshot 2023-12-13 at 4 04 05 PM](https://github.com/aptos-labs/aptos-core/assets/8248583/c1c6fc19-3ace-4931-98f0-732a89ab7c6d)

2. test with enable_expensive_logging = true. Step 1 should show up in metrics 
![Screenshot 2023-12-13 at 4 05 45 PM](https://github.com/aptos-labs/aptos-core/assets/8248583/f9d1760d-8aab-485e-967a-e30235c912ab)
