### PR TITLE
Release aptos-protos crate to crates.io, exclude from workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ dependencies = [
  "aptos-move-debugger",
  "aptos-network-checker",
  "aptos-node",
- "aptos-protos 1.1.2",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-storage-interface",
@@ -254,6 +253,7 @@ dependencies = [
  "aptos-vm",
  "aptos-vm-genesis",
  "async-trait",
+ "backoff",
  "base64 0.13.1",
  "bcs 0.1.4",
  "bollard",
@@ -2013,8 +2013,8 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
- "aptos-protos 1.1.2",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
+ "aptos-protos 1.1.3",
  "aptos-runtimes",
  "async-trait",
  "backoff",
@@ -2042,7 +2042,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "async-trait",
  "backoff",
  "backtrace",
@@ -2086,8 +2086,8 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-moving-average",
- "aptos-protos 1.1.2",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
+ "aptos-protos 1.1.3",
  "aptos-runtimes",
  "async-trait",
  "base64 0.13.1",
@@ -2115,8 +2115,8 @@ dependencies = [
  "aptos-indexer-grpc-server-framework",
  "aptos-indexer-grpc-utils",
  "aptos-metrics-core",
- "aptos-moving-average",
- "aptos-protos 1.1.2",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
+ "aptos-protos 1.1.3",
  "aptos-runtimes",
  "async-trait",
  "base64 0.13.1",
@@ -2155,9 +2155,9 @@ dependencies = [
  "aptos-mempool",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
  "aptos-proptest-helpers",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "aptos-runtimes",
  "aptos-sdk",
  "aptos-secure-storage",
@@ -2201,7 +2201,7 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-inspection-service",
  "aptos-logger",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "aptos-runtimes",
  "aptos-transaction-emitter-lib",
  "aptos-transaction-generator-lib",
@@ -2276,9 +2276,9 @@ dependencies = [
  "aptos-mempool",
  "aptos-mempool-notifications",
  "aptos-metrics-core",
- "aptos-moving-average",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
  "aptos-proptest-helpers",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "aptos-rocksdb-options",
  "aptos-runtimes",
  "aptos-sdk",
@@ -2317,7 +2317,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "async-trait",
  "backoff",
  "backtrace",
@@ -2703,6 +2703,14 @@ dependencies = [
 name = "aptos-moving-average"
 version = "0.1.0"
 source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "aptos-moving-average"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=54d09f427a93e16aaf13abf2115f9e1d46d56cfe#54d09f427a93e16aaf13abf2115f9e1d46d56cfe"
 dependencies = [
  "chrono",
 ]
@@ -3206,7 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.1.2"
+version = "1.1.2-a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a99ec72b1ea1bcc2183bcf483c0aaacdf6777d3e3572779ef9c172782c5062"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -3218,8 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.1.2"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c#af0dcea7144225a709e4f595e58f8026b99e901c"
+version = "1.1.3"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -3546,7 +3555,7 @@ dependencies = [
  "aptos-config",
  "aptos-logger",
  "aptos-metrics-core",
- "aptos-protos 1.1.2",
+ "aptos-protos 1.1.3",
  "aptos-retrier",
  "bcs 0.1.4",
  "crossbeam-channel",
@@ -12360,11 +12369,11 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=54d09f427a93e16aaf13abf2115f9e1d46d56cfe#54d09f427a93e16aaf13abf2115f9e1d46d56cfe"
 dependencies = [
  "anyhow",
- "aptos-moving-average",
- "aptos-protos 1.1.2 (git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=54d09f427a93e16aaf13abf2115f9e1d46d56cfe)",
+ "aptos-protos 1.1.2-a",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -13920,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf#4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=54d09f427a93e16aaf13abf2115f9e1d46d56cfe#54d09f427a93e16aaf13abf2115f9e1d46d56cfe"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -37,7 +37,6 @@ aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }
 aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }
-aptos-protos = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
@@ -47,6 +46,7 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
+backoff = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 bollard = { workspace = true }
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "54d09f427a93e16aaf13abf2115f9e1d46d56cfe" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "54d09f427a93e16aaf13abf2115f9e1d46d56cfe" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/protos/rust/CONTRIBUTING.md
+++ b/protos/rust/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Aptos Protos
+
+## Release process
+To release a new version of the package do the following.
+
+1. Check that the commit you're deploying from (likely just the latest commit of `main`) is green in CI.
+1. Bump the version in `Cargo.toml` according to [semver](https://semver.org/).
+1. Add an entry in the CHANGELOG for the version. We adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Generally this means changing the "Unreleased" section to a version and then making a new "Unreleased" section.
+1. Get the auth token from our password manager. Search for "crates io API token". Run `cargo login` and then paste the token in.
+1. Run `cargo publish --dry-run` first just to make sure that the crate compiles happily.
+1. Double check that the release worked by visitng crates.io: https://crates.io/crates/aptos-protos.
+
+## Workspace
+If you're using this crate from within aptos-core, consider relying on it via the workspace (`aptos-protos = { workspace = true }`). This is the simplest approach and makes iterating on development easier.
+
+For other cases, e.g. when using this crate from other repos or crates in aptos-core have compatibility guarantees to uphold, you may choose to rely on the crate as release on crates.io instead.

--- a/protos/rust/Cargo.toml
+++ b/protos/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos-protos"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Code generated from Aptos protobuf definitions"
 repository = "https://github.com/aptos-labs/aptos-core"


### PR DESCRIPTION
### Description
To avoid circular dependencies due to using aptos-protos across multiple repos (from having crates in aptos-core rely in crates in aptos-indexer-processors that rely on aptos-protos in aptos-core) from this PR I publish aptos-protos to crates.io. I then make all the indexer crates use the crate from crates.io, while everything else keeps using it via the workspace.

1.1.3 is based on the current state of the repo, so there should be no functional changes from this PR.

In this PR I include a guide explaining how to publish the aptos-protos package to crates.io.

More context: https://aptos-org.slack.com/archives/C04PF1X2UKY/p1704470254299569.

### Test Plan
See that commands for target determination stuff work now as intended:
```
cargo clippy -p aptos -p aptos-protos
```
Previously it would give an error like this:
```
error: There are multiple `aptos-moving-average` packages in your project, and the specification `aptos-moving-average` is ambiguous.
```

See that you can run a local testnet:
```
cargo run -p aptos -- node run-local-testnet --with-indexer-api --force-restart --assume-yes
```

I ran `rust_lint.sh` and it looks good.

Let's see how CI goes.