### PR TITLE
[compiler-v2] Fixes an issues in file format gen if temp is used twice

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/approx_the_same.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/approx_the_same.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/approx_the_same.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/approx_the_same.move
@@ -1,0 +1,26 @@
+//# publish
+module 0x42::m {
+    fun assert_approx_the_same(x: u256, y: u256, precision: u128) {
+        if (x < y) {
+            let tmp = x;
+            x = y;
+            y = tmp;
+        };
+        let mult = 1u256;
+        let n = 10u256;
+        while (precision > 0) {
+            if (precision % 2 == 1) {
+                mult = mult * n;
+            };
+            precision = precision / 2;
+            n = n * n; // previous bug: alive in same instr but not after
+        };
+        assert!((x - y) * mult < x, 0);
+    }
+
+    fun exec() {
+        assert_approx_the_same(5672, 5672, 0)
+    }
+}
+
+//# run 0x42::m::exec


### PR DESCRIPTION
The function_generator uses liveness checks to determine whether to copy or move values onto the stack. This check worked wrong for an instruction like `y := OP x,x`. Since `x` is not alive after the instruction, `x` will be moved twice onto the stack, leading to MOVELOC_UNAVAILABLE error.

