### PR TITLE
Fix for loop upper bound bug

### DIFF
--- a/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_loop_upper_bound.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_loop_upper_bound.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+
+task 1 'run'. lines 16-16:
+return values: 1

--- a/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_loop_upper_bound.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_loop_upper_bound.move
@@ -1,0 +1,16 @@
+//# publish
+module 0x42::m {
+
+    fun foo(x: &mut u64): u64 {
+        *x = *x + 1;
+        10
+    }
+
+    fun main(): u64 {
+        let x = 0;
+        for (i in 0..foo(&mut x)) {};
+        x
+    }
+}
+
+//# run 0x42::m::main

--- a/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_type_mismatch.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/control_flow/for_type_mismatch.exp
@@ -29,12 +29,4 @@ error[E04003]: built-in operation not supported
 7 │ │         };
   │ ╰─────────^ Invalid argument to '<'
 
-error[E04003]: built-in operation not supported
-  ┌─ TEMPFILE:5:25
-  │
-5 │         for (i in true..false) {
-  │                   ----  ^^^^^ Invalid argument to '<'
-  │                   │      
-  │                   Found: 'bool'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-
 


### PR DESCRIPTION
### Description

In order to ensure that for loops are consistent with Rust semantics, as well as for efficiency, the upper_bound should be evaluated only once.

### Test Plan
Refer to test `control_flow/for_loop_upper_bound.move`