### PR TITLE
[cleanup] Remove API dependency on ModuleBundle in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
+ "aptos-package-builder",
  "aptos-proptest-helpers",
  "aptos-runtimes",
  "aptos-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,6 @@ dependencies = [
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
- "aptos-package-builder",
  "aptos-proptest-helpers",
  "aptos-runtimes",
  "aptos-sdk",
@@ -713,6 +712,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-framework",
+ "aptos-package-builder",
  "aptos-types",
  "bcs 0.1.4",
  "include_dir 0.7.2",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -57,6 +57,7 @@ aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-meter = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
+aptos-package-builder = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-sdk = { workspace = true }
 move-package = { workspace = true }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -57,7 +57,6 @@ aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-meter = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
-aptos-package-builder = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-sdk = { workspace = true }
 move-package = { workspace = true }

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -6,8 +6,6 @@ use super::new_test_context;
 use aptos_api_test_context::{current_function_name, find_value};
 use aptos_api_types::{MoveModuleBytecode, MoveResource, StateKeyWrapper};
 use aptos_cached_packages::aptos_stdlib;
-use aptos_framework::{BuildOptions, BuiltPackage};
-use aptos_package_builder::PackageBuilder;
 use serde_json::json;
 use std::str::FromStr;
 
@@ -156,26 +154,8 @@ async fn test_get_account_resources_by_invalid_ledger_version() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_account_modules_by_ledger_version() {
     let mut context = new_test_context(current_function_name!());
-
-    let mut builder = PackageBuilder::new("test_package");
-    builder.add_source(
-        "test_module.move",
-        r#"
-        module 0xa550c18::test_module {}
-        "#,
-    );
-    let path = builder.write_to_temp().unwrap();
-
-    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
-        .expect("Should be able to build a package");
-    let code = package.extract_code();
-    let metadata = package
-        .extract_metadata()
-        .expect("Should be able to extract metadata");
-    let payload = aptos_stdlib::code_publish_package_txn(
-        bcs::to_bytes(&metadata).expect("Should be able to serialize metadata"),
-        code,
-    );
+    let payload =
+        aptos_stdlib::publish_module_source("test_module", "module 0xa550c18::test_module {}");
 
     let root_account = context.root_account().await;
     let txn =

--- a/api/src/tests/transaction_vector_test.rs
+++ b/api/src/tests/transaction_vector_test.rs
@@ -202,11 +202,6 @@ fn gen_script(gen: &mut ValueGenerator) -> Script {
 }
 
 #[cfg(test)]
-fn gen_module_code(gen: &mut ValueGenerator) -> Vec<u8> {
-    gen.generate(bytes_strategy())
-}
-
-#[cfg(test)]
 fn sign_transaction(raw_txn: RawTransaction) -> serde_json::Value {
     let private_key = Ed25519PrivateKey::generate_for_testing();
     let public_key = Ed25519PublicKey::from(&private_key);
@@ -313,46 +308,6 @@ async fn test_script_payload() {
         let transaction_factory = context.transaction_factory();
         let raw_txn = transaction_factory
             .script(gen_script(&mut value_gen))
-            .sender(gen_address(&mut value_gen))
-            .sequence_number(gen_u64(&mut value_gen))
-            .expiration_timestamp_secs(gen_u64(&mut value_gen))
-            .max_gas_amount(gen_u64(&mut value_gen))
-            .gas_unit_price(gen_u64(&mut value_gen))
-            .chain_id(ChainId::new(gen_chain_id(&mut value_gen)))
-            .build();
-        let mut signed_txn = sign_transaction(raw_txn);
-        patch(&mut signed_txn);
-        txns.push(signed_txn);
-    }
-
-    context.check_golden_output(json!(txns));
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_module_payload() {
-    fn patch(raw_txn_json: &mut serde_json::Value) {
-        let codes = visit_json_field(raw_txn_json, &[
-            "raw_txn",
-            "payload",
-            "ModuleBundle",
-            "codes",
-        ]);
-
-        for code_element in codes.as_array_mut().unwrap() {
-            let code_obj = code_element.as_object_mut().unwrap();
-            let code = code_obj.get_mut("code").unwrap();
-            *code = byte_array_to_hex(code);
-        }
-    }
-
-    let mut context = new_test_context(current_function_name!());
-
-    let mut value_gen = ValueGenerator::deterministic();
-    let mut txns = vec![];
-    for _ in 0..100 {
-        let transaction_factory = context.transaction_factory();
-        let raw_txn = transaction_factory
-            .module(gen_module_code(&mut value_gen))
             .sender(gen_address(&mut value_gen))
             .sequence_number(gen_u64(&mut value_gen))
             .expiration_timestamp_secs(gen_u64(&mut value_gen))

--- a/api/src/tests/view_function.rs
+++ b/api/src/tests/view_function.rs
@@ -4,8 +4,6 @@
 use super::new_test_context;
 use aptos_api_test_context::current_function_name;
 use aptos_cached_packages::aptos_stdlib;
-use aptos_framework::{BuildOptions, BuiltPackage};
-use aptos_package_builder::PackageBuilder;
 use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -85,31 +83,16 @@ async fn test_versioned_simple_view() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_view_tuple() {
     let mut context = new_test_context(current_function_name!());
-
-    let mut builder = PackageBuilder::new("test_package");
-    builder.add_source(
-        "test_module.move",
+    let payload = aptos_stdlib::publish_module_source(
+        "test_module",
         r#"
         module 0xa550c18::test_module {
-
             #[view]
             public fun return_tuple(): (u64, u64) {
                 (1, 2)
             }
         }
         "#,
-    );
-    let path = builder.write_to_temp().unwrap();
-
-    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
-        .expect("Should be able to build a package");
-    let code = package.extract_code();
-    let metadata = package
-        .extract_metadata()
-        .expect("Should be able to extract metadata");
-    let payload = aptos_stdlib::code_publish_package_txn(
-        bcs::to_bytes(&metadata).expect("Should be able to serialize metadata"),
-        code,
     );
 
     let root_account = context.root_account().await;

--- a/api/src/tests/view_function.rs
+++ b/api/src/tests/view_function.rs
@@ -3,6 +3,9 @@
 
 use super::new_test_context;
 use aptos_api_test_context::current_function_name;
+use aptos_cached_packages::aptos_stdlib;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_package_builder::PackageBuilder;
 use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -79,23 +82,39 @@ async fn test_versioned_simple_view() {
     context.check_golden_output_no_prune(resp);
 }
 
-#[ignore] // TODO: reactivate with real source
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_view_tuple() {
-    aptos_vm::aptos_vm::allow_module_bundle_for_test();
     let mut context = new_test_context(current_function_name!());
 
-    // address 0xA550C18 {
-    //     module TableTestData {
-    //         public fun return_tuple(): (u64, u64) {
-    //             (1, 2)
-    //         }
-    //     }
-    // }
-    let tuple_module = hex::decode("a11ceb0b0500000006010002030205050704070b1b0826200c461900000001000100000203030d5461626c6554657374446174610c72657475726e5f7475706c65000000000000000000000000000000000000000000000000000000000a550c180001000000030601000000000000000602000000000000000200").unwrap();
+    let mut builder = PackageBuilder::new("test_package");
+    builder.add_source(
+        "test_module.move",
+        r#"
+        module 0xa550c18::test_module {
+
+            #[view]
+            public fun return_tuple(): (u64, u64) {
+                (1, 2)
+            }
+        }
+        "#,
+    );
+    let path = builder.write_to_temp().unwrap();
+
+    let package = BuiltPackage::build(path.path().to_path_buf(), BuildOptions::default())
+        .expect("Should be able to build a package");
+    let code = package.extract_code();
+    let metadata = package
+        .extract_metadata()
+        .expect("Should be able to extract metadata");
+    let payload = aptos_stdlib::code_publish_package_txn(
+        bcs::to_bytes(&metadata).expect("Should be able to serialize metadata"),
+        code,
+    );
+
     let root_account = context.root_account().await;
-    let module_txn = root_account
-        .sign_with_transaction_builder(context.transaction_factory().module(tuple_module));
+    let module_txn =
+        root_account.sign_with_transaction_builder(context.transaction_factory().payload(payload));
 
     context.commit_block(&vec![module_txn]).await;
 
@@ -103,7 +122,7 @@ async fn test_view_tuple() {
         .post(
             "/view",
             json!({
-                "function":"0xa550c18::TableTestData::return_tuple",
+                "function":"0xa550c18::test_module::return_tuple",
                 "arguments": [],
                 "type_arguments": [],
             }),

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-framework = { workspace = true }
+aptos-package-builder = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 include_dir = { workspace = true }

--- a/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
@@ -7,6 +7,8 @@ pub use crate::{
     aptos_framework_sdk_builder::*, aptos_token_objects_sdk_builder as aptos_token_objects_stdlib,
     aptos_token_sdk_builder as aptos_token_stdlib,
 };
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_package_builder::PackageBuilder;
 use aptos_types::{account_address::AccountAddress, transaction::TransactionPayload};
 
 pub fn aptos_coin_transfer(to: AccountAddress, amount: u64) -> TransactionPayload {
@@ -15,4 +17,20 @@ pub fn aptos_coin_transfer(to: AccountAddress, amount: u64) -> TransactionPayloa
         to,
         amount,
     )
+}
+
+pub fn publish_module_source(module_name: &str, module_src: &str) -> TransactionPayload {
+    let mut builder = PackageBuilder::new("tmp");
+    builder.add_source(module_name, module_src);
+
+    let tmp_dir = builder.write_to_temp().unwrap();
+    let package = BuiltPackage::build(tmp_dir.path().to_path_buf(), BuildOptions::default())
+        .expect("Should be able to build a package");
+    let code = package.extract_code();
+    let metadata = package
+        .extract_metadata()
+        .expect("Should be able to extract metadata");
+    let metadata_serialized =
+        bcs::to_bytes(&metadata).expect("Should be able to serialize metadata");
+    code_publish_package_txn(metadata_serialized, code)
 }

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -12,7 +12,7 @@ use crate::{
 pub use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{ed25519::Ed25519PublicKey, HashValue};
 use aptos_global_constants::{GAS_UNIT_PRICE, MAX_GAS_AMOUNT};
-use aptos_types::transaction::{EntryFunction, ModuleBundle, Script};
+use aptos_types::transaction::{EntryFunction, Script};
 
 pub struct TransactionBuilder {
     sender: Option<AccountAddress>,
@@ -141,12 +141,6 @@ impl TransactionFactory {
         self.transaction_builder(payload)
     }
 
-    pub fn module(&self, code: Vec<u8>) -> TransactionBuilder {
-        self.payload(TransactionPayload::ModuleBundle(ModuleBundle::singleton(
-            code,
-        )))
-    }
-
     pub fn entry_function(&self, func: EntryFunction) -> TransactionBuilder {
         self.payload(TransactionPayload::EntryFunction(func))
     }
@@ -263,26 +257,5 @@ impl TransactionFactory {
             .unwrap()
             .as_secs()
             + self.transaction_expiration_time
-    }
-}
-
-pub struct DualAttestationMessage {
-    message: Box<[u8]>,
-}
-
-impl DualAttestationMessage {
-    pub fn new<M: Into<Vec<u8>>>(metadata: M, reciever: AccountAddress, amount: u64) -> Self {
-        let mut message = metadata.into();
-        bcs::serialize_into(&mut message, &reciever).unwrap();
-        bcs::serialize_into(&mut message, &amount).unwrap();
-        message.extend(b"@@$$APTOS_ATTEST$$@@");
-
-        Self {
-            message: message.into(),
-        }
-    }
-
-    pub fn message(&self) -> &[u8] {
-        &self.message
     }
 }


### PR DESCRIPTION
### Description

This is a cherry pick from #11274 which brings us closer to removing `ModuleBundle`
execution path from Aptos VM. 

1. Removes the dependencies on the deprecated transaction type from `api` tests.
2. Adds new code publishing approach instead.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
