### PR TITLE
Reducing the number of temporaries generated

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
@@ -56,17 +56,16 @@ fun vectors::test_for_each_mut() {
      var $t13: &vector<u64>
      var $t14: &mut u64
      var $t15: &mut u64
-     var $t16: &mut vector<u64>
+     var $t16: u64
      var $t17: u64
      var $t18: u64
      var $t19: u64
-     var $t20: u64
-     var $t21: bool
-     var $t22: vector<u64>
+     var $t20: bool
+     var $t21: vector<u64>
+     var $t22: u64
      var $t23: u64
      var $t24: u64
      var $t25: u64
-     var $t26: u64
   0: $t2 := 1
   1: $t3 := 2
   2: $t4 := 3
@@ -82,37 +81,36 @@ fun vectors::test_for_each_mut() {
  12: $t13 := freeze_ref($t7)
  13: $t12 := vector::length<u64>($t13)
  14: $t11 := <($t9, $t12)
- 15: if ($t11) goto 16 else goto 28
+ 15: if ($t11) goto 16 else goto 27
  16: label L2
- 17: $t16 := infer($t7)
- 18: $t15 := vector::borrow_mut<u64>($t16, $t9)
- 19: $t14 := infer($t15)
- 20: write_ref($t14, $t5)
- 21: $t18 := 1
- 22: $t17 := +($t5, $t18)
- 23: $t5 := infer($t17)
- 24: $t20 := 1
- 25: $t19 := +($t9, $t20)
- 26: $t9 := infer($t19)
- 27: goto 30
- 28: label L3
- 29: goto 32
- 30: label L4
- 31: goto 11
- 32: label L1
- 33: $t23 := 2
- 34: $t24 := 3
- 35: $t25 := 4
- 36: $t22 := vector($t23, $t24, $t25)
- 37: $t21 := ==($t0, $t22)
- 38: if ($t21) goto 39 else goto 41
- 39: label L5
- 40: goto 44
- 41: label L6
- 42: $t26 := 0
- 43: abort($t26)
- 44: label L7
- 45: return ()
+ 17: $t15 := vector::borrow_mut<u64>($t7, $t9)
+ 18: $t14 := infer($t15)
+ 19: write_ref($t14, $t5)
+ 20: $t17 := 1
+ 21: $t16 := +($t5, $t17)
+ 22: $t5 := infer($t16)
+ 23: $t19 := 1
+ 24: $t18 := +($t9, $t19)
+ 25: $t9 := infer($t18)
+ 26: goto 29
+ 27: label L3
+ 28: goto 31
+ 29: label L4
+ 30: goto 11
+ 31: label L1
+ 32: $t22 := 2
+ 33: $t23 := 3
+ 34: $t24 := 4
+ 35: $t21 := vector($t22, $t23, $t24)
+ 36: $t20 := ==($t0, $t21)
+ 37: if ($t20) goto 38 else goto 40
+ 38: label L5
+ 39: goto 43
+ 40: label L6
+ 41: $t25 := 0
+ 42: abort($t25)
+ 43: label L7
+ 44: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -135,17 +133,17 @@ fun vectors::test_for_each_mut() {
      var $t13: &vector<u64>
      var $t14: &mut u64
      var $t15: &mut u64
-     var $t16: &mut vector<u64>
+     var $t16: u64
      var $t17: u64
      var $t18: u64
      var $t19: u64
-     var $t20: u64
-     var $t21: bool
-     var $t22: vector<u64>
+     var $t20: bool
+     var $t21: vector<u64>
+     var $t22: u64
      var $t23: u64
      var $t24: u64
      var $t25: u64
-     var $t26: u64
+     var $t26: &mut vector<u64>
      var $t27: &mut vector<u64>
      # live vars:
   0: $t2 := 1
@@ -172,9 +170,9 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0, $t5, $t7, $t9
  11: label L0
      # live vars: $t0, $t5, $t7, $t9
- 12: $t27 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t27
- 13: $t13 := freeze_ref($t27)
+ 12: $t26 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t26
+ 13: $t13 := freeze_ref($t26)
      # live vars: $t0, $t5, $t7, $t9, $t13
  14: $t12 := vector::length<u64>($t13)
      # live vars: $t0, $t5, $t7, $t9, $t12
@@ -184,25 +182,25 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0, $t5, $t7, $t9
  17: label L2
      # live vars: $t0, $t5, $t7, $t9
- 18: $t16 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t16
- 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+ 18: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+ 19: $t15 := vector::borrow_mut<u64>($t27, $t9)
      # live vars: $t0, $t5, $t7, $t9, $t15
  20: $t14 := move($t15)
      # live vars: $t0, $t5, $t7, $t9, $t14
  21: write_ref($t14, $t5)
      # live vars: $t0, $t5, $t7, $t9
- 22: $t18 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t18
- 23: $t17 := +($t5, $t18)
-     # live vars: $t0, $t7, $t9, $t17
- 24: $t5 := copy($t17)
+ 22: $t17 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t17
+ 23: $t16 := +($t5, $t17)
+     # live vars: $t0, $t7, $t9, $t16
+ 24: $t5 := copy($t16)
      # live vars: $t0, $t5, $t7, $t9
- 25: $t20 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t20
- 26: $t19 := +($t9, $t20)
-     # live vars: $t0, $t5, $t7, $t19
- 27: $t9 := copy($t19)
+ 25: $t19 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t19
+ 26: $t18 := +($t9, $t19)
+     # live vars: $t0, $t5, $t7, $t18
+ 27: $t9 := copy($t18)
      # live vars: $t0, $t5, $t7, $t9
  28: goto 31
      # live vars: $t0
@@ -216,17 +214,17 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0
  33: label L1
      # live vars: $t0
- 34: $t23 := 2
-     # live vars: $t0, $t23
- 35: $t24 := 3
-     # live vars: $t0, $t23, $t24
- 36: $t25 := 4
-     # live vars: $t0, $t23, $t24, $t25
- 37: $t22 := vector($t23, $t24, $t25)
+ 34: $t22 := 2
      # live vars: $t0, $t22
- 38: $t21 := ==($t0, $t22)
-     # live vars: $t21
- 39: if ($t21) goto 40 else goto 42
+ 35: $t23 := 3
+     # live vars: $t0, $t22, $t23
+ 36: $t24 := 4
+     # live vars: $t0, $t22, $t23, $t24
+ 37: $t21 := vector($t22, $t23, $t24)
+     # live vars: $t0, $t21
+ 38: $t20 := ==($t0, $t21)
+     # live vars: $t20
+ 39: if ($t20) goto 40 else goto 42
      # live vars:
  40: label L5
      # live vars:
@@ -234,9 +232,9 @@ fun vectors::test_for_each_mut() {
      # live vars:
  42: label L6
      # live vars:
- 43: $t26 := 0
-     # live vars: $t26
- 44: abort($t26)
+ 43: $t25 := 0
+     # live vars: $t25
+ 44: abort($t25)
      # live vars:
  45: label L7
      # live vars:
@@ -263,17 +261,17 @@ fun vectors::test_for_each_mut() {
      var $t13: &vector<u64>
      var $t14: &mut u64
      var $t15: &mut u64
-     var $t16: &mut vector<u64>
+     var $t16: u64
      var $t17: u64
      var $t18: u64
      var $t19: u64
-     var $t20: u64
-     var $t21: bool
-     var $t22: vector<u64>
+     var $t20: bool
+     var $t21: vector<u64>
+     var $t22: u64
      var $t23: u64
      var $t24: u64
      var $t25: u64
-     var $t26: u64
+     var $t26: &mut vector<u64>
      var $t27: &mut vector<u64>
      # live vars:
   0: $t2 := 1
@@ -300,9 +298,9 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0, $t5, $t7, $t9
  11: label L0
      # live vars: $t0, $t5, $t7, $t9
- 12: $t27 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t27
- 13: $t13 := freeze_ref($t27)
+ 12: $t26 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t26
+ 13: $t13 := freeze_ref($t26)
      # live vars: $t0, $t5, $t7, $t9, $t13
  14: $t12 := vector::length<u64>($t13)
      # live vars: $t0, $t5, $t7, $t9, $t12
@@ -312,25 +310,25 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0, $t5, $t7, $t9
  17: label L2
      # live vars: $t0, $t5, $t7, $t9
- 18: $t16 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t16
- 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+ 18: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+ 19: $t15 := vector::borrow_mut<u64>($t27, $t9)
      # live vars: $t0, $t5, $t7, $t9, $t15
  20: $t14 := move($t15)
      # live vars: $t0, $t5, $t7, $t9, $t14
  21: write_ref($t14, $t5)
      # live vars: $t0, $t5, $t7, $t9
- 22: $t18 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t18
- 23: $t17 := +($t5, $t18)
-     # live vars: $t0, $t7, $t9, $t17
- 24: $t5 := copy($t17)
+ 22: $t17 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t17
+ 23: $t16 := +($t5, $t17)
+     # live vars: $t0, $t7, $t9, $t16
+ 24: $t5 := copy($t16)
      # live vars: $t0, $t5, $t7, $t9
- 25: $t20 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t20
- 26: $t19 := +($t9, $t20)
-     # live vars: $t0, $t5, $t7, $t19
- 27: $t9 := copy($t19)
+ 25: $t19 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t19
+ 26: $t18 := +($t9, $t19)
+     # live vars: $t0, $t5, $t7, $t18
+ 27: $t9 := copy($t18)
      # live vars: $t0, $t5, $t7, $t9
  28: goto 31
      # live vars: $t0
@@ -344,17 +342,17 @@ fun vectors::test_for_each_mut() {
      # live vars: $t0
  33: label L1
      # live vars: $t0
- 34: $t23 := 2
-     # live vars: $t0, $t23
- 35: $t24 := 3
-     # live vars: $t0, $t23, $t24
- 36: $t25 := 4
-     # live vars: $t0, $t23, $t24, $t25
- 37: $t22 := vector($t23, $t24, $t25)
+ 34: $t22 := 2
      # live vars: $t0, $t22
- 38: $t21 := ==($t0, $t22)
-     # live vars: $t21
- 39: if ($t21) goto 40 else goto 42
+ 35: $t23 := 3
+     # live vars: $t0, $t22, $t23
+ 36: $t24 := 4
+     # live vars: $t0, $t22, $t23, $t24
+ 37: $t21 := vector($t22, $t23, $t24)
+     # live vars: $t0, $t21
+ 38: $t20 := ==($t0, $t21)
+     # live vars: $t20
+ 39: if ($t20) goto 40 else goto 42
      # live vars:
  40: label L5
      # live vars:
@@ -362,9 +360,9 @@ fun vectors::test_for_each_mut() {
      # live vars:
  42: label L6
      # live vars:
- 43: $t26 := 0
-     # live vars: $t26
- 44: abort($t26)
+ 43: $t25 := 0
+     # live vars: $t25
+ 44: abort($t25)
      # live vars:
  45: label L7
      # live vars:
@@ -391,17 +389,17 @@ fun vectors::test_for_each_mut() {
      var $t13: &vector<u64>
      var $t14: &mut u64
      var $t15: &mut u64
-     var $t16: &mut vector<u64>
+     var $t16: u64
      var $t17: u64
      var $t18: u64
      var $t19: u64
-     var $t20: u64
-     var $t21: bool
-     var $t22: vector<u64>
+     var $t20: bool
+     var $t21: vector<u64>
+     var $t22: u64
      var $t23: u64
      var $t24: u64
      var $t25: u64
-     var $t26: u64
+     var $t26: &mut vector<u64>
      var $t27: &mut vector<u64>
      # live vars:
      # graph: {}
@@ -480,16 +478,16 @@ fun vectors::test_for_each_mut() {
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 12: $t27 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t27
-     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t27)[]}
-     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t27=L3073}
+ 12: $t26 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t26
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t26)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t26=L3073}
      # global_to_label: {}
      #
- 13: $t13 := freeze_ref($t27)
+ 13: $t13 := freeze_ref($t26)
      # live vars: $t0, $t5, $t7, $t9, $t13
-     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t27)[call(false) -> L3328],L3328=local($t13)[]}
-     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t13=L3328,$t27=L3073}
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L3073],L3073=local($t26)[call(false) -> L3328],L3328=local($t13)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t13=L3328,$t26=L3073}
      # global_to_label: {}
      #
  14: $t12 := vector::length<u64>($t13)
