### PR TITLE
[protos] Regenerate TS code, pin tool versions in CI

### DIFF
--- a/.github/workflows/check-protos.yaml
+++ b/.github/workflows/check-protos.yaml
@@ -32,12 +32,16 @@ jobs:
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1.24.0
+        with:
+          version: 1.28.1
 
       - uses: pre-commit/action@v3.0.0
 
       # Install protoc itself.
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
+        with:
+          version: "25.x"
 
       # Set up pnpm.
       - uses: pnpm/action-setup@v2

--- a/protos/README.md
+++ b/protos/README.md
@@ -1,6 +1,13 @@
 # Protos
 This directory contains the protobuf definitions for all Aptos services. For the sake of simplifying release and minimizing potential version conflicts, we include all protos and code generated from those protos in one place.
 
+Make sure to install buf, e.g. for Mac:
+```
+brew install bufbuild/buf/buf
+```
+
+If you see unexpected changes, make sure the version of buf you have matches the version we use in CI, see [`.github/workflows/check-protos.yaml`](../.github/workflows/check-protos.yaml).
+
 If you update the proto definitions in `proto/`, you can regenerate the code for all languages based on those protos by running this script:
 ```bash
 ./scripts/build_protos.sh
@@ -9,9 +16,4 @@ If you update the proto definitions in `proto/`, you can regenerate the code for
 If you haven't installed deps yet, run this script from this directory:
 ```bash
 ./scripts/install_deps.sh
-```
-
-Also make sure to install buf, e.g. for Mac:
-```
-brew install bufbuild/buf/buf
 ```

--- a/protos/typescript/src/aptos/indexer/v1/raw_data.ts
+++ b/protos/typescript/src/aptos/indexer/v1/raw_data.ts
@@ -323,6 +323,7 @@ export interface RawDataClient extends Client {
 export const RawDataClient = makeGenericClientConstructor(RawDataService, "aptos.indexer.v1.RawData") as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): RawDataClient;
   service: typeof RawDataService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | bigint | undefined;

--- a/protos/typescript/src/aptos/internal/fullnode/v1/fullnode_data.ts
+++ b/protos/typescript/src/aptos/internal/fullnode/v1/fullnode_data.ts
@@ -595,6 +595,7 @@ export const FullnodeDataClient = makeGenericClientConstructor(
 ) as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): FullnodeDataClient;
   service: typeof FullnodeDataService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | bigint | undefined;

--- a/protos/typescript/src/aptos/remote_executor/v1/network_msg.ts
+++ b/protos/typescript/src/aptos/remote_executor/v1/network_msg.ts
@@ -240,6 +240,7 @@ export const NetworkMessageServiceClient = makeGenericClientConstructor(
 ) as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): NetworkMessageServiceClient;
   service: typeof NetworkMessageServiceService;
+  serviceName: string;
 };
 
 function bytesFromBase64(b64: string): Uint8Array {


### PR DESCRIPTION
### Description
The CI is failing because in CI it generates the code and there are changes. I suspect this isn't a case of failing to check in updated code but of the tool versions changing. To address that, I pin the buf and protoc versions we use in CI.

### Test Plan
See that the check protos CI passes now.