### PR TITLE
[devtools] (Re)Introducing target determinator cargo CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,7 @@ xclippy = [
   "-Aclippy::result-large-err",
   "-Aclippy::mutable-key-type",
 ]
+x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 
 [build]
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-cargo-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.12",
+ "clap-verbosity-flag",
+ "determinator",
+ "env_logger",
+ "guppy",
+ "log",
+ "reqwest",
+ "url",
+]
+
+[[package]]
 name = "aptos-channels"
 version = "0.1.0"
 dependencies = [
@@ -5542,6 +5557,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,6 +5605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6100bc57b6209840798d95cb2775684849d332f7bd788db2a8c8caf7ef82a41a"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -5730,6 +5769,16 @@ checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.7",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c90e95e5bd4e8ac34fa6f37c774b0c6f8ed06ea90c79931fd448fcf941a9767"
+dependencies = [
+ "clap 4.4.12",
+ "log",
 ]
 
 [[package]]
@@ -6599,6 +6648,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "determinator"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf14b901cdfba3f731d01c4c184100e85f586a272d38874824175b845dbaeaf9"
+dependencies = [
+ "camino",
+ "globset",
+ "guppy",
+ "guppy-workspace-hack",
+ "once_cell",
+ "petgraph 0.6.4",
+ "rayon",
+ "serde",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6700,6 +6766,15 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "diffus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0ff24a73b51d9009c40897faf87d31b77345c90ffbf4dc3a1d2957032c5653"
+dependencies = [
+ "itertools 0.10.5",
+]
 
 [[package]]
 name = "digest"
@@ -8129,6 +8204,57 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "guppy"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114a100a9aa9f4c468a7b9e96626cdab267bb652660d8408e8f6d56d4c310edd"
+dependencies = [
+ "ahash 0.8.7",
+ "camino",
+ "cargo_metadata 0.18.1",
+ "cfg-if",
+ "debug-ignore",
+ "fixedbitset 0.4.2",
+ "guppy-summaries",
+ "guppy-workspace-hack",
+ "indexmap 2.1.0",
+ "itertools 0.12.0",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph 0.6.4",
+ "rayon",
+ "semver",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "static_assertions",
+ "target-spec",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "guppy-summaries"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd039b8f587513b48754811cfa37c2ba079df537b490b602fa641ce18f6e72a"
+dependencies = [
+ "camino",
+ "cfg-if",
+ "diffus",
+ "guppy-workspace-hack",
+ "semver",
+ "serde",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -10929,6 +11055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11609,6 +11741,15 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "pbjson"
@@ -14214,7 +14355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
 dependencies = [
  "bytecount",
- "cargo_metadata",
+ "cargo_metadata 0.14.2",
  "error-chain",
  "glob",
  "pulldown-cmark",
@@ -14676,6 +14817,25 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+
+[[package]]
+name = "target-spec"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b81540ee78bd9de9f7dca2378f264cf1f4193da6e2d09b54c0d595131a48f1"
+dependencies = [
+ "cfg-expr",
+ "guppy-workspace-hack",
+ "serde",
+ "target-lexicon",
+ "unicode-ident",
+]
 
 [[package]]
 name = "task-local-extensions"
@@ -15187,6 +15347,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
+ "indexmap 1.9.3",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ members = [
     "crates/transaction-emitter-lib",
     "crates/transaction-generator-lib",
     "crates/validator-transaction-pool",
+    "devtools/aptos-cargo-cli",
     "dkg",
     "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
     "ecosystem/indexer-grpc/indexer-grpc-data-access",
@@ -430,6 +431,7 @@ aptos-vm-types = { path = "aptos-move/aptos-vm-types" }
 aptos-vm-validator = { path = "vm-validator" }
 aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
 aptos-writeset-generator = { path = "aptos-move/writeset-transaction-generator" }
+aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
@@ -476,6 +478,7 @@ cfg-if = "1.0.0"
 ciborium = "0.2"
 claims = "0.7"
 clap = { version = "4.3.9", features = ["derive", "unstable-styles"] }
+clap-verbosity-flag = "2.1.1"
 clap_complete = "4.4.1"
 cloud-storage = { version = "0.11.1", features = ["global-client", "rustls-tls"], default-features = false }
 codespan-reporting = "0.11.1"
@@ -495,6 +498,7 @@ dashmap = "5.2.0"
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
+determinator = "0.12.0"
 diesel = "2.1"
 diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
@@ -522,6 +526,7 @@ git2 = "0.16.1"
 glob = "0.3.0"
 goldenfile = "1.5.2"
 google-cloud-storage = "0.13.0"
+guppy = "0.17.0"
 handlebars = "4.2.2"
 heck = "0.4.1"
 hex = "0.4.3"

--- a/devtools/aptos-cargo-cli/Cargo.toml
+++ b/devtools/aptos-cargo-cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "aptos-cargo-cli"
+description = "A target-determinator-based Cargo CLI"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+clap-verbosity-flag = { workspace = true }
+determinator = { workspace = true }
+env_logger = { workspace = true }
+guppy = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+url = { workspace = true }

--- a/devtools/aptos-cargo-cli/src/bin/cargo-x.rs
+++ b/devtools/aptos-cargo-cli/src/bin/cargo-x.rs
@@ -1,0 +1,36 @@
+// Copyright © Aptos Foundation
+
+use aptos_cargo_cli::{AptosCargoCommand, SelectedPackageArgs};
+use clap::Parser;
+use std::process::exit;
+
+#[derive(Parser)] // requires `derive` feature
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+enum CargoCli {
+    #[command(name = "x")]
+    AptosCargoTool(AptosCargoToolArgs),
+}
+
+#[derive(Parser)]
+struct AptosCargoToolArgs {
+    #[command(subcommand)]
+    cmd: AptosCargoCommand,
+    #[command(flatten)]
+    package_args: SelectedPackageArgs,
+}
+
+fn main() {
+    let CargoCli::AptosCargoTool(args) = CargoCli::parse();
+    let AptosCargoToolArgs { cmd, package_args } = args;
+    let result = cmd.execute(&package_args);
+
+    // At this point, we'll want to print and determine whether to exit for an error code
+    match result {
+        Ok(_) => {},
+        Err(inner) => {
+            println!("{}", inner);
+            exit(1);
+        },
+    }
+}

--- a/devtools/aptos-cargo-cli/src/cargo.rs
+++ b/devtools/aptos-cargo-cli/src/cargo.rs
@@ -1,0 +1,59 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use log::debug;
+use std::{
+    ffi::{OsStr, OsString},
+    process::{Command, Stdio},
+};
+
+pub struct Cargo {
+    inner: Command,
+    pass_through_args: Vec<OsString>,
+}
+
+impl Cargo {
+    pub fn command<S>(command: S) -> Self
+    where
+        S: AsRef<OsStr>,
+    {
+        let mut inner = Command::new("cargo");
+        inner.arg(command);
+        Self {
+            inner,
+            pass_through_args: Vec::new(),
+        }
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.inner.args(args);
+        self
+    }
+
+    pub fn pass_through<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        for arg in args {
+            self.pass_through_args.push(arg.as_ref().to_owned());
+        }
+        self
+    }
+
+    pub fn run(&mut self) {
+        self.inner.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+
+        if !self.pass_through_args.is_empty() {
+            self.inner.arg("--").args(&self.pass_through_args);
+        }
+
+        debug!("Executing command: {:?}", self.inner);
+
+        let _ = self.inner.output();
+    }
+}

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -1,0 +1,141 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use clap::Args;
+use determinator::{Determinator, Utf8Paths0};
+use guppy::{graph::DependencyDirection, CargoMetadata, MetadataCommand};
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use url::Url;
+
+fn workspace_dir() -> PathBuf {
+    let output = Command::new("cargo")
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
+    cargo_path.parent().unwrap().to_path_buf()
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SelectedPackageArgs {
+    #[arg(short, long, global = true)]
+    pub package: Vec<String>,
+    // TODO: add changed_since
+}
+
+impl SelectedPackageArgs {
+    fn compute_changed_files(&self, merge_base: &str) -> anyhow::Result<Utf8Paths0> {
+        let mut command = Command::new("git");
+        command.args(["diff", "-z", "--name-only"]);
+        command.arg(merge_base);
+
+        let output = command.output().map_err(|err| anyhow!("error: {}", err))?;
+        if !output.status.success() {
+            return Err(anyhow!("error"));
+        }
+
+        Utf8Paths0::from_bytes(output.stdout).map_err(|(_path, err)| anyhow!("{}", err))
+    }
+
+    fn git_rev_parse(&self, merge_base: &str) -> String {
+        let output = Command::new("git")
+            .arg("rev-parse")
+            .arg(merge_base)
+            .output()
+            .expect("failed to execute git rev-parse");
+
+        String::from_utf8(output.stdout)
+            .expect("invalid UTF-8")
+            .trim()
+            .to_owned()
+    }
+
+    fn fetch_remote_metadata(&self, merge_base: &str) -> anyhow::Result<CargoMetadata> {
+        let base_sha = self.git_rev_parse(merge_base);
+        let file_name = format!("metadata-{}.json", base_sha);
+        let dir_path = format!(
+            "{}/target/aptos-x-tool",
+            workspace_dir().to_str().expect("invalid UTF-8")
+        );
+        let file_path = format!("{}/{}", dir_path, file_name);
+        let mut contents = String::new();
+
+        // Check if the file exists in the local directory
+        if let Ok(file) = fs::File::open(&file_path) {
+            let mut buf_reader = std::io::BufReader::new(file);
+            buf_reader.read_to_string(&mut contents)?;
+        } else {
+            // Make an HTTP call to the GCS bucket to get the file contents
+            let url = format!(
+                "https://storage.googleapis.com/aptos-core-cargo-metadata-public/{}",
+                file_name
+            );
+            let response = reqwest::blocking::get(url)?.error_for_status()?;
+            let response = response.text()?;
+            contents = response.clone();
+
+            // Write the contents of the file to the local directory
+            fs::create_dir_all("target/aptos-x-tool")?;
+            fs::write(file_path, response)?;
+        }
+
+        // Return the contents of the file
+        Ok(CargoMetadata::parse_json(&contents)?)
+    }
+
+    pub fn compute_packages(&self) -> anyhow::Result<Vec<String>> {
+        if !self.package.is_empty() {
+            return Ok(self.package.clone());
+        }
+
+        // Determine merge base
+        // TODO: support different merge bases
+        let merge_base = "origin/main";
+
+        // Download merge base metadata
+        let base_metadata = self.fetch_remote_metadata(merge_base)?;
+        let base_package_graph = base_metadata.build_graph().unwrap();
+
+        // Compute head metadata
+        let head_metadata = MetadataCommand::new()
+            .exec()
+            .map_err(|e| anyhow!("{}", e))?;
+        let head_package_graph = head_metadata.build_graph().unwrap();
+
+        // Compute changed files
+        let changed_files = self.compute_changed_files(merge_base)?;
+
+        // Run target determinator
+        let mut determinator = Determinator::new(&base_package_graph, &head_package_graph);
+        // The determinator expects a list of changed files to be passed in.
+        determinator.add_changed_paths(&changed_files);
+
+        let determinator_set = determinator.compute();
+        let package_set = determinator_set
+            .affected_set
+            .packages(DependencyDirection::Forward)
+            .map(|package| {
+                let manifest_path = package.manifest_path();
+                let parent_path = manifest_path.parent().expect("must exist");
+                let mut url = Url::from_directory_path(parent_path)
+                    .expect("must be a valid directory path")
+                    .to_string();
+                if url.ends_with('/') {
+                    url.pop();
+                }
+                format!("{}#{}", url, package.name())
+            })
+            .collect();
+
+        Ok(package_set)
+    }
+}

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -1,0 +1,124 @@
+// Copyright © Aptos Foundation
+
+mod cargo;
+mod common;
+
+use cargo::Cargo;
+use clap::{Args, Parser, Subcommand};
+pub use common::SelectedPackageArgs;
+use log::trace;
+
+#[derive(Args, Clone, Debug)]
+#[command(disable_help_flag = true)]
+pub struct CommonArgs {
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    args: Vec<String>,
+}
+
+impl CommonArgs {
+    fn args(&self) -> (Vec<String>, Vec<String>) {
+        if let Some(index) = self.args.iter().position(|arg| arg == "--") {
+            let (left, right) = self.args.split_at(index);
+            (left.to_vec(), right[1..].to_vec())
+        } else {
+            (self.args.clone(), vec![])
+        }
+    }
+}
+
+#[derive(Clone, Subcommand, Debug)]
+pub enum AptosCargoCommand {
+    Check(CommonArgs),
+    Xclippy(CommonArgs),
+    Fmt(CommonArgs),
+    Nextest(CommonArgs),
+    Test(CommonArgs),
+}
+
+impl AptosCargoCommand {
+    fn command(&self) -> &'static str {
+        match self {
+            AptosCargoCommand::Check(_) => "check",
+            AptosCargoCommand::Xclippy(_) => "clippy",
+            AptosCargoCommand::Fmt(_) => "fmt",
+            AptosCargoCommand::Nextest(_) => "nextest",
+            AptosCargoCommand::Test(_) => "test",
+        }
+    }
+
+    fn command_args(&self) -> &CommonArgs {
+        match self {
+            AptosCargoCommand::Check(args) => args,
+            AptosCargoCommand::Xclippy(args) => args,
+            AptosCargoCommand::Fmt(args) => args,
+            AptosCargoCommand::Nextest(args) => args,
+            AptosCargoCommand::Test(args) => args,
+        }
+    }
+
+    fn extra_opts(&self) -> Option<&[&str]> {
+        match self {
+            AptosCargoCommand::Xclippy(_) => Some(&[
+                "-Dwarnings",
+                "-Wclippy::all",
+                "-Aclippy::upper_case_acronyms",
+                "-Aclippy::enum-variant-names",
+                "-Aclippy::result-large-err",
+                "-Aclippy::mutable-key-type",
+            ]),
+            _ => None,
+        }
+    }
+
+    fn split_args(&self) -> (Vec<String>, Vec<String>) {
+        self.command_args().args()
+    }
+
+    pub fn execute(&self, package_args: &SelectedPackageArgs) -> anyhow::Result<()> {
+        let (mut direct_args, mut push_through_args) = self.split_args();
+
+        trace!("parsed direct_args: {:?}", direct_args);
+        trace!("parsed push_through_args: {:?}", push_through_args);
+
+        let packages = package_args.compute_packages()?;
+
+        trace!("affected packages: {:?}", packages);
+
+        for p in packages {
+            direct_args.push("-p".into());
+            direct_args.push(p);
+        }
+
+        if let Some(opts) = self.extra_opts() {
+            for &opt in opts {
+                push_through_args.push(opt.into());
+            }
+        }
+
+        trace!("final direct_args: {:?}", direct_args);
+        trace!("final push_through_args: {:?}", push_through_args);
+
+        Cargo::command(self.command())
+            .args(direct_args)
+            .pass_through(push_through_args)
+            .run();
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+#[clap(author, version)]
+pub struct AptosCargoCli {
+    #[command(subcommand)]
+    cmd: AptosCargoCommand,
+    #[command(flatten)]
+    package_args: SelectedPackageArgs,
+    #[command(flatten)]
+    pub verbose: clap_verbosity_flag::Verbosity,
+}
+
+impl AptosCargoCli {
+    pub fn execute(&self) -> anyhow::Result<()> {
+        self.cmd.execute(&self.package_args)
+    }
+}

--- a/devtools/aptos-cargo-cli/src/main.rs
+++ b/devtools/aptos-cargo-cli/src/main.rs
@@ -1,0 +1,22 @@
+// Copyright © Aptos Foundation
+
+#![forbid(unsafe_code)]
+
+use aptos_cargo_cli::AptosCargoCli;
+use clap::Parser;
+use log::error;
+use std::process::exit;
+
+fn main() {
+    let cli = AptosCargoCli::parse();
+    env_logger::Builder::new()
+        .filter_module("aptos_cargo_cli", cli.verbose.log_level_filter())
+        .init();
+    let result = cli.execute();
+
+    // At this point, we'll want to print and determine whether to exit for an error code
+    if let Err(inner) = result {
+        error!("{}", inner);
+        exit(1);
+    }
+}


### PR DESCRIPTION
Reopening #9463 as a new PR because the other one won't reopen.

### Description

This PR (re)introduces the target-determinator based cargo command wrapper from the diem project, albeit in a simplified and very opinionated way. The implementation details diverge from the original implementation and is tailored to the everyday use-case at Aptos. It uses the `determinator` [crate](https://docs.rs/determinator/latest/determinator/index.html), which was originally used in diem repo, to identify potentially affected packages between local changes and remote. 

As v0, the features are very limited:
- Only identifies changed packages with respect to local origin/main ref. It won't work for other branch such as release branches yet.
- Does not yet allow excluding certain packages such as smoke-tests if they are identified as affected.
- It downloads cargo metadata of origin/main ref from a GCS bucket, if not present locally. This may affect offline development.

There are two binaries:
- aptos-cargo-cli is the default CLI that can be installed and used via `aptos-cargo-cli`.
- cargo-x is the cargo subcommand, which will allow invoking the CLI via `cargo x ...`

There is also a cargo x subcommand for use within aptos-core.

The command supports the following subcommands: `check`, `fmt`, `nextest`, `test`, `xclippy`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

No need to install, simply run `cargo x` within `aptos-core`.

Manual testing