@@ -516,22 +514,22 @@ fun vectors::test_for_each_mut() {
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 18: $t16 := copy($t7)
-     # live vars: $t0, $t5, $t7, $t9, $t16
-     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[]}
-     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t16=L4609}
+ 18: $t27 := copy($t7)
+     # live vars: $t0, $t5, $t7, $t9, $t27
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t27)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t27=L4609}
      # global_to_label: {}
      #
- 19: $t15 := vector::borrow_mut<u64>($t16, $t9)
+ 19: $t15 := vector::borrow_mut<u64>($t27, $t9)
      # live vars: $t0, $t5, $t7, $t9, $t15
-     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[call(true) -> L4864],L4864=local($t15)[]}
-     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t15=L4864,$t16=L4609}
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t27)[call(true) -> L4864],L4864=local($t15)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t15=L4864,$t27=L4609}
      # global_to_label: {}
      #
  20: $t14 := move($t15)
      # live vars: $t0, $t5, $t7, $t9, $t14
-     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t16)[call(true) -> L4864],L4864=local($t15)[skip -> L5121],L5121=local($t14)[]}
-     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t14=L5121,$t15=L4864,$t16=L4609}
+     # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[skip -> L4609],L4609=local($t27)[call(true) -> L4864],L4864=local($t15)[skip -> L5121],L5121=local($t14)[]}
+     # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793,$t14=L5121,$t15=L4864,$t27=L4609}
      # global_to_label: {}
      #
  21: write_ref($t14, $t5)
@@ -540,37 +538,37 @@ fun vectors::test_for_each_mut() {
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 22: $t18 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t18
+ 22: $t17 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t17
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 23: $t17 := +($t5, $t18)
-     # live vars: $t0, $t7, $t9, $t17
+ 23: $t16 := +($t5, $t17)
+     # live vars: $t0, $t7, $t9, $t16
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 24: $t5 := copy($t17)
+ 24: $t5 := copy($t16)
      # live vars: $t0, $t5, $t7, $t9
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 25: $t20 := 1
-     # live vars: $t0, $t5, $t7, $t9, $t20
+ 25: $t19 := 1
+     # live vars: $t0, $t5, $t7, $t9, $t19
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 26: $t19 := +($t9, $t20)
-     # live vars: $t0, $t5, $t7, $t19
+ 26: $t18 := +($t9, $t19)
+     # live vars: $t0, $t5, $t7, $t18
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
      # global_to_label: {}
      #
- 27: $t9 := copy($t19)
+ 27: $t9 := copy($t18)
      # live vars: $t0, $t5, $t7, $t9
      # graph: {L1792=local($t0)[borrow(true) -> L1793],L1793=local($t8)[skip -> L2049],L2049=local($t7)[]}
      # local_to_label: {$t0=L1792,$t7=L2049,$t8=L1793}
@@ -612,37 +610,37 @@ fun vectors::test_for_each_mut() {
      # local_to_label: {$t0=L1792}
      # global_to_label: {}
      #
- 34: $t23 := 2
-     # live vars: $t0, $t23
-     # graph: {L1792=local($t0)[]}
-     # local_to_label: {$t0=L1792}
-     # global_to_label: {}
-     #
- 35: $t24 := 3
-     # live vars: $t0, $t23, $t24
-     # graph: {L1792=local($t0)[]}
-     # local_to_label: {$t0=L1792}
-     # global_to_label: {}
-     #
- 36: $t25 := 4
-     # live vars: $t0, $t23, $t24, $t25
-     # graph: {L1792=local($t0)[]}
-     # local_to_label: {$t0=L1792}
-     # global_to_label: {}
-     #
- 37: $t22 := vector($t23, $t24, $t25)
+ 34: $t22 := 2
      # live vars: $t0, $t22
      # graph: {L1792=local($t0)[]}
      # local_to_label: {$t0=L1792}
      # global_to_label: {}
      #
- 38: $t21 := ==($t0, $t22)
-     # live vars: $t21
+ 35: $t23 := 3
+     # live vars: $t0, $t22, $t23
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 36: $t24 := 4
+     # live vars: $t0, $t22, $t23, $t24
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 37: $t21 := vector($t22, $t23, $t24)
+     # live vars: $t0, $t21
+     # graph: {L1792=local($t0)[]}
+     # local_to_label: {$t0=L1792}
+     # global_to_label: {}
+     #
+ 38: $t20 := ==($t0, $t21)
+     # live vars: $t20
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 39: if ($t21) goto 40 else goto 42
+ 39: if ($t20) goto 40 else goto 42
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -666,13 +664,13 @@ fun vectors::test_for_each_mut() {
      # local_to_label: {}
      # global_to_label: {}
      #
- 43: $t26 := 0
-     # live vars: $t26
+ 43: $t25 := 0
+     # live vars: $t25
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 44: abort($t26)
+ 44: abort($t25)
      # live vars:
      # graph: {}
      # local_to_label: {}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
@@ -167,13 +167,12 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
-     var $t13: u64
+     var $t13: vector<u8>
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: vector<u8>
   0: $t2 := borrow_local($t0)
   1: $t1 := infer($t2)
   2: $t4 := 0
@@ -181,32 +180,31 @@ public fun vectors::guess_flips($t0: vector<u8>) {
   4: label L0
   5: $t6 := vector::length<u8>($t1)
   6: $t5 := <($t3, $t6)
-  7: if ($t5) goto 8 else goto 24
+  7: if ($t5) goto 8 else goto 23
   8: label L2
-  9: $t10 := infer($t1)
- 10: $t9 := vector::borrow<u8>($t10, $t3)
- 11: $t8 := read_ref($t9)
- 12: $t11 := 0
- 13: $t7 := !=($t8, $t11)
- 14: if ($t7) goto 15 else goto 18
- 15: label L5
- 16: goto 28
- 17: goto 19
- 18: label L6
- 19: label L7
- 20: $t13 := 1
- 21: $t12 := +($t3, $t13)
- 22: $t3 := infer($t12)
- 23: goto 26
- 24: label L3
- 25: goto 28
- 26: label L4
- 27: goto 4
- 28: label L1
- 29: $t15 := copy($t0)
- 30: $t14 := infer($t15)
- 31: $t16 := infer($t0)
- 32: return ()
+  9: $t9 := vector::borrow<u8>($t1, $t3)
+ 10: $t8 := read_ref($t9)
+ 11: $t10 := 0
+ 12: $t7 := !=($t8, $t10)
+ 13: if ($t7) goto 14 else goto 17
+ 14: label L5
+ 15: goto 27
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t12 := 1
+ 20: $t11 := +($t3, $t12)
+ 21: $t3 := infer($t11)
+ 22: goto 25
+ 23: label L3
+ 24: goto 27
+ 25: label L4
+ 26: goto 4
+ 27: label L1
+ 28: $t14 := copy($t0)
+ 29: $t13 := infer($t14)
+ 30: $t15 := infer($t0)
+ 31: return ()
 }
 
 
@@ -288,14 +286,13 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
+     var $t14: vector<u8>
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: vector<u8>
   0: $t2 := borrow_local($t0)
   1: $t1 := infer($t2)
   2: $t4 := 0
@@ -303,33 +300,32 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
   4: label L0
   5: $t6 := vector::length<u8>($t1)
   6: $t5 := <($t3, $t6)
-  7: if ($t5) goto 8 else goto 25
+  7: if ($t5) goto 8 else goto 24
   8: label L2
-  9: $t10 := infer($t1)
- 10: $t9 := vector::borrow<u8>($t10, $t3)
- 11: $t8 := read_ref($t9)
- 12: $t11 := 0
- 13: $t7 := ==($t8, $t11)
- 14: if ($t7) goto 15 else goto 17
- 15: label L5
- 16: goto 20
- 17: label L6
- 18: $t12 := 3
- 19: abort($t12)
- 20: label L7
- 21: $t14 := 1
- 22: $t13 := +($t3, $t14)
- 23: $t3 := infer($t13)
- 24: goto 27
- 25: label L3
- 26: goto 29
- 27: label L4
- 28: goto 4
- 29: label L1
- 30: $t15 := infer($t0)
- 31: $t17 := copy($t0)
- 32: $t16 := infer($t17)
- 33: return ()
+  9: $t9 := vector::borrow<u8>($t1, $t3)
+ 10: $t8 := read_ref($t9)
+ 11: $t10 := 0
+ 12: $t7 := ==($t8, $t10)
+ 13: if ($t7) goto 14 else goto 16
+ 14: label L5
+ 15: goto 19
+ 16: label L6
+ 17: $t11 := 3
+ 18: abort($t11)
+ 19: label L7
+ 20: $t13 := 1
+ 21: $t12 := +($t3, $t13)
+ 22: $t3 := infer($t12)
+ 23: goto 26
+ 24: label L3
+ 25: goto 28
+ 26: label L4
+ 27: goto 4
+ 28: label L1
+ 29: $t14 := infer($t0)
+ 30: $t16 := copy($t0)
+ 31: $t15 := infer($t16)
+ 32: return ()
 }
 
 
@@ -342,38 +338,36 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: &vector<u8>
-     var $t9: u8
+     var $t8: u8
+     var $t9: u64
      var $t10: u64
-     var $t11: u64
   0: $t2 := 0
   1: $t1 := infer($t2)
   2: label L0
   3: $t4 := vector::length<u8>($t0)
   4: $t3 := <($t1, $t4)
-  5: if ($t3) goto 6 else goto 22
+  5: if ($t3) goto 6 else goto 21
   6: label L2
-  7: $t8 := infer($t0)
-  8: $t7 := vector::borrow<u8>($t8, $t1)
-  9: $t6 := read_ref($t7)
- 10: $t9 := 0
- 11: $t5 := !=($t6, $t9)
- 12: if ($t5) goto 13 else goto 16
- 13: label L5
- 14: goto 26
- 15: goto 17
- 16: label L6
- 17: label L7
- 18: $t11 := 1
- 19: $t10 := +($t1, $t11)
- 20: $t1 := infer($t10)
- 21: goto 24
- 22: label L3
- 23: goto 26
- 24: label L4
- 25: goto 2
- 26: label L1
- 27: return ()
+  7: $t7 := vector::borrow<u8>($t0, $t1)
+  8: $t6 := read_ref($t7)
+  9: $t8 := 0
+ 10: $t5 := !=($t6, $t8)
+ 11: if ($t5) goto 12 else goto 15
+ 12: label L5
+ 13: goto 25
+ 14: goto 16
+ 15: label L6
+ 16: label L7
+ 17: $t10 := 1
+ 18: $t9 := +($t1, $t10)
+ 19: $t1 := infer($t9)
+ 20: goto 23
+ 21: label L3
+ 22: goto 25
+ 23: label L4
+ 24: goto 2
+ 25: label L1
+ 26: return ()
 }
 
 
@@ -465,13 +459,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
-     var $t13: u64
+     var $t13: vector<u8>
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: vector<u8>
+     var $t16: &vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
@@ -484,9 +478,9 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-  6: $t6 := vector::length<u8>($t17)
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+  6: $t6 := vector::length<u8>($t16)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -494,15 +488,15 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
- 14: $t7 := !=($t8, $t11)
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := !=($t8, $t10)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 19
      # live vars:
@@ -516,11 +510,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
  20: label L7
      # live vars: $t1, $t3
- 21: $t13 := 1
-     # live vars: $t1, $t3, $t13
- 22: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
- 23: $t3 := copy($t12)
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
+ 23: $t3 := copy($t11)
      # live vars: $t1, $t3
  24: goto 27
      # live vars:
@@ -534,11 +528,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars:
  29: label L1
      # live vars:
- 30: $t15 := copy($t0)
+ 30: $t14 := copy($t0)
      # live vars:
- 31: $t14 := copy($t15)
+ 31: $t13 := copy($t14)
      # live vars:
- 32: $t16 := copy($t0)
+ 32: $t15 := copy($t0)
      # live vars:
  33: return ()
 }
