### PR TITLE
stake.move refactoring

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -52,6 +52,7 @@
 <b>use</b> <a href="gas_schedule.md#0x1_gas_schedule">0x1::gas_schedule</a>;
 <b>use</b> <a href="jwks.md#0x1_jwks">0x1::jwks</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
+<b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map">0x1::simple_map</a>;
 <b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
 <b>use</b> <a href="staking_config.md#0x1_staking_config">0x1::staking_config</a>;
@@ -366,6 +367,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="block.md#0x1_block_initialize">block::initialize</a>(&aptos_framework_account, epoch_interval_microsecs);
     <a href="state_storage.md#0x1_state_storage_initialize">state_storage::initialize</a>(&aptos_framework_account);
     <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
+    <a href="reconfiguration_state.md#0x1_reconfiguration_state_initialize">reconfiguration_state::initialize</a>(&aptos_framework_account);
     <a href="dkg.md#0x1_dkg_initialize">dkg::initialize</a>(&aptos_framework_account);
     <a href="jwks.md#0x1_jwks_initialize">jwks::initialize</a>(&aptos_framework_account);
 }
@@ -650,7 +652,7 @@ If it exists, it just returns the signer.
     // validators.
     <a href="aptos_coin.md#0x1_aptos_coin_destroy_mint_cap">aptos_coin::destroy_mint_cap</a>(aptos_framework);
 
