### PR TITLE
[move] inscriptions for Aptos

### DIFF
--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -226,6 +226,15 @@ fn test_token_objects() {
 }
 
 #[test]
+fn test_token_objects_inscriptions() {
+    let named_addresses = BTreeMap::from([(
+        String::from("inscriptions"),
+        AccountAddress::from_hex_literal("0xcafe").unwrap(),
+    )]);
+    run_tests_for_pkg("token_objects/inscriptions", named_addresses);
+}
+
+#[test]
 fn test_two_by_two_transfer() {
     run_tests_for_pkg("scripts/two_by_two_transfer", BTreeMap::new());
 }

--- a/aptos-move/move-examples/token_objects/inscriptions-as-events/Move.toml
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-events/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = 'inscriptions'
+version = '0.0.0'
+
+[addresses]
+inscriptions = "_"
+
+[dependencies]
+AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }

--- a/aptos-move/move-examples/token_objects/inscriptions-as-events/sources/immutable_collection.move
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-events/sources/immutable_collection.move
@@ -1,0 +1,152 @@
+module inscriptions::immutable_collection {
+    use std::option;
+    use std::string::String;
+
+    use aptos_framework::object::{Self, Object};
+
+    use aptos_token_objects::collection::{Self, Collection};
+    use aptos_token_objects::royalty::{Self, Royalty};
+    use aptos_token_objects::token::{Self, Token};
+
+    use inscriptions::inscriptions;
+
+    public entry fun create_collection(
+        creator: &signer,
+        description: String,
+        max_supply: u64,
+        name: String,
+        royalty_numerator: u64,
+        royalty_denominator: u64,
+        royalty_payee_address: address,
+        uri: String,
+    ) {
+        let royalty = royalty::create(
+            royalty_numerator,
+            royalty_denominator,
+            royalty_payee_address,
+        );
+
+        create_collection_object(
+            creator,
+            description,
+            max_supply,
+            name,
+            royalty,
+            uri,
+        );
+    }
+
+    public fun create_collection_object(
+        creator: &signer,
+        description: String,
+        max_supply: u64,
+        name: String,
+        royalty: Royalty,
+        uri: String,
+    ): Object<Collection> {
+        let constructor_ref = collection::create_fixed_collection(
+            creator,
+            description,
+            max_supply,
+            name,
+            option::some(royalty),
+            uri,
+        );
+
+        object::object_from_constructor_ref(&constructor_ref)
+    }
+
+    public entry fun mint_token(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+    ) {
+        mint_token_object(
+            creator,
+            collection_name,
+            data,
+            description,
+            name,
+            uri,
+        );
+    }
+
+    public entry fun mint_token_and_transfer(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+        recipient: address,
+    ) {
+        let token = mint_token_object(
+            creator,
+            collection_name,
+            data,
+            description,
+            name,
+            uri,
+        );
+
+        object::transfer(creator, token, recipient);
+    }
+
+    public fun mint_token_object(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+    ): Object<Token> {
+        let constructor_ref = token::create(
+            creator,
+            collection_name,
+            description,
+            name,
+            option::none(),
+            uri,
+        );
+
+        let _inscription_id = inscriptions::add_inscription(&constructor_ref, data);
+
+        object::object_from_constructor_ref(&constructor_ref)
+    }
+
+    #[test_only]
+    use std::string;
+
+    #[test(creator = @0x123, deployer = @inscriptions)]
+    fun end_to_end_test(creator: &signer, deployer: &signer) {
+        inscriptions::init_for_test(deployer);
+        let collection = string::utf8(b"collection");
+
+        create_collection(
+            creator,
+            string::utf8(b""),
+            5,
+            collection,
+            0,
+            1,
+            @0x123,
+            string::utf8(b""),
+        );
+
+        let data = b"00000000";
+        let token_obj = mint_token_object(
+            creator,
+            collection,
+            data,
+            string::utf8(b""),
+            string::utf8(b""),
+            string::utf8(b""),
+        );
+
+        assert!(inscriptions::is_inscription(token_obj), 0);
+        assert!(inscriptions::inscription_id(token_obj) == 0, 0);
+    }
+}

