### PR TITLE
[Aptos Compression] Small cleanups and metrics improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "bcs 0.1.4",
  "lz4",
  "once_cell",
+ "rand 0.7.3",
  "serde",
  "thiserror",
 ]

--- a/crates/aptos-compression/Cargo.toml
+++ b/crates/aptos-compression/Cargo.toml
@@ -23,4 +23,5 @@ thiserror = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }

--- a/crates/aptos-compression/src/client.rs
+++ b/crates/aptos-compression/src/client.rs
@@ -1,0 +1,27 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// A simple enum for identifying clients of the compression crate. This
+/// allows us to provide a runtime breakdown of compression metrics for
+/// each client.
+#[derive(Clone, Copy, Debug)]
+pub enum CompressionClient {
+    Consensus,
+    DKG,
+    JWKConsensus,
+    Mempool,
+    StateSync,
+}
+
+impl CompressionClient {
+    /// Returns a summary label for the request
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            Self::Consensus => "consensus",
+            Self::DKG => "dkg",
+            Self::JWKConsensus => "jwk_consensus",
+            Self::Mempool => "mempool",
+            Self::StateSync => "state_sync",
+        }
+    }
+}

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -3,14 +3,11 @@
 
 use crate::{
     client::CompressionClient,
-    metrics::{
-        increment_compression_byte_count, increment_compression_error,
-        start_compression_operation_timer, COMPRESS, COMPRESSED_BYTES, DECOMPRESS, RAW_BYTES,
-    },
     Error::{CompressionError, DecompressionError},
 };
 use aptos_logger::prelude::*;
 use lz4::block::CompressionMode;
+use std::time::Instant;
 use thiserror::Error;
 
 /// This crate provides a simple library interface for data compression.
@@ -49,54 +46,44 @@ pub fn compress(
     client: CompressionClient,
     max_bytes: usize,
 ) -> Result<CompressedData, Error> {
+    // Start the compression timer
+    let start_time = Instant::now();
+
+    // Ensure that the raw data size is not greater than the max bytes limit
     if raw_data.len() > max_bytes {
-        return Err(CompressionError(format!(
-            "Uncompressed size greater than max. size: {}, max: {}",
+        let error_string = format!(
+            "Raw data size greater than max bytes limit: {}, max: {}",
             raw_data.len(),
             max_bytes
-        )));
+        );
+        return create_compression_error(&client, error_string);
     }
-    // Start the compression timer
-    let timer = start_compression_operation_timer(COMPRESS, client);
 
     // Compress the data
     let compression_mode = CompressionMode::FAST(ACCELERATION_PARAMETER);
     let compressed_data = match lz4::block::compress(&raw_data, Some(compression_mode), true) {
         Ok(compressed_data) => compressed_data,
         Err(error) => {
-            increment_compression_error(COMPRESS, client);
-            return Err(CompressionError(format!(
-                "Failed to compress the data: {}",
-                error
-            )));
+            let error_string = format!("Failed to compress the data: {}", error);
+            return create_compression_error(&client, error_string);
         },
     };
 
-    // Ensure that the compressed data size is not greater than the max bytes limit. This can
-    // happen in case of uncompressible data, where the compression size will be more than the
-    // uncompressed size.
+    // Ensure that the compressed data size is not greater than the max byte
+    // limit. This can happen in the case of uncompressible data, where the
+    // compressed data is larger than the uncompressed data.
     if compressed_data.len() > max_bytes {
-        return Err(CompressionError(format!(
-            "Compressed size greater than max. size: {}, max: {}",
+        let error_string = format!(
+            "Compressed size greater than max bytes limit: {}, max: {}",
             compressed_data.len(),
             max_bytes
-        )));
+        );
+        return create_compression_error(&client, error_string);
     }
 
     // Stop the timer and update the metrics
-    let compression_duration = timer.stop_and_record();
-    increment_compression_byte_count(RAW_BYTES, client, raw_data.len() as u64);
-    increment_compression_byte_count(COMPRESSED_BYTES, client, compressed_data.len() as u64);
-
-    // Log the relative data compression statistics
-    let relative_data_size = calculate_relative_size(&raw_data, &compressed_data);
-    trace!(
-        "Compressed {} bytes to {} bytes ({} %) in {} seconds.",
-        raw_data.len(),
-        compressed_data.len(),
-        relative_data_size,
-        compression_duration
-    );
+    metrics::observe_compression_operation_time(&client, start_time);
+    metrics::update_compression_metrics(&client, &raw_data, &compressed_data);
 
     Ok(compressed_data)
 }
