### PR TITLE
[Compiler-v2] Generate a compiler error for global memory operation with incorrect type parameter

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -564,6 +564,22 @@ impl<'env> Generator<'env> {
                     self.internal_error(id, "inconsistent type in select expression")
                 }
             },
+            Operation::Exists(None)
+            | Operation::BorrowGlobal(_)
+            | Operation::MoveFrom
+            | Operation::MoveTo
+                if self.env().get_node_instantiation(id)[0]
+                    .get_struct(self.env())
+                    .is_none() =>
+            {
+                self.error(
+                    id,
+                    format!(
+                        "expected `Type::Struct`, found: `{:?}`",
+                        self.env().get_node_instantiation(id)[0]
+                    ),
+                )
+            },
             Operation::Exists(None) => {
                 let inst = self.env().get_node_instantiation(id);
                 let (mid, sid, inst) = inst[0].require_struct();

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -7,8 +7,8 @@ use ethnum::U256;
 use move_model::{
     ast::{Exp, ExpData, Operation, Pattern, TempIndex, Value},
     model::{
-        FieldId, FunId, FunctionEnv, GlobalEnv, NodeId, Parameter, QualifiedId, QualifiedInstId,
-        StructId,
+        FieldId, FunId, FunctionEnv, GlobalEnv, Loc, NodeId, Parameter, QualifiedId,
+        QualifiedInstId, StructId,
     },
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type},
@@ -572,13 +572,17 @@ impl<'env> Generator<'env> {
                     .get_struct(self.env())
                     .is_none() =>
             {
-                self.error(
-                    id,
-                    format!(
-                        "expected `Type::Struct`, found: `{:?}`",
-                        self.env().get_node_instantiation(id)[0]
-                    ),
-                )
+                let err_loc = self.env().get_node_loc(id);
+                let mut reasons: Vec<(Loc, String)> = Vec::new();
+                let reason_msg = format!("Invalid call to {}.", op.display(self.env(), id));
+                reasons.push((err_loc.clone(), reason_msg.clone()));
+                let err_msg  = format!(
+                            "Expected a struct type. Global storage operations are restricted to struct types declared in the current module. \
+                            Found: '{}'",
+                            self.env().get_node_instantiation(id)[0].display(&self.env().get_type_display_ctx())
+                );
+                self.env()
+                    .diag_with_labels(Severity::Error, &err_loc, &err_msg, reasons)
             },
             Operation::Exists(None) => {
                 let inst = self.env().get_node_instantiation(id);

--- a/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.exp
@@ -29,17 +29,19 @@ fun ability::invalid_move_to($t0: &signer) {
 
 [variant baseline]
 fun ability::no_key($t0: address) {
-     var $t1: ability::Impotent
-     var $t2: ability::S<ability::Impotent>
-     var $t3: &mut ability::Impotent
-     var $t4: &ability::Impotent
-     var $t5: bool
-  0: $t1 := move_from<ability::Impotent>($t0)
-  1: $t2 := move_from<ability::S<ability::Impotent>>($t0)
-  2: $t3 := borrow_global<ability::Impotent>($t0)
+     var $t1: address
+     var $t2: ability::Impotent
+     var $t3: ability::S<ability::Impotent>
+     var $t4: &mut ability::Impotent
+     var $t5: &ability::Impotent
+     var $t6: bool
+  0: $t1 := infer($t0)
+  1: $t2 := move_from<ability::Impotent>($t1)
+  2: $t3 := move_from<ability::S<ability::Impotent>>($t0)
   3: $t4 := borrow_global<ability::Impotent>($t0)
-  4: $t5 := exists<ability::Impotent>($t0)
-  5: return ()
+  4: $t5 := borrow_global<ability::Impotent>($t0)
+  5: $t6 := exists<ability::Impotent>($t0)
+  6: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -83,23 +85,26 @@ fun ability::invalid_move_to($t0: &signer) {
 
 [variant baseline]
 fun ability::no_key($t0: address) {
-     var $t1: ability::Impotent
-     var $t2: ability::S<ability::Impotent>
-     var $t3: &mut ability::Impotent
-     var $t4: &ability::Impotent
-     var $t5: bool
+     var $t1: address
+     var $t2: ability::Impotent
+     var $t3: ability::S<ability::Impotent>
+     var $t4: &mut ability::Impotent
+     var $t5: &ability::Impotent
+     var $t6: bool
      # live vars: $t0
-  0: $t1 := move_from<ability::Impotent>($t0)
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t2 := move_from<ability::Impotent>($t1)
      # live vars: $t0
-  1: $t2 := move_from<ability::S<ability::Impotent>>($t0)
-     # live vars: $t0
-  2: $t3 := borrow_global<ability::Impotent>($t0)
+  2: $t3 := move_from<ability::S<ability::Impotent>>($t0)
      # live vars: $t0
   3: $t4 := borrow_global<ability::Impotent>($t0)
      # live vars: $t0
-  4: $t5 := exists<ability::Impotent>($t0)
+  4: $t5 := borrow_global<ability::Impotent>($t0)
+     # live vars: $t0
+  5: $t6 := exists<ability::Impotent>($t0)
      # live vars:
-  5: return ()
+  6: return ()
 }
 
 ============ after MemorySafetyProcessor: ================
@@ -183,47 +188,54 @@ fun ability::invalid_move_to($t0: &signer) {
 
 [variant baseline]
 fun ability::no_key($t0: address) {
-     var $t1: ability::Impotent
-     var $t2: ability::S<ability::Impotent>
-     var $t3: &mut ability::Impotent
-     var $t4: &ability::Impotent
-     var $t5: bool
+     var $t1: address
+     var $t2: ability::Impotent
+     var $t3: ability::S<ability::Impotent>
+     var $t4: &mut ability::Impotent
+     var $t5: &ability::Impotent
+     var $t6: bool
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
-  0: $t1 := move_from<ability::Impotent>($t0)
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     #
+  1: $t2 := move_from<ability::Impotent>($t1)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
-  1: $t2 := move_from<ability::S<ability::Impotent>>($t0)
+  2: $t3 := move_from<ability::S<ability::Impotent>>($t0)
      # live vars: $t0
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
-     #
-  2: $t3 := borrow_global<ability::Impotent>($t0)
-     # live vars: $t0
-     # graph: {L512=global<ability::Impotent>[borrow_global(true) -> L513],L513=local($t3)[]}
-     # local_to_label: {$t3=L513}
-     # global_to_label: {ability::Impotent=L512}
      #
   3: $t4 := borrow_global<ability::Impotent>($t0)
      # live vars: $t0
-     # graph: {L768=global<ability::Impotent>[borrow_global(false) -> L769],L769=local($t4)[]}
+     # graph: {L768=global<ability::Impotent>[borrow_global(true) -> L769],L769=local($t4)[]}
      # local_to_label: {$t4=L769}
      # global_to_label: {ability::Impotent=L768}
      #
-  4: $t5 := exists<ability::Impotent>($t0)
+  4: $t5 := borrow_global<ability::Impotent>($t0)
+     # live vars: $t0
+     # graph: {L1024=global<ability::Impotent>[borrow_global(false) -> L1025],L1025=local($t5)[]}
+     # local_to_label: {$t5=L1025}
+     # global_to_label: {ability::Impotent=L1024}
+     #
+  5: $t6 := exists<ability::Impotent>($t0)
      # live vars:
      # graph: {}
      # local_to_label: {}
      # global_to_label: {}
      #
-  5: return ()
+  6: return ()
 }
 
 ============ after ExplicitDrop: ================
@@ -261,36 +273,44 @@ fun ability::invalid_move_to($t0: &signer) {
 
 [variant baseline]
 fun ability::no_key($t0: address) {
-     var $t1: ability::Impotent
-     var $t2: ability::S<ability::Impotent>
-     var $t3: &mut ability::Impotent
-     var $t4: &ability::Impotent
-     var $t5: bool
-  0: $t1 := move_from<ability::Impotent>($t0)
-  1: destroy($t1)
-  2: $t2 := move_from<ability::S<ability::Impotent>>($t0)
-  3: destroy($t2)
-  4: $t3 := borrow_global<ability::Impotent>($t0)
+     var $t1: address
+     var $t2: ability::Impotent
+     var $t3: ability::S<ability::Impotent>
+     var $t4: &mut ability::Impotent
+     var $t5: &ability::Impotent
+     var $t6: bool
+  0: $t1 := copy($t0)
+  1: $t2 := move_from<ability::Impotent>($t1)
+  2: destroy($t2)
+  3: $t3 := move_from<ability::S<ability::Impotent>>($t0)
+  4: destroy($t3)
   5: $t4 := borrow_global<ability::Impotent>($t0)
-  6: destroy($t3)
-  7: $t5 := exists<ability::Impotent>($t0)
-  8: destroy($t4)
-  9: return ()
+  6: $t5 := borrow_global<ability::Impotent>($t0)
+  7: destroy($t4)
+  8: $t6 := exists<ability::Impotent>($t0)
+  9: destroy($t5)
+ 10: return ()
 }
 
 
 Diagnostics:
 error: no key ability
-   ┌─ tests/ability-checker/ability_violation.move:14:3
+   ┌─ tests/ability-checker/ability_violation.move:4:3
    │
-14 │         move_from<Impotent>(addr);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 4 │         move_from<T>(addr);
+   │         ^^^^^^^^^^^^^^^^^^
+   ·
+14 │         move_from_no_key<Impotent>(addr);
+   │         -------------------------------- in a call inlined at this callsite
 
 error: cannot drop
-   ┌─ tests/ability-checker/ability_violation.move:14:3
+   ┌─ tests/ability-checker/ability_violation.move:4:3
    │
-14 │         move_from<Impotent>(addr);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 4 │         move_from<T>(addr);
+   │         ^^^^^^^^^^^^^^^^^^
+   ·
+14 │         move_from_no_key<Impotent>(addr);
+   │         -------------------------------- in a call inlined at this callsite
 
 error: no key ability
    ┌─ tests/ability-checker/ability_violation.move:15:3
@@ -399,19 +419,21 @@ fun ability::invalid_move_to($t0: &signer) {
 
 [variant baseline]
 fun ability::no_key($t0: address) {
-     var $t1: ability::Impotent
-     var $t2: ability::S<ability::Impotent>
-     var $t3: &mut ability::Impotent
-     var $t4: &ability::Impotent
-     var $t5: bool
-  0: $t1 := move_from<ability::Impotent>($t0)
-  1: destroy($t1)
-  2: $t2 := move_from<ability::S<ability::Impotent>>($t0)
-  3: destroy($t2)
-  4: $t3 := borrow_global<ability::Impotent>($t0)
+     var $t1: address
+     var $t2: ability::Impotent
+     var $t3: ability::S<ability::Impotent>
+     var $t4: &mut ability::Impotent
+     var $t5: &ability::Impotent
+     var $t6: bool
+  0: $t1 := copy($t0)
+  1: $t2 := move_from<ability::Impotent>($t1)
+  2: destroy($t2)
+  3: $t3 := move_from<ability::S<ability::Impotent>>($t0)
+  4: destroy($t3)
   5: $t4 := borrow_global<ability::Impotent>($t0)
-  6: destroy($t3)
-  7: $t5 := exists<ability::Impotent>($t0)
-  8: destroy($t4)
-  9: return ()
+  6: $t5 := borrow_global<ability::Impotent>($t0)
+  7: destroy($t4)
+  8: $t6 := exists<ability::Impotent>($t0)
+  9: destroy($t5)
+ 10: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.move
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.move
@@ -1,8 +1,8 @@
 module 0x42::ability {
-	// TODO(#11377): uncomment will result in a crash
-	// fun move_from_no_key<T>(addr: address) {
-	// 	move_from<T>(addr);
-	// }
+
+	inline fun move_from_no_key<T>(addr: address) {
+		move_from<T>(addr);
+	}
 
 	struct Impotent {}
 
@@ -11,7 +11,7 @@ module 0x42::ability {
 	}
 
 	fun no_key(addr: address) {
-		move_from<Impotent>(addr);
+		move_from_no_key<Impotent>(addr);
 		move_from<S<Impotent>>(addr);
 		borrow_global_mut<Impotent>(addr);
 		borrow_global<Impotent>(addr);

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.exp
@@ -17,20 +17,26 @@ module 0x42::m {
 
 
 Diagnostics:
-error: expected `Type::Struct`, found: `TypeParameter(0)`
+error: Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found: '#0'
   ┌─ tests/bytecode-generator/global_invalid.move:4:17
   │
 4 │         assert!(exists<T>(addr), 0);
   │                 ^^^^^^^^^^^^^^^
+  │                 │
+  │                 Invalid call to exists<#0>.
 
-error: expected `Type::Struct`, found: `TypeParameter(0)`
+error: Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found: '#0'
   ┌─ tests/bytecode-generator/global_invalid.move:5:17
   │
 5 │         let _ = borrow_global<T>(addr);
   │                 ^^^^^^^^^^^^^^^^^^^^^^
+  │                 │
+  │                 Invalid call to BorrowGlobal(Immutable)<#0>.
 
-error: expected `Type::Struct`, found: `TypeParameter(0)`
+error: Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found: '#0'
   ┌─ tests/bytecode-generator/global_invalid.move:6:9
   │
 6 │         move_from<T>(addr);
   │         ^^^^^^^^^^^^^^^^^^
+  │         │
+  │         Invalid call to MoveFrom<#0>.

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.exp
@@ -1,0 +1,36 @@
+// ---- Model Dump
+module 0x42::m {
+    private fun invalid<T>(addr: address) {
+        if exists<T>(addr) {
+          Tuple()
+        } else {
+          Abort(0)
+        };
+        {
+          let _ = BorrowGlobal(Immutable)<T>(addr);
+          MoveFrom<T>(addr);
+          Tuple()
+        }
+    }
+    spec fun $invalid<T>(addr: address);
+} // end 0x42::m
+
+
+Diagnostics:
+error: expected `Type::Struct`, found: `TypeParameter(0)`
+  ┌─ tests/bytecode-generator/global_invalid.move:4:17
+  │
+4 │         assert!(exists<T>(addr), 0);
+  │                 ^^^^^^^^^^^^^^^
+
+error: expected `Type::Struct`, found: `TypeParameter(0)`
+  ┌─ tests/bytecode-generator/global_invalid.move:5:17
+  │
+5 │         let _ = borrow_global<T>(addr);
+  │                 ^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `Type::Struct`, found: `TypeParameter(0)`
+  ┌─ tests/bytecode-generator/global_invalid.move:6:9
+  │
+6 │         move_from<T>(addr);
+  │         ^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/global_invalid.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    fun invalid<T:key + drop>(addr: address) {
+        assert!(exists<T>(addr), 0);
+        let _ = borrow_global<T>(addr);
+        move_from<T>(addr);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/v1.matched
+++ b/third_party/move/move-compiler-v2/tests/v1.matched
@@ -64,8 +64,14 @@ move-compiler/tests/move_check/borrows/return_borrowed_local_invalid.exp   move-
 move-compiler/tests/move_check/borrows/return_mutual_borrows.exp   move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.exp
 move-compiler/tests/move_check/borrows/return_mutual_borrows_invalid.exp   move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
 move-compiler/tests/move_check/borrows/unused_ref.exp   move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.exp
+move-compiler/tests/move_check/folding/non_constant_empty_vec.exp   move-compiler-v2/tests/folding/non_constant_empty_vec.exp
+move-compiler/tests/move_check/folding/unfoldable_constants.exp   move-compiler-v2/tests/folding/unfoldable_constants.exp
+move-compiler/tests/move_check/folding/unfoldable_constants_blocks.exp   move-compiler-v2/tests/folding/unfoldable_constants_blocks.exp
 move-compiler/tests/move_check/inlining/acquires_error_msg.exp   move-compiler-v2/tests/checking/inlining/acquires_error_msg.exp
 move-compiler/tests/move_check/inlining/break_continue_in_lambda.exp   move-compiler-v2/tests/checking/inlining/break_continue_in_lambda.exp
+move-compiler/tests/move_check/inlining/bug_11112.exp   move-compiler-v2/tests/checking/inlining/bug_11112.exp
+move-compiler/tests/move_check/inlining/bug_9717.exp   move-compiler-v2/tests/checking/inlining/bug_9717.exp
+move-compiler/tests/move_check/inlining/bug_9717_looponly.exp   move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
 move-compiler/tests/move_check/inlining/cool_inlining_test.exp   move-compiler-v2/tests/checking/inlining/cool_inlining_test.exp
 move-compiler/tests/move_check/inlining/double_nesting.exp   move-compiler-v2/tests/checking/inlining/double_nesting.exp
 move-compiler/tests/move_check/inlining/inline_accessing_constant.exp   move-compiler-v2/tests/checking/inlining/inline_accessing_constant.exp
@@ -115,6 +121,7 @@ move-compiler/tests/move_check/typing/annotated_types.exp   move-compiler-v2/tes
 move-compiler/tests/move_check/typing/assign_duplicate_assigning.exp   move-compiler-v2/tests/checking/typing/assign_duplicate_assigning.exp
 move-compiler/tests/move_check/typing/assign_nested.exp   move-compiler-v2/tests/checking/typing/assign_nested.exp
 move-compiler/tests/move_check/typing/assign_tuple.exp   move-compiler-v2/tests/checking/typing/assign_tuple.exp
+move-compiler/tests/move_check/typing/assign_tuple_wg.exp   move-compiler-v2/tests/checking/typing/assign_tuple_wg.exp
 move-compiler/tests/move_check/typing/assign_unpack_references.exp   move-compiler-v2/tests/checking/typing/assign_unpack_references.exp
 move-compiler/tests/move_check/typing/assign_unpack_references_invalid.exp   move-compiler-v2/tests/checking/typing/assign_unpack_references_invalid.exp
 move-compiler/tests/move_check/typing/assign_wrong_arity.exp   move-compiler-v2/tests/checking/typing/assign_wrong_arity.exp
@@ -182,17 +189,19 @@ move-compiler/tests/move_check/typing/borrow_local_temp.exp   move-compiler-v2/t
 move-compiler/tests/move_check/typing/borrow_local_temp_invalid.exp   move-compiler-v2/tests/checking/typing/borrow_local_temp_invalid.exp
 move-compiler/tests/move_check/typing/borrow_local_temp_resource.exp   move-compiler-v2/tests/checking/typing/borrow_local_temp_resource.exp
 move-compiler/tests/move_check/typing/break_any_type.exp   move-compiler-v2/tests/checking/typing/break_any_type.exp
+move-compiler/tests/move_check/typing/break_constant.exp   move-compiler-v2/tests/checking/typing/break_constant.exp
 move-compiler/tests/move_check/typing/break_outside_loop.exp   move-compiler-v2/tests/checking/typing/break_outside_loop.exp
 move-compiler/tests/move_check/typing/cast.exp   move-compiler-v2/tests/checking/typing/cast.exp
 move-compiler/tests/move_check/typing/cast_invalid.exp   move-compiler-v2/tests/checking/typing/cast_invalid.exp
 move-compiler/tests/move_check/typing/conditional_global_operations.exp   move-compiler-v2/tests/checking/typing/conditional_global_operations.exp
 move-compiler/tests/move_check/typing/constant_all_valid_types.exp   move-compiler-v2/tests/checking/typing/constant_all_valid_types.exp
 move-compiler/tests/move_check/typing/constant_allowed_but_not_supported.exp   move-compiler-v2/tests/checking/typing/constant_allowed_but_not_supported.exp
+move-compiler/tests/move_check/typing/constant_folding.exp   move-compiler-v2/tests/checking/typing/constant_folding.exp
+move-compiler/tests/move_check/typing/constant_inference.exp   move-compiler-v2/tests/checking/typing/constant_inference.exp
 move-compiler/tests/move_check/typing/constant_internal.exp   move-compiler-v2/tests/checking/typing/constant_internal.exp
 move-compiler/tests/move_check/typing/constant_invalid_base_type.exp   move-compiler-v2/tests/checking/typing/constant_invalid_base_type.exp
 move-compiler/tests/move_check/typing/constant_invalid_usage.exp   move-compiler-v2/tests/checking/typing/constant_invalid_usage.exp
 move-compiler/tests/move_check/typing/constant_non_base_type.exp   move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
-move-compiler/tests/move_check/typing/constant_supported_exps.exp   move-compiler-v2/tests/checking/typing/constant_supported_exps.exp
 move-compiler/tests/move_check/typing/constant_unsupported_exps.exp   move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
 move-compiler/tests/move_check/typing/continue_any_type.exp   move-compiler-v2/tests/checking/typing/continue_any_type.exp
 move-compiler/tests/move_check/typing/continue_outside_loop.exp   move-compiler-v2/tests/checking/typing/continue_outside_loop.exp
@@ -214,6 +223,7 @@ move-compiler/tests/move_check/typing/exp_list_resource_drop.exp   move-compiler
 move-compiler/tests/move_check/typing/explicit_copy.exp   move-compiler-v2/tests/checking/typing/explicit_copy.exp
 move-compiler/tests/move_check/typing/explicit_move.exp   move-compiler-v2/tests/checking/typing/explicit_move.exp
 move-compiler/tests/move_check/typing/global_builtins.exp   move-compiler-v2/tests/checking/typing/global_builtins.exp
+move-compiler/tests/move_check/typing/global_builtins_inferred.exp   move-compiler-v2/tests/checking/typing/global_builtins_inferred.exp
 move-compiler/tests/move_check/typing/global_builtins_invalid.exp   move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
 move-compiler/tests/move_check/typing/global_builtins_script.exp   move-compiler-v2/tests/checking/typing/global_builtins_script.exp
 move-compiler/tests/move_check/typing/hex_and_decimal_address.exp   move-compiler-v2/tests/checking/typing/hex_and_decimal_address.exp
@@ -253,6 +263,7 @@ move-compiler/tests/move_check/typing/module_call_missing_function.exp   move-co
 move-compiler/tests/move_check/typing/module_call_wrong_argument_in_list.exp   move-compiler-v2/tests/checking/typing/module_call_wrong_argument_in_list.exp
 move-compiler/tests/move_check/typing/module_call_wrong_arity.exp   move-compiler-v2/tests/checking/typing/module_call_wrong_arity.exp
 move-compiler/tests/move_check/typing/module_call_wrong_single_argument.exp   move-compiler-v2/tests/checking/typing/module_call_wrong_single_argument.exp
+move-compiler/tests/move_check/typing/move_from_type_argument.exp   move-compiler-v2/tests/checking/typing/move_from_type_argument.exp
 move-compiler/tests/move_check/typing/mutable_eq_and_neq.exp   move-compiler-v2/tests/checking/typing/mutable_eq_and_neq.exp
 move-compiler/tests/move_check/typing/mutate.exp   move-compiler-v2/tests/checking/typing/mutate.exp
 move-compiler/tests/move_check/typing/mutate_field_internal.exp   move-compiler-v2/tests/checking/typing/mutate_field_internal.exp
@@ -282,6 +293,7 @@ move-compiler/tests/move_check/typing/shadowing_invalid_scope.exp   move-compile
 move-compiler/tests/move_check/typing/shadowing_invalid_types.exp   move-compiler-v2/tests/checking/typing/shadowing_invalid_types.exp
 move-compiler/tests/move_check/typing/spec_block_fail.exp   move-compiler-v2/tests/checking/typing/spec_block_fail.exp
 move-compiler/tests/move_check/typing/spec_block_ok.exp   move-compiler-v2/tests/checking/typing/spec_block_ok.exp
+move-compiler/tests/move_check/typing/specs.exp   move-compiler-v2/tests/checking/typing/specs.exp
 move-compiler/tests/move_check/typing/subtype_annotation.exp   move-compiler-v2/tests/checking/typing/subtype_annotation.exp
 move-compiler/tests/move_check/typing/subtype_annotation_invalid.exp   move-compiler-v2/tests/checking/typing/subtype_annotation_invalid.exp
 move-compiler/tests/move_check/typing/subtype_args.exp   move-compiler-v2/tests/checking/typing/subtype_args.exp

--- a/third_party/move/move-compiler-v2/tests/v1.unmatched
+++ b/third_party/move/move-compiler-v2/tests/v1.unmatched
@@ -104,6 +104,7 @@ move-compiler/tests/move_check/commands/{
   while_move_local_2.move,
 }
 move-compiler/tests/move_check/control_flow/{
+  for_user.move,
   infinite_loop_with_dead_exits.move,
   loop_after_loop.move,
 }
@@ -125,11 +126,6 @@ move-compiler/tests/move_check/deprecated/{
 move-compiler/tests/move_check/examples/{
   multi_pool_money_market_token.move,
   simple_money_market_token.move,
-}
-move-compiler/tests/move_check/folding/{
-  non_constant_empty_vec.move,
-  unfoldable_constants.move,
-  unfoldable_constants_blocks.move,
 }
 move-compiler/tests/move_check/instantiation_loops/{
   complex_1.move,
@@ -249,9 +245,9 @@ move-compiler/tests/move_check/typing/{
   bind_pop_resource.move,
   borrow_divergent.move,
   borrow_field_non_ref_non_local_root.move,
-  break_constant.move,
   conditional_copy_invalid.move,
   conditional_drop_invalid.move,
+  constant_supported_exps.move,
   constraints_not_satisfied_all_cases.move,
   constraints_not_satisfied_function_parameter.move,
   constraints_not_satisfied_function_return_type.move,
@@ -265,6 +261,7 @@ move-compiler/tests/move_check/typing/{
   declare_pop_resource.move,
   entry_signature_no_warning.move,
   extraneous_acquire.move,
+  global_invalid.move,
   ignore_inferred_resource.move,
   implicit_deref_borrow_field_not_copyable.move,
   infinite_instantiations_invalid.move,

--- a/third_party/move/move-compiler/tests/move_check/typing/global_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/global_invalid.exp
@@ -1,0 +1,27 @@
+error[E04009]: expected specific type
+  ┌─ tests/move_check/typing/global_invalid.move:4:17
+  │
+4 │         assert!(exists<T>(addr), 0);
+  │                 ^^^^^^^^^^^^^^^
+  │                 │      │
+  │                 │      Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found the type parameter: 'T'
+  │                 Invalid call to exists.
+
+error[E04009]: expected specific type
+  ┌─ tests/move_check/typing/global_invalid.move:5:17
+  │
+5 │         let _ = borrow_global<T>(addr);
+  │                 ^^^^^^^^^^^^^^^^^^^^^^
+  │                 │             │
+  │                 │             Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found the type parameter: 'T'
+  │                 Invalid call to borrow_global.
+
+error[E04009]: expected specific type
+  ┌─ tests/move_check/typing/global_invalid.move:6:9
+  │
+6 │         move_from<T>(addr);
+  │         ^^^^^^^^^^^^^^^^^^
+  │         │         │
+  │         │         Expected a struct type. Global storage operations are restricted to struct types declared in the current module. Found the type parameter: 'T'
+  │         Invalid call to move_from.
+

--- a/third_party/move/move-compiler/tests/move_check/typing/global_invalid.move
+++ b/third_party/move/move-compiler/tests/move_check/typing/global_invalid.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    fun invalid<T:key + drop>(addr: address) {
+        assert!(exists<T>(addr), 0);
+        let _ = borrow_global<T>(addr);
+        move_from<T>(addr);
+    }
+
+}


### PR DESCRIPTION
### Description

For the global memory operation: `exists`, `move_from`, `move_to`, `borrow_global` and `borrow_global_mut`, the compiler requires that the type parameter must be converted into a concrete struct type during generation of stackless bytecode. Otherwise, it will panic with the message `panicked at 'expected Type::Struct, found: ...`, as mentioned in #11377. 

This PR changes this behavior by generating a compiler error instead of panicking.

Close #11377.

### Test Plan

1) Added a new test `global_invalid.move` to validate the result. The same test case is also added to the V1 compiler.
2) Updated the test case `ability_violation.move`.
