### PR TITLE
[grpc] fix deadlock

### DIFF
--- a/docker/compose/indexer-grpc/docker-compose.yaml
+++ b/docker/compose/indexer-grpc/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
       - '--config-path'
       - '/opt/aptos/file-store-config.yaml'
     depends_on:
-      - indexer-grpc-cache-worker
+      - redis
 
   indexer-grpc-data-service:
     image: "${INDEXER_GRPC_IMAGE_REPO:-aptoslabs/indexer-grpc}:${IMAGE_TAG:-main}"
@@ -106,6 +106,7 @@ services:
       - "18084:8084" # health
     depends_on:
       - indexer-grpc-cache-worker
+      - indexer-grpc-file-store
       - redis-replica
 
 # This joins the indexer-grpc compose with the validator-testnet compose using a shared docker network

--- a/docker/compose/indexer-grpc/file-store-config.yaml
+++ b/docker/compose/indexer-grpc/file-store-config.yaml
@@ -5,3 +5,4 @@ server_config:
   file_store_config:
     file_store_type: LocalFileStore
     local_file_store_path: /opt/aptos/file-store
+  chain_id: 2

--- a/docker/compose/indexer-grpc/file-store-config.yaml
+++ b/docker/compose/indexer-grpc/file-store-config.yaml
@@ -5,4 +5,4 @@ server_config:
   file_store_config:
     file_store_type: LocalFileStore
     local_file_store_path: /opt/aptos/file-store
-  chain_id: 2
+  chain_id: 4

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
@@ -43,7 +43,11 @@ impl RunnableConfig for IndexerGrpcCacheWorkerConfig {
         )
         .await
         .context("Failed to create cache worker")?;
-        worker.run().await?;
+        worker
+            .run()
+            .await
+            .context("Failed to run cache worker")
+            .expect("Cache worker failed");
         Ok(())
     }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/main.rs
@@ -9,5 +9,8 @@ use clap::Parser;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<IndexerGrpcCacheWorkerConfig>().await
+    args.run::<IndexerGrpcCacheWorkerConfig>()
+        .await
+        .expect("Cache worker failed");
+    Ok(())
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/main.rs
@@ -11,6 +11,6 @@ async fn main() -> Result<()> {
     let args = ServerArgs::parse();
     args.run::<IndexerGrpcCacheWorkerConfig>()
         .await
-        .expect("Cache worker failed");
+        .expect("Cache worker failed to run");
     Ok(())
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -124,9 +124,7 @@ impl Worker {
                     LocalFileStoreOperator::new(local_file_store.local_file_store_path.clone()),
                 ),
             };
-            // TODO: this is unnecessary
             // TODO: move chain id check somewhere around here
