### PR TITLE
Compute correct accumulated effective block gas fees with module publishing txn(s) in the block

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1282,14 +1282,11 @@ where
                             )
                         });
 
-                    if block_limit_processor.use_module_publishing_block_conflict()
-                        && !block_limit_processor.has_seen_module_rw_conflict()
-                        && !last_input_output.append_and_check_module_rw_conflict(
-                            sequential_reads.module_reads.iter(),
-                            output.module_write_set().keys(),
-                        )
-                    {
-                        block_limit_processor.update_on_first_module_rw_conflict();
+                    if last_input_output.check_and_append_module_rw_conflict(
+                        sequential_reads.module_reads.iter(),
+                        output.module_write_set().keys(),
+                    ) {
+                        block_limit_processor.process_module_rw_conflict();
                     }
 
                     block_limit_processor.accumulate_fee_statement(

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -17,6 +17,7 @@ pub struct BlockGasLimitProcessor<T: Transaction> {
     txn_fee_statements: Vec<FeeStatement>,
     txn_read_write_summaries: Vec<ReadWriteSummary<T>>,
     block_limit_reached: bool,
+    module_rw_conflict: bool,
 }
 
 impl<T: Transaction> BlockGasLimitProcessor<T> {
@@ -29,6 +30,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             txn_fee_statements: Vec::with_capacity(init_size),
             txn_read_write_summaries: Vec::with_capacity(init_size),
             block_limit_reached: false,
+            module_rw_conflict: false,
         }
     }
 
@@ -58,7 +60,11 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
                     txn_read_write_summary.collapse_resource_group_conflicts()
                 },
             );
-            self.compute_conflict_multiplier(conflict_overlap_length as usize)
+            if self.module_rw_conflict {
+                conflict_overlap_length as u64
+            } else {
+                self.compute_conflict_multiplier(conflict_overlap_length as usize)
+            }
         } else {
             assert_none!(txn_read_write_summary);
             1
@@ -81,6 +87,32 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         } else {
             assert_none!(approx_output_size);
         }
+    }
+
+    pub(crate) fn recompute_acc_eff_block_gas_on_module_rw_conflict(&mut self) {
+        if !self
+            .block_gas_limit_type
+            .use_module_publishing_block_conflict()
+        {
+            return;
+        }
+
+        let conflict_multiplier = if let Some(conflict_overlap_length) =
+            self.block_gas_limit_type.conflict_penalty_window()
+        {
+            conflict_overlap_length
+        } else {
+            return;
+        };
+
+        self.accumulated_effective_block_gas = conflict_multiplier as u64
+            * (self.accumulated_fee_statement.execution_gas_used()
+                * self
+                    .block_gas_limit_type
+                    .execution_gas_effective_multiplier()
+                + self.accumulated_fee_statement.io_gas_used()
+                    * self.block_gas_limit_type.io_gas_effective_multiplier());
+        self.module_rw_conflict = true;
     }
 
     fn should_end_block(&mut self, mode: &str) -> bool {
@@ -426,5 +458,60 @@ mod test {
         assert_eq!(1, processor.compute_conflict_multiplier(8));
         assert_eq!(processor.accumulated_effective_block_gas, 20);
         assert!(!processor.should_end_block_parallel());
+    }
+
+    #[test]
+    fn test_module_publishing_txn_conflict() {
+        let conflict_penalty_window = 4;
+        let block_gas_limit = BlockGasLimitType::ComplexLimitV1 {
+            effective_block_gas_limit: 1000,
+            execution_gas_effective_multiplier: 1,
+            io_gas_effective_multiplier: 1,
+            conflict_penalty_window,
+            use_module_publishing_block_conflict: true,
+            block_output_limit: None,
+            include_user_txn_size_in_block_output: true,
+            add_block_limit_outcome_onchain: false,
+            use_granular_resource_group_conflicts: true,
+        };
+
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
+        processor.accumulate_fee_statement(
+            execution_fee(10),
+            Some(ReadWriteSummary::new(
+                to_map(&[InputOutputKey::Group(2, 2)]),
+                to_map(&[InputOutputKey::Group(2, 2)]),
+            )),
+            None,
+        );
+        processor.accumulate_fee_statement(
+            execution_fee(20),
+            Some(ReadWriteSummary::new(
+                to_map(&[InputOutputKey::Group(1, 1)]),
+                to_map(&[InputOutputKey::Group(1, 1)]),
+            )),
+            None,
+        );
+        assert_eq!(1, processor.compute_conflict_multiplier(8));
+        assert_eq!(processor.accumulated_effective_block_gas, 30);
+
+        processor.recompute_acc_eff_block_gas_on_module_rw_conflict();
+        assert_eq!(
+            processor.accumulated_effective_block_gas,
+            30 * conflict_penalty_window as u64
+        );
+
+        processor.accumulate_fee_statement(
+            execution_fee(25),
+            Some(ReadWriteSummary::new(
+                to_map(&[InputOutputKey::Group(1, 1)]),
+                to_map(&[InputOutputKey::Group(1, 1)]),
+            )),
+            None,
+        );
+        assert_eq!(
+            processor.accumulated_effective_block_gas,
+            55 * conflict_penalty_window as u64
+        );
     }
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -138,8 +138,8 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => BTreeMap::new(),
         };
 
-        if !self
-            .append_and_check_module_rw_conflict(input.module_reads.iter(), written_modules.keys())
+        if self
+            .check_and_append_module_rw_conflict(input.module_reads.iter(), written_modules.keys())
         {
             return false;
         }
