### PR TITLE
fix e2e move test - disable stresstest mode

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.rs
@@ -15,7 +15,7 @@ use aptos_framework::natives::aggregator_natives::aggregator_v2::{
 use aptos_language_e2e_tests::executor::ExecutorMode;
 use proptest::prelude::*;
 
-const STRESSTEST_MODE: bool = true;
+const STRESSTEST_MODE: bool = false;
 
 const EAGGREGATOR_OVERFLOW: u64 = 0x02_0001;
 const EAGGREGATOR_UNDERFLOW: u64 = 0x02_0002;


### PR DESCRIPTION
(which runs exhaustive proptests)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