@@ -660,14 +654,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
+     var $t14: vector<u8>
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: vector<u8>
+     var $t17: &vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
@@ -680,9 +674,9 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
-  6: $t6 := vector::length<u8>($t18)
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -690,15 +684,15 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
- 14: $t7 := ==($t8, $t11)
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := ==($t8, $t10)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 18
      # live vars: $t1, $t3
@@ -708,17 +702,17 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  18: label L6
      # live vars:
- 19: $t12 := 3
-     # live vars: $t12
- 20: abort($t12)
+ 19: $t11 := 3
+     # live vars: $t11
+ 20: abort($t11)
      # live vars: $t1, $t3
  21: label L7
      # live vars: $t1, $t3
- 22: $t14 := 1
-     # live vars: $t1, $t3, $t14
- 23: $t13 := +($t3, $t14)
-     # live vars: $t1, $t13
- 24: $t3 := copy($t13)
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 24: $t3 := copy($t12)
      # live vars: $t1, $t3
  25: goto 28
      # live vars:
@@ -732,11 +726,11 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  30: label L1
      # live vars:
- 31: $t15 := copy($t0)
+ 31: $t14 := copy($t0)
      # live vars:
- 32: $t17 := copy($t0)
+ 32: $t16 := copy($t0)
      # live vars:
- 33: $t16 := copy($t17)
+ 33: $t15 := copy($t16)
      # live vars:
  34: return ()
 }
@@ -751,10 +745,10 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: &vector<u8>
-     var $t9: u8
+     var $t8: u8
+     var $t9: u64
      var $t10: u64
-     var $t11: u64
+     var $t11: &vector<u8>
      var $t12: &vector<u8>
      # live vars: $t0
   0: $t2 := 0
@@ -763,9 +757,9 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
-  3: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-  4: $t4 := vector::length<u8>($t12)
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+  4: $t4 := vector::length<u8>($t11)
      # live vars: $t0, $t1, $t4
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
@@ -773,15 +767,15 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   7: label L2
      # live vars: $t0, $t1
-  8: $t8 := copy($t0)
-     # live vars: $t0, $t1, $t8
-  9: $t7 := vector::borrow<u8>($t8, $t1)
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  9: $t7 := vector::borrow<u8>($t12, $t1)
      # live vars: $t0, $t1, $t7
  10: $t6 := read_ref($t7)
      # live vars: $t0, $t1, $t6
- 11: $t9 := 0
-     # live vars: $t0, $t1, $t6, $t9
- 12: $t5 := !=($t6, $t9)
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
+ 12: $t5 := !=($t6, $t8)
      # live vars: $t0, $t1, $t5
  13: if ($t5) goto 14 else goto 17
      # live vars:
@@ -795,11 +789,11 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
  18: label L7
      # live vars: $t0, $t1
- 19: $t11 := 1
-     # live vars: $t0, $t1, $t11
- 20: $t10 := +($t1, $t11)
-     # live vars: $t0, $t10
- 21: $t1 := copy($t10)
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
+ 21: $t1 := copy($t9)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -937,13 +931,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
-     var $t13: u64
+     var $t13: vector<u8>
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: vector<u8>
+     var $t16: &vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
@@ -956,9 +950,9 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-  6: $t6 := vector::length<u8>($t17)
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+  6: $t6 := vector::length<u8>($t16)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -966,15 +960,15 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
- 14: $t7 := !=($t8, $t11)
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := !=($t8, $t10)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 19
      # live vars:
@@ -988,11 +982,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars: $t1, $t3
  20: label L7
      # live vars: $t1, $t3
- 21: $t13 := 1
-     # live vars: $t1, $t3, $t13
- 22: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
- 23: $t3 := copy($t12)
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
+ 23: $t3 := copy($t11)
      # live vars: $t1, $t3
  24: goto 27
      # live vars:
@@ -1006,11 +1000,11 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # live vars:
  29: label L1
      # live vars:
- 30: $t15 := copy($t0)
+ 30: $t14 := copy($t0)
      # live vars:
- 31: $t14 := copy($t15)
+ 31: $t13 := copy($t14)
      # live vars:
- 32: $t16 := copy($t0)
+ 32: $t15 := copy($t0)
      # live vars:
  33: return ()
 }
@@ -1132,14 +1126,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
+     var $t14: vector<u8>
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: vector<u8>
+     var $t17: &vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
   0: $t2 := borrow_local($t0)
@@ -1152,9 +1146,9 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   4: label L0
      # live vars: $t1, $t3
-  5: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
-  6: $t6 := vector::length<u8>($t18)
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
   7: $t5 := <($t3, $t6)
      # live vars: $t1, $t3, $t5
@@ -1162,15 +1156,15 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars: $t1, $t3
   9: label L2
      # live vars: $t1, $t3
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
      # live vars: $t1, $t3, $t9
  12: $t8 := read_ref($t9)
      # live vars: $t1, $t3, $t8
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
- 14: $t7 := ==($t8, $t11)
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
+ 14: $t7 := ==($t8, $t10)
      # live vars: $t1, $t3, $t7
  15: if ($t7) goto 16 else goto 18
      # live vars: $t1, $t3
@@ -1180,17 +1174,17 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  18: label L6
      # live vars:
- 19: $t12 := 3
-     # live vars: $t12
- 20: abort($t12)
+ 19: $t11 := 3
+     # live vars: $t11
+ 20: abort($t11)
      # live vars: $t1, $t3
  21: label L7
      # live vars: $t1, $t3
- 22: $t14 := 1
-     # live vars: $t1, $t3, $t14
- 23: $t13 := +($t3, $t14)
-     # live vars: $t1, $t13
- 24: $t3 := copy($t13)
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
+ 24: $t3 := copy($t12)
      # live vars: $t1, $t3
  25: goto 28
      # live vars:
@@ -1204,11 +1198,11 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # live vars:
  30: label L1
      # live vars:
- 31: $t15 := copy($t0)
+ 31: $t14 := copy($t0)
      # live vars:
- 32: $t17 := copy($t0)
+ 32: $t16 := copy($t0)
      # live vars:
- 33: $t16 := copy($t17)
+ 33: $t15 := copy($t16)
      # live vars:
  34: return ()
 }
@@ -1223,10 +1217,10 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: &vector<u8>
-     var $t9: u8
+     var $t8: u8
+     var $t9: u64
      var $t10: u64
-     var $t11: u64
+     var $t11: &vector<u8>
      var $t12: &vector<u8>
      # live vars: $t0
   0: $t2 := 0
@@ -1235,9 +1229,9 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   2: label L0
      # live vars: $t0, $t1
-  3: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-  4: $t4 := vector::length<u8>($t12)
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+  4: $t4 := vector::length<u8>($t11)
      # live vars: $t0, $t1, $t4
   5: $t3 := <($t1, $t4)
      # live vars: $t0, $t1, $t3
@@ -1245,15 +1239,15 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
   7: label L2
      # live vars: $t0, $t1
-  8: $t8 := copy($t0)
-     # live vars: $t0, $t1, $t8
-  9: $t7 := vector::borrow<u8>($t8, $t1)
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+  9: $t7 := vector::borrow<u8>($t12, $t1)
      # live vars: $t0, $t1, $t7
  10: $t6 := read_ref($t7)
      # live vars: $t0, $t1, $t6
- 11: $t9 := 0
-     # live vars: $t0, $t1, $t6, $t9
- 12: $t5 := !=($t6, $t9)
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
+ 12: $t5 := !=($t6, $t8)
      # live vars: $t0, $t1, $t5
  13: if ($t5) goto 14 else goto 17
      # live vars:
@@ -1267,11 +1261,11 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # live vars: $t0, $t1
  18: label L7
      # live vars: $t0, $t1
- 19: $t11 := 1
-     # live vars: $t0, $t1, $t11
- 20: $t10 := +($t1, $t11)
-     # live vars: $t0, $t10
- 21: $t1 := copy($t10)
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
+ 21: $t1 := copy($t9)
      # live vars: $t0, $t1
  22: goto 25
      # live vars:
@@ -1409,13 +1403,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
-     var $t13: u64
+     var $t13: vector<u8>
      var $t14: vector<u8>
      var $t15: vector<u8>
-     var $t16: vector<u8>
+     var $t16: &vector<u8>
      var $t17: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -1452,13 +1446,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  5: $t17 := copy($t1)
-     # live vars: $t1, $t3, $t17
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t17)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L1281}
+  5: $t16 := copy($t1)
+     # live vars: $t1, $t3, $t16
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t16)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t16=L1281}
      # global_to_label: {}
      #
-  6: $t6 := vector::length<u8>($t17)
+  6: $t6 := vector::length<u8>($t16)
      # live vars: $t1, $t3, $t6
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1482,16 +1476,16 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t10=L2561}
+ 10: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t17)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L2561}
      # global_to_label: {}
      #
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 11: $t9 := vector::borrow<u8>($t17, $t3)
      # live vars: $t1, $t3, $t9
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[call(false) -> L2816],L2816=local($t9)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t10=L2561}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t17)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t17=L2561}
      # global_to_label: {}
      #
  12: $t8 := read_ref($t9)
@@ -1500,13 +1494,13 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 14: $t7 := !=($t8, $t11)
+ 14: $t7 := !=($t8, $t10)
      # live vars: $t1, $t3, $t7
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1544,19 +1538,19 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 21: $t13 := 1
-     # live vars: $t1, $t3, $t13
+ 21: $t12 := 1
+     # live vars: $t1, $t3, $t12
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 22: $t12 := +($t3, $t13)
-     # live vars: $t1, $t12
+ 22: $t11 := +($t3, $t12)
+     # live vars: $t1, $t11
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 23: $t3 := copy($t12)
+ 23: $t3 := copy($t11)
      # live vars: $t1, $t3
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1598,19 +1592,19 @@ public fun vectors::guess_flips($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 30: $t15 := copy($t0)
+ 30: $t14 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 31: $t14 := copy($t15)
+ 31: $t13 := copy($t14)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 32: $t16 := copy($t0)
+ 32: $t15 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -1884,14 +1878,14 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      var $t7: bool
      var $t8: u8
      var $t9: &u8
-     var $t10: &vector<u8>
-     var $t11: u8
+     var $t10: u8
+     var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
+     var $t14: vector<u8>
      var $t15: vector<u8>
      var $t16: vector<u8>
-     var $t17: vector<u8>
+     var $t17: &vector<u8>
      var $t18: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -1928,13 +1922,13 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
-  5: $t18 := copy($t1)
-     # live vars: $t1, $t3, $t18
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t18)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t18=L1281}
+  5: $t17 := copy($t1)
+     # live vars: $t1, $t3, $t17
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L1281],L1281=local($t17)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t17=L1281}
      # global_to_label: {}
      #
-  6: $t6 := vector::length<u8>($t18)
+  6: $t6 := vector::length<u8>($t17)
      # live vars: $t1, $t3, $t6
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -1958,16 +1952,16 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 10: $t10 := copy($t1)
-     # live vars: $t1, $t3, $t10
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t10=L2561}
+ 10: $t18 := copy($t1)
+     # live vars: $t1, $t3, $t18
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t18)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t18=L2561}
      # global_to_label: {}
      #
- 11: $t9 := vector::borrow<u8>($t10, $t3)
+ 11: $t9 := vector::borrow<u8>($t18, $t3)
      # live vars: $t1, $t3, $t9
-     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t10)[call(false) -> L2816],L2816=local($t9)[]}
-     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t10=L2561}
+     # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[skip -> L2561],L2561=local($t18)[call(false) -> L2816],L2816=local($t9)[]}
+     # local_to_label: {$t0=L0,$t1=L257,$t2=L1,$t9=L2816,$t18=L2561}
      # global_to_label: {}
      #
  12: $t8 := read_ref($t9)
@@ -1976,13 +1970,13 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 13: $t11 := 0
-     # live vars: $t1, $t3, $t8, $t11
+ 13: $t10 := 0
+     # live vars: $t1, $t3, $t8, $t10
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 14: $t7 := ==($t8, $t11)
+ 14: $t7 := ==($t8, $t10)
      # live vars: $t1, $t3, $t7
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -2012,13 +2006,13 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 19: $t12 := 3
-     # live vars: $t12
+ 19: $t11 := 3
+     # live vars: $t11
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 20: abort($t12)
+ 20: abort($t11)
      # live vars: $t1, $t3
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -2030,19 +2024,19 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 22: $t14 := 1
-     # live vars: $t1, $t3, $t14
+ 22: $t13 := 1
+     # live vars: $t1, $t3, $t13
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 23: $t13 := +($t3, $t14)
-     # live vars: $t1, $t13
+ 23: $t12 := +($t3, $t13)
+     # live vars: $t1, $t12
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
      # global_to_label: {}
      #
- 24: $t3 := copy($t13)
+ 24: $t3 := copy($t12)
      # live vars: $t1, $t3
      # graph: {L0=local($t0)[borrow(false) -> L1],L1=local($t2)[skip -> L257],L257=local($t1)[]}
      # local_to_label: {$t0=L0,$t1=L257,$t2=L1}
@@ -2084,19 +2078,19 @@ public fun vectors::guess_without_break_with_inline($t0: vector<u8>) {
      # local_to_label: {}
      # global_to_label: {}
      #
- 31: $t15 := copy($t0)
+ 31: $t14 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 32: $t17 := copy($t0)
+ 32: $t16 := copy($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
- 33: $t16 := copy($t17)
+ 33: $t15 := copy($t16)
      # live vars:
      # graph: {}
      # local_to_label: {}
@@ -2115,10 +2109,10 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      var $t5: bool
      var $t6: u8
      var $t7: &u8
-     var $t8: &vector<u8>
-     var $t9: u8
+     var $t8: u8
+     var $t9: u64
      var $t10: u64
-     var $t11: u64
+     var $t11: &vector<u8>
      var $t12: &vector<u8>
      # live vars: $t0
      # graph: {}
@@ -2143,13 +2137,13 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
-  3: $t12 := copy($t0)
-     # live vars: $t0, $t1, $t12
-     # graph: {L768=local($t0)[skip -> L769],L769=local($t12)[]}
-     # local_to_label: {$t0=L768,$t12=L769}
+  3: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t11
+     # graph: {L768=local($t0)[skip -> L769],L769=local($t11)[]}
+     # local_to_label: {$t0=L768,$t11=L769}
      # global_to_label: {}
      #
-  4: $t4 := vector::length<u8>($t12)
+  4: $t4 := vector::length<u8>($t11)
      # live vars: $t0, $t1, $t4
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}
@@ -2173,16 +2167,16 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
-  8: $t8 := copy($t0)
-     # live vars: $t0, $t1, $t8
-     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t8)[]}
-     # local_to_label: {$t0=L768,$t8=L2049}
+  8: $t12 := copy($t0)
+     # live vars: $t0, $t1, $t12
+     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t12)[]}
+     # local_to_label: {$t0=L768,$t12=L2049}
      # global_to_label: {}
      #
-  9: $t7 := vector::borrow<u8>($t8, $t1)
+  9: $t7 := vector::borrow<u8>($t12, $t1)
      # live vars: $t0, $t1, $t7
-     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t8)[call(false) -> L2304],L2304=local($t7)[]}
-     # local_to_label: {$t0=L768,$t7=L2304,$t8=L2049}
+     # graph: {L768=local($t0)[skip -> L2049],L2049=local($t12)[call(false) -> L2304],L2304=local($t7)[]}
+     # local_to_label: {$t0=L768,$t7=L2304,$t12=L2049}
      # global_to_label: {}
      #
  10: $t6 := read_ref($t7)