-    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>();
+    <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">stake::update_validator_set_on_new_epoch</a>(<b>true</b>);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -43,6 +43,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::primary_fungible_store`](primary_fungible_store.md#0x1_primary_fungible_store)
 -  [`0x1::randomness`](randomness.md#0x1_randomness)
 -  [`0x1::reconfiguration`](reconfiguration.md#0x1_reconfiguration)
+-  [`0x1::reconfiguration_state`](reconfiguration_state.md#0x1_reconfiguration_state)
 -  [`0x1::reconfiguration_with_dkg`](reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg)
 -  [`0x1::resource_account`](resource_account.md#0x1_resource_account)
 -  [`0x1::stake`](stake.md#0x1_stake)

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -37,6 +37,7 @@ to synchronize configuration changes for the validators.
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
 <b>use</b> <a href="storage_gas.md#0x1_storage_gas">0x1::storage_gas</a>;
@@ -343,7 +344,6 @@ Signal validators to start using new configuration. Must be called from friend c
 
     <b>let</b> config_ref = <b>borrow_global_mut</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework);
     <b>let</b> current_time = <a href="timestamp.md#0x1_timestamp_now_microseconds">timestamp::now_microseconds</a>();
-
     // Do not do anything <b>if</b> a <a href="reconfiguration.md#0x1_reconfiguration">reconfiguration</a> <a href="event.md#0x1_event">event</a> is already emitted within this transaction.
     //
     // This is OK because:
@@ -360,6 +360,10 @@ Signal validators to start using new configuration. Must be called from friend c
         <b>return</b>
     };
 
+    // If `RECONFIGURE_WITH_DKG` is enabled,
+    // `reconfiguration_with_dkg::start()` already marked it correctly, and this invocation becomes a no-op.
+    <a href="reconfiguration_state.md#0x1_reconfiguration_state_try_mark_as_in_progress">reconfiguration_state::try_mark_as_in_progress</a>();
+
     // Reconfiguration "forces the <a href="block.md#0x1_block">block</a>" <b>to</b> end, <b>as</b> mentioned above. Therefore, we must process the collected fees
     // explicitly so that staking can distribute them.
     //
@@ -375,7 +379,7 @@ Signal validators to start using new configuration. Must be called from friend c
     };
 
     // Call <a href="stake.md#0x1_stake">stake</a> <b>to</b> compute the new validator set and distribute rewards and transaction fees.
-    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>();
+    <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">stake::update_validator_set_on_new_epoch</a>(<b>true</b>);
 
     <a href="storage_gas.md#0x1_storage_gas_on_reconfig">storage_gas::on_reconfig</a>();
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration_state.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration_state.md
@@ -1,0 +1,284 @@
+
+<a id="0x1_reconfiguration_state"></a>
+
+# Module `0x1::reconfiguration_state`
+
+Reconfiguration meta-state resources and util functions.
+
+
+-  [Resource `State`](#0x1_reconfiguration_state_State)
+-  [Struct `StateInactive`](#0x1_reconfiguration_state_StateInactive)
+-  [Struct `StateActive`](#0x1_reconfiguration_state_StateActive)
+-  [Constants](#@Constants_0)
+-  [Function `initialize`](#0x1_reconfiguration_state_initialize)
+-  [Function `is_in_progress`](#0x1_reconfiguration_state_is_in_progress)
+-  [Function `try_mark_as_in_progress`](#0x1_reconfiguration_state_try_mark_as_in_progress)
+-  [Function `start_time_secs`](#0x1_reconfiguration_state_start_time_secs)
+-  [Function `mark_as_completed`](#0x1_reconfiguration_state_mark_as_completed)
+
+
+<pre><code><b>use</b> <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any">0x1::copyable_any</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
+</code></pre>
+
+
+
+<a id="0x1_reconfiguration_state_State"></a>
+
+## Resource `State`
+
+Reconfiguration drivers update this resources to notify other modules of some reconfiguration state.
+
+
+<pre><code><b>struct</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>variant: <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_Any">copyable_any::Any</a></code>
+</dt>
+<dd>
+ The state variant packed as an <code>Any</code>.
+ Currently the variant type is one of the following.
+ - <code>ReconfigStateInactive</code>
+ - <code>ReconfigStateActive</code>
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_StateInactive"></a>
+
+## Struct `StateInactive`
+
+A state variant indicating no reconfiguration is in progress.
+
+
+<pre><code><b>struct</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_StateInactive">StateInactive</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_StateActive"></a>
+
+## Struct `StateActive`
+
+A state variant indicating a reconfiguration is in progress.
+
+
+<pre><code><b>struct</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">StateActive</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>start_time_secs: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_reconfiguration_state_ERECONFIG_NOT_IN_PROGRESS"></a>
+
+
+
+<pre><code><b>const</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_ERECONFIG_NOT_IN_PROGRESS">ERECONFIG_NOT_IN_PROGRESS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_reconfiguration_state_initialize"></a>
+
+## Function `initialize`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_initialize">initialize</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_initialize">initialize</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+    <b>if</b> (!<b>exists</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>(fx, <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> {
+            variant: <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_pack">copyable_any::pack</a>(<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateInactive">StateInactive</a> {})
+        })
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_is_in_progress"></a>
+
+## Function `is_in_progress`
+
+Return whether the reconfiguration state is marked "in progress".
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_is_in_progress">is_in_progress</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_is_in_progress">is_in_progress</a>(): bool <b>acquires</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> {
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@aptos_framework);
+    <b>let</b> variant_type_name = *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(&state.variant));
+    variant_type_name == b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">0x1::reconfiguration_state::StateActive</a>"
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_try_mark_as_in_progress"></a>
+
+## Function `try_mark_as_in_progress`
+
+Mark the reconfiguration state "in progress" if it is currently "stopped".
+The current time is also recorded as the reconfiguration start time. (Some module, e.g., <code><a href="stake.md#0x1_stake">stake</a>.<b>move</b></code>, needs this info).
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_try_mark_as_in_progress">try_mark_as_in_progress</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_try_mark_as_in_progress">try_mark_as_in_progress</a>() <b>acquires</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> {
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@aptos_framework);
+    <b>let</b> variant_type_name = *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(&state.variant));
+    <b>if</b> (variant_type_name == b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateInactive">0x1::reconfiguration_state::StateInactive</a>") {
+        state.variant = <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_pack">copyable_any::pack</a>(<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">StateActive</a> {
+            start_time_secs: <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()
+        });
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_start_time_secs"></a>
+
+## Function `start_time_secs`
+
+Get the unix time when the currently in-progress reconfiguration started.
+Abort if the reconfiguration state is not "in progress".
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">start_time_secs</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">start_time_secs</a>(): u64 <b>acquires</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> {
+    <b>let</b> state = <b>borrow_global</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@aptos_framework);
+    <b>let</b> variant_type_name = *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(&state.variant));
+    <b>if</b> (variant_type_name == b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">0x1::reconfiguration_state::StateActive</a>") {
+        <b>let</b> active = <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_unpack">copyable_any::unpack</a>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">StateActive</a>&gt;(state.variant);
+        active.start_time_secs
+    } <b>else</b> {
+        <b>abort</b>(<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration_state.md#0x1_reconfiguration_state_ERECONFIG_NOT_IN_PROGRESS">ERECONFIG_NOT_IN_PROGRESS</a>))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_reconfiguration_state_mark_as_completed"></a>
+
+## Function `mark_as_completed`
+
+Called at the end of every reconfiguration to mark the state as "stopped".
+Abort if the current state is not "in progress".
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_mark_as_completed">mark_as_completed</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_mark_as_completed">mark_as_completed</a>() <b>acquires</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a> {
+    <b>let</b> state = <b>borrow_global_mut</b>&lt;<a href="reconfiguration_state.md#0x1_reconfiguration_state_State">State</a>&gt;(@aptos_framework);
+    <b>let</b> variant_type_name = *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(&state.variant));
+    <b>if</b> (variant_type_name == b"<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateActive">0x1::reconfiguration_state::StateActive</a>") {
+        state.variant = <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_pack">copyable_any::pack</a>(<a href="reconfiguration_state.md#0x1_reconfiguration_state_StateInactive">StateInactive</a> {});
+    } <b>else</b> {
+        <b>abort</b>(<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration_state.md#0x1_reconfiguration_state_ERECONFIG_NOT_IN_PROGRESS">ERECONFIG_NOT_IN_PROGRESS</a>))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
@@ -18,6 +18,7 @@ Reconfiguration with DKG helper functions.
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="gas_schedule.md#0x1_gas_schedule">0x1::gas_schedule</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
+<b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
 <b>use</b> <a href="version.md#0x1_version">0x1::version</a>;
 </code></pre>
@@ -44,8 +45,9 @@ Do nothing if one is already in progress.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_try_start">try_start</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <b>if</b> (<a href="dkg.md#0x1_dkg_in_progress">dkg::in_progress</a>()) { <b>return</b> };
     <a href="../../aptos-stdlib/../move-stdlib/doc/config_buffer.md#0x1_config_buffer_disable_validator_set_changes">config_buffer::disable_validator_set_changes</a>(<a href="account.md#0x1_account">account</a>);
+    <a href="reconfiguration_state.md#0x1_reconfiguration_state_try_mark_as_in_progress">reconfiguration_state::try_mark_as_in_progress</a>();
     <b>let</b> cur_epoch = <a href="reconfiguration.md#0x1_reconfiguration_current_epoch">reconfiguration::current_epoch</a>();
-    <a href="dkg.md#0x1_dkg_start">dkg::start</a>(cur_epoch, <a href="stake.md#0x1_stake_cur_validator_set">stake::cur_validator_set</a>(), cur_epoch + 1, <a href="stake.md#0x1_stake_next_validator_set">stake::next_validator_set</a>());
+    <a href="dkg.md#0x1_dkg_start">dkg::start</a>(cur_epoch, <a href="stake.md#0x1_stake_cur_validator_set">stake::cur_validator_set</a>(), cur_epoch + 1, <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">stake::update_validator_set_on_new_epoch</a>(<b>false</b>));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -94,9 +94,9 @@ or if their stake drops below the min required, they would get removed at the en
 -  [Function `leave_validator_set`](#0x1_stake_leave_validator_set)
 -  [Function `is_current_epoch_validator`](#0x1_stake_is_current_epoch_validator)
 -  [Function `update_performance_statistics`](#0x1_stake_update_performance_statistics)
--  [Function `on_new_epoch`](#0x1_stake_on_new_epoch)
+-  [Function `update_validator_set_on_new_epoch`](#0x1_stake_update_validator_set_on_new_epoch)
 -  [Function `cur_validator_set`](#0x1_stake_cur_validator_set)
--  [Function `next_validator_set`](#0x1_stake_next_validator_set)
+-  [Function `addresses_from_validator_infos`](#0x1_stake_addresses_from_validator_infos)
 -  [Function `update_stake_pool`](#0x1_stake_update_stake_pool)
 -  [Function `calculate_rewards_amount`](#0x1_stake_calculate_rewards_amount)
 -  [Function `distribute_rewards`](#0x1_stake_distribute_rewards)
@@ -136,7 +136,7 @@ or if their stake drops below the min required, they would get removed at the en
     -  [Function `leave_validator_set`](#@Specification_1_leave_validator_set)
     -  [Function `is_current_epoch_validator`](#@Specification_1_is_current_epoch_validator)
     -  [Function `update_performance_statistics`](#@Specification_1_update_performance_statistics)
-    -  [Function `on_new_epoch`](#@Specification_1_on_new_epoch)
+    -  [Function `update_validator_set_on_new_epoch`](#@Specification_1_update_validator_set_on_new_epoch)
     -  [Function `update_stake_pool`](#@Specification_1_update_stake_pool)
     -  [Function `calculate_rewards_amount`](#@Specification_1_calculate_rewards_amount)
     -  [Function `distribute_rewards`](#@Specification_1_distribute_rewards)
@@ -159,7 +159,9 @@ or if their stake drops below the min required, they would get removed at the en
 <b>use</b> <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64">0x1::fixed_point64</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/math64.md#0x1_math64">0x1::math64</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map">0x1::simple_map</a>;
 <b>use</b> <a href="staking_config.md#0x1_staking_config">0x1::staking_config</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">0x1::table</a>;
@@ -3061,12 +3063,13 @@ This function cannot abort.
 
 </details>
 
-<a id="0x1_stake_on_new_epoch"></a>
+<a id="0x1_stake_update_validator_set_on_new_epoch"></a>
 
-## Function `on_new_epoch`
+## Function `update_validator_set_on_new_epoch`
 
-Triggers at epoch boundary. This function shouldn't abort.
+Triggered during a reconfiguration. This function shouldn't abort.
 
+If <code>commit</code> is true, do the following.
 1. Distribute transaction fees and rewards to stake pools of active and pending inactive validators (requested
 to leave but not yet removed).
 2. Officially move pending active stake to active and move pending inactive stake to inactive.
@@ -3075,9 +3078,12 @@ The staking pool's voting power in this new epoch will be updated to the total a
 pending inactive validators so they no longer can vote.
 4. The validator's voting power in the validator set is updated to be the corresponding staking pool's voting
 power.
+5. Return the new validator set.
+
+If <code>commit</code> is false, still do the calculation but prevent any resource update.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_on_new_epoch">on_new_epoch</a>()
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">update_validator_set_on_new_epoch</a>(commit: bool): <a href="stake.md#0x1_stake_ValidatorSet">stake::ValidatorSet</a>
 </code></pre>
 
 
@@ -3086,111 +3092,133 @@ power.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>, <a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>, <a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>, <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>, <a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">update_validator_set_on_new_epoch</a>(commit: bool): <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> <b>acquires</b> <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>, <a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>, <a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>, <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>, <a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a> {
     <b>let</b> validator_set = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
     <b>let</b> config = <a href="staking_config.md#0x1_staking_config_get">staking_config::get</a>();
     <b>let</b> validator_perf = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
 
+    <b>let</b> new_stakes_by_validator = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new">simple_map::new</a>&lt;<b>address</b>, u64&gt;();
+
     // Process pending <a href="stake.md#0x1_stake">stake</a> and distribute transaction fees and rewards for each currently active validator.
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(&validator_set.active_validators, |validator| {
         <b>let</b> validator: &<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> = validator;
-        <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf, validator.addr, &config);
+        <b>let</b> new_stake = <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf, validator.addr, &config, commit);
+        <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> new_stakes_by_validator, validator.addr, new_stake);
     });
 
     // Process pending <a href="stake.md#0x1_stake">stake</a> and distribute transaction fees and rewards for each currently pending_inactive validator
     // (requested <b>to</b> leave but not removed yet).
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(&validator_set.pending_inactive, |validator| {
         <b>let</b> validator: &<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> = validator;
-        <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf, validator.addr, &config);
+        <b>let</b> new_stake = <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf, validator.addr, &config, commit);
+        <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> new_stakes_by_validator, validator.addr, new_stake);
     });
 
-    // Activate currently pending_active validators.
-    <a href="stake.md#0x1_stake_append">append</a>(&<b>mut</b> validator_set.active_validators, &<b>mut</b> validator_set.pending_active);
+    // Get the list of validators who intend <b>to</b> be in the next validator set.
+    <b>let</b> candidates = <a href="stake.md#0x1_stake_addresses_from_validator_infos">addresses_from_validator_infos</a>(&validator_set.active_validators);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_reverse_append">vector::reverse_append</a>(&<b>mut</b> candidates, <a href="stake.md#0x1_stake_addresses_from_validator_infos">addresses_from_validator_infos</a>(&validator_set.pending_active));
 
-    // Officially deactivate all pending_inactive validators. They will now no longer receive rewards.
-    validator_set.pending_inactive = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
-
-    // Update active validator set so that network <b>address</b>/<b>public</b> key change takes effect.
-    // Moreover, recalculate the total <a href="voting.md#0x1_voting">voting</a> power, and deactivate the validator whose
-    // <a href="voting.md#0x1_voting">voting</a> power is less than the minimum required <a href="stake.md#0x1_stake">stake</a>.
+    // Go through the candidate list, drop those without enough stakes, construct a new validator set and determine their indices.
     <b>let</b> next_epoch_validators = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
+    <b>let</b> next_validator_idx = 0;
     <b>let</b> (minimum_stake, _) = <a href="staking_config.md#0x1_staking_config_get_required_stake">staking_config::get_required_stake</a>(&config);
-    <b>let</b> vlen = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&validator_set.active_validators);
+    <b>let</b> num_candidates = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&candidates);
     <b>let</b> total_voting_power = 0;
-    <b>let</b> i = 0;
+    <b>let</b> candidate_idx = 0;
     <b>while</b> ({
         <b>spec</b> {
             <b>invariant</b> <a href="stake.md#0x1_stake_spec_validators_are_initialized">spec_validators_are_initialized</a>(next_epoch_validators);
         };
-        i &lt; vlen
+        candidate_idx &lt; num_candidates
     }) {
-        <b>let</b> old_validator_info = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&<b>mut</b> validator_set.active_validators, i);
-        <b>let</b> pool_address = old_validator_info.addr;
-        <b>let</b> validator_config = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address);
-        <b>let</b> stake_pool = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
-        <b>let</b> new_validator_info = <a href="stake.md#0x1_stake_generate_validator_info">generate_validator_info</a>(pool_address, stake_pool, *validator_config);
+        <b>let</b> pool_address = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&<b>mut</b> candidates, candidate_idx);
+        <b>let</b> new_voting_power = <b>if</b> (<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&new_stakes_by_validator, &pool_address)) {
+            *<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&new_stakes_by_validator, &pool_address)
+        } <b>else</b> {
+            <b>let</b> candidate_stake_pool = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
+            <a href="stake.md#0x1_stake_get_next_epoch_voting_power">get_next_epoch_voting_power</a>(candidate_stake_pool)
+        };
 
         // A validator needs at least the <b>min</b> <a href="stake.md#0x1_stake">stake</a> required <b>to</b> join the validator set.
-        <b>if</b> (new_validator_info.voting_power &gt;= minimum_stake) {
+        <b>if</b> (new_voting_power &gt;= minimum_stake) {
             <b>spec</b> {
-                <b>assume</b> total_voting_power + new_validator_info.voting_power &lt;= MAX_U128;
+                <b>assume</b> total_voting_power + new_voting_power &lt;= MAX_U128;
             };
-            total_voting_power = total_voting_power + (new_validator_info.voting_power <b>as</b> u128);
+
+            <b>let</b> new_validator_info = <a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> {
+                addr: pool_address,
+                voting_power: new_voting_power,
+                config: *<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address),
+            };
+            new_validator_info.config.validator_index = next_validator_idx;
+
+            total_voting_power = total_voting_power + (new_voting_power <b>as</b> u128);
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> next_epoch_validators, new_validator_info);
+            next_validator_idx = next_validator_idx + 1;
         };
-        i = i + 1;
+        candidate_idx = candidate_idx + 1;
     };
 
-    validator_set.active_validators = next_epoch_validators;
-    validator_set.total_voting_power = total_voting_power;
-    validator_set.total_joining_power = 0;
+    <b>let</b> new_validator_set = <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> {
+        consensus_scheme: validator_set.consensus_scheme,
+        active_validators: next_epoch_validators,
+        pending_active: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        pending_inactive: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        total_voting_power,
+        total_joining_power: 0,
+    };
 
-    // Update validator indices, reset performance scores, and renew lockups.
-    validator_perf.validators = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
-    <b>let</b> recurring_lockup_duration_secs = <a href="staking_config.md#0x1_staking_config_get_recurring_lockup_duration">staking_config::get_recurring_lockup_duration</a>(&config);
-    <b>let</b> vlen = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&validator_set.active_validators);
-    <b>let</b> validator_index = 0;
-    <b>while</b> ({
-        <b>spec</b> {
-            <b>invariant</b> <a href="stake.md#0x1_stake_spec_validators_are_initialized">spec_validators_are_initialized</a>(validator_set.active_validators);
-            <b>invariant</b> len(validator_set.pending_active) == 0;
-            <b>invariant</b> len(validator_set.pending_inactive) == 0;
-            <b>invariant</b> 0 &lt;= validator_index && validator_index &lt;= vlen;
-            <b>invariant</b> vlen == len(validator_set.active_validators);
-            <b>invariant</b> <b>forall</b> i in 0..validator_index:
-                <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validator_set.active_validators[i].addr).validator_index &lt; validator_index;
-            <b>invariant</b> len(validator_perf.validators) == validator_index;
-        };
-        validator_index &lt; vlen
-    }) {
-        <b>let</b> validator_info = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> validator_set.active_validators, validator_index);
-        validator_info.config.validator_index = validator_index;
-        <b>let</b> validator_config = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validator_info.addr);
-        validator_config.validator_index = validator_index;
+    <b>if</b> (commit) {
+        *validator_set = new_validator_set;
 
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> validator_perf.validators, <a href="stake.md#0x1_stake_IndividualValidatorPerformance">IndividualValidatorPerformance</a> {
-            successful_proposals: 0,
-            failed_proposals: 0,
-        });
-
-        // Automatically renew a validator's lockup for validators that will still be in the validator set in the
-        // next epoch.
-        <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(validator_info.addr);
-        <b>if</b> (stake_pool.locked_until_secs &lt;= <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>()) {
+        // Also <b>update</b> validator indices, reset performance scores, and renew lockups.
+        validator_perf.validators = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
+        <b>let</b> recurring_lockup_duration_secs = <a href="staking_config.md#0x1_staking_config_get_recurring_lockup_duration">staking_config::get_recurring_lockup_duration</a>(&config);
+        <b>let</b> vlen = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&validator_set.active_validators);
+        <b>let</b> validator_index = 0;
+        <b>while</b> ({
             <b>spec</b> {
-                <b>assume</b> <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>() + recurring_lockup_duration_secs &lt;= <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
+                <b>invariant</b> <a href="stake.md#0x1_stake_spec_validators_are_initialized">spec_validators_are_initialized</a>(validator_set.active_validators);
+                <b>invariant</b> len(validator_set.pending_active) == 0;
+                <b>invariant</b> len(validator_set.pending_inactive) == 0;
+                <b>invariant</b> 0 &lt;= validator_index && validator_index &lt;= vlen;
+                <b>invariant</b> vlen == len(validator_set.active_validators);
+                <b>invariant</b> <b>forall</b> i in 0..validator_index:
+                    <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validator_set.active_validators[i].addr).validator_index &lt; validator_index;
+                <b>invariant</b> len(validator_perf.validators) == validator_index;
             };
-            stake_pool.locked_until_secs =
-                <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() + recurring_lockup_duration_secs;
+            validator_index &lt; vlen
+        }) {
+            <b>let</b> validator_info = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> validator_set.active_validators, validator_index);
+            <b>let</b> validator_config = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validator_info.addr);
+            validator_config.validator_index = validator_index;
+
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> validator_perf.validators, <a href="stake.md#0x1_stake_IndividualValidatorPerformance">IndividualValidatorPerformance</a> {
+                successful_proposals: 0,
+                failed_proposals: 0,
+            });
+
+            // Automatically renew a validator's lockup for validators that will still be in the validator set in the
+            // next epoch.
+            <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(validator_info.addr);
+            <b>if</b> (stake_pool.locked_until_secs &lt;= <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">reconfiguration_state::start_time_secs</a>()) {
+                <b>spec</b> {
+                    <b>assume</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">reconfiguration_state::start_time_secs</a>() + recurring_lockup_duration_secs &lt;= <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
+                };
+                stake_pool.locked_until_secs =
+                    <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">reconfiguration_state::start_time_secs</a>() + recurring_lockup_duration_secs;
+            };
+
+            validator_index = validator_index + 1;
         };
 
-        validator_index = validator_index + 1;
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>()) {
+            // Update rewards rate after reward distribution.
+            <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_epoch_rewards_rate">staking_config::calculate_and_save_latest_epoch_rewards_rate</a>();
+        };
     };
 
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>()) {
-        // Update rewards rate after reward distribution.
-        <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_epoch_rewards_rate">staking_config::calculate_and_save_latest_epoch_rewards_rate</a>();
-    };
+    new_validator_set
 }
 </code></pre>
 
@@ -3222,14 +3250,13 @@ power.
 
 </details>
 
-<a id="0x1_stake_next_validator_set"></a>
+<a id="0x1_stake_addresses_from_validator_infos"></a>
 
-## Function `next_validator_set`
-
-Compute the validator set for the next epoch.
+## Function `addresses_from_validator_infos`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_next_validator_set">next_validator_set</a>(): <a href="stake.md#0x1_stake_ValidatorSet">stake::ValidatorSet</a>
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_addresses_from_validator_infos">addresses_from_validator_infos</a>(infos: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">stake::ValidatorInfo</a>&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -3238,79 +3265,11 @@ Compute the validator set for the next epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_next_validator_set">next_validator_set</a>(): <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> <b>acquires</b> <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>, <a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>, <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>, <a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a> {
-    // Init.
-    <b>let</b> cur_validator_set = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-    <b>let</b> <a href="staking_config.md#0x1_staking_config">staking_config</a> = <a href="staking_config.md#0x1_staking_config_get">staking_config::get</a>();
-    <b>let</b> validator_perf = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
-    <b>let</b> (minimum_stake, _) = <a href="staking_config.md#0x1_staking_config_get_required_stake">staking_config::get_required_stake</a>(&<a href="staking_config.md#0x1_staking_config">staking_config</a>);
-    <b>let</b> (rewards_rate, rewards_rate_denominator) = <a href="staking_config.md#0x1_staking_config_get_reward_rate">staking_config::get_reward_rate</a>(&<a href="staking_config.md#0x1_staking_config">staking_config</a>);
-
-    // Compute new validator set.
-    <b>let</b> new_active_validators = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    <b>let</b> num_new_actives = 0;
-    <b>let</b> candidate_idx = 0;
-    <b>let</b> new_total_power = 0;
-    <b>let</b> num_cur_actives = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&cur_validator_set.active_validators);
-    <b>let</b> num_cur_pending_actives = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&cur_validator_set.pending_active);
-    <b>let</b> num_candidates = num_cur_actives + num_cur_pending_actives;
-    <b>while</b> (candidate_idx &lt; num_candidates) {
-        <b>let</b> candidate = <b>if</b> (candidate_idx &lt; num_cur_actives) {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&cur_validator_set.active_validators, candidate_idx)
-        } <b>else</b> {
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&cur_validator_set.pending_active, candidate_idx - num_cur_actives)
-        };
-        <b>let</b> stake_pool = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(candidate.addr);
-        <b>let</b> cur_active = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.active);
-        <b>let</b> cur_pending_active = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.pending_active);
-        <b>let</b> cur_pending_inactive = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.pending_inactive);
-
-        <b>let</b> cur_perf = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&validator_perf.validators, candidate.config.validator_index);
-        <b>let</b> cur_reward = <b>if</b> (cur_active &gt; 0) {
-            <a href="stake.md#0x1_stake_calculate_rewards_amount">calculate_rewards_amount</a>(cur_active, cur_perf.successful_proposals, cur_perf.successful_proposals + cur_perf.failed_proposals, rewards_rate, rewards_rate_denominator)
-        } <b>else</b> {
-            0
-        };
-        <b>let</b> cur_fee = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_collect_and_distribute_gas_fees">features::collect_and_distribute_gas_fees</a>()) {
-            <b>let</b> fees_table = &<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework).fees_table;
-            <b>if</b> (<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(fees_table, candidate.addr)) {
-                <b>let</b> fee = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(fees_table, candidate.addr);
-                <a href="coin.md#0x1_coin_value">coin::value</a>(fee)
-            } <b>else</b> {
-                0
-            }
-        } <b>else</b> {
-            0
-        };
-
-        <b>let</b> new_voting_power = cur_active + cur_pending_inactive + cur_pending_active + cur_reward + cur_fee;
-
-        <b>if</b> (new_voting_power &gt;= minimum_stake) {
-            <b>let</b> config = *<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(candidate.addr);
-            config.validator_index = num_new_actives;
-            <b>let</b> new_validator_info = <a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> {
-                addr: candidate.addr,
-                voting_power: new_voting_power,
-                config,
-            };
-
-            // Update <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>.
-            new_total_power = new_total_power + (new_voting_power <b>as</b> u128);
-            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> new_active_validators, new_validator_info);
-            num_new_actives = num_new_actives + 1;
-
-        };
-        candidate_idx = candidate_idx + 1;
-    };
-
-     <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> {
-        consensus_scheme: cur_validator_set.consensus_scheme,
-        active_validators: new_active_validators,
-        pending_inactive: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        pending_active: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        total_voting_power: new_total_power,
-        total_joining_power: 0,
-    }
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_addresses_from_validator_infos">addresses_from_validator_infos</a>(infos: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt; {
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(infos, |obj| {
+        <b>let</b> info: &<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a> = obj;
+        info.addr
+    })
 }
 </code></pre>
 