--- a/aptos-move/move-examples/token_objects/inscriptions-as-events/sources/inscriptions.move
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-events/sources/inscriptions.move
@@ -1,0 +1,147 @@
+module inscriptions::inscriptions {
+    use std::error;
+
+    use aptos_framework::event;
+    use aptos_framework::object::{Self, ConstructorRef, Object};
+
+    use aptos_token_objects::token;
+
+    /// The token does not exist
+    const ETOKEN_DOES_NOT_EXIST: u64 = 1;
+    /// The inscription does not exist
+    const EINSCRIPTION_DOES_NOT_EXIST: u64 = 2;
+
+    #[event]
+    struct InscriptionData has drop, store {
+        inscription_id: u64,
+        data: vector<u8>,
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    struct InscriptionMetadata has key {
+        inscription_id: u64,
+    }
+
+    #[resource_group(scope = module_)]
+    struct InscriptionStateGroup { }
+
+    #[resource_group_member(group = inscriptions::inscriptions::InscriptionStateGroup)]
+    struct InscriptionState has key {
+        next_inscription_id: u64,
+    }
+
+    public fun add_inscription(
+        constructor_ref: &ConstructorRef,
+        data: vector<u8>,
+    ): u64 acquires InscriptionState {
+        assert!(
+            object::object_exists<token::Token>(object::address_from_constructor_ref(constructor_ref)),
+            error::not_found(ETOKEN_DOES_NOT_EXIST),
+        );
+        let object_signer = object::generate_signer(constructor_ref);
+
+        let inscription_id = get_next_inscription_id();
+        let inscription_metadata = InscriptionMetadata { inscription_id };
+        move_to(&object_signer, inscription_metadata);
+
+        let inscription_data = InscriptionData {
+            inscription_id,
+            data,
+        };
+        event::emit(inscription_data);
+
+        inscription_id
+    }
+
+    fun get_next_inscription_id(): u64 acquires InscriptionState {
+        let inscription_state = borrow_global_mut<InscriptionState>(@inscriptions);
+        let inscription_id = inscription_state.next_inscription_id;
+        inscription_state.next_inscription_id = inscription_state.next_inscription_id + 1;
+        inscription_id
+    }
+
+    public fun is_inscription<T: key>(object: Object<T>): bool {
+        exists<InscriptionMetadata>(object::object_address(&object))
+    }
+
+    public fun inscription_id<T: key>(object: Object<T>): u64 acquires InscriptionMetadata {
+        let addr = object::object_address(&object);
+        assert!(
+            exists<InscriptionMetadata>(addr),
+            error::not_found(EINSCRIPTION_DOES_NOT_EXIST),
+        );
+        borrow_global<InscriptionMetadata>(addr).inscription_id
+    }
+
+    fun init_module(deployer: &signer) {
+        let inscription_state = InscriptionState { next_inscription_id: 0 };
+        move_to(deployer, inscription_state);
+    }
+
+    #[test_only]
+    public fun init_for_test(deployer: &signer) {
+        init_module(deployer);
+    }
+
+    #[test_only]
+    use std::option;
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use std::string::{Self, String};
+    #[test_only]
+    use aptos_token_objects::collection;
+    #[test_only]
+    use aptos_token_objects::royalty;
+
+    #[test(creator = @0x123, deployer = @inscriptions)]
+    fun test_create(creator: &signer, deployer: &signer) acquires InscriptionMetadata, InscriptionState {
+        let collection = string::utf8(b"collection");
+        let inscription_0 = b"00000000";
+        let inscription_1 = b"00000000";
+
+        init_for_test(deployer);
+        let _collection_ref = create_collection_helper(creator, collection, 10);
+
+        let token_0_ref = create_token_helper(creator, collection, string::utf8(b"0"));
+        let token_0_obj = object::object_from_constructor_ref<token::Token>(&token_0_ref);
+        assert!(!is_inscription(token_0_obj), 2);
+        add_inscription(&token_0_ref, inscription_0);
+        assert!(event::was_event_emitted(&InscriptionData { inscription_id: 0, data: inscription_0 }), 0);
+        assert!(!event::was_event_emitted(&InscriptionData { inscription_id: 1, data: inscription_1 }), 1);
+        assert!(is_inscription(token_0_obj), 2);
+        assert!(inscription_id(token_0_obj) == 0, 2);
+
+        let token_1_ref = create_token_helper(creator, collection, string::utf8(b"1"));
+        let token_1_obj = object::object_from_constructor_ref<token::Token>(&token_1_ref);
+        add_inscription(&token_1_ref, inscription_1);
+        assert!(event::was_event_emitted(&InscriptionData { inscription_id: 1, data: inscription_1 }), 1);
+        assert!(is_inscription(token_1_obj), 2);
+        assert!(inscription_id(token_1_obj) == 1, 2);
+    }
+
+    #[test_only]
+    fun create_collection_helper(creator: &signer, collection_name: String, max_supply: u64): object::ExtendRef {
+        let constructor_ref = collection::create_fixed_collection(
+            creator,
+            string::utf8(b"collection description"),
+            max_supply,
+            collection_name,
+            option::none(),
+            string::utf8(b"collection uri"),
+        );
+        object::generate_extend_ref(&constructor_ref)
+    }
+
+    #[test_only]
+    fun create_token_helper(creator: &signer, collection_name: String, token_name: String): ConstructorRef {
+        token::create_named_token(
+            creator,
+            collection_name,
+            string::utf8(b"token description"),
+            token_name,
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
+        )
+    }
+}

--- a/aptos-move/move-examples/token_objects/inscriptions-as-state/Move.toml
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-state/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = 'inscriptions'
+version = '0.0.0'
+
+[addresses]
+inscriptions = "_"
+
+[dependencies]
+AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }

--- a/aptos-move/move-examples/token_objects/inscriptions-as-state/sources/immutable_collection.move
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-state/sources/immutable_collection.move
@@ -1,0 +1,152 @@
+module inscriptions::immutable_collection {
+    use std::option;
+    use std::string::String;
+
+    use aptos_framework::object::{Self, Object};
+
+    use aptos_token_objects::collection::{Self, Collection};
+    use aptos_token_objects::royalty::{Self, Royalty};
+    use aptos_token_objects::token::{Self, Token};
+
+    use inscriptions::inscriptions;
+
+    public entry fun create_collection(
+        creator: &signer,
+        description: String,
+        max_supply: u64,
+        name: String,
+        royalty_numerator: u64,
+        royalty_denominator: u64,
+        royalty_payee_address: address,
+        uri: String,
+    ) {
+        let royalty = royalty::create(
+            royalty_numerator,
+            royalty_denominator,
+            royalty_payee_address,
+        );
+
+        create_collection_object(
+            creator,
+            description,
+            max_supply,
+            name,
+            royalty,
+            uri,
+        );
+    }
+
+    public fun create_collection_object(
+        creator: &signer,
+        description: String,
+        max_supply: u64,
+        name: String,
+        royalty: Royalty,
+        uri: String,
+    ): Object<Collection> {
+        let constructor_ref = collection::create_fixed_collection(
+            creator,
+            description,
+            max_supply,
+            name,
+            option::some(royalty),
+            uri,
+        );
+
+        object::object_from_constructor_ref(&constructor_ref)
+    }
+
+    public entry fun mint_token(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+    ) {
+        mint_token_object(
+            creator,
+            collection_name,
+            data,
+            description,
+            name,
+            uri,
+        );
+    }
+
+    public entry fun mint_token_and_transfer(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+        recipient: address,
+    ) {
+        let token = mint_token_object(
+            creator,
+            collection_name,
+            data,
+            description,
+            name,
+            uri,
+        );
+
+        object::transfer(creator, token, recipient);
+    }
+
+    public fun mint_token_object(
+        creator: &signer,
+        collection_name: String,
+        data: vector<u8>,
+        description: String,
+        name: String,
+        uri: String,
+    ): Object<Token> {
+        let constructor_ref = token::create(
+            creator,
+            collection_name,
+            description,
+            name,
+            option::none(),
+            uri,
+        );
+
+        let _inscription_id = inscriptions::add_inscription(&constructor_ref, data);
+
+        object::object_from_constructor_ref(&constructor_ref)
+    }
+
+    #[test_only]
+    use std::string;
+
+    #[test(creator = @0x123, deployer = @inscriptions)]
+    fun end_to_end_test(creator: &signer, deployer: &signer) {
+        inscriptions::init_for_test(deployer);
+        let collection = string::utf8(b"collection");
+
+        create_collection(
+            creator,
+            string::utf8(b""),
+            5,
+            collection,
+            0,
+            1,
+            @0x123,
+            string::utf8(b""),
+        );
+
+        let data = b"00000000";
+        let token_obj = mint_token_object(
+            creator,
+            collection,
+            data,
+            string::utf8(b""),
+            string::utf8(b""),
+            string::utf8(b""),
+        );
+
+        assert!(inscriptions::is_inscription(token_obj), 0);
+        assert!(inscriptions::inscription_id(token_obj) == 0, 0);
+    }
+}

