### PR TITLE
add MOVE_COMPILER_V2 flag for all aptos compile, also reduce dump logging a bit (only if both debug and dump_bytecode flags are selected)

### DIFF
--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -11,7 +11,7 @@ pub mod transaction_fee;
 use anyhow::bail;
 use aptos_framework::{BuildOptions, BuiltPackage, UPGRADE_POLICY_CUSTOM_FIELD};
 pub use harness::*;
-use move_command_line_common::{env::read_bool_env_var, testing::ENABLE_V2};
+use move_command_line_common::{env::read_bool_env_var, testing::MOVE_COMPILER_V2};
 use move_package::{
     package_hooks::PackageHooks, source_package::parsed_manifest::CustomDepInfo, CompilerVersion,
 };
@@ -47,7 +47,7 @@ pub(crate) fn build_package(
     options: BuildOptions,
 ) -> anyhow::Result<BuiltPackage> {
     let mut options = options;
-    if read_bool_env_var(ENABLE_V2) {
+    if read_bool_env_var(MOVE_COMPILER_V2) {
         options.compiler_version = Some(CompilerVersion::V2);
     }
     BuiltPackage::build(package_path.to_owned(), options)

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -7,7 +7,7 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_command_line_common::{env::read_env_var, testing::ENABLE_V2};
+use move_command_line_common::{env::read_bool_env_var, testing::ENABLE_V2};
 use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -40,7 +40,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     if ok != UnitTestResult::Success {
         panic!("move unit tests failed")
     }
-    if read_env_var(ENABLE_V2) == "1" {
+    if read_bool_env_var(ENABLE_V2) {
         // Run test against v2 when ENABLE_V2 is set
         compiler_config.compiler_version = Some(CompilerVersion::V2);
         build_config.compiler_config = compiler_config;

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -7,7 +7,7 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_command_line_common::{env::read_bool_env_var, testing::ENABLE_V2};
+use move_command_line_common::{env::read_bool_env_var, testing::MOVE_COMPILER_V2};
 use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -40,8 +40,8 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     if ok != UnitTestResult::Success {
         panic!("move unit tests failed")
     }
-    if read_bool_env_var(ENABLE_V2) {
-        // Run test against v2 when ENABLE_V2 is set
+    if read_bool_env_var(MOVE_COMPILER_V2) {
+        // Run test against v2 when MOVE_COMPILER_V2 is set
         compiler_config.compiler_version = Some(CompilerVersion::V2);
         build_config.compiler_config = compiler_config;
         ok = run_move_unit_tests(

--- a/third_party/move/move-command-line-common/src/testing.rs
+++ b/third_party/move/move-command-line-common/src/testing.rs
@@ -19,7 +19,7 @@ pub const UPBL: &str = "UPBL";
 pub const UB: &str = "UB";
 
 /// Env variable to enable compiler v2 in tests
-pub const ENABLE_V2: &str = "ENABLE_V2";
+pub const MOVE_COMPILER_V2: &str = "MOVE_COMPILER_V2";
 
 pub const PRETTY: &str = "PRETTY";
 pub const FILTER: &str = "FILTER";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -84,7 +84,12 @@ pub fn run_move_compiler(
                     .map(|f| f.to_string_lossy().as_ref().to_owned())
             })
             .unwrap_or_else(|| "dump".to_owned());
-        pipeline.run_with_dump(&env, &mut targets, &dump_base_name, options.debug)
+        pipeline.run_with_dump(
+            &env,
+            &mut targets,
+            &dump_base_name,
+            options.debug && options.dump_bytecode,
+        )
     } else {
         pipeline.run(&env, &mut targets)
     }

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -675,6 +675,9 @@ impl CompiledPackage {
                         .into_iter()
                         .map(|(k, v)| format!("{}={}", k, v))
                         .collect(),
+                    skip_attribute_checks,
+                    known_attributes: known_attributes.clone(),
+                    debug: flags.debug(),
                     ..Default::default()
                 };
                 compiler_driver_v2(options)?

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -178,8 +178,8 @@ pub enum CompilerVersion {
 
 impl Default for CompilerVersion {
     fn default() -> Self {
-        static ENABLE_V2: Lazy<bool> = Lazy::new(|| read_bool_env_var("ENABLE_V2"));
-        if *ENABLE_V2 {
+        static MOVE_COMPILER_V2: Lazy<bool> = Lazy::new(|| read_bool_env_var("MOVE_COMPILER_V2"));
+        if *MOVE_COMPILER_V2 {
             Self::V2
         } else {
             Self::V1

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -19,11 +19,13 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use clap::*;
+use move_command_line_common::env::read_bool_env_var;
 use move_compiler::{
     command_line::SKIP_ATTRIBUTE_CHECKS, shared::known_attributes::KnownAttribute,
 };
 use move_core_types::account_address::AccountAddress;
 use move_model::model;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use source_package::layout::SourcePackageLayout;
 use std::{
@@ -176,7 +178,12 @@ pub enum CompilerVersion {
 
 impl Default for CompilerVersion {
     fn default() -> Self {
-        Self::V1
+        static ENABLE_V2: Lazy<bool> = Lazy::new(|| read_bool_env_var("ENABLE_V2"));
+        if *ENABLE_V2 {
+            Self::V2
+        } else {
+            Self::V1
+        }
     }
 }
 

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -6,8 +6,8 @@ use anyhow::bail;
 use move_command_line_common::{
     env::read_bool_env_var,
     testing::{
-        add_update_baseline_fix, format_diff, read_env_update_baseline, MOVE_COMPILER_V2, EXP_EXT,
-        EXP_EXT_V2,
+        add_update_baseline_fix, format_diff, read_env_update_baseline, EXP_EXT, EXP_EXT_V2,
+        MOVE_COMPILER_V2,
     },
 };
 use move_compiler::shared::known_attributes::KnownAttribute;

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -6,7 +6,7 @@ use anyhow::bail;
 use move_command_line_common::{
     env::read_bool_env_var,
     testing::{
-        add_update_baseline_fix, format_diff, read_env_update_baseline, ENABLE_V2, EXP_EXT,
+        add_update_baseline_fix, format_diff, read_env_update_baseline, MOVE_COMPILER_V2, EXP_EXT,
         EXP_EXT_V2,
     },
 };
@@ -154,8 +154,8 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let output_v1 = run_test_impl(path, false)?;
     let update_baseline = read_env_update_baseline();
     let res_v1 = check_or_update(path, output_v1.clone(), update_baseline, false);
-    if read_bool_env_var(ENABLE_V2) {
-        // Run test against v2 when ENABLE_V2 is set
+    if read_bool_env_var(MOVE_COMPILER_V2) {
+        // Run test against v2 when MOVE_COMPILER_V2 is set
         let output_v2 = run_test_impl(path, true)?;
         if output_v1 != output_v2 {
             // TODO: compare the result between V1 and V2.

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -4,7 +4,7 @@
 
 use anyhow::bail;
 use move_command_line_common::{
-    env::read_env_var,
+    env::read_bool_env_var,
     testing::{
         add_update_baseline_fix, format_diff, read_env_update_baseline, ENABLE_V2, EXP_EXT,
         EXP_EXT_V2,
@@ -84,10 +84,13 @@ fn run_test_impl(path: &Path, v2_flag: bool) -> datatest_stable::Result<String> 
                 },
                 Err(error) => format!("{:#}\n", error),
             },
-            (_, true) => match ModelBuilder::create(resolved_package, ModelConfig {
-                all_files_as_targets: false,
-                target_filter: None,
-            })
+            (_, true) => match ModelBuilder::create(
+                resolved_package,
+                ModelConfig {
+                    all_files_as_targets: false,
+                    target_filter: None,
+                },
+            )
             .build_model()
             {
                 Ok(_) => "Built model".to_string(),
@@ -154,7 +157,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let output_v1 = run_test_impl(path, false)?;
     let update_baseline = read_env_update_baseline();
     let res_v1 = check_or_update(path, output_v1.clone(), update_baseline, false);
-    if read_env_var(ENABLE_V2) == "1" {
+    if read_bool_env_var(ENABLE_V2) {
         // Run test against v2 when ENABLE_V2 is set
         let output_v2 = run_test_impl(path, true)?;
         if output_v1 != output_v2 {

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -84,13 +84,10 @@ fn run_test_impl(path: &Path, v2_flag: bool) -> datatest_stable::Result<String> 
                 },
                 Err(error) => format!("{:#}\n", error),
             },
-            (_, true) => match ModelBuilder::create(
-                resolved_package,
-                ModelConfig {
-                    all_files_as_targets: false,
-                    target_filter: None,
-                },
-            )
+            (_, true) => match ModelBuilder::create(resolved_package, ModelConfig {
+                all_files_as_targets: false,
+                target_filter: None,
+            })
             .build_model()
             {
                 Ok(_) => "Built model".to_string(),


### PR DESCRIPTION
### Description

Honor MOVE_COMPILER_V2 (was ENABLE_V2) environment variable whenever 'aptos build' is used.  Also decrease V2 bytecode dumping a bit (was with --debug or MOVE_COMPILER_DEBUG, now also need dump-bytecode flag to be selected, to make debugging a bit more mangeable).  Also use standard method to read ENABLE_V2, so that "true" or "1" are acceptable values.

Also pass attributes through correctly to move-compiler-v2.

### Test Plan
Shouldn't affect anything in the default case.  Manually tests show more existing bugs.

### Fixes
https://github.com/aptos-labs/aptos-core/issues/11573
and https://github.com/aptos-labs/aptos-core/issues/11575.
Seems to also fix https://github.com/aptos-labs/aptos-core/issues/11638.

