### PR TITLE
[executor benchmark] more details on transaction failures

### DIFF
--- a/execution/executor-benchmark/src/ledger_update_stage.rs
+++ b/execution/executor-benchmark/src/ledger_update_stage.rs
@@ -13,8 +13,6 @@ pub struct LedgerUpdateStage<V> {
     // If commit_sender is `None`, we will commit all the execution result immediately in this struct.
     commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
     version: Version,
-    allow_discards: bool,
-    allow_aborts: bool,
 }
 
 impl<V> LedgerUpdateStage<V>
@@ -25,15 +23,11 @@ where
         executor: Arc<BlockExecutor<V>>,
         commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
         version: Version,
-        allow_discards: bool,
-        allow_aborts: bool,
     ) -> Self {
         Self {
             executor,
             version,
             commit_sender,
-            allow_discards,
-            allow_aborts,
         }
     }
 
@@ -55,52 +49,6 @@ where
             .unwrap();
 
         self.version += output.transactions_to_commit_len() as Version;
-        let discards = output
-            .compute_status_for_input_txns()
-            .iter()
-            .flat_map(|status| match status.status() {
-                Ok(_) => None,
-                Err(error_code) => Some(format!("{:?}", error_code)),
-            })
-            .collect::<Vec<_>>();
-
-        let aborts = output
-            .compute_status_for_input_txns()
-            .iter()
-            .flat_map(|status| match status.status() {
-                Ok(execution_status) => {
-                    if execution_status.is_success() {
-                        None
-                    } else {
-                        Some(format!("{:?}", execution_status))
-                    }
-                },
-                Err(_) => None,
-            })
-            .collect::<Vec<_>>();
-        if !discards.is_empty() || !aborts.is_empty() {
-            println!(
-                "Some transactions were not successful: {} discards and {} aborts out of {}, examples: discards: {:?}, aborts: {:?}",
-                discards.len(),
-                aborts.len(),
-                output.compute_status_for_input_txns().len(),
-                &discards[..(discards.len().min(3))],
-                &aborts[..(aborts.len().min(3))]
-            )
-        }
-
-        assert!(
-            self.allow_discards || discards.is_empty(),
-            "No discards allowed, {}, examples: {:?}",
-            discards.len(),
-            &discards[..(discards.len().min(3))]
-        );
-        assert!(
-            self.allow_aborts || aborts.is_empty(),
-            "No aborts allowed, {}, examples: {:?}",
-            aborts.len(),
-            &aborts[..(aborts.len().min(3))]
-        );
 
         if let Some(commit_sender) = &self.commit_sender {
             let msg = CommitBlockMessage {

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -103,9 +103,11 @@ pub struct PipelineOpt {
     #[clap(long)]
     skip_commit: bool,
     #[clap(long)]
+    allow_aborts: bool,
+    #[clap(long)]
     allow_discards: bool,
     #[clap(long)]
-    allow_aborts: bool,
+    allow_retries: bool,
     #[clap(long, default_value = "4")]
     num_generator_workers: usize,
     #[clap(flatten)]
@@ -118,8 +120,9 @@ impl PipelineOpt {
             delay_execution_start: self.generate_then_execute,
             split_stages: self.split_stages,
             skip_commit: self.skip_commit,
-            allow_discards: self.allow_discards,
             allow_aborts: self.allow_aborts,
+            allow_discards: self.allow_discards,
+            allow_retries: self.allow_retries,
             num_executor_shards: self.sharding_opt.num_executor_shards,
             use_global_executor: self.sharding_opt.use_global_executor,
             num_generator_workers: self.num_generator_workers,

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -135,4 +135,74 @@ impl StateCheckpointOutput {
             Ok(())
         })
     }
+
+    pub fn check_aborts_discards_retries(
+        &self,
+        allow_aborts: bool,
+        allow_discards: bool,
+        allow_retries: bool,
+    ) {
+        let aborts = self
+            .txns
+            .to_commit
+            .iter()
+            .flat_map(|(txn, output)| match output.status().status() {
+                Ok(execution_status) => {
+                    if execution_status.is_success() {
+                        None
+                    } else {
+                        Some(format!("{:?}: {:?}", txn, output.status()))
+                    }
+                },
+                Err(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        let discards_3 = self
+            .txns
+            .to_discard
+            .iter()
+            .take(3)
+            .map(|(txn, output)| format!("{:?}: {:?}", txn, output.status()))
+            .collect::<Vec<_>>();
+        let retries_3 = self
+            .txns
+            .to_retry
+            .iter()
+            .take(3)
+            .map(|(txn, output)| format!("{:?}: {:?}", txn, output.status()))
+            .collect::<Vec<_>>();
+
+        if !aborts.is_empty() || !discards_3.is_empty() || !retries_3.is_empty() {
+            println!(
+                "Some transactions were not successful: {} aborts, {} discards and {} retries out of {}, examples: aborts: {:?}, discards: {:?}, retries: {:?}",
+                aborts.len(),
+                self.txns.to_discard.len(),
+                self.txns.to_retry.len(),
+                self.input_txns_len(),
+                &aborts[..(aborts.len().min(3))],
+                discards_3,
+                retries_3,
+            )
+        }
+
+        assert!(
+            allow_aborts || aborts.is_empty(),
+            "No aborts allowed, {}, examples: {:?}",
+            aborts.len(),
+            &aborts[..(aborts.len().min(3))]
+        );
+        assert!(
+            allow_discards || discards_3.is_empty(),
+            "No discards allowed, {}, examples: {:?}",
+            self.txns.to_discard.len(),
+            discards_3,
+        );
+        assert!(
+            allow_retries || retries_3.is_empty(),
+            "No retries allowed, {}, examples: {:?}",
+            self.txns.to_retry.len(),
+            retries_3,
+        );
+    }
 }


### PR DESCRIPTION
When transaction fails in executor benchmark, (with allow flags false), we only had output information, but no information about the transaction

So moving the checking logic to a place where we do have both, so we can give more useful info.
Also adding checks on no-retries.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
