### PR TITLE
[Quorum Store] improvements to prevent some batches not getting quorum

### DIFF
--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -148,6 +148,7 @@ impl SignedBatchInfoMsg {
         &self,
         sender: PeerId,
         max_num_batches: usize,
+        max_batch_expiry_gap_usecs: u64,
         validator: &ValidatorVerifier,
     ) -> anyhow::Result<()> {
         ensure!(!self.signed_infos.is_empty(), "Empty message");
@@ -158,7 +159,7 @@ impl SignedBatchInfoMsg {
             max_num_batches
         );
         for signed_info in &self.signed_infos {
-            signed_info.verify(sender, validator)?
+            signed_info.verify(sender, max_batch_expiry_gap_usecs, validator)?
         }
         Ok(())
     }
@@ -207,12 +208,29 @@ impl SignedBatchInfo {
         self.signer
     }
 
-    pub fn verify(&self, sender: PeerId, validator: &ValidatorVerifier) -> anyhow::Result<()> {
-        if sender == self.signer {
-            Ok(validator.verify(self.signer, &self.info, &self.signature)?)
-        } else {
+    pub fn verify(
+        &self,
+        sender: PeerId,
+        max_batch_expiry_gap_usecs: u64,
+        validator: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        if sender != self.signer {
             bail!("Sender {} mismatch signer {}", sender, self.signer);
         }
+
+        if self.expiration()
+            > aptos_infallible::duration_since_epoch().as_micros() as u64
+                + max_batch_expiry_gap_usecs
+        {
+            bail!(
+                "Batch expiration too far in future: {} > {}",
+                self.expiration(),
+                aptos_infallible::duration_since_epoch().as_micros() as u64
+                    + max_batch_expiry_gap_usecs
+            );
+        }
+
+        Ok(validator.verify(self.signer, &self.info, &self.signature)?)
     }
 
     pub fn signature(self) -> bls12381::Signature {
@@ -238,6 +256,7 @@ pub enum SignedBatchInfoError {
     WrongInfo((u64, u64)),
     DuplicatedSignature,
     InvalidAuthor,
+    NotFound,
     AlreadyCommitted,
 }
 

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -238,6 +238,7 @@ pub enum SignedBatchInfoError {
     WrongInfo((u64, u64)),
     DuplicatedSignature,
     InvalidAuthor,
+    AlreadyCommitted,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1207,6 +1207,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             let round_manager_tx = self.round_manager_tx.clone();
             let my_peer_id = self.author;
             let max_num_batches = self.config.quorum_store.receiver_max_num_batches;
+            let max_batch_expiry_gap_usecs =
+                self.config.quorum_store.batch_expiry_gap_when_init_usecs;
             let payload_manager = self.payload_manager.clone();
             self.bounded_executor
                 .spawn(async move {
@@ -1218,6 +1220,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             quorum_store_enabled,
                             peer_id == my_peer_id,
                             max_num_batches,
+                            max_batch_expiry_gap_usecs,
                         )
                     ) {
                         Ok(verified_event) => {

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -19,6 +19,7 @@ pub struct LogSchema {
 pub enum LogEvent {
     CommitViaBlock,
     CommitViaSync,
+    IncrementalProofExpired,
     NetworkReceiveProposal,
     NewEpoch,
     NewRound,

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -4,7 +4,7 @@
 use crate::{
     network::{NetworkSender, QuorumStoreSender},
     quorum_store::{
-        batch_store::BatchStore,
+        batch_store::{BatchStore, BatchWriter},
         counters,
         types::{Batch, PersistedValue},
     },

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -4,6 +4,7 @@ use crate::{
     monitor,
     network::{NetworkSender, QuorumStoreSender},
     quorum_store::{
+        batch_store::BatchWriter,
         counters,
         quorum_store_db::QuorumStoreStorage,
         types::Batch,
@@ -44,6 +45,7 @@ pub struct BatchGenerator {
     my_peer_id: PeerId,
     batch_id: BatchId,
     db: Arc<dyn QuorumStoreStorage>,
+    batch_writer: Arc<dyn BatchWriter>,
     config: QuorumStoreConfig,
     mempool_proxy: MempoolProxy,
     batches_in_progress: HashMap<BatchId, Vec<TransactionSummary>>,
@@ -61,6 +63,7 @@ impl BatchGenerator {
         my_peer_id: PeerId,
         config: QuorumStoreConfig,
         db: Arc<dyn QuorumStoreStorage>,
+        batch_writer: Arc<dyn BatchWriter>,
         mempool_tx: Sender<QuorumStoreRequest>,
         mempool_txn_pull_timeout_ms: u64,
     ) -> Self {
@@ -85,6 +88,7 @@ impl BatchGenerator {
             my_peer_id,
             batch_id,
             db,
+            batch_writer,
             config,
             mempool_proxy: MempoolProxy::new(mempool_tx, mempool_txn_pull_timeout_ms),
             batches_in_progress: HashMap::new(),
@@ -404,6 +408,12 @@ impl BatchGenerator {
                         let batches = self.handle_scheduled_pull(dynamic_pull_max_txn).await;
                         if !batches.is_empty() {
                             last_non_empty_pull = tick_start;
+                            // TODO: time how long this takes
+                            let mut persist_requests = vec![];
+                            for batch in batches.clone().into_iter() {
+                                persist_requests.push(batch.into());
+                            }
+                            self.batch_writer.persist(persist_requests);
                             network_sender.broadcast_batch_msg(batches).await;
                         } else if tick_start.elapsed() > interval.period().checked_div(2).unwrap_or(Duration::ZERO) {
                             // If the pull takes too long, it's also accounted as a non-empty pull to avoid pulling too often.

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -618,6 +618,17 @@ pub static BATCH_CREATION_COMPUTE_LATENCY: Lazy<DurationHistogram> = Lazy::new(|
     )
 });
 
+/// Histogram of the time it takes to persist batches generated locally to the DB.
+pub static BATCH_CREATION_PERSIST_LATENCY: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "quorum_store_batch_creation_persist_latency",
+            "Histogram of the time it takes to persist batches generated locally to the DB.",
+        )
+        .unwrap(),
+    )
+});
+
 /// Histogram of the time durations from created batch to created PoS.
 pub static BATCH_TO_POS_DURATION: Lazy<DurationHistogram> = Lazy::new(|| {
     DurationHistogram::new(

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -181,7 +181,7 @@ impl ProofCoordinator {
         let batch_author = self
             .batch_reader
             .exists(signed_batch_info.digest())
-            .ok_or(SignedBatchInfoError::WrongAuthor)?;
+            .ok_or(SignedBatchInfoError::NotFound)?;
         if batch_author != signed_batch_info.author() {
             return Err(SignedBatchInfoError::WrongAuthor);
         }
@@ -265,9 +265,9 @@ impl ProofCoordinator {
                 }
                 if !state.completed {
                     info!(
-                        "QS: received expire for batch that did not complete: {}, self_voted: {}",
-                        signed_batch_info_info.digest(),
-                        state.self_voted
+                        LogSchema::new(LogEvent::ProofOfStoreInit),
+                        digest = signed_batch_info_info.digest(),
+                        self_voted = state.self_voted,
                     );
                 }
                 Self::update_counters(&state);
@@ -307,7 +307,7 @@ impl ProofCoordinator {
                                     if batch == *existing_proof.get().batch_info() {
                                         let incremental_proof = existing_proof.get();
                                         if !incremental_proof.completed {
-                                            info!("QS: received commit notification for batch that did not complete: {}, self_voted: {}", digest, incremental_proof.self_voted);
+                                            warn!("QS: received commit notification for batch that did not complete: {}, self_voted: {}", digest, incremental_proof.self_voted);
                                         }
                                         Self::update_counters(incremental_proof);
                                         existing_proof.remove();

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -291,6 +291,7 @@ impl InnerBuilder {
             self.author,
             self.config.clone(),
             self.quorum_store_storage.clone(),
+            self.batch_store.clone().unwrap(),
             self.quorum_store_to_mempool_sender,
             self.mempool_txn_pull_timeout_ms,
         );

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::quorum_store::{
-    batch_store::{BatchStore, QuotaManager},
+    batch_store::{BatchStore, BatchWriter, QuotaManager},
     quorum_store_db::QuorumStoreDB,
     types::{PersistedValue, StorageMode},
 };

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -82,6 +82,7 @@ impl UnverifiedEvent {
         quorum_store_enabled: bool,
         self_message: bool,
         max_num_batches: usize,
+        max_batch_expiry_gap_usecs: u64,
     ) -> Result<VerifiedEvent, VerifyError> {
         Ok(match self {
             //TODO: no need to sign and verify the proposal
@@ -107,7 +108,12 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::SignedBatchInfo(sd) => {
                 if !self_message {
-                    sd.verify(peer_id, max_num_batches, validator)?;
+                    sd.verify(
+                        peer_id,
+                        max_num_batches,
+                        max_batch_expiry_gap_usecs,
+                        validator,
+                    )?;
                 }
                 VerifiedEvent::SignedBatchInfo(sd)
             },


### PR DESCRIPTION
### Description

Occasionally, the metrics show batches not getting quorum, in forge and testnet.
1. There are false positives (didn't actually expire, only in the metrics), due to batches getting late votes, after they have been committed. This is resolved by caching the committed batches until expiration time; only really really late votes would cause false positives.
2. There are proofs that actually expire without getting quorum. These are written too late into the QS DB; if the entry does not exist in the DB, the vote is discarded, and in some cases more than 33% of votes are actually discarded. This is resolved by writing to the DB in batch_generator, before broadcasting the Batch.

In addition the counters for counting proof votes are cleaned up, so the votes/stake are counted on expire time (as originally intended).

### Test Plan

Run `realistic_env_max_load_large` and observe that no more proofs fail to get quorum, and metrics look better
