### PR TITLE
[Compiler-v2] Fix 11337

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
@@ -1,37 +1,13 @@
-// ---- Model Dump
-module 0x8675309::M {
-    struct G {
-        f: #0,
-    }
-    struct R {
-        f: u64,
-    }
-    struct S {
-        u: u64,
-    }
-    private fun t0(r: &M::R,r_mut: &mut M::R,s: M::S,s_ref: &M::S,s_mut: &mut M::S) {
-        Eq<u64>(0, 1);
-        Eq<u8>(0, 1);
-        Eq<u8>(0, 1);
-        Eq<u128>(0, 1);
-        Eq<u128>(0, 1);
-        Eq<u64>(Borrow(Immutable)(0), Borrow(Immutable)(1));
-        Eq<bool>(true, false);
-        Eq<u64>(0, 1);
-        Eq<M::S>(Borrow(Immutable)(s), s_ref);
-        Eq<M::S>(Borrow(Mutable)(s), s_ref);
-        Eq<M::S>(Borrow(Mutable)(s), s_mut);
-        Eq<M::S>(Borrow(Immutable)(s), s_mut);
-        Eq<M::S>(s_ref, s_mut);
-        Eq<M::S>(s_mut, s_mut);
-        Eq<M::S>(pack M::S(0), s);
-        Eq<M::R>(r, r);
-        Eq<M::R>(r_mut, r_mut);
-        Eq<M::R>(r, r_mut);
-        Eq<M::R>(r_mut, r);
-        Eq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(1));
-        Eq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(1));
-        Tuple()
-    }
-    spec fun $t0(r: &M::R,r_mut: &mut M::R,s: M::S,s_ref: &M::S,s_mut: &mut M::S);
-} // end 0x8675309::M
+
+Diagnostics:
+error: invalid call of `==`: mutability mismatch (&mut != &) for argument 2
+   ┌─ tests/checking/typing/eq.move:18:20
+   │
+18 │         (&mut s == s_ref: bool);
+   │                    ^^^^^
+
+error: invalid call of `==`: mutability mismatch (&mut != &) for argument 2
+   ┌─ tests/checking/typing/eq.move:27:19
+   │
+27 │         (r_mut == r: bool);
+   │                   ^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.exp
@@ -1,0 +1,14 @@
+// ---- Model Dump
+module 0x42::m {
+    private fun g() {
+        {
+          let ();
+          Tuple()
+        };
+        Tuple()
+    }
+    spec fun $foo(f: |&u64|()) {
+        Tuple()
+    }
+    spec fun $g();
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+
+    inline fun foo(f: |&u64|) {
+    }
+
+    fun g() {
+        foo(|v| {
+            v == &1;
+        });
+    }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
@@ -12,6 +12,30 @@ error: invalid call of `==`: expected `integer` but found `bool` for argument 2
 14 │         0 == false;
    │              ^^^^^
 
+error: invalid call of `==`: expected `&integer` but found `integer` for argument 2
+   ┌─ tests/checking/typing/eq_invalid.move:15:15
+   │
+15 │         &0 == 1;
+   │               ^
+
+error: invalid call of `==`: expected `integer` but found `&integer` for argument 2
+   ┌─ tests/checking/typing/eq_invalid.move:16:14
+   │
+16 │         1 == &0;
+   │              ^^
+
+error: invalid call of `==`: expected `M::S` but found `&M::S` for argument 2
+   ┌─ tests/checking/typing/eq_invalid.move:17:14
+   │
+17 │         s == s_ref;
+   │              ^^^^^
+
+error: invalid call of `==`: expected `&mut M::S` but found `M::S` for argument 2
+   ┌─ tests/checking/typing/eq_invalid.move:18:18
+   │
+18 │         s_mut == s;
+   │                  ^
+
 error: unable to infer type: `M::G2<?8>`
    ┌─ tests/checking/typing/eq_invalid.move:28:9
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutable_eq_and_neq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutable_eq_and_neq.exp
@@ -12,33 +12,33 @@ module 0x8675309::M {
         g: u64,
     }
     private fun t(r1: &mut u64,r2: &mut u64,s: &mut M::S) {
-        Eq<u64>(r1, r1);
-        Eq<u64>(r1, r2);
-        Eq<u64>(r2, r2);
-        Eq<u64>(r2, r2);
-        Neq<u64>(r1, r1);
-        Neq<u64>(r1, r2);
-        Neq<u64>(r2, r2);
-        Neq<u64>(r2, r2);
-        Eq<u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.f(s)));
-        Eq<u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.g(s)));
-        Eq<u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.f(s)));
-        Eq<u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.g(s)));
-        Neq<u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.f(s)));
-        Neq<u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.g(s)));
-        Neq<u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.f(s)));
-        Neq<u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.g(s)));
+        Eq<&mut u64>(r1, r1);
+        Eq<&mut u64>(r1, r2);
+        Eq<&mut u64>(r2, r2);
+        Eq<&mut u64>(r2, r2);
+        Neq<&mut u64>(r1, r1);
+        Neq<&mut u64>(r1, r2);
+        Neq<&mut u64>(r2, r2);
+        Neq<&mut u64>(r2, r2);
+        Eq<&mut u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.f(s)));
+        Eq<&mut u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.g(s)));
+        Eq<&mut u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.f(s)));
+        Eq<&mut u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.g(s)));
+        Neq<&mut u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.f(s)));
+        Neq<&mut u64>(Borrow(Mutable)(select M::S.f(s)), Borrow(Mutable)(select M::S.g(s)));
+        Neq<&mut u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.f(s)));
+        Neq<&mut u64>(Borrow(Mutable)(select M::S.g(s)), Borrow(Mutable)(select M::S.g(s)));
         Tuple()
     }
     private fun t1(p: &mut M::P) {
         {
-          let comp: bool = Eq<M::B>(Borrow(Mutable)(select M::P.b1(p)), Borrow(Mutable)(select M::P.b2(p)));
+          let comp: bool = Eq<&mut M::B>(Borrow(Mutable)(select M::P.b1(p)), Borrow(Mutable)(select M::P.b2(p)));
           select M::B.f(select M::P.b1(p)) = comp
         }
     }
     private fun t2(p: &mut M::P) {
         {
-          let comp: bool = Neq<M::B>(Borrow(Mutable)(select M::P.b1(p)), Borrow(Mutable)(select M::P.b2(p)));
+          let comp: bool = Neq<&mut M::B>(Borrow(Mutable)(select M::P.b1(p)), Borrow(Mutable)(select M::P.b2(p)));
           select M::B.f(select M::P.b1(p)) = comp
         }
     }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
