### PR TITLE
[Compiler v2] [Bugfix] Fix 11491

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -250,6 +250,9 @@ impl<'a> ExplicitDropTransformer<'a> {
             released.insert(t);
         }
         released
+            .into_iter()
+            .filter(|t| !self.is_primitive(*t))
+            .collect()
     }
 
     // Returns a set of locals that can be dropped at given code offset

--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -223,6 +223,7 @@ impl<'a> ExplicitDropTransformer<'a> {
     }
 
     /// Returns the set of locals released by the control flow edge from `pred_offset` to `suc_offset`
+    /// I.e., alive after `pred_offset` but dead before `suc_offset`, and not borrowed before `suc_offset`
     fn released_temps_between(&self, pred_offset: CodeOffset, suc_offset: CodeOffset) -> BTreeSet<TempIndex> {
         let mut released = BTreeSet::new();
         let lifetime_after = &self.get_lifetime_info(suc_offset).before;

--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -155,7 +155,7 @@ impl<'a> ExplicitDropTransformer<'a> {
     ///     - jumps to `label`
     pub fn process_jump(&mut self, pred_offset: CodeOffset, attr_id: AttrId, label: Label) -> Option<(Label, Vec<Bytecode>)> {
         let suc_offset = self.label_offsets.get(&label).expect("label offset");
-        let temps_to_drop = &self.released_by_lifetime_between(pred_offset, *suc_offset);
+        let temps_to_drop = &self.released_temps_between(pred_offset, *suc_offset);
         if temps_to_drop.is_empty() {
             None
         } else {

--- a/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/explicit_drop.rs
@@ -109,8 +109,7 @@ impl<'a> ExplicitDropTransformer<'a> {
             Bytecode::Ret(..) | Bytecode::Abort(..) => self.emit_bytecode(bytecode.clone()),
             _ => {
                 self.emit_bytecode(bytecode.clone());
-                let released_temps = self.released_temps_at(code_offset);
-                self.drop_temps(&released_temps, bytecode.get_attr_id())
+                self.explicit_drops_at(code_offset, bytecode)
             },
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -55,13 +55,18 @@ pub struct LiveVarInfoAtCodeOffset {
 }
 
 impl LiveVarInfoAtCodeOffset {
+    /// Returns the locals that are alive in `before` and dead in `after`
+    pub fn live_var_diff<'a>(before: &'a BTreeMap<TempIndex, LiveVarInfo>, after: &'a BTreeMap<TempIndex, LiveVarInfo>) -> impl Iterator<Item = TempIndex> + 'a {
+        // TODO: make this linear
+        before
+            .keys()
+            .filter(|t| !after.contains_key(t))
+            .cloned()
+    }
+
     /// Returns the temporaries that are alive before the program point and dead after.
     pub fn released_temps(&self) -> impl Iterator<Item = TempIndex> + '_ {
-        // TODO: make this linear
-        self.before
-            .keys()
-            .filter(|t| !self.after.contains_key(t))
-            .cloned()
+        LiveVarInfoAtCodeOffset::live_var_diff(&self.before, &self.after)
     }
 
     /// Creates a set of the temporaries alive before this program point.

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -56,12 +56,12 @@ pub struct LiveVarInfoAtCodeOffset {
 
 impl LiveVarInfoAtCodeOffset {
     /// Returns the locals that are alive in `before` and dead in `after`
-    pub fn live_var_diff<'a>(before: &'a BTreeMap<TempIndex, LiveVarInfo>, after: &'a BTreeMap<TempIndex, LiveVarInfo>) -> impl Iterator<Item = TempIndex> + 'a {
+    pub fn live_var_diff<'a>(
+        before: &'a BTreeMap<TempIndex, LiveVarInfo>,
+        after: &'a BTreeMap<TempIndex, LiveVarInfo>,
+    ) -> impl Iterator<Item = TempIndex> + 'a {
         // TODO: make this linear
-        before
-            .keys()
-            .filter(|t| !after.contains_key(t))
-            .cloned()
+        before.keys().filter(|t| !after.contains_key(t)).cloned()
     }
 
     /// Returns the temporaries that are alive before the program point and dead after.

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -524,6 +524,13 @@ impl LifetimeState {
 }
 
 impl LifetimeState {
+    pub fn lifetime_diff<'a>(&'a self, after: &'a Self) -> impl Iterator<Item = TempIndex> + 'a {
+        self.local_to_label_map
+            .keys()
+            .filter(|t| !after.local_to_label_map.contains_key(t))
+            .cloned()
+    }
+
     /// Returns the locals borrowed
     pub fn borrowed_locals(&self) -> impl Iterator<Item = TempIndex> + '_ {
         self.local_to_label_map.keys().cloned()
@@ -1343,10 +1350,7 @@ impl LifetimeInfoAtCodeOffset {
     /// locals being released need to be determined from livevar analysis results.
     pub fn released_temps(&self) -> impl Iterator<Item = TempIndex> + '_ {
         self.before
-            .local_to_label_map
-            .keys()
-            .filter(|t| !self.after.local_to_label_map.contains_key(t))
-            .cloned()
+            .lifetime_diff(&self.after)
     }
 
     /// Returns true if the value in the variable has been moved at this program point.

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -524,6 +524,7 @@ impl LifetimeState {
 }
 
 impl LifetimeState {
+    /// Returns an iterator over the locals borrowed in `self` but not in `after`
     pub fn lifetime_diff<'a>(&'a self, after: &'a Self) -> impl Iterator<Item = TempIndex> + 'a {
         self.local_to_label_map
             .keys()

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -1350,8 +1350,7 @@ impl LifetimeInfoAtCodeOffset {
     /// any longer. Notice that this is only for locals which are actually borrowed, other
     /// locals being released need to be determined from livevar analysis results.
     pub fn released_temps(&self) -> impl Iterator<Item = TempIndex> + '_ {
-        self.before
-            .lifetime_diff(&self.after)
+        self.before.lifetime_diff(&self.after)
     }
 
     /// Returns true if the value in the variable has been moved at this program point.

--- a/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
@@ -198,18 +198,33 @@ fun test::test(): test::Impotent {
   1: $t2 := pack test::Impotent($t3)
   2: $t1 := move($t2)
   3: $t4 := false
-  4: if ($t4) goto 5 else goto 9
-  5: label L0
-  6: $t0 := move($t1)
-  7: return $t0
-  8: goto 10
-  9: label L1
- 10: label L2
- 11: $t5 := false
- 12: $t0 := pack test::Impotent($t5)
- 13: return $t0
- 14: return $t0
+  4: if ($t4) goto 8 else goto 5
+  5: label L3
+  6: destroy($t1)
+  7: goto 12
+  8: label L0
+  9: $t0 := move($t1)
+ 10: return $t0
+ 11: goto 13
+ 12: label L1
+ 13: label L2
+ 14: $t5 := false
+ 15: $t0 := pack test::Impotent($t5)
+ 16: return $t0
+ 17: return $t0
 }
+
+
+Diagnostics:
+error: cannot drop
+   ┌─ tests/ability-checker/released_by_edge.move:6:3
+   │
+ 6 │ ╭         if (false) {
+ 7 │ │             return x;
+ 8 │ │         } else {
+ 9 │ │
+10 │ │         };
+   │ ╰─────────^
 
 ============ after AbilityChecker: ================
 
@@ -225,15 +240,18 @@ fun test::test(): test::Impotent {
   1: $t2 := pack test::Impotent($t3)
   2: $t1 := move($t2)
   3: $t4 := false
-  4: if ($t4) goto 5 else goto 9
-  5: label L0
-  6: $t0 := move($t1)
-  7: return $t0
-  8: goto 10
-  9: label L1
- 10: label L2
- 11: $t5 := false
- 12: $t0 := pack test::Impotent($t5)
- 13: return $t0
- 14: return $t0
+  4: if ($t4) goto 8 else goto 5
+  5: label L3
+  6: destroy($t1)
+  7: goto 12
+  8: label L0
+  9: $t0 := move($t1)
+ 10: return $t0
+ 11: goto 13
+ 12: label L1
+ 13: label L2
+ 14: $t5 := false
+ 15: $t0 := pack test::Impotent($t5)
+ 16: return $t0
+ 17: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
@@ -202,26 +202,14 @@ fun test::test(): test::Impotent {
   5: label L0
   6: $t0 := move($t1)
   7: return $t0
-  8: goto 11
+  8: goto 10
   9: label L1
- 10: destroy($t1)
- 11: label L2
- 12: $t5 := false
- 13: $t0 := pack test::Impotent($t5)
+ 10: label L2
+ 11: $t5 := false
+ 12: $t0 := pack test::Impotent($t5)
+ 13: return $t0
  14: return $t0
- 15: return $t0
 }
-
-
-Diagnostics:
-error: cannot drop
-   ┌─ tests/ability-checker/released_by_edge.move:8:10
-   │
- 8 │           } else {
-   │ ╭────────────────^
- 9 │ │
-10 │ │         };
-   │ ╰─────────^
 
 ============ after AbilityChecker: ================
 
@@ -241,12 +229,11 @@ fun test::test(): test::Impotent {
   5: label L0
   6: $t0 := move($t1)
   7: return $t0
-  8: goto 11
+  8: goto 10
   9: label L1
- 10: destroy($t1)
- 11: label L2
- 12: $t5 := false
- 13: $t0 := pack test::Impotent($t5)
+ 10: label L2
+ 11: $t5 := false
+ 12: $t0 := pack test::Impotent($t5)
+ 13: return $t0
  14: return $t0
- 15: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.exp
@@ -1,0 +1,252 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun test::test(): test::Impotent {
+     var $t0: test::Impotent
+     var $t1: test::Impotent
+     var $t2: test::Impotent
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+  0: $t3 := false
+  1: $t2 := pack test::Impotent($t3)
+  2: $t1 := infer($t2)
+  3: $t4 := false
+  4: if ($t4) goto 5 else goto 9
+  5: label L0
+  6: $t0 := infer($t1)
+  7: return $t0
+  8: goto 10
+  9: label L1
+ 10: label L2
+ 11: $t5 := false
+ 12: $t0 := pack test::Impotent($t5)
+ 13: return $t0
+ 14: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::test(): test::Impotent {
+     var $t0: test::Impotent
+     var $t1: test::Impotent
+     var $t2: test::Impotent
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     # live vars:
+  0: $t3 := false
+     # live vars: $t3
+  1: $t2 := pack test::Impotent($t3)
+     # live vars: $t2
+  2: $t1 := move($t2)
+     # live vars: $t1
+  3: $t4 := false
+     # live vars: $t1, $t4
+  4: if ($t4) goto 5 else goto 9
+     # live vars: $t1
+  5: label L0
+     # live vars: $t1
+  6: $t0 := move($t1)
+     # live vars: $t0
+  7: return $t0
+     # live vars:
+  8: goto 10
+     # live vars:
+  9: label L1
+     # live vars:
+ 10: label L2
+     # live vars:
+ 11: $t5 := false
+     # live vars: $t5
+ 12: $t0 := pack test::Impotent($t5)
+     # live vars: $t0
+ 13: return $t0
+     # live vars: $t0
+ 14: return $t0
+}
+
+============ after MemorySafetyProcessor: ================
+
+[variant baseline]
+fun test::test(): test::Impotent {
+     var $t0: test::Impotent
+     var $t1: test::Impotent
+     var $t2: test::Impotent
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {}
+     #
+  0: $t3 := false
+     # live vars: $t3
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {}
+     #
+  1: $t2 := pack test::Impotent($t3)
+     # live vars: $t2
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t3}
+     #
+  2: $t1 := move($t2)
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+  3: $t4 := false
+     # live vars: $t1, $t4
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+  4: if ($t4) goto 5 else goto 9
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+  5: label L0
+     # live vars: $t1
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+  6: $t0 := move($t1)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t1,$t2,$t3}
+     #
+  7: return $t0
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {}
+     #
+  8: goto 10
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+  9: label L1
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+ 10: label L2
+     # live vars:
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+ 11: $t5 := false
+     # live vars: $t5
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3}
+     #
+ 12: $t0 := pack test::Impotent($t5)
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {$t2,$t3,$t5}
+     #
+ 13: return $t0
+     # live vars: $t0
+     # graph: {}
+     # local_to_label: {}
+     # global_to_label: {}
+     # moved: {}
+     #
+ 14: return $t0
+}
+
+============ after ExplicitDrop: ================
+
+[variant baseline]
+fun test::test(): test::Impotent {
+     var $t0: test::Impotent
+     var $t1: test::Impotent
+     var $t2: test::Impotent
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+  0: $t3 := false
+  1: $t2 := pack test::Impotent($t3)
+  2: $t1 := move($t2)
+  3: $t4 := false
+  4: if ($t4) goto 5 else goto 9
+  5: label L0
+  6: $t0 := move($t1)
+  7: return $t0
+  8: goto 11
+  9: label L1
+ 10: destroy($t1)
+ 11: label L2
+ 12: $t5 := false
+ 13: $t0 := pack test::Impotent($t5)
+ 14: return $t0
+ 15: return $t0
+}
+
+
+Diagnostics:
+error: cannot drop
+   ┌─ tests/ability-checker/released_by_edge.move:8:10
+   │
+ 8 │           } else {
+   │ ╭────────────────^
+ 9 │ │
+10 │ │         };
+   │ ╰─────────^
+
+============ after AbilityChecker: ================
+
+[variant baseline]
+fun test::test(): test::Impotent {
+     var $t0: test::Impotent
+     var $t1: test::Impotent
+     var $t2: test::Impotent
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+  0: $t3 := false
+  1: $t2 := pack test::Impotent($t3)
+  2: $t1 := move($t2)
+  3: $t4 := false
+  4: if ($t4) goto 5 else goto 9
+  5: label L0
+  6: $t0 := move($t1)
+  7: return $t0
+  8: goto 11
+  9: label L1
+ 10: destroy($t1)
+ 11: label L2
+ 12: $t5 := false
+ 13: $t0 := pack test::Impotent($t5)
+ 14: return $t0
+ 15: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.move
+++ b/third_party/move/move-compiler-v2/tests/ability-checker/released_by_edge.move
@@ -1,0 +1,13 @@
+module 0x42::test {
+	struct Impotent {}
+
+	fun test(): Impotent {
+		let x = Impotent {};
+		if (false) {
+			return x;
+		} else {
+
+		};
+		return Impotent {}
+	}
+}


### PR DESCRIPTION
### Description

Fixes #11491 by checking the difference between the after state of an instruction, and the before state of its successor, and infer drops between the instructions. Currently, we only check for the difference between the before and after state of an instruction.

### Test Plan

Existing tests & `ability_checker/released_by_edge.move`.
