### PR TITLE
[Data Streaming Service] Add stream update notifier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "aptos-storage-service-types",
  "aptos-time-service",
  "aptos-types",
+ "arc-swap",
  "async-trait",
  "claims",
  "enum_dispatch",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -132,7 +132,7 @@ impl Default for StateSyncDriverConfig {
             continuous_syncing_mode: ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs,
             enable_auto_bootstrapping: false,
             fallback_to_output_syncing_secs: 180, // 3 minutes
-            progress_check_interval_ms: 50,
+            progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,
             max_num_stream_timeouts: 12,

--- a/state-sync/data-streaming-service/Cargo.toml
+++ b/state-sync/data-streaming-service/Cargo.toml
@@ -25,6 +25,7 @@ aptos-network = { workspace = true }
 aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 enum_dispatch = { workspace = true }
 futures = { workspace = true }

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -19,7 +19,9 @@ use crate::{
     metrics::{increment_counter, increment_counter_multiple_labels, start_timer},
     stream_engine::{DataStreamEngine, StreamEngine},
     streaming_client::{NotificationFeedback, StreamRequest},
+    streaming_service::StreamUpdateNotification,
 };
+use aptos_channels::aptos_channel;
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
 use aptos_data_client::{
     global_summary::{AdvertisedData, GlobalDataSummary},
@@ -77,6 +79,10 @@ pub struct DataStream<T> {
     // The engine for this data stream
     stream_engine: StreamEngine,
 
+    // The stream update notifier (to notify the streaming service that
+    // the stream has been updated, e.g., data is now ready to be processed).
+    stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
+
     // The current queue of data client requests and pending responses. When the
     // request at the head of the queue completes (i.e., we receive a response),
     // a data notification can be created and sent along the stream.
@@ -121,6 +127,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         data_stream_config: DataStreamingServiceConfig,
         data_stream_id: DataStreamId,
         stream_request: &StreamRequest,
+        stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
         aptos_data_client: T,
         notification_id_generator: Arc<U64IdGenerator>,
         advertised_data: &AdvertisedData,
@@ -141,6 +148,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
             data_stream_id,
             aptos_data_client,
             stream_engine,
+            stream_update_notifier,
             sent_data_requests: None,
             spawned_tasks: vec![],
             notifications_to_responses: BTreeMap::new(),
@@ -374,10 +382,12 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
 
         // Send the request to the network
         let join_handle = spawn_request_task(
+            self.data_stream_id,
             data_client_request,
             self.aptos_data_client.clone(),
             pending_client_response.clone(),
             request_timeout_ms,
+            self.stream_update_notifier.clone(),
         );
         self.spawned_tasks.push(join_handle);
 
@@ -1386,10 +1396,12 @@ fn extract_response_error(
 }
 
 fn spawn_request_task<T: AptosDataClientInterface + Send + Clone + 'static>(
+    data_stream_id: DataStreamId,
     data_client_request: DataClientRequest,
     aptos_data_client: T,
     pending_response: PendingClientResponse,
     request_timeout_ms: u64,
+    stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
 ) -> JoinHandle<()> {
     // Update the requests sent counter
     increment_counter(
@@ -1488,6 +1500,10 @@ fn spawn_request_task<T: AptosDataClientInterface + Send + Clone + 'static>(
 
         // Save the response
         pending_response.lock().client_response = Some(client_response);
+
+        // Send a notification via the stream update notifier
+        let stream_update_notification = StreamUpdateNotification::new(data_stream_id);
+        let _ = stream_update_notifier.push((), stream_update_notification);
     })
 }
 
@@ -1702,4 +1718,65 @@ async fn subscribe_to_transactions_or_outputs_with_proof<
     );
     let (context, payload) = client_response.await?.into_parts();
     Ok(Response::new(context, ResponsePayload::try_from(payload)?))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tests::utils::MockAptosDataClient;