@@ -2191,13 +2185,13 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 11: $t9 := 0
-     # live vars: $t0, $t1, $t6, $t9
+ 11: $t8 := 0
+     # live vars: $t0, $t1, $t6, $t8
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 12: $t5 := !=($t6, $t9)
+ 12: $t5 := !=($t6, $t8)
      # live vars: $t0, $t1, $t5
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}
@@ -2235,19 +2229,19 @@ fun vectors::loops_with_break_no_inline($t0: &vector<u8>) {
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 19: $t11 := 1
-     # live vars: $t0, $t1, $t11
+ 19: $t10 := 1
+     # live vars: $t0, $t1, $t10
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 20: $t10 := +($t1, $t11)
-     # live vars: $t0, $t10
+ 20: $t9 := +($t1, $t10)
+     # live vars: $t0, $t9
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}
      # global_to_label: {}
      #
- 21: $t1 := copy($t10)
+ 21: $t1 := copy($t9)
      # live vars: $t0, $t1
      # graph: {L768=local($t0)[]}
      # local_to_label: {$t0=L768}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
@@ -54,19 +54,17 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
-     var $t23: &vector<u8>
+     var $t21: &vector<u8>
   0: $t3 := 0
   1: $t2 := infer($t3)
   2: $t5 := borrow_local($t0)
@@ -74,45 +72,43 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
   4: label L0
   5: $t7 := vector::length<u8>($t4)
   6: $t6 := <($t2, $t7)
-  7: if ($t6) goto 8 else goto 35
+  7: if ($t6) goto 8 else goto 33
   8: label L2
-  9: $t11 := infer($t4)
- 10: $t10 := vector::borrow<u8>($t11, $t2)
- 11: $t9 := read_ref($t10)
- 12: $t12 := 0
- 13: $t8 := !=($t9, $t12)
- 14: if ($t8) goto 15 else goto 18
- 15: label L5
- 16: goto 39
- 17: goto 19
- 18: label L6
- 19: label L7
- 20: $t14 := 1
- 21: $t13 := +($t2, $t14)
- 22: $t2 := infer($t13)
- 23: $t18 := infer($t4)
- 24: $t17 := vector::borrow<u8>($t18, $t2)
- 25: $t16 := read_ref($t17)
- 26: $t19 := 5
- 27: $t15 := ==($t16, $t19)
- 28: if ($t15) goto 29 else goto 32
- 29: label L8
- 30: goto 39
- 31: goto 33
- 32: label L9
- 33: label L10
+  9: $t10 := vector::borrow<u8>($t4, $t2)
+ 10: $t9 := read_ref($t10)
+ 11: $t11 := 0
+ 12: $t8 := !=($t9, $t11)
+ 13: if ($t8) goto 14 else goto 17
+ 14: label L5
+ 15: goto 37
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t13 := 1
+ 20: $t12 := +($t2, $t13)
+ 21: $t2 := infer($t12)
+ 22: $t16 := vector::borrow<u8>($t4, $t2)
+ 23: $t15 := read_ref($t16)
+ 24: $t17 := 5
+ 25: $t14 := ==($t15, $t17)
+ 26: if ($t14) goto 27 else goto 30
+ 27: label L8
+ 28: goto 37
+ 29: goto 31
+ 30: label L9
+ 31: label L10
+ 32: goto 35
+ 33: label L3
  34: goto 37
- 35: label L3
- 36: goto 39
- 37: label L4
- 38: goto 4
- 39: label L1
- 40: $t21 := copy($t0)
- 41: $t20 := infer($t21)
- 42: $t22 := infer($t0)
- 43: $t23 := infer($t4)
- 44: $t1 := vector::length<u8>($t23)
- 45: return $t1
+ 35: label L4
+ 36: goto 4
+ 37: label L1
+ 38: $t19 := copy($t0)
+ 39: $t18 := infer($t19)
+ 40: $t20 := infer($t0)
+ 41: $t21 := infer($t4)
+ 42: $t1 := vector::length<u8>($t21)
+ 43: return $t1
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -129,18 +125,18 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
@@ -154,9 +150,9 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   4: label L0
      # live vars: $t2, $t4
-  5: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
-  6: $t7 := vector::length<u8>($t24)
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+  6: $t7 := vector::length<u8>($t22)
      # live vars: $t2, $t4, $t7
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
@@ -164,15 +160,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   9: label L2
      # live vars: $t2, $t4
- 10: $t11 := copy($t4)
-     # live vars: $t2, $t4, $t11
- 11: $t10 := vector::borrow<u8>($t11, $t2)
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
      # live vars: $t2, $t4, $t10
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
- 13: $t12 := 0
-     # live vars: $t2, $t4, $t9, $t12
- 14: $t8 := !=($t9, $t12)
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+ 14: $t8 := !=($t9, $t11)
      # live vars: $t2, $t4, $t8
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
@@ -186,23 +182,23 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
  20: label L7
      # live vars: $t2, $t4
- 21: $t14 := 1
-     # live vars: $t2, $t4, $t14
- 22: $t13 := +($t2, $t14)
-     # live vars: $t4, $t13
- 23: $t2 := copy($t13)
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+ 23: $t2 := copy($t12)
      # live vars: $t2, $t4
- 24: $t18 := copy($t4)
-     # live vars: $t2, $t4, $t18
- 25: $t17 := vector::borrow<u8>($t18, $t2)
-     # live vars: $t2, $t4, $t17
- 26: $t16 := read_ref($t17)
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
      # live vars: $t2, $t4, $t16
- 27: $t19 := 5
-     # live vars: $t2, $t4, $t16, $t19
- 28: $t15 := ==($t16, $t19)
+ 26: $t15 := read_ref($t16)
      # live vars: $t2, $t4, $t15
- 29: if ($t15) goto 30 else goto 33
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+ 29: if ($t14) goto 30 else goto 33
      # live vars: $t4
  30: label L8
      # live vars: $t4
@@ -226,15 +222,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t4
  40: label L1
      # live vars: $t4
- 41: $t21 := copy($t0)
+ 41: $t19 := copy($t0)
      # live vars: $t4
- 42: $t20 := copy($t21)
+ 42: $t18 := copy($t19)
      # live vars: $t4
- 43: $t22 := copy($t0)
+ 43: $t20 := copy($t0)
      # live vars: $t4
- 44: $t23 := copy($t4)
-     # live vars: $t23
- 45: $t1 := vector::length<u8>($t23)
+ 44: $t21 := copy($t4)
+     # live vars: $t21
+ 45: $t1 := vector::length<u8>($t21)
      # live vars: $t1
  46: return $t1
 }
@@ -253,18 +249,18 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
@@ -278,9 +274,9 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   4: label L0
      # live vars: $t2, $t4
-  5: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
-  6: $t7 := vector::length<u8>($t24)
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+  6: $t7 := vector::length<u8>($t22)
      # live vars: $t2, $t4, $t7
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
@@ -288,15 +284,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   9: label L2
      # live vars: $t2, $t4
- 10: $t11 := copy($t4)
-     # live vars: $t2, $t4, $t11
- 11: $t10 := vector::borrow<u8>($t11, $t2)
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
      # live vars: $t2, $t4, $t10
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
- 13: $t12 := 0
-     # live vars: $t2, $t4, $t9, $t12
- 14: $t8 := !=($t9, $t12)
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+ 14: $t8 := !=($t9, $t11)
      # live vars: $t2, $t4, $t8
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
@@ -310,23 +306,23 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
  20: label L7
      # live vars: $t2, $t4
- 21: $t14 := 1
-     # live vars: $t2, $t4, $t14
- 22: $t13 := +($t2, $t14)
-     # live vars: $t4, $t13
- 23: $t2 := copy($t13)
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+ 23: $t2 := copy($t12)
      # live vars: $t2, $t4
- 24: $t18 := copy($t4)
-     # live vars: $t2, $t4, $t18
- 25: $t17 := vector::borrow<u8>($t18, $t2)
-     # live vars: $t2, $t4, $t17
- 26: $t16 := read_ref($t17)
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
      # live vars: $t2, $t4, $t16
- 27: $t19 := 5
-     # live vars: $t2, $t4, $t16, $t19
- 28: $t15 := ==($t16, $t19)
+ 26: $t15 := read_ref($t16)
      # live vars: $t2, $t4, $t15
- 29: if ($t15) goto 30 else goto 33
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+ 29: if ($t14) goto 30 else goto 33
      # live vars: $t4
  30: label L8
      # live vars: $t4
@@ -350,15 +346,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t4
  40: label L1
      # live vars: $t4
- 41: $t21 := copy($t0)
+ 41: $t19 := copy($t0)
      # live vars: $t4
- 42: $t20 := copy($t21)
+ 42: $t18 := copy($t19)
      # live vars: $t4
- 43: $t22 := copy($t0)
+ 43: $t20 := copy($t0)
      # live vars: $t4
- 44: $t23 := copy($t4)
-     # live vars: $t23
- 45: $t1 := vector::length<u8>($t23)
+ 44: $t21 := copy($t4)
+     # live vars: $t21
+ 45: $t1 := vector::length<u8>($t21)
      # live vars: $t1
  46: return $t1
 }
@@ -377,18 +373,18 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
@@ -426,13 +422,13 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
-  5: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L1281],L1281=local($t24)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t24=L1281}
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L1281],L1281=local($t22)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t22=L1281}
      # global_to_label: {}
      #
-  6: $t7 := vector::length<u8>($t24)
+  6: $t7 := vector::length<u8>($t22)
      # live vars: $t2, $t4, $t7
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
@@ -456,16 +452,16 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 10: $t11 := copy($t4)
-     # live vars: $t2, $t4, $t11
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t11)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t11=L2561}
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t23)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t23=L2561}
      # global_to_label: {}
      #
- 11: $t10 := vector::borrow<u8>($t11, $t2)
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
      # live vars: $t2, $t4, $t10
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t11)[call(false) -> L2816],L2816=local($t10)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t10=L2816,$t11=L2561}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L2561],L2561=local($t23)[call(false) -> L2816],L2816=local($t10)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t10=L2816,$t23=L2561}
      # global_to_label: {}
      #
  12: $t9 := read_ref($t10)
