### PR TITLE
[dag] refactor/improve dag health monitoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
         files: \.(rs|move)$
@@ -13,7 +13,7 @@ repos:
           - --maxkb=2000
   # Once this issue is resolved, we can add the full license check: https://github.com/Lucas-C/pre-commit-hooks/issues/68
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.3.0
+    rev: v1.5.4
     hooks:
       - id: insert-license
         files: ^(?!third_party/).*\.rs$

--- a/config/src/config/dag_consensus_config.rs
+++ b/config/src/config/dag_consensus_config.rs
@@ -2,7 +2,7 @@
 
 use super::{
     config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, ChainHealthBackoffValues,
-    Error, NodeConfig, QuorumStoreConfig, PipelineBackpressureValues,
+    Error, NodeConfig, PipelineBackpressureValues, QuorumStoreConfig,
 };
 use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};

--- a/config/src/config/dag_consensus_config.rs
+++ b/config/src/config/dag_consensus_config.rs
@@ -2,7 +2,7 @@
 
 use super::{
     config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, ChainHealthBackoffValues,
-    Error, NodeConfig, QuorumStoreConfig,
+    Error, NodeConfig, QuorumStoreConfig, PipelineBackpressureValues,
 };
 use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
@@ -143,6 +143,7 @@ pub struct DagConsensusConfig {
     pub fetcher_config: DagFetcherConfig,
     pub round_state_config: DagRoundStateConfig,
     pub chain_backoff_config: Vec<ChainHealthBackoffValues>,
+    pub pipeline_backpressure_config: Vec<PipelineBackpressureValues>,
     #[serde(default = "QuorumStoreConfig::default_for_dag")]
     pub quorum_store: QuorumStoreConfig,
 }

--- a/consensus/src/dag/anchor_election/leader_reputation_adapter.rs
+++ b/consensus/src/dag/anchor_election/leader_reputation_adapter.rs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    dag::{anchor_election::AnchorElection, storage::CommitEvent},
+    dag::{
+        anchor_election::{AnchorElection, CommitHistory},
+        storage::CommitEvent,
+    },
     liveness::{
-        leader_reputation::{LeaderReputation, MetadataBackend, ReputationHeuristic, VotingPowerRatio},
+        leader_reputation::{
+            LeaderReputation, MetadataBackend, ReputationHeuristic, VotingPowerRatio,
+        },
         proposer_election::ProposerElection,
     },
 };
@@ -121,16 +126,6 @@ impl LeaderReputationAdapter {
             data_source: backend,
         }
     }
