### PR TITLE
TransactionGenerator Workflow 

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -620,6 +620,7 @@ impl TxnEmitter {
         };
         let (txn_generator_creator, _, _) = create_txn_generator_creator(
             &req.transaction_mix_per_phase,
+            root_account,
             &mut all_accounts,
             vec![],
             &txn_executor,

--- a/crates/transaction-generator-lib/src/account_generator.rs
+++ b/crates/transaction-generator-lib/src/account_generator.rs
@@ -1,22 +1,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::{create_account_transaction, TransactionGenerator, TransactionGeneratorCreator};
-use aptos_infallible::RwLock;
-use aptos_logger::{info, sample, sample::SampleRate};
+use crate::{
+    create_account_transaction, ObjectPool, TransactionGenerator, TransactionGeneratorCreator,
+};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
     transaction_builder::TransactionFactory,
     types::{transaction::SignedTransaction, LocalAccount},
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::{sync::Arc, time::Duration};
+use rand::{rngs::StdRng, SeedableRng};
+use std::sync::Arc;
 
 pub struct AccountGenerator {
     rng: StdRng,
     txn_factory: TransactionFactory,
-    addresses_pool: Arc<RwLock<Vec<AccountAddress>>>,
-    accounts_pool: Arc<RwLock<Vec<LocalAccount>>>,
-    add_created_accounts_to_pool: bool,
+    addresses_pool: Option<Arc<ObjectPool<AccountAddress>>>,
+    accounts_pool: Option<Arc<ObjectPool<LocalAccount>>>,
     max_working_set: usize,
     creation_balance: u64,
 }
@@ -25,9 +24,8 @@ impl AccountGenerator {
     pub fn new(
         rng: StdRng,
         txn_factory: TransactionFactory,
-        addresses_pool: Arc<RwLock<Vec<AccountAddress>>>,
-        accounts_pool: Arc<RwLock<Vec<LocalAccount>>>,
-        add_created_accounts_to_pool: bool,
+        addresses_pool: Option<Arc<ObjectPool<AccountAddress>>>,
+        accounts_pool: Option<Arc<ObjectPool<LocalAccount>>>,
         max_working_set: usize,
         creation_balance: u64,
     ) -> Self {
@@ -36,38 +34,9 @@ impl AccountGenerator {
             txn_factory,
             addresses_pool,
             accounts_pool,
-            add_created_accounts_to_pool,
             max_working_set,
             creation_balance,
         }
-    }
-}
-
-fn add_to_sized_pool<T>(
-    pool: &RwLock<Vec<T>>,
-    mut addition: Vec<T>,
-    max_working_set: usize,
-    rng: &mut StdRng,
-) {
-    let mut current = pool.write();
-    if current.len() < max_working_set {
-        current.append(&mut addition);
-        sample!(
-            SampleRate::Duration(Duration::from_secs(120)),
-            info!("Accounts working set increased to {}", current.len())
-        );
-    } else {
-        let start = rng.gen_range(0, current.len() - addition.len());
-        current[start..start + addition.len()].swap_with_slice(&mut addition);
-
-        sample!(
-            SampleRate::Duration(Duration::from_secs(120)),
-            info!(
-                "Already at limit {} > {}, so exchanged accounts in working set",
-                current.len(),
-                max_working_set
-            )
-        );
     }
 }
 
@@ -94,29 +63,25 @@ impl TransactionGenerator for AccountGenerator {
             new_account_addresses.push(receiver_address);
         }
 
-        if self.add_created_accounts_to_pool {
-            add_to_sized_pool(
-                self.accounts_pool.as_ref(),
-                new_accounts,
-                self.max_working_set,
-                &mut self.rng,
-            );
-            add_to_sized_pool(
-                self.addresses_pool.as_ref(),
+        if let Some(addresses_pool) = &self.addresses_pool {
+            addresses_pool.add_to_pool_bounded(
                 new_account_addresses,
                 self.max_working_set,
                 &mut self.rng,
             );
         }
+        if let Some(accounts_pool) = &self.accounts_pool {
+            accounts_pool.add_to_pool_bounded(new_accounts, self.max_working_set, &mut self.rng);
+        }
+
         requests
     }
 }
 
 pub struct AccountGeneratorCreator {
     txn_factory: TransactionFactory,
-    addresses_pool: Arc<RwLock<Vec<AccountAddress>>>,
-    accounts_pool: Arc<RwLock<Vec<LocalAccount>>>,
-    add_created_accounts_to_pool: bool,
+    addresses_pool: Option<Arc<ObjectPool<AccountAddress>>>,
+    accounts_pool: Option<Arc<ObjectPool<LocalAccount>>>,
     max_working_set: usize,
     creation_balance: u64,
 }
@@ -124,22 +89,15 @@ pub struct AccountGeneratorCreator {
 impl AccountGeneratorCreator {
     pub fn new(
         txn_factory: TransactionFactory,
-        addresses_pool: Arc<RwLock<Vec<AccountAddress>>>,
-        accounts_pool: Arc<RwLock<Vec<LocalAccount>>>,
-        add_created_accounts_to_pool: bool,
+        addresses_pool: Option<Arc<ObjectPool<AccountAddress>>>,
+        accounts_pool: Option<Arc<ObjectPool<LocalAccount>>>,
         max_working_set: usize,
         creation_balance: u64,
     ) -> Self {
-        if add_created_accounts_to_pool {
-            addresses_pool.write().reserve(max_working_set);
-            accounts_pool.write().reserve(max_working_set);
-        }
-
         Self {
             txn_factory,
             addresses_pool,
             accounts_pool,
-            add_created_accounts_to_pool,
             max_working_set,
             creation_balance,
         }
@@ -153,7 +111,6 @@ impl TransactionGeneratorCreator for AccountGeneratorCreator {
             self.txn_factory.clone(),
             self.addresses_pool.clone(),
             self.accounts_pool.clone(),
-            self.add_created_accounts_to_pool,
             self.max_working_set,
             self.creation_balance,
         ))

--- a/crates/transaction-generator-lib/src/batch_transfer.rs
+++ b/crates/transaction-generator-lib/src/batch_transfer.rs
@@ -1,13 +1,12 @@
 // Copyright © Aptos Foundation
 
-use crate::{TransactionGenerator, TransactionGeneratorCreator};
-use aptos_infallible::RwLock;
+use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{transaction::SignedTransaction, LocalAccount},
 };
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
 
 pub struct BatchTransferTransactionGenerator {
@@ -15,7 +14,7 @@ pub struct BatchTransferTransactionGenerator {
     batch_size: usize,
     send_amount: u64,
     txn_factory: TransactionFactory,
-    all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+    all_addresses: Arc<ObjectPool<AccountAddress>>,
 }
 
 impl BatchTransferTransactionGenerator {
@@ -24,7 +23,7 @@ impl BatchTransferTransactionGenerator {
         batch_size: usize,
         send_amount: u64,
         txn_factory: TransactionFactory,
-        all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+        all_addresses: Arc<ObjectPool<AccountAddress>>,
     ) -> Self {
         Self {
             rng,
@@ -46,10 +45,7 @@ impl TransactionGenerator for BatchTransferTransactionGenerator {
         for _ in 0..num_to_create {
             let receivers = self
                 .all_addresses
-                .read()
-                .choose_multiple(&mut self.rng, self.batch_size)
-                .cloned()
-                .collect::<Vec<_>>();
+                .clone_from_pool(self.batch_size, &mut self.rng);
             requests.push(
                 account.sign_with_transaction_builder(self.txn_factory.payload(
                     aptos_stdlib::aptos_account_batch_transfer(receivers, vec![
@@ -67,7 +63,7 @@ impl TransactionGenerator for BatchTransferTransactionGenerator {
 pub struct BatchTransferTransactionGeneratorCreator {
     txn_factory: TransactionFactory,
     amount: u64,
-    all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+    all_addresses: Arc<ObjectPool<AccountAddress>>,
     batch_size: usize,
 }
 
@@ -75,7 +71,7 @@ impl BatchTransferTransactionGeneratorCreator {
     pub fn new(
         txn_factory: TransactionFactory,
         amount: u64,
-        all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+        all_addresses: Arc<ObjectPool<AccountAddress>>,
         batch_size: usize,
     ) -> Self {
         Self {

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -23,7 +23,7 @@ pub type TransactionGeneratorWorker = dyn Fn(
         &LocalAccount,
         &TransactionFactory,
         &mut StdRng,
-    ) -> SignedTransaction
+    ) -> Option<SignedTransaction>
     + Send
     + Sync;
 
@@ -49,7 +49,7 @@ pub trait UserModuleTransactionGenerator: Sync + Send {
     /// (like creating and funding additional accounts), you can do so by using provided txn_executor
     async fn create_generator_fn(
         &self,
-        init_accounts: &mut [LocalAccount],
+        root_account: &mut LocalAccount,
         txn_factory: &TransactionFactory,
         txn_executor: &dyn ReliableTransactionSubmitter,
         rng: &mut StdRng,
@@ -96,7 +96,9 @@ impl TransactionGenerator for CustomModulesDelegationGenerator {
                 &self.txn_factory,
                 &mut self.rng,
             );
-            requests.push(request);
+            if let Some(request) = request {
+                requests.push(request);
+            }
         }
         requests
     }
@@ -109,43 +111,119 @@ pub struct CustomModulesDelegationGeneratorCreator {
 }
 
 impl CustomModulesDelegationGeneratorCreator {
+    #[allow(dead_code)]
+    pub fn new_raw(
+        txn_factory: TransactionFactory,
+        packages: Arc<Vec<(Package, LocalAccount)>>,
+        txn_generator: Arc<TransactionGeneratorWorker>,
+    ) -> Self {
+        Self {
+            txn_factory,
+            packages,
+            txn_generator,
+        }
+    }
+
     pub async fn new(
         txn_factory: TransactionFactory,
         init_txn_factory: TransactionFactory,
-        accounts: &mut [LocalAccount],
+        root_account: &mut LocalAccount,
         txn_executor: &dyn ReliableTransactionSubmitter,
         num_modules: usize,
         package_name: &str,
         workload: &mut dyn UserModuleTransactionGenerator,
     ) -> Self {
+        let mut packages = Self::publish_package(
+            init_txn_factory.clone(),
+            root_account,
+            txn_executor,
+            num_modules,
+            package_name,
+            None,
+        )
+        .await;
+        let worker = Self::create_worker(
+            init_txn_factory,
+            root_account,
+            txn_executor,
+            &mut packages,
+            workload,
+        )
+        .await;
+        Self {
+            txn_factory,
+            packages: Arc::new(packages),
+            txn_generator: worker,
+        }
+    }
+
+    pub async fn create_worker(
+        init_txn_factory: TransactionFactory,
+        root_account: &mut LocalAccount,
+        txn_executor: &dyn ReliableTransactionSubmitter,
+        packages: &mut Vec<(Package, LocalAccount)>,
+        workload: &mut dyn UserModuleTransactionGenerator,
+    ) -> Arc<TransactionGeneratorWorker> {
         let mut rng = StdRng::from_entropy();
-        assert!(accounts.len() >= num_modules);
-        let mut requests_create = Vec::with_capacity(accounts.len());
-        let mut requests_publish = Vec::with_capacity(accounts.len());
-        let mut requests_initialize = Vec::with_capacity(accounts.len());
+        let mut requests_initialize = Vec::with_capacity(packages.len());
+
+        for (package, publisher) in packages.iter_mut() {
+            requests_initialize.append(&mut workload.initialize_package(
+                package,
+                publisher,
+                &init_txn_factory,
+                &mut rng,
+            ));
+        }
+
+        if !requests_initialize.is_empty() {
+            info!(
+                "Initializing workload with {} transactions",
+                requests_initialize.len()
+            );
+            txn_executor
+                .execute_transactions(&requests_initialize)
+                .await
+                .unwrap();
+        }
+
+        info!("Done preparing workload for {} packages", packages.len());
+
+        workload
+            .create_generator_fn(root_account, &init_txn_factory, txn_executor, &mut rng)
+            .await
+    }
+
+    pub async fn publish_package(
+        init_txn_factory: TransactionFactory,
+        root_account: &mut LocalAccount,
+        txn_executor: &dyn ReliableTransactionSubmitter,
+        num_modules: usize,
+        package_name: &str,
+        publisher_balance: Option<u64>,
+    ) -> Vec<(Package, LocalAccount)> {
+        let mut rng = StdRng::from_entropy();
+        let mut requests_create = Vec::with_capacity(num_modules);
+        let mut requests_publish = Vec::with_capacity(num_modules);
         let mut package_handler = PackageHandler::new(package_name);
         let mut packages = Vec::new();
-        for account in accounts.iter_mut().take(num_modules) {
-            let mut publisher = LocalAccount::generate(&mut rng);
+        for _i in 0..num_modules {
+            let publisher = LocalAccount::generate(&mut rng);
             let publisher_address = publisher.address();
             requests_create.push(create_account_transaction(
-                account,
+                root_account,
                 publisher_address,
                 &init_txn_factory,
-                2 * init_txn_factory.get_gas_unit_price() * init_txn_factory.get_max_gas_amount(),
+                publisher_balance.unwrap_or(
+                    2 * init_txn_factory.get_gas_unit_price()
+                        * init_txn_factory.get_max_gas_amount(),
+                ),
             ));
 
             let package = package_handler.pick_package(&mut rng, publisher.address());
 
             requests_publish.push(publisher.sign_with_transaction_builder(
                 init_txn_factory.payload(package.publish_transaction_payload()),
-            ));
-
-            requests_initialize.append(&mut workload.initialize_package(
-                &package,
-                &mut publisher,
-                &init_txn_factory,
-                &mut rng,
             ));
 
             packages.push((package, publisher));
@@ -162,28 +240,9 @@ impl CustomModulesDelegationGeneratorCreator {
             .await
             .unwrap();
 
-        if !requests_initialize.is_empty() {
-            info!(
-                "Initializing workload with {} transactions",
-                requests_initialize.len()
-            );
-            txn_executor
-                .execute_transactions(&requests_initialize)
-                .await
-                .unwrap();
-        }
+        info!("Done publishing {} packages", packages.len());
 
-        info!("Done preparing workload for {} packages", packages.len());
-
-        let txn_generator = workload
-            .create_generator_fn(accounts, &init_txn_factory, txn_executor, &mut rng)
-            .await;
-
-        Self {
-            txn_factory,
-            packages: Arc::new(packages),
-            txn_generator,
-        }
+        packages
     }
 }
 

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -4,8 +4,8 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use aptos_infallible::RwLock;
-use aptos_logger::{sample, sample::SampleRate, warn};
+use aptos_infallible::{RwLock, RwLockWriteGuard};
+use aptos_logger::{info, sample, sample::SampleRate, warn};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
     transaction_builder::{aptos_stdlib, TransactionFactory},
@@ -13,6 +13,7 @@ use aptos_sdk::{
 };
 use args::TransactionTypeArg;
 use async_trait::async_trait;
+use rand::{rngs::StdRng, seq::SliceRandom, Rng};
 use std::{
     collections::HashMap,
     sync::{
@@ -32,6 +33,7 @@ mod p2p_transaction_generator;
 pub mod publish_modules;
 pub mod publishing;
 mod transaction_mix_generator;
+mod workflow_delegator;
 use self::{
     account_generator::AccountGeneratorCreator,
     call_custom_modules::CustomModulesDelegationGeneratorCreator,
@@ -43,6 +45,7 @@ use crate::{
     accounts_pool_wrapper::AccountsPoolWrapperCreator,
     batch_transfer::BatchTransferTransactionGeneratorCreator,
     entry_points::EntryPointTransactionGenerator, p2p_transaction_generator::SamplingMode,
+    workflow_delegator::WorkflowTxnGeneratorCreator,
 };
 pub use publishing::module_simple::EntryPoints;
 
@@ -74,6 +77,17 @@ pub enum TransactionType {
     BatchTransfer {
         batch_size: usize,
     },
+    Workflow {
+        workflow_kind: WorkflowKind,
+        num_modules: usize,
+        use_account_pool: bool,
+        move_stages_by_phase: bool,
+    },
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum WorkflowKind {
+    CreateThenMint { count: usize, creation_balance: u64 },
 }
 
 impl Default for TransactionType {
@@ -173,6 +187,7 @@ impl CounterState {
 
 pub async fn create_txn_generator_creator(
     transaction_mix_per_phase: &[Vec<(TransactionType, usize)>],
+    root_account: &mut LocalAccount,
     source_accounts: &mut [LocalAccount],
     initial_burner_accounts: Vec<LocalAccount>,
     txn_executor: &dyn ReliableTransactionSubmitter,
@@ -181,17 +196,17 @@ pub async fn create_txn_generator_creator(
     cur_phase: Arc<AtomicUsize>,
 ) -> (
     Box<dyn TransactionGeneratorCreator>,
-    Arc<RwLock<Vec<AccountAddress>>>,
-    Arc<RwLock<Vec<LocalAccount>>>,
+    Arc<ObjectPool<AccountAddress>>,
+    Arc<ObjectPool<LocalAccount>>,
 ) {
-    let addresses_pool = Arc::new(RwLock::new(
+    let addresses_pool = Arc::new(ObjectPool::new_initial(
         source_accounts
             .iter()
             .chain(initial_burner_accounts.iter())
             .map(|d| d.address())
-            .collect::<Vec<_>>(),
+            .collect(),
     ));
-    let accounts_pool = Arc::new(RwLock::new(initial_burner_accounts));
+    let accounts_pool = Arc::new(ObjectPool::new_initial(initial_burner_accounts));
 
     let mut txn_generator_creator_mix_per_phase: Vec<
         Vec<(Box<dyn TransactionGeneratorCreator>, usize)>,
@@ -200,10 +215,14 @@ pub async fn create_txn_generator_creator(
     fn wrap_accounts_pool(
         inner: Box<dyn TransactionGeneratorCreator>,
         use_account_pool: bool,
-        accounts_pool: Arc<RwLock<Vec<LocalAccount>>>,
+        accounts_pool: &Arc<ObjectPool<LocalAccount>>,
     ) -> Box<dyn TransactionGeneratorCreator> {
         if use_account_pool {
-            Box::new(AccountsPoolWrapperCreator::new(inner, accounts_pool))
+            Box::new(AccountsPoolWrapperCreator::new(
+                inner,
+                accounts_pool.clone(),
+                None,
+            ))
         } else {
             inner
         }
@@ -224,10 +243,10 @@ pub async fn create_txn_generator_creator(
                         SEND_AMOUNT,
                         addresses_pool.clone(),
                         *invalid_transaction_ratio,
-                        SamplingMode::BurnAndRecycle(addresses_pool.read().len() / 2),
+                        SamplingMode::BurnAndRecycle(addresses_pool.len() / 2),
                     )),
                     *sender_use_account_pool,
-                    accounts_pool.clone(),
+                    &accounts_pool,
                 ),
                 TransactionType::CoinTransfer {
                     invalid_transaction_ratio,
@@ -241,7 +260,7 @@ pub async fn create_txn_generator_creator(
                         SamplingMode::Basic,
                     )),
                     *sender_use_account_pool,
-                    accounts_pool.clone(),
+                    &accounts_pool,
                 ),
                 TransactionType::AccountGeneration {
                     add_created_accounts_to_pool,
@@ -249,16 +268,21 @@ pub async fn create_txn_generator_creator(
                     creation_balance,
                 } => Box::new(AccountGeneratorCreator::new(
                     txn_factory.clone(),
-                    addresses_pool.clone(),
-                    accounts_pool.clone(),
-                    *add_created_accounts_to_pool,
+                    add_created_accounts_to_pool.then(|| {
+                        addresses_pool.reserve(*max_account_working_set);
+                        addresses_pool.clone()
+                    }),
+                    add_created_accounts_to_pool.then(|| {
+                        addresses_pool.reserve(*max_account_working_set);
+                        accounts_pool.clone()
+                    }),
                     *max_account_working_set,
                     *creation_balance,
                 )),
                 TransactionType::PublishPackage { use_account_pool } => wrap_accounts_pool(
                     Box::new(PublishPackageCreator::new(txn_factory.clone())),
                     *use_account_pool,
-                    accounts_pool.clone(),
+                    &accounts_pool,
                 ),
                 TransactionType::CallCustomModules {
                     entry_point,
@@ -269,7 +293,7 @@ pub async fn create_txn_generator_creator(
                         CustomModulesDelegationGeneratorCreator::new(
                             txn_factory.clone(),
                             init_txn_factory.clone(),
-                            source_accounts,
+                            root_account,
                             txn_executor,
                             *num_modules,
                             entry_point.package_name(),
@@ -280,7 +304,7 @@ pub async fn create_txn_generator_creator(
                         .await,
                     ),
                     *use_account_pool,
-                    accounts_pool.clone(),
+                    &accounts_pool,
                 ),
                 TransactionType::BatchTransfer { batch_size } => {
                     Box::new(BatchTransferTransactionGeneratorCreator::new(
@@ -290,6 +314,24 @@ pub async fn create_txn_generator_creator(
                         *batch_size,
                     ))
                 },
+                TransactionType::Workflow {
+                    num_modules,
+                    use_account_pool,
+                    workflow_kind,
+                    move_stages_by_phase,
+                } => Box::new(
+                    WorkflowTxnGeneratorCreator::create_workload(
+                        *workflow_kind,
+                        txn_factory.clone(),
+                        init_txn_factory.clone(),
+                        root_account,
+                        txn_executor,
+                        *num_modules,
+                        use_account_pool.then(|| accounts_pool.clone()),
+                        move_stages_by_phase.then(|| cur_phase.clone()),
+                    )
+                    .await,
+                ),
             };
             txn_generator_creator_mix.push((txn_generator_creator, *weight));
         }
@@ -306,22 +348,121 @@ pub async fn create_txn_generator_creator(
     )
 }
 
-fn get_account_to_burn_from_pool(
-    accounts_pool: &Arc<RwLock<Vec<LocalAccount>>>,
-    needed: usize,
-) -> Vec<LocalAccount> {
-    let mut accounts_pool = accounts_pool.write();
-    let num_in_pool = accounts_pool.len();
-    if num_in_pool < needed {
-        sample!(
-            SampleRate::Duration(Duration::from_secs(10)),
-            warn!("Cannot fetch enough accounts from pool, left in pool {}, needed {}", num_in_pool, needed);
-        );
-        return Vec::new();
+/// Simple object pool structure, that you can add and remove from multiple threads.
+/// Taking is done at random positions, but sequentially.
+/// Overflow replaces at random positions as well.
+///
+/// It's efficient to lock the objects for short time - and replace
+/// in place, but its not a concurrent datastructure.
+pub struct ObjectPool<T> {
+    pool: RwLock<Vec<T>>,
+}
+
+impl<T> ObjectPool<T> {
+    pub(crate) fn new_initial(initial: Vec<T>) -> Self {
+        Self {
+            pool: RwLock::new(initial),
+        }
     }
-    accounts_pool
-        .drain((num_in_pool - needed)..)
-        .collect::<Vec<_>>()
+
+    pub(crate) fn new() -> Self {
+        Self::new_initial(Vec::new())
+    }
+
+    pub(crate) fn reserve(&self, additional: usize) {
+        self.pool.write().reserve(additional);
+    }
+
+    pub(crate) fn add_to_pool(&self, mut addition: Vec<T>) {
+        assert!(!addition.is_empty());
+        let mut current = self.pool.write();
+        current.append(&mut addition);
+        sample!(
+            SampleRate::Duration(Duration::from_secs(120)),
+            info!("Pool working set increased to {}", current.len())
+        );
+    }
+
+    pub(crate) fn add_to_pool_bounded(
+        &self,
+        mut addition: Vec<T>,
+        max_size: usize,
+        rng: &mut StdRng,
+    ) {
+        assert!(!addition.is_empty());
+        let mut current = self.pool.write();
+        if current.len() < max_size {
+            if current.len() + addition.len() > max_size {
+                addition.truncate(max_size - current.len());
+            }
+            current.append(&mut addition);
+            sample!(
+                SampleRate::Duration(Duration::from_secs(120)),
+                info!("Pool working set increased to {}", current.len())
+            );
+        } else {
+            let start = rng.gen_range(0, current.len() - addition.len());
+            current[start..start + addition.len()].swap_with_slice(&mut addition);
+
+            sample!(
+                SampleRate::Duration(Duration::from_secs(120)),
+                info!(
+                    "Already at limit {} > {}, so exchanged objects in working set",
+                    current.len(),
+                    max_size
+                )
+            );
+        }
+    }
+
+    pub(crate) fn take_from_pool(
+        &self,
+        needed: usize,
+        return_partial: bool,
+        rng: &mut StdRng,
+    ) -> Vec<T> {
+        let mut current = self.pool.write();
+        let num_in_pool = current.len();
+        if !return_partial && num_in_pool < needed {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(10)),
+                warn!("Cannot fetch enough from shared pool, left in pool {}, needed {}", num_in_pool, needed);
+            );
+            return Vec::new();
+        }
+        let num_to_return = std::cmp::min(num_in_pool, needed);
+        let mut result = current
+            .drain((num_in_pool - num_to_return)..)
+            .collect::<Vec<_>>();
+
+        if current.len() > num_to_return {
+            let start = rng.gen_range(0, current.len() - num_to_return);
+            current[start..start + num_to_return].swap_with_slice(&mut result);
+        }
+        result
+    }
+
+    pub(crate) fn shuffle(&self, rng: &mut StdRng) {
+        self.pool.write().shuffle(rng);
+    }
+
+    pub(crate) fn write_view(&self) -> RwLockWriteGuard<'_, Vec<T>> {
+        self.pool.write()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.pool.read().len()
+    }
+}
+
+impl<T: Clone> ObjectPool<T> {
+    pub(crate) fn clone_from_pool(&self, num_to_copy: usize, rng: &mut StdRng) -> Vec<T> {
+        self.pool
+            .read()
+            .choose_multiple(rng, num_to_copy)
+            .cloned()
+            .collect::<Vec<_>>()
+    }
 }
 
 pub fn create_account_transaction(

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -390,6 +390,8 @@ impl<T> ObjectPool<T> {
         rng: &mut StdRng,
     ) {
         assert!(!addition.is_empty());
+        assert!(addition.len() <= max_size);
+
         let mut current = self.pool.write();
         if current.len() < max_size {
             if current.len() + addition.len() > max_size {
@@ -401,6 +403,7 @@ impl<T> ObjectPool<T> {
                 info!("Pool working set increased to {}", current.len())
             );
         } else {
+            // no underflow as: addition.len() <= max_size < current.len()
             let start = rng.gen_range(0, current.len() - addition.len());
             current[start..start + addition.len()].swap_with_slice(&mut addition);
 

--- a/crates/transaction-generator-lib/src/p2p_transaction_generator.rs
+++ b/crates/transaction-generator-lib/src/p2p_transaction_generator.rs
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::{TransactionGenerator, TransactionGeneratorCreator};
-use aptos_infallible::RwLock;
+use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
     transaction_builder::{aptos_stdlib, TransactionFactory},
@@ -147,21 +146,20 @@ pub struct P2PTransactionGenerator {
     rng: StdRng,
     send_amount: u64,
     txn_factory: TransactionFactory,
-    all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+    all_addresses: Arc<ObjectPool<AccountAddress>>,
     sampler: Box<dyn Sampler<AccountAddress>>,
     invalid_transaction_ratio: usize,
 }
 
 impl P2PTransactionGenerator {
     pub fn new(
-        mut rng: StdRng,
+        rng: StdRng,
         send_amount: u64,
         txn_factory: TransactionFactory,
-        all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+        all_addresses: Arc<ObjectPool<AccountAddress>>,
         invalid_transaction_ratio: usize,
         sampler: Box<dyn Sampler<AccountAddress>>,
     ) -> Self {
-        all_addresses.write().shuffle(&mut rng);
         Self {
             rng,
             send_amount,
@@ -264,7 +262,7 @@ impl TransactionGenerator for P2PTransactionGenerator {
         let mut num_valid_tx = num_to_create * (1 - invalid_size);
 
         let receivers: Vec<AccountAddress> = {
-            let mut all_addrs = self.all_addresses.write();
+            let mut all_addrs = self.all_addresses.write_view();
             self.sampler
                 .sample_from_pool(&mut self.rng, all_addrs.as_mut(), num_to_create)
         };
@@ -297,7 +295,7 @@ impl TransactionGenerator for P2PTransactionGenerator {
 pub struct P2PTransactionGeneratorCreator {
     txn_factory: TransactionFactory,
     amount: u64,
-    all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+    all_addresses: Arc<ObjectPool<AccountAddress>>,
     invalid_transaction_ratio: usize,
     sampling_mode: SamplingMode,
 }
@@ -306,10 +304,13 @@ impl P2PTransactionGeneratorCreator {
     pub fn new(
         txn_factory: TransactionFactory,
         amount: u64,
-        all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
+        all_addresses: Arc<ObjectPool<AccountAddress>>,
         invalid_transaction_ratio: usize,
         sampling_mode: SamplingMode,
     ) -> Self {
+        let mut rng = StdRng::from_entropy();
+        all_addresses.shuffle(&mut rng);
+
         Self {
             txn_factory,
             amount,

--- a/crates/transaction-generator-lib/src/workflow_delegator.rs
+++ b/crates/transaction-generator-lib/src/workflow_delegator.rs
@@ -1,0 +1,257 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_generator::AccountGeneratorCreator, accounts_pool_wrapper::AccountsPoolWrapperCreator,
+    call_custom_modules::CustomModulesDelegationGeneratorCreator,
+    entry_points::EntryPointTransactionGenerator, EntryPoints, ObjectPool,
+    ReliableTransactionSubmitter, TransactionGenerator, TransactionGeneratorCreator, WorkflowKind,
+};
+use aptos_logger::{info, sample, sample::SampleRate};
+use aptos_sdk::{
+    transaction_builder::TransactionFactory,
+    types::{transaction::SignedTransaction, LocalAccount},
+};
+use std::{
+    cmp,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+#[derive(Clone)]
+enum StageTracking {
+    // stage is externally modified
+    ExternallySet(Arc<AtomicUsize>),
+    // we move to a next stage when all accounts have finished with the current stage
+    WhenDone(Arc<AtomicUsize>),
+}
+
+impl StageTracking {
+    fn load_current_stage(&self) -> usize {
+        match self {
+            StageTracking::ExternallySet(stage) | StageTracking::WhenDone(stage) => {
+                stage.load(Ordering::Relaxed)
+            },
+        }
+    }
+}
+
+/// Generator allowing for multi-stage workflows.
+/// List of generators are passed:
+/// gen_0, gen_1, ... gen_n
+/// and on list of account pools, each representing accounts in between two stages:
+/// pool_0, pool_1, ... pool_n-1
+///
+/// pool_i is filled by gen_i, and consumed by gen_i+1, and so there is one less pools than generators.
+///
+/// We start with stage 0, which calls gen_0 pool_per_stage times, which populates pool_0 with accounts.
+///
+/// After that, in stage 1, we call gen_1, which consumes accounts from pool_0, and moves them to pool_1.
+/// We do this until pool_0 is empty.
+///
+/// We proceed, until in the last stage - stage n - calls gen_n, which consumes accounts from pool_n-1.
+///
+/// There are two modes on when to move to the next stage:
+/// - WhenDone means as soon as pool_i is empty, we move to stage i+1
+/// - ExternallySet means we wait for external signal to move to next stage, and we stop creating transactions
+///   until we receive it (or will move early if pool hasn't been consumed yet)
+///
+/// Use WorkflowTxnGeneratorCreator::create_workload to create this generator.
+struct WorkflowTxnGenerator {
+    stage: StageTracking,
+    generators: Vec<Box<dyn TransactionGenerator>>,
+    pool_per_stage: Vec<Arc<ObjectPool<LocalAccount>>>,
+    num_for_first_stage: usize,
+    // Internal counter, so multiple workers (WorkflowTxnGenerator) can coordinate how many times to execute the first stage
+    completed_for_first_stage: Arc<AtomicUsize>,
+}
+
+impl WorkflowTxnGenerator {
+    fn new(
+        stage: StageTracking,
+        generators: Vec<Box<dyn TransactionGenerator>>,
+        pool_per_stage: Vec<Arc<ObjectPool<LocalAccount>>>,
+        num_for_first_stage: usize,
+        completed_for_first_stage: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            stage,
+            generators,
+            pool_per_stage,
+            num_for_first_stage,
+            completed_for_first_stage,
+        }
+    }
+}
+
+impl TransactionGenerator for WorkflowTxnGenerator {
+    fn generate_transactions(
+        &mut self,
+        account: &LocalAccount,
+        mut num_to_create: usize,
+    ) -> Vec<SignedTransaction> {
+        assert_ne!(num_to_create, 0);
+        let mut stage = self.stage.load_current_stage();
+
+        match &self.stage {
+            StageTracking::WhenDone(stage_counter) => {
+                if stage == 0 {
+                    let prev = self
+                        .completed_for_first_stage
+                        .fetch_add(num_to_create, Ordering::Relaxed);
+                    num_to_create =
+                        cmp::min(num_to_create, self.num_for_first_stage.saturating_sub(prev));
+
+                    if num_to_create == 0 {
+                        info!("TransactionGenerator Workflow: Stage 0 is full with {} accounts, moving to stage 1", self.pool_per_stage.get(0).unwrap().len());
+                        let _ = stage_counter.compare_exchange(
+                            0,
+                            1,
+                            Ordering::Relaxed,
+                            Ordering::Relaxed,
+                        );
+                        stage = 1;
+                    }
+                } else if stage < self.pool_per_stage.len()
+                    && self.pool_per_stage.get(stage - 1).unwrap().len() == 0
+                {
+                    info!("TransactionGenerator Workflow: Stage {} has consumed all accounts, moving to stage {}", stage, stage + 1);
+                    let _ = stage_counter.compare_exchange(
+                        stage,
+                        stage + 1,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    );
+                    stage += 1;
+                }
+            },
+            StageTracking::ExternallySet(_) => {
+                if stage == 0 {
+                    let prev = self
+                        .completed_for_first_stage
+                        .fetch_add(num_to_create, Ordering::Relaxed);
+                    num_to_create =
+                        cmp::min(num_to_create, self.num_for_first_stage.saturating_sub(prev));
+
+                    if num_to_create == 0 {
+                        return Vec::new();
+                    }
+                }
+            },
+        }
+
+        sample!(
+            SampleRate::Duration(Duration::from_secs(2)),
+            info!("Cur stage: {}, pool sizes: {:?}", stage, self.pool_per_stage.iter().map(|p| p.len()).collect::<Vec<_>>());
+        );
+
+        let result = if let Some(generator) = self.generators.get_mut(stage) {
+            generator.generate_transactions(account, num_to_create)
+        } else {
+            Vec::new()
+        };
+
+        result
+    }
+}
+
+pub struct WorkflowTxnGeneratorCreator {
+    stage: StageTracking,
+    creators: Vec<Box<dyn TransactionGeneratorCreator>>,
+    pool_per_stage: Vec<Arc<ObjectPool<LocalAccount>>>,
+    num_for_first_stage: usize,
+    completed_for_first_stage: Arc<AtomicUsize>,
+}
+
+impl WorkflowTxnGeneratorCreator {
+    fn new(
+        stage: StageTracking,
+        creators: Vec<Box<dyn TransactionGeneratorCreator>>,
+        pool_per_stage: Vec<Arc<ObjectPool<LocalAccount>>>,
+        num_for_first_stage: usize,
+    ) -> Self {
+        Self {
+            stage,
+            creators,
+            pool_per_stage,
+            num_for_first_stage,
+            completed_for_first_stage: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub async fn create_workload(
+        workflow_kind: WorkflowKind,
+        txn_factory: TransactionFactory,
+        init_txn_factory: TransactionFactory,
+        root_account: &mut LocalAccount,
+        txn_executor: &dyn ReliableTransactionSubmitter,
+        num_modules: usize,
+        _initial_account_pool: Option<Arc<ObjectPool<LocalAccount>>>,
+        cur_phase: Option<Arc<AtomicUsize>>,
+    ) -> Self {
+        let stage_tracking = cur_phase.map_or_else(
+            || StageTracking::WhenDone(Arc::new(AtomicUsize::new(0))),
+            StageTracking::ExternallySet,
+        );
+        match workflow_kind {
+            WorkflowKind::CreateThenMint {
+                count,
+                creation_balance,
+            } => {
+                let created_pool = Arc::new(ObjectPool::new());
+                let minted_pool = Arc::new(ObjectPool::new());
+                let entry_point = EntryPoints::TokenV2AmbassadorMint;
+
+                let creators: Vec<Box<dyn TransactionGeneratorCreator>> = vec![
+                    Box::new(AccountGeneratorCreator::new(
+                        txn_factory.clone(),
+                        None,
+                        Some(created_pool.clone()),
+                        count,
+                        creation_balance,
+                    )),
+                    Box::new(AccountsPoolWrapperCreator::new(
+                        Box::new(
+                            CustomModulesDelegationGeneratorCreator::new(
+                                txn_factory.clone(),
+                                init_txn_factory.clone(),
+                                root_account,
+                                txn_executor,
+                                num_modules,
+                                entry_point.package_name(),
+                                &mut EntryPointTransactionGenerator { entry_point },
+                            )
+                            .await,
+                        ),
+                        created_pool.clone(),
+                        Some(minted_pool.clone()),
+                    )),
+                ];
+                Self::new(
+                    stage_tracking,
+                    creators,
+                    vec![created_pool, minted_pool],
+                    count,
+                )
+            },
+        }
+    }
+}
+
+impl TransactionGeneratorCreator for WorkflowTxnGeneratorCreator {
+    fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+        Box::new(WorkflowTxnGenerator::new(
+            self.stage.clone(),
+            self.creators
+                .iter()
+                .map(|c| c.create_transaction_generator())
+                .collect(),
+            self.pool_per_stage.clone(),
+            self.num_for_first_stage,
+            self.completed_for_first_stage.clone(),
+        ))
+    }
+}

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -313,6 +313,9 @@ enum Command {
         #[clap(long, default_value_t = 1)]
         module_working_set_size: usize,
 
+        #[clap(long)]
+        use_sender_account_pool: bool,
+
         #[clap(long, value_parser)]
         data_dir: PathBuf,
 
@@ -362,6 +365,7 @@ where
             transaction_type,
             transaction_weights,
             module_working_set_size,
+            use_sender_account_pool,
             data_dir,
             checkpoint_dir,
         } => {
@@ -373,7 +377,7 @@ where
                     &transaction_weights,
                     &[],
                     module_working_set_size,
-                    false,
+                    use_sender_account_pool,
                 );
                 assert!(mix_per_phase.len() == 1);
                 Some(mix_per_phase[0].clone())


### PR DESCRIPTION
More sophisticated smart contracts require moving users through a set of states, i.e. registering, joining, playing, collecting winnings.

These changes enable that:
- split out the publishing from creating generator - as we want to publish a single module, and use it for multiple transactions
- create a workflow based on pools, so that you can go to next transaction after all users have move to that stage.


### Test Plan

Usage shown in https://github.com/aptos-labs/aptos-core/pull/11384
