### PR TITLE
[movevm] more validation for sponsored transaction

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -30,7 +30,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_state_view::StateView;
 use aptos_types::{
     account_config,
-    account_config::new_block_event_key,
+    account_config::{new_block_event_key, AccountResource},
     block_executor::{
         config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         partitioner::PartitionedTransactions,
@@ -80,6 +80,7 @@ use move_core_types::{
     ident_str,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
+    move_resource::MoveStructType,
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
     vm_status::StatusType,
@@ -479,7 +480,10 @@ impl AptosVM {
         // Storage refund is zero since no slots are deleted in aborted transactions.
         const ZERO_STORAGE_REFUND: u64 = 0;
 
-        if is_account_init_for_sponsored_transaction(txn_data, &self.features) {
+        let is_account_init_for_sponsored_transaction =
+            is_account_init_for_sponsored_transaction(txn_data, &self.features, resolver)?;
+
+        if is_account_init_for_sponsored_transaction {
             let mut session = self.new_session(resolver, SessionId::run_on_abort(txn_data));
             let status = self.inject_abort_info_if_available(status);
 
@@ -1469,7 +1473,17 @@ impl AptosVM {
             session = self.new_session(resolver, SessionId::txn_meta(&txn_data));
         }
 
-        if is_account_init_for_sponsored_transaction(&txn_data, &self.features) {
+        let is_account_init_for_sponsored_transaction =
+            match is_account_init_for_sponsored_transaction(&txn_data, &self.features, resolver) {
+                Ok(result) => result,
+                Err(err) => {
+                    let vm_status = err.into_vm_status();
+                    let discarded_output = discarded_output(vm_status.status_code());
+                    return (vm_status, discarded_output);
+                },
+            };
+
+        if is_account_init_for_sponsored_transaction {
             if let Err(err) =
                 create_account_if_does_not_exist(&mut session, gas_meter, txn.sender())
             {
@@ -2211,13 +2225,30 @@ fn create_account_if_does_not_exist(
         .map(|_return_vals| ())
 }
 
+/// Signals that the transaction should trigger the flow for creating an account as part of a
+/// sponsored transaction. This occurs when:
+/// * The feature gate is enabled SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION
+/// * There is fee payer
+/// * The sequence number is 0
+/// * There is no account resource for the account
 pub(crate) fn is_account_init_for_sponsored_transaction(
     txn_data: &TransactionMetadata,
     features: &Features,
-) -> bool {
-    txn_data.fee_payer.is_some()
-        && txn_data.sequence_number == 0
-        && features.is_enabled(FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION)
+    resolver: &impl AptosMoveResolver,
+) -> Result<bool, VMError> {
+    Ok(
+        features.is_enabled(FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION)
+            && txn_data.fee_payer.is_some()
+            && txn_data.sequence_number == 0
+            && resolver
+                .get_resource(&txn_data.sender(), &AccountResource::struct_tag())
+                .map(|data| data.is_none())
+                .map_err(|e| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!("{}", e))
+                        .finish(Location::Undefined)
+                })?,
+    )
 }
 
 #[test]

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -243,7 +243,8 @@ pub(crate) fn check_gas(
     // gas to cover storage, execution, and IO costs.
     // TODO: This isn't the cleaning code, thus we localize it just here and will remove it
     // once accountv2 is available and we no longer need to create accounts.
-    if crate::aptos_vm::is_account_init_for_sponsored_transaction(txn_metadata, features) {
+    if crate::aptos_vm::is_account_init_for_sponsored_transaction(txn_metadata, features, resolver)?
+    {
         let gas_unit_price: u64 = txn_metadata.gas_unit_price().into();
         let max_gas_amount: u64 = txn_metadata.max_gas_amount().into();
         let storage_fee_per_state_slot_create: u64 =


### PR DESCRIPTION
Test if the account resource exists before attempting to create the account resource. This solves potential devx issues around gas fees and also prevents potential errors when the account exists but sequence number 0 isn't expensive enough.

added a new test for this condition that failed prior to the fix and also retrofitted another test to be more aware of this corner case

cherry-pick from https://github.com/aptos-labs/aptos-core/pull/11474

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