@@ -108,66 +95,84 @@ pub fn decompress(
     max_size: usize,
 ) -> Result<Vec<u8>, Error> {
     // Start the decompression timer
-    let timer = start_compression_operation_timer(DECOMPRESS, client);
+    let start_time = Instant::now();
 
     // Check size of the data and initialize raw_data
-    let size = match get_decompressed_size(compressed_data, max_size) {
+    let decompressed_size = match get_decompressed_size(compressed_data, max_size) {
         Ok(size) => size,
         Err(error) => {
-            increment_compression_error(DECOMPRESS, client);
-            return Err(DecompressionError(format!(
-                "Failed to get decompressed size: {}",
-                error
-            )));
+            let error_string = format!("Failed to get decompressed size: {}", error);
+            return create_decompression_error(&client, error_string);
         },
     };
-    let mut raw_data = vec![0u8; size];
+    let mut raw_data = vec![0u8; decompressed_size];
 
     // Decompress the data
     if let Err(error) = lz4::block::decompress_to_buffer(compressed_data, None, &mut raw_data) {
-        increment_compression_error(DECOMPRESS, client);
-        return Err(DecompressionError(format!(
-            "Failed to decompress the data: {}",
-            error
-        )));
+        let error_string = format!("Failed to decompress the data: {}", error);
+        return create_decompression_error(&client, error_string);
     };
 
-    // Stop the timer and log the relative data compression statistics
-    let decompression_duration = timer.stop_and_record();
-    let relative_data_size = calculate_relative_size(compressed_data, &raw_data);
-    trace!(
-        "Decompressed {} bytes to {} bytes ({} %) in {} seconds.",
-        compressed_data.len(),
-        raw_data.len(),
-        relative_data_size,
-        decompression_duration
-    );
+    // Stop the timer and update the metrics
+    metrics::observe_decompression_operation_time(&client, start_time);
+    metrics::update_decompression_metrics(&client, compressed_data, &raw_data);
 
     Ok(raw_data)
 }
 
-/// Derived from lz4-rs crate, which starts the compressed payload with the original data size as i32
-/// see: https://github.com/10XGenomics/lz4-rs/blob/0abc0a52af1f6010f9a57640b1dc8eb8d2d697aa/src/block/mod.rs#L162
-fn get_decompressed_size(src: &CompressedData, max_size: usize) -> Result<usize, Error> {
-    if src.len() < 4 {
+/// A simple utility function that wraps the given error string in a compression error
+fn create_compression_error(
+    client: &CompressionClient,
+    error_string: String,
+) -> Result<CompressedData, Error> {
+    // Increment the compression error counter
+    metrics::increment_compression_error(client);
+
+    // Create and return the error
+    Err(CompressionError(error_string))
+}
+
+/// A simple utility function that wraps the given error string in a decompression error
+fn create_decompression_error(
+    client: &CompressionClient,
+    error_string: String,
+) -> Result<Vec<u8>, Error> {
+    // Increment the decompression error counter
+    metrics::increment_decompression_error(client);
+
+    // Create and return the error
+    Err(DecompressionError(error_string))
+}
+
+/// Derived from the lz4-rs crate, which prepends the compressed payload
+/// with the original data size as i32.
+/// See: https://github.com/10XGenomics/lz4-rs/blob/0abc0a52af1f6010f9a57640b1dc8eb8d2d697aa/src/block/mod.rs#L162
+fn get_decompressed_size(
+    compressed_data: &CompressedData,
+    max_size: usize,
+) -> Result<usize, Error> {
+    // Ensure that the compressed data is at least 4 bytes long
+    if compressed_data.len() < 4 {
         return Err(DecompressionError(format!(
-            "Source buffer must at least contain size prefix: {}",
-            src.len()
+            "Compressed data must be at least 4 bytes long! Got: {}",
+            compressed_data.len()
         )));
     }
 
-    let size =
-        (src[0] as i32) | (src[1] as i32) << 8 | (src[2] as i32) << 16 | (src[3] as i32) << 24;
-
+    // Parse the size prefix
+    let size = (compressed_data[0] as i32)
+        | (compressed_data[1] as i32) << 8
+        | (compressed_data[2] as i32) << 16
+        | (compressed_data[3] as i32) << 24;
     if size < 0 {
         return Err(DecompressionError(format!(
-            "Parsed size prefix in buffer must not be negative: {}",
+            "Parsed size prefix in buffer must not be negative! Got: {}",
             size
         )));
     }
 
+    // Ensure that the size is not greater than the max size limit
     let size = size as usize;
-
     if size > max_size {
         return Err(DecompressionError(format!(
             "Parsed size prefix in buffer is too big: {} > {}",
@@ -178,8 +183,38 @@ fn get_decompressed_size(src: &CompressedData, max_size: usize) -> Result<usize,
     Ok(size)
 }
 
-/// Calculates the relative size (%) between the input and output after a
-/// compression/decompression operation, i.e., (output / input) * 100.
-fn calculate_relative_size(input: &[u8], output: &[u8]) -> f64 {
-    (output.len() as f64 / input.len() as f64) * 100.0
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_decompressed_size() {
+        // Create some test data
+        let max_compression_size = 100;
+
+        // Verify that an error is returned when the compressed data length is zero
+        let result = get_decompressed_size(&vec![0u8; 0], max_compression_size);
+        assert!(result.is_err());
+
+        // Verify that an error is returned when the compressed data length is too small
+        let result = get_decompressed_size(&vec![0u8; 3], max_compression_size);
+        assert!(result.is_err());
+
+        // Verify that an error is returned when the compressed data length is too large
+        let mut compressed_data = vec![0u8; max_compression_size];
+        compressed_data[0] = (max_compression_size + 1) as u8;
+        let result = get_decompressed_size(&compressed_data, max_compression_size);
+        assert!(result.is_err());
+
+        // Verify that the correct decompressed size is returned
+        let raw_data = vec![0u8; max_compression_size];
+        let compressed_data = compress(
+            raw_data.clone(),
+            CompressionClient::StateSync,
+            max_compression_size,
+        )
+        .unwrap();
+        let result = get_decompressed_size(&compressed_data, max_compression_size);
+        assert_eq!(result.unwrap(), raw_data.len());
+    }
 }

--- a/crates/aptos-compression/src/metrics.rs
+++ b/crates/aptos-compression/src/metrics.rs
@@ -3,9 +3,11 @@
 
 use crate::client::CompressionClient;
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
+    exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
+    IntCounterVec,
 };
 use once_cell::sync::Lazy;
+use std::time::Instant;
 
 /// Useful metric constants for compression and decompression
 pub const COMPRESS: &str = "compress";
@@ -18,7 +20,7 @@ pub static BYTE_COUNTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_compression_byte_count",
         "Counters for tracking the data compression ratio",
-        &["data_type", "client"]
+        &["operation", "data_type", "client"]
     )
     .unwrap()
 });
@@ -38,35 +40,89 @@ pub static OPERATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_compression_operation_latency",
         "Time it takes to perform a compression/decompression operation",
-        &["operation", "client"]
+        &["operation", "client"],
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
 });
 
 /// Increments the compression byte count based on the given data type
-pub fn increment_compression_byte_count(
+fn increment_compression_byte_count(
+    operation: &str,
     data_type: &str,
-    client: CompressionClient,
+    client: &CompressionClient,
     byte_count: u64,
 ) {
     BYTE_COUNTS
-        .with_label_values(&[data_type, client.get_label()])
+        .with_label_values(&[operation, data_type, client.get_label()])
         .inc_by(byte_count)
 }
 
 /// Increments the compression error count based on the given operation
-pub fn increment_compression_error(operation: &str, client: CompressionClient) {
+pub fn increment_compression_error(client: &CompressionClient) {
+    increment_error_count(COMPRESS, client)
+}
+
+/// Increments the decompression error count based on the given operation
+pub fn increment_decompression_error(client: &CompressionClient) {
+    increment_error_count(DECOMPRESS, client)
+}
+
+/// Increments the error count based on the given operation
+fn increment_error_count(operation: &str, client: &CompressionClient) {
     ERROR_COUNTS
         .with_label_values(&[operation, client.get_label()])
         .inc()
 }
 
-/// Starts the timer for the compression operation using the label
-pub fn start_compression_operation_timer(
-    operation: &str,
-    client: CompressionClient,
-) -> HistogramTimer {
+/// Observes the compression operation time
+pub fn observe_compression_operation_time(client: &CompressionClient, start_time: Instant) {
+    observe_operation_time(COMPRESS, client, start_time)
+}
+
+/// Observes the decompression operation time
+pub fn observe_decompression_operation_time(client: &CompressionClient, start_time: Instant) {
+    observe_operation_time(DECOMPRESS, client, start_time)
+}
+
+/// Observes the operation time based on the given operation
+fn observe_operation_time(operation: &str, client: &CompressionClient, start_time: Instant) {
     OPERATION_LATENCY
         .with_label_values(&[operation, client.get_label()])
-        .start_timer()
+        .observe(start_time.elapsed().as_secs_f64());
+}
+
+/// Updates the compression metrics for the given data sets
+pub fn update_compression_metrics(
+    client: &CompressionClient,
+    raw_data: &Vec<u8>,
+    compressed_data: &Vec<u8>,
+) {
+    update_operation_metrics(COMPRESS, client, raw_data, compressed_data);
+}
+
+/// Updates the decompression metrics for the given data sets
+pub fn update_decompression_metrics(
+    client: &CompressionClient,
+    compressed_data: &Vec<u8>,
+    raw_data: &Vec<u8>,
+) {
+    update_operation_metrics(DECOMPRESS, client, raw_data, compressed_data);
+}
+
+/// Updates the operation metrics based on the given data
+/// (e.g., raw and compressed data sizes).
+fn update_operation_metrics(
+    operation: &str,
+    client: &CompressionClient,
+    raw_data: &Vec<u8>,
+    compressed_data: &Vec<u8>,
+) {
+    increment_compression_byte_count(operation, RAW_BYTES, client, raw_data.len() as u64);
+    increment_compression_byte_count(
+        operation,
+        COMPRESSED_BYTES,
+        client,
+        compressed_data.len() as u64,
+    );
 }

--- a/crates/aptos-compression/src/metrics.rs
+++ b/crates/aptos-compression/src/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::client::CompressionClient;
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
 };
@@ -11,31 +12,6 @@ pub const COMPRESS: &str = "compress";
 pub const DECOMPRESS: &str = "decompress";
 pub const COMPRESSED_BYTES: &str = "compressed_bytes";
 pub const RAW_BYTES: &str = "raw_bytes";
-
-/// A simple enum for identifying clients of the compression crate. This
-/// allows us to provide a runtime breakdown of compression metrics for
-/// each client.
-#[derive(Clone, Debug)]
-pub enum CompressionClient {
-    Consensus,
-    Mempool,
-    StateSync,
-    DKG,
-    JWKConsensus,
-}
-
-impl CompressionClient {
-    /// Returns a summary label for the request
-    pub fn get_label(&self) -> &'static str {
-        match self {
-            Self::Consensus => "consensus",
-            Self::Mempool => "mempool",
-            Self::StateSync => "state_sync",
-            CompressionClient::DKG => "dkg",
-            CompressionClient::JWKConsensus => "jwk_consensus",
-        }
-    }
-}
 
 /// Counters for tracking the data compression ratio (i.e., total byte counts)
 pub static BYTE_COUNTS: Lazy<IntCounterVec> = Lazy::new(|| {

--- a/crates/aptos-compression/src/tests.rs
+++ b/crates/aptos-compression/src/tests.rs
@@ -16,13 +16,20 @@ use aptos_types::{
     },
     write_set::WriteSet,
 };
+use rand::Rng;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
-const MAX_COMPRESSION_SIZE: usize = 64 * 1024 * 1024;
+// Useful test constants
+const MAX_COMPRESSION_SIZE: usize = 64 * 1024 * 1024; // 64 MiBi
+const MIB: usize = 1024 * 1024;
 
 #[test]
 fn test_basic_compression() {
+    // Test compress random bytes
+    let raw_bytes: Vec<_> = (0..MIB).map(|_| rand::thread_rng().gen::<u8>()).collect();
+    test_compress_and_decompress(raw_bytes);
+
     // Test epoch ending ledger infos
     let epoch_ending_ledger_infos = create_epoch_ending_ledger_infos(0, 999);
     test_compress_and_decompress(epoch_ending_ledger_infos);
@@ -38,6 +45,7 @@ fn test_basic_compression() {
 
 #[test]
 fn test_compression_limits() {
+    // Create test data
     let too_small_bytes = 1;
     let transactions_with_proof = create_transaction_list_with_proof(1000, 1999, 1999, true);
 

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -7,7 +7,7 @@ use crate::{
     network::MempoolSyncMsg,
 };
 use anyhow::{format_err, Result};
-use aptos_compression::metrics::CompressionClient;
+use aptos_compression::client::CompressionClient;
 use aptos_config::config::{NodeConfig, MAX_APPLICATION_MESSAGE_SIZE};
 use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -5,8 +5,9 @@
 use crate::protocols::wire::handshake::v1::ProtocolId;
 use aptos_config::network_id::NetworkContext;
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
-    Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, register_histogram_vec, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec,
+    IntGauge, IntGaugeVec,
 };
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_short_hex_str::AsShortHexStr;
@@ -584,7 +585,8 @@ pub static NETWORK_APPLICATION_SERIALIZATION_METRIC: Lazy<HistogramVec> = Lazy::
     register_histogram_vec!(
         "aptos_network_serialization_metric",
         "Time it takes to perform message serialization and deserialization",
-        &["protocol_id", "operation"]
+        &["protocol_id", "operation"],
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
 });

--- a/network/framework/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/framework/src/protocols/wire/handshake/v1/mod.rs
@@ -15,7 +15,7 @@
 
 use crate::counters::{start_serialization_timer, DESERIALIZATION_LABEL, SERIALIZATION_LABEL};
 use anyhow::anyhow;
-use aptos_compression::metrics::CompressionClient;
+use aptos_compression::client::CompressionClient;
 use aptos_config::{config::MAX_APPLICATION_MESSAGE_SIZE, network_id::NetworkId};
 use aptos_types::chain_id::ChainId;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -13,7 +13,7 @@ use crate::{
     responses::Error::DegenerateRangeError,
     Epoch, StorageServiceRequest, COMPRESSION_SUFFIX_LABEL,
 };
-use aptos_compression::{client::CompressionClient, CompressedData, CompressionError};
+use aptos_compression::{client::CompressionClient, CompressedData};
 use aptos_config::config::{
     AptosDataClientConfig, StorageServiceConfig, MAX_APPLICATION_MESSAGE_SIZE,
 };
@@ -47,8 +47,8 @@ pub enum Error {
     UnexpectedResponseError(String),
 }
 
-impl From<CompressionError> for Error {
-    fn from(error: CompressionError) -> Self {
+impl From<aptos_compression::Error> for Error {
+    fn from(error: aptos_compression::Error) -> Self {
         Error::UnexpectedErrorEncountered(error.to_string())
     }
 }


### PR DESCRIPTION
### Description
This PR offers several small cleanups and metrics improvements to the `aptos-compression` crate (each in their own commit):
1. Move the compression client to a separate file. This prevents us from having to expose the metrics file globally.
2. Add a new error type so that we can differentiate between compression and decompression errors. 
3. Several small code cleanups and metric improvements. This includes: (i) adding metrics for sent and received messages (not just sent messages, as is being tracked today); (ii) better histogram buckets for tracking serialization and compression; and (iii) better metrics for tracking compression and decompression errors.

### Test Plan
New and existing test infrastructure.