-
-    pub(crate) fn get_voting_power_participation_ratio(&self, round: u64) -> VotingPowerRatio {
-        let mut voting_power_ratio = self.reputation.get_voting_power_participation_ratio(round);
-        // TODO: fix this once leader reputation is fixed
-        if voting_power_ratio < 0.67 {
-            voting_power_ratio = 1.0;
-        }
-
-        voting_power_ratio
-    }
 }
 
 impl AnchorElection for LeaderReputationAdapter {
@@ -140,5 +135,17 @@ impl AnchorElection for LeaderReputationAdapter {
 
     fn update_reputation(&self, commit_event: CommitEvent) {
         self.data_source.push(commit_event)
+    }
+}
+
+impl CommitHistory for LeaderReputationAdapter {
+    fn get_voting_power_participation_ratio(&self, round: Round) -> VotingPowerRatio {
+        let mut voting_power_ratio = self.reputation.get_voting_power_participation_ratio(round);
+        // TODO: fix this once leader reputation is fixed
+        if voting_power_ratio < 0.67 {
+            voting_power_ratio = 1.0;
+        }
+
+        voting_power_ratio
     }
 }

--- a/consensus/src/dag/anchor_election/mod.rs
+++ b/consensus/src/dag/anchor_election/mod.rs
@@ -3,18 +3,11 @@
 
 use crate::dag::storage::CommitEvent;
 use aptos_consensus_types::common::{Author, Round};
-use std::time::Duration;
 
 pub trait AnchorElection: Send + Sync {
     fn get_anchor(&self, round: Round) -> Author;
 
     fn update_reputation(&self, commit_event: CommitEvent);
-}
-
-pub trait TChainHealthBackoff: Send + Sync {
-    fn get_round_backoff(&self, round: Round) -> (f64, Option<Duration>);
-
-    fn get_round_payload_limits(&self, round: Round) -> (f64, Option<(u64, u64)>);
 }
 
 mod leader_reputation_adapter;

--- a/consensus/src/dag/anchor_election/mod.rs
+++ b/consensus/src/dag/anchor_election/mod.rs
@@ -18,5 +18,4 @@ mod leader_reputation_adapter;
 mod round_robin;
 
 pub use leader_reputation_adapter::{LeaderReputationAdapter, MetadataBackendAdapter};
-#[cfg(test)]
 pub use round_robin::RoundRobinAnchorElection;

--- a/consensus/src/dag/anchor_election/mod.rs
+++ b/consensus/src/dag/anchor_election/mod.rs
@@ -1,13 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dag::storage::CommitEvent;
+use crate::{dag::storage::CommitEvent, liveness::leader_reputation::VotingPowerRatio};
 use aptos_consensus_types::common::{Author, Round};
 
 pub trait AnchorElection: Send + Sync {
     fn get_anchor(&self, round: Round) -> Author;
 
     fn update_reputation(&self, commit_event: CommitEvent);
+}
+
+pub trait CommitHistory: Send + Sync {
+    fn get_voting_power_participation_ratio(&self, round: Round) -> VotingPowerRatio;
 }
 
 mod leader_reputation_adapter;

--- a/consensus/src/dag/anchor_election/round_robin.rs
+++ b/consensus/src/dag/anchor_election/round_robin.rs
@@ -1,7 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dag::{anchor_election::AnchorElection, storage::CommitEvent};
+use super::CommitHistory;
+use crate::{
+    dag::{anchor_election::AnchorElection, storage::CommitEvent},
+    liveness::leader_reputation::VotingPowerRatio,
+};
 use aptos_consensus_types::common::{Author, Round};
 
 pub struct RoundRobinAnchorElection {
@@ -20,4 +24,10 @@ impl AnchorElection for RoundRobinAnchorElection {
     }
 
     fn update_reputation(&self, _event: CommitEvent) {}
+}
+
+impl CommitHistory for RoundRobinAnchorElection {
+    fn get_voting_power_participation_ratio(&self, _round: Round) -> VotingPowerRatio {
+        1.0
+    }
 }

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -15,7 +15,7 @@ use super::{
     },
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
-    storage::DAGStorage,
+    storage::{CommitEvent, DAGStorage},
     types::{CertifiedNodeMessage, DAGMessage},
     DAGRpcResult, ProofNotifier,
 };
