### PR TITLE
[State Sync] Update the optimistic fetch handler to handle check-to-use race.

### DIFF
--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -26,7 +26,7 @@ use aptos_storage_service_types::{
     responses::{StorageServerSummary, StorageServiceResponse},
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
-use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::future::join_all;
@@ -62,9 +62,17 @@ impl OptimisticFetchRequest {
         config: StorageServiceConfig,
         target_ledger_info: &LedgerInfoWithSignatures,
     ) -> aptos_storage_service_types::Result<StorageServiceRequest, Error> {
-        // Calculate the number of versions to fetch
+        // Verify that the target version is higher than the highest known version
         let known_version = self.highest_known_version();
         let target_version = target_ledger_info.ledger_info().version();
+        if target_version <= known_version {
+            return Err(Error::InvalidRequest(format!(
+                "Target version: {:?} is not higher than known version: {:?}!",
+                target_version, known_version
+            )));
+        }
+
+        // Calculate the number of versions to fetch
         let mut num_versions_to_fetch =
             target_version.checked_sub(known_version).ok_or_else(|| {
                 Error::UnexpectedErrorEncountered(
@@ -222,7 +230,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 
 /// Handles the ready optimistic fetches by removing them from the
 /// active map and notifying the peer of the new data.
-async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
+pub(crate) async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
     bounded_executor: BoundedExecutor,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
@@ -235,8 +243,14 @@ async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
     peers_with_ready_optimistic_fetches: Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
 ) {
     for (peer_network_id, target_ledger_info) in peers_with_ready_optimistic_fetches {
-        // Remove the optimistic fetch from the active map
-        let ready_optimistic_fetch = optimistic_fetches.clone().remove(&peer_network_id);
+        // Remove the optimistic fetch from the active map. Note: we only do this if
+        // the known version is lower than the target version. This is because
+        // the peer may have updated their highest known version since we last checked.
+        let ready_optimistic_fetch =
+            optimistic_fetches.remove_if(&peer_network_id, |_, optimistic_fetch| {
+                optimistic_fetch.highest_known_version()
+                    < target_ledger_info.ledger_info().version()
+            });
 
         // Handle the optimistic fetch request
         if let Some((_, optimistic_fetch)) = ready_optimistic_fetch {
@@ -316,8 +330,6 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
         Some(ledger_info) => ledger_info.clone(),
         None => return Ok(vec![]),
     };
-    let highest_synced_version = highest_synced_ledger_info.ledger_info().version();
-    let highest_synced_epoch = highest_synced_ledger_info.ledger_info().epoch();
 
     // Identify the peers with expired, invalid and ready optimistic fetches
     let (
@@ -335,8 +347,6 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
         storage,
         time_service,
         highest_synced_ledger_info,
-        highest_synced_version,
-        highest_synced_epoch,
     )
     .await;
 
@@ -366,8 +376,6 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
     storage: T,
     time_service: TimeService,
     highest_synced_ledger_info: LedgerInfoWithSignatures,
-    highest_synced_version: Version,
-    highest_synced_epoch: u64,
 ) -> (
     Vec<PeerNetworkId>,
     Vec<PeerNetworkId>,
@@ -409,8 +417,6 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
             storage,
             time_service,
             highest_synced_ledger_info,
-            highest_synced_version,
-            highest_synced_epoch,
             peers_and_highest_synced_data,
         )
         .await;
@@ -435,8 +441,6 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
     storage: T,
     time_service: TimeService,
     highest_synced_ledger_info: LedgerInfoWithSignatures,
-    highest_synced_version: Version,
-    highest_synced_epoch: u64,
     peers_and_highest_synced_data: HashMap<PeerNetworkId, (u64, u64)>,
 ) -> (
     Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
@@ -445,6 +449,10 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
     // Create the peer lists for ready and invalid optimistic fetches
     let peers_with_ready_optimistic_fetches = Arc::new(Mutex::new(vec![]));
     let peers_with_invalid_optimistic_fetches = Arc::new(Mutex::new(vec![]));
+
+    // Identify the highest synced version and epoch
+    let highest_synced_version = highest_synced_ledger_info.ledger_info().version();
+    let highest_synced_epoch = highest_synced_ledger_info.ledger_info().epoch();
 
     // Go through all peers and highest synced data and identify the relevant entries
     let mut active_tasks = vec![];


### PR DESCRIPTION
### Description
This PR updates the optimistic fetch handler to better tolerate optimistic fetch requests that have been updated between: (i) when we first check to see if the request can be handled (i.e., we have the data to service the request); and (ii) when the request is finally handled (i.e., we fetch the data to send to the peer). It's possible that between these two times, a peer updates the optimistic fetch request with a higher known version. In this case, we want to avoid sending the old data to the peer and handle the new optimistic fetch request only when new data is ready.

Note: this race is rare and it does not cause any issues (except logging an error). But, this PR fixes the issue by ensuring that we only handle the request if it hasn't been updated since we last checked.

### Test Plan
New and existing test infrastructure.