### PR TITLE
[Compiler V2] [Bugfix] Fix 11379

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -179,16 +179,15 @@ fn released_temps(
 
     // this is needed because unused vars are not released by live var info
     for dst in bytecode.dests() {
-        if !live_var_info.before.contains_key(&dst)
-            && !live_var_info.after.contains_key(&dst)
-            && !life_time_info.before.is_borrowed(dst)
-            && !life_time_info.after.is_borrowed(dst)
-        {
-            // TODO: triggered in ability-checker/ability_violation.move
-            // debug_assert!(
-            //     !life_time_info.after.is_borrowed(dst),
-            //     "dead assignment borrowed later"
-            // );
+        if !live_var_info.before.contains_key(&dst) && !live_var_info.after.contains_key(&dst) {
+            debug_assert!(
+                !life_time_info.before.is_borrowed(dst),
+                "local assigned while still borrowed"
+            );
+            debug_assert!(
+                !life_time_info.after.is_borrowed(dst),
+                "dead assignment borrowed later"
+            );
             released_temps.insert(dst);
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -167,7 +167,7 @@ fn released_temps(
         }
     }
     for t in life_time_info.released_temps() {
-        if !live_var_info.after.contains_key(&t) {
+        if life_time_info.before.is_borrowed(t) && !live_var_info.after.contains_key(&t) {
             released_temps.insert(t);
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -524,14 +524,14 @@ impl LifetimeState {
 }
 
 impl LifetimeState {
-    /// Returns the locals borrowed
-    pub fn borrowed_locals(&self) -> impl Iterator<Item = TempIndex> + '_ {
-        self.local_to_label_map.keys().cloned()
-    }
-
     /// Checks if the given local is borrowed
     pub fn is_borrowed(&self, temp: TempIndex) -> bool {
-        self.borrowed_locals().contains(&temp)
+        match self.local_to_label_map.get(&temp) {
+            Some(label) => {
+                !self.effective_children(label).is_empty()
+            },
+            None => false,
+        }
     }
 }
 

--- a/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/ability_violation.exp
@@ -308,11 +308,13 @@ fun ability::no_key($t0: address) {
   3: $t3 := move_from<ability::S<ability::Impotent>>($t0)
   4: destroy($t3)
   5: $t4 := borrow_global<ability::Impotent>($t0)
-  6: $t5 := borrow_global<ability::Impotent>($t0)
-  7: destroy($t4)
-  8: $t6 := exists<ability::Impotent>($t0)
+  6: destroy($t4)
+  7: $t5 := borrow_global<ability::Impotent>($t0)
+  8: destroy($t4)
   9: destroy($t5)
- 10: return ()
+ 10: $t6 := exists<ability::Impotent>($t0)
+ 11: destroy($t5)
+ 12: return ()
 }
 
 
@@ -434,9 +436,11 @@ fun ability::no_key($t0: address) {
   3: $t3 := move_from<ability::S<ability::Impotent>>($t0)
   4: destroy($t3)
   5: $t4 := borrow_global<ability::Impotent>($t0)
-  6: $t5 := borrow_global<ability::Impotent>($t0)
-  7: destroy($t4)
-  8: $t6 := exists<ability::Impotent>($t0)
+  6: destroy($t4)
+  7: $t5 := borrow_global<ability::Impotent>($t0)
+  8: destroy($t4)
   9: destroy($t5)
- 10: return ()
+ 10: $t6 := exists<ability::Impotent>($t0)
+ 11: destroy($t5)
+ 12: return ()
 }


### PR DESCRIPTION
### Description

Closes #11379 by changing the implementation of `is_borrowed`.

### Test Plan
Existing tests, especially `ability-checker/ability_violation.move` which triggered the debug assertion before.
