### PR TITLE
[compiler-v2] Copy propagation transformation and related optimizations

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -40,7 +40,7 @@ pub struct FunctionGenerator<'a> {
     code: Vec<FF::Bytecode>,
 }
 
-/// Immutable context for a function, seperated from the mutable generator state, to reduce
+/// Immutable context for a function, separated from the mutable generator state, to reduce
 /// borrow conflicts.
 #[derive(Clone)]
 pub struct FunctionContext<'env> {

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -11,8 +11,9 @@ mod options;
 pub mod pipeline;
 
 use crate::pipeline::{
-    ability_checker::AbilityChecker, explicit_drop::ExplicitDrop,
-    livevar_analysis_processor::LiveVarAnalysisProcessor,
+    ability_checker::AbilityChecker, avail_copies_analysis::AvailCopiesAnalysisProcessor,
+    copy_propagation::CopyPropagation, dead_store_elimination::DeadStoreElimination,
+    explicit_drop::ExplicitDrop, livevar_analysis_processor::LiveVarAnalysisProcessor,
     reference_safety_processor::ReferenceSafetyProcessor, visibility_checker::VisibilityChecker,
 };
 use anyhow::bail;
@@ -180,7 +181,24 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
         // Ability checker is functionally not relevant so can be completely skipped if safety is off
         pipeline.add_processor(Box::new(AbilityChecker {}));
     }
-    // Run live var again because it is invalidated by ExplicitDrop but needed by file format generator
+    // ----------------------------------------------------------
+    // ----------- Default optimization pipeline ----------------
+    // The default optimization pipeline is currently always run by the compiler.
+    // While this section of the pipeline is optional, some code that used to previously compile
+    // may no longer compile without this section because of using too many local (temp) variables.
+    //
+    // Available copies analysis is needed by copy propagation.
+    pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(CopyPropagation {}));
+    // Live var analysis is needed by dead store elimination.
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
+        with_copy_inference: false,
+    }));
+    pipeline.add_processor(Box::new(DeadStoreElimination {}));
+    // ------------ End default optimization pipeline ------------
+    // ----------------------------------------------------------
+    // Run live var analysis again because it could be invalidated by previous pipeline steps,
+    // but it is needed by file format generator.
     pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
         with_copy_inference: false,
     }));

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -184,6 +184,8 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     // ----------------------------------------------------------
     // ----------- Default optimization pipeline ----------------
     // The default optimization pipeline is currently always run by the compiler.
+    // Any compiler errors or warnings should be reported before running this section, as we can
+    // potentially delete or change code through these optimizations.
     // While this section of the pipeline is optional, some code that used to previously compile
     // may no longer compile without this section because of using too many local (temp) variables.
     //

