### PR TITLE
[compiler-v2] Disable attribute warnings for the time being

### DIFF
--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -109,7 +109,8 @@ pub fn run_checker(options: Options) -> anyhow::Result<GlobalEnv> {
             sources: options.dependencies.clone(),
             address_map: addrs.clone(),
         }],
-        options.skip_attribute_checks,
+        // TODO: Enable attribute checks again once we have a general solution
+        true,
         if !options.skip_attribute_checks && options.known_attributes.is_empty() {
             KnownAttribute::get_all_attribute_names()
         } else {


### PR DESCRIPTION
Those warnings are expected and distract from understanding test output. We should turn those on again once we have a better way to declare attributes.