@@ -3322,14 +3281,16 @@ Compute the validator set for the next epoch.
 
 ## Function `update_stake_pool`
 
-Update individual validator's stake pool
+Calculate the stake amount of a stake pool for the next epoch.
+Update individual validator's stake pool if <code>commit == <b>true</b></code>.
+
 1. distribute transaction fees to active/pending_inactive delegations
 2. distribute rewards to active/pending_inactive delegations
 3. process pending_active, pending_inactive correspondingly
 This function shouldn't abort.
 
 
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf: &<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>, pool_address: <b>address</b>, <a href="staking_config.md#0x1_staking_config">staking_config</a>: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>)
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf: &<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>, pool_address: <b>address</b>, <a href="staking_config.md#0x1_staking_config">staking_config</a>: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>, commit: bool): u64
 </code></pre>
 
 
@@ -3342,8 +3303,11 @@ This function shouldn't abort.
     validator_perf: &<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>,
     pool_address: <b>address</b>,
     <a href="staking_config.md#0x1_staking_config">staking_config</a>: &StakingConfig,
-) <b>acquires</b> <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>, <a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>, <a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a> {
+    commit: bool,
+): u64 <b>acquires</b> <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>, <a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>, <a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a> {
     <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
+    <b>let</b> active_amount = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.active);
+    <b>let</b> current_pending_inactive_amount = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.pending_inactive);
     <b>let</b> validator_config = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address);
     <b>let</b> cur_validator_perf = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&validator_perf.validators, validator_config.validator_index);
     <b>let</b> num_successful_proposals = cur_validator_perf.successful_proposals;