@@ -474,13 +470,13 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 13: $t12 := 0
-     # live vars: $t2, $t4, $t9, $t12
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 14: $t8 := !=($t9, $t12)
+ 14: $t8 := !=($t9, $t11)
      # live vars: $t2, $t4, $t8
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
@@ -518,55 +514,55 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 21: $t14 := 1
-     # live vars: $t2, $t4, $t14
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 22: $t13 := +($t2, $t14)
-     # live vars: $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 23: $t2 := copy($t13)
+ 23: $t2 := copy($t12)
      # live vars: $t2, $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 24: $t18 := copy($t4)
-     # live vars: $t2, $t4, $t18
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t18)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t18=L6145}
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t24)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t24=L6145}
      # global_to_label: {}
      #
- 25: $t17 := vector::borrow<u8>($t18, $t2)
-     # live vars: $t2, $t4, $t17
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t18)[call(false) -> L6400],L6400=local($t17)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t17=L6400,$t18=L6145}
-     # global_to_label: {}
-     #
- 26: $t16 := read_ref($t17)
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
      # live vars: $t2, $t4, $t16
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L6145],L6145=local($t24)[call(false) -> L6400],L6400=local($t16)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t16=L6400,$t24=L6145}
      # global_to_label: {}
      #
- 27: $t19 := 5
-     # live vars: $t2, $t4, $t16, $t19
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
-     # global_to_label: {}
-     #
- 28: $t15 := ==($t16, $t19)
+ 26: $t15 := read_ref($t16)
      # live vars: $t2, $t4, $t15
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 29: if ($t15) goto 30 else goto 33
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
+     # global_to_label: {}
+     #
+ 29: if ($t14) goto 30 else goto 33
      # live vars: $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
@@ -634,31 +630,31 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 41: $t21 := copy($t0)
+ 41: $t19 := copy($t0)
      # live vars: $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 42: $t20 := copy($t21)
+ 42: $t18 := copy($t19)
      # live vars: $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 43: $t22 := copy($t0)
+ 43: $t20 := copy($t0)
      # live vars: $t4
      # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[]}
      # local_to_label: {$t0=L512,$t4=L769,$t5=L513}
      # global_to_label: {}
      #
- 44: $t23 := copy($t4)
-     # live vars: $t23
-     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L11265],L11265=local($t23)[]}
-     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t23=L11265}
+ 44: $t21 := copy($t4)
+     # live vars: $t21
+     # graph: {L512=local($t0)[borrow(false) -> L513],L513=local($t5)[skip -> L769],L769=local($t4)[skip -> L11265],L11265=local($t21)[]}
+     # local_to_label: {$t0=L512,$t4=L769,$t5=L513,$t21=L11265}
      # global_to_label: {}
      #
- 45: $t1 := vector::length<u8>($t23)
+ 45: $t1 := vector::length<u8>($t21)
      # live vars: $t1
      # graph: {}
      # local_to_label: {}

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
@@ -12,19 +12,17 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
-     var $t23: &vector<u8>
+     var $t21: &vector<u8>
   0: $t3 := 0
   1: $t2 := infer($t3)
   2: $t5 := borrow_local($t0)
@@ -32,45 +30,43 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
   4: label L0
   5: $t7 := vector::length<u8>($t4)
   6: $t6 := <($t2, $t7)
-  7: if ($t6) goto 8 else goto 35
+  7: if ($t6) goto 8 else goto 33
   8: label L2
-  9: $t11 := infer($t4)
- 10: $t10 := vector::borrow<u8>($t11, $t2)
- 11: $t9 := read_ref($t10)
- 12: $t12 := 0
- 13: $t8 := !=($t9, $t12)
- 14: if ($t8) goto 15 else goto 18
- 15: label L5
- 16: goto 39
- 17: goto 19
- 18: label L6
- 19: label L7
- 20: $t14 := 1
- 21: $t13 := +($t2, $t14)
- 22: $t2 := infer($t13)
- 23: $t18 := infer($t4)
- 24: $t17 := vector::borrow<u8>($t18, $t2)
- 25: $t16 := read_ref($t17)
- 26: $t19 := 5
- 27: $t15 := ==($t16, $t19)
- 28: if ($t15) goto 29 else goto 32
- 29: label L8
- 30: goto 39
- 31: goto 33
- 32: label L9
- 33: label L10
+  9: $t10 := vector::borrow<u8>($t4, $t2)
+ 10: $t9 := read_ref($t10)
+ 11: $t11 := 0
+ 12: $t8 := !=($t9, $t11)
+ 13: if ($t8) goto 14 else goto 17
+ 14: label L5
+ 15: goto 37
+ 16: goto 18
+ 17: label L6
+ 18: label L7
+ 19: $t13 := 1
+ 20: $t12 := +($t2, $t13)
+ 21: $t2 := infer($t12)
+ 22: $t16 := vector::borrow<u8>($t4, $t2)
+ 23: $t15 := read_ref($t16)
+ 24: $t17 := 5
+ 25: $t14 := ==($t15, $t17)
+ 26: if ($t14) goto 27 else goto 30
+ 27: label L8
+ 28: goto 37
+ 29: goto 31
+ 30: label L9
+ 31: label L10
+ 32: goto 35
+ 33: label L3
  34: goto 37
- 35: label L3
- 36: goto 39
- 37: label L4
- 38: goto 4
- 39: label L1
- 40: $t21 := copy($t0)
- 41: $t20 := infer($t21)
- 42: $t22 := infer($t0)
- 43: $t23 := infer($t4)
- 44: $t1 := vector::length<u8>($t23)
- 45: return $t1
+ 35: label L4
+ 36: goto 4
+ 37: label L1
+ 38: $t19 := copy($t0)
+ 39: $t18 := infer($t19)
+ 40: $t20 := infer($t0)
+ 41: $t21 := infer($t4)
+ 42: $t1 := vector::length<u8>($t21)
+ 43: return $t1
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -87,18 +83,18 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t8: bool
      var $t9: u8
      var $t10: &u8
-     var $t11: &vector<u8>
-     var $t12: u8
+     var $t11: u8
+     var $t12: u64
      var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: u8
-     var $t17: &u8
-     var $t18: &vector<u8>
-     var $t19: u8
+     var $t14: bool
+     var $t15: u8
+     var $t16: &u8
+     var $t17: u8
+     var $t18: vector<u8>
+     var $t19: vector<u8>
      var $t20: vector<u8>
-     var $t21: vector<u8>
-     var $t22: vector<u8>
+     var $t21: &vector<u8>
+     var $t22: &vector<u8>
      var $t23: &vector<u8>
      var $t24: &vector<u8>
      # live vars: $t0
@@ -112,9 +108,9 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   4: label L0
      # live vars: $t2, $t4
-  5: $t24 := copy($t4)
-     # live vars: $t2, $t4, $t24
-  6: $t7 := vector::length<u8>($t24)
+  5: $t22 := copy($t4)
+     # live vars: $t2, $t4, $t22
+  6: $t7 := vector::length<u8>($t22)
      # live vars: $t2, $t4, $t7
   7: $t6 := <($t2, $t7)
      # live vars: $t2, $t4, $t6
@@ -122,15 +118,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
   9: label L2
      # live vars: $t2, $t4
- 10: $t11 := copy($t4)
-     # live vars: $t2, $t4, $t11
- 11: $t10 := vector::borrow<u8>($t11, $t2)
+ 10: $t23 := copy($t4)
+     # live vars: $t2, $t4, $t23
+ 11: $t10 := vector::borrow<u8>($t23, $t2)
      # live vars: $t2, $t4, $t10
  12: $t9 := read_ref($t10)
      # live vars: $t2, $t4, $t9
- 13: $t12 := 0
-     # live vars: $t2, $t4, $t9, $t12
- 14: $t8 := !=($t9, $t12)
+ 13: $t11 := 0
+     # live vars: $t2, $t4, $t9, $t11
+ 14: $t8 := !=($t9, $t11)
      # live vars: $t2, $t4, $t8
  15: if ($t8) goto 16 else goto 19
      # live vars: $t4
@@ -144,23 +140,23 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t2, $t4
  20: label L7
      # live vars: $t2, $t4
- 21: $t14 := 1
-     # live vars: $t2, $t4, $t14
- 22: $t13 := +($t2, $t14)
-     # live vars: $t4, $t13
- 23: $t2 := copy($t13)
+ 21: $t13 := 1
+     # live vars: $t2, $t4, $t13
+ 22: $t12 := +($t2, $t13)
+     # live vars: $t4, $t12
+ 23: $t2 := copy($t12)
      # live vars: $t2, $t4
- 24: $t18 := copy($t4)
-     # live vars: $t2, $t4, $t18
- 25: $t17 := vector::borrow<u8>($t18, $t2)
-     # live vars: $t2, $t4, $t17
- 26: $t16 := read_ref($t17)
+ 24: $t24 := copy($t4)
+     # live vars: $t2, $t4, $t24
+ 25: $t16 := vector::borrow<u8>($t24, $t2)
      # live vars: $t2, $t4, $t16
- 27: $t19 := 5
-     # live vars: $t2, $t4, $t16, $t19
- 28: $t15 := ==($t16, $t19)
+ 26: $t15 := read_ref($t16)
      # live vars: $t2, $t4, $t15
- 29: if ($t15) goto 30 else goto 33
+ 27: $t17 := 5
+     # live vars: $t2, $t4, $t15, $t17
+ 28: $t14 := ==($t15, $t17)
+     # live vars: $t2, $t4, $t14
+ 29: if ($t14) goto 30 else goto 33
      # live vars: $t4
  30: label L8
      # live vars: $t4
@@ -184,15 +180,15 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t4
  40: label L1
      # live vars: $t4
- 41: $t21 := copy($t0)
+ 41: $t19 := copy($t0)
      # live vars: $t4
- 42: $t20 := copy($t21)
+ 42: $t18 := copy($t19)
      # live vars: $t4
- 43: $t22 := copy($t0)
+ 43: $t20 := copy($t0)
      # live vars: $t4
