### PR TITLE
[compiler-v2] Fixes an issue in post-processing of exp_builder

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/spec_construct.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/spec_construct.exp
@@ -8,7 +8,7 @@ module 0x42::m {
         data: vector<m::E>,
     }
     public fun foo(v: &m::S): u8 {
-        select m::E.k(vector::borrow<m::E>(Borrow(Immutable)(NoOp(v)), 0))
+        select m::E.k(vector::borrow<m::E>(Borrow(Immutable)(select m::S.data(v)), 0))
     }
     spec fun $foo(v: m::S): u8 {
         select m::E.k(vector::$borrow<m::E>(select m::S.data(v), 0))
@@ -22,13 +22,12 @@ public fun m::foo($t0: &m::S): u8 {
      var $t1: u8
      var $t2: &m::E
      var $t3: &vector<m::E>
-     var $t4: vector<m::E>
-     var $t5: u64
-     var $t6: &u8
-  0: $t3 := borrow_local($t4)
-  1: $t5 := 0
-  2: $t2 := vector::borrow<m::E>($t3, $t5)
-  3: $t6 := borrow_field<m::E>.k($t2)
-  4: $t1 := read_ref($t6)
+     var $t4: u64
+     var $t5: &u8
+  0: $t3 := borrow_field<m::S>.data($t0)
+  1: $t4 := 0
+  2: $t2 := vector::borrow<m::E>($t3, $t4)
+  3: $t5 := borrow_field<m::E>.k($t2)
+  4: $t1 := read_ref($t5)
   5: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.exp
@@ -1,0 +1,54 @@
+// ---- Model Dump
+module 0x42::simple_map {
+    use std::error;
+    use std::option;
+    use std::vector;
+    struct Element {
+        key: #0,
+        value: #1,
+    }
+    struct SimpleMap {
+        data: vector<simple_map::Element<#0, #1>>,
+    }
+    public fun borrow<Key,Value>(map: &simple_map::SimpleMap<#0, #1>,key: &#0): &#1 {
+        {
+          let maybe_idx: option::Option<u64> = simple_map::find<Key, Value>(map, key);
+          if option::is_some<u64>(Borrow(Immutable)(maybe_idx)) {
+            Tuple()
+          } else {
+            Abort(error::invalid_argument(2))
+          };
+          {
+            let idx: u64 = option::extract<u64>(Borrow(Mutable)(maybe_idx));
+            Borrow(Immutable)(select simple_map::Element.value(vector::borrow<simple_map::Element<Key, Value>>(Borrow(Immutable)(select simple_map::SimpleMap.data(map)), idx)))
+          }
+        }
+    }
+    private fun find<Key,Value>(map: &simple_map::SimpleMap<#0, #1>,key: &#0): option::Option<u64> {
+        {
+          let leng: u64 = vector::length<simple_map::Element<Key, Value>>(Borrow(Immutable)(select simple_map::SimpleMap.data(map)));
+          {
+            let i: u64 = 0;
+            loop {
+              if Lt<u64>(i, leng) {
+                {
+                  let element: &simple_map::Element<Key, Value> = vector::borrow<simple_map::Element<Key, Value>>(Borrow(Immutable)(select simple_map::SimpleMap.data(map)), i);
+                  if Eq<&Key>(Borrow(Immutable)(select simple_map::Element.key(element)), key) {
+                    return option::some<u64>(i)
+                  } else {
+                    Tuple()
+                  };
+                  i: u64 = Add<u64>(i, 1);
+                  Tuple()
+                }
+              } else {
+                break
+              }
+            };
+            option::none<u64>()
+          }
+        }
+    }
+    spec fun $borrow<Key,Value>(map: &simple_map::SimpleMap<#0, #1>,key: &#0): &#1;
+    spec fun $find<Key,Value>(map: &simple_map::SimpleMap<#0, #1>,key: &#0): option::Option<u64>;
+} // end 0x42::simple_map

--- a/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.move
@@ -1,0 +1,44 @@
+module 0x42::simple_map {
+    use std::error;
+    use std::option;
+    use std::vector;
+
+    const EKEY_NOT_FOUND: u64 = 2;
+
+    struct SimpleMap<Key, Value> has copy, drop, store {
+        data: vector<Element<Key, Value>>,
+    }
+
+    struct Element<Key, Value> has copy, drop, store {
+        key: Key,
+        value: Value,
+    }
+
+    public fun borrow<Key: store, Value: store>(
+        map: &SimpleMap<Key, Value>,
+        key: &Key,
+    ): &Value {
+        let maybe_idx = find(map, key);
+        assert!(option::is_some(&maybe_idx), error::invalid_argument(EKEY_NOT_FOUND));
+        let idx = option::extract(&mut maybe_idx);
+        // Below call triggers nested post processing for inner .data and outer .value selection
+        &vector::borrow(&map.data, idx).value
+    }
+
+
+    fun find<Key: store, Value: store>(
+        map: &SimpleMap<Key, Value>,
+        key: &Key,
+    ): option::Option<u64> {
+        let leng = vector::length(&map.data);
+        let i = 0;
+        while (i < leng) {
+            let element = vector::borrow(&map.data, i);
+            if (&element.key == key) {
+                return option::some(i)
+            };
+            i = i + 1;
+        };
+        option::none<u64>()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
@@ -12,14 +12,13 @@ public fun m::foo($t0: &m::S): u8 {
      var $t1: u8
      var $t2: &m::E
      var $t3: &vector<m::E>
-     var $t4: vector<m::E>
-     var $t5: u64
-     var $t6: &u8
-  0: $t3 := borrow_local($t4)
-  1: $t5 := 0
-  2: $t2 := vector::borrow<m::E>($t3, $t5)
-  3: $t6 := borrow_field<m::E>.k($t2)
-  4: $t1 := read_ref($t6)
+     var $t4: u64
+     var $t5: &u8
+  0: $t3 := borrow_field<m::S>.data($t0)
+  1: $t4 := 0
+  2: $t2 := vector::borrow<m::E>($t3, $t4)
+  3: $t5 := borrow_field<m::E>.k($t2)
+  4: $t1 := read_ref($t5)
   5: return $t1
 }
 
@@ -39,19 +38,18 @@ public fun m::foo($t0: &m::S): u8 {
      var $t1: u8
      var $t2: &m::E
      var $t3: &vector<m::E>
-     var $t4: vector<m::E>
-     var $t5: u64
-     var $t6: &u8
-     # live vars: $t4
-  0: $t3 := borrow_local($t4)
+     var $t4: u64
+     var $t5: &u8
+     # live vars: $t0
+  0: $t3 := borrow_field<m::S>.data($t0)
      # live vars: $t3
-  1: $t5 := 0
-     # live vars: $t3, $t5
-  2: $t2 := vector::borrow<m::E>($t3, $t5)
+  1: $t4 := 0
+     # live vars: $t3, $t4
+  2: $t2 := vector::borrow<m::E>($t3, $t4)
      # live vars: $t2
-  3: $t6 := borrow_field<m::E>.k($t2)
-     # live vars: $t6
-  4: $t1 := read_ref($t6)
+  3: $t5 := borrow_field<m::E>.k($t2)
+     # live vars: $t5
+  4: $t1 := read_ref($t5)
      # live vars: $t1
   5: return $t1
 }
@@ -73,11 +71,12 @@ B0:
 }
 public foo(Arg0: &S): u8 {
 B0:
-	0: ImmBorrowLoc[1](loc0: vector<E>)
-	1: LdU64(0)
-	2: VecImmBorrow(3)
-	3: ImmBorrowField[0](E.k: u8)
-	4: ReadRef
-	5: Ret
+	0: MoveLoc[0](Arg0: &S)
+	1: ImmBorrowField[0](S.data: vector<E>)
+	2: LdU64(0)
+	3: VecImmBorrow(3)
+	4: ImmBorrowField[1](E.k: u8)
+	5: ReadRef
+	6: Ret
 }
 }

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1521,7 +1521,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                                     .specialize_with_defaults(struct_ty)
                                     .skip_reference()
                                 {
-                                    RewriteResult::Rewritten(
+                                    RewriteResult::RewrittenAndDescend(
                                         ExpData::Call(
                                             id,
                                             Operation::Select(


### PR DESCRIPTION
During building of expressions, placeholders are used for expressions which can't be decided because of incomplete type inference. At the end when inference is complete, a post processing phase is run to replace those placeholders. This uses the expression rewriter, but that one doesn't descend on rewrite steps.

This adds a new `RewrittenAndDescend` variant to rewrite functions which instructs the rewriter to descend on rewritten exps. Fortunately, this is cleanly possible because we not longer use `Result` as a return value.

Adds one test case which exposed this behavior from `simple_map` in the aptos stdlib.
