### PR TITLE
[Framework] Fix typo in state storage module

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/state_storage.md
+++ b/aptos-move/framework/aptos-framework/doc/state_storage.md
@@ -67,7 +67,7 @@
 
 ## Resource `StateStorageUsage`
 
-This is updated at the beginning of each opoch, reflecting the storage
+This is updated at the beginning of each epoch, reflecting the storage
 usage after the last txn of the previous epoch is committed.
 
 

--- a/aptos-move/framework/aptos-framework/sources/state_storage.move
+++ b/aptos-move/framework/aptos-framework/sources/state_storage.move
@@ -14,7 +14,7 @@ module aptos_framework::state_storage {
         bytes: u64,
     }
 
-    /// This is updated at the beginning of each opoch, reflecting the storage
+    /// This is updated at the beginning of each epoch, reflecting the storage
     /// usage after the last txn of the previous epoch is committed.
     struct StateStorageUsage has key, store {
         epoch: u64,


### PR DESCRIPTION
Fix `opoch` to `epoch`