@@ -3359,34 +3323,52 @@ This function shouldn't abort.
         num_successful_proposals,
         num_total_proposals,
         rewards_rate,
-        rewards_rate_denominator
+        rewards_rate_denominator,
+        commit,
     );
     <b>let</b> rewards_pending_inactive = <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(
         &<b>mut</b> stake_pool.pending_inactive,
         num_successful_proposals,
         num_total_proposals,
         rewards_rate,
-        rewards_rate_denominator
+        rewards_rate_denominator,
+        commit,
     );
     <b>spec</b> {
         <b>assume</b> rewards_active + rewards_pending_inactive &lt;= <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
     };
     <b>let</b> rewards_amount = rewards_active + rewards_pending_inactive;
+
     // Pending active <a href="stake.md#0x1_stake">stake</a> can now be active.
-    <a href="coin.md#0x1_coin_merge">coin::merge</a>(&<b>mut</b> stake_pool.active, <a href="coin.md#0x1_coin_extract_all">coin::extract_all</a>(&<b>mut</b> stake_pool.pending_active));
+    <b>let</b> pending_active_amount = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.pending_active);
+    <b>if</b> (commit) {
+        <a href="coin.md#0x1_coin_merge">coin::merge</a>(&<b>mut</b> stake_pool.active, <a href="coin.md#0x1_coin_extract_all">coin::extract_all</a>(&<b>mut</b> stake_pool.pending_active));
+    };
 
     // Additionally, distribute transaction fees.
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_collect_and_distribute_gas_fees">features::collect_and_distribute_gas_fees</a>()) {
+    <b>let</b> txn_fee_amount = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_collect_and_distribute_gas_fees">features::collect_and_distribute_gas_fees</a>()) {
         <b>let</b> fees_table = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework).fees_table;
         <b>if</b> (<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(fees_table, pool_address)) {
-            <b>let</b> <a href="coin.md#0x1_coin">coin</a> = <a href="../../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(fees_table, pool_address);
-            <a href="coin.md#0x1_coin_merge">coin::merge</a>(&<b>mut</b> stake_pool.active, <a href="coin.md#0x1_coin">coin</a>);
-        };
+            <b>if</b> (commit) {
+                <b>let</b> <a href="coin.md#0x1_coin">coin</a> = <a href="../../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(fees_table, pool_address);
+                <b>let</b> amount = <a href="coin.md#0x1_coin_value">coin::value</a>(&<a href="coin.md#0x1_coin">coin</a>);
+                <a href="coin.md#0x1_coin_merge">coin::merge</a>(&<b>mut</b> stake_pool.active, <a href="coin.md#0x1_coin">coin</a>);
+                amount
+            } <b>else</b> {
+                0
+            }
+        } <b>else</b> {
+            0
+        }
+    } <b>else</b> {
+        0
     };
 
     // Pending inactive <a href="stake.md#0x1_stake">stake</a> is only fully unlocked and moved into inactive <b>if</b> the current lockup cycle <b>has</b> expired
     <b>let</b> current_lockup_expiration = stake_pool.locked_until_secs;