--- a/aptos-move/move-examples/token_objects/inscriptions-as-state/sources/inscriptions.move
+++ b/aptos-move/move-examples/token_objects/inscriptions-as-state/sources/inscriptions.move
@@ -1,0 +1,157 @@
+module inscriptions::inscriptions {
+    use std::error;
+
+    use aptos_framework::event;
+    use aptos_framework::object::{Self, ConstructorRef, Object};
+
+    use aptos_token_objects::token;
+
+    /// The token does not exist
+    const ETOKEN_DOES_NOT_EXIST: u64 = 1;
+    /// The inscription does not exist
+    const EINSCRIPTION_DOES_NOT_EXIST: u64 = 2;
+
+    #[event]
+    struct InscriptionMintEvent has drop, store {
+        inscription_id: u64,
+        object: Object<InscriptionData>,
+    }
+
+    struct InscriptionData has key {
+        inscription_id: u64,
+        data: vector<u8>,
+    }
+
+    #[resource_group(scope = module_)]
+    struct InscriptionStateGroup { }
+
+    #[resource_group_member(group = inscriptions::inscriptions::InscriptionStateGroup)]
+    struct InscriptionState has key {
+        next_inscription_id: u64,
+    }
+
+    public fun add_inscription(
+        constructor_ref: &ConstructorRef,
+        data: vector<u8>,
+    ): u64 acquires InscriptionState {
+        assert!(
+            object::object_exists<token::Token>(object::address_from_constructor_ref(constructor_ref)),
+            error::not_found(ETOKEN_DOES_NOT_EXIST),
+        );
+        let object_signer = object::generate_signer(constructor_ref);
+
+        let inscription_id = get_next_inscription_id();
+        let inscription_data = InscriptionData { inscription_id, data };
+        move_to(&object_signer, inscription_data);
+
+        let inscription_mint_event = InscriptionMintEvent {
+            inscription_id,
+            object: object::object_from_constructor_ref(constructor_ref),
+        };
+        event::emit(inscription_mint_event);
+
+        inscription_id
+    }
+
+    fun get_next_inscription_id(): u64 acquires InscriptionState {
+        let inscription_state = borrow_global_mut<InscriptionState>(@inscriptions);
+        let inscription_id = inscription_state.next_inscription_id;
+        inscription_state.next_inscription_id = inscription_state.next_inscription_id + 1;
+        inscription_id
+    }
+
+    public fun is_inscription<T: key>(object: Object<T>): bool {
+        exists<InscriptionData>(object::object_address(&object))
+    }
+
+
+    inline fun borrow_data<T: key>(object: &Object<T>): &InscriptionData {
+        let addr = object::object_address(object);
+        assert!(
+            exists<InscriptionData>(addr),
+            error::not_found(EINSCRIPTION_DOES_NOT_EXIST),
+        );
+        borrow_global<InscriptionData>(addr)
+    }
+
+    public fun data<T: key>(object: Object<T>): vector<u8> acquires InscriptionData {
+        borrow_data(&object).data
+    }
+
+    public fun inscription_id<T: key>(object: Object<T>): u64 acquires InscriptionData {
+        borrow_data(&object).inscription_id
+    }
+
+    fun init_module(deployer: &signer) {
+        let inscription_state = InscriptionState { next_inscription_id: 0 };
+        move_to(deployer, inscription_state);
+    }
+
+    #[test_only]
+    public fun init_for_test(deployer: &signer) {
+        init_module(deployer);
+    }
+
+    #[test_only]
+    use std::option;
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use std::string::{Self, String};
+    #[test_only]
+    use aptos_token_objects::collection;
+    #[test_only]
+    use aptos_token_objects::royalty;
+
+    #[test(creator = @0x123, deployer = @inscriptions)]
+    fun test_create(creator: &signer, deployer: &signer) acquires InscriptionData, InscriptionState {
+        let collection = string::utf8(b"collection");
+        let inscription_0 = b"00000000";
+        let inscription_1 = b"00000000";
+
+        init_for_test(deployer);
+        let _collection_ref = create_collection_helper(creator, collection, 10);
+
+        let token_0_ref = create_token_helper(creator, collection, string::utf8(b"0"));
+        let token_0_obj = object::object_from_constructor_ref<token::Token>(&token_0_ref);
+        assert!(!is_inscription(token_0_obj), 2);
+        add_inscription(&token_0_ref, inscription_0);
+        let inscription_0_obj = object::convert(token_0_obj);
+        assert!(event::was_event_emitted(&InscriptionMintEvent { inscription_id: 0, object: inscription_0_obj }), 0);
+        assert!(is_inscription(inscription_0_obj), 1);
+        assert!(inscription_id(inscription_0_obj) == 0, 2);
+
+        let token_1_ref = create_token_helper(creator, collection, string::utf8(b"1"));
+        let token_0_obj = object::object_from_constructor_ref<token::Token>(&token_1_ref);
+        add_inscription(&token_1_ref, inscription_1);
+        let inscription_1_obj = object::convert(token_0_obj);
+        assert!(event::was_event_emitted(&InscriptionMintEvent { inscription_id: 1, object: inscription_1_obj }), 3);
+        assert!(is_inscription(inscription_1_obj), 4);
+        assert!(inscription_id(inscription_1_obj) == 1, 5);
+    }
+
+    #[test_only]
+    fun create_collection_helper(creator: &signer, collection_name: String, max_supply: u64): object::ExtendRef {
+        let constructor_ref = collection::create_fixed_collection(
+            creator,
+            string::utf8(b"collection description"),
+            max_supply,
+            collection_name,
+            option::none(),
+            string::utf8(b"collection uri"),
+        );
+        object::generate_extend_ref(&constructor_ref)
+    }
+
+    #[test_only]
+    fun create_token_helper(creator: &signer, collection_name: String, token_name: String): ConstructorRef {
+        token::create_named_token(
+            creator,
+            collection_name,
+            string::utf8(b"token description"),
+            token_name,
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
+        )
+    }
+}

