### PR TITLE
[forge] Update realistic_network_tuned_for_throughput_test to use latest onchain execution config

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1867,11 +1867,18 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             let mut on_chain_execution_config = OnChainExecutionConfig::default_for_genesis();
-            if let OnChainExecutionConfig::V4(config_v4) = &mut on_chain_execution_config {
-                config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
-                config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
-            } else {
-                panic!("Unexpected on-chain execution config type, if OnChainExecutionConfig::default_for_genesis() has been updated, this test must be updated too.")
+            // Need to update if the default changes
+            match &mut on_chain_execution_config {
+                OnChainExecutionConfig::Missing
+                | OnChainExecutionConfig::V1(_)
+                | OnChainExecutionConfig::V2(_)
+                | OnChainExecutionConfig::V3(_) => {
+                    unreachable!("Unexpected on-chain execution config type, if OnChainExecutionConfig::default_for_genesis() has been updated, this test must be updated too.")
+                }
+                OnChainExecutionConfig::V4(config_v4) => {
+                    config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                    config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+                }
             }
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(on_chain_execution_config).expect("must serialize");

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -23,7 +23,9 @@ use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
     transaction_builder::aptos_stdlib,
-    types::on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig},
+    types::on_chain_config::{
+        BlockGasLimitType, OnChainConsensusConfig, OnChainExecutionConfig, TransactionShufflerType,
+    },
 };
 use aptos_testcases::{
     compatibility_test::SimpleValidatorUpgrade,
@@ -1864,13 +1866,15 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
             }
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
+            let mut on_chain_execution_config = OnChainExecutionConfig::default_for_genesis();
+            if let OnChainExecutionConfig::V4(config_v4) = &mut on_chain_execution_config {
+                config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+            } else {
+                panic!("Unexpected on-chain execution config type, if OnChainExecutionConfig::default_for_genesis() has been updated, this test must be updated too.")
+            }
             helm_values["chain"]["on_chain_execution_config"] =
-                serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
-                    .expect("must serialize");
-            helm_values["chain"]["on_chain_execution_config"]["V3"]["block_gas_limit"] =
-                serde_yaml::Value::Null;
-            helm_values["chain"]["on_chain_execution_config"]["V3"]["transaction_shuffler_type"]
-                ["sender_aware_v2"] = 256.into();
+                serde_yaml::to_value(on_chain_execution_config).expect("must serialize");
         }));
 
     if ENABLE_VFNS {


### PR DESCRIPTION
### Description

The default was changed. Future changes should be more apparent now.

### Test Plan

Ran ad-hoc forge run
