### PR TITLE
[CLI] Upgrade processors code used in local testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
  "libsecp256k1",
  "merlin",
  "more-asserts",
- "num-bigint 0.3.3",
+ "num-bigint 0.4.4",
  "num-integer",
  "once_cell",
  "p256",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=af795c0a082385908d8ff3c72e54d53810e337fc#af795c0a082385908d8ff3c72e54d53810e337fc"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
 dependencies = [
  "chrono",
 ]
@@ -6634,7 +6634,8 @@ dependencies = [
 [[package]]
 name = "diesel-async"
 version = "0.4.1"
-source = "git+https://github.com/banool/diesel_async?rev=7115c8668b88d56029cb1471e84d2ea0234ff035#7115c8668b88d56029cb1471e84d2ea0234ff035"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
 dependencies = [
  "async-trait",
  "bb8",
@@ -11090,7 +11091,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -11102,6 +11102,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -12366,10 +12367,10 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=af795c0a082385908d8ff3c72e54d53810e337fc#af795c0a082385908d8ff3c72e54d53810e337fc"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
 dependencies = [
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=af795c0a082385908d8ff3c72e54d53810e337fc)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
  "aptos-protos 1.1.2 (git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c)",
  "async-trait",
  "base64 0.13.1",
@@ -13926,7 +13927,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=af795c0a082385908d8ff3c72e54d53810e337fc#af795c0a082385908d8ff3c72e54d53810e337fc"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ dashmap = "5.2.0"
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
-diesel = "2.1.0"
+diesel = "2.1"
 diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"
@@ -562,7 +562,7 @@ mockall = "0.11.4"
 more-asserts = "0.3.0"
 native-tls = "0.2.10"
 ntest = "0.9.0"
-num-bigint = { version = "0.3.2", features = ["rand"] }
+num-bigint = { version = "0.4.4", features = ["rand"] }
 num_cpus = "1.13.1"
 num-derive = "0.3.3"
 num-integer = "0.1.42"
@@ -763,5 +763,3 @@ debug = true
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
-# More context here: https://github.com/weiznich/diesel_async/pull/121.
-diesel-async = { git = "https://github.com/banool/diesel_async", rev = "7115c8668b88d56029cb1471e84d2ea0234ff035" }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## Unreleased
 - Hide the V2 compiler from input options until the V2 compiler is ready for release
 - Updated CLI source compilation to use rust toolchain version 1.74.1 (from 1.72.1).
+- Upgraded indexer processors for local testnet from 2d5cb211a89a8705674e9e1e741c841dd899c558 to 4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf. Upgraded Hasura metadata accordingly.
+- Upgraded Hasura GraphQL engine image from 2.35.0 to 2.36.1.
 
 ## [2.3.2] - 2023/11/28
 - Services in the local testnet now bind to 127.0.0.1 by default (unless the CLI is running inside a container, which most users should not do) rather than 0.0.0.0. You can override this behavior with the `--bind-to` flag. This fixes an issue preventing the local testnet from working on Windows.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "af795c0a082385908d8ff3c72e54d53810e337fc" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "af795c0a082385908d8ff3c72e54d53810e337fc" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aptos/src/node/local_testnet/hasura_metadata.json
+++ b/crates/aptos/src/node/local_testnet/hasura_metadata.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 288,
+  "resource_version": 296,
   "metadata": {
     "version": 3,
     "sources": [
@@ -93,7 +93,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["account_address", "transaction_version"],
+                  "columns": [
+                    "account_address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -209,7 +212,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["account_address", "transaction_version"],
+                  "columns": [
+                    "account_address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -288,7 +294,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["address", "transaction_version"],
+                  "columns": [
+                    "address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -725,6 +734,7 @@
               "name": "current_collections_v2",
               "schema": "public"
             },
+            "object_relationships": [],
             "select_permissions": [
               {
                 "role": "anonymous",
@@ -1469,7 +1479,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["delegator_address", "pool_address"],
+                  "columns": [
+                    "delegator_address",
+                    "pool_address"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -1608,7 +1621,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["db", "is_indexer_up"],
+                  "columns": [
+                    "db",
+                    "is_indexer_up"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -1624,7 +1640,9 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["chain_id"],
+                  "columns": [
+                    "chain_id"
+                  ],
                   "filter": {}
                 }
               }
@@ -1639,7 +1657,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["address", "transaction_version"],
+                  "columns": [
+                    "address",
+                    "transaction_version"
+                  ],
                   "filter": {},
                   "limit": 100,
                   "allow_aggregations": true
@@ -1656,7 +1677,10 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["num_active_delegator", "pool_address"],
+                  "columns": [
+                    "num_active_delegator",
+                    "pool_address"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -1740,7 +1764,11 @@
               {
                 "role": "anonymous",
                 "permission": {
-                  "columns": ["handle", "key_type", "value_type"],
+                  "columns": [
+                    "handle",
+                    "key_type",
+                    "value_type"
+                  ],
                   "filter": {},
                   "limit": 100
                 }
@@ -2042,6 +2070,13 @@
               "from_env": "INDEXER_V2_POSTGRES_URL"
             },
             "isolation_level": "read-committed",
+            "pool_settings": {
+              "connection_lifetime": 600,
+              "idle_timeout": 180,
+              "max_connections": 100,
+              "total_max_connections": 1500,
+              "pool_timeout": 120
+            },
             "use_prepared_statements": false
           }
         }
@@ -2077,7 +2112,9 @@
             "query_name": "Latest Processor Status"
           }
         },
-        "methods": ["GET"],
+        "methods": [
+          "GET"
+        ],
         "name": "Latest Processor Status",
         "url": "get_lastest_processor_status"
       }

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -24,11 +24,11 @@ use std::{collections::HashSet, path::PathBuf};
 use tracing::{info, warn};
 
 const INDEXER_API_CONTAINER_NAME: &str = "local-testnet-indexer-api";
-const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.35.0";
+const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.36.1";
 
 /// This Hasura metadata originates from the aptos-indexer-processors repo.
 ///
-/// This metadata is from revision: 2d5cb211a89a8705674e9e1e741c841dd899c558.
+/// This metadata is from revision: 4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf.
 ///
 /// The metadata file is not taken verbatim, it is currently edited by hand to remove
 /// any references to tables that aren't created by the Rust processor migrations.


### PR DESCRIPTION
### Description
This PR updates the CLI to use the latest processor code / Hasura metadata.

I make some changes to the deps to match the deps changes just landed in aptos-indexer-processors: https://github.com/aptos-labs/aptos-indexer-processors/pull/225. The changes to num-bigint look fine: https://github.com/rust-num/num-bigint/blob/master/RELEASES.md. If I take another crack it I might find that some of the version bumps here are unnecessary, but it's good to stay on top of these anyway. We'll see how the tests go.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --with-indexer-api --force-restart --assume-yes
```

See that the local testnet comes up and the indexer API works, including with the web UI.

Run the TS SDK v2 tests against the local testnet:
```
pnpm test
```
```
Test Suites: 41 passed, 41 total
Tests:       1 skipped, 509 passed, 510 total
```