--- a/ecosystem/python/sdk/aptos_sdk/inscriptions_as_events_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/inscriptions_as_events_client.py
@@ -1,0 +1,211 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+from typing import Any, List
+
+from .account import Account
+from .account_address import AccountAddress
+from .aptos_token_client import AptosTokenClient
+from .async_client import RestClient
+from .bcs import Serializer
+from .transactions import EntryFunction, TransactionArgument, TransactionPayload
+
+MODULE_ADDRESS: AccountAddress = AccountAddress.from_str(
+    "0xfa3911d7715238b2e3bd5b26b6a35e11ffa16cff318bc11471e84eccee8bd291"
+)
+
+
+def set_module_address(module_address: AccountAddress):
+    global MODULE_ADDRESS
+    MODULE_ADDRESS = module_address
+
+
+def get_module_address() -> AccountAddress:
+    global MODULE_ADDRESS
+    return MODULE_ADDRESS
+
+
+class InscriptionData:
+    inscription_id: int
+    data: bytes
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{get_module_address()}::inscriptions::InscriptionData"
+
+    def __init__(self, inscription_id: int, data: bytes):
+        self.inscription_id = inscription_id
+        self.data = data
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionData:
+        print(resource)
+        return InscriptionData(
+            resource["inscription_id"],
+            bytes.fromhex(resource["data"].lstrip("0x")),
+        )
+
+    def __str__(self) -> str:
+        data = base64.b64encode(self.data)
+        return f"InscriptionData[inscription_id: {self.inscription_id}, data: {data!r}]"
+
+
+class InscriptionMetadata:
+    inscription_id: int
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{get_module_address()}::inscriptions::InscriptionMetadata"
+
+    def __init__(self, inscription_id):
+        self.inscription_id = inscription_id
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionMetadata:
+        return InscriptionMetadata(
+            resource["inscription_id"],
+        )
+
+    def __str__(self) -> str:
+        return f"Object[inscription_id: {self.inscription_id}]"
+
+
+class InscriptionState:
+    next_inscription_id: int
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{get_module_address()}::inscriptions::InscriptionState"
+
+    def __init__(self, next_inscription_id):
+        self.next_inscription_id = next_inscription_id
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionState:
+        return InscriptionState(resource["next_inscription_id"])
+
+    def __str__(self) -> str:
+        return f"InscriptionState[next_inscription_id: {self.next_inscription_id}]"
+
+
+class InscriptionsClient:
+    rest_client: RestClient
+    token_client: AptosTokenClient
+
+    def __init__(self, client: AptosTokenClient):
+        self.token_client = client
+        self.rest_client = client.client
+
+    @staticmethod
+    def create_collection_payload(
+        description: str,
+        max_supply: int,
+        name: str,
+        royalty_numerator: int,
+        royalty_denominator: int,
+        royalty_payee_address: AccountAddress,
+        uri: str,
+    ) -> TransactionPayload:
+        transaction_arguments = [
+            TransactionArgument(description, Serializer.str),
+            TransactionArgument(max_supply, Serializer.u64),
+            TransactionArgument(name, Serializer.str),
+            TransactionArgument(royalty_numerator, Serializer.u64),
+            TransactionArgument(royalty_denominator, Serializer.u64),
+            TransactionArgument(royalty_payee_address, Serializer.struct),
+            TransactionArgument(uri, Serializer.str),
+        ]
+
+        payload = EntryFunction.natural(
+            f"{get_module_address()}::immutable_collection",
+            "create_collection",
+            [],
+            transaction_arguments,
+        )
+
+        return TransactionPayload(payload)
+
+    async def create_collection(
+        self,
+        creator: Account,
+        description: str,
+        max_supply: int,
+        name: str,
+        royalty_numerator: int,
+        royalty_denominator: int,
+        royalty_payee_address: AccountAddress,
+        uri: str,
+    ) -> str:
+        payload = InscriptionsClient.create_collection_payload(
+            description,
+            max_supply,
+            name,
+            royalty_numerator,
+            royalty_denominator,
+            royalty_payee_address,
+            uri,
+        )
+        signed_transaction = await self.rest_client.create_bcs_signed_transaction(
+            creator, payload
+        )
+        return await self.rest_client.submit_bcs_transaction(signed_transaction)
+
+    @staticmethod
+    def mint_token_payload(
+        collection: str,
+        data: bytes,
+        description: str,
+        name: str,
+        uri: str,
+    ) -> TransactionPayload:
+        transaction_arguments = [
+            TransactionArgument(collection, Serializer.str),
+            TransactionArgument(data, Serializer.to_bytes),
+            TransactionArgument(description, Serializer.str),
+            TransactionArgument(name, Serializer.str),
+            TransactionArgument(uri, Serializer.str),
+        ]
+
+        payload = EntryFunction.natural(
+            f"{get_module_address()}::immutable_collection",
+            "mint_token",
+            [],
+            transaction_arguments,
+        )
+
+        return TransactionPayload(payload)
+
+    async def mint_token(
+        self,
+        creator: Account,
+        collection: str,
+        data: bytes,
+        description: str,
+        name: str,
+        uri: str,
+    ) -> str:
+        payload = InscriptionsClient.mint_token_payload(
+            collection,
+            data,
+            description,
+            name,
+            uri,
+        )
+        signed_transaction = await self.rest_client.create_bcs_signed_transaction(
+            creator, payload
+        )
+        return await self.rest_client.submit_bcs_transaction(signed_transaction)
+
+    async def inscriptions_from_transaction(
+        self, txn_hash: str
+    ) -> List[InscriptionData]:
+        output = await self.rest_client.transaction_by_hash(txn_hash)
+        mints = []
+        for event in output["events"]:
+            if event["type"] != InscriptionData.struct_tag():
+                continue
+            mints.append(InscriptionData.parse(event["data"]))
+        return mints

