### PR TITLE
[Rust] Upgrade to Rust version 1.74.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.72.1"
+rust-version = "1.74.1"
 
 [workspace.dependencies]
 # Internal crate dependencies.

--- a/aptos-move/aptos-gas-calibration/src/measurements_helpers.rs
+++ b/aptos-move/aptos-gas-calibration/src/measurements_helpers.rs
@@ -16,7 +16,7 @@ use move_core_types::{
 };
 use std::{fs::ReadDir, path::PathBuf, string::String, time::Instant};
 
-//// CONSTANTS
+// CONSTANTS
 const PREFIX: &str = "calibrate_";
 
 /// Generate a TransactionPayload for modules

--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -101,7 +101,7 @@ impl<'a, 'b, 'c, 'd> SafeNativeContext<'a, 'b, 'c, 'd> {
 
     /// Returns a reference to the struct representing on-chain features.
     pub fn get_feature_flags(&self) -> &Features {
-        self.features.deref()
+        self.features
     }
 
     /// Checks if the timed feature corresponding to the given flag is enabled.

--- a/aptos-move/aptos-sdk-builder/src/common.rs
+++ b/aptos-move/aptos-sdk-builder/src/common.rs
@@ -157,8 +157,8 @@ pub(crate) fn get_required_helper_types(abis: &[EntryABI]) -> BTreeSet<&TypeTag>
 
 pub(crate) fn filter_transaction_scripts(abis: &[EntryABI]) -> Vec<EntryABI> {
     abis.iter()
-        .cloned()
         .filter(|abi| abi.is_transaction_script_abi())
+        .cloned()
         .collect()
 }
 

--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -43,7 +43,6 @@ pub fn output(
     // generator. Disable those functiosn for now.
     let abis_vec = abis
         .iter()
-        .cloned()
         .filter(|abi| {
             if let EntryABI::EntryFunction(sf) = abi {
                 sf.module_name().name().as_str() != "code"
@@ -56,6 +55,7 @@ pub fn output(
                 true
             }
         })
+        .cloned()
         .collect::<Vec<_>>();
 
     let abis = abis_vec.as_slice();

--- a/aptos-move/aptos-vm-benchmarks/src/helper.rs
+++ b/aptos-move/aptos-vm-benchmarks/src/helper.rs
@@ -9,10 +9,10 @@ use move_binary_format::CompiledModule;
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
 use std::{fs::ReadDir, path::PathBuf, string::String, time::Instant};
 
-//// CONSTANTS
+// CONSTANTS
 const PREFIX: &str = "benchmark";
 
-//// generate a TransactionPayload for modules
+// generate a TransactionPayload for modules
 pub fn generate_module_payload(package: &BuiltPackage) -> TransactionPayload {
     // extract package data
     let code = package.extract_code();
@@ -27,7 +27,7 @@ pub fn generate_module_payload(package: &BuiltPackage) -> TransactionPayload {
     )
 }
 
-//// sign transaction to create a Module and return transaction status
+// sign transaction to create a Module and return transaction status
 pub fn execute_module_txn(
     executor: &mut FakeExecutor,
     account: &Account,
@@ -59,14 +59,14 @@ pub fn execute_module_txn(
     println!("txn status: {:?}", txn_status);
 }
 
-//// sign user transaction and only records the body of the transaction
+// sign user transaction and only records the body of the transaction
 pub fn execute_user_txn(executor: &mut FakeExecutor, module_name: &ModuleId, function_name: &str) {
     let elapsed =
         executor.exec_func_record_running_time(module_name, function_name, vec![], vec![], 10);
     println!("running time (microseconds): {}", elapsed);
 }
 
-//// publish module under user and sign user transaction
+// publish module under user and sign user transaction
 pub fn publish(
     package: &BuiltPackage,
     executor: &mut FakeExecutor,
@@ -104,7 +104,7 @@ pub fn publish(
  * GETTER FUNCTIONS
  *
  */
-//// get module name
+// get module name
 pub fn get_module_name(
     address: AccountAddress,
     identifier: &String,
@@ -124,7 +124,7 @@ pub fn get_module_name(
     module_id
 }
 
-//// get all directories of Move projects
+// get all directories of Move projects
 pub fn get_dir_paths(dirs: ReadDir) -> Vec<PathBuf> {
     let mut dir_paths = Vec::new();
     for dir in dirs {
@@ -138,7 +138,7 @@ pub fn get_dir_paths(dirs: ReadDir) -> Vec<PathBuf> {
     dir_paths
 }
 
-//// get functional identifiers
+// get functional identifiers
 pub fn get_functional_identifiers(
     cm: CompiledModule,
     identifier: &String,

--- a/aptos-move/aptos-vm-benchmarks/src/main.rs
+++ b/aptos-move/aptos-vm-benchmarks/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use move_binary_format::CompiledModule;
 use std::{fs::read_dir, path::PathBuf};
 
-//// CLI options
+// CLI options
 #[derive(Parser, Debug)]
 struct Cli {
     #[clap(default_value = "")]

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -328,7 +328,7 @@ impl<'r, 'l> SessionExt<'r, 'l> {
                 if let Some(resource_group_tag) = resource_group_tag {
                     if resource_groups
                         .entry(resource_group_tag)
-                        .or_insert_with(BTreeMap::new)
+                        .or_default()
                         .insert(struct_tag, blob_op)
                         .is_some()
                     {

--- a/aptos-move/framework/src/docgen.rs
+++ b/aptos-move/framework/src/docgen.rs
@@ -89,7 +89,7 @@ impl DocgenOptions {
                 .landing_page_template
                 .as_ref()
                 .map(|s| vec![s.clone()])
-                .unwrap_or_else(Vec::new),
+                .unwrap_or_default(),
             references_file: self.references_file.clone(),
             include_dep_diagrams: self.include_dep_diagram,
             include_call_diagrams: false,

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -121,7 +121,7 @@ where
 
             baseline
                 .entry(k.clone())
-                .or_insert_with(BTreeMap::new)
+                .or_default()
                 .insert(idx as TxnIndex, value_to_update);
         }
         Self(baseline)

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -148,7 +148,7 @@ impl DagDriver {
                         highest_strong_links_round,
                         &self.epoch_state.verifier,
                     )
-                    .unwrap_or(vec![]),
+                    .unwrap_or_default(),
             )
         };
         self.round_state

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -181,7 +181,7 @@ impl RpcHandler for NodeBroadcastHandler {
         let votes_by_peer = self
             .votes_by_round_peer
             .entry(node.metadata().round())
-            .or_insert(BTreeMap::new());
+            .or_default();
         match votes_by_peer.get(node.metadata().author()) {
             None => {
                 let signature = node.sign_vote(&self.signer)?;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -389,7 +389,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 .saturating_sub(use_history_from_previous_epoch_max_count as u64),
         );
         // If we are considering beyond the current epoch, we need to fetch validators for those epochs
-        let epoch_to_proposers = if epoch_state.epoch > first_epoch_to_consider {
+        if epoch_state.epoch > first_epoch_to_consider {
             self.storage
                 .aptos_db()
                 .get_epoch_ending_ledger_infos(first_epoch_to_consider - 1, epoch_state.epoch)
@@ -409,8 +409,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 })
         } else {
             HashMap::from([(epoch_state.epoch, proposers)])
-        };
-        epoch_to_proposers
+        }
     }
 
     fn process_epoch_retrieval(

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -411,7 +411,7 @@ struct AuthorToTwinIds(HashMap<Author, Vec<TwinId>>);
 
 impl AuthorToTwinIds {
     pub fn extend_author_to_twin_ids(&mut self, author: Author, twin_id: TwinId) {
-        self.0.entry(author).or_insert_with(Vec::new);
+        self.0.entry(author).or_default();
 
         self.0.get_mut(&author).unwrap().push(twin_id)
     }
@@ -430,7 +430,7 @@ impl DropConfig {
     }
 
     pub fn drop_message_for(&mut self, src: &TwinId, dst: &TwinId) -> bool {
-        self.0.entry(*src).or_insert_with(HashSet::new).insert(*dst)
+        self.0.entry(*src).or_default().insert(*dst)
     }
 
     pub fn split_network(
@@ -472,7 +472,7 @@ impl DropConfigRound {
         partition_first: &[TwinId],
         partition_second: &[TwinId],
     ) -> bool {
-        let config = self.0.entry(round).or_insert_with(DropConfig::default);
+        let config = self.0.entry(round).or_default();
         config.split_network(partition_first, partition_second)
     }
 }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1041,7 +1041,7 @@ impl RoundManager {
                             unexpected_event => unreachable!("Unexpected event {:?}", unexpected_event),
                         }
                     };
-                    proposals.sort_by_key(|a| get_round(a));
+                    proposals.sort_by_key(get_round);
                     for proposal in proposals {
                         let result = match proposal {
                             VerifiedEvent::ProposalMsg(proposal_msg) => {

--- a/consensus/src/sender_aware_shuffler.rs
+++ b/consensus/src/sender_aware_shuffler.rs
@@ -116,7 +116,7 @@ impl PendingTransactions {
         self.ordered_txns.push_back(txn.clone());
         self.txns_by_senders
             .entry(txn.sender())
-            .or_insert_with(VecDeque::new)
+            .or_default()
             .push_back(txn);
     }
 

--- a/crates/aptos-log-derive/src/lib.rs
+++ b/crates/aptos-log-derive/src/lib.rs
@@ -153,7 +153,7 @@ fn extract_attr(attrs: &[Attribute]) -> Option<ValueType> {
             for segment in path.segments {
                 // Only handle schema attrs
                 if segment.ident == "schema" {
-                    for meta in &nested {
+                    if let Some(meta) = (&nested).into_iter().next() {
                         let path = if let NestedMeta::Meta(Meta::Path(path)) = meta {
                             path
                         } else {

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -57,7 +57,7 @@ struct TruncatedLogString(String);
 
 impl TruncatedLogString {
     const DEFAULT_MAX_LEN: usize = 10 * 1024;
-    const TRUNCATION_SUFFIX: &str = "(truncated)";
+    const TRUNCATION_SUFFIX: &'static str = "(truncated)";
 
     fn new(s: String) -> Self {
         let mut truncated = s;

--- a/crates/aptos-logger/src/kv.rs
+++ b/crates/aptos-logger/src/kv.rs
@@ -13,10 +13,7 @@
 //! ```
 
 use serde::Serialize;
-use std::{
-    borrow::{Borrow, Cow},
-    fmt,
-};
+use std::{borrow::Cow, fmt};
 
 /// The key part of a logging key value pair e.g. `info!(key = value)`
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
@@ -32,7 +29,7 @@ impl Key {
     }
 
     pub fn as_str(&self) -> &'_ Self {
-        self.borrow()
+        self
     }
 }
 

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 - Hide the V2 compiler from input options until the V2 compiler is ready for release
+- Updated CLI source compilation to use rust toolchain version 1.74.1 (from 1.72.1).
 
 ## [2.3.2] - 2023/11/28
 - Services in the local testnet now bind to 127.0.0.1 by default (unless the CLI is running inside a container, which most users should not do) rather than 0.0.0.0. You can override this behavior with the `--bind-to` flag. This fixes an issue preventing the local testnet from working on Windows.

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -80,7 +80,7 @@ target "builder-base" {
   context    = "."
   contexts = {
     # Run `docker buildx imagetools inspect rust:1.74.1-bullseye` to find the latest multi-platform hash
-    rust = "docker-image://rust:1.74.1-bullseye@sha256:a9271d7222f7de1867f72c1e8fdc590d908fc68756c3b49ef48b1cdac2f6b495"
+    rust = "docker-image://rust:1.74.1-bullseye@sha256:698e0acd00a30c8842887c3792c5c68e1d23565cfcc11d0203dbe4eeb31213c0"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -294,7 +294,7 @@ async fn process_transactions_from_node_response(
     }
 }
 
-//// Setup the cache operator with init signal, includeing chain id and starting version from fullnode.
+// Setup the cache operator with init signal, including chain id and starting version from fullnode.
 async fn verify_fullnode_init_signal(
     cache_operator: &mut CacheOperator<redis::aio::ConnectionManager>,
     init_signal: TransactionsFromNodeResponse,

--- a/ecosystem/node-checker/fn-check-client/src/main.rs
+++ b/ecosystem/node-checker/fn-check-client/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
         for node_result in node_results {
             nhc_responses
                 .entry(account_address)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(node_result);
         }
     }

--- a/ecosystem/node-checker/src/checker/state_sync_version.rs
+++ b/ecosystem/node-checker/src/checker/state_sync_version.rs
@@ -45,7 +45,7 @@ impl StateSyncVersionChecker {
         // We convert to i64 to avoid potential overflow if somehow the ledger version went backwards.
         let target_progress = latest_target_version as i64 - previous_target_version as i64;
         match target_progress {
-            target_progress if (target_progress == 0) => Self::build_result(
+            0 => Self::build_result(
                 "Ledger version is not increasing".to_string(),
                 25,
                 format!(

--- a/execution/block-partitioner/src/test_utils.rs
+++ b/execution/block-partitioner/src/test_utils.rs
@@ -197,7 +197,7 @@ pub fn verify_partitioner_output(
             old_txn_idxs_seen.insert(old_txn_idx);
             old_txn_idxs_by_sender
                 .entry(sender)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(old_txn_idx);
             let new_txn_idx = start_txn_idx + pos_in_sub_block;
             for loc in txn_with_dep.txn.write_hints().iter() {

--- a/execution/block-partitioner/src/v2/types.rs
+++ b/execution/block-partitioner/src/v2/types.rs
@@ -20,6 +20,7 @@ impl Ord for SubBlockIdx {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for SubBlockIdx {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         (self.round_id, self.shard_id).partial_cmp(&(other.round_id, other.shard_id))
@@ -68,6 +69,7 @@ impl Ord for ShardedTxnIndexV2 {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for ShardedTxnIndexV2 {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         (self.sub_block_idx, self.pre_partitioned_txn_idx)

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -811,14 +811,8 @@ fn test_get_conflicting_grps_transfer_indices() {
             for (sender_idx, receiver_idx) in transfer_indices {
                 assert!(sender_idx < num_signer_accounts);
                 assert!(receiver_idx < num_signer_accounts);
-                adj_list
-                    .entry(sender_idx)
-                    .or_insert(HashSet::new())
-                    .insert(receiver_idx);
-                adj_list
-                    .entry(receiver_idx)
-                    .or_insert(HashSet::new())
-                    .insert(sender_idx);
+                adj_list.entry(sender_idx).or_default().insert(receiver_idx);
+                adj_list.entry(receiver_idx).or_default().insert(sender_idx);
             }
 
             assert_eq!(get_num_connected_components(&adj_list), connected_txn_grps);

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -250,9 +250,7 @@ impl TransactionStore {
 
         self.clean_committed_transactions(&address, acc_seq_num);
 
-        self.transactions
-            .entry(address)
-            .or_insert_with(AccountTransactions::new);
+        self.transactions.entry(address).or_default();
 
         if let Some(txns) = self.transactions.get_mut(&address) {
             // capacity check

--- a/network/netcore/src/framing.rs
+++ b/network/netcore/src/framing.rs
@@ -152,8 +152,7 @@ mod test {
     fn write_large_u16frame() {
         let (mut a, _b) = MemorySocket::new_pair();
 
-        let mut buf = Vec::new();
-        buf.resize((u16::max_value() as usize) * 2, 0);
+        let buf = vec![0; (u16::max_value() as usize) * 2];
 
         let result = block_on(write_u16frame(&mut a, &buf));
         assert!(result.is_err());

--- a/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -25,13 +25,13 @@ use aptos_config::{
     config::{NodeConfig, PeerMonitoringServiceConfig, PeerRole},
     network_id::NetworkId,
 };
-use aptos_infallible::RwLock;
 use aptos_peer_monitoring_service_types::{
     request::PeerMonitoringServiceRequest,
     response::{LatencyPingResponse, PeerMonitoringServiceResponse},
 };
 use aptos_time_service::TimeServiceTrait;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_peer_updater_loop_multiple_peers() {
@@ -283,8 +283,8 @@ async fn test_latency_ping() {
             // Verify that a latency ping is received for each peer
             for _ in 0..2 {
                 // Get the network request
+                let mut mock_monitoring_server = mock_monitoring_server.write().await;
                 let network_request = mock_monitoring_server
-                    .write()
                     .next_request(&NetworkId::Public)
                     .await
                     .unwrap();
@@ -403,8 +403,8 @@ async fn test_network_info() {
             // Verify that a network info request is received for each peer
             for _ in 0..3 {
                 // Get the network request
+                let mut mock_monitoring_server = mock_monitoring_server.write().await;
                 let network_request = mock_monitoring_server
-                    .write()
                     .next_request(&NetworkId::Validator)
                     .await
                     .unwrap();
@@ -522,8 +522,8 @@ async fn test_node_info() {
             // Verify that a node info request is received for each peer
             for _ in 0..3 {
                 // Get the node request
+                let mut mock_monitoring_server = mock_monitoring_server.write().await;
                 let network_request = mock_monitoring_server
-                    .write()
                     .next_request(&NetworkId::Validator)
                     .await
                     .unwrap();

--- a/peer-monitoring-service/client/src/tests/utils.rs
+++ b/peer-monitoring-service/client/src/tests/utils.rs
@@ -1090,6 +1090,7 @@ pub async fn wait_for_node_info_request_failure(
     .await;
 }
 
+#[allow(clippy::await_holding_lock)] // This appears to be a false positive!
 /// Waits for the peer monitor state to be updated with
 /// the specified request failure.
 pub async fn wait_for_request_failure(
@@ -1126,6 +1127,7 @@ pub async fn wait_for_request_failure(
     .await;
 }
 
+#[allow(clippy::await_holding_lock)] // This appears to be a false positive!
 /// Waits for the peer monitor state to be updated with
 /// metadata after the given timestamp.
 pub async fn wait_for_peer_state_update(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.74.1"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -10,7 +10,7 @@ OS = "linux"
 
 IMAGES = {
     "debian": "debian:bullseye",
-    "rust": "rust:1.72.1-bullseye",
+    "rust": "rust:1.74.1-bullseye",
 }
 
 

--- a/storage/backup/backup-cli/src/metadata/mod.rs
+++ b/storage/backup/backup-cli/src/metadata/mod.rs
@@ -225,6 +225,7 @@ impl PartialEq<Self> for CompactionTimestampsMeta {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd<Self> for CompactionTimestampsMeta {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.file_compacted_at.partial_cmp(&other.file_compacted_at)

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -293,7 +293,7 @@ impl<'a, R: MoveResolver> TableInfoParser<'a, R> {
             None => {
                 self.pending_on
                     .entry(handle)
-                    .or_insert_with(DashSet::new)
+                    .or_default()
                     .insert(bytes.clone());
             },
         }

--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -213,7 +213,7 @@ impl<'a, R: MoveResolver> TableInfoParser<'a, R> {
             None => {
                 self.pending_on
                     .entry(handle)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(bytes.clone());
             },
         }

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -77,7 +77,7 @@ impl SchemaBatch {
         self.rows
             .lock()
             .entry(S::COLUMN_FAMILY_NAME)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(WriteOp::Value { key, value });
 
         Ok(())
@@ -89,7 +89,7 @@ impl SchemaBatch {
         self.rows
             .lock()
             .entry(S::COLUMN_FAMILY_NAME)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(WriteOp::Deletion { key });
 
         Ok(())

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -100,7 +100,6 @@ use aptos_types::{
     state_store::state_storage_usage::StateStorageUsage,
 };
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, HashMap},
     sync::{Arc, MutexGuard, Weak},
 };
@@ -497,7 +496,7 @@ where
         // at or below it belongs to the requested shard.
         for i in (0..4).rev() {
             if let Some(node) = subtree.get_node_if_in_mem(since_generation) {
-                match node.inner().borrow() {
+                match node.inner() {
                     NodeInner::Internal(internal_node) => {
                         subtree = match (shard_id >> i) & 1 {
                             0 => {
@@ -549,7 +548,7 @@ where
             } else {
                 false
             };
-            match node.inner().borrow() {
+            match node.inner() {
                 NodeInner::Internal(internal_node) => {
                     let depth = pos.len();
                     pos.push(false);

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -220,7 +220,7 @@ impl SuccessCriteriaChecker {
     ) -> anyhow::Result<()> {
         let traffic_name_addition = traffic_name
             .map(|n| format!(" for {}", n))
-            .unwrap_or_else(|| "".to_string());
+            .unwrap_or_default();
         Self::check_throughput(
             success_criteria.min_avg_tps,
             success_criteria.max_expired_tps,

--- a/third_party/move/move-analyzer/src/symbols.rs
+++ b/third_party/move/move-analyzer/src/symbols.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_or_default)]
+#![allow(clippy::non_canonical_partial_ord_impl)]
+
 //! This module is responsible for building symbolication information on top of compiler's typed
 //! AST, in particular identifier definitions to be used for implementing go-to-def and
 //! go-to-references language server commands.

--- a/third_party/move/move-borrow-graph/src/graph.rs
+++ b/third_party/move/move-borrow-graph/src/graph.rs
@@ -68,7 +68,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
                     None => full_borrows.insert(borrower, edge.loc),
                     Some(f) => field_borrows
                         .entry(f.clone())
-                        .or_insert_with(BTreeMap::new)
+                        .or_default()
                         .insert(borrower, edge.loc),
                 };
             }

--- a/third_party/move/move-borrow-graph/src/references.rs
+++ b/third_party/move/move-borrow-graph/src/references.rs
@@ -209,6 +209,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> PartialEq for BorrowEdge<Loc, Lbl> {
 
 impl<Loc: Copy, Lbl: Clone + Ord> Eq for BorrowEdge<Loc, Lbl> {}
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl<Loc: Copy, Lbl: Clone + Ord> PartialOrd for BorrowEdge<Loc, Lbl> {
     fn partial_cmp(&self, other: &BorrowEdge<Loc, Lbl>) -> Option<Ordering> {
         BorrowEdgeNoLoc::new(self).partial_cmp(&BorrowEdgeNoLoc::new(other))

--- a/third_party/move/move-bytecode-verifier/src/struct_defs.rs
+++ b/third_party/move/move-bytecode-verifier/src/struct_defs.rs
@@ -127,7 +127,7 @@ impl<'a> StructDefGraphBuilder<'a> {
                 if let Some(struct_def_idx) = self.handle_to_def.get(sh_idx) {
                     neighbors
                         .entry(cur_idx)
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(*struct_def_idx);
                 }
             },
@@ -135,7 +135,7 @@ impl<'a> StructDefGraphBuilder<'a> {
                 if let Some(struct_def_idx) = self.handle_to_def.get(sh_idx) {
                     neighbors
                         .entry(cur_idx)
-                        .or_insert_with(BTreeSet::new)
+                        .or_default()
                         .insert(*struct_def_idx);
                 }
                 for t in inners {

--- a/third_party/move/move-compiler/src/cfgir/cfg.rs
+++ b/third_party/move/move-compiler/src/cfgir/cfg.rs
@@ -617,7 +617,7 @@ impl<'a> ReverseBlockCFG<'a> {
         for terminal_predecessor in &end_blocks {
             forward_successors
                 .entry(*terminal_predecessor)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(terminal);
         }
         forward_predecessor.insert(terminal, end_blocks);

--- a/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
+++ b/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
@@ -133,10 +133,7 @@ impl<'a> Context<'a> {
             .neighbors_by_node
             .entry(current.clone())
             .or_insert_with(UniqueMap::new);
-        let current_used_addresses = self
-            .addresses_by_node
-            .entry(current.clone())
-            .or_insert_with(BTreeSet::new);
+        let current_used_addresses = self.addresses_by_node.entry(current.clone()).or_default();
         current_neighbors.remove(&mident);
         current_neighbors.add(mident, neighbor).unwrap();
         current_used_addresses.insert(mident.value.address);
@@ -150,9 +147,9 @@ impl<'a> Context<'a> {
                 let m = self
                     .module_neighbors
                     .entry(node)
-                    .or_insert_with(BTreeMap::new)
+                    .or_default()
                     .entry(new_neighbor)
-                    .or_insert_with(BTreeMap::new);
+                    .or_default();
                 if m.contains_key(&dep_type) {
                     return;
                 }
@@ -173,7 +170,7 @@ impl<'a> Context<'a> {
     fn add_address_usage(&mut self, address: Address) {
         self.addresses_by_node
             .entry(self.current_node.clone().unwrap())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(address);
     }
 }

--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -248,7 +248,7 @@ pub fn program(
         for s in scripts {
             collected
                 .entry(s.function_name.value())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(s)
         }
         let mut keyed: BTreeMap<Symbol, E::Script> = BTreeMap::new();
@@ -523,7 +523,6 @@ fn module_(
             .add_diag(diag!(Declarations::InvalidName, (name.loc(), msg)));
     }
 
-    let name = name;
     let name_loc = name.0.loc;
     let current_module = sp(name_loc, ModuleIdent_::new(*context.cur_address(), name));
     if context

--- a/third_party/move/move-compiler/src/shared/unique_set.rs
+++ b/third_party/move/move-compiler/src/shared/unique_set.rs
@@ -118,6 +118,7 @@ impl<T: TName> PartialEq for UniqueSet<T> {
 }
 impl<T: TName> Eq for UniqueSet<T> {}
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl<T: TName> PartialOrd for UniqueSet<T> {
     fn partial_cmp(&self, other: &UniqueSet<T>) -> Option<Ordering> {
         (self.0).0.keys().partial_cmp((other.0).0.keys())

--- a/third_party/move/move-compiler/src/typing/infinite_instantiations.rs
+++ b/third_party/move/move-compiler/src/typing/infinite_instantiations.rs
@@ -95,7 +95,7 @@ impl<'a> Context<'a> {
                     .for_each(|t| Self::add_tparam_edges(acc, tparam, info.clone(), t))
             },
             Param(tp) => {
-                let tp_neighbors = acc.entry(tp.clone()).or_insert_with(BTreeMap::new);
+                let tp_neighbors = acc.entry(tp.clone()).or_default();
                 match tp_neighbors.get(tparam) {
                     Some(EdgeInfo {
                         edge: Edge::Nested, ..

--- a/third_party/move/move-compiler/src/typing/recursive_structs.rs
+++ b/third_party/move/move-compiler/src/typing/recursive_structs.rs
@@ -36,7 +36,7 @@ impl Context {
         }
         self.struct_neighbors
             .entry(self.current_struct.unwrap())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(*sname, loc);
     }
 

--- a/third_party/move/move-core/types/src/gas_algebra.rs
+++ b/third_party/move/move-core/types/src/gas_algebra.rs
@@ -179,6 +179,7 @@ impl<U> PartialEq for GasQuantity<U> {
 
 impl<U> Eq for GasQuantity<U> {}
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl<U> PartialOrd for GasQuantity<U> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp_impl(other))

--- a/third_party/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
+++ b/third_party/move/move-ir-compiler/move-bytecode-source-map/src/marking.rs
@@ -51,14 +51,14 @@ impl FunctionMarking {
     pub fn code_offset(&mut self, code_offset: CodeOffset, message: String) {
         self.code_offsets
             .entry(code_offset)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 
     pub fn type_param(&mut self, type_param_index: usize, message: String) {
         self.type_param_offsets
             .entry(type_param_index)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 }
@@ -72,16 +72,13 @@ impl StructMarking {
     }
 
     pub fn field(&mut self, field_index: MemberCount, message: String) {
-        self.fields
-            .entry(field_index)
-            .or_insert_with(Vec::new)
-            .push(message)
+        self.fields.entry(field_index).or_default().push(message)
     }
 
     pub fn type_param(&mut self, type_param_index: usize, message: String) {
         self.type_param_offsets
             .entry(type_param_index)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(message)
     }
 }
@@ -102,7 +99,7 @@ impl MarkedSourceMapping {
     ) {
         self.function_marks
             .entry(function_definition_index.0)
-            .or_insert_with(FunctionMarking::new)
+            .or_default()
             .code_offset(code_offset, message)
     }
 
@@ -114,7 +111,7 @@ impl MarkedSourceMapping {
     ) {
         self.function_marks
             .entry(function_definition_index.0)
-            .or_insert_with(FunctionMarking::new)
+            .or_default()
             .type_param(type_param_offset, message)
     }
 
@@ -126,7 +123,7 @@ impl MarkedSourceMapping {
     ) {
         self.struct_marks
             .entry(struct_definition_index.0)
-            .or_insert_with(StructMarking::new)
+            .or_default()
             .field(field_index, message)
     }
 
@@ -138,7 +135,7 @@ impl MarkedSourceMapping {
     ) {
         self.struct_marks
             .entry(struct_definition_index.0)
-            .or_insert_with(StructMarking::new)
+            .or_default()
             .type_param(type_param_offset, message)
     }
 }

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
@@ -1483,7 +1483,7 @@ fn parse_acquire_list(
     Ok(al)
 }
 
-//// Spec language parsing ////
+// Spec language parsing //
 
 // parses Name '.' Name and returns pair of strings.
 fn spec_parse_dot_name(

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -236,10 +236,7 @@ impl<'env> ModelBuilder<'env> {
         entry: SpecOrBuiltinFunEntry,
     ) {
         // TODO: check whether overloads are distinguishable
-        self.spec_fun_table
-            .entry(name)
-            .or_insert_with(Vec::new)
-            .push(entry);
+        self.spec_fun_table.entry(name).or_default().push(entry);
     }
 
     /// Defines a spec variable.

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1762,18 +1762,14 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
     {
         use SpecBlockContext::*;
         match context {
-            Function(name) => update(
-                self.fun_specs
-                    .entry(name.symbol)
-                    .or_insert_with(Spec::default),
-            ),
+            Function(name) => update(self.fun_specs.entry(name.symbol).or_default()),
             FunctionCode(name, spec_info) => update(
                 self.fun_specs
                     .entry(name.symbol)
-                    .or_insert_with(Spec::default)
+                    .or_default()
                     .on_impl
                     .entry(spec_info.offset)
-                    .or_insert_with(Spec::default),
+                    .or_default(),
             ),
             FunctionCodeV2(..) => update(
                 // For v2 compilation only: direct to builder which will be flushed at end
@@ -1789,11 +1785,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     .expect("schema defined")
                     .spec,
             ),
-            Struct(name) => update(
-                self.struct_specs
-                    .entry(name.symbol)
-                    .or_insert_with(Spec::default),
-            ),
+            Struct(name) => update(self.struct_specs.entry(name.symbol).or_default()),
             Module => update(&mut self.module_spec),
         }
     }

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1125,7 +1125,7 @@ impl GlobalEnv {
         for memory in &inv.mem_usage {
             self.global_invariants_for_memory
                 .entry(memory.clone())
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(id);
         }
         self.global_invariants.insert(id, inv);
@@ -3965,7 +3965,7 @@ impl<'env> FunctionEnv<'env> {
                 let type_name = mid.qualified(sid);
                 modify_targets
                     .entry(type_name)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(target.clone());
             });
         }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -109,7 +109,7 @@ impl TranslatedSpec {
                         .mk_join_opt_bool(
                             Operation::And,
                             Some(exp.clone()),
-                            code.as_ref().map(|c| eq_code(c)),
+                            code.as_ref().map(eq_code),
                         )
                         .unwrap()
                 })
@@ -117,7 +117,7 @@ impl TranslatedSpec {
                     self.aborts_with
                         .iter()
                         .flat_map(|(_, codes)| codes.iter())
-                        .map(|c| eq_code(c)),
+                        .map(eq_code),
                 ),
         )
     }

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -867,7 +867,7 @@ fn create_domain_map(
     let mut default_domain = None;
 
     let mut insert_map = |elems: &Vec<ModelValue>, val: &ModelValue| -> Option<()> {
-        map.entry(elems[0].clone()).or_insert_with(BTreeMap::new);
+        map.entry(elems[0].clone()).or_default();
         map.get_mut(&elems[0])
             .unwrap()
             .insert(elems[1].extract_number()?, extract_bool(val)?);

--- a/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
@@ -515,7 +515,7 @@ impl PerFunctionRelevance {
                             .or_insert_with(PerBytecodeRelevance::default)
                             .insts
                             .entry(rel_inst)
-                            .or_insert_with(BTreeSet::new)
+                            .or_default()
                             .extend(wellformed_inv_inst);
                     }
                 }

--- a/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_instrumentation_v2.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_instrumentation_v2.rs
@@ -174,7 +174,7 @@ impl Analyzer {
         for inst in func_insts {
             self.func_insts
                 .entry(inst)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(invariant.id);
         }
         if is_generic {

--- a/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis_v2.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis_v2.rs
@@ -148,9 +148,8 @@ fn compute_disabled_invs_for_fun(
                 .cloned()
                 .expect(COMPILED_MODULE_AVAILABLE);
             for called_fun_id in called_funs {
-                let disabled_invs_for_called = disabled_invs_for_fun
-                    .entry(called_fun_id)
-                    .or_insert_with(BTreeSet::new);
+                let disabled_invs_for_called =
+                    disabled_invs_for_fun.entry(called_fun_id).or_default();
                 // if caller has any disabled_invs that callee does not, add them to called
                 // and add called to the worklist for further processing
                 if !disabled_invs_for_caller.is_subset(disabled_invs_for_called) {
@@ -377,9 +376,7 @@ fn compute_funs_that_modify_inv(
                     let fun_id = fun_env.get_qualified_id();
                     fun_id_set.insert(fun_id);
                     funs_that_modify_some_inv.insert(fun_id);
-                    let inv_set = invs_modified_by_fun
-                        .entry(fun_id)
-                        .or_insert_with(BTreeSet::new);
+                    let inv_set = invs_modified_by_fun.entry(fun_id).or_default();
                     inv_set.insert(*inv_id);
                 }
             }

--- a/third_party/move/move-prover/move-docgen/src/docgen.rs
+++ b/third_party/move/move-prover/move-docgen/src/docgen.rs
@@ -719,6 +719,7 @@ impl<'env> Docgen<'env> {
         }
     }
 
+    #[allow(clippy::format_collect)]
     fn gen_html_table(&self, input: &str, column_names: Vec<&str>) {
         let row_blocks = input.split("\n\n").collect::<Vec<_>>();
 
@@ -782,7 +783,7 @@ impl<'env> Docgen<'env> {
                 let req_tag = *parts.get(1).unwrap_or(&"");
                 let label_link = self
                     .resolve_to_label(module_name, false)
-                    .unwrap_or(String::new());
+                    .unwrap_or_default();
                 let module_link = label_link.split('#').next().unwrap_or("").to_string();
                 let suffix = format!(" of the <a href={}>{}</a> module", module_link, module_name);
                 (req_tag, module_link, suffix)
@@ -834,7 +835,7 @@ impl<'env> Docgen<'env> {
             if tag.starts_with("http://") || tag.starts_with("https://") {
                 format!("<a href=\"{}\">{}</a>", tag, text)
             } else if tag.contains("::") {
-                let parts = tag.clone().split("::").collect::<Vec<_>>();
+                let parts = tag.split("::").collect::<Vec<_>>();
                 if let Some(module_name) = parts.first() {
                     let label_link = self
                         .resolve_to_label(module_name, false)

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1631,7 +1631,7 @@ impl Loader {
             .write()
             .structs
             .entry(name.clone())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfoCache::new)
             .struct_tag = Some((struct_tag.clone(), gas_context.cost - cur_cost));
@@ -1759,7 +1759,7 @@ impl Loader {
         let info = cache
             .structs
             .entry(name.clone())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfoCache::new);
         info.struct_layout_info = Some(StructLayoutInfoCacheItem {
@@ -1938,7 +1938,7 @@ impl Loader {
         let info = cache
             .structs
             .entry(name.clone())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(ty_args.to_vec())
             .or_insert_with(StructInfoCache::new);
         info.annotated_struct_layout = Some(struct_layout.clone());

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::non_canonical_partial_ord_impl)]
+
 use derivative::Derivative;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},

--- a/third_party/move/testing-infra/test-generation/src/abstract_state.rs
+++ b/third_party/move/testing-infra/test-generation/src/abstract_state.rs
@@ -136,10 +136,7 @@ impl CallGraph {
     }
 
     pub fn add_call(&mut self, caller: FunctionHandleIndex, callee: FunctionHandleIndex) {
-        self.calls
-            .entry(caller)
-            .or_insert_with(HashSet::new)
-            .insert(callee);
+        self.calls.entry(caller).or_default().insert(callee);
     }
 
     pub fn can_call(&self, my_index: FunctionHandleIndex) -> Vec<FunctionHandleIndex> {

--- a/third_party/move/tools/move-cli/src/base/prove.rs
+++ b/third_party/move/tools/move-cli/src/base/prove.rs
@@ -213,7 +213,7 @@ pub fn run_move_prover(
         let basedir = path
             .file_name()
             .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(String::new);
+            .unwrap_or_default();
         writeln!(
             message_writer,
             "{} proving {} modules from package `{}` in {:.3}s",

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -156,10 +156,7 @@ impl ModuleCoverageMap {
     }
 
     pub fn insert_multi(&mut self, func_name: Identifier, pc: u64, count: u64) {
-        let func_entry = self
-            .function_maps
-            .entry(func_name)
-            .or_insert_with(FunctionCoverage::new);
+        let func_entry = self.function_maps.entry(func_name).or_default();
         let pc_entry = func_entry.entry(pc).or_insert(0);
         *pc_entry += count;
     }
@@ -170,10 +167,7 @@ impl ModuleCoverageMap {
 
     pub fn merge(&mut self, another: ModuleCoverageMap) {
         for (key, val) in another.function_maps {
-            self.function_maps
-                .entry(key)
-                .or_insert_with(FunctionCoverage::new)
-                .extend(val);
+            self.function_maps.entry(key).or_default().extend(val);
         }
     }
 
@@ -330,10 +324,7 @@ impl TraceMap {
         func_name: Identifier,
         pc: u64,
     ) {
-        let exec_entry = self
-            .exec_maps
-            .entry(exec_id.to_owned())
-            .or_insert_with(Vec::new);
+        let exec_entry = self.exec_maps.entry(exec_id.to_owned()).or_default();
         exec_entry.push(TraceEntry {
             module_addr,
             module_name,

--- a/third_party/move/tools/move-coverage/src/summary.rs
+++ b/third_party/move/tools/move-coverage/src/summary.rs
@@ -292,10 +292,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
                             // move to branch info if there are more than one branches
                             if exits.len() > 1 {
                                 for (src, dst) in exits.into_iter() {
-                                    fn_branches
-                                        .entry(src)
-                                        .or_insert_with(BTreeSet::new)
-                                        .insert(dst);
+                                    fn_branches.entry(src).or_default().insert(dst);
                                 }
                             }
                         }
@@ -400,7 +397,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
             for (func_name, path) in path_store.into_iter() {
                 let path_count = func_path_cov_stats
                     .entry(func_name)
-                    .or_insert_with(BTreeMap::new)
+                    .or_default()
                     .entry(path)
                     .or_insert(0);
                 *path_count += 1;

--- a/third_party/move/tools/move-unit-test/src/test_reporter.rs
+++ b/third_party/move/tools/move-unit-test/src/test_reporter.rs
@@ -409,21 +409,21 @@ impl TestStatistics {
     pub fn test_failure(&mut self, test_failure: TestFailure, test_plan: &ModuleTestPlan) {
         self.failed
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(test_failure);
     }
 
     pub fn test_success(&mut self, test_info: TestRunInfo, test_plan: &ModuleTestPlan) {
         self.passed
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(test_info);
     }
 
     pub fn test_output(&mut self, test_name: TestName, test_plan: &ModuleTestPlan, output: String) {
         self.output
             .entry(test_plan.module_id.clone())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(test_name, output);
     }
 

--- a/types/src/block_executor/partitioner.rs
+++ b/types/src/block_executor/partitioner.rs
@@ -96,7 +96,7 @@ impl CrossShardEdges {
     pub fn add_edge(&mut self, txn_idx: ShardedTxnIndex, storage_locations: Vec<StorageLocation>) {
         self.edges
             .entry(txn_idx)
-            .or_insert_with(Vec::new)
+            .or_default()
             .extend(storage_locations);
     }
 

--- a/types/src/proof/accumulator/mock.rs
+++ b/types/src/proof/accumulator/mock.rs
@@ -128,7 +128,7 @@ impl MockTransactionAccumulator {
             let mut left_subtrees = self.frozen_subtrees(left);
             let right_subtrees = maybe_right
                 .map(|right| self.frozen_subtrees(right))
-                .unwrap_or_else(Vec::new);
+                .unwrap_or_default();
             left_subtrees.extend(right_subtrees);
             left_subtrees
         }
@@ -225,7 +225,7 @@ impl MockTransactionAccumulator {
                 let mut left_subtrees = self.frozen_subtree_diff(Some(old_left), new_left, 0);
                 let right_subtrees = maybe_new_right
                     .map(|new_right| self.frozen_subtree_diff(maybe_old_right, new_right, 0))
-                    .unwrap_or_else(Vec::new);
+                    .unwrap_or_default();
                 left_subtrees.extend(right_subtrees);
                 left_subtrees
             }

--- a/types/src/state_store/state_key.rs
+++ b/types/src/state_store/state_key.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::non_canonical_partial_ord_impl)]
+
 use crate::{access_path::AccessPath, state_store::table::TableHandle};
 use anyhow::Result;
 use aptos_crypto::{

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -426,6 +426,7 @@ impl TransactionWrite for WriteOp {
     }
 }
 
+#[allow(clippy::format_collect)]
 impl std::fmt::Debug for WriteOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
### Description
This PR updates `aptos-core` to use rust version `1.74.1` (from `1.72.1`). Rust `1.74` has baked for > a [month](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html). We're currently 3+ months behind.

### Test Plan
Existing test infrastructure.