### PR TITLE
fix aptos_vm to build with and without fuzzing, test, and testing

### DIFF
--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -70,6 +70,6 @@ rand_core = { workspace = true }
 
 [features]
 default = []
-fuzzing = ["move-core-types/fuzzing", "move-binary-format/fuzzing", "move-vm-types/fuzzing", "aptos-framework/fuzzing"]
+fuzzing = ["move-core-types/fuzzing", "move-binary-format/fuzzing", "move-vm-types/fuzzing", "aptos-framework/fuzzing", "aptos-types/fuzzing"]
 failpoints = ["fail/failpoints", "move-vm-runtime/failpoints"]
 testing = ["move-unit-test", "aptos-framework/testing"]

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -27,6 +27,10 @@ use aptos_gas_schedule::{AptosGasParameters, VMGasParameters};
 use aptos_logger::{enabled, prelude::*, Level};
 use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_metrics_core::TimerHelper;
+#[cfg(any(test, feature = "testing"))]
+use aptos_types::state_store::StateViewId;
+#[cfg(any(test, feature = "fuzzing"))]
+use aptos_types::validator_txn::ValidatorTransaction;
 use aptos_types::{
     account_config,
     account_config::new_block_event_key,
@@ -56,13 +60,6 @@ use aptos_types::{
     },
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-
-#[cfg(any(test, feature = "fuzzing"))]
-use aptos_types::validator_txn::ValidatorTransaction;
-
-#[cfg(any(test, feature = "testing"))]
-use aptos_types::state_store::StateViewId;
-
 use aptos_utils::{aptos_try, return_on_failure};
 use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_error, speculative_log};
 use aptos_vm_types::{


### PR DESCRIPTION
### Description

Solve the problem that aptos-vm doesn't always build for some coverage
tests due to certain feature selections breaking the code.

### Test Plan

Manually forced package `aptos-vm` builds with various configurations:
- `cargo build -features "testing" -p aptos-vm`
- `cargo build -features "fuzzing -p aptos-vm"`
- `cargo build -p aptos-vm`
- `cargo test -p aptos-vm`

### Fixes
https://github.com/aptos-labs/aptos-core/issues/11445