--- a/ecosystem/python/sdk/aptos_sdk/inscriptions_as_state_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/inscriptions_as_state_client.py
@@ -1,0 +1,223 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+from typing import Any, List
+
+from .account import Account
+from .account_address import AccountAddress
+from .aptos_token_client import AptosTokenClient, ReadObject
+from .async_client import RestClient
+from .bcs import Serializer
+from .transactions import EntryFunction, TransactionArgument, TransactionPayload
+
+MODULE_ADDRESS: AccountAddress = AccountAddress.from_str(
+    "0xfa3911d7715238b2e3bd5b26b6a35e11ffa16cff318bc11471e84eccee8bd291"
+)
+
+
+def set_module_address(module_address: AccountAddress):
+    global MODULE_ADDRESS
+    MODULE_ADDRESS = module_address
+
+
+def get_module_address() -> AccountAddress:
+    global MODULE_ADDRESS
+    return MODULE_ADDRESS
+
+
+class InscriptionData:
+    inscription_id: int
+    data: bytes
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{MODULE_ADDRESS}::inscriptions::InscriptionData"
+
+    def __init__(self, inscription_id: int, data: bytes):
+        self.inscription_id = inscription_id
+        self.data = data
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionData:
+        return InscriptionData(
+            resource["inscription_id"],
+            bytes.fromhex(resource["data"].lstrip("0x")),
+        )
+
+    def __str__(self) -> str:
+        data = base64.b64encode(self.data)
+        return f"InscriptionData[inscription_id: {self.inscription_id}, data: {data!r}]"
+
+
+class InscriptionMintEvent:
+    inscription_id: int
+    object_: AccountAddress
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{MODULE_ADDRESS}::inscriptions::InscriptionMintEvent"
+
+    def __init__(self, inscription_id: int, object_: AccountAddress):
+        self.inscription_id = inscription_id
+        self.object_ = object_
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionMintEvent:
+        return InscriptionMintEvent(
+            resource["inscription_id"],
+            resource["object"],
+        )
+
+    def __str__(self) -> str:
+        return f"InscriptionMintEvent[inscription_id: {self.inscription_id}, object: {self.object_}]"
+
+
+class InscriptionState:
+    next_inscription_id: int
+
+    @staticmethod
+    def struct_tag() -> str:
+        return f"{MODULE_ADDRESS}::inscriptions::InscriptionState"
+
+    def __init__(self, next_inscription_id):
+        self.next_inscription_id = next_inscription_id
+
+    @staticmethod
+    def parse(resource: dict[str, Any]) -> InscriptionState:
+        return InscriptionState(resource["next_inscription_id"])
+
+    def __str__(self) -> str:
+        return f"InscriptionState[next_inscription_id: {self.next_inscription_id}]"
+
+
+class InscriptionsClient:
+    rest_client: RestClient
+    token_client: AptosTokenClient
+    additional_resources: dict[str, Any]
+
+    def __init__(self, client: AptosTokenClient):
+        self.token_client = client
+        self.rest_client = client.client
+        self.additional_resources = {InscriptionData.struct_tag(): InscriptionData}
+
+    async def read_object(
+        self,
+        address: AccountAddress,
+        additional_resources: dict[str, Any] = dict(),
+    ) -> ReadObject:
+        local_resources = dict(self.additional_resources, **additional_resources)
+        return await self.token_client.read_object(address, local_resources)
+
+    @staticmethod
+    def create_collection_payload(
+        description: str,
+        max_supply: int,
+        name: str,
+        royalty_numerator: int,
+        royalty_denominator: int,
+        royalty_payee_address: AccountAddress,
+        uri: str,
+    ) -> TransactionPayload:
+        transaction_arguments = [
+            TransactionArgument(description, Serializer.str),
+            TransactionArgument(max_supply, Serializer.u64),
+            TransactionArgument(name, Serializer.str),
+            TransactionArgument(royalty_numerator, Serializer.u64),
+            TransactionArgument(royalty_denominator, Serializer.u64),
+            TransactionArgument(royalty_payee_address, Serializer.struct),
+            TransactionArgument(uri, Serializer.str),
+        ]
+
+        payload = EntryFunction.natural(
+            f"{get_module_address()}::immutable_collection",
+            "create_collection",
+            [],
+            transaction_arguments,
+        )
+
+        return TransactionPayload(payload)
+
+    async def create_collection(
+        self,
+        creator: Account,
+        description: str,
+        max_supply: int,
+        name: str,
+        royalty_numerator: int,
+        royalty_denominator: int,
+        royalty_payee_address: AccountAddress,
+        uri: str,
+    ) -> str:
+        payload = InscriptionsClient.create_collection_payload(
+            description,
+            max_supply,
+            name,
+            royalty_numerator,
+            royalty_denominator,
+            royalty_payee_address,
+            uri,
+        )
+        signed_transaction = await self.rest_client.create_bcs_signed_transaction(
+            creator, payload
+        )
+        return await self.rest_client.submit_bcs_transaction(signed_transaction)
+
+    @staticmethod
+    def mint_token_payload(
+        collection: str,
+        data: bytes,
+        description: str,
+        name: str,
+        uri: str,
+    ) -> TransactionPayload:
+        transaction_arguments = [
+            TransactionArgument(collection, Serializer.str),
+            TransactionArgument(data, Serializer.to_bytes),
+            TransactionArgument(description, Serializer.str),
+            TransactionArgument(name, Serializer.str),
+            TransactionArgument(uri, Serializer.str),
+        ]
+
+        payload = EntryFunction.natural(
+            f"{get_module_address()}::immutable_collection",
+            "mint_token",
+            [],
+            transaction_arguments,
+        )
+
+        return TransactionPayload(payload)
+
+    async def mint_token(
+        self,
+        creator: Account,
+        collection: str,
+        data: bytes,
+        description: str,
+        name: str,
+        uri: str,
+    ) -> str:
+        payload = InscriptionsClient.mint_token_payload(
+            collection,
+            data,
+            description,
+            name,
+            uri,
+        )
+        signed_transaction = await self.rest_client.create_bcs_signed_transaction(
+            creator, payload
+        )
+        return await self.rest_client.submit_bcs_transaction(signed_transaction)
+
+    async def inscriptions_from_transaction(
+        self, txn_hash: str
+    ) -> List[InscriptionMintEvent]:
+        output = await self.rest_client.transaction_by_hash(txn_hash)
+        mints = []
+        for event in output["events"]:
+            if event["type"] != InscriptionMintEvent.struct_tag():
+                continue
+            mints.append(InscriptionMintEvent.parse(event["data"]))
+        return mints

