### PR TITLE
Reduce max_execution_gas / max_io_gas on v1.8

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -167,12 +167,12 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [
             max_execution_gas: InternalGas,
             { 7.. => "max_execution_gas" },
-            20_000_000_000,
+            5_000_000_000,
         ],
         [
             max_io_gas: InternalGas,
             { 7.. => "max_io_gas" },
-            10_000_000_000,
+            5_000_000_000,
         ],
         [
             max_storage_fee: Fee,

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,24 +1,11 @@
 ---
 remote_endpoint: ~
-name: "v1.8.1"
+name: "v1.8.2"
 proposals:
-  - name: step_1_upgrade_framework
+  - name: step_1_update_txn_gas_limits
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework to v1.8.1"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.8"
+      title: "[AIP-60] Update txn gas limits"
+      description: "[AIP-60] Update txn gas limits"
     execution_mode: MultiStep
     update_sequence:
       - DefaultGas
-      - Framework:
-          bytecode_version: 6
-          git_hash: ~
-  - name: step_2_change_operator_beneficiary
-    metadata:
-      title: "AIP-51: Changing beneficiaries for operators"
-      description: "AIP-51: This allows operator to change their beneficiaries."
-      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/251"
-    execution_mode: MultiStep
-    update_sequence:
-      - FeatureFlag:
-          enabled:
-            - operator_beneficiary_change

--- a/aptos-move/e2e-move-tests/src/tests/smart_data_structures.data/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/smart_data_structures.data/sources/test.move
@@ -24,7 +24,7 @@ module 0xcafe::test {
     public entry fun create_smart_vector(acct: &signer) {
         let v = smart_vector::empty();
         let i: u64 = 0;
-        while (i < 10000) {
+        while (i < 5000) {
             smart_vector::push_back(&mut v, i);
             i = i + 1;
         };
@@ -33,18 +33,18 @@ module 0xcafe::test {
 
     public entry fun update_smart_vector(acct: &signer) acquires SmartVectorStore {
         let v = &mut borrow_global_mut<SmartVectorStore>(signer::address_of(acct)).v;
-        smart_vector::push_back(v, 10000);
+        smart_vector::push_back(v, 5000);
     }
 
     public entry fun read_smart_vector(acct: &signer) acquires SmartVectorStore {
         let v = &borrow_global<SmartVectorStore>(signer::address_of(acct)).v;
-        smart_vector::borrow(v, 5000);
+        smart_vector::borrow(v, 2000);
     }
 
     public entry fun create_vector(acct: &signer) {
         let v = vector::empty();
         let i: u64 = 0;
-        while (i < 10000) {
+        while (i < 5000) {
             vector::push_back(&mut v, i);
             i = i + 1;
         };
@@ -53,12 +53,12 @@ module 0xcafe::test {
 
     public entry fun update_vector(acct: &signer) acquires VectorStore {
         let v = &mut borrow_global_mut<VectorStore>(signer::address_of(acct)).v;
-        vector::push_back(v, 10000);
+        vector::push_back(v, 5000);
     }
 
     public entry fun read_vector(acct: &signer) acquires VectorStore {
         let v = &borrow_global<VectorStore>(signer::address_of(acct)).v;
-        vector::borrow(v, 5000);
+        vector::borrow(v, 2000);
     }
 
     public entry fun create_smart_table(acct: &signer) {

--- a/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
+++ b/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
@@ -23,6 +23,8 @@ fn test_refunds() {
         ],
         vec![],
     );
+    h.modify_gas_schedule(|params| params.vm.txn.max_execution_gas = 40_000_000_000.into());
+
     let mod_addr = AccountAddress::from_hex_literal("0xcafe").unwrap();
     let user_addr = AccountAddress::from_hex_literal("0x100").unwrap();
     let mod_acc = h.new_account_at(mod_addr);


### PR DESCRIPTION
in support of [AIP](https://github.com/aptos-foundation/AIPs/blob/49e3883bf80f16c91e8e995769f5b6e2b0077a92/aips/reduce_largest_accepted_transactions.md), with more explanations there.

New values come to approximatelly 90ms for execution limit, and 100ms for io limit.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