-            file_store_operator.verify_storage_bucket_existence().await;
             // This ensures that metadata is created before we start the cache worker
             let mut starting_version = file_store_operator.get_latest_version().await;
             while starting_version.is_none() {

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -361,10 +361,10 @@ async fn process_streaming_response(
 
     let mut current_version = starting_version;
     let mut batch_start_time = std::time::Instant::now();
-    let mut start_time = std::time::Instant::now();
 
     // 4. Process the streaming response.
     loop {
+        let start_time = std::time::Instant::now();
         let received = match resp_stream.next().await {
             Some(r) => r,
             _ => {
@@ -409,7 +409,6 @@ async fn process_streaming_response(
                     // TODO: Reasses whether this metric useful
                     LATEST_PROCESSED_VERSION_OLD.set(current_version as i64);
                     PROCESSED_BATCH_SIZE.set(num_of_transactions as i64);
-                    start_time = std::time::Instant::now();
                 },
                 GrpcDataStatus::StreamInit(new_version) => {
                     error!(

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -201,9 +201,9 @@ impl RawData for RawDataServerWrapper {
                 let mut cache_operator = CacheOperator::new(conn);
                 file_store_operator.verify_storage_bucket_existence().await;
 
-                // Validate redis chain id
+                // Validate redis chain id. Must be present by the time it gets here
                 let chain_id = match cache_operator.get_chain_id().await {
-                    Ok(chain_id) => chain_id,
+                    Ok(chain_id) => chain_id.unwrap(),
                     Err(e) => {
                         ERROR_COUNT
                             .with_label_values(&["redis_get_chain_id_failed"])

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -7,7 +7,7 @@ use crate::metrics::{
     PROCESSED_LATENCY_IN_SECS, PROCESSED_LATENCY_IN_SECS_ALL, PROCESSED_VERSIONS_COUNT,
     SHORT_CONNECTION_COUNT,
 };
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{Context, Result};
 use aptos_indexer_grpc_utils::{
     build_protobuf_encoded_transaction_wrappers,
     cache_operator::{CacheBatchGetStatus, CacheOperator},
@@ -202,7 +202,6 @@ impl RawData for RawDataServerWrapper {
                     },
                 };
                 let mut cache_operator = CacheOperator::new(conn);
-                file_store_operator.verify_storage_bucket_existence().await;
 
                 // Validate chain id
                 let mut metadata = file_store_operator.get_file_store_metadata().await;

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
@@ -44,12 +44,13 @@ impl RunnableConfig for IndexerGrpcFileStoreWorkerConfig {
             self.enable_expensive_logging.unwrap_or(false),
             self.chain_id,
         )
-        .await?;
+        .await
+        .expect("Failed to create file store processor");
         processor
             .run()
             .await
             .expect("File store processor exited unexpectedly");
-        Err(anyhow::anyhow!("File store processor exited unexpectedly"))
+        Ok(())
     }
 
     fn get_server_name(&self) -> String {

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod metrics;
 pub mod processor;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use aptos_indexer_grpc_server_framework::RunnableConfig;
 use aptos_indexer_grpc_utils::{config::IndexerGrpcFileStoreConfig, types::RedisUrl};
 use processor::Processor;
@@ -16,6 +16,7 @@ pub struct IndexerGrpcFileStoreWorkerConfig {
     pub file_store_config: IndexerGrpcFileStoreConfig,
     pub redis_main_instance_address: RedisUrl,
     pub enable_expensive_logging: Option<bool>,
+    pub chain_id: u64,
 }
 
 impl IndexerGrpcFileStoreWorkerConfig {
@@ -23,11 +24,13 @@ impl IndexerGrpcFileStoreWorkerConfig {
         file_store_config: IndexerGrpcFileStoreConfig,
         redis_main_instance_address: RedisUrl,
         enable_expensive_logging: Option<bool>,
+        chain_id: u64,
     ) -> Self {
         Self {
             file_store_config,
             redis_main_instance_address,
             enable_expensive_logging,
+            chain_id,
         }
     }
 }
@@ -39,9 +42,9 @@ impl RunnableConfig for IndexerGrpcFileStoreWorkerConfig {
             self.redis_main_instance_address.clone(),
             self.file_store_config.clone(),
             self.enable_expensive_logging.unwrap_or(false),
+            self.chain_id,
         )
-        .await
-        .context("Failed to create processor for file store worker")?;
+        .await?;
         processor
             .run()
             .await

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/main.rs
@@ -9,5 +9,8 @@ use clap::Parser;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
-    args.run::<IndexerGrpcFileStoreWorkerConfig>().await
+    args.run::<IndexerGrpcFileStoreWorkerConfig>()
+        .await
+        .expect("Failed to run server");
+    Ok(())
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
@@ -44,21 +44,24 @@ where
         register_probes_and_metrics_handler(health_port).await;
         Ok(())
     });
-    let main_task_handler = tokio::spawn(async move { config.run().await });
+    let main_task_handler =
+        tokio::spawn(async move { config.run().await.expect("task should exit with Ok.") });
     tokio::select! {
         res = task_handler => {
             if let Err(e) = res {
                 error!("Probes and metrics handler panicked or was shutdown: {:?}", e);
                 process::exit(1);
+            } else {
+                panic!("Probes and metrics handler exited unexpectedly");
             }
-            Ok(())
         },
         res = main_task_handler => {
             if let Err(e) = res {
                 error!("Main task panicked or was shutdown: {:?}", e);
                 process::exit(1);
+            } else {
+                panic!("Main task exited unexpectedly");
             }
-            Ok(())
         },
     }
 }


### PR DESCRIPTION
### Description
To avoid a deadlock between cache worker and filestore, we should just have filestore update all the config, both in the metadata file and in the cache. Cache worker would no longer touch config such as chain_id and file_store_metadata_version

Note, this is breaking as we now need chain_id in the filestore yaml. Followups are
1. internally, we need chain id automation in deployment
2. also we need the chain id automation for localnet
3. externally, we may ship it with grpc release?

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

![Screenshot 2023-12-19 at 12 15 37 PM](https://github.com/aptos-labs/aptos-core/assets/8248583/72d01f0c-e633-4d42-b7e2-d89e98743cea)

Initial upload of metadata.json fails, but verify it's eventually created. 
```
│ {"timestamp":"2023-12-19T22:53:33.275282Z","level":"ERROR","fields":{"message":"[File worker] Failed to update file store metadata. Retrying.","batch_start_version":0,"service_type":"file_worker"},"filename":"ecosystem/index │
```