### PR TITLE
High level requirement tables for framework modules

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aggregator.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator.md
@@ -27,6 +27,7 @@ at the moment.**
 -  [Specification](#@Specification_1)
     -  [Struct `Aggregator`](#@Specification_1_Aggregator)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `limit`](#@Specification_1_limit)
     -  [Function `add`](#@Specification_1_add)
     -  [Function `sub`](#@Specification_1_sub)
@@ -306,6 +307,11 @@ Destroys an aggregator and removes it from its <code>AggregatorFactory</code>.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> intrinsic;

--- a/aptos-move/framework/aptos-framework/doc/aggregator_factory.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_factory.md
@@ -18,6 +18,7 @@ can be enabled for the public.
 -  [Function `new_aggregator`](#0x1_aggregator_factory_new_aggregator)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize_aggregator_factory`](#@Specification_1_initialize_aggregator_factory)
     -  [Function `create_aggregator_internal`](#@Specification_1_create_aggregator_internal)
     -  [Function `create_aggregator`](#@Specification_1_create_aggregator)
@@ -239,6 +240,11 @@ Returns a new aggregator.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> aborts_if_is_strict;

--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -20,6 +20,7 @@
 -  [Function `can_receive_direct_coin_transfers`](#0x1_aptos_account_can_receive_direct_coin_transfers)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `create_account`](#@Specification_1_create_account)
     -  [Function `batch_transfer`](#@Specification_1_batch_transfer)
     -  [Function `transfer`](#@Specification_1_transfer)
@@ -558,6 +559,11 @@ By default, this returns true if an account has not explicitly set whether the c
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> aborts_if_is_strict;

--- a/aptos-move/framework/aptos-framework/doc/aptos_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_coin.md
@@ -21,6 +21,8 @@ modified from https://github.com/move-language/move/tree/main/language/documenta
 -  [Function `claim_mint_capability`](#0x1_aptos_coin_claim_mint_capability)
 -  [Function `find_delegation`](#0x1_aptos_coin_find_delegation)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `destroy_mint_cap`](#@Specification_1_destroy_mint_cap)
     -  [Function `configure_accounts_for_test`](#@Specification_1_configure_accounts_for_test)
@@ -466,6 +468,50 @@ Claim the delegated mint capability and destroy the delegated token.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>The native token, APT, must be initialized during genesis.</td>
+<td>Medium</td>
+<td>The initialize function is only called once, during genesis.</td>
+<td>Formally verified via <a href="#high-level-req-1">initialize</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>The APT coin may only be created exactly once.</td>
+<td>Medium</td>
+<td>The initialization function may only be called once.</td>
+<td>Enforced through the <a href="https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move">coin</a> module, which has been audited.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Any type of operation on the APT coin should fail if the user has not registered for the coin.</td>
+<td>Medium</td>
+<td>Coin operations may succeed only on valid user coin registration.</td>
+<td>Enforced through the <a href="https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move">coin</a> module, which has been audited.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -490,7 +536,9 @@ Claim the delegated mint capability and destroy the delegated token.
 <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt;&gt;(addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="aggregator_factory.md#0x1_aggregator_factory_AggregatorFactory">aggregator_factory::AggregatorFactory</a>&gt;(addr);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(addr);
+// This enforces <a id="high-level-req-3" href="#high-level-req">high level requirement 3</a>:
 <b>ensures</b> <b>global</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(addr).mint_cap ==  MintCapability&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt; {};
 <b>ensures</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt;&gt;(addr);
 <b>ensures</b> result_1 == BurnCapability&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt; {};

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -57,6 +57,7 @@ on a proposal multiple times as long as the total voting power of these votes do
 -  [Function `initialize_for_verification`](#0x1_aptos_governance_initialize_for_verification)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `store_signer_cap`](#@Specification_1_store_signer_cap)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `update_governance_config`](#@Specification_1_update_governance_config)
@@ -1736,6 +1737,11 @@ Return a signer for making changes to 0x1 as part of on-chain governance proposa
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -20,6 +20,7 @@ This module defines a struct storing the metadata of the block and new block eve
 -  [Function `emit_writeset_block_event`](#0x1_block_emit_writeset_block_event)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Resource `BlockResource`](#@Specification_1_BlockResource)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `update_epoch_interval_microsecs`](#@Specification_1_update_epoch_interval_microsecs)
@@ -619,6 +620,11 @@ new block event for WriteSetPayload.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>invariant</b> [suspendable] <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="block.md#0x1_block_BlockResource">BlockResource</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/chain_id.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_id.md
@@ -12,6 +12,8 @@ This code provides a container for storing a chain id and functions to initializ
 -  [Function `initialize`](#0x1_chain_id_initialize)
 -  [Function `get`](#0x1_chain_id_get)
 -  [Specification](#@Specification_0)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_0_initialize)
     -  [Function `get`](#@Specification_0_get)
 
@@ -107,6 +109,42 @@ Return the chain ID of this instance.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>During genesis, the ChainId resource should be created and moved under the Aptos framework account with the specified chain id.</td>
+<td>Medium</td>
+<td>The chain_id::initialize function is responsible for generating the ChainId resource and then storing it under the aptos_framework account.</td>
+<td>Formally verified via <a href="#high-level-req-1">initialize</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>The chain id can only be fetched if the chain id resource exists under the Aptos framework account.</td>
+<td>Low</td>
+<td>The chain_id::get function fetches the chain id by borrowing the ChainId resource from the aptos_framework account.</td>
+<td>Formally verified via <a href="#high-level-req-2">get</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -127,6 +165,7 @@ Return the chain ID of this instance.
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>ensures</b> <b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(addr);
 <b>ensures</b> <b>global</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(addr).id == id;
 </code></pre>
@@ -145,7 +184,8 @@ Return the chain ID of this instance.
 
 
 
-<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(@aptos_framework);
+<pre><code>// This enforces <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="chain_id.md#0x1_chain_id_ChainId">ChainId</a>&gt;(@aptos_framework);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/chain_status.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_status.md
@@ -17,6 +17,8 @@ which reflect that the system has been successfully initialized.
 -  [Function `assert_operating`](#0x1_chain_status_assert_operating)
 -  [Function `assert_genesis`](#0x1_chain_status_assert_genesis)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `set_genesis_end`](#@Specification_1_set_genesis_end)
     -  [Function `assert_operating`](#@Specification_1_assert_operating)
     -  [Function `assert_genesis`](#@Specification_1_assert_genesis)
@@ -217,8 +219,53 @@ Helper function to assert genesis state.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>The end of genesis mark should persist throughout the entire life of the chain.</td>
+<td>Medium</td>
+<td>The Aptos framework account should never drop the GenesisEndMarker resource.</td>
+<td>Audited that GenesisEndMarker is published at the end of genesis and never removed. Formally verified via <a href="#high-level-req-1">set_genesis_end</a> that GenesisEndMarker is published.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>The status of the chain should never be genesis and operating at the same time.</td>
+<td>Low</td>
+<td>The status of the chain is determined by the GenesisEndMarker resource.</td>
+<td>Formally verified via <a href="#high-level-req-2">global invariant</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>The status of the chain should only be changed once, from genesis to operating.</td>
+<td>Low</td>
+<td>Attempting to assign a resource type more than once will abort.</td>
+<td>Formally verified via <a href="#high-level-req-3">set_genesis_end</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
+// This enforces <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:
 <b>invariant</b> <a href="chain_status.md#0x1_chain_status_is_genesis">is_genesis</a>() == !<a href="chain_status.md#0x1_chain_status_is_operating">is_operating</a>();
 </code></pre>
 
@@ -239,7 +286,9 @@ Helper function to assert genesis state.
 <b>pragma</b> delegate_invariants_to_caller;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
+// This enforces <a id="high-level-req-3" href="#high-level-req">high level requirement 3</a>:
 <b>aborts_if</b> <b>exists</b>&lt;<a href="chain_status.md#0x1_chain_status_GenesisEndMarker">GenesisEndMarker</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>ensures</b> <b>global</b>&lt;<a href="chain_status.md#0x1_chain_status_GenesisEndMarker">GenesisEndMarker</a>&gt;(@aptos_framework) == <a href="chain_status.md#0x1_chain_status_GenesisEndMarker">GenesisEndMarker</a> {};
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/code.md
+++ b/aptos-move/framework/aptos-framework/doc/code.md
@@ -28,6 +28,8 @@ This module supports functionality related to code management.
 -  [Function `request_publish`](#0x1_code_request_publish)
 -  [Function `request_publish_with_allowed_deps`](#0x1_code_request_publish_with_allowed_deps)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `publish_package`](#@Specification_1_publish_package)
     -  [Function `publish_package_txn`](#@Specification_1_publish_package_txn)
@@ -884,6 +886,82 @@ Native function to initiate module loading, including a list of allowed dependen
 
 ## Specification
 
+
+
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>Updating a package should fail if the user is not the owner of it.</td>
+<td>Critical</td>
+<td>The publish_package function may only be able to update the package if the signer is the actual owner of the package.</td>
+<td>The Aptos upgrade native functions have been manually audited.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>The arbitrary upgrade policy should never be used.</td>
+<td>Critical</td>
+<td>There should never be a pass of an arbitrary upgrade policy to the request_publish native function.</td>
+<td>Manually audited that it aborts if package.upgrade_policy.policy == 0.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Should perform accurate compatibility checks when the policy indicates compatibility, ensuring it meets the required conditions.</td>
+<td>Critical</td>
+<td>Specifies if it should perform compatibility checks for upgrades. The check only passes if a new module has (a) the same public functions, and (b) for existing resources, no layout change.</td>
+<td>The Move upgradability patterns have been manually audited.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Package upgrades should abide by policy change rules. In particular, The new upgrade policy must be equal to or stricter when compared to the old one. The original upgrade policy must not be immutable. The new package must contain all modules contained in the old package.</td>
+<td>Medium</td>
+<td>A package may only be updated using the publish_package function when the check_upgradability function returns true.</td>
+<td>This is audited by a manual review of the check_upgradability patterns.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>The upgrade policy of a package must not exceed the strictness level imposed by its dependencies.</td>
+<td>Medium</td>
+<td>The upgrade_policy of a package may only be less than its dependencies throughout the upgrades. In addition, the native code properly restricts the use of dependencies outside the passed-in metadata.</td>
+<td>This has been manually audited.</td>
+</tr>
+
+<tr>
+<td>6</td>
+<td>The extension for package metadata is currently unused.</td>
+<td>Medium</td>
+<td>The extension field in PackageMetadata should be unused.</td>
+<td>Data invariant on the extension field has been manually audited.</td>
+</tr>
+
+<tr>
+<td>7</td>
+<td>The upgrade number of a package increases incrementally in a monotonic manner with each subsequent upgrade.</td>
+<td>Low</td>
+<td>On each upgrade of a particular package, the publish_package function updates the upgrade_number for that package.</td>
+<td>Post condition on upgrade_number has been manually audited.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -60,6 +60,7 @@ This module provides the foundation for typesafe Coins.
 -  [Function `destroy_burn_cap`](#0x1_coin_destroy_burn_cap)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Struct `AggregatableCoin`](#@Specification_1_AggregatableCoin)
     -  [Function `initialize_supply_config`](#@Specification_1_initialize_supply_config)
     -  [Function `allow_supply_upgrades`](#@Specification_1_allow_supply_upgrades)
@@ -2031,6 +2032,11 @@ Destroy a burn capability.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -12,6 +12,8 @@ Reconfiguration, and may be updated by root.
 -  [Function `initialize`](#0x1_consensus_config_initialize)
 -  [Function `set`](#0x1_consensus_config_set)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `set`](#@Specification_1_set)
 
@@ -130,6 +132,50 @@ This can be called by on-chain governance to update on-chain consensus configs.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>During genesis, the Aptos framework account should be assigned the consensus config resource.</td>
+<td>Medium</td>
+<td>The consensus_config::initialize function calls the assert_aptos_framework function to ensure that the signer is the aptos_framework and then assigns the ConsensusConfig resource to it.</td>
+<td>Formally verified via <a href="#high-level-req-1">initialize</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Only aptos framework account is allowed to update the consensus configuration.</td>
+<td>Medium</td>
+<td>The consensus_config::set function ensures that the signer is aptos_framework.</td>
+<td>Formally verified via <a href="#high-level-req-2">set</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Only a valid configuration can be used during initialization and update.</td>
+<td>Medium</td>
+<td>Both the initialize and set functions validate the config by ensuring its length to be greater than 0.</td>
+<td>Formally verified via <a href="#high-level-req-3.1">initialize</a> and <a href="#high-level-req-3.2">set</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -150,8 +196,10 @@ Aborts if StateStorageUsage already exists.
 
 
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-3.1" href="#high-level-req">high level requirement 3</a>:
 <b>aborts_if</b> !(len(config) &gt; 0);
 <b>ensures</b> <b>global</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(addr) == <a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a> { config };
 </code></pre>
@@ -175,8 +223,10 @@ When setting now time must be later than last_reconfiguration_time.
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+// This enforces <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-3.2" href="#high-level-req">high level requirement 3</a>:
 <b>aborts_if</b> !(len(config) &gt; 0);
 <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();

--- a/aptos-move/framework/aptos-framework/doc/create_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/create_signer.md
@@ -18,6 +18,7 @@ on account to have access to this.
 -  [Function `create_signer`](#0x1_create_signer_create_signer)
 -  [Specification](#@Specification_0)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `create_signer`](#@Specification_0_create_signer)
 
 
@@ -76,7 +77,7 @@ on account to have access to this.
 <td>The account owner should have the ability to create a signer for their account.</td>
 <td>Medium</td>
 <td>Before an Account resource is created, a signer is created for the specified new_address, and later, the Account resource is assigned to this signer.</td>
-<td>Enforced by the move vm</td>
+<td>Enforced by the <a href="https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-vm/types/src/values/values_impl.rs#L1129">move vm</a>.</td>
 </tr>
 
 <tr>
@@ -92,12 +93,17 @@ on account to have access to this.
 <td>A signer should be returned for addresses that are not registered as accounts.</td>
 <td>Low</td>
 <td>The signer is just a struct that wraps an address, allows for non-accounts to have a signer.</td>
-<td>Formally verified via create_signer</td>
+<td>Formally verified via <a href="#0x1_create_signer_create_signer">create_signer</a>.</td>
 </tr>
 
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -207,6 +207,8 @@ transferred to A
 -  [Function `update_governanace_records_for_redeem_pending_inactive_shares`](#0x1_delegation_pool_update_governanace_records_for_redeem_pending_inactive_shares)
 -  [Function `multiply_then_divide`](#0x1_delegation_pool_multiply_then_divide)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -4199,6 +4201,114 @@ Deprecated, prefer math64::mul_div
 
 ## Specification
 
+
+
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>Every DelegationPool has only one corresponding StakePool stored at the same address.</td>
+<td>Critical</td>
+<td>Upon calling the initialize_delegation_pool function, a resource account is created from the "owner" signer to host the delegation pool resource and own the underlying stake pool.</td>
+<td>Audited that the address of StakePool equals address of DelegationPool and the data invariant on the DelegationPool.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>The signer capability within the delegation pool has an address equal to the address of the delegation pool.</td>
+<td>Critical</td>
+<td>The initialize_delegation_pool function moves the DelegationPool resource to the address associated with stake_pool_signer, which also possesses the signer capability.</td>
+<td>Audited that the address of signer cap equals address of DelegationPool.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>A delegator holds shares exclusively in one inactive shares pool, which could either be an already inactive pool or the pending_inactive pool.</td>
+<td>High</td>
+<td>The get_stake function returns the inactive stake owned by a delegator and checks which state the shares are in via the get_pending_withdrawal function.</td>
+<td>Audited that either inactive or pending_inactive stake after invoking the get_stake function is zero and both are never non-zero.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>The specific pool in which the delegator possesses inactive shares becomes designated as the pending withdrawal pool for that delegator.</td>
+<td>Medium</td>
+<td>The get_pending_withdrawal function checks if any pending withdrawal exists for a delegate address and if there is neither inactive nor pending_inactive stake, the pending_withdrawal_exists returns false.</td>
+<td>This has been audited.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>The existence of a pending withdrawal implies that it is associated with a pool where the delegator possesses inactive shares.</td>
+<td>Medium</td>
+<td>In the get_pending_withdrawal function, if withdrawal_exists is true, the function returns true and a non-zero amount</td>
+<td>get_pending_withdrawal has been audited.</td>
+</tr>
+
+<tr>
+<td>6</td>
+<td>An inactive shares pool should have coins allocated to it; otherwise, it should become deleted.</td>
+<td>Medium</td>
+<td>The redeem_inactive_shares function has a check that destroys the inactive shares pool, given that it is empty.</td>
+<td>shares pools have been audited.</td>
+</tr>
+
+<tr>
+<td>7</td>
+<td>The index of the pending withdrawal will not exceed the current OLC on DelegationPool.</td>
+<td>High</td>
+<td>The get_pending_withdrawal function has a check which ensures that withdrawal_olc.index < pool.observed_lockup_cycle.index.</td>
+<td>This has been audited.</td>
+</tr>
+
+<tr>
+<td>8</td>
+<td>Slashing is not possible for inactive stakes.</td>
+<td>Critical</td>
+<td>The number of inactive staked coins must be greater than or equal to the total_coins_inactive of the pool.</td>
+<td>This has been audited.</td>
+</tr>
+
+<tr>
+<td>9</td>
+<td>The delegator's active or pending inactive stake will always meet or exceed the minimum allowed value.</td>
+<td>Medium</td>
+<td>The add_stake, unlock and reactivate_stake functions ensure the active_shares or pending_inactive_shares balance for the delegator is greater than or equal to the MIN_COINS_ON_SHARES_POOL value.</td>
+<td>Audited the comparison of active_shares or inactive_shares balance for the delegator with the MIN_COINS_ON_SHARES_POOL value.</td>
+</tr>
+
+<tr>
+<td>10</td>
+<td>The delegation pool exists at a given address.</td>
+<td>Low</td>
+<td>Functions that operate on the DelegationPool abort if there is no DelegationPool struct under the given pool_address.</td>
+<td>Audited that there is no DelegationPool structure assigned to the pool_address given as a parameter.</td>
+</tr>
+
+<tr>
+<td>11</td>
+<td>The initialization of the delegation pool is contingent upon enabling the delegation pools feature.</td>
+<td>Critical</td>
+<td>The initialize_delegation_pool function should proceed if the DELEGATION_POOLS feature is enabled.</td>
+<td>This has been audited.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify=<b>false</b>;

--- a/aptos-move/framework/aptos-framework/doc/event.md
+++ b/aptos-move/framework/aptos-framework/doc/event.md
@@ -20,6 +20,7 @@ events emitted to a handle and emit events to the event store.
 -  [Function `destroy_handle`](#0x1_event_destroy_handle)
 -  [Specification](#@Specification_0)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `emit`](#@Specification_0_emit)
     -  [Function `write_module_event_to_store`](#@Specification_0_write_module_event_to_store)
     -  [Function `emit_event`](#@Specification_0_emit_event)
@@ -339,6 +340,11 @@ Destroy a unique handle.
 
 </table>
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -15,6 +15,8 @@ it costs to execute Move on the network.
 -  [Function `set_gas_schedule`](#0x1_gas_schedule_set_gas_schedule)
 -  [Function `set_storage_gas_config`](#0x1_gas_schedule_set_storage_gas_config)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `set_gas_schedule`](#@Specification_1_set_gas_schedule)
     -  [Function `set_storage_gas_config`](#@Specification_1_set_storage_gas_config)
@@ -257,6 +259,58 @@ This can be called by on-chain governance to update the gas schedule.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>During genesis, the Aptos framework account should be assigned the gas schedule resource.</td>
+<td>Medium</td>
+<td>The gas_schedule::initialize function calls the assert_aptos_framework function to ensure that the signer is the aptos_framework and then assigns the GasScheduleV2 resource to it.</td>
+<td>Formally verified via <a href="#high-level-req-1">initialize</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Only the Aptos framework account should be allowed to update the gas schedule resource.</td>
+<td>Critical</td>
+<td>The gas_schedule::set_gas_schedule function calls the assert_aptos_framework function to ensure that the signer is the aptos framework account.</td>
+<td>Formally verified via <a href="#high-level-req-2">set_gas_schedule</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Only valid gas schedule should be allowed for initialization and update.</td>
+<td>Medium</td>
+<td>The initialize and set_gas_schedule functions ensures that the gas_schedule_blob is not empty.</td>
+<td>Formally verified via <a href="#high-level-req-3.3">initialize</a> and <a href="#high-level-req-3.2">set_gas_schedule</a>.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Only a gas schedule with the feature version greater or equal than the current feature version is allowed to be provided when performing an update operation.</td>
+<td>Medium</td>
+<td>The set_gas_schedule function validates the feature_version of the new_gas_schedule by ensuring that it is greater or equal than the current gas_schedule.feature_version.</td>
+<td>Formally verified via <a href="#high-level-req-4">set_gas_schedule</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -275,7 +329,9 @@ This can be called by on-chain governance to update the gas schedule.
 
 
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
+// This enforces <a id="high-level-req-3.3" href="#high-level-req">high level requirement 3</a>:
 <b>aborts_if</b> len(gas_schedule_blob) == 0;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(addr);
 <b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(addr);
@@ -299,10 +355,13 @@ This can be called by on-chain governance to update the gas schedule.
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
+// This enforces <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:
 <b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
+// This enforces <a id="high-level-req-3.2" href="#high-level-req">high level requirement 3</a>:
 <b>aborts_if</b> len(gas_schedule_blob) == 0;
 <b>let</b> new_gas_schedule = <a href="util.md#0x1_util_spec_from_bytes">util::spec_from_bytes</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(gas_schedule_blob);
 <b>let</b> <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a> = <b>global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-4" href="#high-level-req">high level requirement 4</a>:
 <b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) && new_gas_schedule.feature_version &lt; <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>.feature_version;
 <b>ensures</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
 <b>ensures</b> <b>global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) == new_gas_schedule;

--- a/aptos-move/framework/aptos-framework/doc/governance_proposal.md
+++ b/aptos-move/framework/aptos-framework/doc/governance_proposal.md
@@ -14,6 +14,7 @@ This is separate from the AptosGovernance module to avoid circular dependency be
 -  [Specification](#@Specification_0)
     -  [Function `create_proposal`](#@Specification_0_create_proposal)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `create_empty_proposal`](#@Specification_0_create_empty_proposal)
 
 
@@ -143,6 +144,11 @@ Useful for AptosGovernance to create an empty proposal as proof.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>aborts_if</b> <b>false</b>;

--- a/aptos-move/framework/aptos-framework/doc/guid.md
+++ b/aptos-move/framework/aptos-framework/doc/guid.md
@@ -19,6 +19,7 @@ A module for generating globally unique identifiers
 -  [Function `eq_id`](#0x1_guid_eq_id)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `create`](#@Specification_1_create)
     -  [Function `create_id`](#@Specification_1_create_id)
     -  [Function `id`](#@Specification_1_id)
@@ -367,6 +368,11 @@ Return true if the GUID's ID is <code>id</code>
 
 </table>
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/managed_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/managed_coin.md
@@ -16,6 +16,7 @@ By utilizing this current module, a developer can create his own coin and care l
 -  [Function `register`](#0x1_managed_coin_register)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `burn`](#@Specification_1_burn)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `mint`](#@Specification_1_mint)
@@ -299,6 +300,11 @@ Required if user wants to start accepting deposits of <code>CoinType</code> in h
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -84,6 +84,8 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `is_owner`](#0x1_object_is_owner)
 -  [Function `owns`](#0x1_object_owns)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `address_to_object`](#@Specification_1_address_to_object)
     -  [Function `create_object_address`](#@Specification_1_create_object_address)
     -  [Function `create_user_derived_object_address`](#@Specification_1_create_user_derived_object_address)
@@ -2138,6 +2140,74 @@ Return true if the provided address has indirect or direct ownership of the prov
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>It's not possible to create an object twice on the same address.</td>
+<td>Critical</td>
+<td>The create_object_internal function includes an assertion to ensure that the object being created does not already exist at the specified address.</td>
+<td>Formally verified via <a href="#high-level-req-1">create_object_internal</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Only its owner may transfer an object.</td>
+<td>Critical</td>
+<td>The transfer function mandates that the transaction be signed by the owner's address, ensuring that only the rightful owner may initiate the object transfer.</td>
+<td>Audited that it aborts if anyone other than the owner attempts to transfer.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>The indirect owner of an object may transfer the object.</td>
+<td>Medium</td>
+<td>The owns function evaluates to true when the given address possesses either direct or indirect ownership of the specified object.</td>
+<td>Audited that it aborts if address transferring is not indirect owner.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Objects may never change the address which houses them.</td>
+<td>Low</td>
+<td>After creating an object, transfers to another owner may occur. However, the address which stores the object may not be changed.</td>
+<td>This is implied by <a href="#high-level-req">high-level requirement 1</a>.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>If an ungated transfer is disabled on an object in an indirect ownership chain, a transfer should not occur.</td>
+<td>Medium</td>
+<td>Calling disable_ungated_transfer disables direct transfer, and only TransferRef may trigger transfers. The transfer_with_ref function is called.</td>
+<td>Formally verified via <a href="#high-level-req-5">transfer_with_ref</a>.</td>
+</tr>
+
+<tr>
+<td>6</td>
+<td>Object addresses must not overlap with other addresses in different domains.</td>
+<td>Critical</td>
+<td>The current addressing scheme with suffixes does not conflict with any existing addresses, such as resource accounts. The GUID space is explicitly separated to ensure this doesn't happen.</td>
+<td>This is true by construction if one correctly ensures the usage of INIT_GUID_CREATION_NUM during the creation of GUID.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> aborts_if_is_strict;
 <a id="0x1_object_g_roll"></a>
 <b>global</b> <a href="object.md#0x1_object_g_roll">g_roll</a>: u8;
@@ -2567,7 +2637,8 @@ Return true if the provided address has indirect or direct ownership of the prov
 
 
 
-<pre><code><b>aborts_if</b> <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>);
+<pre><code>// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
+<b>aborts_if</b> <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>);
 <b>ensures</b> <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>);
 <b>ensures</b> <b>global</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>).guid_creation_num == <a href="object.md#0x1_object_INIT_GUID_CREATION_NUM">INIT_GUID_CREATION_NUM</a> + 1;
 <b>ensures</b> result == <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> { self: <a href="object.md#0x1_object">object</a>, can_delete };
@@ -2765,6 +2836,7 @@ Return true if the provided address has indirect or direct ownership of the prov
 
 <pre><code><b>let</b> <a href="object.md#0x1_object">object</a> = <b>global</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(ref.self);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(ref.self);
+// This enforces <a id="high-level-req-5" href="#high-level-req">high level requirement 5</a>:
 <b>aborts_if</b> <a href="object.md#0x1_object">object</a>.owner != ref.owner;
 <b>ensures</b> <b>global</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(ref.self).owner == <b>to</b>;
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/optional_aggregator.md
+++ b/aptos-move/framework/aptos-framework/doc/optional_aggregator.md
@@ -29,6 +29,8 @@ aggregator (parallelizable) or via normal integers.
 -  [Function `read`](#0x1_optional_aggregator_read)
 -  [Function `is_parallelizable`](#0x1_optional_aggregator_is_parallelizable)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Struct `OptionalAggregator`](#@Specification_1_OptionalAggregator)
     -  [Function `new_integer`](#@Specification_1_new_integer)
     -  [Function `add_integer`](#@Specification_1_add_integer)
@@ -677,6 +679,49 @@ Returns true if optional aggregator uses parallelizable implementation.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>When creating a new integer instance, it guarantees that the limit assigned is a value passed into the function as an argument, and the value field becomes zero.</td>
+<td>High</td>
+<td>The new_integer function sets the limit field to the argument passed in, and the value field is set to zero.</td>
+<td>Formally verified via <a href="#high-level-req-1">new_integer</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>For a given integer instance it should always be possible to: (1) return the limit value of the integer resource, (2) return the current value stored in that particular instance, and (3) destroy the integer instance.</td>
+<td>Low</td>
+<td>The following functions should not abort if the Integer instance exists: limit(), read_integer(), destroy_integer().</td>
+<td>Formally verified via: <a href="#high-level-req-2.1">read_integer</a>, <a href="#high-level-req-2.2">limit</a>, and <a href="#high-level-req-2.3">destroy_integer</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Every successful switch must end with the aggregator type changed from non-parallelizable to parallelizable or vice versa.</td>
+<td>High</td>
+<td>The switch function run, if successful, should always change the aggregator type.</td>
+<td>Formally verified via <a href="#high-level-req-3">switch_and_zero_out</a>.</td>
+</tr>
+
+</table>
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -732,6 +777,7 @@ Returns true if optional aggregator uses parallelizable implementation.
 
 <pre><code><b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result.limit == limit;
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>ensures</b> result.value == 0;
 </code></pre>
 
@@ -785,7 +831,8 @@ Check for overflow.
 
 
 
-<pre><code><b>aborts_if</b> <b>false</b>;
+<pre><code>// This enforces <a id="high-level-req-2.2" href="#high-level-req">high level requirement 2</a>:
+<b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 
@@ -801,7 +848,8 @@ Check for overflow.
 
 
 
-<pre><code><b>aborts_if</b> <b>false</b>;
+<pre><code>// This enforces <a id="high-level-req-2.1" href="#high-level-req">high level requirement 2</a>:
+<b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 
@@ -817,7 +865,8 @@ Check for overflow.
 
 
 
-<pre><code><b>aborts_if</b> <b>false</b>;
+<pre><code>// This enforces <a id="high-level-req-2.3" href="#high-level-req">high level requirement 2</a>:
+<b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 
@@ -880,6 +929,7 @@ The AggregatorFactory is under the @aptos_framework when Option<Aggregator> does
 <b>aborts_if</b> <a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>) && len(vec_ref) != 0;
 <b>aborts_if</b> !<a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>) && len(vec_ref) == 0;
 <b>aborts_if</b> !<a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>) && !<b>exists</b>&lt;<a href="aggregator_factory.md#0x1_aggregator_factory_AggregatorFactory">aggregator_factory::AggregatorFactory</a>&gt;(@aptos_framework);
+// This enforces <a id="high-level-req-3" href="#high-level-req">high level requirement 3</a>:
 <b>ensures</b> <a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<b>old</b>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>)) ==&gt; !<a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>);
 <b>ensures</b> !<a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<b>old</b>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>)) ==&gt; <a href="optional_aggregator.md#0x1_optional_aggregator_is_parallelizable">is_parallelizable</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>);
 <b>ensures</b> <a href="optional_aggregator.md#0x1_optional_aggregator_optional_aggregator_value">optional_aggregator_value</a>(<a href="optional_aggregator.md#0x1_optional_aggregator">optional_aggregator</a>) == 0;

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -38,6 +38,8 @@ fungible asset to it. This emits an deposit event.
 -  [Function `transfer_with_ref`](#0x1_primary_fungible_store_transfer_with_ref)
 -  [Function `may_be_unburn`](#0x1_primary_fungible_store_may_be_unburn)
 -  [Specification](#@Specification_0)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
 
 
 <pre><code><b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
@@ -620,6 +622,122 @@ Transfer <code>amount</code> of FA from the primary store of <code>from</code> t
 
 ## Specification
 
+
+
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>Creating a fungible asset with primary store support should initiate a derived reference and store it under the metadata object.</td>
+<td>Medium</td>
+<td>The function create_primary_store_enabled_fungible_asset makes an existing object, fungible, via for the object and then stores it under the object address.</td>
+<td>Audited that the DeriveRefPod has been properly initialized and stored under the metadata object.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Fetching and creating a primary fungible store of an asset should only succeed if the object supports primary store.</td>
+<td>Low</td>
+<td>The function create_primary_store is used to create a primary store by borrowing the DeriveRef resource from the object. In case the resource does not exist, creation will fail. The function ensure_primary_store_exists is used to fetch the primary store if it exists, otherwise it will create one via the create_primary function.</td>
+<td>Audited that it aborts if the DeriveRefPod doesn't exist. Audited that it aborts if the FungibleStore resource exists already under the object address.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>It should be possible to create a primary store to hold a fungible asset.</td>
+<td>Medium</td>
+<td>The function create_primary_store borrows the DeriveRef resource from DeriveRefPod and then creates the store which is returned.</td>
+<td>Audited that it returns the newly created FungibleStore.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Fetching the balance or the frozen status of a primary store should never abort.</td>
+<td>Low</td>
+<td>The function balance returns the balance of the store, if the store exists, otherwise it returns 0. The function is_frozen returns the frozen flag of the fungible store, if the store exists, otherwise it returns false.</td>
+<td>Audited that the balance function returns the balance of the FungibleStore. Audited that the is_frozen function returns the frozen status of the FungibleStore resource. Audited that it never aborts.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>The ability to withdraw, deposit, transfer, mint and burn should only be available for assets with primary store support.</td>
+<td>Medium</td>
+<td>The primary store is fetched before performing either of withdraw, deposit, transfer, mint, burn operation. If the FungibleStore resource doesn't exist the operation will fail.</td>
+<td>Audited that it aborts if the primary store FungibleStore doesn't exist.</td>
+</tr>
+
+<tr>
+<td>6</td>
+<td>The action of depositing a fungible asset of the same type as the store should never fail if the store is not frozen.</td>
+<td>Medium</td>
+<td>The function deposit fetches the owner's store, if it doesn't exist it will be created, and then deposits the fungible asset to it. The function deposit_with_ref fetches the owner's store, if it doesn't exist Depositing fails if the metadata of the FungibleStore and FungibleAsset differs.</td>
+<td>Audited that it aborts if the store is frozen (deposit). Audited that the balance of the store is increased by the deposit amount (deposit, deposit_with_ref). Audited that it aborts if the metadata of the store and the asset differs (deposit, deposit_with_ref).</td>
+</tr>
+
+<tr>
+<td>7</td>
+<td>Withdrawing should only be allowed to the owner of an existing store with sufficient balance.</td>
+<td>Critical</td>
+<td>The withdraw function fetches the owner's store via the primary_store function and then calls store. The withdraw_with_ref function fetches the store of the owner via primary_store function and calls the and the balance of the store.</td>
+<td>Audited that it aborts if the owner doesn't own the store (withdraw). Audited that it aborts if the store is frozen (withdraw). Audited that it aborts if the transfer ref's metadata doesn't match the withdrawing store's metadata (withdraw_with_ref). Audited that it aborts if the store doesn't have sufficient balance. Audited that the store is not burned. Audited that the balance of the store is decreased by the amount withdrawn.</td>
+</tr>
+
+<tr>
+<td>8</td>
+<td>Only the fungible store owner is allowed to unburn a burned store.</td>
+<td>High</td>
+<td>The function may_be_unburn checks if the store is burned and then proceeds to call</td>
+<td>Audited that the store is unburned successfully.</td>
+</tr>
+
+<tr>
+<td>9</td>
+<td>Only the owner of a primary store can transfer its balance to any recipient's primary store.</td>
+<td>High</td>
+<td>The function transfer fetches sender and recipient's primary stores, if the sender's store is withdraws the assets from the sender's store and then deposits to the recipient's store. The function transfer_with_ref fetches the sender's and recipient's stores and calls the the asset to the recipient with the ref.</td>
+<td>Audited the deposit and withdraw (transfer). Audited the deposit_with_ref and withdraw_with_ref (transfer_with_ref). Audited that the store balance of the sender is decreased by the specified amount and its added to the recipients store. (transfer, transfer_with_ref) Audited that the sender's store is not burned (transfer).</td>
+</tr>
+
+<tr>
+<td>10</td>
+<td>Minting an amount of assets to an unfrozen store is only allowed with a valid mint reference.</td>
+<td>High</td>
+<td>The mint function fetches the primary store and calls the fungible_asset::mint_to, which mints with MintRef's metadata which internally validates the amount and the increases the total supply of the asset. And the minted asset is deposited to the provided store by validating that the store is unfrozen and the store's metadata is the same as the depositing asset's metadata.</td>
+<td>Audited that it aborts if the amount is equal to 0. Audited that it aborts if the store is frozen. Audited that it aborts if the mint_ref's metadata is not the same as the store's metadata. Audited that the asset's total supply is increased by the amount minted. Audited that the balance of the store is increased by the minted amount.</td>
+</tr>
+
+<tr>
+<td>11</td>
+<td>Burning an amount of assets from an existing unfrozen store is only allowed with a valid burn reference.</td>
+<td>High</td>
+<td>The burn function fetches the primary store and calls the fungible_asset::burn_from function which withdraws the amount from the store while enforcing that the store has enough balance and burns the withdrawn asset after validating the asset's metadata and the BurnRef's metadata followed by decreasing the supply of the asset.</td>
+<td>Audited that it aborts if the metadata of the store is not same as the BurnRef's metadata. Audited that it aborts if the burning amount is 0. Audited that it aborts if the store doesn't have enough balance. Audited that it aborts if the asset's metadata is not same as the BurnRef's metadata. Audited that the total supply of the asset is decreased. Audited that the store's balance is reduced by the amount burned.</td>
+</tr>
+
+<tr>
+<td>12</td>
+<td>Setting the frozen flag of a store is only allowed with a valid reference.</td>
+<td>High</td>
+<td>The function set_frozen_flag fetches the primary store and calls fungible_asset::set_frozen_flag which validates the TransferRef's metadata with the store's metadata and then updates the frozen flag.</td>
+<td>Audited that it aborts if the store's metadata is not same as the the TransferRef's metadata. Audited that the status of the frozen flag is updated correctly.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;

--- a/aptos-move/framework/aptos-framework/doc/resource_account.md
+++ b/aptos-move/framework/aptos-framework/doc/resource_account.md
@@ -86,6 +86,7 @@ module.resource_signer_cap = option::some(resource_signer_cap);
 -  [Function `retrieve_resource_account_cap`](#0x1_resource_account_retrieve_resource_account_cap)
 -  [Specification](#@Specification_3)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `create_resource_account`](#@Specification_3_create_resource_account)
     -  [Function `create_resource_account_and_fund`](#@Specification_3_create_resource_account_and_fund)
     -  [Function `create_resource_account_and_publish_package`](#@Specification_3_create_resource_account_and_publish_package)
@@ -456,6 +457,11 @@ the SignerCapability.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -108,6 +108,7 @@ or if their stake drops below the min required, they would get removed at the en
 -  [Function `assert_owner_cap_exists`](#0x1_stake_assert_owner_cap_exists)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Resource `ValidatorSet`](#@Specification_1_ValidatorSet)
     -  [Function `initialize_validator_fees`](#@Specification_1_initialize_validator_fees)
     -  [Function `add_transaction_fee`](#@Specification_1_add_transaction_fee)
@@ -3642,6 +3643,11 @@ Returns validator's next epoch voting power, including pending_active, active, a
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>invariant</b> [suspendable] <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework) ==&gt; <a href="stake.md#0x1_stake_validator_set_is_valid">validator_set_is_valid</a>();

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -28,6 +28,7 @@ Provides the configuration for staking and rewards
 -  [Function `validate_rewards_config`](#0x1_staking_config_validate_rewards_config)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Resource `StakingConfig`](#@Specification_1_StakingConfig)
     -  [Resource `StakingRewardsConfig`](#@Specification_1_StakingRewardsConfig)
     -  [Function `initialize`](#@Specification_1_initialize)
@@ -1035,6 +1036,11 @@ Can only be called as part of the Aptos governance proposal process established 
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>invariant</b> [suspendable] <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -79,6 +79,8 @@ pool.
 -  [Function `create_resource_account_seed`](#0x1_staking_contract_create_resource_account_seed)
 -  [Function `new_staking_contracts_holder`](#0x1_staking_contract_new_staking_contracts_holder)
 -  [Specification](#@Specification_1)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `stake_pool_address`](#@Specification_1_stake_pool_address)
     -  [Function `last_recorded_principal`](#@Specification_1_last_recorded_principal)
     -  [Function `commission_percentage`](#@Specification_1_commission_percentage)
@@ -2171,6 +2173,90 @@ Create a new staking_contracts resource.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>The Store structure for the staker exists after the staking contract is created.</td>
+<td>Medium</td>
+<td>The create_staking_contract_with_coins function ensures that the staker account has a Store structure assigned.</td>
+<td>Formally verified via <a href="#high-level-req-1">CreateStakingContractWithCoinsAbortsifAndEnsures</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>A staking contract is created and stored in a mapping within the Store resource.</td>
+<td>High</td>
+<td>The create_staking_contract_with_coins function adds the newly created StakingContract to the staking_contracts map with the operator as a key of the Store resource, effectively storing the staking contract.</td>
+<td>Formally verified via <a href="#high-level-req-2">CreateStakingContractWithCoinsAbortsifAndEnsures</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Adding stake to the stake pool increases the principal value of the pool, reflecting the additional stake amount.</td>
+<td>High</td>
+<td>The add_stake function transfers the specified amount of staked coins from the staker's account to the stake pool associated with the staking contract. It increases the principal value of the staking contract by the added stake amount.</td>
+<td>Formally verified via <a href="#high-level-req-3">add_stake</a>.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>The staker may update the voter of a staking contract, enabling them to modify the assigned voter address and ensure it accurately reflects their desired choice.</td>
+<td>High</td>
+<td>The update_voter function ensures that the voter address in a staking contract may be updated by the staker, resulting in the modification of the delegated voter address in the associated stake pool to reflect the new address provided.</td>
+<td>Formally verified via <a href="#high-level-req-4">update_voter</a>.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>Only the owner of the stake pool has the permission to reset the lockup period of the pool.</td>
+<td>Critical</td>
+<td>The reset_lockup function ensures that only the staker who owns the stake pool has the authority to reset the lockup period of the pool.</td>
+<td>Formally verified via <a href="#high-level-req-5">reset_lockup</a>.</td>
+</tr>
+
+<tr>
+<td>6</td>
+<td>Unlocked funds are correctly distributed to recipients based on their distribution shares, taking into account the associated commission percentage.</td>
+<td>High</td>
+<td>The distribution process, implemented in the distribute_internal function, accurately allocates unlocked funds to their intended recipients based on their distribution shares. It guarantees that each recipient receives the correct amount of funds, considering the commission percentage associated with the staking contract.</td>
+<td>Audited that the correct amount of unlocked funds is distributed according to distribution shares.</td>
+</tr>
+
+<tr>
+<td>7</td>
+<td>The stake pool ensures that the commission is correctly requested and paid out from the old operator's stake pool before allowing the switch to the new operator.</td>
+<td>High</td>
+<td>The switch_operator function initiates the commission payout from the stake pool associated with the old operator, ensuring a smooth transition. Paying out the commission before the switch guarantees that the staker receives the appropriate commission amount and maintains the integrity of the staking process.</td>
+<td>Audited that the commission is paid to the old operator.</td>
+</tr>
+
+<tr>
+<td>8</td>
+<td>Stakers can withdraw their funds from the staking contract, ensuring the unlocked amount becomes available for withdrawal after the lockup period.</td>
+<td>High</td>
+<td>The unlock_stake function ensures that the requested amount is properly unlocked from the stake pool, considering the lockup period and that the funds become available for withdrawal when the lockup expires.</td>
+<td>Audited that funds are unlocked properly.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -2412,6 +2498,7 @@ Staking_contract exists the stacker/operator pair.
 <b>let</b> <b>post</b> post_store = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
 <b>let</b> <b>post</b> post_staking_contract = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(post_store.staking_contracts, operator);
 <b>aborts_if</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.principal + amount &gt; MAX_U64;
+// This enforces <a id="high-level-req-3" href="#high-level-req">high level requirement 3</a>:
 <b>ensures</b> post_staking_contract.principal == <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.principal + amount;
 </code></pre>
 
@@ -2454,6 +2541,7 @@ Only active validator can update locked_until_secs.
 
 
 <pre><code><b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+// This enforces <a id="high-level-req-5" href="#high-level-req">high level requirement 5</a>:
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_ContractExistsAbortsIf">ContractExistsAbortsIf</a>{staker: staker_address};
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_IncreaseLockupWithCapAbortsIf">IncreaseLockupWithCapAbortsIf</a>{staker: staker_address};
 </code></pre>
@@ -2548,6 +2636,7 @@ Staking_contract exists the stacker/operator pair.
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+// This enforces <a id="high-level-req-4" href="#high-level-req">high level requirement 4</a>:
 <b>requires</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.commission_percentage &gt;= 0 && <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.<a href="staking_contract.md#0x1_staking_contract_commission_percentage">commission_percentage</a> &lt;= 100;
 <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
 <b>let</b> staking_contracts = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address).staking_contracts;
@@ -2924,6 +3013,7 @@ a staking_contract exists for the staker/operator pair.
     <b>let</b> <a href="account.md#0x1_account">account</a> = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(staker_address);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address) && !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(staker_address);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address) && <a href="account.md#0x1_account">account</a>.guid_creation_num + 9 &gt;= <a href="account.md#0x1_account_MAX_GUID_CREATION_NUM">account::MAX_GUID_CREATION_NUM</a>;
+    // This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
     <b>ensures</b> <b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
     <b>let</b> store = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
     <b>let</b> staking_contracts = store.staking_contracts;

--- a/aptos-move/framework/aptos-framework/doc/staking_proxy.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_proxy.md
@@ -14,6 +14,8 @@
 -  [Function `set_staking_contract_voter`](#0x1_staking_proxy_set_staking_contract_voter)
 -  [Function `set_stake_pool_voter`](#0x1_staking_proxy_set_stake_pool_voter)
 -  [Specification](#@Specification_0)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `set_operator`](#@Specification_0_set_operator)
     -  [Function `set_voter`](#@Specification_0_set_voter)
     -  [Function `set_vesting_contract_operator`](#@Specification_0_set_vesting_contract_operator)
@@ -259,6 +261,66 @@
 
 ## Specification
 
+
+
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>When updating the Vesting operator, it should be updated throughout all depending units.</td>
+<td>Medium</td>
+<td>The VestingContract contains a StakingInfo object that has an operator field, and this operator is mapped to a StakingContract object that in turn encompasses a StakePool object where the operator matches.</td>
+<td>Audited that it ensures the two operator fields hold the new value after the update.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>When updating the Vesting voter, it should be updated throughout all depending units.</td>
+<td>Medium</td>
+<td>The VestingContract contains a StakingInfo object that has an operator field, and this operator is mapped to a StakingContract object that in turn encompasses a StakePool object where the operator matches.</td>
+<td>Audited that it ensures the two operator fields hold the new value after the update.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>The operator and voter of a Vesting Contract should only be updated by the owner of the contract.</td>
+<td>High</td>
+<td>The owner-operator-voter model, as defined in the documentation, grants distinct abilities to each role. Therefore, it's crucial to ensure that only the owner has the authority to modify the operator or voter, to prevent the compromise of the StakePool.</td>
+<td>Audited that it ensures the signer owns the AdminStore resource and that the operator or voter intended for the update actually exists.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>The operator and voter of a Staking Contract should only be updated by the owner of the contract.</td>
+<td>High</td>
+<td>The owner-operator-voter model, as defined in the documentation, grants distinct abilities to each role. Therefore, it's crucial to ensure that only the owner has the authority to modify the operator or voter, to prevent the compromise of the StakePool.</td>
+<td>Audited the patterns of updating operators and voters in the staking contract.</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>Staking Contract's operators should be unique inside a store.</td>
+<td>Medium</td>
+<td>Duplicates among operators could result in incorrectly updating the operator or voter associated with the incorrect StakingContract.</td>
+<td>Enforced via <a href="https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/staking_contract.move#L87">SimpleMap</a>.</td>
+</tr>
+
+</table>
+
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/state_storage.md
+++ b/aptos-move/framework/aptos-framework/doc/state_storage.md
@@ -16,6 +16,7 @@
 -  [Function `on_reconfig`](#0x1_state_storage_on_reconfig)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `on_new_block`](#@Specification_1_on_new_block)
     -  [Function `current_items_and_bytes`](#@Specification_1_current_items_and_bytes)
@@ -343,6 +344,11 @@ guarantees a fresh state view then.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/storage_gas.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_gas.md
@@ -239,6 +239,7 @@ The below index is automatically generated from source code:
 -  [Specification](#@Specification_16)
     -  [Struct `Point`](#@Specification_16_Point)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Struct `UsageGasConfig`](#@Specification_16_UsageGasConfig)
     -  [Struct `GasCurve`](#@Specification_16_GasCurve)
     -  [Function `base_8192_exponential_curve`](#@Specification_16_base_8192_exponential_curve)
@@ -1286,6 +1287,11 @@ A non decreasing curve must ensure that next is greater than cur.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>invariant</b> x &lt;= <a href="storage_gas.md#0x1_storage_gas_BASIS_POINT_DENOMINATION">BASIS_POINT_DENOMINATION</a>;

--- a/aptos-move/framework/aptos-framework/doc/system_addresses.md
+++ b/aptos-move/framework/aptos-framework/doc/system_addresses.md
@@ -20,6 +20,7 @@
 -  [Function `is_reserved_address`](#0x1_system_addresses_is_reserved_address)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `assert_core_resource`](#@Specification_1_assert_core_resource)
     -  [Function `assert_core_resource_address`](#@Specification_1_assert_core_resource_address)
     -  [Function `is_core_resource_address`](#@Specification_1_is_core_resource_address)
@@ -432,6 +433,11 @@ Return true if <code>addr</code> is either the VM address or an Aptos Framework 
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/timestamp.md
+++ b/aptos-move/framework/aptos-framework/doc/timestamp.md
@@ -17,6 +17,7 @@ It interacts with the other modules in the following ways:
 -  [Function `now_seconds`](#0x1_timestamp_now_seconds)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `update_global_time`](#@Specification_1_update_global_time)
 
 
@@ -260,6 +261,11 @@ Gets the current time in seconds.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code>// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a> and <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:

--- a/aptos-move/framework/aptos-framework/doc/transaction_context.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_context.md
@@ -19,6 +19,8 @@
     -  [Function `generate_unique_address`](#@Specification_0_generate_unique_address)
     -  [Function `generate_auid_address`](#@Specification_0_generate_auid_address)
     -  [Function `get_script_hash`](#@Specification_0_get_script_hash)
+    -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `auid_address`](#@Specification_0_auid_address)
 
 
@@ -280,6 +282,7 @@ the generated unique address wrapped in the AUID class.
 
 
 <pre><code><b>pragma</b> opaque;
+// This enforces <a id="high-level-req-1" href="#high-level-req">high level requirement 1</a>:
 <b>ensures</b> [abstract] len(result) == 32;
 </code></pre>
 
@@ -323,6 +326,7 @@ the generated unique address wrapped in the AUID class.
 
 
 <pre><code><b>pragma</b> opaque;
+// This enforces <a id="high-level-req-3" href="#high-level-req">high level requirement 3</a>:
 <b>ensures</b> [abstract] result == <a href="transaction_context.md#0x1_transaction_context_spec_generate_unique_address">spec_generate_unique_address</a>();
 </code></pre>
 
@@ -339,7 +343,59 @@ the generated unique address wrapped in the AUID class.
 
 
 
+
+<a id="high-level-req"></a>
+
+### High-level Requirements
+
+<table>
+<tr>
+<th>No.</th><th>Property</th><th>Criticality</th><th>Implementation</th><th>Enforcement</th>
+</tr>
+
+<tr>
+<td>1</td>
+<td>Fetching the transaction hash should return a vector with 32 bytes.</td>
+<td>Medium</td>
+<td>The get_transaction_hash function calls the native function get_txn_hash, which fetches the NativeTransactionContext struct and returns the txn_hash field.</td>
+<td>Audited that the native function returns the txn hash, whose size is 32 bytes. This has been modeled as the abstract postcondition that the returned vector is of length 32. Formally verified via <a href="#high-level-req-1">get_txn_hash</a>.</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Fetching the unique address should never abort.</td>
+<td>Low</td>
+<td>The function auid_address returns the unique address from a supplied AUID resource.</td>
+<td>Formally verified via <a href="#high-level-req-2">auid_address</a>.</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Generating the unique address should return a vector with 32 bytes.</td>
+<td>Medium</td>
+<td>The generate_auid_address function checks calls the native function generate_unique_address which fetches the NativeTransactionContext struct, increments the auid_counter by one, and then creates a new authentication key from a preimage, which is then returned.</td>
+<td>Audited that the native function returns an address, and the length of an address is 32 bytes. This has been modeled as the abstract postcondition that the returned vector is of length 32. Formally verified via <a href="#high-level-req-3">generate_auid_address</a>.</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Fetching the script hash of the current entry function should never fail and should return a vector with 32 bytes if the transaction payload is a script, otherwise an empty vector.</td>
+<td>Low</td>
+<td>The native function get_script_hash returns the NativeTransactionContext.script_hash field.</td>
+<td>Audited that the native function holds the required property. This has been modeled as the abstract spec. Formally verified via <a href="#high-level-req-4">get_script_hash</a>.</td>
+</tr>
+
+</table>
+
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
+
+
 <pre><code><b>pragma</b> opaque;
+// This enforces <a id="high-level-req-4" href="#high-level-req">high level requirement 4</a>:
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] result == <a href="transaction_context.md#0x1_transaction_context_spec_get_script_hash">spec_get_script_hash</a>();
 <b>ensures</b> [abstract] len(result) == 32;
@@ -367,7 +423,8 @@ the generated unique address wrapped in the AUID class.
 
 
 
-<pre><code><b>aborts_if</b> <b>false</b>;
+<pre><code>// This enforces <a id="high-level-req-2" href="#high-level-req">high level requirement 2</a>:
+<b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_fee.md
@@ -26,6 +26,7 @@ This module provides an interface to burn or collect and redistribute transactio
 -  [Function `emit_fee_statement`](#0x1_transaction_fee_emit_fee_statement)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Resource `CollectedFeesPerBlock`](#@Specification_1_CollectedFeesPerBlock)
     -  [Function `initialize_fee_collection_and_distribution`](#@Specification_1_initialize_fee_collection_and_distribution)
     -  [Function `upgrade_burn_percentage`](#@Specification_1_upgrade_burn_percentage)
@@ -753,6 +754,11 @@ Only called during genesis.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -18,6 +18,7 @@
 -  [Function `epilogue_gas_payer`](#0x1_transaction_validation_epilogue_gas_payer)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `prologue_common`](#@Specification_1_prologue_common)
     -  [Function `module_prologue`](#@Specification_1_module_prologue)
@@ -714,6 +715,11 @@ Called by the Adapter
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/util.md
+++ b/aptos-move/framework/aptos-framework/doc/util.md
@@ -11,6 +11,7 @@ Utility functions used by the framework modules.
 -  [Specification](#@Specification_0)
     -  [Function `from_bytes`](#@Specification_0_from_bytes)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `address_from_bytes`](#@Specification_0_address_from_bytes)
 
 
@@ -106,6 +107,11 @@ owned.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> opaque;

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -14,6 +14,7 @@ Maintains the version number for the blockchain.
 -  [Function `initialize_for_test`](#0x1_version_initialize_for_test)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `set_version`](#@Specification_1_set_version)
     -  [Function `initialize_for_test`](#@Specification_1_initialize_for_test)
@@ -234,6 +235,11 @@ to update the version.
 </table>
 
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -61,6 +61,7 @@ the resolution process.
 -  [Function `get_proposal`](#0x1_voting_get_proposal)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
+    -  [Module-level Specification](#module-level-spec)
     -  [Function `register`](#@Specification_1_register)
     -  [Function `create_proposal`](#@Specification_1_create_proposal)
     -  [Function `create_proposal_v2`](#@Specification_1_create_proposal_v2)
@@ -1698,6 +1699,11 @@ Return true if the voting period of the given proposal has already ended.
 
 </table>
 
+
+
+<a id="module-level-spec"></a>
+
+### Module-level Specification
 
 
 <pre><code><b>pragma</b> verify = <b>true</b>;

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -1,4 +1,109 @@
 spec aptos_framework::account {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: The initialization of the account module should result in the proper system initialization with valid
+    /// and consistent resources.
+    /// Criticality: High
+    /// Implementation: Initialization of the account module creates a valid address_map table and moves the resources
+    /// to the OriginatingAddress under the aptos_framework account.
+    /// Enforcement: Audited that the address_map table is created and populated correctly with the expected initial
+    /// values.
+    ///
+    /// No.: 2
+    /// Property: After successfully creating an account, the account resources should initialize with the default data,
+    /// ensuring the proper initialization of the account state.
+    /// Criticality: High
+    /// Implementation: Creating an account via the create_account function validates the state and moves a new account
+    /// resource under new_address.
+    /// Enforcement: Formally verified via [high-level-req-2](create_account).
+    ///
+    /// No.: 3
+    /// Property: Checking the existence of an account under a given address never results in an abort.
+    /// Criticality: Low
+    /// Implementation: The exists_at function returns a boolean value indicating the existence of an account under the
+    /// given address.
+    /// Enforcement: Formally verified by the [high-level-req-3](aborts_if) condition.
+    ///
+    /// No.: 4
+    /// Property: The account module maintains bounded sequence numbers for all accounts, guaranteeing they remain
+    /// within the specified limit.
+    /// Criticality: Medium
+    /// Implementation: The sequence number of an account may only increase up to MAX_U64 in a succeeding manner.
+    /// Enforcement: Formally verified via [high-level-req-4](increment_sequence_number) that it remains within the defined boundary of
+    /// MAX_U64.
+    ///
+    /// No.: 5
+    /// Property: Only the ed25519 and multied25519 signature schemes are permissible.
+    /// Criticality: Low
+    /// Implementation: Exclusively perform key rotation using either the ed25519 or multied25519 signature schemes.
+    /// Currently restricts the offering of rotation/signing capabilities to the ed25519 or multied25519 schemes.
+    /// Enforcement: Formally Verified: [high-level-req-5.1](rotate_authentication_key),
+    /// [high-level-req-5.2](offer_rotation_capability), and [high-level-req-5.3](offer_signer_capability).
+    /// Verified that it aborts if the account_scheme is not ED25519_SCHEME and not MULTI_ED25519_SCHEME. Audited
+    /// that the scheme enums correspond correctly to signature logic.
+    ///
+    /// No.: 6
+    /// Property: Exclusively permit the rotation of the authentication key of an account for the account owner or any
+    /// user who possesses rotation capabilities associated with that account.
+    /// Criticality: Critical
+    /// Implementation: In the rotate_authentication_key function, the authentication key derived from the
+    /// from_public_key_bytes should match the signer's current authentication key. Only the delegate_signer granted the
+    /// rotation capabilities may invoke the rotate_authentication_key_with_rotation_capability function.
+    /// Enforcement: Formally Verified via [high-level-req-6.1](rotate_authentication_key) and
+    /// [high-level-req-6.2](rotate_authentication_key_with_rotation_capability).
+    ///
+    /// No.: 7
+    /// Property: Only the owner of an account may offer or revoke the following capabilities: (1)
+    /// offer_rotation_capability, (2) offer_signer_capability, (3) revoke_rotation_capability, and (4)
+    /// revoke_signer_capability.
+    /// Criticality: Critical
+    /// Implementation: An account resource may only be modified by the owner of the account utilizing:
+    /// rotation_capability_offer, signer_capability_offer.
+    /// Enforcement: Formally verified via [high-level-req-7.1](offer_rotation_capability),
+    /// [high-level-req-7.2](offer_signer_capability), and [high-level-req-7.3](revoke_rotation_capability).
+    /// and [high-level-req-7.4](revoke_signer_capability).
+    ///
+    /// No.: 8
+    /// Property: The capability to create a signer for the account is exclusively reserved for either the account owner
+    /// or the account that has been granted the signing capabilities.
+    /// Criticality: Critical
+    /// Implementation: Signer creation for the account may only be successfully executed by explicitly granting the
+    /// signing capabilities with the create_authorized_signer function.
+    /// Enforcement: Formally verified via [high-level-req-8](create_authorized_signer).
+    ///
+    /// No.: 9
+    /// Property: Rotating the authentication key requires two valid signatures. With the private key of the current
+    /// authentication key. With the private key of the new authentication key.
+    /// Criticality: Critical
+    /// Implementation: The rotate_authentication_key verifies two signatures (current and new) before rotating to the
+    /// new key. The first signature ensures the user has the intended capability, and the second signature ensures that
+    /// the user owns the new key.
+    /// Enforcement: Formally verified via [high-level-req-9.1](rotate_authentication_key) and
+    /// [high-level-req-9.2](rotate_authentication_key_with_rotation_capability).
+    ///
+    /// No.: 10
+    /// Property: The rotation of the authentication key updates the account's authentication key with the newly supplied
+    /// one.
+    /// Criticality: High
+    /// Implementation: The auth_key may only update to the provided new_auth_key after verifying the signature.
+    /// Enforcement: Formally Verified in [high-level-req-10](rotate_authentication_key_internal) that the
+    /// authentication key of an account is modified to the provided authentication key if the signature verification
+    /// was successful.
+    ///
+    /// No.: 11
+    /// Property: The creation number is monotonically increasing.
+    /// Criticality: Low
+    /// Implementation: The guid_creation_num in the Account structure is monotonically increasing.
+    /// Enforcement: Formally Verified via [high-level-req-11](guid_creation_num).
+    ///
+    /// No.: 12
+    /// Property: The Account resource is persistent.
+    /// Criticality: Low
+    /// Implementation: The Account structure assigned to the address should be persistent.
+    /// Enforcement: Audited that the Account structure is persistent.
+    /// </high-level-req>
+    ///
+
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -23,6 +128,7 @@ spec aptos_framework::account {
             || account_address == @aptos_token
             || !(len(authentication_key) == 32)
         );
+        /// [high-level-req-2]
         ensures exists<Account>(account_address);
     }
 
@@ -46,6 +152,7 @@ spec aptos_framework::account {
     }
 
     spec exists_at {
+        /// [high-level-req-3]
         aborts_if false;
     }
 
@@ -72,6 +179,7 @@ spec aptos_framework::account {
     spec increment_sequence_number(addr: address) {
         let sequence_number = global<Account>(addr).sequence_number;
         aborts_if !exists<Account>(addr);
+        /// [high-level-req-4]
         aborts_if sequence_number == MAX_U64;
         modifies global<Account>(addr);
         let post post_sequence_number = global<Account>(addr).sequence_number;
@@ -87,6 +195,7 @@ spec aptos_framework::account {
     /// The length of new_auth_key is 32.
     spec rotate_authentication_key_internal(account: &signer, new_auth_key: vector<u8>) {
         let addr = signer::address_of(account);
+        /// [high-level-req-10]
         let post account_resource = global<Account>(addr);
         aborts_if !exists<Account>(addr);
         aborts_if vector::length(new_auth_key) != 32;
@@ -140,6 +249,7 @@ spec aptos_framework::account {
         let account_resource = global<Account>(addr);
         aborts_if !exists<Account>(addr);
 
+        /// [high-level-req-6.1]
         include from_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: from_public_key_bytes };
         aborts_if from_scheme == ED25519_SCHEME && ({
             let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(from_public_key_bytes);
@@ -150,6 +260,8 @@ spec aptos_framework::account {
             let from_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(from_public_key_bytes);
             account_resource.authentication_key != from_auth_key
         });
+
+        /// [high-level-req-5.1]
         aborts_if from_scheme != ED25519_SCHEME && from_scheme != MULTI_ED25519_SCHEME;
 
         let curr_auth_key = from_bcs::deserialize<address>(account_resource.authentication_key);
@@ -162,11 +274,12 @@ spec aptos_framework::account {
             new_public_key: to_public_key_bytes,
         };
 
+        /// [high-level-req-9.1]
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf {
             scheme: from_scheme,
             public_key_bytes: from_public_key_bytes,
             signature: cap_rotate_key,
-            challenge: challenge,
+            challenge,
         };
 
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf {
@@ -220,12 +333,14 @@ spec aptos_framework::account {
             current_auth_key: curr_auth_key,
             new_public_key: new_public_key_bytes,
         };
+        /// [high-level-req-6.2]
         aborts_if !option::spec_contains(offerer_account_resource.rotation_capability_offer.for, delegate_address);
+        /// [high-level-req-9.1]
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf {
             scheme: new_scheme,
             public_key_bytes: new_public_key_bytes,
             signature: cap_update_table,
-            challenge: challenge,
+            challenge,
         };
 
         let new_auth_key_vector = spec_assert_valid_rotation_proof_signature_and_get_auth_key(new_scheme, new_public_key_bytes, cap_update_table, challenge);
@@ -294,8 +409,10 @@ spec aptos_framework::account {
             proof_challenge
         );
 
+        /// [high-level-req-5.2]
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
 
+        /// [high-level-req-7.1]
         modifies global<Account>(source_address);
         let post offer_for = global<Account>(source_address).rotation_capability_offer.for;
         ensures option::spec_borrow(offer_for) == recipient_address;
@@ -345,8 +462,10 @@ spec aptos_framework::account {
             proof_challenge
         );
 
+        /// [high-level-req-5.3]
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
 
+        /// [high-level-req-7.2]
         modifies global<Account>(source_address);
         let post offer_for = global<Account>(source_address).signer_capability_offer.for;
         ensures option::spec_borrow(offer_for) == recipient_address;
@@ -386,6 +505,7 @@ spec aptos_framework::account {
 
     spec revoke_any_signer_capability(account: &signer) {
         modifies global<Account>(signer::address_of(account));
+        /// [high-level-req-7.4]
         aborts_if !exists<Account>(signer::address_of(account));
         let account_resource = global<Account>(signer::address_of(account));
         aborts_if !option::is_some(account_resource.signer_capability_offer.for);
@@ -408,6 +528,7 @@ spec aptos_framework::account {
         modifies global<Account>(addr);
         aborts_if !exists<Account>(addr);
         let account_resource = global<Account>(addr);
+        /// [high-level-req-7.3]
         aborts_if !option::is_some(account_resource.rotation_capability_offer.for);
         let post offer_for = global<Account>(addr).rotation_capability_offer.for;
         ensures !option::spec_is_some(offer_for);
@@ -416,8 +537,9 @@ spec aptos_framework::account {
     /// The Account existed under the signer.
     /// The value of signer_capability_offer.for of Account resource under the signer is offerer_address.
     spec create_authorized_signer(account: &signer, offerer_address: address): signer {
+        /// [high-level-req-8]
         include AccountContainsAddr{
-            account: account,
+            account,
             address: offerer_address,
         };
         modifies global<Account>(offerer_address);
@@ -492,6 +614,7 @@ spec aptos_framework::account {
             account: account_signer,
         };
         modifies global<Account>(addr);
+        /// [high-level-req-11]
         ensures global<Account>(addr).guid_creation_num == old(global<Account>(addr).guid_creation_num) + 1;
     }
 

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
@@ -1,4 +1,29 @@
 spec aptos_framework::optional_aggregator {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: When creating a new integer instance, it guarantees that the limit assigned is a value passed into the
+    /// function as an argument, and the value field becomes zero.
+    /// Criticality: High
+    /// Implementation: The new_integer function sets the limit field to the argument passed in, and the value field is
+    /// set to zero.
+    /// Enforcement: Formally verified via [high-level-req-1](new_integer).
+    ///
+    /// No.: 2
+    /// Property: For a given integer instance it should always be possible to: (1) return the limit value of the integer
+    /// resource, (2) return the current value stored in that particular instance, and (3) destroy the integer instance.
+    /// Criticality: Low
+    /// Implementation: The following functions should not abort if the Integer instance exists: limit(), read_integer(),
+    /// destroy_integer().
+    /// Enforcement: Formally verified via: [high-level-req-2.1](read_integer), [high-level-req-2.2](limit), and
+    /// [high-level-req-2.3](destroy_integer).
+    ///
+    /// No.: 3
+    /// Property: Every successful switch must end with the aggregator type changed from non-parallelizable to
+    /// parallelizable or vice versa.
+    /// Criticality: High
+    /// Implementation: The switch function run, if successful, should always change the aggregator type.
+    /// Enforcement: Formally verified via [high-level-req-3](switch_and_zero_out).
+    /// </high-level-req>
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -15,6 +40,7 @@ spec aptos_framework::optional_aggregator {
     spec new_integer(limit: u128): Integer {
         aborts_if false;
         ensures result.limit == limit;
+        /// [high-level-req-1]
         ensures result.value == 0;
     }
 
@@ -27,14 +53,17 @@ spec aptos_framework::optional_aggregator {
     }
 
     spec limit {
+        /// [high-level-req-2.2]
         aborts_if false;
     }
 
     spec read_integer {
+        /// [high-level-req-2.1]
         aborts_if false;
     }
 
     spec destroy_integer {
+        /// [high-level-req-2.3]
         aborts_if false;
     }
 
@@ -105,6 +134,7 @@ spec aptos_framework::optional_aggregator {
         aborts_if is_parallelizable(optional_aggregator) && len(vec_ref) != 0;
         aborts_if !is_parallelizable(optional_aggregator) && len(vec_ref) == 0;
         aborts_if !is_parallelizable(optional_aggregator) && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        /// [high-level-req-3]
         ensures is_parallelizable(old(optional_aggregator)) ==> !is_parallelizable(optional_aggregator);
         ensures !is_parallelizable(old(optional_aggregator)) ==> is_parallelizable(optional_aggregator);
         ensures optional_aggregator_value(optional_aggregator) == 0;

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
@@ -1,4 +1,34 @@
 spec aptos_framework::aptos_coin {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: The native token, APT, must be initialized during genesis.
+    /// Criticality: Medium
+    /// Implementation: The initialize function is only called once, during genesis.
+    /// Enforcement: Formally verified via [high-level-req-1](initialize).
+    ///
+    /// No.: 2
+    /// Property: The APT coin may only be created exactly once.
+    /// Criticality: Medium
+    /// Implementation: The initialization function may only be called once.
+    /// Enforcement: Enforced through the [https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move](coin)
+    /// module, which has been audited.
+    ///
+    /// No.: 3
+    /// Property: The abilities to mint Aptos tokens should be transferable, duplicatable, and destroyable.
+    /// Criticality: High
+    /// Implementation: The MintCapability struct has the copy and store abilities. This means that it can be duplicated
+    /// and stored in different object wrappers (such as MintCapStore). This capability is tested against the
+    /// destroy_mint_cap and claim_mint_capability functions.
+    /// Enforcement: Verified via [high-level-req-3](initialize).
+
+    /// No.: 4
+    /// Property: Any type of operation on the APT coin should fail if the user has not registered for the coin.
+    /// Criticality: Medium
+    /// Implementation: Coin operations may succeed only on valid user coin registration.
+    /// Enforcement: Enforced through the [https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move](coin)
+    /// module, which has been audited.
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -14,8 +44,10 @@ spec aptos_framework::aptos_coin {
         aborts_if exists<MintCapStore>(addr);
         aborts_if exists<coin::CoinInfo<AptosCoin>>(addr);
         aborts_if !exists<aggregator_factory::AggregatorFactory>(addr);
+        /// [high-level-req-1]
         ensures exists<MintCapStore>(addr);
         // property 3: The abilities to mint Aptos tokens should be transferable, duplicatable, and destroyable.
+        /// [high-level-req-3]
         ensures global<MintCapStore>(addr).mint_cap ==  MintCapability<AptosCoin> {};
         ensures exists<coin::CoinInfo<AptosCoin>>(addr);
         ensures result_1 == BurnCapability<AptosCoin> {};

--- a/aptos-move/framework/aptos-framework/sources/chain_id.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_id.spec.move
@@ -1,4 +1,22 @@
 spec aptos_framework::chain_id {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: During genesis, the ChainId resource should be created and moved under the Aptos framework account
+    /// with the specified chain id.
+    /// Criticality: Medium
+    /// Implementation: The chain_id::initialize function is responsible for generating the ChainId resource and then
+    /// storing it under the aptos_framework account.
+    /// Enforcement: Formally verified via [high-level-req-1](initialize).
+    ///
+    /// No.: 2
+    /// Property: The chain id can only be fetched if the chain id resource exists under the Aptos
+    /// framework account.
+    /// Criticality: Low
+    /// Implementation: The chain_id::get function fetches the chain id by borrowing the ChainId
+    /// resource from the aptos_framework account.
+    /// Enforcement: Formally verified via [high-level-req-2](get).
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -9,11 +27,13 @@ spec aptos_framework::chain_id {
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
         aborts_if exists<ChainId>(@aptos_framework);
+        /// [high-level-req-1]
         ensures exists<ChainId>(addr);
         ensures global<ChainId>(addr).id == id;
     }
 
     spec get {
+        /// [high-level-req-2]
         aborts_if !exists<ChainId>(@aptos_framework);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/chain_status.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_status.spec.move
@@ -1,9 +1,30 @@
 spec aptos_framework::chain_status {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: The end of genesis mark should persist throughout the entire life of the chain.
+    /// Criticality: Medium
+    /// Implementation: The Aptos framework account should never drop the GenesisEndMarker resource.
+    /// Enforcement: Audited that GenesisEndMarker is published at the end of genesis and never removed. Formally
+    /// verified via [high-level-req-1](set_genesis_end) that GenesisEndMarker is published.
+    ///
+    /// No.: 2
+    /// Property: The status of the chain should never be genesis and operating at the same time.
+    /// Criticality: Low
+    /// Implementation: The status of the chain is determined by the GenesisEndMarker resource.
+    /// Enforcement: Formally verified via [high-level-req-2](global invariant).
+    ///
+    /// No.: 3
+    /// Property: The status of the chain should only be changed once, from genesis to operating.
+    /// Criticality: Low
+    /// Implementation: Attempting to assign a resource type more than once will abort.
+    /// Enforcement: Formally verified via [high-level-req-3](set_genesis_end).
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
+        /// [high-level-req-2]
         invariant is_genesis() == !is_operating();
-
     }
 
     spec set_genesis_end(aptos_framework: &signer) {
@@ -12,7 +33,9 @@ spec aptos_framework::chain_status {
         pragma delegate_invariants_to_caller;
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
+        /// [high-level-req-3]
         aborts_if exists<GenesisEndMarker>(@aptos_framework);
+        /// [high-level-req-1]
         ensures global<GenesisEndMarker>(@aptos_framework) == GenesisEndMarker {};
     }
 

--- a/aptos-move/framework/aptos-framework/sources/code.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/code.spec.move
@@ -1,4 +1,62 @@
 spec aptos_framework::code {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: Updating a package should fail if the user is not the owner of it.
+    /// Criticality: Critical
+    /// Implementation: The publish_package function may only be able to update the package if the signer is the actual
+    /// owner of the package.
+    /// Enforcement: The Aptos upgrade native functions have been manually audited.
+    ///
+    /// No.: 2
+    /// Property: The arbitrary upgrade policy should never be used.
+    /// Criticality: Critical
+    /// Implementation: There should never be a pass of an arbitrary upgrade policy to the
+    /// request_publish native function.
+    /// Enforcement: Manually audited that it aborts if package.upgrade_policy.policy == 0.
+    ///
+    /// No.: 3
+    /// Property: Should perform accurate compatibility checks when the policy indicates
+    /// compatibility, ensuring it meets the required conditions.
+    /// Criticality: Critical
+    /// Implementation: Specifies if it should perform compatibility checks for upgrades. The check
+    /// only passes if a new module has (a) the same public functions, and (b) for existing resources,
+    /// no layout change.
+    /// Enforcement: The Move upgradability patterns have been manually audited.
+    ///
+    /// No.: 4
+    /// Property: Package upgrades should abide by policy change rules. In particular, The new
+    /// upgrade policy must be equal to or stricter when compared to the old one. The original
+    /// upgrade policy must not be immutable. The new package must contain all modules contained
+    /// in the old package.
+    /// Criticality: Medium
+    /// Implementation: A package may only be updated using the publish_package function when the
+    /// check_upgradability function returns true.
+    /// Enforcement: This is audited by a manual review of the check_upgradability patterns.
+    ///
+    /// No.: 5
+    /// Property: The upgrade policy of a package must not exceed the strictness level imposed by
+    /// its dependencies.
+    /// Criticality: Medium
+    /// Implementation: The upgrade_policy of a package may only be less than its dependencies
+    /// throughout the upgrades. In addition, the native code properly restricts the use of
+    /// dependencies outside the passed-in metadata.
+    /// Enforcement: This has been manually audited.
+    ///
+    /// No.: 6
+    /// Property: The extension for package metadata is currently unused.
+    /// Criticality: Medium
+    /// Implementation: The extension field in PackageMetadata should be unused.
+    /// Enforcement: Data invariant on the extension field has been manually audited.
+    ///
+    /// No.: 7
+    /// Property: The upgrade number of a package increases incrementally in a monotonic manner
+    /// with each subsequent upgrade.
+    /// Criticality: Low
+    /// Implementation: On each upgrade of a particular package, the publish_package function
+    /// updates the upgrade_number for that package.
+    /// Enforcement: Post condition on upgrade_number has been manually audited.
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
@@ -1,4 +1,26 @@
 spec aptos_framework::consensus_config {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: During genesis, the Aptos framework account should be assigned the consensus config resource.
+    /// Criticality: Medium
+    /// Implementation: The consensus_config::initialize function calls the assert_aptos_framework function to ensure
+    /// that the signer is the aptos_framework and then assigns the ConsensusConfig resource to it.
+    /// Enforcement: Formally verified via [high-level-req-1](initialize).
+    ///
+    /// No.: 2
+    /// Property: Only aptos framework account is allowed to update the consensus configuration.
+    /// Criticality: Medium
+    /// Implementation: The consensus_config::set function ensures that the signer is aptos_framework.
+    /// Enforcement: Formally verified via [high-level-req-2](set).
+    ///
+    /// No.: 3
+    /// Property: Only a valid configuration can be used during initialization and update.
+    /// Criticality: Medium
+    /// Implementation: Both the initialize and set functions validate the config by ensuring its length to be greater
+    /// than 0.
+    /// Enforcement: Formally verified via [high-level-req-3.1](initialize) and [high-level-req-3.2](set).
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -9,8 +31,10 @@ spec aptos_framework::consensus_config {
     spec initialize(aptos_framework: &signer, config: vector<u8>) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
+        /// [high-level-req-1]
         aborts_if !system_addresses::is_aptos_framework_address(addr);
         aborts_if exists<ConsensusConfig>(@aptos_framework);
+        /// [high-level-req-3.1]
         aborts_if !(len(config) > 0);
         ensures global<ConsensusConfig>(addr) == ConsensusConfig { config };
     }
@@ -32,8 +56,10 @@ spec aptos_framework::consensus_config {
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         include staking_config::StakingRewardsConfigRequirement;
         let addr = signer::address_of(account);
+        /// [high-level-req-2]
         aborts_if !system_addresses::is_aptos_framework_address(addr);
         aborts_if !exists<ConsensusConfig>(@aptos_framework);
+        /// [high-level-req-3.2]
         aborts_if !(len(config) > 0);
 
         requires chain_status::is_operating();

--- a/aptos-move/framework/aptos-framework/sources/create_signer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/create_signer.spec.move
@@ -14,7 +14,7 @@ spec aptos_framework::create_signer {
     /// Criticality: Medium
     /// Implementation: Before an Account resource is created, a signer is created for the specified new_address, and
     /// later, the Account resource is assigned to this signer.
-    /// Enforcement: Enforced by the move vm
+    /// Enforcement: Enforced by the [https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-vm/types/src/values/values_impl.rs#L1129](move vm).
     ///
     /// No.: 3
     /// Property: An account should only be able to create a signer for another account if that account has granted it
@@ -28,7 +28,7 @@ spec aptos_framework::create_signer {
     /// Property: A signer should be returned for addresses that are not registered as accounts.
     /// Criticality: Low
     /// Implementation: The signer is just a struct that wraps an address, allows for non-accounts to have a signer.
-    /// Enforcement: Formally verified via create_signer
+    /// Enforcement: Formally verified via [0x1_create_signer_create_signer](create_signer).
     /// </high-level-req>
     ///
     spec module {

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.spec.move
@@ -1,4 +1,94 @@
 spec aptos_framework::delegation_pool {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: Every DelegationPool has only one corresponding StakePool stored at the same address.
+    /// Criticality: Critical
+    /// Implementation: Upon calling the initialize_delegation_pool function, a resource account is created from the
+    /// "owner" signer to host the delegation pool resource and own the underlying stake pool.
+    /// Enforcement: Audited that the address of StakePool equals address of DelegationPool and the data invariant on the DelegationPool.
+    ///
+    /// No.: 2
+    /// Property: The signer capability within the delegation pool has an address equal to the address of the
+    /// delegation pool.
+    /// Criticality: Critical
+    /// Implementation: The initialize_delegation_pool function moves the DelegationPool resource to the address
+    /// associated with stake_pool_signer, which also possesses the signer capability.
+    /// Enforcement: Audited that the address of signer cap equals address of DelegationPool.
+    ///
+    /// No.: 3
+    /// Property: A delegator holds shares exclusively in one inactive shares pool, which could either be an already
+    /// inactive pool or the pending_inactive pool.
+    /// Criticality: High
+    /// Implementation: The get_stake function returns the inactive stake owned by a delegator and checks which
+    /// state the shares are in via the get_pending_withdrawal function.
+    /// Enforcement: Audited that either inactive or pending_inactive stake after invoking the get_stake function is
+    /// zero and both are never non-zero.
+    ///
+    /// No.: 4
+    /// Property: The specific pool in which the delegator possesses inactive shares becomes designated as the
+    /// pending withdrawal pool for that delegator.
+    /// Criticality: Medium
+    /// Implementation: The get_pending_withdrawal function checks if any pending withdrawal exists for a delegate
+    /// address and if there is neither inactive nor pending_inactive stake, the pending_withdrawal_exists returns
+    /// false.
+    /// Enforcement: This has been audited.
+    ///
+    /// No.: 5
+    /// Property: The existence of a pending withdrawal implies that it is associated with a pool where the
+    /// delegator possesses inactive shares.
+    /// Criticality: Medium
+    /// Implementation: In the get_pending_withdrawal function, if withdrawal_exists is true, the function returns
+    /// true and a non-zero amount
+    /// Enforcement: get_pending_withdrawal has been audited.
+    ///
+    /// No.: 6
+    /// Property: An inactive shares pool should have coins allocated to it; otherwise, it should become deleted.
+    /// Criticality: Medium
+    /// Implementation: The redeem_inactive_shares function has a check that destroys the inactive shares pool,
+    /// given that it is empty.
+    /// Enforcement: shares pools have been audited.
+    ///
+    /// No.: 7
+    /// Property: The index of the pending withdrawal will not exceed the current OLC on DelegationPool.
+    /// Criticality: High
+    /// Implementation: The get_pending_withdrawal function has a check which ensures that withdrawal_olc.index <
+    /// pool.observed_lockup_cycle.index.
+    /// Enforcement: This has been audited.
+    ///
+    /// No.: 8
+    /// Property: Slashing is not possible for inactive stakes.
+    /// Criticality: Critical
+    /// Implementation: The number of inactive staked coins must be greater than or equal to the
+    /// total_coins_inactive of the pool.
+    /// Enforcement: This has been audited.
+    ///
+    /// No.: 9
+    /// Property: The delegator's active or pending inactive stake will always meet or exceed the minimum allowed
+    /// value.
+    /// Criticality: Medium
+    /// Implementation: The add_stake, unlock and reactivate_stake functions ensure the active_shares or
+    /// pending_inactive_shares balance for the delegator is greater than or equal to the MIN_COINS_ON_SHARES_POOL
+    /// value.
+    /// Enforcement: Audited the comparison of active_shares or inactive_shares balance for the delegator with the
+    /// MIN_COINS_ON_SHARES_POOL value.
+    ///
+    /// No.: 10
+    /// Property: The delegation pool exists at a given address.
+    /// Criticality: Low
+    /// Implementation: Functions that operate on the DelegationPool abort if there is no DelegationPool struct
+    /// under the given pool_address.
+    /// Enforcement: Audited that there is no DelegationPool structure assigned to the pool_address given as a
+    /// parameter.
+    ///
+    /// No.: 11
+    /// Property: The initialization of the delegation pool is contingent upon enabling the delegation pools
+    /// feature.
+    /// Criticality: Critical
+    /// Implementation: The initialize_delegation_pool function should proceed if the DELEGATION_POOLS feature is
+    /// enabled.
+    /// Enforcement: This has been audited.
+    /// </high-level-req>
+    ///
     spec module {
         // TODO: verification disabled until this module is specified.
         pragma verify=false;

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
@@ -1,4 +1,138 @@
 spec aptos_framework::fungible_asset {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: The metadata associated with the fungible asset is subject to precise size constraints.
+    /// Criticality: Medium
+    /// Implementation: The add_fungibility function has size limitations for the name, symbol, number of decimals,
+    /// icon_uri, and project_uri field of the Metadata resource.
+    /// Enforcement: This has been audited.
+    ///
+    /// No.: 2
+    /// Property: Adding fungibility to an existing object should initialize the metadata and supply resources and store
+    /// them under the metadata object address.
+    /// Criticality: Low
+    /// Implementation: The add_fungibility function initializes the Metadata and Supply resources and moves them under
+    /// the metadata object.
+    /// Enforcement: Audited that the Metadata and Supply resources are initialized properly.
+    ///
+    /// No.: 3
+    /// Property: Generating mint, burn and transfer references can only be done at object creation time and if the
+    /// object was added fungibility.
+    /// Criticality: Low
+    /// Implementation: The following functions generate the related references of the Metadata object: 1.
+    /// generate_mint_ref 2. generate_burn_ref 3. generate_transfer_ref
+    /// Enforcement: Audited that the Metadata object exists within the constructor ref.
+    ///
+    /// No.: 4
+    /// Property: Only the owner of a store should be allowed to withdraw fungible assets from it.
+    /// Criticality: High
+    /// Implementation: The fungible_asset::withdraw function ensures that the signer owns the store by asserting that
+    /// the object address matches the address of the signer.
+    /// Enforcement: Audited that the address of the signer owns the object.
+    ///
+    /// No.: 5
+    /// Property: The transfer, withdrawal and deposit operation should never change the current supply of the fungible
+    /// asset.
+    /// Criticality: High
+    /// Implementation: The transfer function withdraws the fungible assets from the store and deposits them to the
+    /// receiver. The withdraw function extracts the fungible asset from the fungible asset store. The deposit function
+    /// adds the balance to the fungible asset store.
+    /// Enforcement: Audited that the supply before and after the operation remains constant.
+    ///
+    /// No.: 6
+    /// Property: The owner of the store should only be able to withdraw a certain amount if its store has sufficient
+    /// balance and is not frozen, unless the withdrawal is performed with a reference, and afterwards the store balance
+    /// should be decreased.
+    /// Criticality: High
+    /// Implementation: The withdraw function ensures that the store is not frozen before calling withdraw_internal
+    /// which ensures that the withdrawing amount is greater than 0 and less than the total balance from the store.
+    /// The withdraw_with_ref ensures that the reference's metadata matches the store metadata.
+    /// Enforcement: Audited that it aborts if the withdrawing store is frozen. Audited that it aborts if the store doesn't have sufficient balance. Audited that the balance of the withdrawing store is reduced by amount.
+    ///
+    /// No.: 7
+    /// Property: Only the same type of fungible assets should be deposited in a fungible asset store, if the store is
+    /// not frozen, unless the deposit is performed with a reference, and afterwards the store balance should be
+    /// increased.
+    /// Criticality: High
+    /// Implementation: The deposit function ensures that store is not frozen and proceeds to call the deposit_internal
+    /// function which validates the store's metadata and the depositing asset's metadata followed by increasing the
+    /// store balance by the given amount. The deposit_with_ref ensures that the reference's metadata matches the
+    /// depositing asset's metadata.
+    /// Enforcement: Audited that it aborts if the store is frozen. Audited that it aborts if the asset and asset store are different. Audited that the store's balance is increased by the deposited amount.
+    ///
+    /// No.: 8
+    /// Property: An object should only be allowed to hold one store for fungible assets.
+    /// Criticality: Medium
+    /// Implementation: The create_store function initializes a new FungibleStore resource and moves it under the
+    /// object address.
+    /// Enforcement: Audited that the resource was moved under the object.
+    ///
+    /// No.: 9
+    /// Property: When a new store is created, the balance should be set by default to the value zero.
+    /// Criticality: High
+    /// Implementation: The create_store function initializes a new fungible asset store with zero balance and stores it
+    /// under the given construtorRef object.
+    /// Enforcement: Audited that the store is properly initialized with zero balance.
+    ///
+    /// No.: 10
+    /// Property: A store should only be deleted if it's balance is zero.
+    /// Criticality: Medium
+    /// Implementation: The remove_store function validates the store's balance and removes the store under the object
+    /// address.
+    /// Enforcement: Audited that aborts if the balance of the store is not zero. Audited that store is removed from the
+    /// object address.
+    ///
+    /// No.: 11
+    /// Property: Minting and burning should alter the total supply value, and the store balances.
+    /// Criticality: High
+    /// Implementation: The mint process increases the total supply by the amount minted using the increase_supply
+    /// function. The burn process withdraws the burn amount from the given store and decreases the total supply by the
+    /// amount burned using the decrease_supply function.
+    /// Enforcement: Audited the mint and burn functions that the supply was adjusted accordingly.
+    ///
+    /// No.: 12
+    /// Property: It must not be possible to burn an amount of fungible assets larger than their current supply.
+    /// Criticality: High
+    /// Implementation: The burn process ensures that the store has enough balance to burn, by asserting that the
+    /// supply.current >= amount inside the decrease_supply function.
+    /// Enforcement: Audited that it aborts if the provided store doesn't have sufficient balance.
+    ///
+    /// No.: 13
+    /// Property: Enabling or disabling store's frozen status should only be done with a valid transfer reference.
+    /// Criticality: High
+    /// Implementation: The set_frozen_flag function ensures that the TransferRef is provided via function argument and
+    /// that the store's metadata matches the metadata from the reference. It then proceeds to update the frozen flag of
+    /// the store.
+    /// Enforcement: Audited that it aborts if the metadata doesn't match. Audited that the frozen flag is updated properly.
+    ///
+    /// No.: 14
+    /// Property: Extracting a specific amount from the fungible asset should be possible only if the total amount that
+    /// it holds is greater or equal to the provided amount.
+    /// Criticality: High
+    /// Implementation: The extract function validates that the fungible asset has enough balance to extract and then
+    /// updates it by subtracting the extracted amount.
+    /// Enforcement: Audited that it aborts if the asset didn't have sufficient balance. Audited that the balance of the asset is updated. Audited that the extract function returns the extracted asset.
+    ///
+    /// No.: 15
+    /// Property: Merging two fungible assets should only be possible if both share the same metadata.
+    /// Criticality: Medium
+    /// Implementation: The merge function validates the metadata of the src and dst asset.
+    /// Enforcement: Audited that it aborts if the metadata of the src and dst are not the same.
+    ///
+    /// No.: 16
+    /// Property: Post merging two fungible assets, the source asset should have the amount value equal to the sum of
+    /// the two.
+    /// Criticality: High
+    /// Implementation: The merge function increases dst_fungible_asset.amount by src_fungible_asset.amount.
+    /// Enforcement: Audited that the dst_fungible_asset balance is increased by amount.
+    ///
+    /// No.: 17
+    /// Property: Fungible assets with zero balance should be destroyed when the amount reaches value 0.
+    /// Criticality: Medium
+    /// Implementation: The destroy_zero ensures that the balance of the asset has the value 0 and destroy the asset.
+    /// Enforcement: Audited that it aborts if the balance of the asset is non zero.
+    /// </high-level-req>
+    ///
     spec module {
         // TODO: verification disabled until this module is specified.
         pragma verify=false;

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -1,4 +1,50 @@
 spec aptos_framework::object {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: It's not possible to create an object twice on the same address.
+    /// Criticality: Critical
+    /// Implementation: The create_object_internal function includes an assertion to ensure that the object being
+    /// created does not already exist at the specified address.
+    /// Enforcement: Formally verified via [high-level-req-1](create_object_internal).
+    ///
+    /// No.: 2
+    /// Property: Only its owner may transfer an object.
+    /// Criticality: Critical
+    /// Implementation: The transfer function mandates that the transaction be signed by the owner's address, ensuring
+    /// that only the rightful owner may initiate the object transfer.
+    /// Enforcement: Audited that it aborts if anyone other than the owner attempts to transfer.
+    ///
+    /// No.: 3
+    /// Property: The indirect owner of an object may transfer the object.
+    /// Criticality: Medium
+    /// Implementation: The owns function evaluates to true when the given address possesses either direct or indirect
+    /// ownership of the specified object.
+    /// Enforcement: Audited that it aborts if address transferring is not indirect owner.
+    ///
+    /// No.: 4
+    /// Property: Objects may never change the address which houses them.
+    /// Criticality: Low
+    /// Implementation: After creating an object, transfers to another owner may occur. However, the address which
+    /// stores the object may not be changed.
+    /// Enforcement: This is implied by [high-level-req](high-level requirement 1).
+    ///
+    /// No.: 5
+    /// Property: If an ungated transfer is disabled on an object in an indirect ownership chain, a transfer should not
+    /// occur.
+    /// Criticality: Medium
+    /// Implementation: Calling disable_ungated_transfer disables direct transfer, and only TransferRef may trigger
+    /// transfers. The transfer_with_ref function is called.
+    /// Enforcement: Formally verified via [high-level-req-5](transfer_with_ref).
+    ///
+    /// No.: 6
+    /// Property: Object addresses must not overlap with other addresses in different domains.
+    /// Criticality: Critical
+    /// Implementation: The current addressing scheme with suffixes does not conflict with any existing addresses,
+    /// such as resource accounts. The GUID space is explicitly separated to ensure this doesn't happen.
+    /// Enforcement: This is true by construction if one correctly ensures the usage of INIT_GUID_CREATION_NUM during
+    /// the creation of GUID.
+    /// </high-level-req>
+    ///
     spec module {
         pragma aborts_if_is_strict;
         //ghost variable
@@ -260,6 +306,7 @@ spec aptos_framework::object {
     can_delete: bool,
     ): ConstructorRef {
         // property 1: Creating an object twice on the same address must never occur.
+        /// [high-level-req-1]
         aborts_if exists<ObjectCore>(object);
         ensures exists<ObjectCore>(object);
         // property 6: Object addresses must not overlap with other addresses in different domains.
@@ -345,6 +392,7 @@ spec aptos_framework::object {
     spec transfer_with_ref(ref: LinearTransferRef, to: address) {
         let object = global<ObjectCore>(ref.self);
         aborts_if !exists<ObjectCore>(ref.self);
+        /// [high-level-req-5]
         aborts_if object.owner != ref.owner;
         ensures global<ObjectCore>(ref.self).owner == to;
     }

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.spec.move
@@ -1,4 +1,129 @@
 spec aptos_framework::primary_fungible_store {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: Creating a fungible asset with primary store support should initiate a derived reference and store it
+    /// under the metadata object.
+    /// Criticality: Medium
+    /// Implementation: The function create_primary_store_enabled_fungible_asset makes an existing object, fungible, via
+    /// the fungible_asset::add_fungibility function and initializes the DeriveRefPod resource by generating a DeriveRef
+    /// for the object and then stores it under the object address.
+    /// Enforcement: Audited that the DeriveRefPod has been properly initialized and stored under the metadata object.
+    ///
+    /// No.: 2
+    /// Property: Fetching and creating a primary fungible store of an asset should only succeed if the object supports
+    /// primary store.
+    /// Criticality: Low
+    /// Implementation: The function create_primary_store is used to create a primary store by borrowing the DeriveRef
+    /// resource from the object. In case the resource does not exist, creation will fail. The function
+    /// ensure_primary_store_exists is used to fetch the primary store if it exists, otherwise it will create one via
+    /// the create_primary function.
+    /// Enforcement: Audited that it aborts if the DeriveRefPod doesn't exist. Audited that it aborts if the
+    /// FungibleStore resource exists already under the object address.
+    ///
+    /// No.: 3
+    /// Property: It should be possible to create a primary store to hold a fungible asset.
+    /// Criticality: Medium
+    /// Implementation: The function create_primary_store borrows the DeriveRef resource from DeriveRefPod and then
+    /// creates the store which is returned.
+    /// Enforcement: Audited that it returns the newly created FungibleStore.
+    ///
+    /// No.: 4
+    /// Property: Fetching the balance or the frozen status of a primary store should never abort.
+    /// Criticality: Low
+    /// Implementation: The function balance returns the balance of the store, if the store exists, otherwise it returns 0.
+    /// The function is_frozen returns the frozen flag of the fungible store, if the store exists, otherwise it returns
+    /// false.
+    /// Enforcement: Audited that the balance function returns the balance of the FungibleStore. Audited that the
+    /// is_frozen function returns the frozen status of the FungibleStore resource. Audited that it never aborts.
+    ///
+    /// No.: 5
+    /// Property: The ability to withdraw, deposit, transfer, mint and burn should only be available for assets with
+    /// primary store support.
+    /// Criticality: Medium
+    /// Implementation: The primary store is fetched before performing either of withdraw, deposit, transfer, mint, burn
+    /// operation. If the FungibleStore resource doesn't exist the operation will fail.
+    /// Enforcement: Audited that it aborts if the primary store FungibleStore doesn't exist.
+    ///
+    /// No.: 6
+    /// Property: The action of depositing a fungible asset of the same type as the store should never fail if the store
+    /// is not frozen.
+    /// Criticality: Medium
+    /// Implementation: The function deposit fetches the owner's store, if it doesn't exist it will be created, and then
+    /// deposits the fungible asset to it. The function deposit_with_ref fetches the owner's store, if it doesn't exist
+    /// it will be created, and then deposit the fungible asset via the fungible_asset::deposit_with_ref function.
+    /// Depositing fails if the metadata of the FungibleStore and FungibleAsset differs.
+    /// Enforcement: Audited that it aborts if the store is frozen (deposit). Audited that the balance of the store is
+    /// increased by the deposit amount (deposit, deposit_with_ref). Audited that it aborts if the metadata of the store
+    /// and the asset differs (deposit, deposit_with_ref).
+    ///
+    /// No.: 7
+    /// Property: Withdrawing should only be allowed to the owner of an existing store with sufficient balance.
+    /// Criticality: Critical
+    /// Implementation: The withdraw function fetches the owner's store via the primary_store function and then calls
+    /// fungible_asset::withdraw which validates the owner of the store, checks the frozen status and the balance of the
+    /// store. The withdraw_with_ref function fetches the store of the owner via primary_store function and calls the
+    /// fungible_asset::withdraw_with_ref which validates transfer_ref's metadata with the withdrawing stores metadata,
+    /// and the balance of the store.
+    /// Enforcement: Audited that it aborts if the owner doesn't own the store (withdraw). Audited that it aborts if the
+    /// store is frozen (withdraw). Audited that it aborts if the transfer ref's metadata doesn't match the withdrawing
+    /// store's metadata (withdraw_with_ref). Audited that it aborts if the store doesn't have sufficient balance.
+    /// Audited that the store is not burned. Audited that the balance of the store is decreased by the amount withdrawn.
+    ///
+    /// No.: 8
+    /// Property: Only the fungible store owner is allowed to unburn a burned store.
+    /// Criticality: High
+    /// Implementation: The function may_be_unburn checks if the store is burned and then proceeds to call
+    /// object::unburn which ensures that the owner of the object matches the address of the signer.
+    /// Enforcement: Audited that the store is unburned successfully.
+    ///
+    /// No.: 9
+    /// Property: Only the owner of a primary store can transfer its balance to any recipient's primary store.
+    /// Criticality: High
+    /// Implementation: The function transfer fetches sender and recipient's primary stores, if the sender's store is
+    /// burned it unburns the store and calls the fungile_asset::transfer to proceed with the transfer, which first
+    /// withdraws the assets from the sender's store and then deposits to the recipient's store.
+    /// The function transfer_with_ref fetches the sender's and recipient's stores and calls the
+    /// fungible_asset::transfer_with_ref function which withdraws the asset with the ref from the sender and deposits
+    /// the asset to the recipient with the ref.
+    /// Enforcement: Audited the deposit and withdraw (transfer). Audited the deposit_with_ref and
+    /// withdraw_with_ref (transfer_with_ref). Audited that the store balance of the sender is decreased by the
+    /// specified amount and its added to the recipients store. (transfer, transfer_with_ref) Audited that the sender's
+    /// store is not burned (transfer).
+    ///
+    /// No.: 10
+    /// Property: Minting an amount of assets to an unfrozen store is only allowed with a valid mint reference.
+    /// Criticality: High
+    /// Implementation: The mint function fetches the primary store and calls the fungible_asset::mint_to, which mints
+    /// with MintRef's metadata which internally validates the amount and the increases the total supply of the asset.
+    /// And the minted asset is deposited to the provided store by validating that the store is unfrozen and the store's
+    /// metadata is the same as the depositing asset's metadata.
+    /// Enforcement: Audited that it aborts if the amount is equal to 0. Audited that it aborts if the store is frozen.
+    /// Audited that it aborts if the mint_ref's metadata is not the same as the store's metadata. Audited that the
+    /// asset's total supply is increased by the amount minted. Audited that the balance of the store is increased by
+    /// the minted amount.
+    ///
+    /// No.: 11
+    /// Property: Burning an amount of assets from an existing unfrozen store is only allowed with a valid burn
+    /// reference.
+    /// Criticality: High
+    /// Implementation: The burn function fetches the primary store and calls the fungible_asset::burn_from function
+    /// which withdraws the amount from the store while enforcing that the store has enough balance and burns the
+    /// withdrawn asset after validating the asset's metadata and the BurnRef's metadata followed by decreasing the
+    /// supply of the asset.
+    /// Enforcement: Audited that it aborts if the metadata of the store is not same as the BurnRef's metadata.
+    /// Audited that it aborts if the burning amount is 0. Audited that it aborts if the store doesn't have enough
+    /// balance. Audited that it aborts if the asset's metadata is not same as the BurnRef's metadata. Audited that the
+    /// total supply of the asset is decreased. Audited that the store's balance is reduced by the amount burned.
+    ///
+    /// No.: 12
+    /// Property: Setting the frozen flag of a store is only allowed with a valid reference.
+    /// Criticality: High
+    /// Implementation: The function set_frozen_flag fetches the primary store and calls fungible_asset::set_frozen_flag
+    /// which validates the TransferRef's metadata with the store's metadata and then updates the frozen flag.
+    /// Enforcement: Audited that it aborts if the store's metadata is not same as the the TransferRef's metadata.
+    /// Audited that the status of the frozen flag is updated correctly.
+    /// </high-level-req>
+    ///
     spec module {
         // TODO: verification disabled until this module is specified.
         pragma verify = false;

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -1,4 +1,47 @@
 spec aptos_framework::reconfiguration {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: The Configuration resource is stored under the Aptos framework account with initial values upon
+    /// module's initialization.
+    /// Criticality: Medium
+    /// Implementation: The Configuration resource may only be initialized with specific values and published under the
+    /// aptos_framework account.
+    /// Enforcement: Formally verified via [high-level-req-1](initialize).
+    ///
+    /// No.: 2
+    /// Property: The reconfiguration status may be determined at any time without causing an abort, indicating whether
+    /// or not the system allows reconfiguration.
+    /// Criticality: Low
+    /// Implementation: The reconfiguration_enabled function will never abort and always returns a boolean value that
+    /// accurately represents whether the system allows reconfiguration.
+    /// Enforcement: Formally verified via [high-level-req-2](reconfiguration_enabled).
+    ///
+    /// No.: 3
+    /// Property: For each reconfiguration, the epoch value (config_ref.epoch) increases by 1, and one 'NewEpochEvent'
+    /// is emitted.
+    /// Criticality: Critical
+    /// Implementation: After reconfiguration, the reconfigure() function increases the epoch value of the configuration
+    /// by one and increments the counter of the NewEpochEvent's EventHandle by one.
+    /// Enforcement: Audited that these two values remain in sync.
+    ///
+    /// No.: 4
+    /// Property: Reconfiguration is possible only if genesis has started and reconfiguration is enabled. Also, the last
+    /// reconfiguration must not be the current time, returning early without further actions otherwise.
+    /// Criticality: High
+    /// Implementation: The reconfigure() function may only execute to perform successful reconfiguration when genesis
+    /// has started and when reconfiguration is enabled. Without satisfying both conditions, the function returns early
+    /// without executing any further actions.
+    /// Enforcement: Formally verified via [high-level-req-4](reconfigure).
+    ///
+    /// No.: 5
+    /// Property: Consecutive reconfigurations without the passage of time are not permitted.
+    /// Criticality: High
+    /// Implementation: The reconfigure() function enforces the restriction that reconfiguration may only be performed
+    /// when the current time is not equal to the last_reconfiguration_time.
+    /// Enforcement: Formally verified via [high-level-req-5](reconfigure).
+    /// </high-level-req>
+    ///
+
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
@@ -31,7 +74,9 @@ spec aptos_framework::reconfiguration {
         requires exists<Account>(addr);
         aborts_if !(global<Account>(addr).guid_creation_num == 2);
         aborts_if exists<Configuration>(@aptos_framework);
-        // property 1: During the module's initialization, it guarantees that the Configuration resource will move under the Aptos framework account with initial values.
+        // property 1: During the module's initialization, it guarantees that the Configuration resource will move under
+        // the Aptos framework account with initial values.
+        /// [high-level-req-1]
         ensures exists<Configuration>(@aptos_framework);
         ensures config.epoch == 0 && config.last_reconfiguration_time == 0;
         ensures config.events == event::EventHandle<NewEpochEvent> {
@@ -105,11 +150,15 @@ spec aptos_framework::reconfiguration {
         // TODO: property 4: Only performs reconfiguration if genesis has started and reconfiguration is enabled.
         // Also, the last reconfiguration must not be the current time, returning early without further actions otherwise.
         // property 5: Consecutive reconfigurations without the passage of time are not permitted.
+        /// [high-level-req-4]
+        /// [high-level-req-5]
         ensures !success ==> global<Configuration>(@aptos_framework).epoch == old(global<Configuration>(@aptos_framework).epoch);
     }
 
     spec reconfiguration_enabled {
-        // property 2: The reconfiguration status may be determined at any time without causing an abort, indicating whether or not the system allows reconfiguration.
+        // property 2: The reconfiguration status may be determined at any time without causing an abort, indicating
+        // whether or not the system allows reconfiguration.
+        /// [high-level-req-2]
         aborts_if false;
         ensures result == !exists<DisableReconfiguration>(@aptos_framework);
     }

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
@@ -1,4 +1,44 @@
 spec aptos_framework::staking_proxy {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: When updating the Vesting operator, it should be updated throughout all depending units.
+    /// Criticality: Medium
+    /// Implementation: The VestingContract contains a StakingInfo object that has an operator field, and this operator
+    /// is mapped to a StakingContract object that in turn encompasses a StakePool object where the operator matches.
+    /// Enforcement: Audited that it ensures the two operator fields hold the new value after the update.
+    ///
+    /// No.: 2
+    /// Property: When updating the Vesting voter, it should be updated throughout all depending units.
+    /// Criticality: Medium
+    /// Implementation: The VestingContract contains a StakingInfo object that has an operator field, and this operator
+    /// is mapped to a StakingContract object that in turn encompasses a StakePool object where the operator matches.
+    /// Enforcement: Audited that it ensures the two operator fields hold the new value after the update.
+    ///
+    /// No.: 3
+    /// Property: The operator and voter of a Vesting Contract should only be updated by the owner of the contract.
+    /// Criticality: High
+    /// Implementation: The owner-operator-voter model, as defined in the documentation, grants distinct abilities to
+    /// each role. Therefore, it's crucial to ensure that only the owner has the authority to modify the operator or
+    /// voter, to prevent the compromise of the StakePool.
+    /// Enforcement: Audited that it ensures the signer owns the AdminStore resource and that the operator or voter
+    /// intended for the update actually exists.
+    ///
+    /// No.: 4
+    /// Property: The operator and voter of a Staking Contract should only be updated by the owner of the contract.
+    /// Criticality: High
+    /// Implementation: The owner-operator-voter model, as defined in the documentation, grants distinct abilities to
+    /// each role. Therefore, it's crucial to ensure that only the owner has the authority to modify the operator or
+    /// voter, to prevent the compromise of the StakePool.
+    /// Enforcement: Audited the patterns of updating operators and voters in the staking contract.
+    ///
+    /// No.: 5
+    /// Property: Staking Contract's operators should be unique inside a store.
+    /// Criticality: Medium
+    /// Implementation: Duplicates among operators could result in incorrectly updating the operator or voter
+    /// associated with the incorrect StakingContract.
+    /// Enforcement: Enforced via [https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/staking_contract.move#L87](SimpleMap).
+    /// </high-level-req>
+    ///
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
@@ -1,8 +1,42 @@
 spec aptos_framework::transaction_context {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: Fetching the transaction hash should return a vector with 32 bytes.
+    /// Criticality: Medium
+    /// Implementation: The get_transaction_hash function calls the native function get_txn_hash, which fetches the
+    /// NativeTransactionContext struct and returns the txn_hash field.
+    /// Enforcement: Audited that the native function returns the txn hash, whose size is 32 bytes. This has been
+    /// modeled as the abstract postcondition that the returned vector is of length 32. Formally verified via [high-level-req-1](get_txn_hash).
+    ///
+    /// No.: 2
+    /// Property: Fetching the unique address should never abort.
+    /// Criticality: Low
+    /// Implementation: The function auid_address returns the unique address from a supplied AUID resource.
+    /// Enforcement: Formally verified via [high-level-req-2](auid_address).
+    ///
+    /// No.: 3
+    /// Property: Generating the unique address should return a vector with 32 bytes.
+    /// Criticality: Medium
+    /// Implementation: The generate_auid_address function checks calls the native function generate_unique_address
+    /// which fetches the NativeTransactionContext struct, increments the auid_counter by one, and then creates a new
+    /// authentication key from a preimage, which is then returned.
+    /// Enforcement: Audited that the native function returns an address, and the length of an address is 32 bytes.
+    /// This has been modeled as the abstract postcondition that the returned vector is of length 32.
+    /// Formally verified via [high-level-req-3](generate_auid_address).
+    ///
+    /// No.: 4
+    /// Property: Fetching the script hash of the current entry function should never fail and should return a vector
+    /// with 32 bytes if the transaction payload is a script, otherwise an empty vector.
+    /// Criticality: Low
+    /// Implementation: The native function get_script_hash returns the NativeTransactionContext.script_hash field.
+    /// Enforcement: Audited that the native function holds the required property. This has been modeled as the abstract
+    /// spec. Formally verified via [high-level-req-4](get_script_hash).
+    /// </high-level-req>
     spec get_script_hash(): vector<u8> {
         pragma opaque;
         // property 4: Fetching the script hash of the current entry function should never fail
         // and should return a vector with 32 bytes if the transaction payload is a script, otherwise an empty vector.
+        /// [high-level-req-4]
         aborts_if [abstract] false;
         ensures [abstract] result == spec_get_script_hash();
         ensures [abstract] len(result) == 32;
@@ -17,6 +51,7 @@ spec aptos_framework::transaction_context {
     spec get_transaction_hash(): vector<u8> {
         pragma opaque;
         // property 1: Fetching the transaction hash should return a vector with 32 bytes, if the auid feature flag is enabled.
+        /// [high-level-req-1]
         ensures [abstract] len(result) == 32;
     }
     spec generate_unique_address(): address {
@@ -27,10 +62,12 @@ spec aptos_framework::transaction_context {
     spec generate_auid_address(): address {
         pragma opaque;
         // property 3: Generating the unique address should return a vector with 32 bytes, if the auid feature flag is enabled.
+        /// [high-level-req-3]
         ensures [abstract] result == spec_generate_unique_address();
     }
     spec auid_address(auid: &AUID): address {
         // property 2: Fetching the unique address should never abort.
+        /// [high-level-req-2]
         aborts_if false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/vesting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.spec.move
@@ -1,8 +1,113 @@
 spec aptos_framework::vesting {
+    /// <high-level-req>
+    /// No.: 1
+    /// Property: In order to retrieve the address of the underlying stake pool, the vesting start timestamp of the
+    /// vesting contract, the duration of the vesting period, the remaining grant of a vesting contract, the beneficiary
+    /// account of a shareholder in a vesting contract, the percentage of accumulated rewards that is paid to the
+    /// operator as commission, the operator who runs the validator, the voter who will be voting on-chain, and the
+    /// vesting schedule of a vesting contract, the supplied vesting contract should exist.
+    /// Criticality: Low
+    /// Implementation: The vesting_start_secs, period_duration_secs, remaining_grant, beneficiary,
+    /// operator_commission_percentage, operator, voter, and vesting_schedule functions ensure that the supplied vesting
+    /// contract address exists by calling the assert_vesting_contract_exists function.
+    /// Enforcement: Formally verified via [high-level-req-1](assert_vesting_contract_exists).
+    ///
+    /// No.: 2
+    /// Property: The vesting pool should not exceed a maximum of 30 shareholders.
+    /// Criticality: Medium
+    /// Implementation: The maximum number of shareholders a vesting pool can support is stored as a constant in
+    /// MAXIMUM_SHAREHOLDERS which is passed to the pool_u64::create function.
+    /// Enforcement: Formally verified via a [high-level-spec-2](global invariant).
+    ///
+    /// No.: 3
+    /// Property: Retrieving all the vesting contracts of a given address and retrieving the list of beneficiaries from
+    /// a vesting contract should never fail.
+    /// Criticality: Medium
+    /// Implementation: The function vesting_contracts checks if the supplied admin address contains an AdminStore
+    /// resource and returns all the vesting contracts as a vector<address>. Otherwise it returns an empty vector. The
+    /// function get_beneficiary checks for a given vesting contract, a specific shareholder exists, and if so, the
+    /// beneficiary will be returned, otherwise it will simply return the address of the shareholder.
+    /// Enforcement: Formally verified via [high-level-spec-3.1](vesting_contracts) and
+    /// [high-level-spec-3.2](get_beneficiary).
+    ///
+    /// No.: 4
+    /// Property: The shareholders should be able to start vesting only after the vesting cliff and the first vesting
+    /// period have transpired.
+    /// Criticality: High
+    /// Implementation: The end of the vesting cliff is stored under VestingContract.vesting_schedule.start_timestamp_secs.
+    /// The vest function always checks that timestamp::now_seconds is greater or equal to the end of the vesting cliff
+    /// period.
+    /// Enforcement: Audited the check for the end of vesting cliff: [https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/vesting.move#L566](vest) module.
+    ///
+    /// No.: 5
+    /// Property: In order to retrieve the total accumulated rewards that have not been distributed, the accumulated
+    /// rewards of a given beneficiary, the list of al shareholders in a vesting contract,the shareholder address given
+    /// the beneficiary address in a given vesting contract, to terminate a vesting contract and to distribute any
+    /// withdrawable stake from the stake pool, the supplied vesting contract should exist and be active.
+    /// Criticality: Low
+    /// Implementation: The distribute, terminate_vesting_contract, shareholder, shareholders, accumulated_rewards,
+    /// and total_accumulated_rewards functions ensure that the supplied vesting contract address exists and is active
+    /// by calling the assert_active_vesting_contract function.
+    /// Enforcement: Formally verified via [high-level-spec-5](ActiveVestingContractAbortsIf).
+    ///
+    /// No.: 6
+    /// Property: A new vesting schedule should not be allowed to start vesting in the past or to supply an empty
+    /// schedule or for the period duration to be zero.
+    /// Criticality: High
+    /// Implementation: The create_vesting_schedule function ensures that the length of the schedule vector is greater
+    /// than 0, that the period duration is greater than 0 and that the start_timestamp_secs is greater or equal to
+    /// timestamp::now_seconds.
+    /// Enforcement: Formally verified via [high-level-req-6](create_vesting_schedule).
+    ///
+    /// No.: 7
+    /// Property: The shareholders should be able to vest the tokens from previous periods.
+    /// Criticality: High
+    /// Implementation: When vesting, the last_completed_period is checked against the next period to vest. This allows
+    /// to unlock vested tokens for the next period since last vested, in case they didn't call vest for some periods.
+    /// Enforcement: Audited that vesting doesn't skip periods, but gradually increments to allow shareholders to
+    /// retrieve all the vested tokens.
+    ///
+    /// No.: 8
+    /// Property: Actions such as obtaining a list of shareholders, calculating accrued rewards, distributing
+    /// withdrawable stake, and terminating the vesting contract should be accessible exclusively while the vesting
+    /// contract remains active.
+    /// Criticality: Low
+    /// Implementation: Restricting access to inactive vesting contracts is achieved through the
+    /// assert_active_vesting_contract function.
+    /// Enforcement: Formally verified via [high-level-spec-8](ActiveVestingContractAbortsIf).
+    ///
+    /// No.: 9
+    /// Property: The ability to terminate a vesting contract should only be available to the owner.
+    /// Criticality: High
+    /// Implementation: Limiting the access of accounts to specific function, is achieved by asserting that the signer
+    /// matches the admin of the VestingContract.
+    /// Enforcement: Formally verified via [high-level-req-9](verify_admin).
+    ///
+    /// No.: 10
+    /// Property: A new vesting contract should not be allowed to have an empty list of shareholders, have a different
+    /// amount of shareholders than buy-ins, and provide a withdrawal address which is either reserved or not registered
+    /// for apt.
+    /// Criticality: High
+    /// Implementation: The create_vesting_contract function ensures that the withdrawal_address is not a reserved
+    /// address, that it is registered for apt, that the list of shareholders is non-empty, and that the amount of
+    /// shareholders matches the amount of buy_ins.
+    /// Enforcement: Formally verified via [high-level-req-10](create_vesting_contract).
+    ///
+    /// No.: 11
+    /// Property: Creating a vesting contract account should require the signer (admin) to own an admin store and should
+    /// enforce that the seed of the resource account is composed of the admin store's nonce, the vesting pool salt,
+    /// and the custom contract creation seed.
+    /// Criticality: Medium
+    /// Implementation: The create_vesting_contract_account concatenates to the seed first the admin_store.nonce then
+    /// the VESTING_POOL_SALT then the contract_creation_seed and then it is passed to the create_resource_account
+    /// function.
+    /// Enforcement: Enforced via [high-level-req-11](create_vesting_contract_account).
+    /// </high-level-req>
     spec module {
         pragma verify = true;
         pragma aborts_if_is_strict;
         // property 2: The vesting pool should not exceed a maximum of 30 shareholders.
+        /// [high-level-spec-2]
         invariant forall pool: Pool: len(pool.shareholders) <= MAXIMUM_SHAREHOLDERS;
     }
 
@@ -31,6 +136,7 @@ spec aptos_framework::vesting {
     }
 
     spec vesting_contracts(admin: address): vector<address> {
+        /// [high-level-spec-3.1]
         aborts_if false;
     }
 
@@ -134,6 +240,7 @@ spec aptos_framework::vesting {
         start_timestamp_secs: u64,
         period_duration: u64,
     ): VestingSchedule {
+        /// [high-level-req-6]
         aborts_if !(len(schedule) > 0);
         aborts_if !(period_duration > 0);
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
@@ -143,6 +250,7 @@ spec aptos_framework::vesting {
     spec create_vesting_contract {
         // TODO: Data invariant does not hold.
         pragma verify = false;
+        /// [high-level-req-10]
         aborts_if withdrawal_address == @aptos_framework || withdrawal_address == @vm_reserved;
         aborts_if !exists<account::Account>(withdrawal_address);
         aborts_if !exists<coin::CoinStore<AptosCoin>>(withdrawal_address);
@@ -407,6 +515,7 @@ spec aptos_framework::vesting {
         let second = concat(first, VESTING_POOL_SALT);
         let end = concat(second, contract_creation_seed);
 
+        /// [high-level-req-11]
         let resource_addr = account::spec_create_resource_address(admin_addr, end);
         aborts_if !exists<AdminStore>(admin_addr);
         aborts_if len(account::ZERO_AUTH_KEY) != 32;
@@ -426,10 +535,12 @@ spec aptos_framework::vesting {
     }
 
     spec verify_admin(admin: &signer, vesting_contract: &VestingContract) {
+        /// [high-level-req-9]
         aborts_if signer::address_of(admin) != vesting_contract.admin;
     }
 
     spec assert_vesting_contract_exists(contract_address: address) {
+        /// [high-level-req-1]
         aborts_if !exists<VestingContract>(contract_address);
     }
 
@@ -508,6 +619,7 @@ spec aptos_framework::vesting {
     }
 
     spec get_beneficiary(contract: &VestingContract, shareholder: address): address {
+        /// [high-level-spec-3.2]
         aborts_if false;
     }
 
@@ -530,8 +642,10 @@ spec aptos_framework::vesting {
 
     spec schema ActiveVestingContractAbortsIf<VestingContract> {
         contract_address: address;
+        /// [high-level-spec-5]
         aborts_if !exists<VestingContract>(contract_address);
         let vesting_contract = global<VestingContract>(contract_address);
+        /// [high-level-spec-8]
         aborts_if vesting_contract.state != VESTING_POOL_ACTIVE;
     }
 }


### PR DESCRIPTION
### Description

Add high-level requirement tables for the following modules:

- [x] account
- [x] chain_id
- [x] code
- [x] delegation_pool
- [x] fungible_asset
- [x] consensus_config
- [x] gas_schedule
- [x] object
- [x] primary_fungible_store
- [x] optional_aggregator
- [x] staking_proxy
- [x] reconfiguration
- [x] staking_contract
- [x] aptos_coin
- [x] chain_status
- [x] genesis
- [x] transaction_context
- [x] vesting

And update docgen to support web links and header for module-level specification.