### PR TITLE
[State Sync] Move commit post-processor to dedicated task

### DIFF
--- a/api/openapi-spec-generator/src/fake_context.rs
+++ b/api/openapi-spec-generator/src/fake_context.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 // This is necessary for building the API with how the code is structured currently.
 pub fn get_fake_context() -> Context {
-    let mempool = MockSharedMempool::new();
+    let mempool = MockSharedMempool::new_with_runtime();
     Context::new(
         ChainId::test(),
         Arc::new(MockDbReaderWriter),

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -638,7 +638,7 @@ impl TestContext {
 
         self.mempool
             .mempool_notifier
-            .notify_new_commit(txns, timestamp, 1000)
+            .notify_new_commit(txns, timestamp)
             .await
             .unwrap();
     }

--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -131,8 +131,9 @@ pub fn start_state_sync_and_get_notification_handles(
         setup_aptos_data_client(node_config, network_client, db_rw.reader.clone())?;
 
     // Start the data streaming service
+    let state_sync_config = node_config.state_sync;
     let (streaming_service_client, streaming_service_runtime) =
-        setup_data_streaming_service(node_config.state_sync, aptos_data_client.clone())?;
+        setup_data_streaming_service(state_sync_config, aptos_data_client.clone())?;
 
     // Create the chunk executor and persistent storage
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
@@ -140,11 +141,14 @@ pub fn start_state_sync_and_get_notification_handles(
 
     // Create notification senders and listeners for mempool, consensus and the storage service
     let (mempool_notifier, mempool_listener) =
-        aptos_mempool_notifications::new_mempool_notifier_listener_pair();
+        aptos_mempool_notifications::new_mempool_notifier_listener_pair(
+            state_sync_config
+                .state_sync_driver
+                .max_pending_mempool_notifications,
+        );
     let (consensus_notifier, consensus_listener) =
         aptos_consensus_notifications::new_consensus_notifier_listener_pair(
-            node_config
-                .state_sync
+            state_sync_config
                 .state_sync_driver
                 .commit_notification_timeout_ms,
         );
@@ -153,7 +157,7 @@ pub fn start_state_sync_and_get_notification_handles(
 
     // Start the state sync storage service
     let storage_service_runtime = setup_state_sync_storage_service(
-        node_config.state_sync,
+        state_sync_config,
         peers_and_metadata,
         network_service_events,
         &db_rw,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -114,10 +114,10 @@ pub struct StateSyncDriverConfig {
     pub max_num_stream_timeouts: u64,
     /// The maximum number of data chunks pending execution or commit
     pub max_pending_data_chunks: u64,
+    /// The maximum number of pending mempool commit notifications
+    pub max_pending_mempool_notifications: u64,
     /// The maximum time (ms) to wait for a data stream notification
     pub max_stream_wait_time_ms: u64,
-    /// The maximum time (ms) allowed for mempool to ack a commit notification
-    pub mempool_commit_ack_timeout_ms: u64,
     /// The version lag we'll tolerate before snapshot syncing
     pub num_versions_to_skip_snapshot_sync: u64,
 }
@@ -137,8 +137,8 @@ impl Default for StateSyncDriverConfig {
             max_consecutive_stream_notifications: 10,
             max_num_stream_timeouts: 12,
             max_pending_data_chunks: 100,
+            max_pending_mempool_notifications: 100,
             max_stream_wait_time_ms: 5000,
-            mempool_commit_ack_timeout_ms: 5000, // 5 seconds
             num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.
         }
     }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -785,7 +785,7 @@ impl Client {
     }
 
     pub async fn wait_for_version(&self, version: u64) -> Result<State> {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
         const DEFAULT_DELAY: Duration = Duration::from_millis(500);
 
         let start = std::time::Instant::now();

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -20,7 +20,7 @@ use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_consensus_types::common::TransactionSummary;
 use aptos_event_notifications::ReconfigNotificationListener;
-use aptos_infallible::Mutex;
+use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::{MempoolCommitNotification, MempoolNotificationListener};
 use aptos_network::{
@@ -51,7 +51,7 @@ pub(crate) async fn coordinator<NetworkClient, TransactionValidator, ConfigProvi
     network_service_events: NetworkServiceEvents<MempoolSyncMsg>,
     mut client_events: MempoolEventsReceiver,
     mut quorum_store_requests: mpsc::Receiver<QuorumStoreRequest>,
-    mut mempool_listener: MempoolNotificationListener,
+    mempool_listener: MempoolNotificationListener,
     mut mempool_reconfig_events: ReconfigNotificationListener<ConfigProvider>,
     peer_update_interval_ms: u64,
     peers_and_metadata: Arc<PeersAndMetadata>,
@@ -75,6 +75,9 @@ pub(crate) async fn coordinator<NetworkClient, TransactionValidator, ConfigProvi
     let mut scheduled_broadcasts = FuturesUnordered::new();
     let mut update_peers_interval =
         tokio::time::interval(Duration::from_millis(peer_update_interval_ms));
+
+    // Spawn a dedicated task to handle commit notifications from state sync
+    spawn_commit_notification_handler(&smp, mempool_listener);
 
     // Use a BoundedExecutor to restrict only `workers_available` concurrent
     // worker tasks that can process incoming transactions.
@@ -101,9 +104,6 @@ pub(crate) async fn coordinator<NetworkClient, TransactionValidator, ConfigProvi
             msg = quorum_store_requests.select_next_some() => {
                 tasks::process_quorum_store_request(&smp, msg);
             },
-            msg = mempool_listener.select_next_some() => {
-                handle_commit_notification(&mut smp, msg, &mut mempool_listener);
-            },
             reconfig_notification = mempool_reconfig_events.select_next_some() => {
                 handle_mempool_reconfig_event(&mut smp, &bounded_executor, reconfig_notification.on_chain_configs).await;
             },
@@ -123,6 +123,24 @@ pub(crate) async fn coordinator<NetworkClient, TransactionValidator, ConfigProvi
         LogEntry::CoordinatorRuntime,
         LogEvent::Terminated
     ));
+}
+
+/// Spawn a task to handle commit notifications from state sync
+fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
+    smp: &SharedMempool<NetworkClient, TransactionValidator>,
+    mut mempool_listener: MempoolNotificationListener,
+) where
+    NetworkClient: NetworkClientInterface<MempoolSyncMsg> + 'static,
+    TransactionValidator: TransactionValidation + 'static,
+{
+    let mempool = smp.mempool.clone();
+    let mempool_validator = smp.validator.clone();
+
+    tokio::spawn(async move {
+        while let Some(commit_notification) = mempool_listener.next().await {
+            handle_commit_notification(&mempool, &mempool_validator, commit_notification);
+        }
+    });
 }
 
 /// Spawn a task for processing `MempoolClientRequest`s from a client such as API service
@@ -182,12 +200,11 @@ async fn handle_client_request<NetworkClient, TransactionValidator>(
 
 /// Handle removing committed transactions from local mempool immediately.  This should be done
 /// immediately to ensure broadcasts of committed transactions stop as soon as possible.
-fn handle_commit_notification<NetworkClient, TransactionValidator>(
-    smp: &mut SharedMempool<NetworkClient, TransactionValidator>,
+fn handle_commit_notification<TransactionValidator>(
+    mempool: &Arc<Mutex<CoreMempool>>,
+    mempool_validator: &Arc<RwLock<TransactionValidator>>,
     msg: MempoolCommitNotification,
-    mempool_listener: &mut MempoolNotificationListener,
 ) where
-    NetworkClient: NetworkClientInterface<MempoolSyncMsg>,
     TransactionValidator: TransactionValidation,
 {
     debug!(
@@ -203,7 +220,7 @@ fn handle_commit_notification<NetworkClient, TransactionValidator>(
         msg.transactions.len(),
     );
     process_committed_transactions(
-        &smp.mempool,
+        mempool,
         msg.transactions
             .iter()
             .map(|txn| TransactionSummary {
@@ -213,18 +230,13 @@ fn handle_commit_notification<NetworkClient, TransactionValidator>(
             .collect(),
         msg.block_timestamp_usecs,
     );
-    smp.validator.write().notify_commit();
-    let counter_result = if mempool_listener.ack_commit_notification(msg).is_err() {
-        error!(LogSchema::event_log(
-            LogEntry::StateSyncCommit,
-            LogEvent::CallbackFail
-        ));
-        counters::REQUEST_FAIL_LABEL
-    } else {
-        counters::REQUEST_SUCCESS_LABEL
-    };
+    mempool_validator.write().notify_commit();
     let latency = start_time.elapsed();
-    counters::mempool_service_latency(counters::COMMIT_STATE_SYNC_LABEL, counter_result, latency);
+    counters::mempool_service_latency(
+        counters::COMMIT_STATE_SYNC_LABEL,
+        counters::REQUEST_SUCCESS_LABEL,
+        latency,
+    );
 }
 
 /// Spawn a task to restart the transaction validator with the new reconfig data.

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -42,11 +42,11 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
 };
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Handle;
 
 /// Mock of a running instance of shared mempool.
 pub struct MockSharedMempool {
-    _runtime: Option<Runtime>,
+    _runtime: Option<Handle>,
     _handle: Option<Handle>,
     pub ac_client: MempoolClientSender,
     pub mempool: Arc<Mutex<CoreMempool>>,
@@ -59,21 +59,30 @@ impl MockSharedMempool {
     /// Returns the runtime on which the shared mempool is running
     /// and the channel through which shared mempool receives client events.
     pub fn new() -> Self {
-        let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
-        let _entered_runtime = runtime.enter();
+        // Create the shared mempool
         let (ac_client, mempool, quorum_store_sender, mempool_notifier) = Self::start(
-            runtime.handle(),
+            &Handle::current(),
             &DbReaderWriter::new(MockDbReaderWriter),
             MockVMValidator,
         );
         Self {
-            _runtime: Some(runtime),
+            _runtime: Some(Handle::current()),
             _handle: None,
             ac_client,
             mempool,
             consensus_to_mempool_sender: quorum_store_sender,
             mempool_notifier,
         }
+    }
+
+    /// Creates a mock shared mempool and runtime
+    pub fn new_with_runtime() -> Self {
+        // Create a runtime
+        let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
+        let _entered_runtime = runtime.enter();
+
+        // Create and return the shared mempool
+        Self::new()
     }
 
     /// Creates a mock of a running instance of shared mempool inside a tokio runtime;
@@ -121,7 +130,7 @@ impl MockSharedMempool {
         let (ac_client, client_events) = mpsc::channel(1_024);
         let (quorum_store_sender, quorum_store_receiver) = mpsc::channel(1_024);
         let (mempool_notifier, mempool_listener) =
-            aptos_mempool_notifications::new_mempool_notifier_listener_pair();
+            aptos_mempool_notifications::new_mempool_notifier_listener_pair(100);
         let (reconfig_sender, reconfig_events) = aptos_channel::new(QueueStyle::LIFO, 1, None);
         let reconfig_event_subscriber = ReconfigNotificationListener {
             notification_receiver: reconfig_events,

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -604,7 +604,7 @@ fn start_node_mempool(
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_quorum_store_sender, quorum_store_receiver) = mpsc::channel(1_024);
     let (_mempool_notifier, mempool_listener) =
-        aptos_mempool_notifications::new_mempool_notifier_listener_pair();
+        aptos_mempool_notifications::new_mempool_notifier_listener_pair(100);
     let (reconfig_sender, reconfig_events) = aptos_channel::new(QueueStyle::LIFO, 1, None);
     let reconfig_event_subscriber = ReconfigNotificationListener {
         notification_receiver: reconfig_events,

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -585,7 +585,7 @@ fn setup_mempool(
     let (ac_endpoint_sender, ac_endpoint_receiver) = mpsc_channel();
     let (quorum_store_sender, quorum_store_receiver) = mpsc_channel();
     let (mempool_notifier, mempool_listener) =
-        aptos_mempool_notifications::new_mempool_notifier_listener_pair();
+        aptos_mempool_notifications::new_mempool_notifier_listener_pair(100);
 
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
     let vm_validator = Arc::new(RwLock::new(MockVMValidator));

--- a/state-sync/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/driver_factory.rs
@@ -124,13 +124,8 @@ impl DriverFactory {
         let consensus_notification_handler = ConsensusNotificationHandler::new(consensus_listener);
         let (error_notification_sender, error_notification_listener) =
             ErrorNotificationListener::new();
-        let mempool_notification_handler = MempoolNotificationHandler::new(
-            mempool_notification_sender,
-            node_config
-                .state_sync
-                .state_sync_driver
-                .mempool_commit_ack_timeout_ms,
-        );
+        let mempool_notification_handler =
+            MempoolNotificationHandler::new(mempool_notification_sender);
         let storage_service_notification_handler =
             StorageServiceNotificationHandler::new(storage_service_notification_sender);
 
@@ -144,7 +139,7 @@ impl DriverFactory {
 
         // Create the storage synchronizer
         let event_subscription_service = Arc::new(Mutex::new(event_subscription_service));
-        let (storage_synchronizer, _, _, _) = StorageSynchronizer::new(
+        let (storage_synchronizer, _) = StorageSynchronizer::new(
             node_config.state_sync.state_sync_driver,
             chunk_executor,
             commit_notification_sender.clone(),

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    histogram_opts, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
-    HistogramTimer, HistogramVec, IntCounterVec, IntGaugeVec,
+    exponential_buckets, histogram_opts, register_histogram_vec, register_int_counter_vec,
+    register_int_gauge_vec, HistogramTimer, HistogramVec, IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -16,6 +16,7 @@ pub const STORAGE_SYNCHRONIZER_APPLY_CHUNK: &str = "apply_chunk";
 pub const STORAGE_SYNCHRONIZER_EXECUTE_CHUNK: &str = "execute_chunk";
 pub const STORAGE_SYNCHRONIZER_UPDATE_LEDGER: &str = "update_ledger";
 pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
+pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS: &str = "commit_post_process";
 
 /// An enum representing the component currently executing
 pub enum ExecutingComponent {
@@ -144,19 +145,13 @@ pub static STORAGE_SYNCHRONIZER_GAUGES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-// Latency buckets for storage synchronizer operations
-const STORAGE_SYNCHRONIZER_LATENCY_BUCKETS_SECS: &[f64] = &[
-    0.05, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 7.5, 10.0, 15.0, 20.0, 30.0, 40.0,
-    60.0, 120.0, 180.0, 240.0, 300.0,
-];
-
 /// Counter for tracking storage synchronizer latencies
 pub static STORAGE_SYNCHRONIZER_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_state_sync_storage_synchronizer_latencies",
         "Counters related to the storage synchronizer latencies",
         &["label"],
-        STORAGE_SYNCHRONIZER_LATENCY_BUCKETS_SECS.to_vec()
+        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
 });

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -151,7 +151,7 @@ pub static STORAGE_SYNCHRONIZER_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
         "aptos_state_sync_storage_synchronizer_latencies",
         "Counters related to the storage synchronizer latencies",
         &["label"],
-        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
+        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
     )
     .unwrap()
 });

--- a/state-sync/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-driver/src/notification_handlers.rs
@@ -396,14 +396,12 @@ impl FusedStream for ErrorNotificationListener {
 /// A simple handler for sending notifications to mempool
 #[derive(Clone)]
 pub struct MempoolNotificationHandler<M> {
-    mempool_commit_ack_timeout_ms: u64,
     mempool_notification_sender: M,
 }
 
 impl<M: MempoolNotificationSender> MempoolNotificationHandler<M> {
-    pub fn new(mempool_notification_sender: M, mempool_commit_ack_timeout_ms: u64) -> Self {
+    pub fn new(mempool_notification_sender: M) -> Self {
         Self {
-            mempool_commit_ack_timeout_ms,
             mempool_notification_sender,
         }
     }
@@ -416,11 +414,7 @@ impl<M: MempoolNotificationSender> MempoolNotificationHandler<M> {
     ) -> Result<(), Error> {
         let result = self
             .mempool_notification_sender
-            .notify_new_commit(
-                committed_transactions,
-                block_timestamp_usecs,
-                self.mempool_commit_ack_timeout_ms,
-            )
+            .notify_new_commit(committed_transactions, block_timestamp_usecs)
             .await;
 
         if let Err(error) = result {

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -34,10 +34,7 @@ use aptos_types::{
     },
 };
 use async_trait::async_trait;
-use futures::{
-    channel::{mpsc, mpsc::UnboundedSender},
-    SinkExt, StreamExt,
-};
+use futures::{channel::mpsc, SinkExt, StreamExt};
 use std::{
     future::Future,
     sync::{
@@ -190,7 +187,7 @@ impl<
         metadata_storage: MetadataStorage,
         storage: DbReaderWriter,
         runtime: Option<&Runtime>,
-    ) -> (Self, JoinHandle<()>, JoinHandle<()>, JoinHandle<()>) {
+    ) -> (Self, StorageSynchronizerHandles) {
         // Create a channel to notify the executor when data chunks are ready
         let max_pending_data_chunks = driver_config.max_pending_data_chunks as usize;
         let (executor_notifier, executor_listener) = mpsc::channel(max_pending_data_chunks);
@@ -201,6 +198,10 @@ impl<
 
         // Create a channel to notify the committer when the ledger has been updated
         let (committer_notifier, committer_listener) = mpsc::channel(max_pending_data_chunks);
+
+        // Create a channel to notify the commit post-processor when a chunk has been committed
+        let (commit_post_processor_notifier, commit_post_processor_listener) =
+            mpsc::channel(max_pending_data_chunks);
 
         // Create a shared pending data chunk counter
         let pending_data_chunks = Arc::new(AtomicU64::new(0));
@@ -229,8 +230,16 @@ impl<
         // Spawn the committer that commits executed (but pending) chunks
         let committer_handle = spawn_committer(
             chunk_executor.clone(),
-            committer_listener,
             error_notification_sender.clone(),
+            committer_listener,
+            commit_post_processor_notifier,
+            pending_data_chunks.clone(),
+            runtime.clone(),
+        );
+
+        // Spawn the commit post-processor that handles commit notifications
+        let commit_post_processor_handle = spawn_commit_post_processor(
+            commit_post_processor_listener,
             event_subscription_service,
             mempool_notification_handler,
             storage_service_notification_handler,
@@ -243,6 +252,7 @@ impl<
         utils::initialize_sync_gauges(storage.reader.clone())
             .expect("Failed to initialize the metric gauges!");
 
+        // Create the storage synchronizer
         let storage_synchronizer = Self {
             chunk_executor,
             commit_notification_sender,
@@ -256,12 +266,15 @@ impl<
             storage,
         };
 
-        (
-            storage_synchronizer,
-            executor_handle,
-            ledger_updater_handle,
-            committer_handle,
-        )
+        // Create the storage synchronizer handles
+        let storage_synchronizer_handles = StorageSynchronizerHandles {
+            executor: executor_handle,
+            ledger_updater: ledger_updater_handle,
+            committer: committer_handle,
+            commit_post_processor: commit_post_processor_handle,
+        };
+
+        (storage_synchronizer, storage_synchronizer_handles)
     }
 
     /// Notifies the executor of new data chunks
@@ -383,6 +396,14 @@ impl<
     fn finish_chunk_executor(&self) {
         self.chunk_executor.finish()
     }
+}
+
+/// A simple container that holds the handles to the spawned storage synchronizer threads
+pub struct StorageSynchronizerHandles {
+    pub executor: JoinHandle<()>,
+    pub ledger_updater: JoinHandle<()>,
+    pub committer: JoinHandle<()>,
+    pub commit_post_processor: JoinHandle<()>,
 }
 
 /// A chunk of data to be executed and/or committed to storage (i.e., states,
@@ -612,20 +633,13 @@ fn spawn_ledger_updater<ChunkExecutor: ChunkExecutorTrait + 'static>(
 }
 
 /// Spawns a dedicated committer that commits executed (but pending) chunks
-fn spawn_committer<
-    ChunkExecutor: ChunkExecutorTrait + 'static,
-    MempoolNotifier: MempoolNotificationSender,
-    StorageServiceNotifier: StorageServiceNotificationSender,
->(
+fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
     chunk_executor: Arc<ChunkExecutor>,
-    mut committer_listener: mpsc::Receiver<NotificationId>,
     error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
-    event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
-    mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
-    storage_service_notification_handler: StorageServiceNotificationHandler<StorageServiceNotifier>,
+    mut committer_listener: mpsc::Receiver<NotificationId>,
+    mut commit_post_processor_notifier: mpsc::Sender<ChunkCommitNotification>,
     pending_data_chunks: Arc<AtomicU64>,
     runtime: Option<Handle>,
-    storage: Arc<dyn DbReader>,
 ) -> JoinHandle<()> {
     // Create a committer
     let committer = async move {
@@ -656,21 +670,20 @@ fn spawn_committer<
                         utils::update_new_epoch_metrics();
                     }
 
-                    // Handle the committed transaction notification (e.g., notify mempool).
-                    // We do this here due to synchronization issues with mempool and
-                    // storage. See: https://github.com/aptos-labs/aptos-core/issues/553
-                    let committed_transactions = CommittedTransactions {
-                        events: notification.subscribable_events,
-                        transactions: notification.committed_transactions,
-                    };
-                    utils::handle_committed_transactions(
-                        committed_transactions,
-                        storage.clone(),
-                        mempool_notification_handler.clone(),
-                        event_subscription_service.clone(),
-                        storage_service_notification_handler.clone(),
-                    )
-                    .await;
+                    // Notify the commit post-processor of the committed chunk
+                    if let Err(error) = commit_post_processor_notifier.send(notification).await {
+                        let error = format!(
+                            "Failed to notify the commit post-processor! Error: {:?}",
+                            error
+                        );
+                        send_storage_synchronizer_error(
+                            error_notification_sender.clone(),
+                            notification_id,
+                            error,
+                        )
+                        .await;
+                        decrement_pending_data_chunks(pending_data_chunks.clone());
+                    }
                 },
                 Err(error) => {
                     let error = format!("Failed to commit executed chunk! Error: {:?}", error);
@@ -680,14 +693,56 @@ fn spawn_committer<
                         error,
                     )
                     .await;
+                    decrement_pending_data_chunks(pending_data_chunks.clone());
                 },
             };
-            decrement_pending_data_chunks(pending_data_chunks.clone());
         }
     };
 
     // Spawn the committer
     spawn(runtime, committer)
+}
+
+/// Spawns a dedicated commit post-processor that handles commit notifications
+fn spawn_commit_post_processor<
+    MempoolNotifier: MempoolNotificationSender,
+    StorageServiceNotifier: StorageServiceNotificationSender,
+>(
+    mut commit_post_processor_listener: mpsc::Receiver<ChunkCommitNotification>,
+    event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+    mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
+    storage_service_notification_handler: StorageServiceNotificationHandler<StorageServiceNotifier>,
+    pending_data_chunks: Arc<AtomicU64>,
+    runtime: Option<Handle>,
+    storage: Arc<dyn DbReader>,
+) -> JoinHandle<()> {
+    // Create a commit post-processor
+    let commit_post_processor = async move {
+        while let Some(notification) = commit_post_processor_listener.next().await {
+            let _timer = metrics::start_timer(
+                &metrics::STORAGE_SYNCHRONIZER_LATENCIES,
+                metrics::STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS,
+            );
+
+            // Handle the committed transaction notification (e.g., notify mempool)
+            let committed_transactions = CommittedTransactions {
+                events: notification.subscribable_events,
+                transactions: notification.committed_transactions,
+            };
+            utils::handle_committed_transactions(
+                committed_transactions,
+                storage.clone(),
+                mempool_notification_handler.clone(),
+                event_subscription_service.clone(),
+                storage_service_notification_handler.clone(),
+            )
+            .await;
+            decrement_pending_data_chunks(pending_data_chunks.clone());
+        }
+    };
+
+    // Spawn the commit post-processor
+    spawn(runtime, commit_post_processor)
 }
 
 /// Spawns a dedicated receiver that commits state values from a state snapshot
@@ -910,7 +965,7 @@ async fn finalize_storage_and_send_commit<
     MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
 >(
     chunk_executor: Arc<ChunkExecutor>,
-    commit_notification_sender: &mut UnboundedSender<CommitNotification>,
+    commit_notification_sender: &mut mpsc::UnboundedSender<CommitNotification>,
     metadata_storage: MetadataStorage,
     state_snapshot_receiver: Box<
         dyn StateSnapshotReceiver<StateKey, StateValue> + 'receiver_lifetime,

--- a/state-sync/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-driver/src/tests/driver.rs
@@ -358,7 +358,7 @@ async fn create_driver_for_tests(
     let (consensus_notifier, consensus_listener) =
         aptos_consensus_notifications::new_consensus_notifier_listener_pair(5000);
     let (mempool_notifier, mempool_listener) =
-        aptos_mempool_notifications::new_mempool_notifier_listener_pair();
+        aptos_mempool_notifications::new_mempool_notifier_listener_pair(100);
 
     // Create the storage service notifier and listener
     let (storage_service_notifier, storage_service_listener) =

--- a/state-sync/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/tests/driver_factory.rs
@@ -50,7 +50,7 @@ fn test_new_initialized_configs() {
     bootstrap_genesis::<AptosVM>(&db_rw, get_genesis_txn(&node_config).unwrap()).unwrap();
 
     // Create mempool and consensus notifiers
-    let (mempool_notifier, _) = new_mempool_notifier_listener_pair();
+    let (mempool_notifier, _) = new_mempool_notifier_listener_pair(100);
     let (_, consensus_listener) = new_consensus_notifier_listener_pair(0);
 
     // Create the event subscription service and a reconfig subscriber

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -8,7 +8,9 @@ use crate::{
         CommitNotification, CommitNotificationListener, CommittedTransactions,
         ErrorNotificationListener, MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
-    storage_synchronizer::{StorageSynchronizer, StorageSynchronizerInterface},
+    storage_synchronizer::{
+        StorageSynchronizer, StorageSynchronizerHandles, StorageSynchronizerInterface,
+    },
     tests::{
         mocks::{
             create_mock_db_writer, create_mock_executor, create_mock_reader_writer,
@@ -38,13 +40,13 @@ use claims::assert_matches;
 use futures::StreamExt;
 use mockall::predicate::always;
 use std::{sync::Arc, time::Duration};
-use tokio::{task::JoinHandle, time::timeout};
+use tokio::time::timeout;
 
 // Useful test constants
 const TEST_TIMEOUT_SECS: u64 = 30;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_apply_transaction_outputs() {
+async fn test_apply_outputs() {
     // Create test data
     let transaction_to_commit = create_transaction();
     let event_to_commit = create_event(None);
@@ -78,8 +80,6 @@ async fn test_apply_transaction_outputs() {
         mut mempool_listener,
         mut storage_service_listener,
         mut storage_synchronizer,
-        _,
-        _,
         _,
     ) = create_storage_synchronizer(chunk_executor, mock_reader_writer);
 
@@ -116,7 +116,7 @@ async fn test_apply_transaction_outputs() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_apply_transaction_outputs_error() {
+async fn test_apply_outputs_error() {
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
     chunk_executor
@@ -125,7 +125,7 @@ async fn test_apply_transaction_outputs_error() {
         .returning(|_, _, _| Err(format_err!("Failed to apply chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to apply a chunk of outputs
@@ -146,7 +146,7 @@ async fn test_apply_transaction_outputs_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_apply_transaction_outputs_send_error() {
+async fn test_apply_outputs_send_error() {
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
     chunk_executor
@@ -155,10 +155,11 @@ async fn test_apply_transaction_outputs_send_error() {
         .returning(|_, _, _| Ok(()));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, ledger_updater, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Explicitly drop the ledger updater to cause a send error for the executor
+    let ledger_updater = storage_synchronizer_handles.ledger_updater;
     ledger_updater.abort();
 
     // Attempt to apply a chunk of outputs
@@ -179,7 +180,7 @@ async fn test_apply_transaction_outputs_send_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_apply_transaction_outputs_update_error() {
+async fn test_apply_outputs_update_error() {
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
     chunk_executor
@@ -191,7 +192,7 @@ async fn test_apply_transaction_outputs_update_error() {
         .returning(|| Err(format_err!("Failed to update the ledger!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to apply a chunk of outputs
@@ -212,75 +213,7 @@ async fn test_apply_transaction_outputs_update_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_commit_chunk_error_execution() {
-    // Setup the mock executor
-    let mut chunk_executor = create_mock_executor();
-    chunk_executor
-        .expect_enqueue_chunk_by_execution()
-        .with(always(), always(), always())
-        .returning(|_, _, _| Ok(()));
-    chunk_executor.expect_update_ledger().returning(|| Ok(()));
-    chunk_executor
-        .expect_commit_chunk()
-        .return_once(|| Err(format_err!("Failed to commit chunk!")));
-
-    // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
-        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
-
-    // Attempt to execute a chunk of transactions
-    let notification_id = 100;
-    storage_synchronizer
-        .execute_transactions(
-            notification_id,
-            create_transaction_list_with_proof(),
-            create_epoch_ending_ledger_info(),
-            None,
-        )
-        .await
-        .unwrap();
-
-    // Verify we get an error notification and that there's no pending data
-    verify_error_notification(&mut error_listener, notification_id).await;
-    verify_no_pending_data(&storage_synchronizer);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_commit_chunk_error_output_application() {
-    // Setup the mock executor
-    let mut chunk_executor = create_mock_executor();
-    chunk_executor
-        .expect_enqueue_chunk_by_transaction_outputs()
-        .with(always(), always(), always())
-        .returning(|_, _, _| Ok(()));
-    chunk_executor.expect_update_ledger().returning(|| Ok(()));
-    chunk_executor
-        .expect_commit_chunk()
-        .return_once(|| Err(format_err!("Failed to commit chunk!")));
-
-    // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
-        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
-
-    // Attempt to apply a chunk of outputs
-    let notification_id = 101;
-    storage_synchronizer
-        .apply_transaction_outputs(
-            notification_id,
-            create_output_list_with_proof(),
-            create_epoch_ending_ledger_info(),
-            None,
-        )
-        .await
-        .unwrap();
-
-    // Verify we get an error notification and that there's no pending data
-    verify_error_notification(&mut error_listener, notification_id).await;
-    verify_no_pending_data(&storage_synchronizer);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_commit_chunk_apply_send_error() {
+async fn test_apply_outputs_update_send_error() {
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
     chunk_executor
@@ -290,10 +223,11 @@ async fn test_commit_chunk_apply_send_error() {
     chunk_executor.expect_update_ledger().returning(|| Ok(()));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, committer) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Explicitly drop the committer to cause a send error for the ledger updater
+    let committer = storage_synchronizer_handles.committer;
     committer.abort();
 
     // Attempt to apply a chunk of outputs
@@ -314,28 +248,80 @@ async fn test_commit_chunk_apply_send_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_commit_chunk_execute_send_error() {
+async fn test_apply_outputs_commit_error() {
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
     chunk_executor
-        .expect_enqueue_chunk_by_execution()
+        .expect_enqueue_chunk_by_transaction_outputs()
         .with(always(), always(), always())
         .returning(|_, _, _| Ok(()));
     chunk_executor.expect_update_ledger().returning(|| Ok(()));
+    chunk_executor
+        .expect_commit_chunk()
+        .return_once(|| Err(format_err!("Failed to commit chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, committer) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
-    // Explicitly drop the committer to cause a send error for the ledger updater
-    committer.abort();
-
-    // Attempt to execute a chunk of transactions
-    let notification_id = 100;
+    // Attempt to apply a chunk of outputs
+    let notification_id = 101;
     storage_synchronizer
-        .execute_transactions(
+        .apply_transaction_outputs(
             notification_id,
-            create_transaction_list_with_proof(),
+            create_output_list_with_proof(),
+            create_epoch_ending_ledger_info(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Verify we get an error notification and that there's no pending data
+    verify_error_notification(&mut error_listener, notification_id).await;
+    verify_no_pending_data(&storage_synchronizer);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_outputs_commit_send_error() {
+    // Create test data
+    let transaction_to_commit = create_transaction();
+    let event_to_commit = create_event(None);
+
+    // Setup the mock executor
+    let mut chunk_executor = create_mock_executor();
+    chunk_executor
+        .expect_enqueue_chunk_by_transaction_outputs()
+        .with(always(), always(), always())
+        .returning(|_, _, _| Ok(()));
+    chunk_executor.expect_update_ledger().returning(|| Ok(()));
+    let expected_commit_return = Ok(ChunkCommitNotification {
+        subscribable_events: vec![event_to_commit.clone()],
+        committed_transactions: vec![transaction_to_commit.clone()],
+        reconfiguration_occurred: false,
+    });
+    chunk_executor
+        .expect_commit_chunk()
+        .return_once(move || expected_commit_return);
+
+    // Create the mock DB reader/writer
+    let highest_synced_version = 1090;
+    let mock_reader_writer =
+        create_mock_reader_writer_with_version(None, None, highest_synced_version);
+
+    // Create the storage synchronizer
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
+        create_storage_synchronizer(chunk_executor, mock_reader_writer);
+
+    // Explicitly drop the commit post processor to cause a send error for the ledger updater
+    let commit_post_processor = storage_synchronizer_handles.commit_post_processor;
+    commit_post_processor.abort();
+
+    // Attempt to apply a chunk of outputs
+    let notification_id = 555;
+    storage_synchronizer
+        .apply_transaction_outputs(
+            notification_id,
+            create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
         )
@@ -383,8 +369,6 @@ async fn test_execute_transactions() {
         mut storage_service_listener,
         mut storage_synchronizer,
         _,
-        _,
-        _,
     ) = create_storage_synchronizer(chunk_executor, mock_reader_writer);
 
     // Subscribe to the expected event
@@ -429,7 +413,7 @@ async fn test_execute_transactions_error() {
         .returning(|_, _, _| Err(format_err!("Failed to execute chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to execute a chunk of transactions
@@ -459,10 +443,11 @@ async fn test_execute_transactions_send_error() {
         .returning(|_, _, _| Ok(()));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, ledger_updater, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Explicitly drop the ledger updater to cause a send error for the executor
+    let ledger_updater = storage_synchronizer_handles.ledger_updater;
     ledger_updater.abort();
 
     // Attempt to execute a chunk of transactions
@@ -495,11 +480,132 @@ async fn test_execute_transactions_update_error() {
         .returning(|| Err(format_err!("Failed to update the ledger!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to execute a chunk of transactions
     let notification_id = 100;
+    storage_synchronizer
+        .execute_transactions(
+            notification_id,
+            create_transaction_list_with_proof(),
+            create_epoch_ending_ledger_info(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Verify we get an error notification and that there's no pending data
+    verify_error_notification(&mut error_listener, notification_id).await;
+    verify_no_pending_data(&storage_synchronizer);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_transactions_update_send_error() {
+    // Setup the mock executor
+    let mut chunk_executor = create_mock_executor();
+    chunk_executor
+        .expect_enqueue_chunk_by_execution()
+        .with(always(), always(), always())
+        .returning(|_, _, _| Ok(()));
+    chunk_executor.expect_update_ledger().returning(|| Ok(()));
+
+    // Create the storage synchronizer
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
+        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
+
+    // Explicitly drop the committer to cause a send error for the ledger updater
+    let committer = storage_synchronizer_handles.committer;
+    committer.abort();
+
+    // Attempt to execute a chunk of transactions
+    let notification_id = 100;
+    storage_synchronizer
+        .execute_transactions(
+            notification_id,
+            create_transaction_list_with_proof(),
+            create_epoch_ending_ledger_info(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Verify we get an error notification and that there's no pending data
+    verify_error_notification(&mut error_listener, notification_id).await;
+    verify_no_pending_data(&storage_synchronizer);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_transactions_commit_error() {
+    // Setup the mock executor
+    let mut chunk_executor = create_mock_executor();
+    chunk_executor
+        .expect_enqueue_chunk_by_execution()
+        .with(always(), always(), always())
+        .returning(|_, _, _| Ok(()));
+    chunk_executor.expect_update_ledger().returning(|| Ok(()));
+    chunk_executor
+        .expect_commit_chunk()
+        .return_once(|| Err(format_err!("Failed to commit chunk!")));
+
+    // Create the storage synchronizer
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) =
+        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
+
+    // Attempt to execute a chunk of transactions
+    let notification_id = 100;
+    storage_synchronizer
+        .execute_transactions(
+            notification_id,
+            create_transaction_list_with_proof(),
+            create_epoch_ending_ledger_info(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Verify we get an error notification and that there's no pending data
+    verify_error_notification(&mut error_listener, notification_id).await;
+    verify_no_pending_data(&storage_synchronizer);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_execute_transactions_commit_send_error() {
+    // Create test data
+    let transaction_to_commit = create_transaction();
+    let event_to_commit = create_event(None);
+
+    // Setup the mock executor
+    let mut chunk_executor = create_mock_executor();
+    chunk_executor
+        .expect_enqueue_chunk_by_execution()
+        .with(always(), always(), always())
+        .returning(|_, _, _| Ok(()));
+    let expected_commit_return = Ok(ChunkCommitNotification {
+        subscribable_events: vec![event_to_commit.clone()],
+        committed_transactions: vec![transaction_to_commit.clone()],
+        reconfiguration_occurred: false,
+    });
+    chunk_executor.expect_update_ledger().returning(|| Ok(()));
+    chunk_executor
+        .expect_commit_chunk()
+        .return_once(move || expected_commit_return);
+
+    // Create the mock DB reader/writer
+    let highest_synced_version = 10101;
+    let mock_reader_writer =
+        create_mock_reader_writer_with_version(None, None, highest_synced_version);
+
+    // Create the storage synchronizer
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, storage_synchronizer_handles) =
+        create_storage_synchronizer(chunk_executor, mock_reader_writer);
+
+    // Explicitly drop the commit post processor to cause a send error for the ledger updater
+    let commit_post_processor = storage_synchronizer_handles.commit_post_processor;
+    commit_post_processor.abort();
+
+    // Attempt to execute a chunk of transactions
+    let notification_id = 700;
     storage_synchronizer
         .execute_transactions(
             notification_id,
@@ -523,7 +629,7 @@ async fn test_initialize_state_synchronizer_missing_info() {
     output_list_with_proof.proof.transaction_infos = vec![]; // This is invalid!
 
     // Create the storage synchronizer
-    let (_, _, _, _, _, mut storage_synchronizer, _, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, None),
     );
@@ -555,7 +661,7 @@ async fn test_initialize_state_synchronizer_receiver_error() {
         });
 
     // Create the storage synchronizer
-    let (_, _, _, _, _, mut storage_synchronizer, _, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, Some(db_writer)),
     );
@@ -619,7 +725,7 @@ async fn test_save_states_completion() {
         .returning(|_, _, _| Ok(()));
 
     // Create the storage synchronizer
-    let (mut commit_listener, _, _, _, _, mut storage_synchronizer, _, _, _) =
+    let (mut commit_listener, _, _, _, _, mut storage_synchronizer, _) =
         create_storage_synchronizer(
             chunk_executor,
             create_mock_reader_writer(None, Some(db_writer)),
@@ -683,7 +789,7 @@ async fn test_save_states_dropped_error_listener() {
         .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
 
     // Create the storage synchronizer (drop all listeners)
-    let (_, _, _, _, _, mut storage_synchronizer, _, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, Some(db_writer)),
     );
@@ -724,11 +830,10 @@ async fn test_save_states_invalid_chunk() {
         .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _, _) =
-        create_storage_synchronizer(
-            create_mock_executor(),
-            create_mock_reader_writer(None, Some(db_writer)),
-        );
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
+        create_mock_executor(),
+        create_mock_reader_writer(None, Some(db_writer)),
+    );
 
     // Initialize the state synchronizer
     let _join_handle = storage_synchronizer
@@ -751,7 +856,7 @@ async fn test_save_states_invalid_chunk() {
 #[should_panic]
 fn test_save_states_without_initialize() {
     // Create the storage synchronizer
-    let (_, _, _, _, _, mut storage_synchronizer, _, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, None),
     );
@@ -772,9 +877,7 @@ fn create_storage_synchronizer(
     MempoolNotificationListener,
     StorageServiceNotificationListener,
     StorageSynchronizer<MockChunkExecutor, PersistentMetadataStorage>,
-    JoinHandle<()>,
-    JoinHandle<()>,
-    JoinHandle<()>,
+    StorageSynchronizerHandles,
 ) {
     aptos_logger::Logger::init_for_testing();
 
@@ -790,11 +893,8 @@ fn create_storage_synchronizer(
 
     // Create the mempool notification handler
     let (mempool_notification_sender, mempool_notification_listener) =
-        aptos_mempool_notifications::new_mempool_notifier_listener_pair();
-    let mempool_notification_handler = MempoolNotificationHandler::new(
-        mempool_notification_sender,
-        StateSyncDriverConfig::default().mempool_commit_ack_timeout_ms,
-    );
+        aptos_mempool_notifications::new_mempool_notifier_listener_pair(100);
+    let mempool_notification_handler = MempoolNotificationHandler::new(mempool_notification_sender);
 
     // Create the storage service handler
     let (storage_service_notifier, storage_service_listener) =
@@ -807,19 +907,18 @@ fn create_storage_synchronizer(
     let metadata_storage = PersistentMetadataStorage::new(db_path.path());
 
     // Create the storage synchronizer
-    let (storage_synchronizer, executor_handle, ledger_updater_handle, committer_handle) =
-        StorageSynchronizer::new(
-            StateSyncDriverConfig::default(),
-            Arc::new(mock_chunk_executor),
-            commit_notification_sender,
-            error_notification_sender,
-            event_subscription_service.clone(),
-            mempool_notification_handler,
-            storage_service_notification_handler,
-            metadata_storage,
-            mock_reader_writer,
-            None,
-        );
+    let (storage_synchronizer, storage_synchronizer_handles) = StorageSynchronizer::new(
+        StateSyncDriverConfig::default(),
+        Arc::new(mock_chunk_executor),
+        commit_notification_sender,
+        error_notification_sender,
+        event_subscription_service.clone(),
+        mempool_notification_handler,
+        storage_service_notification_handler,
+        metadata_storage,
+        mock_reader_writer,
+        None,
+    );
 
     (
         commit_notification_listener,
@@ -828,9 +927,7 @@ fn create_storage_synchronizer(
         mempool_notification_listener,
         storage_service_listener,
         storage_synchronizer,
-        executor_handle,
-        ledger_updater_handle,
-        committer_handle,
+        storage_synchronizer_handles,
     )
 }
 

--- a/state-sync/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-driver/src/tests/utils.rs
@@ -269,7 +269,7 @@ pub async fn verify_commit_notification(
     expected_events: Vec<ContractEvent>,
     expected_highest_synced_version: u64,
 ) {
-    // Verify mempool is notified and ack the notification
+    // Verify mempool is notified
     let mempool_notification = mempool_notification_listener.select_next_some().await;
     let committed_transactions: Vec<CommittedTransaction> = expected_transactions
         .into_iter()
@@ -279,7 +279,6 @@ pub async fn verify_commit_notification(
         })
         .collect();
     assert_eq!(mempool_notification.transactions, committed_transactions);
-    let _ = mempool_notification_listener.ack_commit_notification(mempool_notification);
 
     // Verify the event listener is notified about the specified events
     if let Some(event_listener) = event_listener {


### PR DESCRIPTION
### Description

This PR makes several modifications to the way in which state sync handles post-processing of committed transactions, (e.g., notifying mempool, the storage service and the event subscription service). Specifically:
1. Instead of handling post-processing in the same task as the commit operation, we add a dedicated task to do it. The benefit of this is that is reduces the commit time in the state sync pipeline. Adding the new task updates the pipeline from `execute/apply -> update -> commit` to `execute/apply -> update -> commit -> commit post-process`.  The e2e performance tests show a ~10% reduction in commit time.
2. When notifying mempool of the committed transactions, we no longer wait for an `ack`. The ack is redundant (i.e., if we fail to receive an ack, we log an error and do nothing). This allows us to now have multiple mempool notifications in-flight at the same time, avoiding unnecessary blocking.
3.  We modify mempool to spawn a dedicated task to handle the incoming notifications from state sync. This avoids unnecessary contention with the main mempool loop.

This PR offers several commits:
1. Update state sync to move commit post-processing to a dedicated task.
2. Update the state sync and mempool unit tests to handle the new logic.

### Test Plan
New and existing test infrastructure.