### PR TITLE
[Quorom Store] enable BatchResponseV2

### DIFF
--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -457,7 +457,7 @@ impl QuorumStoreSender for NetworkSender {
             .send_rpc(recipient, msg, timeout)
             .await?;
         match response {
-            // TODO: deprecated, remove after two releases
+            // TODO: deprecated, remove after another release (likely v1.11)
             ConsensusMsg::BatchResponse(batch) => {
                 batch.verify_with_digest(request_digest)?;
                 Ok(BatchResponse::Batch(*batch))

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -377,8 +377,6 @@ impl InnerBuilder {
                 Some(&counters::BATCH_RETRIEVAL_TASK_MSGS),
             );
         let aptos_db_clone = self.aptos_db.clone();
-        // TODO: Once v2 handler is released, remove this flag and always use v2
-        let use_v2 = false;
         spawn_named!("batch_serve", async move {
             info!(epoch = epoch, "Batch retrieval task starts");
             while let Some(rpc_request) = batch_retrieval_rx.next().await {
@@ -398,23 +396,15 @@ impl InnerBuilder {
                         },
                     }
                 };
-                let msg = if use_v2 {
-                    Some(ConsensusMsg::BatchResponseV2(Box::new(response)))
-                } else if let BatchResponse::Batch(batch) = response {
-                    Some(ConsensusMsg::BatchResponse(Box::new(batch)))
-                } else {
-                    None
-                };
 
-                if let Some(msg) = msg {
-                    let bytes = rpc_request.protocol.to_bytes(&msg).unwrap();
-                    if let Err(e) = rpc_request
-                        .response_sender
-                        .send(Ok(bytes.into()))
-                        .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
-                    {
-                        warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
-                    }
+                let msg = ConsensusMsg::BatchResponseV2(Box::new(response));
+                let bytes = rpc_request.protocol.to_bytes(&msg).unwrap();
+                if let Err(e) = rpc_request
+                    .response_sender
+                    .send(Ok(bytes.into()))
+                    .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
+                {
+                    warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
                 }
             }
             info!(epoch = epoch, "Batch retrieval task stops");


### PR DESCRIPTION
### Description

Enable BatchResponseV2 which was introduced in #11162, but not enabled then for backwards compatibility.

Do not add to 1.9 branch before deployment.