### PR TITLE
[move][trivial] Remove unused module cache

### DIFF
--- a/third_party/move/tools/move-bytecode-utils/src/module_cache.rs
+++ b/third_party/move/tools/move-bytecode-utils/src/module_cache.rs
@@ -2,16 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use move_binary_format::CompiledModule;
-use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
-use std::{
-    borrow::Borrow,
-    cell::RefCell,
-    collections::{btree_map::Entry, BTreeMap},
-    fmt::Debug,
-    sync::{Arc, RwLock},
-};
+use move_core_types::language_storage::ModuleId;
+use std::{borrow::Borrow, fmt::Debug};
 
 /// A persistent storage that can fetch the bytecode for a given module id
 /// TODO: do we want to implement this in a way that allows clients to cache struct layouts?
@@ -20,104 +14,4 @@ pub trait GetModule {
     type Item: Borrow<CompiledModule>;
 
     fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error>;
-}
-
-/// Simple in-memory module cache
-pub struct ModuleCache<R: ModuleResolver> {
-    cache: RefCell<BTreeMap<ModuleId, CompiledModule>>,
-    resolver: R,
-}
-
-#[allow(clippy::len_without_is_empty)]
-impl<R: ModuleResolver> ModuleCache<R> {
-    pub fn new(resolver: R) -> Self {
-        ModuleCache {
-            cache: RefCell::new(BTreeMap::new()),
-            resolver,
-        }
-    }
-
-    pub fn add(&self, id: ModuleId, m: CompiledModule) {
-        self.cache.borrow_mut().insert(id, m);
-    }
-
-    pub fn len(&self) -> usize {
-        self.cache.borrow().len()
-    }
-}
-
-impl<R: ModuleResolver> GetModule for ModuleCache<R> {
-    type Error = anyhow::Error;
-    type Item = CompiledModule;
-
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
-        Ok(Some(match self.cache.borrow_mut().entry(id.clone()) {
-            Entry::Vacant(entry) => {
-                let module_bytes = self
-                    .resolver
-                    .get_module(id)
-                    .map_err(|_| anyhow!("Failed to get module {:?}", id))?
-                    .ok_or_else(|| anyhow!("Module {:?} doesn't exist", id))?;
-                let module = CompiledModule::deserialize(&module_bytes)
-                    .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
-                entry.insert(module.clone());
-                module
-            },
-            Entry::Occupied(entry) => entry.get().clone(),
-        }))
-    }
-}
-
-/// Simple in-memory module cache that implements Sync
-pub struct SyncModuleCache<R: ModuleResolver> {
-    cache: RwLock<BTreeMap<ModuleId, Arc<CompiledModule>>>,
-    resolver: R,
-}
-
-#[allow(clippy::len_without_is_empty)]
-impl<R: ModuleResolver> SyncModuleCache<R> {
-    pub fn new(resolver: R) -> Self {
-        SyncModuleCache {
-            cache: RwLock::new(BTreeMap::new()),
-            resolver,
-        }
-    }
-
-    pub fn add(&self, id: ModuleId, m: CompiledModule) {
-        self.cache.write().unwrap().insert(id, Arc::new(m));
-    }
-
-    pub fn len(&self) -> usize {
-        self.cache.read().unwrap().len()
-    }
-}
-
-impl<R: ModuleResolver> GetModule for SyncModuleCache<R> {
-    type Error = anyhow::Error;
-    type Item = Arc<CompiledModule>;
-
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Arc<CompiledModule>>, Self::Error> {
-        if let Some(compiled_module) = self.cache.read().unwrap().get(id) {
-            return Ok(Some(compiled_module.clone()));
-        }
-
-        if let Some(module_bytes) = self
-            .resolver
-            .get_module(id)
-            .map_err(|_| anyhow!("Failed to get module {:?}", id))?
-        {
-            let module = Arc::new(
-                CompiledModule::deserialize(&module_bytes)
-                    .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?,
-            );
-
-            self.cache
-                .write()
-                .unwrap()
-                .insert(id.clone(), module.clone());
-            Ok(Some(module))
-        } else {
-            Ok(None)
-        }
-    }
 }


### PR DESCRIPTION
### Description

Removed dead code from bytecode utils. Cherry pick from #11177. Needed to minimize usages of `GetModule` trait and fix error propagation in resolvers.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
