### PR TITLE
[Cargo] Bump mini-moka to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9591,9 +9591,9 @@ dependencies = [
 
 [[package]]
 name = "mini-moka"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e0b72e7c9042467008b10279fc732326bd605459ae03bda88825909dd19b56"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -550,7 +550,7 @@ lz4 = "1.24.0"
 maplit = "1.0.2"
 merlin = "3"
 mime = "0.3.16"
-mini-moka = { version = "0.10.2", features = ["sync"] }
+mini-moka = { version = "0.10.3", features = ["sync"] }
 mirai-annotations = "1.12.0"
 mockall = "0.11.4"
 more-asserts = "0.3.0"


### PR DESCRIPTION
### Description
This PR cherry-picks the following PR/commit into the `v1.9` release branch: https://github.com/aptos-labs/aptos-core/pull/11604 

### Test Plan
Existing test infrastructure.