@@ -1,37 +1,13 @@
-// ---- Model Dump
-module 0x8675309::M {
-    struct G {
-        f: #0,
-    }
-    struct R {
-        f: u64,
-    }
-    struct S {
-        u: u64,
-    }
-    private fun t0(r: &M::R,r_mut: &mut M::R,s: M::S,s_ref: &M::S,s_mut: &mut M::S) {
-        Neq<u64>(0, 1);
-        Neq<u8>(0, 1);
-        Neq<u8>(0, 1);
-        Neq<u128>(0, 1);
-        Neq<u128>(0, 1);
-        Neq<u64>(Borrow(Immutable)(0), Borrow(Immutable)(1));
-        Neq<bool>(true, false);
-        Neq<u64>(0, 1);
-        Neq<M::S>(Borrow(Immutable)(s), s_ref);
-        Neq<M::S>(Borrow(Mutable)(s), s_ref);
-        Neq<M::S>(Borrow(Mutable)(s), s_mut);
-        Neq<M::S>(Borrow(Immutable)(s), s_mut);
-        Neq<M::S>(s_ref, s_mut);
-        Neq<M::S>(s_mut, s_mut);
-        Neq<M::S>(pack M::S(0), s);
-        Neq<M::R>(r, r);
-        Neq<M::R>(r_mut, r_mut);
-        Neq<M::R>(r, r_mut);
-        Neq<M::R>(r_mut, r);
-        Neq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(2));
-        Neq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(2));
-        Tuple()
-    }
-    spec fun $t0(r: &M::R,r_mut: &mut M::R,s: M::S,s_ref: &M::S,s_mut: &mut M::S);
-} // end 0x8675309::M
+
+Diagnostics:
+error: invalid call of `!=`: mutability mismatch (&mut != &) for argument 2
+   ┌─ tests/checking/typing/neq.move:18:20
+   │
+18 │         (&mut s != s_ref: bool);
+   │                    ^^^^^
+
+error: invalid call of `!=`: mutability mismatch (&mut != &) for argument 2
+   ┌─ tests/checking/typing/neq.move:27:19
+   │
+27 │         (r_mut != r: bool);
+   │                   ^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
@@ -12,6 +12,30 @@ error: invalid call of `!=`: expected `integer` but found `bool` for argument 2
 14 │         0 != false;
    │              ^^^^^
 
+error: invalid call of `!=`: expected `&integer` but found `integer` for argument 2
+   ┌─ tests/checking/typing/neq_invalid.move:15:15
+   │
+15 │         &0 != 1;
+   │               ^
+
+error: invalid call of `!=`: expected `integer` but found `&integer` for argument 2
+   ┌─ tests/checking/typing/neq_invalid.move:16:14
+   │
+16 │         1 != &0;
+   │              ^^
+
+error: invalid call of `!=`: expected `M::S` but found `&M::S` for argument 2
+   ┌─ tests/checking/typing/neq_invalid.move:17:14
+   │
+17 │         s != s_ref;
+   │              ^^^^^
+
+error: invalid call of `!=`: expected `&mut M::S` but found `M::S` for argument 2
+   ┌─ tests/checking/typing/neq_invalid.move:18:18
+   │
+18 │         s_mut != s;
+   │                  ^
+
 error: unable to infer type: `M::G0<?4>`
    ┌─ tests/checking/typing/neq_invalid.move:26:9
    │

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2599,8 +2599,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             }
             let mut success = true;
             for (i, arg_ty) in arg_types.iter().enumerate() {
-                let arg_ty = if cand.get_operation().allows_ref_param_for_value() {
-                    // Drop reference type if there is any.
+                let arg_ty = if cand.get_operation().allows_ref_param_for_value()
+                    && self.mode != ExpTranslationMode::Impl
+                {
+                    // Drop reference when translating specifications for eq/neq operation.
                     if let Type::Reference(_, target_ty) = arg_ty {
                         target_ty.as_ref().clone()
                     } else {


### PR DESCRIPTION
### Description

Close #11337 by dropping reference only when building a model for specifications. 

Note that the current solution will bring a new issue when handling equality on variance. I will file an issue once this is landed.

### Test plan

A new test `third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.move` is added to validate the fix.