-    <b>if</b> (<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt;= current_lockup_expiration) {
+    <b>let</b> reconfig_start_time_secs = <a href="reconfiguration_state.md#0x1_reconfiguration_state_start_time_secs">reconfiguration_state::start_time_secs</a>();
+    <b>let</b> lockup_expired = reconfig_start_time_secs &gt;= current_lockup_expiration;
+    <b>if</b> (lockup_expired && commit) {
         <a href="coin.md#0x1_coin_merge">coin::merge</a>(
             &<b>mut</b> stake_pool.inactive,
             <a href="coin.md#0x1_coin_extract_all">coin::extract_all</a>(&<b>mut</b> stake_pool.pending_inactive),
@@ -3400,6 +3382,11 @@ This function shouldn't abort.
             rewards_amount,
         },
     );
+
+    active_amount
+        + pending_active_amount
+        + <b>if</b> (lockup_expired) { 0 } <b>else</b> { current_pending_inactive_amount }
+        + rewards_amount + txn_fee_amount
 }
 </code></pre>
 
@@ -3457,10 +3444,13 @@ Calculate the rewards amount.
 
 ## Function `distribute_rewards`
 
-Mint rewards corresponding to current epoch's <code><a href="stake.md#0x1_stake">stake</a></code> and <code>num_successful_votes</code>.
+Calculate rewards corresponding to current epoch's <code><a href="stake.md#0x1_stake">stake</a></code> and <code>num_successful_votes</code>.
+Mint them if <code>commit == <b>true</b></code>.
+
+Return the reward amount.
 
 
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(<a href="stake.md#0x1_stake">stake</a>: &<b>mut</b> <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;, num_successful_proposals: u64, num_total_proposals: u64, rewards_rate: u64, rewards_rate_denominator: u64): u64
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(<a href="stake.md#0x1_stake">stake</a>: &<b>mut</b> <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;, num_successful_proposals: u64, num_total_proposals: u64, rewards_rate: u64, rewards_rate_denominator: u64, commit: bool): u64
 </code></pre>
 
 