+    use aptos_channels::message_queues::QueueStyle;
+    use futures::StreamExt;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn completed_request_notifies_streaming_service() {
+        // Create a data client request
+        let data_client_request =
+            DataClientRequest::NumberOfStates(NumberOfStatesRequest { version: 0 });
+
+        // Create a mock data client
+        let data_client_config = AptosDataClientConfig::default();
+        let aptos_data_client =
+            MockAptosDataClient::new(data_client_config, true, false, true, true);
+
+        // Create a new pending client response
+        let pending_client_response = Arc::new(Mutex::new(Box::new(
+            data_notification::PendingClientResponse::new(data_client_request.clone()),
+        )));
+
+        // Create a stream update notifier and listener
+        let (stream_update_notifier, mut stream_update_listener) =
+            aptos_channel::new(QueueStyle::LIFO, 1, None);
+
+        // Verify the request is still pending (the request hasn't been sent yet)
+        assert!(pending_client_response.lock().client_response.is_none());
+
+        // Spawn the request task
+        let data_stream_id = 10101;
+        let join_handle = spawn_request_task(
+            data_stream_id,
+            data_client_request,
+            aptos_data_client,
+            pending_client_response.clone(),
+            1000,
+            stream_update_notifier.clone(),
+        );
+
+        // Wait for the request to complete
+        join_handle.await.unwrap();
+
+        // Verify the request was completed and we now have a response
+        assert!(pending_client_response.lock().client_response.is_some());
+
+        // Verify that a stream update notification is received
+        match timeout(Duration::from_secs(5), stream_update_listener.next()).await {
+            Ok(Some(stream_update_notification)) => {
+                assert_eq!(stream_update_notification.data_stream_id, data_stream_id);
+            },
+            result => panic!(
+                "Stream update notification was not received! Result: {:?}",
+                result
+            ),
+        }
+    }
 }