@@ -439,20 +439,38 @@ impl DagBootstrapper {
     ) -> (
         Arc<dyn AnchorElection>,
         Option<Arc<LeaderReputationAdapter>>,
+        Option<Vec<CommitEvent>>,
     ) {
         match &self.onchain_config.anchor_election_mode {
             AnchorElectionMode::RoundRobin => {
                 let election = Arc::new(RoundRobinAnchorElection::new(
                     self.epoch_state.verifier.get_ordered_account_addresses(),
                 ));
-                (election, None)
+                (election, None, None)
             },
             AnchorElectionMode::LeaderReputation(reputation_type) => {
-                let leader_reputation = match reputation_type {
-                    ProposerAndVoterV2(config) => self.build_leader_reputation_components(config),
+                let (commit_events, leader_reputation) = match reputation_type {
+                    ProposerAndVoterV2(config) => {
+                        let commit_events = self
+                            .storage
+                            .get_latest_k_committed_events(
+                                config.voter_window_num_validators_multiplier as u64
+                                    * self.epoch_state.verifier.len() as u64,
+                            )
+                            .expect("Failed to read commit events from storage");
+                        (
+                            commit_events,
+                            self.build_leader_reputation_components(config),
+                        )
+                    },
                     ProposerAndVoter(_) => unreachable!("unsupported mode"),
                 };
-                (leader_reputation.clone(), Some(leader_reputation))
+
+                (
+                    leader_reputation.clone(),
+                    Some(leader_reputation),
+                    Some(commit_events),
+                )
             },
         }
     }
@@ -460,6 +478,7 @@ impl DagBootstrapper {
     fn bootstrap_dag_store(
         &self,
         anchor_election: Arc<dyn AnchorElection>,
+        commit_events: Option<Vec<CommitEvent>>,
         dag_window_size_config: u64,
     ) -> BootstrapBaseState {
         let ledger_info_from_storage = self
@@ -505,8 +524,8 @@ impl DagBootstrapper {
             dag.clone(),
             anchor_election.clone(),
             ordered_notifier.clone(),
-            self.storage.clone(),
             self.onchain_config.dag_ordering_causal_history_window as Round,
+            commit_events,
         );
 
         BootstrapBaseState {
@@ -632,10 +651,12 @@ impl DagBootstrapper {
     }
 
     fn full_bootstrap(&self) -> (BootstrapBaseState, NetworkHandler, DagFetcherService) {
-        let (anchor_election, may_be_leader_reputation) = self.build_anchor_election();
+        let (anchor_election, may_be_leader_reputation, commit_events) =
+            self.build_anchor_election();
 
         let mut base_state = self.bootstrap_dag_store(
             anchor_election.clone(),
+            commit_events,
             self.onchain_config.dag_ordering_causal_history_window as u64,
         );
         base_state.may_be_leader_reputation = may_be_leader_reputation;

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -2,17 +2,14 @@
 
 use super::{
     adapter::{OrderedNotifierAdapter, TLedgerInfoProvider},
-    anchor_election::{AnchorElection, RoundRobinAnchorElection},
+    anchor_election::{AnchorElection, CommitHistory, RoundRobinAnchorElection},
     dag_driver::DagDriver,
     dag_fetcher::{DagFetcher, DagFetcherService, FetchRequestHandler},
     dag_handler::NetworkHandler,
     dag_network::TDAGNetworkSender,
     dag_state_sync::{DagStateSynchronizer, StateSyncTrigger},
     dag_store::Dag,
-    health::{
-        ChainHealthBackoff, HealthBackoff, NoChainHealth, PipelineLatencyBasedBackpressure,
-        TChainHealth,
-    },
+    health::{ChainHealthBackoff, HealthBackoff, PipelineLatencyBasedBackpressure, TChainHealth},
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
     storage::{CommitEvent, DAGStorage},
@@ -77,7 +74,7 @@ struct BootstrapBaseState {
     order_rule: OrderRule,
     ledger_info_provider: Arc<dyn TLedgerInfoProvider>,
     ordered_notifier: Arc<OrderedNotifierAdapter>,
-    may_be_leader_reputation: Option<Arc<LeaderReputationAdapter>>,
+    commit_history: Arc<dyn CommitHistory>,
 }
 
 #[enum_dispatch(TDagMode)]
@@ -438,7 +435,7 @@ impl DagBootstrapper {
         &self,
     ) -> (
         Arc<dyn AnchorElection>,
-        Option<Arc<LeaderReputationAdapter>>,
+        Arc<dyn CommitHistory>,
         Option<Vec<CommitEvent>>,
     ) {
         match &self.onchain_config.anchor_election_mode {
@@ -446,7 +443,7 @@ impl DagBootstrapper {
                 let election = Arc::new(RoundRobinAnchorElection::new(
                     self.epoch_state.verifier.get_ordered_account_addresses(),
                 ));
-                (election, None, None)
+                (election.clone(), election, None)
             },
             AnchorElectionMode::LeaderReputation(reputation_type) => {
                 let (commit_events, leader_reputation) = match reputation_type {
@@ -468,7 +465,7 @@ impl DagBootstrapper {
 
                 (
                     leader_reputation.clone(),
-                    Some(leader_reputation),
+                    leader_reputation,
                     Some(commit_events),
                 )
             },
@@ -478,6 +475,7 @@ impl DagBootstrapper {
     fn bootstrap_dag_store(
         &self,
         anchor_election: Arc<dyn AnchorElection>,
+        commit_history: Arc<dyn CommitHistory>,
         commit_events: Option<Vec<CommitEvent>>,
         dag_window_size_config: u64,
     ) -> BootstrapBaseState {
@@ -533,7 +531,7 @@ impl DagBootstrapper {
             order_rule,
             ledger_info_provider,
             ordered_notifier,
-            may_be_leader_reputation: None,
+            commit_history,
         }
     }
 
@@ -563,7 +561,7 @@ impl DagBootstrapper {
             ledger_info_provider,
             order_rule,
             ordered_notifier,
-            may_be_leader_reputation,
+            commit_history,
         } = base_state;
 
         let state_sync_trigger = StateSyncTrigger::new(
@@ -594,13 +592,10 @@ impl DagBootstrapper {
             )),
         );
 
-        let chain_health: Arc<dyn TChainHealth> = match may_be_leader_reputation {
-            Some(adapter) => ChainHealthBackoff::new(
-                ChainHealthBackoffConfig::new(self.config.chain_backoff_config.clone()),
-                adapter.clone(),
-            ),
-            None => NoChainHealth::new(),
-        };
+        let chain_health: Arc<dyn TChainHealth> = ChainHealthBackoff::new(
+            ChainHealthBackoffConfig::new(self.config.chain_backoff_config.clone()),
+            commit_history.clone(),
+        );
         let pipeline_health = PipelineLatencyBasedBackpressure::new(
             PipelineBackpressureConfig::new(self.config.pipeline_backpressure_config.clone()),
             ordered_notifier.clone(),
@@ -651,15 +646,14 @@ impl DagBootstrapper {
     }
 
     fn full_bootstrap(&self) -> (BootstrapBaseState, NetworkHandler, DagFetcherService) {
-        let (anchor_election, may_be_leader_reputation, commit_events) =
-            self.build_anchor_election();
+        let (anchor_election, commit_history, commit_events) = self.build_anchor_election();
 
-        let mut base_state = self.bootstrap_dag_store(
+        let base_state = self.bootstrap_dag_store(
             anchor_election.clone(),
+            commit_history,
             commit_events,
             self.onchain_config.dag_ordering_causal_history_window as u64,
         );
-        base_state.may_be_leader_reputation = may_be_leader_reputation;
 
         let (handler, fetch_service) = self.bootstrap_components(&base_state);
         (base_state, handler, fetch_service)

--- a/consensus/src/dag/health/backoff.rs
+++ b/consensus/src/dag/health/backoff.rs
@@ -1,0 +1,77 @@
+use super::{pipeline_health::TPipelineHealth, TChainHealth};
+use aptos_config::config::DagPayloadConfig;
+use aptos_consensus_types::common::Round;
+use aptos_types::epoch_state::EpochState;
+use std::{sync::Arc, time::Duration};
+
+pub struct HealthBackoff {
+    epoch_state: Arc<EpochState>,
+    chain_health: Arc<dyn TChainHealth>,
+    pipeline_health: Arc<dyn TPipelineHealth>,
+}
+
+impl HealthBackoff {
+    pub fn new(
+        epoch_state: Arc<EpochState>,
+        chain_health: Arc<dyn TChainHealth>,
+        pipeline_health: Arc<dyn TPipelineHealth>,
+    ) -> Self {
+        Self {
+            epoch_state,
+            chain_health,
+            pipeline_health,
+        }
+    }
+
+    pub fn calculate_payload_limits(
+        &self,
+        round: Round,
+        payload_config: &DagPayloadConfig,
+    ) -> (u64, u64) {
+        let chain_backoff = self
+            .chain_health
+            .get_round_payload_limits(round)
+            .unwrap_or((u64::MAX, u64::MAX));
+        let pipeline_backoff = self
+            .pipeline_health
+            .get_payload_limits()
+            .unwrap_or((u64::MAX, u64::MAX));
+        let voting_power_ratio = self.chain_health.voting_power_ratio(round);
+
+        let max_txns_per_round = vec![
+            payload_config.max_sending_txns_per_round,
+            chain_backoff.0,
+            pipeline_backoff.0,
+        ]
+        .into_iter()
+        .min()
+        .expect("must not be empty");
+
+        let max_size_per_round_bytes = vec![
+            payload_config.max_sending_size_per_round_bytes,
+            chain_backoff.1,
+            pipeline_backoff.1,
+        ]
+        .into_iter()
+        .min()
+        .expect("must not be empty");
+
+        let max_txns = max_txns_per_round.saturating_div(
+            (self.epoch_state.verifier.len() as f64 * voting_power_ratio).ceil() as u64,
+        );
+        let max_txn_size_bytes = max_size_per_round_bytes.saturating_div(
+            (self.epoch_state.verifier.len() as f64 * voting_power_ratio).ceil() as u64,
+        );
+
+        (max_txns, max_txn_size_bytes)
+    }
+
+    pub fn backoff_duration(&self, round: Round) -> Duration {
+        let chain_backoff = self.chain_health.get_round_backoff(round);
+        let pipeline_backoff = self.pipeline_health.get_backoff();
+
+        chain_backoff
+            .unwrap_or_default()
+            .max(pipeline_backoff.unwrap_or_default())
+    }
+}

--- a/consensus/src/dag/health/backoff.rs
+++ b/consensus/src/dag/health/backoff.rs
@@ -38,7 +38,7 @@ impl HealthBackoff {
             .unwrap_or((u64::MAX, u64::MAX));
         let voting_power_ratio = self.chain_health.voting_power_ratio(round);
 
-        let max_txns_per_round = vec![
+        let max_txns_per_round = [
             payload_config.max_sending_txns_per_round,
             chain_backoff.0,
             pipeline_backoff.0,
@@ -47,7 +47,7 @@ impl HealthBackoff {
         .min()
         .expect("must not be empty");
 
-        let max_size_per_round_bytes = vec![
+        let max_size_per_round_bytes = [
             payload_config.max_sending_size_per_round_bytes,
             chain_backoff.1,
             pipeline_backoff.1,

--- a/consensus/src/dag/health/backoff.rs
+++ b/consensus/src/dag/health/backoff.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 use super::{pipeline_health::TPipelineHealth, TChainHealth};
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::Round;

--- a/consensus/src/dag/health/backoff.rs
+++ b/consensus/src/dag/health/backoff.rs
@@ -56,6 +56,7 @@ impl HealthBackoff {
         .min()
         .expect("must not be empty");
 
+        // TODO: figure out receiver side checks
         let max_txns = max_txns_per_round.saturating_div(
             (self.epoch_state.verifier.len() as f64 * voting_power_ratio).ceil() as u64,
         );

--- a/consensus/src/dag/health/chain_health.rs
+++ b/consensus/src/dag/health/chain_health.rs
@@ -1,0 +1,88 @@
+use crate::{
+    counters::CHAIN_HEALTH_BACKOFF_TRIGGERED,
+    dag::anchor_election::LeaderReputationAdapter,
+    liveness::{leader_reputation::VotingPowerRatio, proposal_generator::ChainHealthBackoffConfig},
+};
+use aptos_config::config::ChainHealthBackoffValues;
+use aptos_consensus_types::common::Round;
+use std::{sync::Arc, time::Duration};
+
+pub trait TChainHealth: Send + Sync {
+    fn get_round_backoff(&self, round: Round) -> Option<Duration>;
+
+    fn get_round_payload_limits(&self, round: Round) -> Option<(u64, u64)>;
+
+    fn voting_power_ratio(&self, round: Round) -> VotingPowerRatio;
+}
+
+pub struct NoChainHealth {}
+
+impl NoChainHealth {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+}
+
+impl TChainHealth for NoChainHealth {
+    fn get_round_backoff(&self, _round: Round) -> Option<Duration> {
+        None
+    }
+
+    fn get_round_payload_limits(&self, _round: Round) -> Option<(u64, u64)> {
+        None
+    }
+
+    fn voting_power_ratio(&self, _round: Round) -> VotingPowerRatio {
+        1.0
+    }
+}
+
+pub struct ChainHealthBackoff {
+    config: ChainHealthBackoffConfig,
+    adapter: Arc<LeaderReputationAdapter>,
+}
+
+impl ChainHealthBackoff {
+    pub fn new(
+        config: ChainHealthBackoffConfig,
+        adapter: Arc<LeaderReputationAdapter>,
+    ) -> Arc<Self> {
+        Arc::new(Self { adapter, config })
+    }
+
+    fn get_chain_health_backoff(&self, round: Round) -> Option<&ChainHealthBackoffValues> {
+        let voting_power_ratio = self.adapter.get_voting_power_participation_ratio(round);
+        let chain_health_backoff = self.config.get_backoff(voting_power_ratio);
+
+        chain_health_backoff
+    }
+}
+
+impl TChainHealth for ChainHealthBackoff {
+    fn get_round_backoff(&self, round: Round) -> Option<Duration> {
+        let chain_health_backoff = self.get_chain_health_backoff(round);
+        let backoff_duration = if let Some(value) = chain_health_backoff {
+            CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(1.0);
+            Some(Duration::from_millis(value.backoff_proposal_delay_ms))
+        } else {
+            CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(0.0);
+            None
+        };
+        backoff_duration
+    }
+
+    fn get_round_payload_limits(&self, round: Round) -> Option<(u64, u64)> {
+        let chain_health_backoff = self.get_chain_health_backoff(round);
+        let backoff_limits = chain_health_backoff.map(|value| {
+            (
+                value.max_sending_block_txns_override,
+                value.max_sending_block_bytes_override,
+            )
+        });
+        backoff_limits
+    }
+
+    fn voting_power_ratio(&self, round: Round) -> VotingPowerRatio {
+        self.adapter.get_voting_power_participation_ratio(round)
+    }
+}

--- a/consensus/src/dag/health/chain_health.rs
+++ b/consensus/src/dag/health/chain_health.rs
@@ -66,25 +66,23 @@ impl ChainHealthBackoff {
 impl TChainHealth for ChainHealthBackoff {
     fn get_round_backoff(&self, round: Round) -> Option<Duration> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
-        let backoff_duration = if let Some(value) = chain_health_backoff {
+        if let Some(value) = chain_health_backoff {
             CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(1.0);
             Some(Duration::from_millis(value.backoff_proposal_delay_ms))
         } else {
             CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(0.0);
             None
-        };
-        backoff_duration
+        }
     }
 
     fn get_round_payload_limits(&self, round: Round) -> Option<(u64, u64)> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
-        let backoff_limits = chain_health_backoff.map(|value| {
+        chain_health_backoff.map(|value| {
             (
                 value.max_sending_block_txns_override,
                 value.max_sending_block_bytes_override,
             )
-        });
-        backoff_limits
+        })
     }
 
     fn voting_power_ratio(&self, round: Round) -> VotingPowerRatio {

--- a/consensus/src/dag/health/chain_health.rs
+++ b/consensus/src/dag/health/chain_health.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 use crate::{
     counters::CHAIN_HEALTH_BACKOFF_TRIGGERED,
     dag::anchor_election::CommitHistory,

--- a/consensus/src/dag/health/mod.rs
+++ b/consensus/src/dag/health/mod.rs
@@ -1,0 +1,7 @@
+mod backoff;
+mod chain_health;
+mod pipeline_health;
+
+pub use backoff::HealthBackoff;
+pub use chain_health::{NoChainHealth, TChainHealth, ChainHealthBackoff};
+pub use pipeline_health::{PipelineLatencyBasedBackpressure, NoPipelineBackpressure, TPipelineHealth};

--- a/consensus/src/dag/health/mod.rs
+++ b/consensus/src/dag/health/mod.rs
@@ -3,5 +3,7 @@ mod chain_health;
 mod pipeline_health;
 
 pub use backoff::HealthBackoff;
-pub use chain_health::{NoChainHealth, TChainHealth, ChainHealthBackoff};
-pub use pipeline_health::{PipelineLatencyBasedBackpressure, NoPipelineBackpressure, TPipelineHealth};
+pub use chain_health::{ChainHealthBackoff, NoChainHealth, TChainHealth};
+pub use pipeline_health::{
+    NoPipelineBackpressure, PipelineLatencyBasedBackpressure, TPipelineHealth,
+};

--- a/consensus/src/dag/health/mod.rs
+++ b/consensus/src/dag/health/mod.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 mod backoff;
 mod chain_health;
 mod pipeline_health;

--- a/consensus/src/dag/health/mod.rs
+++ b/consensus/src/dag/health/mod.rs
@@ -5,7 +5,9 @@ mod chain_health;
 mod pipeline_health;
 
 pub use backoff::HealthBackoff;
-pub use chain_health::{ChainHealthBackoff, NoChainHealth, TChainHealth};
-pub use pipeline_health::{
-    NoPipelineBackpressure, PipelineLatencyBasedBackpressure, TPipelineHealth,
-};
+#[cfg(test)]
+pub use chain_health::NoChainHealth;
+pub use chain_health::{ChainHealthBackoff, TChainHealth};
+#[cfg(test)]
+pub use pipeline_health::NoPipelineBackpressure;
+pub use pipeline_health::PipelineLatencyBasedBackpressure;

--- a/consensus/src/dag/health/pipeline_health.rs
+++ b/consensus/src/dag/health/pipeline_health.rs
@@ -1,0 +1,64 @@
+use crate::{
+    dag::adapter::OrderedNotifierAdapter, liveness::proposal_generator::PipelineBackpressureConfig,
+};
+use std::{sync::Arc, time::Duration};
+
+pub trait TPipelineHealth: Send + Sync {
+    fn get_backoff(&self) -> Option<Duration>;
+
+    fn get_payload_limits(&self) -> Option<(u64, u64)>;
+}
+
+pub struct NoPipelineBackpressure {}
+
+impl NoPipelineBackpressure {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+}
+
+impl TPipelineHealth for NoPipelineBackpressure {
+    fn get_backoff(&self) -> Option<Duration> {
+        None
+    }
+
+    fn get_payload_limits(&self) -> Option<(u64, u64)> {
+        None
+    }
+}
+
+pub struct PipelineLatencyBasedBackpressure {
+    pipeline_config: PipelineBackpressureConfig,
+    adapter: Arc<OrderedNotifierAdapter>,
+}
+
+impl PipelineLatencyBasedBackpressure {
+    pub(in crate::dag) fn new(
+        pipeline_config: PipelineBackpressureConfig,
+        adapter: Arc<OrderedNotifierAdapter>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            pipeline_config,
+            adapter,
+        })
+    }
+}
+
+impl TPipelineHealth for PipelineLatencyBasedBackpressure {
+    fn get_backoff(&self) -> Option<Duration> {
+        let latency = self.adapter.pipeline_pending_latency();
+        self.pipeline_config
+            .get_backoff(latency)
+            .map(|config| Duration::from_millis(config.backpressure_proposal_delay_ms))
+    }
+
+    fn get_payload_limits(&self) -> Option<(u64, u64)> {
+        let latency = self.adapter.pipeline_pending_latency();
+        self.pipeline_config.get_backoff(latency).map(|config| {
+            (
+                config.max_sending_block_txns_override,
+                config.max_sending_block_bytes_override,
+            )
+        })
+    }
+}

--- a/consensus/src/dag/health/pipeline_health.rs
+++ b/consensus/src/dag/health/pipeline_health.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 use crate::{
     dag::adapter::OrderedNotifierAdapter, liveness::proposal_generator::PipelineBackpressureConfig,
 };

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -13,6 +13,7 @@ mod dag_network;
 mod dag_state_sync;
 mod dag_store;
 mod errors;
+mod health;
 mod observability;
 mod order_rule;
 mod rb_handler;
@@ -21,7 +22,6 @@ mod storage;
 #[cfg(test)]
 mod tests;
 mod types;
-mod health;
 
 pub use adapter::{ProofNotifier, StorageAdapter};
 pub use bootstrap::DagBootstrapper;

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -21,6 +21,7 @@ mod storage;
 #[cfg(test)]
 mod tests;
 mod types;
+mod health;
 
 pub use adapter::{ProofNotifier, StorageAdapter};
 pub use bootstrap::DagBootstrapper;

--- a/consensus/src/dag/round_state.rs
+++ b/consensus/src/dag/round_state.rs
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::anchor_election::TChainHealthBackoff;
 use crate::dag::{
     observability::tracing::{observe_round, RoundStage},
     types::NodeCertificate,
@@ -35,6 +34,7 @@ impl RoundState {
         &mut self,
         highest_strong_links_round: Round,
         strong_links: Vec<NodeCertificate>,
+        minimum_delay: Duration,
     ) {
         match self.current_round.cmp(&highest_strong_links_round) {
             // we're behind, move forward immediately
@@ -44,7 +44,7 @@ impl RoundState {
             },
             Ordering::Equal => {
                 self.responsive_check
-                    .check_for_new_round(highest_strong_links_round, strong_links)
+                    .check_for_new_round(highest_strong_links_round, strong_links, minimum_delay)
                     .await
             },
             Ordering::Greater => (),
@@ -68,6 +68,7 @@ pub trait ResponsiveCheck: Send {
         &mut self,
         highest_strong_links_round: Round,
         strong_links: Vec<NodeCertificate>,
+        minimum_delay: Duration,
     );
 
     fn reset(&mut self);
@@ -90,6 +91,7 @@ impl ResponsiveCheck for OptimisticResponsive {
         &mut self,
         highest_strong_links_round: Round,
         _strong_links: Vec<NodeCertificate>,
+        minimum_delay: Duration,
     ) {
         let new_round = highest_strong_links_round + 1;
         let _ = self.event_sender.send(new_round).await;
@@ -114,7 +116,6 @@ pub struct AdaptiveResponsive {
     minimal_wait_time: Duration,
     event_sender: tokio::sync::mpsc::Sender<Round>,
     state: State,
-    chain_backoff: Arc<dyn TChainHealthBackoff>,
 }
 
 impl AdaptiveResponsive {
@@ -122,7 +123,6 @@ impl AdaptiveResponsive {
         event_sender: tokio::sync::mpsc::Sender<Round>,
         epoch_state: Arc<EpochState>,
         minimal_wait_time: Duration,
-        chain_backoff: Arc<dyn TChainHealthBackoff>,
     ) -> Self {
         Self {
             epoch_state,
@@ -130,7 +130,6 @@ impl AdaptiveResponsive {
             minimal_wait_time,
             event_sender,
             state: State::Initial,
-            chain_backoff,
         }
     }
 }
@@ -141,6 +140,7 @@ impl ResponsiveCheck for AdaptiveResponsive {
         &mut self,
         highest_strong_links_round: Round,
         strong_links: Vec<NodeCertificate>,
+        minimum_delay: Duration,
     ) {
         if matches!(self.state, State::Sent) {
             return;
@@ -156,13 +156,8 @@ impl ResponsiveCheck for AdaptiveResponsive {
             .sum_voting_power(strong_links.iter().map(|cert| cert.metadata().author()))
             .expect("Unable to sum voting power from strong links");
 
-        let (_, backoff_duration) = self.chain_backoff.get_round_backoff(new_round);
-        let wait_time = if let Some(duration) = backoff_duration {
-            duration.max(self.minimal_wait_time)
-        } else {
-            self.minimal_wait_time
-        };
-
+        let wait_time = self.minimal_wait_time.max(minimum_delay);
+        
         // voting power == 3f+1 or pass minimal wait time
         let duration_since_start = duration_since_epoch().saturating_sub(self.start_time);
         if voting_power == self.epoch_state.verifier.total_voting_power()

--- a/consensus/src/dag/round_state.rs
+++ b/consensus/src/dag/round_state.rs
@@ -91,7 +91,7 @@ impl ResponsiveCheck for OptimisticResponsive {
         &mut self,
         highest_strong_links_round: Round,
         _strong_links: Vec<NodeCertificate>,
-        minimum_delay: Duration,
+        _minimum_delay: Duration,
     ) {
         let new_round = highest_strong_links_round + 1;
         let _ = self.event_sender.send(new_round).await;

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -147,8 +147,8 @@ fn setup(
         dag.clone(),
         Arc::new(RoundRobinAnchorElection::new(validators)),
         Arc::new(TestNotifier { tx }),
-        storage.clone(),
         TEST_DAG_WINDOW as Round,
+        None
     );
 
     let fetch_requester = Arc::new(MockFetchRequester {});

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -148,7 +148,7 @@ fn setup(
         Arc::new(RoundRobinAnchorElection::new(validators)),
         Arc::new(TestNotifier { tx }),
         TEST_DAG_WINDOW as Round,
-        None
+        None,
     );
 
     let fetch_requester = Arc::new(MockFetchRequester {});

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -106,8 +106,8 @@ fn create_order_rule(
             dag,
             anchor_election,
             Arc::new(TestNotifier { tx }),
-            Arc::new(MockStorage::new()),
             TEST_DAG_WINDOW as Round,
+            None,
         ),
         rx,
     )

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -578,7 +578,11 @@ impl LeaderReputation {
     // Compute chain health metrics, and
     // - return participating voting power percentage for the window_for_chain_health
     // - update metric counters for different windows
-    fn compute_chain_health_and_add_metrics(&self, history: &[NewBlockEvent], round: Round) -> VotingPowerRatio {
+    fn compute_chain_health_and_add_metrics(
+        &self,
+        history: &[NewBlockEvent],
+        round: Round,
+    ) -> VotingPowerRatio {
         let candidates = self.epoch_to_proposers.get(&self.epoch).unwrap();
         // use f64 counter, as total voting power is u128
         let total_voting_power = self.voting_powers.iter().map(|v| *v as f64).sum();

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -374,9 +374,17 @@ pub struct ProposerAndVoterConfig {
     pub use_history_from_previous_epoch_max_count: u32,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorElectionMode {
+    RoundRobin,
+    LeaderReputation(LeaderReputationType),
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct DagConsensusConfigV1 {
     pub dag_ordering_causal_history_window: usize,
+    pub anchor_election_mode: AnchorElectionMode,
 }
 
 impl Default for DagConsensusConfigV1 {
@@ -384,6 +392,18 @@ impl Default for DagConsensusConfigV1 {
     fn default() -> Self {
         Self {
             dag_ordering_causal_history_window: 10,
+            anchor_election_mode: AnchorElectionMode::LeaderReputation(
+                LeaderReputationType::ProposerAndVoterV2(ProposerAndVoterConfig {
+                    active_weight: 1000,
+                    inactive_weight: 10,
+                    failed_weight: 1,
+                    failure_threshold_percent: 10,
+                    proposer_window_num_validators_multiplier: 10,
+                    voter_window_num_validators_multiplier: 1,
+                    weight_by_voting_power: true,
+                    use_history_from_previous_epoch_max_count: 5,
+                }),
+            ),
         }
     }
 }

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -38,8 +38,9 @@ pub use self::{
         Version, APTOS_MAX_KNOWN_VERSION, APTOS_VERSION_2, APTOS_VERSION_3, APTOS_VERSION_4,
     },
     consensus_config::{
-        ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1, LeaderReputationType,
-        OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType, ValidatorTxnConfig,
+        AnchorElectionMode, ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1,
+        LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType,
+        ValidatorTxnConfig,
     },
     execution_config::{
         BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig,


### PR DESCRIPTION
### Description

- Refactors Chain health backoff by decoupling it from LeaderReputationAdapter.
- Adds PipelineBackpressure mechanism
- Organizes both chain health and pipeline backpressure into a health module
- Adds on chain configs for leader reputation adapter.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