--- a/ecosystem/python/sdk/examples/inscriptions_as_events.py
+++ b/ecosystem/python/sdk/examples/inscriptions_as_events.py
@@ -1,0 +1,84 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+This demonstrates how to use the simple inscriptions package.
+"""
+import asyncio
+from urllib.request import urlretrieve
+
+import aptos_sdk.cli as aptos_sdk_cli
+import aptos_sdk.inscriptions_as_events_client as inscriptions
+from aptos_sdk.account import Account
+from aptos_sdk.account_address import AccountAddress
+from aptos_sdk.aptos_token_client import AptosTokenClient
+from aptos_sdk.async_client import FaucetClient, RestClient
+from aptos_sdk.inscriptions_as_events_client import InscriptionsClient
+
+from .common import FAUCET_URL, NODE_URL
+
+
+async def publish_inscriptions(inscriptions_dir: str) -> AccountAddress:
+    rest_client = RestClient(NODE_URL)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    await aptos_sdk_cli.publish_package(
+        inscriptions_dir, {"inscriptions": alice.address()}, alice, NODE_URL
+    )
+    return alice.address()
+
+
+async def main(inscriptions_account: AccountAddress = inscriptions.MODULE_ADDRESS):
+    inscriptions.set_module_address(inscriptions_account)
+
+    rest_client = RestClient(NODE_URL)
+    aptos_token_client = AptosTokenClient(rest_client)
+    inscriptions_client = InscriptionsClient(aptos_token_client)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    alice_balance = await rest_client.account_balance(alice.address())
+    print(f"Alice: {alice.address()} {alice_balance}")
+
+    collection_name = "Immutable Inscriptions Demo"
+
+    txn_hash = await inscriptions_client.create_collection(
+        alice,
+        "Behold the power of Inscriptions on Aptos",
+        100,
+        collection_name,
+        0,
+        1,
+        alice.address(),
+        "",
+    )
+    await rest_client.wait_for_transaction(txn_hash)
+
+    path, headers = urlretrieve("https://aptos.dev/img/nyan.jpeg")
+    with open(path, "rb") as file:
+        data = file.read()
+
+    txn_hash = await inscriptions_client.mint_token(
+        alice,
+        collection_name,
+        data,
+        "Nyan, a cat for the next generation",
+        "Nyan",
+        "https://aptos.dev/img/nyan.jpeg",
+    )
+    await rest_client.wait_for_transaction(txn_hash)
+
+    tokens = await aptos_token_client.tokens_minted_from_transaction(txn_hash)
+    assert len(tokens) == 1
+    await aptos_token_client.read_object(tokens[0])
+    inscription_data = await inscriptions_client.inscriptions_from_transaction(txn_hash)
+    assert len(inscription_data) == 1
+    assert inscription_data[0].data == data
+
+    rest_client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ecosystem/python/sdk/examples/inscriptions_as_state.py
+++ b/ecosystem/python/sdk/examples/inscriptions_as_state.py
@@ -1,0 +1,86 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+This demonstrates how to use the simple inscriptions package.
+"""
+import asyncio
+from urllib.request import urlretrieve
+
+import aptos_sdk.cli as aptos_sdk_cli
+import aptos_sdk.inscriptions_as_state_client as inscriptions
+from aptos_sdk.account import Account
+from aptos_sdk.account_address import AccountAddress
+from aptos_sdk.aptos_token_client import AptosTokenClient
+from aptos_sdk.async_client import FaucetClient, RestClient
+from aptos_sdk.inscriptions_as_state_client import InscriptionsClient
+
+from .common import FAUCET_URL, NODE_URL
+
+
+async def publish_inscriptions(inscriptions_dir: str) -> AccountAddress:
+    rest_client = RestClient(NODE_URL)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    await aptos_sdk_cli.publish_package(
+        inscriptions_dir, {"inscriptions": alice.address()}, alice, NODE_URL
+    )
+    return alice.address()
+
+
+async def main(inscriptions_account: AccountAddress = inscriptions.MODULE_ADDRESS):
+    inscriptions.set_module_address(inscriptions_account)
+
+    rest_client = RestClient(NODE_URL)
+    aptos_token_client = AptosTokenClient(rest_client)
+    inscriptions_client = InscriptionsClient(aptos_token_client)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    await rest_client.account_balance(alice.address())
+
+    collection_name = "Immutable Inscriptions Demo"
+
+    txn_hash = await inscriptions_client.create_collection(
+        alice,
+        "Behold the power of Inscriptions on Aptos",
+        100,
+        collection_name,
+        0,
+        1,
+        alice.address(),
+        "",
+    )
+    await rest_client.wait_for_transaction(txn_hash)
+
+    path, headers = urlretrieve("https://aptos.dev/img/nyan.jpeg")
+    with open(path, "rb") as file:
+        data = file.read()
+
+    txn_hash = await inscriptions_client.mint_token(
+        alice,
+        collection_name,
+        data,
+        "Nyan, a cat for the next generation",
+        "Nyan",
+        "https://aptos.dev/img/nyan.jpeg",
+    )
+    await rest_client.wait_for_transaction(txn_hash)
+
+    tokens = await aptos_token_client.tokens_minted_from_transaction(txn_hash)
+    assert len(tokens) == 1
+    value = await inscriptions_client.read_object(tokens[0])
+    inscription_events = await inscriptions_client.inscriptions_from_transaction(
+        txn_hash
+    )
+    assert len(inscription_events) == 1
+    assert value.resources[inscriptions.InscriptionData].data == data
+    print(f"Inscription created at {tokens[0]}")
+
+    rest_client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ecosystem/python/sdk/examples/inscriptions_evaluator.py
+++ b/ecosystem/python/sdk/examples/inscriptions_evaluator.py
@@ -1,0 +1,80 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+This demonstrates how to use the simple inscriptions package.
+Note, because the API is identical for both state and event inscriptions
+this can be used seamlessly to test either of them, so long as the address
+points to the correct contract.
+"""
+import asyncio
+
+import aptos_sdk.cli as aptos_sdk_cli
+import aptos_sdk.inscriptions_as_state_client as inscriptions
+from aptos_sdk.account import Account
+from aptos_sdk.account_address import AccountAddress
+from aptos_sdk.aptos_token_client import AptosTokenClient
+from aptos_sdk.async_client import FaucetClient, RestClient
+from aptos_sdk.inscriptions_as_state_client import InscriptionsClient
+
+from .common import FAUCET_URL, NODE_URL
+
+
+async def publish_inscriptions(inscriptions_dir: str) -> AccountAddress:
+    rest_client = RestClient(NODE_URL)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    rest_client.close()
+
+    await aptos_sdk_cli.publish_package(
+        inscriptions_dir, {"inscriptions": alice.address()}, alice, NODE_URL
+    )
+
+    return alice.address()
+
+
+async def main(inscriptions_account: AccountAddress = inscriptions.MODULE_ADDRESS):
+    inscriptions.set_module_address(inscriptions_account)
+
+    rest_client = RestClient(NODE_URL)
+    aptos_token_client = AptosTokenClient(rest_client)
+    inscriptions_client = InscriptionsClient(aptos_token_client)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+
+    alice = Account.generate()
+    await faucet_client.fund_account(alice.address(), 1_000_000_000)
+    await rest_client.account_balance(alice.address())
+
+    collection_name = "Immutable Inscriptions Demo"
+
+    txn_hash = await inscriptions_client.create_collection(
+        alice,
+        "Behold the power of Inscriptions on Aptos",
+        100,
+        collection_name,
+        0,
+        1,
+        alice.address(),
+        "",
+    )
+    await rest_client.wait_for_transaction(txn_hash)
+
+    for size in [0, 2**10, 10 * 2**10, 50 * 2**10, 62 * 2**10]:
+        data = size * b"\x00"
+
+        txn_hash = await inscriptions_client.mint_token(
+            alice,
+            collection_name,
+            data,
+            "Nyan, a cat for the next generation",
+            "Nyan",
+            "https://aptos.dev/img/nyan.jpeg",
+        )
+        await rest_client.wait_for_transaction(txn_hash)
+        result = await rest_client.transaction_by_hash(txn_hash)
+        print(f"{size} -- {result['gas_used']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ecosystem/python/sdk/examples/integration_test.py
+++ b/ecosystem/python/sdk/examples/integration_test.py
@@ -44,6 +44,44 @@ class Test(unittest.IsolatedAsyncioTestCase):
         contract_address = await hello_blockchain.publish_contract(hello_blockchain_dir)
         await hello_blockchain.main(contract_address)
 
+    async def test_inscriptions_as_events(self):
+        from . import inscriptions_as_events
+
+        inscriptions_dir = os.path.join(
+            "..",
+            "..",
+            "..",
+            "aptos-move",
+            "move-examples",
+            "token_objects",
+            "inscriptions-as-events",
+        )
+        AptosCLIWrapper.test_package(
+            inscriptions_dir, {"inscriptions": AccountAddress.from_str("0xa")}
+        )
+        module_addr = await inscriptions_as_events.publish_inscriptions(
+            inscriptions_dir
+        )
+        await inscriptions_as_events.main(module_addr)
+
+    async def test_inscriptions_as_state(self):
+        from . import inscriptions_as_state
+
+        inscriptions_dir = os.path.join(
+            "..",
+            "..",
+            "..",
+            "aptos-move",
+            "move-examples",
+            "token_objects",
+            "inscriptions-as-state",
+        )
+        AptosCLIWrapper.test_package(
+            inscriptions_dir, {"inscriptions": AccountAddress.from_str("0xa")}
+        )
+        module_addr = await inscriptions_as_state.publish_inscriptions(inscriptions_dir)
+        await inscriptions_as_state.main(module_addr)
+
     async def test_large_package_publisher(self):
         from . import large_package_publisher
 

--- a/ecosystem/python/sdk/mypy.ini
+++ b/ecosystem/python/sdk/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-ecdsa.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This is a quick demo of one way in which we could do inscriptions on Aptos.

The details:
* Builds upon our digital asset standard (token objects)
* inscription obtains a unique global id beginning from 0
* inscriptions store data as events
* current inscriptions are limited to the transaction size limit of 64K, so like 62K images

This includes an immutable collection inscription contract for some initial minting. The expectation is that launchpads will build their own way to create inscriptions, but this immutable collection contract works pretty well for phase 1 inscriptions.

I would love feedback about how we can make this standard better. Should we include content type? We definitely need a demo using the on-chain indexers for testnet -- but let's first agree on the contract itself.

I'll push out an AIP on this topic very shortly for further conversations, but for now, let's start on this PR.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
