### PR TITLE
[Prover][Move-Model] fix #11532

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: field `z` not declared in struct `update_field_ok::R` (update field)
+   ┌─ tests/checking/specs/update_field_err.move:16:9
+   │
+16 │         update_field(r, z, 1)
+   │         ^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `u64` but found `bool`
+   ┌─ tests/checking/specs/update_field_err.move:20:28
+   │
+20 │         update_field(r, x, true)
+   │                            ^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.move
@@ -1,0 +1,23 @@
+module 0x42::update_field_ok {
+    struct R {
+        x: u64,
+        y: u64,
+    }
+
+    fun f(r: &mut R) {
+        r.x = 1;
+    }
+    spec f {
+        aborts_if false;
+        ensures r == assign_x_1(old(r));
+    }
+
+    spec fun assign_x_1(r: R): R {
+        update_field(r, z, 1)
+    }
+
+    spec fun assign_x_2(r: R): R {
+        update_field(r, x, true)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.exp
@@ -1,0 +1,20 @@
+// ---- Model Dump
+module 0x42::update_field_ok {
+    struct R {
+        x: u64,
+        y: u64,
+    }
+    private fun f(r: &mut update_field_ok::R) {
+        select update_field_ok::R.x(r) = 1;
+        Tuple()
+    }
+    spec {
+      aborts_if false;
+      ensures Eq<update_field_ok::R>($t0, update_field_ok::assign_x_1(Old<update_field_ok::R>($t0)));
+    }
+
+    spec fun $f(r: &mut update_field_ok::R);
+    spec fun assign_x_1(r: update_field_ok::R): update_field_ok::R {
+        update update_field_ok::R.x<update_field_ok::R>(r, 1)
+    }
+} // end 0x42::update_field_ok

--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.move
@@ -1,0 +1,18 @@
+module 0x42::update_field_ok {
+    struct R {
+        x: u64,
+        y: u64,
+    }
+
+    fun f(r: &mut R) {
+        r.x = 1;
+    }
+    spec f {
+        aborts_if false;
+        ensures r == assign_x_1(old(r));
+    }
+
+    spec fun assign_x_1(r: R): R {
+        update_field(r, x, 1)
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2479,30 +2479,35 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             None,
         ) = &args[1].value
         {
-            let field_name = self.symbol_pool().make(name.value.as_str());
-            let constraint =
-                Constraint::SomeStruct([(field_name, expected_type.clone())].into_iter().collect());
-            if let Err(e) = self.subs.eval_constraint(
-                &self.unification_context,
-                loc,
-                expected_type,
-                self.type_variance(),
-                WideningOrder::RightToLeft,
-                constraint,
-            ) {
-                self.report_unification_error(loc, e, "update field")
-            }
             let struct_exp = self.translate_exp(args[0], expected_type);
+            let expected_type = &self.subs.specialize(expected_type);
             if let Type::Struct(mid, sid, inst) = self.subs.specialize(expected_type) {
                 // field_map contains the instantiated field type.
                 let field_map = self
                     .parent
                     .parent
                     .lookup_struct_fields(mid.qualified_inst(sid, inst));
-                let field_type = field_map.get(&field_name).cloned().unwrap_or(Type::Error); // this error is reported via type unification
+                let field_name = self.symbol_pool().make(name.value.as_str());
+                let expected_field_type =
+                    field_map.get(&field_name).cloned().unwrap_or(Type::Error); // this error is reported via type unification
+                let constraint = Constraint::SomeStruct(
+                    [(field_name, expected_field_type.clone())]
+                        .into_iter()
+                        .collect(),
+                );
+                if let Err(e) = self.subs.eval_constraint(
+                    &self.unification_context,
+                    loc,
+                    expected_type,
+                    self.type_variance(),
+                    WideningOrder::RightToLeft,
+                    constraint,
+                ) {
+                    self.report_unification_error(loc, e, "update field")
+                }
 
                 // Translate the new value with the field type as the expected type.
-                let value_exp = self.translate_exp(args[2], &field_type);
+                let value_exp = self.translate_exp(args[2], &expected_field_type);
                 let id = self.new_node_id_with_type_loc(expected_type, loc);
                 self.set_node_instantiation(id, vec![expected_type.clone()]);
                 ExpData::Call(


### PR DESCRIPTION
### Description

`update_field(x, f, val): X` is a built-in function in the prover where `x` is an instance of struct `X` , `f` is a field of `X` and `val` is a value that has the same type with `f`. It will return a new instance of `X` where all other fields keep the value of `x` and the field `f` takes the value `val`.

Currently, the function `translate_update_field` contains a constraint check for the field `f`, which is problematic because the expected type of `f` in this constraint is X instead of the type of `f`. 

This PR closes #11532 by fixing the expected type for the field.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

1) Manually check DPN test passes (this will be added to unit test soon);
2) Add two new tests to tests/checking/specs;
3) Existing tests still pass.