### PR TITLE
[compiler-v2] Enable aptos transactional tests for debugging

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/src/lib.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/lib.rs
@@ -4,4 +4,4 @@
 
 mod aptos_test_harness;
 
-pub use aptos_test_harness::run_aptos_test;
+pub use aptos_test_harness::{run_aptos_test, run_aptos_test_with_config};

--- a/aptos-move/aptos-transactional-test-harness/tests/tests.rs
+++ b/aptos-move/aptos-transactional-test-harness/tests/tests.rs
@@ -2,6 +2,18 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_transactional_test_harness::run_aptos_test;
+use aptos_transactional_test_harness::run_aptos_test_with_config;
+use move_transactional_test_runner::vm_test_harness::TestRunConfig;
+use std::path::Path;
 
-datatest_stable::harness!(run_aptos_test, "tests", r".*\.(mvir|move)$");
+datatest_stable::harness!(runner, "tests", r".*\.(mvir|move)$");
+
+fn runner(path: &Path) -> anyhow::Result<(), Box<dyn std::error::Error>> {
+    if path.to_str().unwrap().contains("v2-tests/") {
+        // TODO: we may later want to change this to comparison testing. For now we are mostly
+        //    interested in debugging v2 bytecode.
+        run_aptos_test_with_config(path, TestRunConfig::CompilerV2)
+    } else {
+        run_aptos_test_with_config(path, TestRunConfig::CompilerV1)
+    }
+}

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/smoke_test.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/smoke_test.exp
@@ -1,0 +1,87 @@
+processed 6 tasks
+
+task 1 'print-bytecode'. lines 4-30:
+// Move bytecode v7
+module f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6.hello_world {
+use 0000000000000000000000000000000000000000000000000000000000000001::string;
+use 0000000000000000000000000000000000000000000000000000000000000001::aptos_coin;
+use 0000000000000000000000000000000000000000000000000000000000000001::coin;
+use 0000000000000000000000000000000000000000000000000000000000000001::signer;
+
+
+struct ModuleData has store, key {
+	global_counter: u64,
+	state: String
+}
+
+public foo(Arg0: address): u64 {
+B0:
+	0: MoveLoc[0](Arg0: address)
+	1: Call coin::balance<AptosCoin>(address): u64
+	2: Ret
+}
+entry public hi(Arg0: &signer, Arg1: String) {
+L0:	loc2: String
+B0:
+	0: MoveLoc[0](Arg0: &signer)
+	1: Call signer::address_of(&signer): address
+	2: MutBorrowGlobal[0](ModuleData)
+	3: StLoc[2](loc0: &mut ModuleData)
+	4: CopyLoc[2](loc0: &mut ModuleData)
+	5: MutBorrowField[0](ModuleData.state: String)
+	6: StLoc[3](loc1: &mut String)
+	7: CopyLoc[1](Arg1: String)
+	8: StLoc[4](loc2: String)
+	9: MoveLoc[4](loc2: String)
+	10: CopyLoc[3](loc1: &mut String)
+	11: WriteRef
+	12: MoveLoc[3](loc1: &mut String)
+	13: Pop
+	14: MoveLoc[2](loc0: &mut ModuleData)
+	15: Pop
+	16: Ret
+}
+init_module(Arg0: &signer) {
+L0:	loc1: vector<u8>
+L1:	loc2: String
+L2:	loc3: String
+L3:	loc4: ModuleData
+B0:
+	0: LdU64(0)
+	1: LdConst[0](Vector(U8): [4, 105, 110, 105, 116])
+	2: StLoc[1](loc0: vector<u8>)
+	3: CopyLoc[1](loc0: vector<u8>)
+	4: StLoc[2](loc1: vector<u8>)
+	5: MoveLoc[2](loc1: vector<u8>)
+	6: Call string::utf8(vector<u8>): String
+	7: StLoc[3](loc2: String)
+	8: CopyLoc[3](loc2: String)
+	9: StLoc[4](loc3: String)
+	10: MoveLoc[4](loc3: String)
+	11: Pack[0](ModuleData)
+	12: StLoc[5](loc4: ModuleData)
+	13: MoveLoc[0](Arg0: &signer)
+	14: MoveLoc[5](loc4: ModuleData)
+	15: MoveTo[0](ModuleData)
+	16: Ret
+}
+}
+
+task 3 'run'. lines 65-65:
+Events:
+{
+    type:    0x1::transaction_fee::FeeStatement
+    data:    "05000000000000000400000000000000020000000000000000000000000000000000000000000000"
+}mutable inputs after call: local#0: 0
+return values: 0
+
+task 4 'view'. lines 67-67:
+store key 0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::hello_world::ModuleData {
+    global_counter: 0
+    state: copy drop store 0x1::string::String {
+        bytes: 68656c6c6f20776f726c64
+    }
+}
+
+task 5 'run'. lines 69-69:
+Error: Failed to execute transaction. ExecutionStatus: MoveAbort { location: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6::hello_world, code: 12, info: None }

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/smoke_test.move
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/smoke_test.move
@@ -1,0 +1,69 @@
+//# init --addresses Alice=0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6
+//#      --private-keys Alice=56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
+
+//# print-bytecode --input module
+module Alice::hello_world {
+    use aptos_framework::signer;
+    use aptos_framework::coin;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use std::string::{Self, String};
+
+    struct ModuleData has key, store {
+        global_counter: u64,
+        state: String,
+    }
+
+    fun init_module(sender: &signer) {
+        move_to(
+            sender,
+            ModuleData { global_counter: 0, state: string::utf8(b"init") }
+        );
+    }
+
+    public fun foo(addr: address): u64 {
+        coin::balance<AptosCoin>(addr)
+    }
+
+    public entry fun hi(sender: &signer, msg: String) acquires ModuleData {
+        borrow_global_mut<ModuleData>(signer::address_of(sender)).state = msg;
+    }
+}
+
+//# publish --private-key 56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
+module Alice::hello_world {
+    use aptos_framework::signer;
+    use aptos_framework::coin;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use std::string::{Self, String};
+
+    struct ModuleData has key, store {
+        global_counter: u64,
+        state: String,
+    }
+
+    fun init_module(sender: &signer) {
+        move_to(
+            sender,
+            ModuleData { global_counter: 0, state: string::utf8(b"init") }
+        );
+    }
+
+    public fun foo(addr: address): u64 {
+        coin::balance<AptosCoin>(addr)
+    }
+
+    public entry fun hi(sender: &signer, msg: String) acquires ModuleData {
+        borrow_global_mut<ModuleData>(signer::address_of(sender)).state = msg;
+    }
+
+    public entry fun hi_abort(sender: &signer) {
+        assert!(!exists<ModuleData>(signer::address_of(sender)), 12);
+    }
+}
+
+
+//# run --signers Alice --args x"68656C6C6F20776F726C64" --show-events -- Alice::hello_world::hi
+
+//# view --address Alice --resource Alice::hello_world::ModuleData
+
+//# run --signers Alice -- Alice::hello_world::hi_abort

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -686,11 +686,13 @@ fn compile_source_unit_v2(
                     .map(|p| p.to_string_lossy().to_string())
             })
             .collect();
+        remove_sub_dirs(&mut dirs);
         dirs.extend(deps.iter().cloned());
         dirs.into_iter().collect()
     } else {
         deps.to_vec()
     };
+
     let options = move_compiler_v2::Options {
         sources: vec![path],
         dependencies: deps,
@@ -718,6 +720,17 @@ fn compile_source_unit_v2(
         Ok((unit, None))
     } else {
         Ok((unit, Some(error_str)))
+    }
+}
+
+fn remove_sub_dirs(dirs: &mut BTreeSet<String>) {
+    for dir in dirs.clone() {
+        for other_dir in dirs.clone() {
+            if dir != other_dir && dir.starts_with(&other_dir) {
+                dirs.remove(&dir);
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This just sets the framework up so we can test v2 code. It doesn't yet configure comparison testing which we may do later