@@ -3475,6 +3465,7 @@ Mint rewards corresponding to current epoch's <code><a href="stake.md#0x1_stake"
     num_total_proposals: u64,
     rewards_rate: u64,
     rewards_rate_denominator: u64,
+    commit: bool,
 ): u64 <b>acquires</b> <a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a> {
     <b>let</b> stake_amount = <a href="coin.md#0x1_coin_value">coin::value</a>(<a href="stake.md#0x1_stake">stake</a>);
     <b>let</b> rewards_amount = <b>if</b> (stake_amount &gt; 0) {
@@ -3482,7 +3473,7 @@ Mint rewards corresponding to current epoch's <code><a href="stake.md#0x1_stake"
     } <b>else</b> {
         0
     };
-    <b>if</b> (rewards_amount &gt; 0) {
+    <b>if</b> (rewards_amount &gt; 0 && commit) {
         <b>let</b> mint_cap = &<b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework).mint_cap;
         <b>let</b> rewards = <a href="coin.md#0x1_coin_mint">coin::mint</a>(rewards_amount, mint_cap);
         <a href="coin.md#0x1_coin_merge">coin::merge</a>(<a href="stake.md#0x1_stake">stake</a>, rewards);
@@ -4526,12 +4517,12 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 
 
-<a id="@Specification_1_on_new_epoch"></a>
+<a id="@Specification_1_update_validator_set_on_new_epoch"></a>
 
-### Function `on_new_epoch`
+### Function `update_validator_set_on_new_epoch`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_on_new_epoch">on_new_epoch</a>()
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake.md#0x1_stake_update_validator_set_on_new_epoch">update_validator_set_on_new_epoch</a>(commit: bool): <a href="stake.md#0x1_stake_ValidatorSet">stake::ValidatorSet</a>
 </code></pre>
 
 
@@ -4553,7 +4544,7 @@ Returns validator's next epoch voting power, including pending_active, active, a
 ### Function `update_stake_pool`
 
 
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf: &<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>, pool_address: <b>address</b>, <a href="staking_config.md#0x1_staking_config">staking_config</a>: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>)
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_update_stake_pool">update_stake_pool</a>(validator_perf: &<a href="stake.md#0x1_stake_ValidatorPerformance">stake::ValidatorPerformance</a>, pool_address: <b>address</b>, <a href="staking_config.md#0x1_staking_config">staking_config</a>: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>, commit: bool): u64
 </code></pre>
 
 
@@ -4661,7 +4652,7 @@ Returns validator's next epoch voting power, including pending_active, active, a
 ### Function `distribute_rewards`
 
 
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(<a href="stake.md#0x1_stake">stake</a>: &<b>mut</b> <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;, num_successful_proposals: u64, num_total_proposals: u64, rewards_rate: u64, rewards_rate_denominator: u64): u64
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(<a href="stake.md#0x1_stake">stake</a>: &<b>mut</b> <a href="coin.md#0x1_coin_Coin">coin::Coin</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">aptos_coin::AptosCoin</a>&gt;, num_successful_proposals: u64, num_total_proposals: u64, rewards_rate: u64, rewards_rate_denominator: u64, commit: bool): u64
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -3097,6 +3097,8 @@ If <code>commit</code> is false, still do the calculation but prevent any resour
     <b>let</b> config = <a href="staking_config.md#0x1_staking_config_get">staking_config::get</a>();
     <b>let</b> validator_perf = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
 
+    // This map will store the new <a href="voting.md#0x1_voting">voting</a> power of every current validator.
+    // This is later used <b>to</b> compute new validator set.
     <b>let</b> new_stakes_by_validator = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new">simple_map::new</a>&lt;<b>address</b>, u64&gt;();
 
     // Process pending <a href="stake.md#0x1_stake">stake</a> and distribute transaction fees and rewards for each currently active validator.

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -297,7 +297,7 @@ module aptos_framework::genesis {
         // validators.
         aptos_coin::destroy_mint_cap(aptos_framework);
 
-        stake::on_new_epoch();
+        stake::update_validator_set_on_new_epoch(true);
     }
 
     /// Sets up the initial validator set for the network.

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -20,6 +20,7 @@ module aptos_framework::genesis {
     use aptos_framework::gas_schedule;
     use aptos_framework::jwks;
     use aptos_framework::reconfiguration;
+    use aptos_framework::reconfiguration_state;
     use aptos_framework::stake;
     use aptos_framework::staking_contract;
     use aptos_framework::staking_config;
@@ -386,7 +387,6 @@ module aptos_framework::genesis {
 
     #[verify_only]
     use std::features;
-    use aptos_framework::reconfiguration_state;
 
     #[verify_only]
     fun initialize_for_verification(

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -132,6 +132,7 @@ module aptos_framework::genesis {
         block::initialize(&aptos_framework_account, epoch_interval_microsecs);
         state_storage::initialize(&aptos_framework_account);
         timestamp::set_time_has_started(&aptos_framework_account);
+        reconfiguration_state::initialize(&aptos_framework_account);
         dkg::initialize(&aptos_framework_account);
         jwks::initialize(&aptos_framework_account);
     }
@@ -385,6 +386,7 @@ module aptos_framework::genesis {
 
     #[verify_only]
     use std::features;
+    use aptos_framework::reconfiguration_state;
 
     #[verify_only]
     fun initialize_for_verification(

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -138,7 +138,7 @@ module aptos_framework::reconfiguration {
         };
 
         // Call stake to compute the new validator set and distribute rewards and transaction fees.
-        stake::on_new_epoch();
+        stake::update_validator_set_on_new_epoch(true);
 
         storage_gas::on_reconfig();
 

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -11,6 +11,7 @@ module aptos_framework::reconfiguration {
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;
     use aptos_framework::chain_status;
+    use aptos_framework::reconfiguration_state;
     use aptos_framework::storage_gas;
     use aptos_framework::transaction_fee;
 
@@ -102,7 +103,6 @@ module aptos_framework::reconfiguration {
 
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
         let current_time = timestamp::now_microseconds();
-
         // Do not do anything if a reconfiguration event is already emitted within this transaction.
         //
         // This is OK because:
@@ -118,6 +118,10 @@ module aptos_framework::reconfiguration {
         if (current_time == config_ref.last_reconfiguration_time) {
             return
         };
+
+        // If `RECONFIGURE_WITH_DKG` is enabled,
+        // `reconfiguration_with_dkg::start()` already marked it correctly, and this invocation becomes a no-op.
+        reconfiguration_state::try_mark_as_in_progress();
 
         // Reconfiguration "forces the block" to end, as mentioned above. Therefore, we must process the collected fees
         // explicitly so that staking can distribute them.

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
@@ -1,0 +1,112 @@
+module aptos_framework::reconfiguration_state {
+    use std::error;
+    use std::string;
+    use aptos_std::copyable_any;
+    use aptos_std::copyable_any::Any;
+    use aptos_framework::system_addresses;
+    use aptos_framework::timestamp;
+
+    friend aptos_framework::genesis;
+    friend aptos_framework::reconfiguration;
+    friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::stake;
+
+    const ERECONFIG_NOT_IN_PROGRESS: u64 = 1;
+
+    /// Reconfiguration drivers update this resources to notify other modules of some reconfiguration state.
+    struct State has key {
+        /// The state variant packed as an `Any`.
+        /// Currently the variant type is one of the following.
+        /// - `ReconfigStateInactive`
+        /// - `ReconfigStateActive`
+        variant: Any,
+    }
+
+    /// A state variant indicating no reconfiguration is in progress.
+    struct StateInactive has copy, drop, store {}
+
+    /// A state variant indicating a reconfiguration is in progress.
+    struct StateActive has copy, drop, store {
+        start_time_us: u64,
+    }
+
+    public(friend) fun initialize(fx: &signer) {
+        system_addresses::assert_aptos_framework(fx);
+        if (!exists<State>(@aptos_framework)) {
+            move_to(fx, State {
+                variant: copyable_any::pack(StateInactive {})
+            })
+        }
+    }
+
+    /// Return whether the reconfiguration state is marked "in progress".
+    public(friend) fun is_in_progress(): bool acquires State {
+        let state = borrow_global<State>(@aptos_framework);
+        let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+        variant_type_name == b"0x1::reconfiguration_state::StateActive"
+    }
+
+    /// Mark the reconfiguration state "in progress" if it is currently "stopped".
+    /// The current time is also recorded as the reconfiguration start time. (Some module, e.g., `stake.move`, needs this info).
+    public(friend) fun try_mark_as_in_progress() acquires State {
+        let state = borrow_global_mut<State>(@aptos_framework);
+        let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+        if (variant_type_name == b"0x1::reconfiguration_state::StateInactive") {
+            state.variant = copyable_any::pack(StateActive {
+                start_time_us: timestamp::now_microseconds()
+            });
+        };
+    }
+
+    /// Get the reconfiguration start time (microsecond-level timestamp).
+    /// Abort if the reconfiguration state is not "in progress".
+    public(friend) fun start_time_us(): u64 acquires State {
+        let state = borrow_global<State>(@aptos_framework);
+        let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+        if (variant_type_name == b"0x1::reconfiguration_state::StateActive") {
+            let active = copyable_any::unpack<StateActive>(state.variant);
+            active.start_time_us
+        } else {
+            abort(error::invalid_state(ERECONFIG_NOT_IN_PROGRESS))
+        }
+    }
+
+    /// Called at the end of every reconfiguration to mark the state as "stopped".
+    /// Abort if the current state is not "in progress".
+    public(friend) fun mark_as_completed() acquires State {
+        let state = borrow_global_mut<State>(@aptos_framework);
+        let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+        if (variant_type_name == b"0x1::reconfiguration_state::StateActive") {
+            state.variant = copyable_any::pack(StateInactive {});
+        } else {
+            abort(error::invalid_state(ERECONFIG_NOT_IN_PROGRESS))
+        }
+    }
+
+    #[test(fx = @aptos_framework)]
+    fun basic(fx: &signer) acquires State {
+        // Setip.
+        timestamp::set_time_has_started_for_testing(fx);
+        initialize(fx);
+
+        // Initially no reconfig is in progress.
+        assert!(!is_in_progress(), 1);
+
+        // "try_start" should work.
+        timestamp::fast_forward_seconds(123);
+        try_mark_as_in_progress();
+        assert!(is_in_progress(), 1);
+        assert!(123000000 == start_time_us(), 1);
+
+        // Redundant `try_start` should be no-op.
+        timestamp::fast_forward_seconds(1);
+        try_mark_as_in_progress();
+        assert!(is_in_progress(), 1);
+        assert!(123000000 == start_time_us(), 1);
+
+        // A `finish` call should work when the state is marked "in progess".
+        timestamp::fast_forward_seconds(10);
+        mark_as_completed();
+        assert!(!is_in_progress(), 1);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
@@ -7,6 +7,7 @@ module aptos_framework::reconfiguration_with_dkg {
     use aptos_framework::execution_config;
     use aptos_framework::gas_schedule;
     use aptos_framework::reconfiguration;
+    use aptos_framework::reconfiguration_state;
     use aptos_framework::stake;
     friend aptos_framework::block;
     friend aptos_framework::aptos_governance;
@@ -16,6 +17,7 @@ module aptos_framework::reconfiguration_with_dkg {
     public(friend) fun try_start(account: &signer) {
         if (dkg::in_progress()) { return };
         config_buffer::disable_validator_set_changes(account);
+        reconfiguration_state::try_mark_as_in_progress();
         let cur_epoch = reconfiguration::current_epoch();
         dkg::start(cur_epoch, stake::cur_validator_set(), cur_epoch + 1, stake::next_validator_set());
     }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
@@ -19,7 +19,7 @@ module aptos_framework::reconfiguration_with_dkg {
         config_buffer::disable_validator_set_changes(account);
         reconfiguration_state::try_mark_as_in_progress();
         let cur_epoch = reconfiguration::current_epoch();
-        dkg::start(cur_epoch, stake::cur_validator_set(), cur_epoch + 1, stake::next_validator_set());
+        dkg::start(cur_epoch, stake::cur_validator_set(), cur_epoch + 1, stake::update_validator_set_on_new_epoch(false));
     }
 
     /// Apply buffered on-chain configs (except for ValidatorSet, which is done inside `reconfiguration::reconfigure()`).

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1070,6 +1070,8 @@ module aptos_framework::stake {
         let config = staking_config::get();
         let validator_perf = borrow_global_mut<ValidatorPerformance>(@aptos_framework);
 
+        // This map will store the new voting power of every current validator.
+        // This is later used to compute new validator set.
         let new_stakes_by_validator = simple_map::new<address, u64>();
 
         // Process pending stake and distribute transaction fees and rewards for each currently active validator.

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -384,7 +384,7 @@ spec aptos_framework::stake {
         ensures post_stake_pool.delegated_voter == new_voter;
     }
 
-    spec on_new_epoch {
+    spec update_validator_set_on_new_epoch {
         pragma verify_duration_estimate = 120;
         pragma disable_invariants_in_body;
         // The following resource requirement cannot be discharged by the global


### PR DESCRIPTION
### Description
1. Define `0x1::reconfiguration_state::State` to store `reconfig_start_time`.
1. Update `stake::update_stake_pool()` to use `reconfig_start_time` instead of the current time when checking if `pending_inactive` should be released. This is to avoid potentially large gap between DKG stakes and new epoch stakes.
1. Refactor `stake::update_stake_pool()` to `stake::update_stake_pool(commit: bool): u64` to enable read-only mode and return new stake.
1. `stake::on_new_epoch()` refactored to `stake::update_validator_set_on_new_epoch(commit: bool): ValidatorSet` to enable read-only mode and return new validator set.

### Code path overview
See [here](https://github.com/aptos-labs/aptos-core/pull/11458#issue-2051522444)


### Test Plan
existing UTs