### PR TITLE
use new api to get block event

### DIFF
--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -324,15 +324,8 @@ impl DAGStorage for StorageAdapter {
     }
 
     fn get_latest_k_committed_events(&self, k: u64) -> anyhow::Result<Vec<CommitEvent>> {
-        let latest_db_version = self.aptos_db.get_latest_version().unwrap_or(0);
         let mut commit_events = vec![];
-        for event in self.aptos_db.get_events(
-            &new_block_event_key(),
-            u64::MAX,
-            Order::Descending,
-            k,
-            latest_db_version,
-        )? {
+        for event in self.aptos_db.get_latest_block_events(k as usize)? {
             let new_block_event = bcs::from_bytes::<NewBlockEvent>(event.event.event_data())?;
             if self
                 .epoch_to_validators

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -24,9 +24,9 @@ use aptos_crypto::HashValue;
 use aptos_executor_types::StateComputeResult;
 use aptos_infallible::RwLock;
 use aptos_logger::error;
-use aptos_storage_interface::{DbReader, Order};
+use aptos_storage_interface::DbReader;
 use aptos_types::{
-    account_config::{new_block_event_key, NewBlockEvent},
+    account_config::NewBlockEvent,
     aggregate_signature::AggregateSignature,
     block_info::BlockInfo,
     epoch_change::EpochChangeProof,

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -42,7 +42,7 @@ impl OrderRule {
         dag_window_size_config: Round,
     ) -> Self {
         let commit_events = storage
-            .get_latest_k_committed_events(dag_window_size_config)
+            .get_latest_k_committed_events(10 * epoch_state.verifier.len() as u64)
             .expect("Failed to read commit events from storage");
         // make sure it's sorted
         assert!(commit_events


### PR DESCRIPTION
### Description

Uses the new storage API to get block events and fixes the commit event evaluation length.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