- 44: $t23 := copy($t4)
-     # live vars: $t23
- 45: $t1 := vector::length<u8>($t23)
+ 44: $t21 := copy($t4)
+     # live vars: $t21
+ 45: $t1 := vector::length<u8>($t21)
      # live vars: $t1
  46: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/inferred_copy.exp
@@ -19,13 +19,11 @@ fun m::f2_ok() {
      var $t0: m::R
      var $t1: m::R
      var $t2: u64
-     var $t3: m::R
   0: $t2 := 0
   1: $t1 := pack m::R($t2)
   2: $t0 := infer($t1)
-  3: $t3 := infer($t0)
-  4: m::some2($t3, $t0)
-  5: return ()
+  3: m::some2($t0, $t0)
+  4: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -37,15 +37,13 @@ fun m::foo(): u64 {
      var $t32: &vector<u64>
      var $t33: u64
      var $t34: u64
-     var $t35: &mut vector<u64>
+     var $t35: u64
      var $t36: u64
      var $t37: u64
      var $t38: u64
-     var $t39: u64
-     var $t40: u64
-     var $t41: &u64
-     var $t42: &vector<u64>
-     var $t43: u64
+     var $t39: &u64
+     var $t40: &vector<u64>
+     var $t41: u64
   0: $t3 := 1
   1: $t4 := 2
   2: $t5 := 3
@@ -91,7 +89,7 @@ fun m::foo(): u64 {
  42: $t10 := infer($t26)
  43: label L8
  44: $t28 := <($t10, $t12)
- 45: if ($t28) goto 46 else goto 68
+ 45: if ($t28) goto 46 else goto 66
  46: label L10
  47: $t32 := freeze_ref($t9)
  48: $t31 := vector::borrow<u64>($t32, $t10)
@@ -99,32 +97,30 @@ fun m::foo(): u64 {
  50: $t33 := read_ref($t30)
  51: $t34 := 1
  52: $t29 := >($t33, $t34)
- 53: if ($t29) goto 54 else goto 62
+ 53: if ($t29) goto 54 else goto 60
  54: label L13
- 55: $t35 := infer($t9)
- 56: $t36 := infer($t25)
- 57: vector::swap<u64>($t35, $t36, $t10)
- 58: $t38 := 1
- 59: $t37 := +($t25, $t38)
- 60: $t25 := infer($t37)
- 61: goto 63
- 62: label L14
- 63: label L15
- 64: $t40 := 1
- 65: $t39 := +($t10, $t40)
- 66: $t10 := infer($t39)
+ 55: vector::swap<u64>($t9, $t25, $t10)
+ 56: $t36 := 1
+ 57: $t35 := +($t25, $t36)
+ 58: $t25 := infer($t35)
+ 59: goto 61
+ 60: label L14
+ 61: label L15
+ 62: $t38 := 1
+ 63: $t37 := +($t10, $t38)
+ 64: $t10 := infer($t37)
+ 65: goto 68
+ 66: label L11
  67: goto 70
- 68: label L11
- 69: goto 72
- 70: label L12
- 71: goto 43
- 72: label L9
- 73: $t8 := infer($t25)
- 74: $t42 := freeze_ref($t6)
- 75: $t43 := 0
- 76: $t41 := vector::borrow<u64>($t42, $t43)
- 77: $t0 := read_ref($t41)
- 78: return $t0
+ 68: label L12
+ 69: goto 43
+ 70: label L9
+ 71: $t8 := infer($t25)
+ 72: $t40 := freeze_ref($t6)
+ 73: $t41 := 0
+ 74: $t39 := vector::borrow<u64>($t40, $t41)
+ 75: $t0 := read_ref($t39)
+ 76: return $t0
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -166,18 +162,17 @@ fun m::foo(): u64 {
      var $t32: &vector<u64>
      var $t33: u64
      var $t34: u64
-     var $t35: &mut vector<u64>
+     var $t35: u64
      var $t36: u64
      var $t37: u64
      var $t38: u64
-     var $t39: u64
-     var $t40: u64
-     var $t41: &u64
-     var $t42: &vector<u64>
-     var $t43: u64
+     var $t39: &u64
+     var $t40: &vector<u64>
+     var $t41: u64
+     var $t42: &mut vector<u64>
+     var $t43: &mut vector<u64>
      var $t44: &mut vector<u64>
      var $t45: &mut vector<u64>
-     var $t46: &mut vector<u64>
      # live vars:
   0: $t3 := 1
      # live vars: $t3
@@ -199,9 +194,9 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t11
   9: $t10 := copy($t11)
      # live vars: $t6, $t9, $t10
- 10: $t44 := copy($t9)
-     # live vars: $t6, $t9, $t10, $t44
- 11: $t14 := freeze_ref($t44)
+ 10: $t42 := copy($t9)
+     # live vars: $t6, $t9, $t10, $t42
+ 11: $t14 := freeze_ref($t42)
      # live vars: $t6, $t9, $t10, $t14
  12: $t13 := vector::length<u64>($t14)
      # live vars: $t6, $t9, $t10, $t13
@@ -215,9 +210,9 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12
  17: label L2
      # live vars: $t6, $t9, $t10, $t12
- 18: $t45 := copy($t9)
-     # live vars: $t6, $t9, $t10, $t12, $t45
- 19: $t20 := freeze_ref($t45)
+ 18: $t43 := copy($t9)
+     # live vars: $t6, $t9, $t10, $t12, $t43
+ 19: $t20 := freeze_ref($t43)
      # live vars: $t6, $t9, $t10, $t12, $t20
  20: $t19 := vector::borrow<u64>($t20, $t10)
      # live vars: $t6, $t9, $t10, $t12, $t19
@@ -273,13 +268,13 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25
  46: $t28 := <($t10, $t12)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t28
- 47: if ($t28) goto 48 else goto 71
+ 47: if ($t28) goto 48 else goto 70
      # live vars: $t6, $t9, $t10, $t12, $t25
  48: label L10
      # live vars: $t6, $t9, $t10, $t12, $t25
- 49: $t46 := copy($t9)
-     # live vars: $t6, $t9, $t10, $t12, $t25, $t46
- 50: $t32 := freeze_ref($t46)
+ 49: $t44 := copy($t9)
+     # live vars: $t6, $t9, $t10, $t12, $t25, $t44
+ 50: $t32 := freeze_ref($t44)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t32
  51: $t31 := vector::borrow<u64>($t32, $t10)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t31
@@ -291,55 +286,53 @@ fun m::foo(): u64 {
      # live vars: $t6, $t9, $t10, $t12, $t25, $t33, $t34
  55: $t29 := >($t33, $t34)
      # live vars: $t6, $t9, $t10, $t12, $t25, $t29
- 56: if ($t29) goto 57 else goto 65
+ 56: if ($t29) goto 57 else goto 64
      # live vars: $t6, $t9, $t10, $t12, $t25
  57: label L13
      # live vars: $t6, $t9, $t10, $t12, $t25
- 58: $t35 := copy($t9)
-     # live vars: $t6, $t9, $t10, $t12, $t25, $t35
- 59: $t36 := copy($t25)
-     # live vars: $t6, $t9, $t10, $t12, $t25, $t35, $t36
- 60: vector::swap<u64>($t35, $t36, $t10)
+ 58: $t45 := copy($t9)
+     # live vars: $t6, $t9, $t10, $t12, $t25, $t45
+ 59: vector::swap<u64>($t45, $t25, $t10)
      # live vars: $t6, $t9, $t10, $t12, $t25
- 61: $t38 := 1
+ 60: $t36 := 1
+     # live vars: $t6, $t9, $t10, $t12, $t25, $t36
+ 61: $t35 := +($t25, $t36)
+     # live vars: $t6, $t9, $t10, $t12, $t35
+ 62: $t25 := copy($t35)
+     # live vars: $t6, $t9, $t10, $t12, $t25
+ 63: goto 65
+     # live vars: $t6, $t9, $t10, $t12, $t25
+ 64: label L14
+     # live vars: $t6, $t9, $t10, $t12, $t25
+ 65: label L15
+     # live vars: $t6, $t9, $t10, $t12, $t25
+ 66: $t38 := 1
      # live vars: $t6, $t9, $t10, $t12, $t25, $t38
- 62: $t37 := +($t25, $t38)
-     # live vars: $t6, $t9, $t10, $t12, $t37
- 63: $t25 := copy($t37)
+ 67: $t37 := +($t10, $t38)
+     # live vars: $t6, $t9, $t12, $t25, $t37
+ 68: $t10 := copy($t37)
      # live vars: $t6, $t9, $t10, $t12, $t25
- 64: goto 66
-     # live vars: $t6, $t9, $t10, $t12, $t25
- 65: label L14
-     # live vars: $t6, $t9, $t10, $t12, $t25
- 66: label L15
-     # live vars: $t6, $t9, $t10, $t12, $t25
- 67: $t40 := 1
-     # live vars: $t6, $t9, $t10, $t12, $t25, $t40
- 68: $t39 := +($t10, $t40)
-     # live vars: $t6, $t9, $t12, $t25, $t39
- 69: $t10 := copy($t39)
-     # live vars: $t6, $t9, $t10, $t12, $t25
- 70: goto 73
+ 69: goto 72
      # live vars: $t6
- 71: label L11
+ 70: label L11
      # live vars: $t6
- 72: goto 75
+ 71: goto 74
      # live vars: $t6, $t9, $t10, $t12, $t25
- 73: label L12
+ 72: label L12
      # live vars: $t6, $t9, $t10, $t12, $t25
- 74: goto 45
+ 73: goto 45
      # live vars: $t6
- 75: label L9
+ 74: label L9
      # live vars: $t6
- 76: $t8 := copy($t25)
+ 75: $t8 := copy($t25)
      # live vars: $t6
- 77: $t42 := freeze_ref($t6)
-     # live vars: $t42
- 78: $t43 := 0
-     # live vars: $t42, $t43
- 79: $t41 := vector::borrow<u64>($t42, $t43)
-     # live vars: $t41
- 80: $t0 := read_ref($t41)
+ 76: $t40 := freeze_ref($t6)
+     # live vars: $t40
+ 77: $t41 := 0
+     # live vars: $t40, $t41
+ 78: $t39 := vector::borrow<u64>($t40, $t41)
+     # live vars: $t39
+ 79: $t0 := read_ref($t39)
      # live vars: $t0
- 81: return $t0
+ 80: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
@@ -65,15 +65,13 @@ fun m::f2_fail() {
      var $t2: u64
      var $t3: &mut m::R
      var $t4: &mut m::R
-     var $t5: &mut m::R
   0: $t2 := 0
   1: $t1 := pack m::R($t2)
   2: $t0 := infer($t1)
   3: $t4 := borrow_local($t0)
   4: $t3 := infer($t4)
-  5: $t5 := infer($t3)
-  6: m::some2($t5, $t3)
-  7: return ()
+  5: m::some2($t3, $t3)
+  6: return ()
 }
 
 
@@ -163,6 +161,14 @@ fun m::some($t0: &mut m::R) {
 fun m::some2($t0: &mut m::R, $t1: &mut m::R) {
   0: return ()
 }
+
+
+Diagnostics:
+error: implicit copy of mutable reference in local `x` which is used later in argument list
+   ┌─ tests/live-var/mut_ref.move:41:9
+   │
+41 │         some2(x, x); // expected error because multiple use
+   │         ^^^^^^^^^^^ implicitly copied here
 
 ============ after LiveVarAnalysisProcessor: ================
 
@@ -272,7 +278,6 @@ fun m::f2_fail() {
      var $t2: u64
      var $t3: &mut m::R
      var $t4: &mut m::R
-     var $t5: &mut m::R
      # live vars:
   0: $t2 := 0
      # live vars: $t2
@@ -284,11 +289,9 @@ fun m::f2_fail() {
      # live vars: $t4
   4: $t3 := move($t4)
      # live vars: $t3
-  5: $t5 := copy($t3)
-     # live vars: $t3, $t5
-  6: m::some2($t5, $t3)
+  5: m::some2($t3, $t3)
      # live vars:
-  7: return ()
+  6: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.move
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.move
@@ -38,7 +38,7 @@ module 0x42::m {
     fun f2_fail() {
         let r = R { v: 0 };
         let x = &mut r;
-        some2(x, x); // error is no longer raised in the live-var analysis phase
+        some2(x, x); // expected error because multiple use
     }
 
     fun f3_ok() {

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
 error: cannot copy mutable reference in local `s1` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:15:17
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:15:9
    │
 14 │         let f = freeze(s1);
    │                 ---------- previous call result
 15 │         mut_imm(s1, f);
-   │                 ^^ copied here
+   │         ^^^^^^^^^^^^^^ copied here
 
 error: cannot pass mutable reference in local, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:15:9
@@ -17,12 +17,12 @@ error: cannot pass mutable reference in local, which is still borrowed, as funct
    │         ^^^^^^^^^^^^^^ passed here
 
 error: cannot copy mutable reference in local `s1` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:17
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
    │
 16 │         let f = &s1.f;
    │                 ----- previous field borrow
 17 │         mut_imm(s1, f);
-   │                 ^^ copied here
+   │         ^^^^^^^^^^^^^^ copied here
 
 error: cannot pass mutable reference in local, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
@@ -68,12 +68,12 @@ error: cannot mutable borrow local since other references exists
    │                ^^^^^^^^^ mutable borrow attempted here
 
 error: cannot copy mutable reference in local `s1` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:17
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
    │
 24 │         let f = &mut s1.f;
    │                 --------- previous mutable field borrow
 25 │         mut_mut(s1, f);
-   │                 ^^ copied here
+   │         ^^^^^^^^^^^^^^ copied here
 
 error: cannot pass mutable reference in local, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
@@ -118,7 +118,7 @@ error: cannot pass mutable reference in local, which is still borrowed, as funct
    │         ^^^^^^^^^^ passed here
 
 error: cannot copy mutable reference in local `s1` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:31:17
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:31:9
    │
 30 │         let f = id_mut(&mut s1.f);
    │                 -----------------
@@ -126,7 +126,7 @@ error: cannot copy mutable reference in local `s1` which is still borrowed
    │                 │      previous mutable field borrow
    │                 used by mutable call result
 31 │         mut_mut(s1, f);
-   │                 ^^ copied here
+   │         ^^^^^^^^^^^^^^ copied here
 
 error: cannot pass mutable reference in local, which is still borrowed, as function argument
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:31:9

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -462,7 +462,6 @@ L7:	loc8: &mut vector<u64>
 L8:	loc9: &mut vector<u64>
 L9:	loc10: u64
 L10:	loc11: u64
-L11:	loc12: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[1](loc0: u64)
@@ -476,7 +475,7 @@ B1:
 	8: CopyLoc[1](loc0: u64)
 	9: MoveLoc[3](loc2: u64)
 	10: Lt
-	11: BrFalse(69)
+	11: BrFalse(67)
 B2:
 	12: LdU64(1)
 	13: StLoc[4](loc3: u64)
@@ -494,7 +493,7 @@ B3:
 	24: CopyLoc[5](loc4: u64)
 	25: MoveLoc[7](loc6: u64)
 	26: Lt
-	27: BrFalse(60)
+	27: BrFalse(58)
 B4:
 	28: CopyLoc[0](Arg0: &mut vector<u64>)
 	29: StLoc[8](loc7: &mut vector<u64>)
@@ -511,43 +510,41 @@ B4:
 	40: VecImmBorrow(2)
 	41: ReadRef
 	42: Gt
-	43: BrFalse(53)
+	43: BrFalse(51)
 B5:
 	44: CopyLoc[0](Arg0: &mut vector<u64>)
 	45: StLoc[10](loc9: &mut vector<u64>)
-	46: CopyLoc[1](loc0: u64)
-	47: StLoc[11](loc10: u64)
-	48: MoveLoc[10](loc9: &mut vector<u64>)
-	49: MoveLoc[11](loc10: u64)
-	50: CopyLoc[5](loc4: u64)
-	51: VecSwap(2)
-	52: Branch(53)
+	46: MoveLoc[10](loc9: &mut vector<u64>)
+	47: CopyLoc[1](loc0: u64)
+	48: CopyLoc[5](loc4: u64)
+	49: VecSwap(2)
+	50: Branch(51)
 B6:
-	53: LdU64(1)
-	54: StLoc[12](loc11: u64)
-	55: MoveLoc[5](loc4: u64)
-	56: MoveLoc[12](loc11: u64)
-	57: Add
-	58: StLoc[5](loc4: u64)
-	59: Branch(61)
+	51: LdU64(1)
+	52: StLoc[11](loc10: u64)
+	53: MoveLoc[5](loc4: u64)
+	54: MoveLoc[11](loc10: u64)
+	55: Add
+	56: StLoc[5](loc4: u64)
+	57: Branch(59)
 B7:
-	60: Branch(62)
+	58: Branch(60)
 B8:
-	61: Branch(18)
+	59: Branch(18)
 B9:
-	62: LdU64(1)
-	63: StLoc[13](loc12: u64)
-	64: MoveLoc[1](loc0: u64)
-	65: MoveLoc[13](loc12: u64)
-	66: Add
-	67: StLoc[1](loc0: u64)
-	68: Branch(70)
+	60: LdU64(1)
+	61: StLoc[12](loc11: u64)
+	62: MoveLoc[1](loc0: u64)
+	63: MoveLoc[12](loc11: u64)
+	64: Add
+	65: StLoc[1](loc0: u64)
+	66: Branch(68)
 B10:
-	69: Branch(71)
+	67: Branch(69)
 B11:
-	70: Branch(2)
+	68: Branch(2)
 B12:
-	71: Ret
+	69: Ret
 }
 vcopy(Arg0: &vector<u64>): vector<u64> {
 L0:	loc1: u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/side_effecting_args.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/side_effecting_args.exp
@@ -1,0 +1,15 @@
+processed 5 tasks
+
+task 1 'run'. lines 33-33:
+return values: 6
+
+task 2 'run'. lines 35-35:
+return values: 8
+
+task 3 'run'. lines 37-37:
+return values: 7
+
+task 4 'run'. lines 39-39:
+return values: 9
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/side_effecting_args.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/side_effecting_args.move
@@ -1,0 +1,39 @@
+//# publish
+module 0xdeadbeef::test {
+    fun add(a: u64, b: u64, c: u64): u64 {
+        a + b + c
+    }
+
+    fun inc(x: &mut u64): u64 {
+        *x = *x + 1;
+        *x
+    }
+
+    fun test1(): u64 {
+        let x = 1;
+        add(x, inc(&mut x), inc(&mut x))
+    }
+
+    fun test2(): u64 {
+        let x = 1;
+        add({x = x + 1; x}, {x = x + 1; x}, x)
+    }
+
+    fun test3(): u64 {
+        let x = 1;
+        add({x = x + 1; x}, x, {x = x + 1; x})
+    }
+
+    fun test4(): u64 {
+        let x = 1;
+        add({x = x + 1; x}, {x = x + 1; x}, {x = x + 1; x})
+    }
+}
+
+//# run 0xdeadbeef::test::test1
+
+//# run 0xdeadbeef::test::test2
+
+//# run 0xdeadbeef::test::test3
+
+//# run 0xdeadbeef::test::test4


### PR DESCRIPTION
### Description

Closes https://github.com/aptos-labs/aptos-core/issues/11276.

In order to enforce left-to-right evaluation of arguments to a function, we had introduced saving each arg evaluation (in order) in a temporary. While there was some optimization to reduce the number of temporaries, it still was too many to break one of the framework code.

In this PR, we further reduce the number of temporaries, by not creating them when all args to a function are guaranteed to not mutate locals (i.e., side-effect free). Our analysis here is fairly simple, as we expect copy propagation (in the future) to eliminate many of the unnecessary temps.

### Test Plan

I have added a new test, which among other things, showcases that we cannot just scan for blocks to detect side-effects: move functions can also be side-effecting.

I have manually tested that the bug mentioned in #11276 is fixed by this PR.

All other test output changes seem to revert to the state before we introduced the temporaries for arguments in #11156.