--- a/third_party/move/move-compiler-v2/src/pipeline/avail_copies_analysis.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/avail_copies_analysis.rs
@@ -1,0 +1,337 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements the "definitely available copies" analysis, also called "available copies" analysis (in short).
+//! This analysis is a prerequisite for the copy propagation transformation.
+//!
+//! A copy is of the form `a := b` (i.e., `a` is assigned `b`), where `a` and `b` are locals/temporaries.
+//!
+//! A definitely available copy at a given program point `P` is a copy `a := b` that has reached `P`
+//! along all possible program paths such that neither `a` nor `b` is overwritten along any of these paths.
+//! That is, `a` and `b` are always available unmodified at `P` after the copy `a := b`,
+//! making it definitely available.
+//!
+//! This is a forward "must" analysis.
+//! In a forward analysis, we reason about facts at a program point `P` using facts at its predecessors.
+//! The "must" qualifier means that the analysis facts must be true at `P`,
+//! irrespective of what path lead to `P`.
+
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{AbortAction, Bytecode, Operation},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Collection of definitely available copies.
+/// For a copy `a := b`, we store the key-value pair `(a, b)` in the internal map.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AvailCopies(BTreeMap</*dst*/ TempIndex, /*src*/ TempIndex>);
+
+impl AvailCopies {
+    /// Create a new (empty) collection of definitely available copies.
+    fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Make a copy `dst := src` available.
+    /// If either `dst` or `src` is in `borrowed_locals`, then the copy is not made available.
+    /// To call this method, `dst := x` should not already be available for any `x`.
+    fn make_copy_available(
+        &mut self,
+        dst: TempIndex,
+        src: TempIndex,
+        borrowed_locals: &BTreeSet<TempIndex>,
+    ) {
+        // Note that we are conservative here for the sake of simplicity, and disallow copies
+        // when either `dst` or `src` is borrowed. We could track more copies as available by using
+        // reference analysis.
+        if !borrowed_locals.contains(&dst) && !borrowed_locals.contains(&src) {
+            let old_src = self.0.insert(dst, src);
+            if let Some(old_src) = old_src {
+                panic!(
+                    "ICE: copy `$t{} = $t{}` already available, \
+                        cannot have `$t{} = $t{}` available as well",
+                    dst, old_src, dst, src
+                );
+            }
+        }
+    }
+
+    /// Kill all available copies of the form `x := y` where `x` or `y` is `tmp`.
+    /// If `tmp` is in `borrowed_locals`, then no copies are killed.
+    fn kill_copies_with(&mut self, tmp: TempIndex, borrowed_locals: &BTreeSet<TempIndex>) {
+        if !borrowed_locals.contains(&tmp) {
+            // TODO: consider optimizing the following operation by keeping a two-way map between
+            // `dst -> src` and `src -> set(dst)`. Another optimization to consider is to use im::OrdMap.
+            self.0.retain(|dst, src| *dst != tmp && *src != tmp);
+        }
+    }
+
+    /// Given a set of available copies: `tmp_1 := tmp_0, tmp_2 := tmp_1,..., tmp_n := tmp_n-1`, forming
+    /// the copy chain: `tmp_0 --copied-to--> tmp_1 --copied-to--> tmp_2 -> ... -> tmp_n-1 -> tmp_n`,
+    /// return the head of the copy chain `tmp_0` for any input `tmp_x` (x in 0..=n) in the chain.
+    ///
+    /// Note that it is required that the copy chain is acyclic: we don't check for this explicitly,
+    /// but the natural way of constructing the copy chain for move bytecode ensures this.
+    pub fn get_head_of_copy_chain(&self, mut tmp: TempIndex) -> TempIndex {
+        while let Some(src) = self.0.get(&tmp) {
+            tmp = *src;
+        }
+        tmp
+    }
+}
+
+impl Default for AvailCopies {
+    /// Create a default (empty) collection of definitely available copies.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AbstractDomain for AvailCopies {
+    /// Keep only those copies in `self` that are available in both `self` and `other`.
+    /// Report if `self` has changed.
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut result = JoinResult::Unchanged;
+        let prev_copies = std::mem::take(&mut self.0);
+        for (dst_, src_) in &other.0 {
+            if let Some(src) = prev_copies.get(dst_) {
+                if src != src_ {
+                    // We are removing the available copy (dst, src) from self.
+                    result = JoinResult::Changed;
+                } else {
+                    self.0.insert(*dst_, *src_);
+                }
+            }
+            // else: a copy of the form (dst_, _) is not already available in self, so no change to self.
+        }
+        if prev_copies.len() != self.0.len() {
+            // We have removed some copies from self.
+            result = JoinResult::Changed;
+        }
+        result
+    }
+}
+
+/// Definitely available copies before and after a stackless bytecode instruction.
+#[derive(Clone)]
+struct AvailCopiesState {
+    before: AvailCopies,
+    after: AvailCopies,
+}
+
+/// Mapping from code offsets to definitely available copies before and after the instruction at the code offset.
+#[derive(Clone)]
+pub struct AvailCopiesAnnotation(BTreeMap<CodeOffset, AvailCopiesState>);
+
+impl AvailCopiesAnnotation {
+    /// Get the definitely available copies before the instruction at the given `code_offset`.
+    pub fn before(&self, code_offset: &CodeOffset) -> Option<&AvailCopies> {
+        if let Some(state) = self.0.get(code_offset) {
+            Some(&state.before)
+        } else {
+            None
+        }
+    }
+}
+
+/// The definitely available copies analysis for a function.
+pub struct AvailCopiesAnalysis {
+    borrowed_locals: BTreeSet<TempIndex>, // Locals borrowed in the function being analyzed.
+}
+
+impl AvailCopiesAnalysis {
+    /// Create a new instance of definitely available copies analysis.
+    /// `code` is the bytecode of the function being analyzed.
+    pub fn new(code: &[Bytecode]) -> Self {
+        Self {
+            borrowed_locals: Self::get_borrowed_locals(code),
+        }
+    }
+
+    /// Analyze the given function and return the definitely available copies annotation.
+    fn analyze(&self, func_target: &FunctionTarget) -> AvailCopiesAnnotation {
+        let code = func_target.get_bytecode();
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        let block_state_map = self.analyze_function(AvailCopies::new(), code, &cfg);
+        let per_bytecode_state =
+            self.state_per_instruction(block_state_map, code, &cfg, |before, after| {
+                AvailCopiesState {
+                    before: before.clone(),
+                    after: after.clone(),
+                }
+            });
+        AvailCopiesAnnotation(per_bytecode_state)
+    }
+
+    /// Get the set of locals that have been borrowed in the function being analyzed.
+    fn get_borrowed_locals(code: &[Bytecode]) -> BTreeSet<TempIndex> {
+        code.iter()
+            .filter_map(|bc| {
+                if let Bytecode::Call(_, _, Operation::BorrowLoc, srcs, _) = bc {
+                    // BorrowLoc should have only one source.
+                    srcs.first().cloned()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl TransferFunctions for AvailCopiesAnalysis {
+    type State = AvailCopies;
+
+    // This is a forward analysis.
+    const BACKWARD: bool = false;
+
+    fn execute(&self, state: &mut Self::State, instr: &Bytecode, _offset: CodeOffset) {
+        use Bytecode::*;
+        match instr {
+            Assign(_, dst, src, _) => {
+                state.kill_copies_with(*dst, &self.borrowed_locals);
+                state.make_copy_available(*dst, *src, &self.borrowed_locals);
+            },
+            Load(_, dst, _) => {
+                state.kill_copies_with(*dst, &self.borrowed_locals);
+            },
+            Call(_, dsts, _, _, on_abort) => {
+                for dst in dsts {
+                    state.kill_copies_with(*dst, &self.borrowed_locals);
+                }
+                if let Some(AbortAction(_, dst)) = on_abort {
+                    state.kill_copies_with(*dst, &self.borrowed_locals);
+                }
+            },
+            _ => (),
+        }
+    }
+}
+
+impl DataflowAnalysis for AvailCopiesAnalysis {}
+
+/// Processor for the definitely available copies analysis.
+pub struct AvailCopiesAnalysisProcessor();
+
+impl FunctionTargetProcessor for AvailCopiesAnalysisProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        let analysis = AvailCopiesAnalysis::new(target.get_bytecode());
+        let annotation = analysis.analyze(&target);
+        data.annotations.set(annotation, true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "available_copies".to_string()
+    }
+}
+
+impl AvailCopiesAnalysisProcessor {
+    /// Registers annotation formatter at the given function target.
+    /// Helps with testing and debugging.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_avail_copies_annotation));
+    }
+}
+
+// ====================================================================
+// Formatting functionality for available copies annotation.
+
+pub fn format_avail_copies_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    let AvailCopiesAnnotation(map) = target.get_annotations().get::<AvailCopiesAnnotation>()?;
+    let AvailCopiesState { before, after } = map.get(&code_offset)?;
+    let mut s = String::new();
+    s.push_str("before: ");
+    s.push_str(&format_avail_copies(before, target));
+    s.push_str(", after: ");
+    s.push_str(&format_avail_copies(after, target));
+    Some(s)
+}
+
+fn format_avail_copies(state: &AvailCopies, target: &FunctionTarget<'_>) -> String {
+    let mut s = String::new();
+    s.push_str("{");
+    let mut first = true;
+    for (dst, src) in &state.0 {
+        if first {
+            first = false;
+        } else {
+            s.push_str(", ");
+        }
+        s.push_str(
+            &vec![dst, src]
+                .into_iter()
+                .map(|tmp| {
+                    let name = target.get_local_raw_name(*tmp);
+                    name.display(target.symbol_pool()).to_string()
+                })
+                .join(" := "),
+        );
+    }
+    s.push_str("}");
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_avail_copies_join() {
+        let mut a = AvailCopies::new();
+        let mut b = AvailCopies::new();
+        let borrowed_locals: BTreeSet<TempIndex> = BTreeSet::new();
+        a.make_copy_available(1, 2, &borrowed_locals);
+        b.make_copy_available(3, 4, &borrowed_locals);
+        // a = (1, 2), b = (3, 4)
+        assert_eq!(a.join(&b), JoinResult::Changed);
+        assert_eq!(a.0.len(), 0);
+        a.make_copy_available(3, 4, &borrowed_locals);
+        // a = (3, 4), b = (3, 4)
+        assert_eq!(a.join(&b), JoinResult::Unchanged);
+        assert_eq!(a, b);
+        a.make_copy_available(1, 2, &borrowed_locals);
+        // a = (1, 2), (3, 4), b = (3, 4)
+        assert_eq!(a.join(&b), JoinResult::Changed);
+        assert_eq!(a, b);
+        b.make_copy_available(1, 2, &borrowed_locals);
+        // a = (3, 4), b = (1, 2), (3, 4)
+        assert_eq!(a.join(&b), JoinResult::Unchanged);
+        assert_eq!(a.0.len(), 1);
+    }
+
+    #[test]
+    fn test_get_head_of_copy_chain() {
+        let mut copies = AvailCopies::new();
+        let borrowed_locals: BTreeSet<TempIndex> = BTreeSet::new();
+        copies.make_copy_available(1, 0, &borrowed_locals);
+        copies.make_copy_available(2, 1, &borrowed_locals);
+        copies.make_copy_available(3, 2, &borrowed_locals);
+        copies.make_copy_available(4, 3, &borrowed_locals);
+        copies.make_copy_available(44, 14, &borrowed_locals);
+        // copies = (1, 0), (2, 1), (3, 2), (4, 3), (44, 14)
+        for i in 0..=4 {
+            assert_eq!(copies.get_head_of_copy_chain(i), 0);
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/copy_propagation.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/copy_propagation.rs
@@ -1,0 +1,86 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements copy propagation transformation.
+//!
+//! prerequisite: the `AvailCopiesAnnotation` should already be computed by running the `AvailCopiesAnalysis`.
+//! side effect: all annotations will be removed from the function target annotations as the code
+//!     potentially change, possibly rendering the annotations incorrect.
+//!
+//! Given definitely available copies at each program point, this transformation replaces the use of locals
+//! with their copy-chain heads, possibly rendering several copies redundant (i.e., creating dead stores).
+//! For example, consider the following code:
+//! ```
+//! let b = a;
+//! let c = b;
+//! let d = c + 1;
+//! ```
+//! This transformation will modify the code will to:
+//! ```
+//! let b = a;  // redundant copy
+//! let c = a;  // redundant copy
+//! let d = a + 1;
+//! ```
+
+use crate::pipeline::avail_copies_analysis::{AvailCopies, AvailCopiesAnnotation};
+use move_binary_format::file_format::CodeOffset;
+use move_model::model::FunctionEnv;
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+};
+
+/// A processor which performs copy propagation transformation.
+pub struct CopyPropagation {}
+
+impl CopyPropagation {
+    /// Transforms the `code` of a `target` function using the `avail_copies_annotation`,
+    /// by replacing the use of locals with their copy-chain heads.
+    /// Returns the transformed code.
+    fn transform(
+        target: &FunctionTarget,
+        code: Vec<Bytecode>,
+        avail_copies_annotation: &AvailCopiesAnnotation,
+    ) -> Vec<Bytecode> {
+        let mut new_code = vec![];
+        let default_avail_copies = AvailCopies::default();
+        for (offset, instr) in code.into_iter().enumerate() {
+            let avail_copies = avail_copies_annotation
+                .before(&(offset as CodeOffset))
+                .unwrap_or(&default_avail_copies);
+            let mut propagated_src = |dst| avail_copies.get_head_of_copy_chain(dst);
+            new_code.push(instr.remap_src_vars(target, &mut propagated_src));
+        }
+        new_code
+    }
+}
+
+impl FunctionTargetProcessor for CopyPropagation {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let code = std::mem::take(&mut data.code);
+        let target = FunctionTarget::new(func_env, &data);
+        let avail_copies = target
+            .get_annotations()
+            .get::<AvailCopiesAnnotation>()
+            .expect("avail copies annotation is a prerequisite");
+        let new_code = Self::transform(&target, code, avail_copies);
+        data.code = new_code;
+        // Annotations may no longer be valid after this transformation, so remove them.
+        data.annotations.clear();
+        data
+    }
+
+    fn name(&self) -> String {
+        "copy_propagation".to_string()
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/copy_propagation.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/copy_propagation.rs
@@ -10,13 +10,13 @@
 //! Given definitely available copies at each program point, this transformation replaces the use of locals
 //! with their copy-chain heads, possibly rendering several copies redundant (i.e., creating dead stores).
 //! For example, consider the following code:
-//! ```
+//! ```move
 //! let b = a;
 //! let c = b;
 //! let d = c + 1;
 //! ```
 //! This transformation will modify the code will to:
-//! ```
+//! ```move
 //! let b = a;  // redundant copy
 //! let c = a;  // redundant copy
 //! let d = a + 1;

--- a/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
@@ -1,0 +1,77 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements the "dead store elimination" transformation. This transformation pairs well with
+//! copy propagation transformation, as it removes the dead stores that copy propagation may introduce.
+//!
+//! prerequisite: the `LiveVarAnnotation` should already be computed by running the `LiveVarAnalysisProcessor`.
+//! side effect: all annotations will be removed from the function target annotations.
+//!
+//! Given live variables at each program point, this transformation removes dead stores, i.e.,
+//! assignments and loads to locals which are not live afterwards.
+
+use crate::pipeline::livevar_analysis_processor::LiveVarAnnotation;
+use move_binary_format::file_format::CodeOffset;
+use move_model::model::FunctionEnv;
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+};
+
+/// A processor which performs dead store elimination transformation.
+pub struct DeadStoreElimination {}
+
+impl DeadStoreElimination {
+    /// Transforms the `code` of a function using the `live_vars_annotation`,
+    /// by removing assignments and loads to locals which are not live afterwards.
+    /// Returns the transformed code.
+    fn transform(code: Vec<Bytecode>, live_vars_annotation: &LiveVarAnnotation) -> Vec<Bytecode> {
+        let mut new_code = vec![];
+        for (offset, instr) in code.into_iter().enumerate() {
+            if let Bytecode::Assign(_, dst, ..) | Bytecode::Load(_, dst, _) = instr {
+                // Is the local that was just assigned to/loaded into, not live afterwards?
+                // Then this is a dead store, we don't need to emit it.
+                if !live_vars_annotation
+                    .get_live_var_info_at(offset as CodeOffset)
+                    .expect("live var info is a prerequisite")
+                    .after
+                    .contains_key(&dst)
+                {
+                    continue;
+                }
+            }
+            new_code.push(instr);
+        }
+        new_code
+    }
+}
+
+impl FunctionTargetProcessor for DeadStoreElimination {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let code = std::mem::take(&mut data.code);
+        let target = FunctionTarget::new(func_env, &data);
+        let live_var_annotation = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("live variable annotation is a prerequisite");
+        let new_code = Self::transform(code, live_var_annotation);
+        data.code = new_code;
+        // Annotations may no longer be valid after this transformation, so remove them.
+        data.annotations.clear();
+        data
+    }
+
+    fn name(&self) -> String {
+        "dead_store_elimination".to_string()
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
@@ -27,7 +27,7 @@ impl DeadStoreElimination {
     /// Transforms the `code` of a function using the `live_vars_annotation`,
     /// by removing assignments and loads to locals which are not live afterwards.
     /// Also removes self-assignments.
-    /// 
+    ///
     /// Returns the transformed code.
     fn transform(code: Vec<Bytecode>, live_vars_annotation: &LiveVarAnnotation) -> Vec<Bytecode> {
         let mut new_code = vec![];

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -1,7 +1,11 @@
 // Copyright © Aptos Foundation
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 pub mod ability_checker;
+pub mod avail_copies_analysis;
+pub mod copy_propagation;
+pub mod dead_store_elimination;
 pub mod explicit_drop;
 pub mod livevar_analysis_processor;
 pub mod reference_safety_processor;

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.exp
@@ -1,0 +1,110 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := +($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t5 := 1
+  2: $t4 := +($t0, $t5)
+  3: $t0 := infer($t4)
+  4: $t3 := infer($t0)
+  5: $t1 := m::add($t2, $t3)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     # before: {}, after: {}
+  0: $t2 := +($t0, $t1)
+     # before: {}, after: {}
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  1: $t5 := 1
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  2: $t4 := +($t0, $t5)
+     # before: {$t2 := $t0}, after: {$t0 := $t4}
+  3: $t0 := infer($t4)
+     # before: {$t0 := $t4}, after: {$t0 := $t4, $t3 := $t0}
+  4: $t3 := infer($t0)
+     # before: {$t0 := $t4, $t3 := $t0}, after: {$t0 := $t4, $t3 := $t0}
+  5: $t1 := m::add($t2, $t3)
+     # before: {$t0 := $t4, $t3 := $t0}, after: {$t0 := $t4, $t3 := $t0}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := +($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t5 := 1
+  2: $t4 := +($t0, $t5)
+  3: $t0 := infer($t4)
+  4: $t3 := infer($t4)
+  5: $t1 := m::add($t2, $t4)
+  6: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := +($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t5 := 1
+  2: $t4 := +($t0, $t5)
+  3: $t1 := m::add($t2, $t4)
+  4: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun add(a: u64, b: u64): u64 {
+        a + b
+    }
+
+    public fun test(p: u64): u64 {
+        add(p, {p = p + 1; p})
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_1.exp
@@ -1,0 +1,94 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := infer($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := 0
+  4: $t3 := infer($t4)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t5 := 1
+  9: $t2 := +($t3, $t5)
+ 10: return $t2
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: {}, after: {$t3 := $t1}
+  0: $t3 := infer($t1)
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  1: if ($t0) goto 2 else goto 6
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  2: label L0
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  3: $t4 := 0
+     # before: {$t3 := $t1}, after: {$t3 := $t4}
+  4: $t3 := infer($t4)
+     # before: {$t3 := $t4}, after: {$t3 := $t4}
+  5: goto 7
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  6: label L1
+     # before: {}, after: {}
+  7: label L2
+     # before: {}, after: {}
+  8: $t5 := 1
+     # before: {}, after: {}
+  9: $t2 := +($t3, $t5)
+     # before: {}, after: {}
+ 10: return $t2
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := infer($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := 0
+  4: $t3 := infer($t4)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t5 := 1
+  9: $t2 := +($t3, $t5)
+ 10: return $t2
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := infer($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := 0
+  4: $t3 := infer($t4)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t5 := 1
+  9: $t2 := +($t3, $t5)
+ 10: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_1.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+
+    fun foo(b: bool, p: u64): u64 {
+        let a = p;
+        if (b) {
+            a = 0; // kills copy `a := p`
+        };
+        a + 1 // should not have any copies available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.exp
@@ -1,0 +1,75 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := infer($t2)
+  6: label L2
+  7: $t3 := infer($t4)
+  8: return $t3
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+     # before: {}, after: {}
+  0: if ($t0) goto 1 else goto 4
+     # before: {}, after: {}
+  1: label L0
+     # before: {}, after: {$t4 := $t1}
+  2: $t4 := infer($t1)
+     # before: {$t4 := $t1}, after: {$t4 := $t1}
+  3: goto 6
+     # before: {}, after: {}
+  4: label L1
+     # before: {}, after: {$t4 := $t2}
+  5: $t4 := infer($t2)
+     # before: {}, after: {}
+  6: label L2
+     # before: {}, after: {$t3 := $t4}
+  7: $t3 := infer($t4)
+     # before: {$t3 := $t4}, after: {$t3 := $t4}
+  8: return $t3
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := infer($t2)
+  6: label L2
+  7: $t3 := infer($t4)
+  8: return $t4
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := infer($t2)
+  6: label L2
+  7: return $t4
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(b: bool, p: u64, q: u64): u64 {
+        let a: u64;
+        if (b) {
+            a = p;
+        } else {
+            a = q;
+        };
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.exp
@@ -1,0 +1,73 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t3 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t3 := infer($t1)
+  6: label L2
+  7: $t2 := infer($t3)
+  8: return $t2
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # before: {}, after: {}
+  0: if ($t0) goto 1 else goto 4
+     # before: {}, after: {}
+  1: label L0
+     # before: {}, after: {$t3 := $t1}
+  2: $t3 := infer($t1)
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  3: goto 6
+     # before: {}, after: {}
+  4: label L1
+     # before: {}, after: {$t3 := $t1}
+  5: $t3 := infer($t1)
+     # before: {$t3 := $t1}, after: {$t3 := $t1}
+  6: label L2
+     # before: {$t3 := $t1}, after: {$t2 := $t3, $t3 := $t1}
+  7: $t2 := infer($t3)
+     # before: {$t2 := $t3, $t3 := $t1}, after: {$t2 := $t3, $t3 := $t1}
+  8: return $t2
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t3 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t3 := infer($t1)
+  6: label L2
+  7: $t2 := infer($t1)
+  8: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 3
+  1: label L0
+  2: goto 4
+  3: label L1
+  4: label L2
+  5: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(b: bool, p: u64): u64 {
+        let a: u64;
+        if (b) {
+            a = p;
+        } else {
+            a = p;
+        };
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
@@ -1,0 +1,112 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
+  3: $t6 := m::id($t4)
+  4: $t5 := m::id($t6)
+  5: $t1 := m::id($t5)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # before: {}, after: {$t1 := $t0}
+  0: $t1 := infer($t0)
+     # before: {$t1 := $t0}, after: {$t1 := $t0}
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t0}
+  1: $t3 := infer($t0)
+     # before: {$t2 := $t0, $t3 := $t0}, after: {$t2 := $t0, $t3 := $t0, $t4 := $t3}
+  2: $t4 := infer($t3)
+     # before: {$t2 := $t0, $t3 := $t0, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t0, $t4 := $t3}
+  3: $t6 := m::id($t4)
+     # before: {$t2 := $t0, $t3 := $t0, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t0, $t4 := $t3}
+  4: $t5 := m::id($t6)
+     # before: {$t2 := $t0, $t3 := $t0, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t0, $t4 := $t3}
+  5: $t1 := m::id($t5)
+     # before: {$t2 := $t0, $t3 := $t0, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t0, $t4 := $t3}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t0)
+  3: $t6 := m::id($t0)
+  4: $t5 := m::id($t6)
+  5: $t1 := m::id($t5)
+  6: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+  0: return $t0
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t6 := m::id($t0)
+  1: $t5 := m::id($t6)
+  2: $t1 := m::id($t5)
+  3: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun id(x: u64): u64 {
+        x
+    }
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = p;
+        let c = b;
+        id(id(id(c)))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
@@ -1,0 +1,114 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
+  3: $t5 := borrow_local($t2)
+  4: m::update($t5)
+  5: $t1 := infer($t4)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+     # before: {}, after: {}
+  0: $t1 := 0
+     # before: {}, after: {}
+  1: write_ref($t0, $t1)
+     # before: {}, after: {}
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     # before: {}, after: {}
+  0: $t2 := infer($t0)
+     # before: {}, after: {$t3 := $t0}
+  1: $t3 := infer($t0)
+     # before: {$t3 := $t0}, after: {$t3 := $t0, $t4 := $t3}
+  2: $t4 := infer($t3)
+     # before: {$t3 := $t0, $t4 := $t3}, after: {$t3 := $t0, $t4 := $t3}
+  3: $t5 := borrow_local($t2)
+     # before: {$t3 := $t0, $t4 := $t3}, after: {$t3 := $t0, $t4 := $t3}
+  4: m::update($t5)
+     # before: {$t3 := $t0, $t4 := $t3}, after: {$t1 := $t4, $t3 := $t0, $t4 := $t3}
+  5: $t1 := infer($t4)
+     # before: {$t1 := $t4, $t3 := $t0, $t4 := $t3}, after: {$t1 := $t4, $t3 := $t0, $t4 := $t3}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t0)
+  3: $t5 := borrow_local($t2)
+  4: m::update($t5)
+  5: $t1 := infer($t0)
+  6: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t2 := infer($t0)
+  1: $t5 := borrow_local($t2)
+  2: m::update($t5)
+  3: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun update(p: &mut u64) {
+        *p = 0;
+    }
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = p;
+        let c = b;
+        update(&mut a);
+        c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
@@ -1,0 +1,57 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t0 := infer($t3)
+  3: $t1 := infer($t0)
+  4: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t2}
+  1: $t3 := infer($t2)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t0 := $t3, $t3 := $t2}
+  2: $t0 := infer($t3)
+     # before: {$t0 := $t3, $t3 := $t2}, after: {$t0 := $t3, $t1 := $t0, $t3 := $t2}
+  3: $t1 := infer($t0)
+     # before: {$t0 := $t3, $t1 := $t0, $t3 := $t2}, after: {$t0 := $t3, $t1 := $t0, $t3 := $t2}
+  4: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t0 := infer($t0)
+  3: $t1 := infer($t2)
+  4: return $t2
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun cyclic(p: u64): u64 {
+        let a = p;
+        let b = a;
+        p = b;
+        p
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.exp
@@ -1,0 +1,52 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t1 := infer($t3)
+  3: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t2}
+  1: $t3 := infer($t2)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t1 := $t3, $t2 := $t0, $t3 := $t2}
+  2: $t1 := infer($t3)
+     # before: {$t1 := $t3, $t2 := $t0, $t3 := $t2}, after: {$t1 := $t3, $t2 := $t0, $t3 := $t2}
+  3: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t1 := infer($t0)
+  3: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    fun dead(p: u64): u64 {
+        let a = p;
+        let a = a;
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
@@ -1,0 +1,40 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+  0: $t0 := infer($t0)
+  1: $t1 := infer($t0)
+  2: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     # before: {}, after: {}
+  0: $t0 := infer($t0)
+     # before: {}, after: {$t1 := $t0}
+  1: $t1 := infer($t0)
+     # before: {$t1 := $t0}, after: {$t1 := $t0}
+  2: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+  0: $t0 := infer($t0)
+  1: $t1 := infer($t0)
+  2: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+  0: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+    fun dead(p: u64): u64 {
+        p = p;
+        p
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
@@ -1,0 +1,70 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t2)
+  3: $t5 := infer($t4)
+  4: $t1 := read_ref($t5)
+  5: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+     # before: {}, after: {}
+  0: $t3 := borrow_local($t0)
+     # before: {}, after: {$t2 := $t3}
+  1: $t2 := infer($t3)
+     # before: {$t2 := $t3}, after: {$t2 := $t3, $t4 := $t2}
+  2: $t4 := infer($t2)
+     # before: {$t2 := $t3, $t4 := $t2}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  4: $t1 := read_ref($t5)
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  5: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t3)
+  4: $t1 := read_ref($t3)
+  5: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t1 := read_ref($t3)
+  2: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &p;
+        let b = a;
+        let c = b;
+        *c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
@@ -1,0 +1,78 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # before: {}, after: {}
+  0: $t3 := borrow_local($t0)
+     # before: {}, after: {$t2 := $t3}
+  1: $t2 := infer($t3)
+     # before: {$t2 := $t3}, after: {$t2 := $t3}
+  2: $t4 := infer($t0)
+     # before: {$t2 := $t3}, after: {$t2 := $t3, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t3, $t5 := $t4}, after: {$t2 := $t3, $t5 := $t4, $t6 := $t5}
+  4: $t6 := infer($t5)
+     # before: {$t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}
+  5: $t1 := infer($t6)
+     # before: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t4)
+  5: $t1 := infer($t4)
+  6: return $t4
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t4 := infer($t0)
+  2: return $t4
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &p;
+        let b = p;
+        let c = b;
+        let d = c;
+        d
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
@@ -1,0 +1,163 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := 0
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := 10
+  6: $t6 := <($t4, $t7)
+  7: if ($t6) goto 8 else goto 14
+  8: label L2
+  9: $t2 := infer($t0)
+ 10: $t9 := 1
+ 11: $t8 := +($t4, $t9)
+ 12: $t4 := infer($t8)
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 4
+ 18: label L1
+ 19: $t1 := infer($t2)
+ 20: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # before: {}, after: {}
+  0: $t3 := 0
+     # before: {}, after: {$t2 := $t3}
+  1: $t2 := infer($t3)
+     # before: {$t2 := $t3}, after: {$t2 := $t3}
+  2: $t5 := 0
+     # before: {$t2 := $t3}, after: {$t2 := $t3, $t4 := $t5}
+  3: $t4 := infer($t5)
+     # before: {}, after: {}
+  4: label L0
+     # before: {}, after: {}
+  5: $t7 := 10
+     # before: {}, after: {}
+  6: $t6 := <($t4, $t7)
+     # before: {}, after: {}
+  7: if ($t6) goto 8 else goto 14
+     # before: {}, after: {}
+  8: label L2
+     # before: {}, after: {$t2 := $t0}
+  9: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 10: $t9 := 1
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 11: $t8 := +($t4, $t9)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t4 := $t8}
+ 12: $t4 := infer($t8)
+     # before: {$t2 := $t0, $t4 := $t8}, after: {$t2 := $t0, $t4 := $t8}
+ 13: goto 16
+     # before: {}, after: {}
+ 14: label L3
+     # before: {}, after: {}
+ 15: goto 18
+     # before: {$t2 := $t0, $t4 := $t8}, after: {$t2 := $t0, $t4 := $t8}
+ 16: label L4
+     # before: {$t2 := $t0, $t4 := $t8}, after: {$t2 := $t0, $t4 := $t8}
+ 17: goto 4
+     # before: {}, after: {}
+ 18: label L1
+     # before: {}, after: {$t1 := $t2}
+ 19: $t1 := infer($t2)
+     # before: {$t1 := $t2}, after: {$t1 := $t2}
+ 20: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := 0
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := 10
+  6: $t6 := <($t4, $t7)
+  7: if ($t6) goto 8 else goto 14
+  8: label L2
+  9: $t2 := infer($t0)
+ 10: $t9 := 1
+ 11: $t8 := +($t4, $t9)
+ 12: $t4 := infer($t8)
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 4
+ 18: label L1
+ 19: $t1 := infer($t2)
+ 20: return $t2
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := 0
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := 10
+  6: $t6 := <($t4, $t7)
+  7: if ($t6) goto 8 else goto 14
+  8: label L2
+  9: $t2 := infer($t0)
+ 10: $t9 := 1
+ 11: $t8 := +($t4, $t9)
+ 12: $t4 := infer($t8)
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 4
+ 18: label L1
+ 19: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = 0;
+        let count = 0;
+        while (count < 10) {
+            a = p;
+            count = count + 1;
+        };
+        a // copy `a := p` should not be available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
@@ -1,0 +1,152 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := infer($t0)
+  1: $t4 := 0
+  2: $t3 := infer($t4)
+  3: label L0
+  4: $t6 := 10
+  5: $t5 := <($t3, $t6)
+  6: if ($t5) goto 7 else goto 13
+  7: label L2
+  8: $t2 := infer($t0)
+  9: $t8 := 1
+ 10: $t7 := +($t3, $t8)
+ 11: $t3 := infer($t7)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 3
+ 17: label L1
+ 18: $t1 := infer($t2)
+ 19: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  1: $t4 := 0
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t4}
+  2: $t3 := infer($t4)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  3: label L0
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  4: $t6 := 10
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  5: $t5 := <($t3, $t6)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  6: if ($t5) goto 7 else goto 13
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  7: label L2
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  8: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+  9: $t8 := 1
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 10: $t7 := +($t3, $t8)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t7}
+ 11: $t3 := infer($t7)
+     # before: {$t2 := $t0, $t3 := $t7}, after: {$t2 := $t0, $t3 := $t7}
+ 12: goto 15
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 13: label L3
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 14: goto 17
+     # before: {$t2 := $t0, $t3 := $t7}, after: {$t2 := $t0, $t3 := $t7}
+ 15: label L4
+     # before: {$t2 := $t0, $t3 := $t7}, after: {$t2 := $t0, $t3 := $t7}
+ 16: goto 3
+     # before: {$t2 := $t0}, after: {$t2 := $t0}
+ 17: label L1
+     # before: {$t2 := $t0}, after: {$t1 := $t2, $t2 := $t0}
+ 18: $t1 := infer($t2)
+     # before: {$t1 := $t2, $t2 := $t0}, after: {$t1 := $t2, $t2 := $t0}
+ 19: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := infer($t0)
+  1: $t4 := 0
+  2: $t3 := infer($t4)
+  3: label L0
+  4: $t6 := 10
+  5: $t5 := <($t3, $t6)
+  6: if ($t5) goto 7 else goto 13
+  7: label L2
+  8: $t2 := infer($t0)
+  9: $t8 := 1
+ 10: $t7 := +($t3, $t8)
+ 11: $t3 := infer($t7)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 3
+ 17: label L1
+ 18: $t1 := infer($t0)
+ 19: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t4 := 0
+  1: $t3 := infer($t4)
+  2: label L0
+  3: $t6 := 10
+  4: $t5 := <($t3, $t6)
+  5: if ($t5) goto 6 else goto 11
+  6: label L2
+  7: $t8 := 1
+  8: $t7 := +($t3, $t8)
+  9: $t3 := infer($t7)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 2
+ 15: label L1
+ 16: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let count = 0;
+        while (count < 10) {
+            a = p;
+            count = count + 1;
+        };
+        a // copy `a := p` should be available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
@@ -1,0 +1,76 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t3 := infer($t4)
+  3: $t5 := 1
+  4: write_ref($t3, $t5)
+  5: $t1 := infer($t2)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+     # before: {}, after: {}
+  0: $t2 := infer($t0)
+     # before: {}, after: {}
+  1: $t4 := borrow_local($t0)
+     # before: {}, after: {$t3 := $t4}
+  2: $t3 := infer($t4)
+     # before: {$t3 := $t4}, after: {$t3 := $t4}
+  3: $t5 := 1
+     # before: {$t3 := $t4}, after: {$t3 := $t4}
+  4: write_ref($t3, $t5)
+     # before: {$t3 := $t4}, after: {$t1 := $t2, $t3 := $t4}
+  5: $t1 := infer($t2)
+     # before: {$t1 := $t2, $t3 := $t4}, after: {$t1 := $t2, $t3 := $t4}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t3 := infer($t4)
+  3: $t5 := 1
+  4: write_ref($t4, $t5)
+  5: $t1 := infer($t2)
+  6: return $t2
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t5 := 1
+  3: write_ref($t4, $t5)
+  4: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = &mut p;
+        *b = 1;
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
@@ -1,0 +1,113 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t4 := infer($t5)
+  5: $t7 := 0
+  6: write_ref($t4, $t7)
+  7: $t8 := borrow_local($t3)
+  8: $t9 := borrow_field<m::S>.a($t8)
+  9: $t1 := read_ref($t9)
+ 10: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+     # before: {}, after: {}
+  0: $t2 := infer($t0)
+     # before: {}, after: {}
+  1: $t3 := infer($t2)
+     # before: {}, after: {}
+  2: $t6 := borrow_local($t2)
+     # before: {}, after: {}
+  3: $t5 := borrow_field<m::S>.a($t6)
+     # before: {}, after: {$t4 := $t5}
+  4: $t4 := infer($t5)
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+  5: $t7 := 0
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+  6: write_ref($t4, $t7)
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+  7: $t8 := borrow_local($t3)
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+  8: $t9 := borrow_field<m::S>.a($t8)
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+  9: $t1 := read_ref($t9)
+     # before: {$t4 := $t5}, after: {$t4 := $t5}
+ 10: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t4 := infer($t5)
+  5: $t7 := 0
+  6: write_ref($t5, $t7)
+  7: $t8 := borrow_local($t3)
+  8: $t9 := borrow_field<m::S>.a($t8)
+  9: $t1 := read_ref($t9)
+ 10: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t7 := 0
+  5: write_ref($t5, $t7)
+  6: $t8 := borrow_local($t3)
+  7: $t9 := borrow_field<m::S>.a($t8)
+  8: $t1 := read_ref($t9)
+  9: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+
+    struct S {
+        a: u64,
+        b: u64,
+    }
+
+    fun test(s: S): u64 {
+        let p = s;
+        let q = p;
+        let ref = &mut p.a;
+        *ref = 0;
+        q.a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -1,0 +1,84 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t2)
+  3: $t5 := infer($t4)
+  4: $t6 := 0
+  5: write_ref($t2, $t6)
+  6: $t1 := read_ref($t5)
+  7: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+     # before: {}, after: {}
+  0: $t3 := borrow_local($t0)
+     # before: {}, after: {$t2 := $t3}
+  1: $t2 := infer($t3)
+     # before: {$t2 := $t3}, after: {$t2 := $t3, $t4 := $t2}
+  2: $t4 := infer($t2)
+     # before: {$t2 := $t3, $t4 := $t2}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  4: $t6 := 0
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  5: write_ref($t2, $t6)
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  6: $t1 := read_ref($t5)
+     # before: {$t2 := $t3, $t4 := $t2, $t5 := $t4}, after: {$t2 := $t3, $t4 := $t2, $t5 := $t4}
+  7: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t3)
+  4: $t6 := 0
+  5: write_ref($t3, $t6)
+  6: $t1 := read_ref($t3)
+  7: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t6 := 0
+  2: write_ref($t3, $t6)
+  3: $t1 := read_ref($t3)
+  4: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
@@ -1,0 +1,92 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t7 := 0
+  6: write_ref($t2, $t7)
+  7: $t1 := infer($t6)
+  8: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # before: {}, after: {}
+  0: $t3 := borrow_local($t0)
+     # before: {}, after: {$t2 := $t3}
+  1: $t2 := infer($t3)
+     # before: {$t2 := $t3}, after: {$t2 := $t3}
+  2: $t4 := infer($t0)
+     # before: {$t2 := $t3}, after: {$t2 := $t3, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t3, $t5 := $t4}, after: {$t2 := $t3, $t5 := $t4, $t6 := $t5}
+  4: $t6 := infer($t5)
+     # before: {$t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t2 := $t3, $t5 := $t4, $t6 := $t5}
+  5: $t7 := 0
+     # before: {$t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t2 := $t3, $t5 := $t4, $t6 := $t5}
+  6: write_ref($t2, $t7)
+     # before: {$t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}
+  7: $t1 := infer($t6)
+     # before: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t3, $t5 := $t4, $t6 := $t5}
+  8: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t4)
+  5: $t7 := 0
+  6: write_ref($t3, $t7)
+  7: $t1 := infer($t4)
+  8: return $t4
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t0)
+  1: $t4 := infer($t0)
+  2: $t7 := 0
+  3: write_ref($t3, $t7)
+  4: return $t4
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.move
@@ -1,0 +1,11 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &mut p;
+        let b = p;
+        let c = b;
+        let d = c;
+        *a = 0;
+        d
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.exp
@@ -1,0 +1,76 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t2}
+  1: $t3 := infer($t2)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3}
+  2: $t4 := infer($t3)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  4: $t6 := infer($t5)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  5: $t1 := infer($t6)
+     # before: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t0)
+  4: $t6 := infer($t0)
+  5: $t1 := infer($t0)
+  6: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+  0: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.move
@@ -6,7 +6,7 @@ module 0xc0ffee::m {
         d: u64,
         e: u64,
     }
-    
+
     fun sequential(p: Foo): Foo {
         let a = p;
         let b = a;

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    struct Foo has copy {
+        a: u64,
+        b: u64,
+        c: u64,
+        d: u64,
+        e: u64,
+    }
+    
+    fun sequential(p: Foo): Foo {
+        let a = p;
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        e
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.exp
@@ -1,0 +1,76 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t2}
+  1: $t3 := infer($t2)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3}
+  2: $t4 := infer($t3)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4}
+  3: $t5 := infer($t4)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4}, after: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  4: $t6 := infer($t5)
+     # before: {$t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  5: $t1 := infer($t6)
+     # before: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}, after: {$t1 := $t6, $t2 := $t0, $t3 := $t2, $t4 := $t3, $t5 := $t4, $t6 := $t5}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t0)
+  4: $t6 := infer($t0)
+  5: $t1 := infer($t0)
+  6: return $t0
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun sequential(p: u64): u64 {
+        let a = p;
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        e
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
@@ -1,0 +1,76 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t5 := 1
+  3: $t4 := +($t0, $t5)
+  4: $t0 := infer($t4)
+  5: $t1 := +($t3, $t2)
+  6: return $t1
+}
+
+============ after available_copies: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: {}, after: {$t2 := $t0}
+  0: $t2 := infer($t0)
+     # before: {$t2 := $t0}, after: {$t2 := $t0, $t3 := $t2}
+  1: $t3 := infer($t2)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t2 := $t0, $t3 := $t2}
+  2: $t5 := 1
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t2 := $t0, $t3 := $t2}
+  3: $t4 := +($t0, $t5)
+     # before: {$t2 := $t0, $t3 := $t2}, after: {$t0 := $t4, $t3 := $t2}
+  4: $t0 := infer($t4)
+     # before: {$t0 := $t4, $t3 := $t2}, after: {$t0 := $t4, $t3 := $t2}
+  5: $t1 := +($t3, $t2)
+     # before: {$t0 := $t4, $t3 := $t2}, after: {$t0 := $t4, $t3 := $t2}
+  6: return $t1
+}
+
+============ after copy_propagation: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t5 := 1
+  3: $t4 := +($t0, $t5)
+  4: $t0 := infer($t4)
+  5: $t1 := +($t2, $t2)
+  6: return $t1
+}
+
+============ after dead_store_elimination: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t5 := 1
+  2: $t4 := +($t0, $t5)
+  3: $t1 := +($t2, $t2)
+  4: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.move
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun copy_kill(p: u64): u64 {
+        let a = p;
+        let b = a;
+        p = p + 1;
+        b + a
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/deep_exp.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/deep_exp.exp
@@ -1,25 +1,6 @@
-comparison between v1 and v2 failed:
-= processed 2 tasks
-= 
-+ task 0 'publish'. lines 1-27:
-+ Error: compilation errors:
-+  error: exceeded maximal local count: 255
-+    ┌─ TEMPFILE:18:5
-+    │  
-+ 18 │ ╭     public fun test(): u64 {
-+ 19 │ │         f1(0)
-+ 20 │ │     }
-+    │ ╰─────^
-+ 
-+ 
-+ 
-= task 1 'run'. lines 29-29:
-- return values: 625
-+ Error: Function execution failed with VMError: {
-+     major_status: LINKER_ERROR,
-+     sub_status: None,
-+     location: undefined,
-+     indices: redacted,
-+     offsets: redacted,
-+ }
-= 
+processed 2 tasks
+
+task 1 'run'. lines 29-29:
+return values: 625
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-model/bytecode/src/annotations.rs
+++ b/third_party/move/move-model/bytecode/src/annotations.rs
@@ -96,6 +96,11 @@ impl Annotations {
             .and_then(|(d, _)| d.value.downcast::<T>().ok())
     }
 
+    /// Clears all annotations.
+    pub fn clear(&mut self) {
+        self.map.clear()
+    }
+
     /// Mark whether the annotations all reach a fixedpoint status
     pub fn reached_fixedpoint(&self) -> bool {
         self.map.values().all(|(_, fixedpoint)| *fixedpoint)

--- a/third_party/move/move-model/bytecode/src/dataflow_domains.rs
+++ b/third_party/move/move-model/bytecode/src/dataflow_domains.rs
@@ -19,9 +19,11 @@ use std::{
 /// Represents the abstract outcome of a join.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JoinResult {
-    /// The left operand subsumes the right operand: L union R == L.
+    /// The left operand remains unchanged when joined with the right operand,
+    /// i.e., the L.join(R) operation leaves L unchanged.
     Unchanged,
-    /// The left operand does not subsume the right one and was changed as part of the join.
+    /// The left operand changes when joined with the right operand,
+    /// i.e., the L.join(R) operation changes L.
     Changed,
 }
 


### PR DESCRIPTION
This PR adds the following analyses and transformations on the stackless bytecode, and enables them by default in the compiler v2:
* Available copies analysis
* Copy propagation transformation
* Dead store elimination

The overall effect is (potentially): (a) reduction in the number of locals created, (b) reduction in the number of instructions.

### Description

#### Available copies analysis

This analysis computes for each program point, which copies of the form `a := b` (`a` assigned to `b`) are definitely available. It is implemented as a forwards must analysis.

#### Copy propagation transformation

This analysis transforms the bytecode by making use of the available copies information, and replacing uses of locals with their copy-chain heads. This transformation creates a lot of dead stores.

For example:
```
let a = 1;
let b = a;
let c = b;
c  // copy-chain: a <- b <- c
```

is transformed into:
```
let a = 1;
let b = a;  // dead store
let c = a;  // dead store, copy-chain head of `b` is `a`
a  // copy-chain head of `c` is `a`
```

#### Dead store elimination

This transformation deletes stackless bytecode instructions that do wasteful writes to locals:
- write to a local that is never used again
- self assignment to a local (i.e., `x := x`)

### Test Plan
* All the transactional tests comparing v1 vs v2 pass as before, except `deep_exp` which now passes correctly with the same o/p in v1 and v2.
* Several copy propagation specific tests added with IR displayed for relevant stages of the optimization pipeline.