--- a/state-sync/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/streaming_service.rs
@@ -11,6 +11,7 @@ use crate::{
         StreamRequest, StreamRequestMessage, StreamingServiceListener, TerminateStreamRequest,
     },
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
 use aptos_data_client::{
     global_summary::{GlobalDataSummary, OptimalChunkSizes},
@@ -24,11 +25,30 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 
+// Note: we limit the queue depth to 1 because it doesn't make sense for the progress checker
+// to execute for every notification (because it will process all the updates at once, anyway).
+// Thus, if there are X pending notifications, the first one will handle all pending updates, and
+// the next X-1 will be no-ops. This prevents us from wasting the CPU, unnecessarily.
+const STREAM_PROGRESS_UPDATE_CHANNEL_SIZE: usize = 1;
+
 // Useful constants for the Data Streaming Service
 const GLOBAL_DATA_REFRESH_LOG_FREQ_SECS: u64 = 3;
 const NO_DATA_TO_FETCH_LOG_FREQ_SECS: u64 = 3;
 const STREAM_REQUEST_ERROR_LOG_FREQ_SECS: u64 = 3;
 const TERMINATE_NO_FEEDBACK: &str = "no_feedback";
+
+/// A simple notification sent to the storage service when a
+/// stream has been updated and is ready to be processed.
+#[derive(Clone, Copy, Debug)]
+pub struct StreamUpdateNotification {
+    pub data_stream_id: DataStreamId,
+}
+
+impl StreamUpdateNotification {
+    pub fn new(data_stream_id: DataStreamId) -> Self {
+        Self { data_stream_id }
+    }
+}
 
 /// The data streaming service that responds to data stream requests.
 pub struct DataStreamingService<T> {
@@ -50,6 +70,14 @@ pub struct DataStreamingService<T> {
     // The listener through which to hear new client stream requests
     stream_requests: StreamingServiceListener,
 
+    // The stream update notifier that notifies the streaming service to check
+    // the progress of the data streams. This provides a way for data streams
+    // to immediately notify the streaming service when new data is ready.
+    stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
+
+    // The stream update listener to listen for data stream update notifications
+    stream_update_listener: aptos_channel::Receiver<(), StreamUpdateNotification>,
+
     // Unique ID generators to maintain unique IDs across streams
     stream_id_generator: U64IdGenerator,
     notification_id_generator: Arc<U64IdGenerator>,
@@ -66,6 +94,11 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
         stream_requests: StreamingServiceListener,
         time_service: TimeService,
     ) -> Self {
+        // Create the stream update notifier and listener
+        let (stream_update_notifier, stream_update_listener) =
+            aptos_channel::new(QueueStyle::LIFO, STREAM_PROGRESS_UPDATE_CHANNEL_SIZE, None);
+
+        // Create the streaming service
         Self {
             data_client_config,
             streaming_service_config,
@@ -73,6 +106,8 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
             global_data_summary: GlobalDataSummary::empty(),
             data_streams: HashMap::new(),
             stream_requests,
+            stream_update_notifier,
+            stream_update_listener,
             stream_id_generator: U64IdGenerator::new(),
             notification_id_generator: Arc::new(U64IdGenerator::new()),
             time_service,
@@ -81,25 +116,40 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
 
     /// Starts the dedicated streaming service
     pub async fn start_service(mut self) {
+        // Create a ticker that periodically refreshes the global data summary
         let mut data_refresh_interval = IntervalStream::new(interval(Duration::from_millis(
             self.streaming_service_config
                 .global_summary_refresh_interval_ms,
         )))
         .fuse();
+
+        // Create a ticker that periodically checks the progress of all data streams
         let mut progress_check_interval = IntervalStream::new(interval(Duration::from_millis(
             self.streaming_service_config.progress_check_interval_ms,
         )))
         .fuse();
 
+        // Start the service loop
         loop {
             ::futures::select! {
                 stream_request = self.stream_requests.select_next_some() => {
-                    self.handle_stream_request_message(stream_request);
+                    self.handle_stream_request_message(stream_request, self.stream_update_notifier.clone());
                 }
                 _ = data_refresh_interval.select_next_some() => {
                     self.refresh_global_data_summary();
                 }
                 _ = progress_check_interval.select_next_some() => {
+                    // Check the progress of all data streams at a scheduled interval
+                    self.check_progress_of_all_data_streams().await;
+                }
+                notification = self.stream_update_listener.select_next_some() => {
+                    // Check the progress of all data streams when notified
+                    trace!(LogSchema::new(LogEntry::CheckStreamProgress)
+                            .message(&format!(
+                                "Received update notification from: {:?}.",
+                                notification.data_stream_id
+                            ))
+                        );
                     self.check_progress_of_all_data_streams().await;
                 }
             }
@@ -107,7 +157,11 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
     }
 
     /// Handles new stream request messages from clients
-    fn handle_stream_request_message(&mut self, request_message: StreamRequestMessage) {
+    fn handle_stream_request_message(
+        &mut self,
+        request_message: StreamRequestMessage,
+        stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
+    ) {
         if let StreamRequest::TerminateStream(request) = request_message.stream_request {
             // Process the feedback request
             if let Err(error) = self.process_terminate_stream_request(&request) {
@@ -119,7 +173,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
         }
 
         // Process the stream request
-        let response = self.process_new_stream_request(&request_message);
+        let response = self.process_new_stream_request(&request_message, stream_update_notifier);
         if let Err(error) = &response {
             sample!(
                 SampleRate::Duration(Duration::from_secs(STREAM_REQUEST_ERROR_LOG_FREQ_SECS)),
@@ -198,6 +252,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
     fn process_new_stream_request(
         &mut self,
         request_message: &StreamRequestMessage,
+        stream_update_notifier: aptos_channel::Sender<(), StreamUpdateNotification>,
     ) -> Result<DataStreamListener, Error> {
         // Increment the stream creation counter
         metrics::increment_counter(
@@ -215,6 +270,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStreamingService<
             self.streaming_service_config,
             stream_id,
             &request_message.stream_request,
+            stream_update_notifier,
             self.aptos_data_client.clone(),
             self.notification_id_generator.clone(),
             &self.global_data_summary.advertised_data,
@@ -397,12 +453,21 @@ mod streaming_service_tests {
         data_stream::{DataStreamId, DataStreamListener},
         error::Error,
         streaming_client::{
-            GetAllStatesRequest, NotificationAndFeedback, NotificationFeedback, StreamRequest,
-            StreamRequestMessage, TerminateStreamRequest,
+            DataStreamingClient, GetAllStatesRequest, NotificationAndFeedback,
+            NotificationFeedback, StreamRequest, StreamRequestMessage, TerminateStreamRequest,
         },
+        streaming_service::StreamUpdateNotification,
         tests,
-        tests::utils::MIN_ADVERTISED_STATES,
+        tests::{
+            streaming_service,
+            utils::{
+                get_data_notification, MIN_ADVERTISED_EPOCH_END, MIN_ADVERTISED_STATES,
+                MIN_ADVERTISED_TRANSACTION_OUTPUT,
+            },
+        },
     };
+    use aptos_channels::{aptos_channel, message_queues::QueueStyle};
+    use aptos_config::config::DataStreamingServiceConfig;
     use futures::{
         channel::{oneshot, oneshot::Receiver},
         FutureExt, StreamExt,
@@ -414,6 +479,74 @@ mod streaming_service_tests {
     use tokio::time::timeout;
 
     const MAX_STREAM_WAIT_SECS: u64 = 60;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_check_stream_progress_update() {
+        // Create a streaming service config with an infrequent progress check interval
+        let streaming_service_config = DataStreamingServiceConfig {
+            progress_check_interval_ms: 1_000_000,
+            ..Default::default()
+        };
+
+        // Create the streaming client and service
+        let (streaming_client, streaming_service) =
+            streaming_service::create_streaming_client_and_server(
+                Some(streaming_service_config),
+                false,
+                false,
+                true,
+                false,
+            );
+
+        // Get the stream update notifier
+        let stream_update_notifier = streaming_service.stream_update_notifier.clone();
+
+        // Spawn the storage service
+        tokio::spawn(streaming_service.start_service());
+
+        // Request a continuous output stream and get a data stream listener
+        let mut stream_listener = streaming_client
+            .continuously_stream_transaction_outputs(
+                MIN_ADVERTISED_TRANSACTION_OUTPUT - 1,
+                MIN_ADVERTISED_EPOCH_END,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Get the first data notification from the stream
+        let _ = get_data_notification(&mut stream_listener).await.unwrap();
+
+        // Continuously send update notifications to the streaming service
+        // until the next data notification is received.
+        let wait_for_notification = async move {
+            loop {
+                // Send an update notification to the streaming service
+                stream_update_notifier
+                    .push((), StreamUpdateNotification::new(0))
+                    .unwrap();
+
+                // Sleep for a while
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                // Check if a data notification was received
+                if get_data_notification(&mut stream_listener).await.is_ok() {
+                    return; // Data notification received!
+                }
+            }
+        };
+        if let Err(error) = timeout(
+            Duration::from_secs(MAX_STREAM_WAIT_SECS),
+            wait_for_notification,
+        )
+        .await
+        {
+            panic!(
+                "Failed to send update notification to streaming service: {:?}",
+                error
+            );
+        }
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_drop_data_streams() {
@@ -434,7 +567,10 @@ mod streaming_service_tests {
             for _ in 0..num_data_streams {
                 // Create a new data stream
                 let (new_stream_request, response_receiver) = create_new_stream_request();
-                streaming_service.handle_stream_request_message(new_stream_request);
+                streaming_service.handle_stream_request_message(
+                    new_stream_request,
+                    create_stream_update_notifier(),
+                );
                 let data_stream_listener =
                     response_receiver.now_or_never().unwrap().unwrap().unwrap();
                 let data_stream_id = data_stream_listener.data_stream_id;
@@ -489,7 +625,10 @@ mod streaming_service_tests {
             for _ in 0..num_data_streams {
                 // Create a new data stream
                 let (new_stream_request, response_receiver) = create_new_stream_request();
-                streaming_service.handle_stream_request_message(new_stream_request);
+                streaming_service.handle_stream_request_message(
+                    new_stream_request,
+                    create_stream_update_notifier(),
+                );
                 let data_stream_listener =
                     response_receiver.now_or_never().unwrap().unwrap().unwrap();
                 let data_stream_id = data_stream_listener.data_stream_id;
@@ -523,7 +662,10 @@ mod streaming_service_tests {
                 // Terminate the data stream (with no feedback)
                 let (terminate_stream_request, _) =
                     create_terminate_stream_request(data_stream_id, None);
-                streaming_service.handle_stream_request_message(terminate_stream_request);
+                streaming_service.handle_stream_request_message(
+                    terminate_stream_request,
+                    create_stream_update_notifier(),
+                );
 
                 // Verify the stream has been removed
                 let all_data_stream_ids = streaming_service.get_all_data_stream_ids();
@@ -556,7 +698,10 @@ mod streaming_service_tests {
                 for _ in 0..num_data_streams {
                     // Create a new data stream
                     let (new_stream_request, response_receiver) = create_new_stream_request();
-                    streaming_service.handle_stream_request_message(new_stream_request);
+                    streaming_service.handle_stream_request_message(
+                        new_stream_request,
+                        create_stream_update_notifier(),
+                    );
                     let data_stream_listener =
                         response_receiver.now_or_never().unwrap().unwrap().unwrap();
                     let data_stream_id = data_stream_listener.data_stream_id;
@@ -591,8 +736,10 @@ mod streaming_service_tests {
                                 *data_stream_id,
                                 notification_and_feedback,
                             );
-                            streaming_service
-                                .handle_stream_request_message(terminate_stream_request);
+                            streaming_service.handle_stream_request_message(
+                                terminate_stream_request,
+                                create_stream_update_notifier(),
+                            );
 
                             // Verify the stream has been removed
                             let all_data_stream_ids = streaming_service.get_all_data_stream_ids();
@@ -648,5 +795,11 @@ mod streaming_service_tests {
             response_sender,
         };
         (request_message, response_receiver)
+    }
+
+    /// Creates a returns a new stream update notifier (dropping the listener)
+    fn create_stream_update_notifier() -> aptos_channel::Sender<(), StreamUpdateNotification> {
+        let (stream_update_notifier, _) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+        stream_update_notifier
     }
 }

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -20,6 +20,7 @@ use crate::{
         GetAllTransactionsOrOutputsRequest, GetAllTransactionsRequest, NotificationFeedback,
         StreamRequest,
     },
+    streaming_service::StreamUpdateNotification,
     tests::utils::{
         create_data_client_response, create_ledger_info, create_output_list_with_proof,
         create_random_u64, create_transaction_list_with_proof, get_data_notification,
@@ -29,6 +30,7 @@ use crate::{
         MIN_ADVERTISED_TRANSACTION, MIN_ADVERTISED_TRANSACTION_OUTPUT,
     },
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
 use aptos_data_client::{
     global_summary::{AdvertisedData, GlobalDataSummary, OptimalChunkSizes},
@@ -2063,6 +2065,7 @@ fn create_data_stream(
         streaming_service_config,
         create_random_u64(10000),
         &stream_request,
+        create_stream_update_notifier(),
         aptos_data_client,
         notification_generator,
         &advertised_data,
@@ -2113,6 +2116,12 @@ fn create_optimal_chunk_sizes(chunk_sizes: u64) -> OptimalChunkSizes {
         transaction_chunk_size: chunk_sizes,
         transaction_output_chunk_size: chunk_sizes,
     }
+}
+
+/// Creates a returns a new stream update notifier (dropping the listener)
+fn create_stream_update_notifier() -> aptos_channel::Sender<(), StreamUpdateNotification> {
+    let (stream_update_notifier, _) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+    stream_update_notifier
 }
 
 /// A utility function that creates and returns all types of


### PR DESCRIPTION
### Description
This PR adds a stream update notifier to the data streaming service. Whenever a data response is now received, the stream update notifier will be used to notify the data streaming service to process the response immediately (as opposed to waiting for each loop iteration at `50ms` apart). This helps to reduce the time between when a data response is received, and state sync is able to process it (this reduction is evident in the experiments).

The PR offers two commits:
1. Add a simple stream update notifier to the data streaming service (including several unit tests). Note: we still keep the existing (periodic) progress checks for redundancy. We can consider removing these in the future, but I'd prefer to leave them as-is (for now).
2. Spawn a dedicated task for data summary refreshes, so that it can be moved out of the streaming service loop.

### Test Plan
Existing test infrastructure.