### PR TITLE
[dag] concurrent dag store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7469,7 +7469,7 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
  "impl-rlp",
- "scale-info 2.10.0",
+ "scale-info 1.0.0",
  "tiny-keccak",
 ]
 
@@ -7550,7 +7550,7 @@ dependencies = [
  "impl-codec 0.6.0",
  "impl-rlp",
  "primitive-types 0.12.2",
- "scale-info 2.10.0",
+ "scale-info 1.0.0",
  "uint",
 ]
 
@@ -12869,7 +12869,7 @@ dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
  "impl-rlp",
- "scale-info 2.10.0",
+ "scale-info 1.0.0",
  "uint",
 ]
 

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    dag_store::PersistentDagStore,
+    dag_store::DagStore,
     observability::counters::{NUM_NODES_PER_BLOCK, NUM_ROUNDS_PER_BLOCK},
 };
 use crate::{
@@ -91,7 +91,7 @@ pub(crate) fn compute_initial_block_and_ledger_info(
 
 pub(super) struct OrderedNotifierAdapter {
     executor_channel: UnboundedSender<OrderedBlocks>,
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     parent_block_info: Arc<RwLock<BlockInfo>>,
     epoch_state: Arc<EpochState>,
     ledger_info_provider: Arc<RwLock<LedgerInfoProvider>>,
@@ -101,7 +101,7 @@ pub(super) struct OrderedNotifierAdapter {
 impl OrderedNotifierAdapter {
     pub(super) fn new(
         executor_channel: UnboundedSender<OrderedBlocks>,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
         epoch_state: Arc<EpochState>,
         parent_block_info: BlockInfo,
         ledger_info_provider: Arc<RwLock<LedgerInfoProvider>>,

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -8,7 +8,7 @@ use super::{
     dag_handler::NetworkHandler,
     dag_network::TDAGNetworkSender,
     dag_state_sync::{DagStateSynchronizer, StateSyncTrigger},
-    dag_store::Dag,
+    dag_store::PersistentDagStore,
     health::{ChainHealthBackoff, HealthBackoff, PipelineLatencyBasedBackpressure, TChainHealth},
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
@@ -60,7 +60,7 @@ use futures_channel::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, ops::Deref, sync::Arc, time::Duration};
 use tokio::{
     runtime::Handle,
     select,
@@ -70,7 +70,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 
 #[derive(Clone)]
 struct BootstrapBaseState {
-    dag_store: Arc<RwLock<Dag>>,
+    dag_store: Arc<PersistentDagStore>,
     order_rule: OrderRule,
     ledger_info_provider: Arc<dyn TLedgerInfoProvider>,
     ordered_notifier: Arc<OrderedNotifierAdapter>,
@@ -131,7 +131,7 @@ impl ActiveMode {
     ) -> Option<Mode> {
         info!(
             LogSchema::new(LogEvent::ActiveMode)
-                .round(self.base_state.dag_store.read().highest_round()),
+                .round(self.base_state.dag_store.deref().read().highest_round()),
             highest_committed_round = self
                 .base_state
                 .ledger_info_provider
@@ -500,13 +500,13 @@ impl DagBootstrapper {
                 .saturating_sub(dag_window_size_config),
         );
 
-        let dag = Arc::new(RwLock::new(Dag::new(
+        let dag = Arc::new(PersistentDagStore::new(
             self.epoch_state.clone(),
             self.storage.clone(),
             self.payload_manager.clone(),
             initial_round,
             dag_window_size_config,
-        )));
+        ));
 
         let ordered_notifier = Arc::new(OrderedNotifierAdapter::new(
             self.ordered_nodes_tx.clone(),

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -8,7 +8,7 @@ use super::{
     dag_handler::NetworkHandler,
     dag_network::TDAGNetworkSender,
     dag_state_sync::{DagStateSynchronizer, StateSyncTrigger},
-    dag_store::PersistentDagStore,
+    dag_store::DagStore,
     health::{ChainHealthBackoff, HealthBackoff, PipelineLatencyBasedBackpressure, TChainHealth},
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
@@ -70,7 +70,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 
 #[derive(Clone)]
 struct BootstrapBaseState {
-    dag_store: Arc<PersistentDagStore>,
+    dag_store: Arc<DagStore>,
     order_rule: OrderRule,
     ledger_info_provider: Arc<dyn TLedgerInfoProvider>,
     ordered_notifier: Arc<OrderedNotifierAdapter>,
@@ -500,7 +500,7 @@ impl DagBootstrapper {
                 .saturating_sub(dag_window_size_config),
         );
 
-        let dag = Arc::new(PersistentDagStore::new(
+        let dag = Arc::new(DagStore::new(
             self.epoch_state.clone(),
             self.storage.clone(),
             self.payload_manager.clone(),

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -153,11 +153,12 @@ impl DagDriver {
             (
                 highest_strong_links_round,
                 // unwrap is for round 0
-                dag_reader.get_strong_links_for_round(
-                    highest_strong_links_round,
-                    &self.epoch_state.verifier,
-                )
-                .unwrap_or_default(),
+                dag_reader
+                    .get_strong_links_for_round(
+                        highest_strong_links_round,
+                        &self.epoch_state.verifier,
+                    )
+                    .unwrap_or_default(),
             )
         };
 

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{dag_store::PersistentDagStore, health::HealthBackoff};
+use super::{dag_store::DagStore, health::HealthBackoff};
 use crate::{
     dag::{
         adapter::TLedgerInfoProvider,
@@ -44,7 +44,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 pub(crate) struct DagDriver {
     author: Author,
     epoch_state: Arc<EpochState>,
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     payload_client: Arc<dyn PayloadClient>,
     reliable_broadcast: Arc<ReliableBroadcast<DAGMessage, ExponentialBackoff, DAGRpcResult>>,
     time_service: TimeService,
@@ -65,7 +65,7 @@ impl DagDriver {
     pub fn new(
         author: Author,
         epoch_state: Arc<EpochState>,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
         payload_client: Arc<dyn PayloadClient>,
         reliable_broadcast: Arc<ReliableBroadcast<DAGMessage, ExponentialBackoff, DAGRpcResult>>,
         time_service: TimeService,

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -1,12 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::health::HealthBackoff;
+use super::{dag_store::PersistentDagStore, health::HealthBackoff};
 use crate::{
     dag::{
         adapter::TLedgerInfoProvider,
         dag_fetcher::TFetchRequester,
-        dag_store::Dag,
         errors::DagDriverError,
         observability::{
             counters::{self, NODE_PAYLOAD_SIZE, NUM_TXNS_PER_NODE},
@@ -24,11 +23,10 @@ use crate::{
     },
     payload_client::PayloadClient,
 };
-use anyhow::bail;
+use anyhow::{bail, ensure};
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Payload, PayloadFilter};
 use aptos_crypto::hash::CryptoHash;
-use aptos_infallible::RwLock;
 use aptos_logger::{debug, error};
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_time_service::{TimeService, TimeServiceTrait};
@@ -46,7 +44,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 pub(crate) struct DagDriver {
     author: Author,
     epoch_state: Arc<EpochState>,
-    dag: Arc<RwLock<Dag>>,
+    dag: Arc<PersistentDagStore>,
     payload_client: Arc<dyn PayloadClient>,
     reliable_broadcast: Arc<ReliableBroadcast<DAGMessage, ExponentialBackoff, DAGRpcResult>>,
     time_service: TimeService,
@@ -67,7 +65,7 @@ impl DagDriver {
     pub fn new(
         author: Author,
         epoch_state: Arc<EpochState>,
-        dag: Arc<RwLock<Dag>>,
+        dag: Arc<PersistentDagStore>,
         payload_client: Arc<dyn PayloadClient>,
         reliable_broadcast: Arc<ReliableBroadcast<DAGMessage, ExponentialBackoff, DAGRpcResult>>,
         time_service: TimeService,
@@ -127,28 +125,39 @@ impl DagDriver {
 
     async fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
         let (highest_strong_link_round, strong_links) = {
-            let mut dag_writer = self.dag.write();
+            {
+                let dag_reader = self.dag.read();
 
-            if !dag_writer.all_exists(node.parents_metadata()) {
-                if let Err(err) = self.fetch_requester.request_for_certified_node(node) {
-                    error!("request to fetch failed: {}", err);
+                // Ensure the window hasn't moved, so we don't request fetch unnecessarily.
+                ensure!(node.round() >= dag_reader.lowest_round(), "stale node");
+
+                if !dag_reader.all_exists(node.parents_metadata()) {
+                    if let Err(err) = self.fetch_requester.request_for_certified_node(node) {
+                        error!("request to fetch failed: {}", err);
+                    }
+                    bail!(DagDriverError::MissingParents);
                 }
-                bail!(DagDriverError::MissingParents);
             }
 
-            dag_writer.add_node(node)?;
+            // Note on concurrency: it is possible that a prune operation kicks in here and
+            // moves the window forward making the `node` stale, but we guarantee that the
+            // order rule only visits `window` length rounds, so having node around should
+            // be fine. Any stale node inserted due to this race will be cleaned up with
+            // the next prune operation.
 
+            self.dag.add_node(node)?;
+
+            let dag_reader = self.dag.read();
             let highest_strong_links_round =
-                dag_writer.highest_strong_links_round(&self.epoch_state.verifier);
+                dag_reader.highest_strong_links_round(&self.epoch_state.verifier);
             (
                 highest_strong_links_round,
                 // unwrap is for round 0
-                dag_writer
-                    .get_strong_links_for_round(
-                        highest_strong_links_round,
-                        &self.epoch_state.verifier,
-                    )
-                    .unwrap_or_default(),
+                dag_reader.get_strong_links_for_round(
+                    highest_strong_links_round,
+                    &self.epoch_state.verifier,
+                )
+                .unwrap_or_default(),
             )
         };
 
@@ -320,12 +329,10 @@ impl RpcHandler for DagDriver {
         debug!(LogSchema::new(LogEvent::ReceiveCertifiedNode)
             .remote_peer(*certified_node.author())
             .round(certified_node.round()));
-        {
-            let dag_reader = self.dag.read();
-            if dag_reader.exists(certified_node.metadata()) {
-                return Ok(CertifiedAck::new(epoch));
-            }
+        if self.dag.read().exists(certified_node.metadata()) {
+            return Ok(CertifiedAck::new(epoch));
         }
+
         observe_node(certified_node.timestamp(), NodeStage::CertifiedNodeReceived);
         NUM_TXNS_PER_NODE.observe(certified_node.payload().len() as f64);
         NODE_PAYLOAD_SIZE.observe(certified_node.payload().size() as f64);

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{dag_store::PersistentDagStore, DAGRpcResult};
+use super::{dag_store::DagStore, DAGRpcResult};
 use crate::dag::{
     dag_network::{RpcResultWithResponder, TDAGNetworkSender},
     errors::FetchRequestHandleError,
@@ -129,7 +129,7 @@ impl LocalFetchRequest {
 
 pub struct DagFetcherService {
     inner: DagFetcher,
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     request_rx: Receiver<LocalFetchRequest>,
     ordered_authors: Vec<Author>,
 }
@@ -138,7 +138,7 @@ impl DagFetcherService {
     pub fn new(
         epoch_state: Arc<EpochState>,
         network: Arc<dyn TDAGNetworkSender>,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
         time_service: TimeService,
         config: DagFetcherConfig,
     ) -> (
@@ -224,7 +224,7 @@ pub trait TDagFetcher: Send {
         &self,
         remote_request: RemoteFetchRequest,
         responders: Vec<Author>,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
     ) -> anyhow::Result<()>;
 }
 
@@ -257,7 +257,7 @@ impl TDagFetcher for DagFetcher {
         &self,
         remote_request: RemoteFetchRequest,
         responders: Vec<Author>,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
     ) -> anyhow::Result<()> {
         debug!(
             LogSchema::new(LogEvent::FetchNodes),
@@ -316,12 +316,12 @@ impl TDagFetcher for DagFetcher {
 }
 
 pub struct FetchRequestHandler {
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     author_to_index: HashMap<Author, usize>,
 }
 
 impl FetchRequestHandler {
-    pub fn new(dag: Arc<PersistentDagStore>, epoch_state: Arc<EpochState>) -> Self {
+    pub fn new(dag: Arc<DagStore>, epoch_state: Arc<EpochState>) -> Self {
         Self {
             dag,
             author_to_index: epoch_state.verifier.address_to_validator_index().clone(),

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -75,6 +75,7 @@ impl NetworkHandler {
             move |rpc_request: IncomingDAGRequest| {
                 let epoch_state = epoch_state.clone();
                 async move {
+                    let epoch = rpc_request.req.epoch;
                     let result = rpc_request
                         .req
                         .try_into()
@@ -85,16 +86,15 @@ impl NetworkHandler {
                             )?;
                             Ok(dag_message)
                         });
-                    (result, rpc_request.sender, rpc_request.responder)
+                    (result, epoch, rpc_request.sender, rpc_request.responder)
                 }
             },
         );
 
         loop {
             select! {
-                (msg, author, responder) = verified_msg_stream.select_next_some() => {
-                    debug!("receive verified message");
-                    match self.process_verified_message(msg, author, responder).await {
+                (msg, epoch, author, responder) = verified_msg_stream.select_next_some() => {
+                    monitor!("dag_on_verified_msg", match self.process_verified_message(msg, epoch, author, responder).await {
                         Ok(sync_status) => {
                             if matches!(sync_status, SyncOutcome::NeedsSync(_) | SyncOutcome::EpochEnds) {
                                 return sync_status;
@@ -103,30 +103,32 @@ impl NetworkHandler {
                         Err(e) =>  {
                             warn!(error = ?e, "error processing rpc");
                         }
-                    }
+                    });
                 },
                 Some(new_round) = self.new_round_event.recv() => {
-                    self.dag_driver.enter_new_round(new_round).await;
-                    self.node_receiver.gc();
+                    monitor!("dag_on_new_round_event", {
+                        self.dag_driver.enter_new_round(new_round).await;
+                        self.node_receiver.gc();
+                    });
                 }
                 Some(res) = self.node_fetch_waiter.next() => {
-                    match res {
+                    monitor!("dag_on_node_fetch", match res {
                         Ok(node) => if let Err(e) = self.node_receiver.process(node).await {
                             warn!(error = ?e, "error processing node fetch notification");
                         },
                         Err(e) => {
                             debug!("sender dropped channel: {}", e);
                         },
-                    };
+                    });
                 },
                 Some(res) = self.certified_node_fetch_waiter.next() => {
-                    match res {
+                    monitor!("dag_on_cert_node_fetch", match res {
                         Ok(certified_node) => if let Err(e) = self.dag_driver.process(certified_node).await {
                             warn!(error = ?e, "error processing certified node fetch notification");                        },
                         Err(e) => {
                             debug!("sender dropped channel: {}", e);
                         },
-                    };
+                    });
                 }
             }
         }
@@ -135,6 +137,7 @@ impl NetworkHandler {
     async fn process_verified_message(
         &mut self,
         dag_message_result: anyhow::Result<DAGMessage>,
+        epoch: u64,
         author: Author,
         responder: RpcResponder,
     ) -> anyhow::Result<SyncOutcome> {
@@ -142,63 +145,73 @@ impl NetworkHandler {
             match dag_message_result {
                 Ok(dag_message) => {
                     debug!(
+                        epoch = epoch,
                         author = author,
                         message = dag_message,
-                        "process verified message"
+                        "Verified DAG message"
                     );
                     match dag_message {
-                        DAGMessage::NodeMsg(node) => self
-                            .node_receiver
-                            .process(node)
-                            .await
-                            .map(|r| r.into())
-                            .map_err(|err| {
-                                err.downcast::<NodeBroadcastHandleError>()
-                                    .map_or(DAGError::Unknown, |err| {
-                                        DAGError::NodeBroadcastHandleError(err)
-                                    })
-                            }),
+                        DAGMessage::NodeMsg(node) => monitor!(
+                            "dag_on_node_msg",
+                            self.node_receiver
+                                .process(node)
+                                .await
+                                .map(|r| r.into())
+                                .map_err(|err| {
+                                    err.downcast::<NodeBroadcastHandleError>()
+                                        .map_or(DAGError::Unknown, |err| {
+                                            DAGError::NodeBroadcastHandleError(err)
+                                        })
+                                })
+                        ),
                         DAGMessage::CertifiedNodeMsg(certified_node_msg) => {
-                            match self.state_sync_trigger.check(certified_node_msg).await? {
-                                SyncOutcome::Synced(Some(certified_node_msg)) => self
-                                    .dag_driver
-                                    .process(certified_node_msg.certified_node())
-                                    .await
-                                    .map(|r| r.into())
-                                    .map_err(|err| {
-                                        err.downcast::<DagDriverError>()
-                                            .map_or(DAGError::Unknown, |err| {
-                                                DAGError::DagDriverError(err)
-                                            })
-                                    }),
-                                status @ (SyncOutcome::NeedsSync(_) | SyncOutcome::EpochEnds) => {
-                                    return Ok(status)
-                                },
-                                _ => unreachable!(),
-                            }
+                            monitor!("dag_on_cert_node_msg", {
+                                match self.state_sync_trigger.check(certified_node_msg).await? {
+                                    SyncOutcome::Synced(Some(certified_node_msg)) => self
+                                        .dag_driver
+                                        .process(certified_node_msg.certified_node())
+                                        .await
+                                        .map(|r| r.into())
+                                        .map_err(|err| {
+                                            err.downcast::<DagDriverError>()
+                                                .map_or(DAGError::Unknown, |err| {
+                                                    DAGError::DagDriverError(err)
+                                                })
+                                        }),
+                                    status @ (SyncOutcome::NeedsSync(_)
+                                    | SyncOutcome::EpochEnds) => return Ok(status),
+                                    _ => unreachable!(),
+                                }
+                            })
                         },
-                        DAGMessage::FetchRequest(request) => self
-                            .fetch_receiver
-                            .process(request)
-                            .await
-                            .map(|r| r.into())
-                            .map_err(|err| {
-                                err.downcast::<FetchRequestHandleError>()
-                                    .map_or(DAGError::Unknown, DAGError::FetchRequestHandleError)
-                            }),
+                        DAGMessage::FetchRequest(request) => monitor!(
+                            "dag_on_fetch_request",
+                            self.fetch_receiver
+                                .process(request)
+                                .await
+                                .map(|r| r.into())
+                                .map_err(|err| {
+                                    err.downcast::<FetchRequestHandleError>().map_or(
+                                        DAGError::Unknown,
+                                        DAGError::FetchRequestHandleError,
+                                    )
+                                })
+                        ),
                         _ => unreachable!("verification must catch this error"),
                     }
                 },
                 Err(err) => {
-                    error!(error = ?err, "error verifying message");
+                    error!(error = ?err, "DAG message verification failed");
                     Err(DAGError::MessageVerificationError)
                 },
             }
         };
 
         debug!(
-            "responding to process_rpc {:?}",
-            response.as_ref().map(|r| r.name())
+            epoch = epoch,
+            sender = author,
+            response = response.as_ref().map(|r| r.name()),
+            "RPC response"
         );
 
         let response: DAGRpcResult = response

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -70,7 +70,7 @@ impl InMemDag {
 
     pub fn highest_round(&self) -> Round {
         // If stale nodes exist on the BTreeMap, ignore their rounds when calculating
-        // the highest round.        
+        // the highest round.
         *self
             .nodes_by_round
             .last_key_value()
@@ -455,7 +455,7 @@ impl DagStore {
         self.dag.write().validate_new_node(&node)?;
 
         // Note on concurrency: it is possible that a prune operation kicks in here and
-        // moves the window forward making the `node` stale. Any stale node inserted 
+        // moves the window forward making the `node` stale. Any stale node inserted
         // due to this race will be cleaned up with the next prune operation.
 
         // mutate after all checks pass

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -12,10 +12,12 @@ use crate::{
 use anyhow::{anyhow, ensure};
 use aptos_consensus_types::common::{Author, Round};
 use aptos_crypto::HashValue;
+use aptos_infallible::RwLock;
 use aptos_logger::{debug, error, warn};
 use aptos_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -37,14 +39,12 @@ impl NodeStatus {
         *self = NodeStatus::Ordered(self.as_node().clone());
     }
 }
-/// Data structure that stores the DAG representation, it maintains round based index.
+/// Data structure that stores the in-memory DAG representation, it maintains round based index.
 #[derive(Clone)]
 pub struct Dag {
     nodes_by_round: BTreeMap<Round, Vec<Option<NodeStatus>>>,
     /// Map between peer id to vector index
     author_to_index: HashMap<Author, usize>,
-    storage: Arc<dyn DAGStorage>,
-    payload_manager: Arc<dyn TPayloadManager>,
     start_round: Round,
     epoch_state: Arc<EpochState>,
     /// The window we maintain between highest committed round and initial round
@@ -52,57 +52,12 @@ pub struct Dag {
 }
 
 impl Dag {
-    pub fn new(
-        epoch_state: Arc<EpochState>,
-        storage: Arc<dyn DAGStorage>,
-        payload_manager: Arc<dyn TPayloadManager>,
-        start_round: Round,
-        window_size: u64,
-    ) -> Self {
-        let mut all_nodes = storage.get_certified_nodes().unwrap_or_default();
-        all_nodes.sort_unstable_by_key(|(_, node)| node.round());
-        let mut to_prune = vec![];
-        // Reconstruct the continuous dag starting from start_round and gc unrelated nodes
-        let mut dag = Self::new_empty(
-            epoch_state,
-            storage.clone(),
-            payload_manager,
-            start_round,
-            window_size,
-        );
-        for (digest, certified_node) in all_nodes {
-            // TODO: save the storage call in this case
-            if let Err(e) = dag.add_node(certified_node) {
-                debug!("Delete node after bootstrap due to {}", e);
-                to_prune.push(digest);
-            }
-        }
-        if let Err(e) = storage.delete_certified_nodes(to_prune) {
-            error!("Error deleting expired nodes: {:?}", e);
-        }
-        if dag.is_empty() {
-            warn!(
-                "[DAG] Start with empty DAG store at {}, need state sync",
-                dag.start_round
-            );
-        }
-        dag
-    }
-
-    pub fn new_empty(
-        epoch_state: Arc<EpochState>,
-        storage: Arc<dyn DAGStorage>,
-        payload_manager: Arc<dyn TPayloadManager>,
-        start_round: Round,
-        window_size: u64,
-    ) -> Self {
+    pub fn new_empty(epoch_state: Arc<EpochState>, start_round: Round, window_size: u64) -> Self {
         let author_to_index = epoch_state.verifier.address_to_validator_index().clone();
         let nodes_by_round = BTreeMap::new();
         Self {
             nodes_by_round,
             author_to_index,
-            storage,
-            payload_manager,
             start_round,
             epoch_state,
             window_size,
@@ -133,14 +88,29 @@ impl Dag {
             .map_or_else(|| highest_round.saturating_sub(1), |_| highest_round)
     }
 
-    pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
+    #[cfg(test)]
+    pub fn add_node_for_test(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
+        self.validate_new_node(&node)?;
+        self.add_validated_node(node)
+    }
+
+    fn add_validated_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
+        let node = Arc::new(node);
+        let round_ref = self
+            .get_node_ref_mut(node.round(), node.author())
+            .expect("must be present");
+        ensure!(round_ref.is_none(), "race during insertion");
+        *round_ref = Some(NodeStatus::Unordered(node.clone()));
+        Ok(())
+    }
+
+    fn validate_new_node(&mut self, node: &CertifiedNode) -> anyhow::Result<()> {
         ensure!(
             node.epoch() == self.epoch_state.epoch,
             "different epoch {}, current {}",
             node.epoch(),
             self.epoch_state.epoch
         );
-        let node = Arc::new(node);
         let author = node.metadata().author();
         let index = *self
             .author_to_index
@@ -169,13 +139,6 @@ impl Dag {
             .entry(round)
             .or_insert_with(|| vec![None; self.author_to_index.len()]);
         ensure!(round_ref[index].is_none(), "duplicate node");
-
-        // mutate after all checks pass
-        self.storage.save_certified_node(&node)?;
-        debug!("Added node {}", node.id());
-        round_ref[index] = Some(NodeStatus::Unordered(node.clone()));
-        self.payload_manager
-            .prefetch_payload_data(node.payload(), node.metadata().timestamp());
         Ok(())
     }
 
@@ -211,10 +174,14 @@ impl Dag {
         round_ref[*index].as_ref()
     }
 
-    pub fn get_node_ref_mut(&mut self, round: Round, author: &Author) -> Option<&mut NodeStatus> {
+    fn get_node_ref_mut(
+        &mut self,
+        round: Round,
+        author: &Author,
+    ) -> Option<&mut Option<NodeStatus>> {
         let index = self.author_to_index.get(author)?;
         let round_ref = self.nodes_by_round.get_mut(&round)?;
-        round_ref[*index].as_mut()
+        Some(&mut round_ref[*index])
     }
 
     fn get_round_iter(&self, round: Round) -> Option<impl Iterator<Item = &NodeStatus>> {
@@ -367,7 +334,7 @@ impl Dag {
         DagSnapshotBitmask::new(lowest_round, bitmask)
     }
 
-    pub(super) fn prune(&mut self) {
+    pub(super) fn prune(&mut self) -> BTreeMap<u64, Vec<Option<NodeStatus>>> {
         let to_keep = self.nodes_by_round.split_off(&self.start_round);
         let to_prune = std::mem::replace(&mut self.nodes_by_round, to_keep);
         debug!(
@@ -375,22 +342,19 @@ impl Dag {
             self.start_round,
             to_prune.first_key_value().map(|v| v.0).unwrap()
         );
-        let digests = to_prune
-            .iter()
-            .flat_map(|(_, round_ref)| round_ref.iter().flatten())
-            .map(|node_status| *node_status.as_node().metadata().digest())
-            .collect();
-        if let Err(e) = self.storage.delete_certified_nodes(digests) {
-            error!("Error deleting expired nodes: {:?}", e);
-        }
+        to_prune
     }
 
-    pub fn commit_callback(&mut self, commit_round: Round) {
+    fn commit_callback(
+        &mut self,
+        commit_round: Round,
+    ) -> Option<BTreeMap<u64, Vec<Option<NodeStatus>>>> {
         let new_start_round = commit_round.saturating_sub(3 * self.window_size);
         if new_start_round > self.start_round {
             self.start_round = new_start_round;
-            self.prune();
+            return Some(self.prune());
         }
+        None
     }
 
     pub(super) fn highest_ordered_anchor_round(&self) -> Option<Round> {
@@ -406,5 +370,116 @@ impl Dag {
 
     pub fn is_empty(&self) -> bool {
         self.nodes_by_round.is_empty() && self.start_round > 1
+    }
+}
+
+pub struct PersistentDagStore {
+    dag: RwLock<Dag>,
+    storage: Arc<dyn DAGStorage>,
+    payload_manager: Arc<dyn TPayloadManager>,
+}
+
+impl PersistentDagStore {
+    pub fn new(
+        epoch_state: Arc<EpochState>,
+        storage: Arc<dyn DAGStorage>,
+        payload_manager: Arc<dyn TPayloadManager>,
+        start_round: Round,
+        window_size: u64,
+    ) -> Self {
+        let mut all_nodes = storage.get_certified_nodes().unwrap_or_default();
+        all_nodes.sort_unstable_by_key(|(_, node)| node.round());
+        let mut to_prune = vec![];
+        // Reconstruct the continuous dag starting from start_round and gc unrelated nodes
+        let dag = Self::new_empty(
+            epoch_state,
+            storage.clone(),
+            payload_manager,
+            start_round,
+            window_size,
+        );
+        for (digest, certified_node) in all_nodes {
+            // TODO: save the storage call in this case
+            if let Err(e) = dag.add_node(certified_node) {
+                debug!("Delete node after bootstrap due to {}", e);
+                to_prune.push(digest);
+            }
+        }
+        if let Err(e) = storage.delete_certified_nodes(to_prune) {
+            error!("Error deleting expired nodes: {:?}", e);
+        }
+        if dag.read().is_empty() {
+            warn!(
+                "[DAG] Start with empty DAG store at {}, need state sync",
+                start_round
+            );
+        }
+        dag
+    }
+
+    pub fn new_empty(
+        epoch_state: Arc<EpochState>,
+        storage: Arc<dyn DAGStorage>,
+        payload_manager: Arc<dyn TPayloadManager>,
+        start_round: Round,
+        window_size: u64,
+    ) -> Self {
+        let dag = Dag::new_empty(epoch_state, start_round, window_size);
+        Self {
+            dag: RwLock::new(dag),
+            storage,
+            payload_manager,
+        }
+    }
+
+    pub fn new_for_test(
+        dag: Dag,
+        storage: Arc<dyn DAGStorage>,
+        payload_manager: Arc<dyn TPayloadManager>,
+    ) -> Self {
+        Self {
+            dag: RwLock::new(dag),
+            storage,
+            payload_manager,
+        }
+    }
+
+    pub fn add_node(&self, node: CertifiedNode) -> anyhow::Result<()> {
+        self.dag.write().validate_new_node(&node)?;
+
+        // Note on concurrency: it is possible that a prune operation kicks in here and
+        // moves the window forward making the `node` stale. Any stale node inserted 
+        // due to this race will be cleaned up with the next prune operation.
+
+        // mutate after all checks pass
+        self.storage.save_certified_node(&node)?;
+
+        debug!("Added node {}", node.id());
+        self.payload_manager
+            .prefetch_payload_data(node.payload(), node.metadata().timestamp());
+
+        self.dag.write().add_validated_node(node)
+    }
+
+    pub fn commit_callback(&self, commit_round: Round) {
+        let to_prune = self.dag.write().commit_callback(commit_round);
+        if let Some(to_prune) = to_prune {
+            let digests = to_prune
+                .iter()
+                .flat_map(|(_, round_ref)| round_ref.iter().flatten())
+                .map(|node_status| *node_status.as_node().metadata().digest())
+                .collect();
+            if let Err(e) = self.storage.delete_certified_nodes(digests) {
+                error!("Error deleting expired nodes: {:?}", e);
+            }
+        }
+    }
+}
+
+impl Deref for PersistentDagStore {
+    type Target = RwLock<Dag>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.dag
     }
 }

--- a/consensus/src/dag/health/chain_health.rs
+++ b/consensus/src/dag/health/chain_health.rs
@@ -68,6 +68,7 @@ impl ChainHealthBackoff {
 impl TChainHealth for ChainHealthBackoff {
     fn get_round_backoff(&self, round: Round) -> Option<Duration> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
+        
         if let Some(value) = chain_health_backoff {
             CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(1.0);
             Some(Duration::from_millis(value.backoff_proposal_delay_ms))
@@ -79,6 +80,7 @@ impl TChainHealth for ChainHealthBackoff {
 
     fn get_round_payload_limits(&self, round: Round) -> Option<(u64, u64)> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
+        
         chain_health_backoff.map(|value| {
             (
                 value.max_sending_block_txns_override,

--- a/consensus/src/dag/health/chain_health.rs
+++ b/consensus/src/dag/health/chain_health.rs
@@ -68,7 +68,7 @@ impl ChainHealthBackoff {
 impl TChainHealth for ChainHealthBackoff {
     fn get_round_backoff(&self, round: Round) -> Option<Duration> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
-        
+
         if let Some(value) = chain_health_backoff {
             CHAIN_HEALTH_BACKOFF_TRIGGERED.observe(1.0);
             Some(Duration::from_millis(value.backoff_proposal_delay_ms))
@@ -80,7 +80,7 @@ impl TChainHealth for ChainHealthBackoff {
 
     fn get_round_payload_limits(&self, round: Round) -> Option<(u64, u64)> {
         let chain_health_backoff = self.get_chain_health_backoff(round);
-        
+
         chain_health_backoff.map(|value| {
             (
                 value.max_sending_block_txns_override,

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -1,10 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::dag_store::PersistentDagStore;
 use crate::dag::{
     adapter::OrderedNotifier,
     anchor_election::AnchorElection,
-    dag_store::{Dag, NodeStatus},
+    dag_store::NodeStatus,
     observability::{
         logging::{LogEvent, LogSchema},
         tracing::{observe_node, NodeStage},
@@ -24,7 +25,7 @@ pub struct OrderRule {
     epoch_state: Arc<EpochState>,
     // TODO: try to share order rule, instead of this Arc.
     lowest_unordered_anchor_round: Arc<RwLock<Round>>,
-    dag: Arc<RwLock<Dag>>,
+    dag: Arc<PersistentDagStore>,
     anchor_election: Arc<dyn AnchorElection>,
     notifier: Arc<dyn OrderedNotifier>,
     dag_window_size_config: Round,
@@ -34,7 +35,7 @@ impl OrderRule {
     pub fn new(
         epoch_state: Arc<EpochState>,
         lowest_unordered_anchor_round: Round,
-        dag: Arc<RwLock<Dag>>,
+        dag: Arc<PersistentDagStore>,
         anchor_election: Arc<dyn AnchorElection>,
         notifier: Arc<dyn OrderedNotifier>,
         dag_window_size_config: Round,

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::dag_store::PersistentDagStore;
+use super::dag_store::DagStore;
 use crate::dag::{
     adapter::OrderedNotifier,
     anchor_election::AnchorElection,
@@ -25,7 +25,7 @@ pub struct OrderRule {
     epoch_state: Arc<EpochState>,
     // TODO: try to share order rule, instead of this Arc.
     lowest_unordered_anchor_round: Arc<RwLock<Round>>,
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     anchor_election: Arc<dyn AnchorElection>,
     notifier: Arc<dyn OrderedNotifier>,
     dag_window_size_config: Round,
@@ -35,7 +35,7 @@ impl OrderRule {
     pub fn new(
         epoch_state: Arc<EpochState>,
         lowest_unordered_anchor_round: Round,
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
         anchor_election: Arc<dyn AnchorElection>,
         notifier: Arc<dyn OrderedNotifier>,
         dag_window_size_config: Round,

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -2,18 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{dag_store::DagStore, health::HealthBackoff};
-use crate::{dag::{
-    dag_fetcher::TFetchRequester,
-    dag_network::RpcHandler,
-    errors::NodeBroadcastHandleError,
-    observability::{
-        logging::{LogEvent, LogSchema},
-        tracing::{observe_node, NodeStage},
+use crate::{
+    dag::{
+        dag_fetcher::TFetchRequester,
+        dag_network::RpcHandler,
+        errors::NodeBroadcastHandleError,
+        observability::{
+            logging::{LogEvent, LogSchema},
+            tracing::{observe_node, NodeStage},
+        },
+        storage::DAGStorage,
+        types::{Node, NodeCertificate, Vote},
+        NodeId,
     },
-    storage::DAGStorage,
-    types::{Node, NodeCertificate, Vote},
-    NodeId,
-}, util::is_vtxn_expected};
+    util::is_vtxn_expected,
+};
 use anyhow::{bail, ensure};
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Round};

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -15,13 +15,13 @@ use crate::{
         storage::DAGStorage,
         types::{Node, NodeCertificate, Vote},
         NodeId,
-    },
-    util::is_vtxn_expected,
+        util::is_vtxn_expected,
+    }
 };
+use super::{dag_store::PersistentDagStore, health::HealthBackoff};
 use anyhow::{bail, ensure};
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Round};
-use aptos_infallible::RwLock;
 use aptos_logger::{debug, error};
 use aptos_types::{
     epoch_state::EpochState,
@@ -33,7 +33,7 @@ use async_trait::async_trait;
 use std::{collections::BTreeMap, mem, sync::Arc};
 
 pub(crate) struct NodeBroadcastHandler {
-    dag: Arc<RwLock<Dag>>,
+    dag: Arc<PersistentDagStore>,
     votes_by_round_peer: BTreeMap<Round, BTreeMap<Author, Vote>>,
     signer: Arc<ValidatorSigner>,
     epoch_state: Arc<EpochState>,
@@ -47,7 +47,7 @@ pub(crate) struct NodeBroadcastHandler {
 
 impl NodeBroadcastHandler {
     pub fn new(
-        dag: Arc<RwLock<Dag>>,
+        dag: Arc<PersistentDagStore>,
         signer: Arc<ValidatorSigner>,
         epoch_state: Arc<EpochState>,
         storage: Arc<dyn DAGStorage>,

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -1,24 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::health::HealthBackoff;
-use crate::{
-    dag::{
-        dag_fetcher::TFetchRequester,
-        dag_network::RpcHandler,
-        dag_store::Dag,
-        errors::NodeBroadcastHandleError,
-        observability::{
-            logging::{LogEvent, LogSchema},
-            tracing::{observe_node, NodeStage},
-        },
-        storage::DAGStorage,
-        types::{Node, NodeCertificate, Vote},
-        NodeId,
-        util::is_vtxn_expected,
-    }
-};
-use super::{dag_store::PersistentDagStore, health::HealthBackoff};
+use super::{dag_store::DagStore, health::HealthBackoff};
+use crate::{dag::{
+    dag_fetcher::TFetchRequester,
+    dag_network::RpcHandler,
+    errors::NodeBroadcastHandleError,
+    observability::{
+        logging::{LogEvent, LogSchema},
+        tracing::{observe_node, NodeStage},
+    },
+    storage::DAGStorage,
+    types::{Node, NodeCertificate, Vote},
+    NodeId,
+}, util::is_vtxn_expected};
 use anyhow::{bail, ensure};
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Round};
@@ -33,7 +28,7 @@ use async_trait::async_trait;
 use std::{collections::BTreeMap, mem, sync::Arc};
 
 pub(crate) struct NodeBroadcastHandler {
-    dag: Arc<PersistentDagStore>,
+    dag: Arc<DagStore>,
     votes_by_round_peer: BTreeMap<Round, BTreeMap<Author, Vote>>,
     signer: Arc<ValidatorSigner>,
     epoch_state: Arc<EpochState>,
@@ -47,7 +42,7 @@ pub(crate) struct NodeBroadcastHandler {
 
 impl NodeBroadcastHandler {
     pub fn new(
-        dag: Arc<PersistentDagStore>,
+        dag: Arc<DagStore>,
         signer: Arc<ValidatorSigner>,
         epoch_state: Arc<EpochState>,
         storage: Arc<dyn DAGStorage>,

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         dag_driver::DagDriver,
         dag_fetcher::TFetchRequester,
         dag_network::{RpcWithFallback, TDAGNetworkSender},
-        dag_store::PersistentDagStore,
+        dag_store::DagStore,
         errors::DagDriverError,
         health::{HealthBackoff, NoChainHealth, NoPipelineBackpressure},
         order_rule::OrderRule,
@@ -121,7 +121,7 @@ fn setup(
     let mock_ledger_info = LedgerInfo::mock_genesis(None);
     let mock_ledger_info = generate_ledger_info_with_sig(signers, mock_ledger_info);
     let storage = Arc::new(MockStorage::new_with_ledger_info(mock_ledger_info.clone()));
-    let dag = Arc::new(PersistentDagStore::new(
+    let dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         dag_driver::DagDriver,
         dag_fetcher::TFetchRequester,
         dag_network::{RpcWithFallback, TDAGNetworkSender},
-        dag_store::Dag,
+        dag_store::PersistentDagStore,
         errors::DagDriverError,
         health::{HealthBackoff, NoChainHealth, NoPipelineBackpressure},
         order_rule::OrderRule,
@@ -25,7 +25,6 @@ use crate::{
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::DagPayloadConfig;
 use aptos_consensus_types::common::{Author, Round};
-use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
 use aptos_time_service::TimeService;
 use aptos_types::{
@@ -122,13 +121,13 @@ fn setup(
     let mock_ledger_info = LedgerInfo::mock_genesis(None);
     let mock_ledger_info = generate_ledger_info_with_sig(signers, mock_ledger_info);
     let storage = Arc::new(MockStorage::new_with_ledger_info(mock_ledger_info.clone()));
-    let dag = Arc::new(RwLock::new(Dag::new(
+    let dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
         0,
         TEST_DAG_WINDOW,
-    )));
+    ));
 
     let rb = Arc::new(ReliableBroadcast::new(
         signers.iter().map(|s| s.author()).collect(),

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         adapter::OrderedNotifier,
         dag_fetcher::{FetchRequestHandler, TDagFetcher},
         dag_state_sync::DagStateSynchronizer,
-        dag_store::Dag,
+        dag_store::PersistentDagStore,
         storage::DAGStorage,
         tests::{
             dag_test::MockStorage,
@@ -19,7 +19,6 @@ use crate::{
 };
 use aptos_consensus_types::common::{Author, Round};
 use aptos_crypto::HashValue;
-use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::RBNetworkSender;
 use aptos_time_service::TimeService;
 use aptos_types::{
@@ -74,7 +73,7 @@ impl TDAGNetworkSender for MockDAGNetworkSender {
 }
 
 struct MockDagFetcher {
-    target_dag: Arc<RwLock<Dag>>,
+    target_dag: Arc<PersistentDagStore>,
     epoch_state: Arc<EpochState>,
 }
 
@@ -84,17 +83,15 @@ impl TDagFetcher for MockDagFetcher {
         &self,
         remote_request: RemoteFetchRequest,
         _responders: Vec<Author>,
-        new_dag: Arc<RwLock<Dag>>,
+        new_dag: Arc<PersistentDagStore>,
     ) -> anyhow::Result<()> {
         let response = FetchRequestHandler::new(self.target_dag.clone(), self.epoch_state.clone())
             .process(remote_request)
             .await
             .unwrap();
 
-        let mut new_dag_writer = new_dag.write();
-
         for node in response.certified_nodes().into_iter().rev() {
-            new_dag_writer.add_node(node).unwrap()
+            new_dag.write().add_node_for_test(node).unwrap()
         }
 
         Ok(())
@@ -152,33 +149,31 @@ async fn test_dag_state_sync() {
         .collect::<Vec<_>>();
     let nodes = generate_dag_nodes(&virtual_dag, &validators);
 
-    let mut fast_dag = Dag::new(
+    let fast_dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         Arc::new(MockStorage::new()),
         Arc::new(MockPayloadManager {}),
         1,
         0,
-    );
+    ));
     for round_nodes in &nodes {
         for node in round_nodes.iter().flatten() {
-            fast_dag.add_node(node.clone()).unwrap();
+            fast_dag.write().add_node_for_test(node.clone()).unwrap();
         }
     }
-    let fast_dag = Arc::new(RwLock::new(fast_dag));
 
-    let mut slow_dag = Dag::new(
+    let slow_dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         Arc::new(MockStorage::new()),
         Arc::new(MockPayloadManager {}),
         1,
         0,
-    );
+    ));
     for round_nodes in nodes.iter().take(SLOW_DAG_ROUNDS as usize) {
         for node in round_nodes.iter().flatten() {
-            slow_dag.add_node(node.clone()).unwrap();
+            slow_dag.write().add_node_for_test(node.clone()).unwrap();
         }
     }
-    let slow_dag = Arc::new(RwLock::new(slow_dag));
 
     let li_node = nodes[LI_ROUNDS as usize - 1]
         .first()
@@ -229,9 +224,9 @@ async fn test_dag_state_sync() {
     let new_dag = sync_result.unwrap();
 
     assert_eq!(
-        new_dag.lowest_round(),
+        new_dag.read().lowest_round(),
         (LI_ROUNDS - TEST_DAG_WINDOW) as Round
     );
-    assert_eq!(new_dag.highest_round(), NUM_ROUNDS as Round);
-    assert_none!(new_dag.highest_ordered_anchor_round(),);
+    assert_eq!(new_dag.read().highest_round(), NUM_ROUNDS as Round);
+    assert_none!(new_dag.read().highest_ordered_anchor_round(),);
 }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         adapter::OrderedNotifier,
         dag_fetcher::{FetchRequestHandler, TDagFetcher},
         dag_state_sync::DagStateSynchronizer,
-        dag_store::PersistentDagStore,
+        dag_store::DagStore,
         storage::DAGStorage,
         tests::{
             dag_test::MockStorage,
@@ -73,7 +73,7 @@ impl TDAGNetworkSender for MockDAGNetworkSender {
 }
 
 struct MockDagFetcher {
-    target_dag: Arc<PersistentDagStore>,
+    target_dag: Arc<DagStore>,
     epoch_state: Arc<EpochState>,
 }
 
@@ -83,7 +83,7 @@ impl TDagFetcher for MockDagFetcher {
         &self,
         remote_request: RemoteFetchRequest,
         _responders: Vec<Author>,
-        new_dag: Arc<PersistentDagStore>,
+        new_dag: Arc<DagStore>,
     ) -> anyhow::Result<()> {
         let response = FetchRequestHandler::new(self.target_dag.clone(), self.epoch_state.clone())
             .process(remote_request)
@@ -149,7 +149,7 @@ async fn test_dag_state_sync() {
         .collect::<Vec<_>>();
     let nodes = generate_dag_nodes(&virtual_dag, &validators);
 
-    let fast_dag = Arc::new(PersistentDagStore::new(
+    let fast_dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         Arc::new(MockStorage::new()),
         Arc::new(MockPayloadManager {}),
@@ -162,7 +162,7 @@ async fn test_dag_state_sync() {
         }
     }
 
-    let slow_dag = Arc::new(PersistentDagStore::new(
+    let slow_dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         Arc::new(MockStorage::new()),
         Arc::new(MockPayloadManager {}),

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -3,7 +3,7 @@
 
 use super::helpers::MockPayloadManager;
 use crate::dag::{
-    dag_store::Dag,
+    dag_store::PersistentDagStore,
     storage::{CommitEvent, DAGStorage},
     tests::helpers::{new_certified_node, TEST_DAG_WINDOW},
     types::{CertifiedNode, DagSnapshotBitmask, Node},
@@ -109,7 +109,12 @@ impl DAGStorage for MockStorage {
     }
 }
 
-fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
+fn setup() -> (
+    Vec<ValidatorSigner>,
+    Arc<EpochState>,
+    PersistentDagStore,
+    Arc<MockStorage>,
+) {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
@@ -117,7 +122,7 @@ fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
     });
     let storage = Arc::new(MockStorage::new());
     let payload_manager = Arc::new(MockPayloadManager {});
-    let dag = Dag::new(
+    let dag = PersistentDagStore::new(
         epoch_state.clone(),
         storage.clone(),
         payload_manager,
@@ -129,80 +134,85 @@ fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
 
 #[test]
 fn test_dag_insertion_succeed() {
-    let (signers, epoch_state, mut dag, _) = setup();
+    let (signers, epoch_state, dag, _) = setup();
 
     // Round 1 - nodes 0, 1, 2 links to vec![]
     for signer in &signers[0..3] {
         let node = new_certified_node(1, signer.author(), vec![]);
-        assert!(dag.add_node(node).is_ok());
+        assert!(dag.write().add_node_for_test(node).is_ok());
     }
     let parents = dag
+        .read()
         .get_strong_links_for_round(1, &epoch_state.verifier)
         .unwrap();
 
     // Round 2 nodes 0, 1, 2 links to 0, 1, 2
     for signer in &signers[0..3] {
         let node = new_certified_node(2, signer.author(), parents.clone());
-        assert!(dag.add_node(node).is_ok());
+        assert!(dag.write().add_node_for_test(node).is_ok());
     }
 
     // Round 3 nodes 1, 2 links to 0, 1, 2
     let parents = dag
+        .read()
         .get_strong_links_for_round(2, &epoch_state.verifier)
         .unwrap();
 
     for signer in &signers[1..3] {
         let node = new_certified_node(3, signer.author(), parents.clone());
-        assert!(dag.add_node(node).is_ok());
+        assert!(dag.write().add_node_for_test(node).is_ok());
     }
 
     // not enough strong links
     assert!(dag
+        .read()
         .get_strong_links_for_round(3, &epoch_state.verifier)
         .is_none());
 }
 
 #[test]
 fn test_dag_insertion_failure() {
-    let (signers, epoch_state, mut dag, _) = setup();
+    let (signers, epoch_state, dag, _) = setup();
 
     // Round 1 - nodes 0, 1, 2 links to vec![]
     for signer in &signers[0..3] {
         let node = new_certified_node(1, signer.author(), vec![]);
-        assert!(dag.add_node(node.clone()).is_ok());
+        assert!(dag.write().add_node_for_test(node.clone()).is_ok());
         // duplicate node
-        assert!(dag.add_node(node).is_err());
+        assert!(dag.write().add_node_for_test(node).is_err());
     }
 
     let missing_node = new_certified_node(1, signers[3].author(), vec![]);
     let mut parents = dag
+        .read()
         .get_strong_links_for_round(1, &epoch_state.verifier)
         .unwrap();
     parents.push(missing_node.certificate());
 
     let node = new_certified_node(2, signers[0].author(), parents.clone());
     // parents not exist
-    assert!(dag.add_node(node).is_err());
+    assert!(dag.write().add_node_for_test(node).is_err());
 
     let node = new_certified_node(3, signers[0].author(), vec![]);
     // round too high
-    assert!(dag.add_node(node).is_err());
+    assert!(dag.write().add_node_for_test(node).is_err());
 
     let node = new_certified_node(2, signers[0].author(), parents[0..3].to_vec());
-    assert!(dag.add_node(node).is_ok());
+    assert!(dag.write().add_node_for_test(node).is_ok());
     let node = new_certified_node(2, signers[0].author(), vec![]);
     // equivocation node
-    assert!(dag.add_node(node).is_err());
+    assert!(dag.write().add_node_for_test(node).is_err());
 }
 
 #[test]
 fn test_dag_recover_from_storage() {
-    let (signers, epoch_state, mut dag, storage) = setup();
+    let (signers, epoch_state, dag, storage) = setup();
 
     let mut metadatas = vec![];
 
     for round in 1..10 {
         let parents = dag
+            .read()
             .get_strong_links_for_round(round, &epoch_state.verifier)
             .unwrap_or_default();
         for signer in &signers[0..3] {
@@ -211,7 +221,7 @@ fn test_dag_recover_from_storage() {
             assert!(dag.add_node(node).is_ok());
         }
     }
-    let new_dag = Dag::new(
+    let new_dag = PersistentDagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
@@ -220,7 +230,7 @@ fn test_dag_recover_from_storage() {
     );
 
     for metadata in &metadatas {
-        assert!(new_dag.exists(metadata));
+        assert!(new_dag.read().exists(metadata));
     }
 
     let new_epoch_state = Arc::new(EpochState {
@@ -228,7 +238,7 @@ fn test_dag_recover_from_storage() {
         verifier: epoch_state.verifier.clone(),
     });
 
-    let _new_epoch_dag = Dag::new(
+    let _new_epoch_dag = PersistentDagStore::new(
         new_epoch_state,
         storage.clone(),
         Arc::new(MockPayloadManager {}),
@@ -240,40 +250,42 @@ fn test_dag_recover_from_storage() {
 
 #[test]
 fn test_dag_bitmask() {
-    let (signers, epoch_state, mut dag, _) = setup();
+    let (signers, epoch_state, dag, _) = setup();
 
     assert_eq!(
-        dag.bitmask(15),
+        dag.read().bitmask(15),
         DagSnapshotBitmask::new(1, vec![vec![false; 4]; 15])
     );
 
     for round in 1..5 {
         let parents = dag
+            .read()
             .get_strong_links_for_round(round, &epoch_state.verifier)
             .unwrap_or_default();
         for signer in &signers[0..3] {
             let node = new_certified_node(round, signer.author(), parents.clone());
-            assert!(dag.add_node(node).is_ok());
+            assert!(dag.write().add_node_for_test(node).is_ok());
         }
     }
     let mut bitmask = vec![vec![true, true, true, false]; 4];
     bitmask.resize(15, vec![false; 4]);
-    assert_eq!(dag.bitmask(15), DagSnapshotBitmask::new(1, bitmask));
+    assert_eq!(dag.read().bitmask(15), DagSnapshotBitmask::new(1, bitmask));
 
     // Populate the fourth author for all rounds
     for round in 1..5 {
         let parents = dag
+            .read()
             .get_strong_links_for_round(round, &epoch_state.verifier)
             .unwrap_or_default();
         let node = new_certified_node(round, signers[3].author(), parents.clone());
-        assert!(dag.add_node(node).is_ok());
+        assert!(dag.write().add_node_for_test(node).is_ok());
     }
     assert_eq!(
-        dag.bitmask(15),
+        dag.read().bitmask(15),
         DagSnapshotBitmask::new(5, vec![vec![false; 4]; 11])
     );
     assert_eq!(
-        dag.bitmask(6),
+        dag.read().bitmask(6),
         DagSnapshotBitmask::new(5, vec![vec![false; 4]; 2])
     );
 }

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -3,7 +3,7 @@
 
 use super::helpers::MockPayloadManager;
 use crate::dag::{
-    dag_store::PersistentDagStore,
+    dag_store::DagStore,
     storage::{CommitEvent, DAGStorage},
     tests::helpers::{new_certified_node, TEST_DAG_WINDOW},
     types::{CertifiedNode, DagSnapshotBitmask, Node},
@@ -112,7 +112,7 @@ impl DAGStorage for MockStorage {
 fn setup() -> (
     Vec<ValidatorSigner>,
     Arc<EpochState>,
-    PersistentDagStore,
+    DagStore,
     Arc<MockStorage>,
 ) {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
@@ -122,7 +122,7 @@ fn setup() -> (
     });
     let storage = Arc::new(MockStorage::new());
     let payload_manager = Arc::new(MockPayloadManager {});
-    let dag = PersistentDagStore::new(
+    let dag = DagStore::new(
         epoch_state.clone(),
         storage.clone(),
         payload_manager,
@@ -221,7 +221,7 @@ fn test_dag_recover_from_storage() {
             assert!(dag.add_node(node).is_ok());
         }
     }
-    let new_dag = PersistentDagStore::new(
+    let new_dag = DagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
@@ -238,7 +238,7 @@ fn test_dag_recover_from_storage() {
         verifier: epoch_state.verifier.clone(),
     });
 
-    let _new_epoch_dag = PersistentDagStore::new(
+    let _new_epoch_dag = DagStore::new(
         new_epoch_state,
         storage.clone(),
         Arc::new(MockPayloadManager {}),

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -3,12 +3,11 @@
 use super::dag_test::MockStorage;
 use crate::dag::{
     dag_fetcher::FetchRequestHandler,
-    dag_store::Dag,
+    dag_store::PersistentDagStore,
     tests::helpers::{new_certified_node, MockPayloadManager, TEST_DAG_WINDOW},
     types::{DagSnapshotBitmask, FetchResponse, RemoteFetchRequest},
     RpcHandler,
 };
-use aptos_infallible::RwLock;
 use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
 use claims::assert_ok_eq;
 use std::sync::Arc;
@@ -21,13 +20,13 @@ async fn test_dag_fetcher_receiver() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(
+    let dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         storage,
         Arc::new(MockPayloadManager {}),
         0,
         TEST_DAG_WINDOW,
-    )));
+    ));
 
     let mut fetcher = FetchRequestHandler::new(dag.clone(), epoch_state);
 
@@ -36,7 +35,7 @@ async fn test_dag_fetcher_receiver() {
     // Round 1 - nodes 0, 1, 2 links to vec![]
     for signer in &signers[0..3] {
         let node = new_certified_node(1, signer.author(), vec![]);
-        assert!(dag.write().add_node(node.clone()).is_ok());
+        assert!(dag.add_node(node.clone()).is_ok());
         first_round_nodes.push(node);
     }
 

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -3,7 +3,7 @@
 use super::dag_test::MockStorage;
 use crate::dag::{
     dag_fetcher::FetchRequestHandler,
-    dag_store::PersistentDagStore,
+    dag_store::DagStore,
     tests::helpers::{new_certified_node, MockPayloadManager, TEST_DAG_WINDOW},
     types::{DagSnapshotBitmask, FetchResponse, RemoteFetchRequest},
     RpcHandler,
@@ -20,7 +20,7 @@ async fn test_dag_fetcher_receiver() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(PersistentDagStore::new(
+    let dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         storage,
         Arc::new(MockPayloadManager {}),

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -4,7 +4,7 @@
 use crate::dag::{
     adapter::OrderedNotifier,
     anchor_election::RoundRobinAnchorElection,
-    dag_store::Dag,
+    dag_store::{Dag, PersistentDagStore},
     order_rule::OrderRule,
     tests::{
         dag_test::MockStorage,
@@ -14,7 +14,7 @@ use crate::dag::{
     CertifiedNode,
 };
 use aptos_consensus_types::common::{Author, Round};
-use aptos_infallible::{Mutex, RwLock};
+use aptos_infallible::Mutex;
 use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
 use async_trait::async_trait;
 use futures_channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
@@ -93,7 +93,7 @@ impl OrderedNotifier for TestNotifier {
 
 fn create_order_rule(
     epoch_state: Arc<EpochState>,
-    dag: Arc<RwLock<Dag>>,
+    dag: Arc<PersistentDagStore>,
 ) -> (OrderRule, UnboundedReceiver<Vec<Arc<CertifiedNode>>>) {
     let anchor_election = Arc::new(RoundRobinAnchorElection::new(
         epoch_state.verifier.get_ordered_account_addresses(),
@@ -134,10 +134,10 @@ proptest! {
             epoch: 1,
             verifier: validator_verifier,
         });
-        let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()), Arc::new(MockPayloadManager{}), 0, TEST_DAG_WINDOW);
+        let mut dag = Dag::new_empty(epoch_state.clone(), 0, TEST_DAG_WINDOW);
         for round_nodes in &nodes {
             for node in round_nodes.iter().flatten() {
-                dag.add_node(node.clone()).unwrap();
+                dag.add_node_for_test(node.clone()).unwrap();
             }
         }
         let flatten_nodes: Vec<_> = nodes.into_iter().flatten().flatten().collect();
@@ -145,7 +145,7 @@ proptest! {
         rayon::scope(|s| {
             for seq in sequences {
                 s.spawn(|_| {
-                    let dag = Arc::new(RwLock::new(dag.clone()));
+                    let dag = Arc::new(PersistentDagStore::new_for_test(dag.clone(),Arc::new(MockStorage::new()), Arc::new(MockPayloadManager {})));
                     let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
                     for idx in seq {
                         order_rule.process_new_node(flatten_nodes[idx].metadata());
@@ -159,7 +159,7 @@ proptest! {
             }
         });
         // order produced by process_all
-        let dag = Arc::new(RwLock::new(dag.clone()));
+        let dag = Arc::new(PersistentDagStore::new_for_test(dag.clone(),Arc::new(MockStorage::new()), Arc::new(MockPayloadManager {})));
         let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
         order_rule.process_all();
         let mut ordered = vec![];
@@ -221,20 +221,18 @@ fn test_order_rule_basic() {
         epoch: 1,
         verifier: validator_verifier,
     });
-    let mut dag = Dag::new(
-        epoch_state.clone(),
-        Arc::new(MockStorage::new()),
-        Arc::new(MockPayloadManager {}),
-        0,
-        TEST_DAG_WINDOW,
-    );
+    let mut dag = Dag::new_empty(epoch_state.clone(), 0, TEST_DAG_WINDOW);
     for round_nodes in &nodes {
         for node in round_nodes.iter().flatten() {
-            dag.add_node(node.clone()).unwrap();
+            dag.add_node_for_test(node.clone()).unwrap();
         }
     }
     let display = |node: &NodeMetadata| (node.round(), *author_indexes.get(node.author()).unwrap());
-    let dag = Arc::new(RwLock::new(dag.clone()));
+    let dag = Arc::new(PersistentDagStore::new_for_test(
+        dag.clone(),
+        Arc::new(MockStorage::new()),
+        Arc::new(MockPayloadManager {}),
+    ));
     let (mut order_rule, mut receiver) = create_order_rule(epoch_state, dag);
     for node in nodes.iter().flatten().flatten() {
         order_rule.process_new_node(node.metadata());

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -4,7 +4,7 @@
 use crate::dag::{
     adapter::OrderedNotifier,
     anchor_election::RoundRobinAnchorElection,
-    dag_store::{InMemDag, DagStore},
+    dag_store::{DagStore, InMemDag},
     order_rule::OrderRule,
     tests::{
         dag_test::MockStorage,

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::dag::{
     dag_fetcher::TFetchRequester,
-    dag_store::PersistentDagStore,
+    dag_store::DagStore,
     errors::NodeBroadcastHandleError,
     health::{HealthBackoff, NoChainHealth, NoPipelineBackpressure},
     rb_handler::NodeBroadcastHandler,
@@ -49,7 +49,7 @@ async fn test_node_broadcast_receiver_succeed() {
 
     // Scenario: Start DAG from beginning
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(PersistentDagStore::new(
+    let dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
@@ -108,7 +108,7 @@ async fn test_node_broadcast_receiver_failure() {
         .iter()
         .map(|signer| {
             let storage = Arc::new(MockStorage::new());
-            let dag = Arc::new(PersistentDagStore::new(
+            let dag = Arc::new(DagStore::new(
                 epoch_state.clone(),
                 storage.clone(),
                 Arc::new(MockPayloadManager {}),
@@ -195,7 +195,7 @@ async fn test_node_broadcast_receiver_storage() {
     });
 
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(PersistentDagStore::new(
+    let dag = Arc::new(DagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::dag::{
     dag_fetcher::TFetchRequester,
-    dag_store::Dag,
+    dag_store::PersistentDagStore,
     errors::NodeBroadcastHandleError,
     health::{HealthBackoff, NoChainHealth, NoPipelineBackpressure},
     rb_handler::NodeBroadcastHandler,
@@ -16,7 +16,6 @@ use crate::dag::{
     NodeId, RpcHandler, Vote,
 };
 use aptos_config::config::DagPayloadConfig;
-use aptos_infallible::RwLock;
 use aptos_types::{
     aggregate_signature::PartialSignatures,
     epoch_state::EpochState,
@@ -50,13 +49,13 @@ async fn test_node_broadcast_receiver_succeed() {
 
     // Scenario: Start DAG from beginning
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(
+    let dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
         0,
         TEST_DAG_WINDOW,
-    )));
+    ));
 
     let health_backoff = HealthBackoff::new(
         epoch_state.clone(),
@@ -109,13 +108,13 @@ async fn test_node_broadcast_receiver_failure() {
         .iter()
         .map(|signer| {
             let storage = Arc::new(MockStorage::new());
-            let dag = Arc::new(RwLock::new(Dag::new(
+            let dag = Arc::new(PersistentDagStore::new(
                 epoch_state.clone(),
                 storage.clone(),
                 Arc::new(MockPayloadManager {}),
                 0,
                 TEST_DAG_WINDOW,
-            )));
+            ));
 
             NodeBroadcastHandler::new(
                 dag,
@@ -196,13 +195,13 @@ async fn test_node_broadcast_receiver_storage() {
     });
 
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(
+    let dag = Arc::new(PersistentDagStore::new(
         epoch_state.clone(),
         storage.clone(),
         Arc::new(MockPayloadManager {}),
         0,
         TEST_DAG_WINDOW,
-    )));
+    ));
 
     let node = new_node(1, 10, signers[0].author(), vec![]);
 


### PR DESCRIPTION
### Description

- Separated in-memory component of Dag store from persistence.
- `PersistentDagStore` handles both persistence and maintains the in-memory DAG store.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