@@ -150,26 +150,24 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         true
     }
 
-    pub(crate) fn append_and_check_module_rw_conflict<'a>(
+    pub(crate) fn check_and_append_module_rw_conflict<'a>(
         &self,
         module_reads_keys: impl Iterator<Item = &'a T::Key>,
-        written_modules_keys: impl Iterator<Item = &'a T::Key>,
+        module_writes_keys: impl Iterator<Item = &'a T::Key>,
     ) -> bool {
-        if !self.module_read_write_intersection.load(Ordering::Relaxed) {
-            // Check if adding new read & write modules leads to intersections.
-            if Self::append_and_check(module_reads_keys, &self.module_reads, &self.module_writes)
-                || Self::append_and_check(
-                    written_modules_keys,
-                    &self.module_writes,
-                    &self.module_reads,
-                )
-            {
-                self.module_read_write_intersection
-                    .store(true, Ordering::Release);
-                return false;
-            }
+        if self.module_read_write_intersection.load(Ordering::Relaxed) {
+            return true;
         }
-        true
+
+        // Check if adding new read & write modules leads to intersections.
+        if Self::append_and_check(module_reads_keys, &self.module_reads, &self.module_writes)
+            || Self::append_and_check(module_writes_keys, &self.module_writes, &self.module_reads)
+        {
+            self.module_read_write_intersection
+                .store(true, Ordering::Release);
+            return true;
+        }
+        false
     }
 
     pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<CapturedReads<T>>> {

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -138,26 +138,37 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => BTreeMap::new(),
         };
 
-        if !self.module_read_write_intersection.load(Ordering::Relaxed) {
-            // Check if adding new read & write modules leads to intersections.
-            if Self::append_and_check(
-                input.module_reads.iter(),
-                &self.module_reads,
-                &self.module_writes,
-            ) || Self::append_and_check(
-                written_modules.keys(),
-                &self.module_writes,
-                &self.module_reads,
-            ) {
-                self.module_read_write_intersection
-                    .store(true, Ordering::Release);
-                return false;
-            }
+        if !self
+            .append_and_check_module_rw_conflict(input.module_reads.iter(), written_modules.keys())
+        {
+            return false;
         }
 
         self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
         self.outputs[txn_idx as usize].store(Some(Arc::new(TxnOutput::from_output_status(output))));
 
+        true
+    }
+
+    pub(crate) fn append_and_check_module_rw_conflict<'a>(
+        &self,
+        module_reads_keys: impl Iterator<Item = &'a T::Key>,
+        written_modules_keys: impl Iterator<Item = &'a T::Key>,
+    ) -> bool {
+        if !self.module_read_write_intersection.load(Ordering::Relaxed) {
+            // Check if adding new read & write modules leads to intersections.
+            if Self::append_and_check(module_reads_keys, &self.module_reads, &self.module_writes)
+                || Self::append_and_check(
+                    written_modules_keys,
+                    &self.module_writes,
+                    &self.module_reads,
+                )
+            {
+                self.module_read_write_intersection
+                    .store(true, Ordering::Release);
+                return false;
+            }
+        }
         true
     }
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -596,9 +596,11 @@ impl OverallMeasuring {
         );
         info!("{} GPS: {} gas/s", prefix, delta_gas.gas / elapsed);
         info!(
-            "{} effectiveGPS: {} gas/s",
+            "{} effectiveGPS: {} gas/s ({} effective block gas, in {} s)",
             prefix,
-            delta_gas.effective_block_gas / elapsed
+            delta_gas.effective_block_gas / elapsed,
+            delta_gas.effective_block_gas,
+            elapsed
         );
         info!("{} ioGPS: {} gas/s", prefix, delta_gas.io_gas / elapsed);
         info!(

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -40,7 +40,7 @@ impl BlockExecutorConfigFromOnchain {
                     io_gas_effective_multiplier: 1,
                     block_output_limit: Some(1_000_000_000_000),
                     conflict_penalty_window: 8,
-                    use_module_publishing_block_conflict: false,
+                    use_module_publishing_block_conflict: true,
                     include_user_txn_size_in_block_output: true,
                     add_block_limit_outcome_onchain: false,
                     use_granular_resource_group_conflicts: false,

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -255,6 +255,17 @@ impl BlockGasLimitType {
         }
     }
 
+    pub fn use_module_publishing_block_conflict(&self) -> bool {
+        match self {
+            BlockGasLimitType::NoLimit => false,
+            BlockGasLimitType::Limit(_) => false,
+            BlockGasLimitType::ComplexLimitV1 {
+                use_module_publishing_block_conflict,
+                ..
+            } => *use_module_publishing_block_conflict,
+        }
+    }
+
     pub fn include_user_txn_size_in_block_output(&self) -> bool {
         match self {
             BlockGasLimitType::NoLimit => false,

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -77,7 +77,7 @@ impl OnChainExecutionConfig {
                 io_gas_effective_multiplier: 1,
                 conflict_penalty_window: 6,
                 use_granular_resource_group_conflicts: false,
-                use_module_publishing_block_conflict: false,
+                use_module_publishing_block_conflict: true,
                 block_output_limit: Some(3 * 1024 * 1024),
                 include_user_txn_size_in_block_output: true,
                 add_block_limit_outcome_onchain: false,


### PR DESCRIPTION
Start computing the accumulated block gas fee normally until you find a module publishing txn. Then recompute the accumulated block gas fee by setting conflict_multiplier == conflict_penalty_window for all preceeding txns, and continue accumulating with the same conflict_multiplier for subsequent txns in the block subsequent txns as well

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
