### PR TITLE
[State Sync] Introduce metrics to track end-to-end pipeline latencies.

### DIFF
--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -805,10 +805,7 @@ impl AptosDataClient {
                     peer,
                     request,
                 };
-                let context = ResponseContext {
-                    id,
-                    response_callback: Box::new(response_callback),
-                };
+                let context = ResponseContext::new(id, Box::new(response_callback));
                 Ok(Response::new(context, response))
             },
             Err(error) => {

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -10,7 +10,7 @@ use aptos_types::{
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, time::Instant};
 
 /// The API offered by the Aptos Data Client.
 #[async_trait]
@@ -209,12 +209,24 @@ pub type ResponseId = u64;
 
 #[derive(Debug)]
 pub struct ResponseContext {
+    /// The time at which this response context was created
+    pub creation_time: Instant,
     /// A unique identifier for this request/response pair. Intended mostly for
     /// debugging.
     pub id: ResponseId,
     /// A callback for notifying the data-client source about an error with this
     /// response.
     pub response_callback: Box<dyn ResponseCallback>,
+}
+
+impl ResponseContext {
+    pub fn new(id: ResponseId, response_callback: Box<dyn ResponseCallback>) -> Self {
+        Self {
+            creation_time: Instant::now(),
+            id,
+            response_callback,
+        }
+    }
 }
 
 /// A response from the Data Client for a single API call.

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -9,7 +9,10 @@ use aptos_types::{
     state_store::state_value::StateValueChunkWithProof,
     transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
 };
-use std::fmt::{Debug, Formatter};
+use std::{
+    fmt::{Debug, Formatter},
+    time::Instant,
+};
 
 /// A unique ID used to identify each notification.
 pub type NotificationId = u64;
@@ -17,8 +20,19 @@ pub type NotificationId = u64;
 /// A single data notification with an ID and data payload.
 #[derive(Clone, Debug)]
 pub struct DataNotification {
+    pub creation_time: Instant,
     pub notification_id: NotificationId,
     pub data_payload: DataPayload,
+}
+
+impl DataNotification {
+    pub fn new(notification_id: NotificationId, data_payload: DataPayload) -> Self {
+        Self {
+            creation_time: Instant::now(),
+            notification_id,
+            data_payload,
+        }
+    }
 }
 
 /// A single payload (e.g. chunk) of data delivered to a data listener.

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -771,6 +771,13 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
                 self.notification_id_generator.clone(),
             )?
         {
+            // Update the metrics for the data notification send latency
+            metrics::observe_duration(
+                &metrics::DATA_NOTIFICATION_SEND_LATENCY,
+                data_client_request.get_label(),
+                response_context.creation_time,
+            );
+
             // Save the response context for this notification ID
             let notification_id = data_notification.notification_id;
             self.insert_notification_response_mapping(notification_id, response_context)?;

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -424,10 +424,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
     async fn send_end_of_stream_notification(&mut self) -> Result<(), Error> {
         // Create end of stream notification
         let notification_id = self.notification_id_generator.next();
-        let data_notification = DataNotification {
-            notification_id,
-            data_payload: DataPayload::EndOfStream,
-        };
+        let data_notification = DataNotification::new(notification_id, DataPayload::EndOfStream);
 
         // Send the data notification
         info!(

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2184,7 +2184,7 @@ fn update_response_chunk_size_metrics(
     client_request: &DataClientRequest,
     client_response_payload: &ResponsePayload,
 ) {
-    metrics::observe_value(
+    metrics::observe_values(
         &metrics::RECEIVED_DATA_RESPONSE_CHUNK_SIZE,
         client_request.get_label(),
         client_response_payload.get_label(),

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2062,8 +2062,10 @@ fn create_data_notification(
     target_ledger_info: Option<LedgerInfoWithSignatures>,
     stream_engine: StreamEngine,
 ) -> Result<DataNotification, Error> {
+    // Create a unique notification ID
     let notification_id = notification_id_generator.next();
 
+    // Get the data payload
     let client_response_type = client_response.get_label();
     let data_payload = match client_response {
         ResponsePayload::StateValuesWithProof(states_chunk) => {
@@ -2131,10 +2133,9 @@ fn create_data_notification(
         _ => invalid_response_type!(client_response_type),
     };
 
-    Ok(DataNotification {
-        notification_id,
-        data_payload,
-    })
+    // Create and return the data notification
+    let data_notification = DataNotification::new(notification_id, data_payload);
+    Ok(data_notification)
 }
 
 /// Extracts the number of new versions and target

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -76,10 +76,7 @@ async fn test_stream_blocked() {
                 start_epoch: 0,
                 end_epoch: 0,
             });
-        let context = ResponseContext {
-            id: 0,
-            response_callback: Box::new(NoopResponseCallback),
-        };
+        let context = ResponseContext::new(0, Box::new(NoopResponseCallback));
         let pending_response = PendingClientResponse::new_with_response(
             client_request.clone(),
             Ok(Response::new(context, ResponsePayload::NumberOfStates(10))),
@@ -237,10 +234,7 @@ async fn test_stream_invalid_response() {
         start_epoch: MIN_ADVERTISED_EPOCH_END,
         end_epoch: MIN_ADVERTISED_EPOCH_END + 1,
     });
-    let context = ResponseContext {
-        id: 0,
-        response_callback: Box::new(NoopResponseCallback),
-    };
+    let context = ResponseContext::new(0, Box::new(NoopResponseCallback));
     let pending_response = PendingClientResponse::new_with_response(
         client_request.clone(),
         Ok(Response::new(context, ResponsePayload::NumberOfStates(10))),

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -863,11 +863,7 @@ impl ResponseCallback for NoopResponseCallback {
 /// Creates a data client response using a specified payload and random id
 pub fn create_data_client_response<T>(payload: T) -> Response<T> {
     let id = create_random_u64(MAX_RESPONSE_ID);
-    let response_callback = Box::new(NoopResponseCallback);
-    let context = ResponseContext {
-        id,
-        response_callback,
-    };
+    let context = ResponseContext::new(id, Box::new(NoopResponseCallback));
     Response::new(context, payload)
 }
 

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -9,7 +9,7 @@ use crate::{
     metadata_storage::MetadataStorageInterface,
     metrics,
     metrics::ExecutingComponent,
-    storage_synchronizer::StorageSynchronizerInterface,
+    storage_synchronizer::{NotificationMetadata, StorageSynchronizerInterface},
     utils,
     utils::{OutputFallbackHandler, SpeculativeStreamState, PENDING_DATA_LOG_FREQ_SECS},
 };
@@ -621,8 +621,12 @@ impl<
                 },
                 DataPayload::TransactionsWithProof(transactions_with_proof) => {
                     let payload_start_version = transactions_with_proof.first_transaction_version;
-                    self.process_transaction_or_output_payload(
+                    let notification_metadata = NotificationMetadata::new(
+                        data_notification.creation_time,
                         data_notification.notification_id,
+                    );
+                    self.process_transaction_or_output_payload(
+                        notification_metadata,
                         Some(transactions_with_proof),
                         None,
                         payload_start_version,
@@ -632,8 +636,12 @@ impl<
                 DataPayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
                     let payload_start_version =
                         transaction_outputs_with_proof.first_transaction_output_version;
-                    self.process_transaction_or_output_payload(
+                    let notification_metadata = NotificationMetadata::new(
+                        data_notification.creation_time,
                         data_notification.notification_id,
+                    );
+                    self.process_transaction_or_output_payload(
+                        notification_metadata,
                         None,
                         Some(transaction_outputs_with_proof),
                         payload_start_version,
@@ -1100,7 +1108,7 @@ impl<
     /// Process a single transaction or transaction output data payload
     async fn process_transaction_or_output_payload(
         &mut self,
-        notification_id: NotificationId,
+        notification_metadata: NotificationMetadata,
         transaction_list_with_proof: Option<TransactionListWithProof>,
         transaction_outputs_with_proof: Option<TransactionOutputListWithProof>,
         payload_start_version: Option<Version>,
@@ -1112,7 +1120,7 @@ impl<
                 && self.state_value_syncer.transaction_output_to_sync.is_some())
         {
             self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
+                notification_metadata.notification_id,
                 NotificationFeedback::InvalidPayloadData,
             )))
             .await?;
@@ -1125,7 +1133,7 @@ impl<
         if bootstrapping_mode.is_fast_sync() {
             return self
                 .verify_transaction_info_to_sync(
-                    notification_id,
+                    notification_metadata.notification_id,
                     transaction_outputs_with_proof,
                     payload_start_version,
                 )
@@ -1138,7 +1146,7 @@ impl<
             .expected_next_version()?;
         let payload_start_version = self
             .verify_payload_start_version(
-                notification_id,
+                notification_metadata.notification_id,
                 payload_start_version,
                 expected_start_version,
             )
@@ -1152,7 +1160,7 @@ impl<
         // Get the end of epoch ledger info if the payload ends the epoch
         let end_of_epoch_ledger_info = self
             .get_end_of_epoch_ledger_info(
-                notification_id,
+                notification_metadata.notification_id,
                 payload_start_version,
                 transaction_list_with_proof.as_ref(),
                 transaction_outputs_with_proof.as_ref(),
@@ -1165,7 +1173,7 @@ impl<
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     utils::apply_transaction_outputs(
                         self.storage_synchronizer.clone(),
-                        notification_id,
+                        notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
                         transaction_outputs_with_proof,
@@ -1173,7 +1181,7 @@ impl<
                     .await?
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
-                        notification_id,
+                        notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
                     )))
                     .await?;
@@ -1186,7 +1194,7 @@ impl<
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
                         self.storage_synchronizer.clone(),
-                        notification_id,
+                        notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
                         transaction_list_with_proof,
@@ -1194,7 +1202,7 @@ impl<
                     .await?
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
-                        notification_id,
+                        notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
                     )))
                     .await?;
@@ -1207,7 +1215,7 @@ impl<
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
                         self.storage_synchronizer.clone(),
-                        notification_id,
+                        notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
                         transaction_list_with_proof,
@@ -1217,7 +1225,7 @@ impl<
                 {
                     utils::apply_transaction_outputs(
                         self.storage_synchronizer.clone(),
-                        notification_id,
+                        notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
                         transaction_outputs_with_proof,
@@ -1225,7 +1233,7 @@ impl<
                     .await?
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
-                        notification_id,
+                        notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
                     )))
                     .await?;

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -29,6 +29,7 @@ pub const STORAGE_SYNCHRONIZER_EXECUTE_CHUNK: &str = "execute_chunk";
 pub const STORAGE_SYNCHRONIZER_UPDATE_LEDGER: &str = "update_ledger";
 pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
 pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS: &str = "commit_post_process";
+pub const STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK: &str = "state_value_chunk";
 
 /// An enum representing the component currently executing
 pub enum ExecutingComponent {

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -6,11 +6,23 @@ use aptos_metrics_core::{
     register_int_gauge_vec, HistogramTimer, HistogramVec, IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
+use std::time::Instant;
 
-/// Useful metric labels
+/// Driver metric labels
 pub const DRIVER_CLIENT_NOTIFICATION: &str = "driver_client_notification";
 pub const DRIVER_CONSENSUS_COMMIT_NOTIFICATION: &str = "driver_consensus_commit_notification";
 pub const DRIVER_CONSENSUS_SYNC_NOTIFICATION: &str = "driver_consensus_sync_notification";
+
+/// Data notification metric labels
+pub const NOTIFICATION_CREATE_TO_APPLY: &str = "notification_create_to_apply";
+pub const NOTIFICATION_CREATE_TO_COMMIT: &str = "notification_create_to_commit";
+pub const NOTIFICATION_CREATE_TO_COMMIT_POST_PROCESS: &str =
+    "notification_create_to_commit_post_process";
+pub const NOTIFICATION_CREATE_TO_EXECUTE: &str = "notification_create_to_execute";
+pub const NOTIFICATION_CREATE_TO_RECEIVE: &str = "notification_create_to_receive";
+pub const NOTIFICATION_CREATE_TO_UPDATE_LEDGER: &str = "notification_create_to_update_ledger";
+
+/// Storage synchronizer metric labels
 pub const STORAGE_SYNCHRONIZER_PENDING_DATA: &str = "storage_synchronizer_pending_data";
 pub const STORAGE_SYNCHRONIZER_APPLY_CHUNK: &str = "apply_chunk";
 pub const STORAGE_SYNCHRONIZER_EXECUTE_CHUNK: &str = "execute_chunk";
@@ -91,6 +103,17 @@ pub static DRIVER_COUNTERS: Lazy<IntCounterVec> = Lazy::new(|| {
         "aptos_state_sync_driver_counters",
         "Counters related to the state sync driver",
         &["label"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking data notification latencies
+pub static DATA_NOTIFICATION_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_state_sync_data_notification_latencies",
+        "Counters related to the data notification latencies",
+        &["label"],
+        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
 });
@@ -179,6 +202,13 @@ pub fn increment_gauge(gauge: &Lazy<IntGaugeVec>, label: &str, delta: u64) {
 /// Decrements the gauge with the specific label by the given delta
 pub fn decrement_gauge(gauge: &Lazy<IntGaugeVec>, label: &str, delta: u64) {
     gauge.with_label_values(&[label]).sub(delta as i64);
+}
+
+/// Adds a new duration observation for the given histogram and label
+pub fn observe_duration(histogram: &Lazy<HistogramVec>, label: &str, start_time: Instant) {
+    histogram
+        .with_label_values(&[label])
+        .observe(start_time.elapsed().as_secs_f64());
 }
 
 /// Adds a new observation for the given histogram, label and value

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -399,10 +399,10 @@ async fn test_data_stream_state_values() {
         .unwrap();
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
-    };
+        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
@@ -471,10 +471,10 @@ async fn test_data_stream_transactions() {
         .unwrap();
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::TransactionsWithProof(create_transaction_list_with_proof()),
-    };
+        DataPayload::TransactionsWithProof(create_transaction_list_with_proof()),
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
@@ -543,12 +543,10 @@ async fn test_data_stream_transaction_outputs() {
         .unwrap();
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::TransactionOutputsWithProof(
-            TransactionOutputListWithProof::new_empty(),
-        ),
-    };
+        DataPayload::TransactionOutputsWithProof(TransactionOutputListWithProof::new_empty()),
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
@@ -616,10 +614,10 @@ async fn test_data_stream_transactions_or_outputs() {
         .unwrap();
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::EpochEndingLedgerInfos(vec![create_epoch_ending_ledger_info()]),
-    };
+        DataPayload::EpochEndingLedgerInfos(vec![create_epoch_ending_ledger_info()]),
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get an invalid payload error
@@ -1064,10 +1062,10 @@ async fn test_snapshot_sync_existing_state() {
         .unwrap();
 
     // Send an invalid notification (incorrect data type)
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
-    };
+        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get an invalid payload error
@@ -1333,10 +1331,10 @@ async fn test_waypoint_mismatch() {
         waypoint_version,
         waypoint_epoch,
     )];
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::EpochEndingLedgerInfos(invalid_ledger_info),
-    };
+        DataPayload::EpochEndingLedgerInfos(invalid_ledger_info),
+    );
     notification_sender.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -171,13 +171,13 @@ async fn test_data_stream_transactions_with_target() {
     drive_progress(&mut continuous_syncer, &sync_request).await;
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::ContinuousTransactionOutputsWithProof(
+        DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
             TransactionOutputListWithProof::new_empty(),
         ),
-    };
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
@@ -250,13 +250,13 @@ async fn test_data_stream_transaction_outputs() {
     let mut transaction_output_with_proof = TransactionOutputListWithProof::new_empty();
     transaction_output_with_proof.first_transaction_output_version =
         Some(current_synced_version - 1);
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::ContinuousTransactionOutputsWithProof(
+        DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
             transaction_output_with_proof,
         ),
-    };
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
@@ -331,13 +331,13 @@ async fn test_data_stream_transactions_or_outputs_with_target() {
     drive_progress(&mut continuous_syncer, &sync_request).await;
 
     // Send an invalid output along the stream
-    let data_notification = DataNotification {
+    let data_notification = DataNotification::new(
         notification_id,
-        data_payload: DataPayload::ContinuousTransactionOutputsWithProof(
+        DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
             TransactionOutputListWithProof::new_empty(),
         ),
-    };
+    );
     notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -4,7 +4,7 @@
 use crate::{
     error::Error,
     metadata_storage::MetadataStorageInterface,
-    storage_synchronizer::StorageSynchronizerInterface,
+    storage_synchronizer::{NotificationMetadata, StorageSynchronizerInterface},
     tests::utils::{create_empty_epoch_state, create_epoch_ending_ledger_info},
 };
 use anyhow::Result as AnyhowResult;
@@ -452,7 +452,7 @@ mock! {
     impl StorageSynchronizerInterface for StorageSynchronizer {
         async fn apply_transaction_outputs(
             &mut self,
-            notification_id: NotificationId,
+            notification_metadata: NotificationMetadata,
             output_list_with_proof: TransactionOutputListWithProof,
             target_ledger_info: LedgerInfoWithSignatures,
             end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
@@ -460,7 +460,7 @@ mock! {
 
         async fn execute_transactions(
             &mut self,
-            notification_id: NotificationId,
+            notification_metadata: NotificationMetadata,
             transaction_list_with_proof: TransactionListWithProof,
             target_ledger_info: LedgerInfoWithSignatures,
             end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -9,7 +9,8 @@ use crate::{
         ErrorNotificationListener, MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     storage_synchronizer::{
-        StorageSynchronizer, StorageSynchronizerHandles, StorageSynchronizerInterface,
+        NotificationMetadata, StorageSynchronizer, StorageSynchronizerHandles,
+        StorageSynchronizerInterface,
     },
     tests::{
         mocks::{
@@ -92,7 +93,7 @@ async fn test_apply_outputs() {
     // Attempt to apply a chunk of outputs
     storage_synchronizer
         .apply_transaction_outputs(
-            0,
+            NotificationMetadata::new_for_test(0),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -132,7 +133,7 @@ async fn test_apply_outputs_error() {
     let notification_id = 100;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -166,7 +167,7 @@ async fn test_apply_outputs_send_error() {
     let notification_id = 101;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -199,7 +200,7 @@ async fn test_apply_outputs_update_error() {
     let notification_id = 101;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -234,7 +235,7 @@ async fn test_apply_outputs_update_send_error() {
     let notification_id = 101;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -268,7 +269,7 @@ async fn test_apply_outputs_commit_error() {
     let notification_id = 101;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -320,7 +321,7 @@ async fn test_apply_outputs_commit_send_error() {
     let notification_id = 555;
     storage_synchronizer
         .apply_transaction_outputs(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_output_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -380,7 +381,7 @@ async fn test_execute_transactions() {
     // Attempt to execute a chunk of transactions
     storage_synchronizer
         .execute_transactions(
-            0,
+            NotificationMetadata::new_for_test(0),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -420,7 +421,7 @@ async fn test_execute_transactions_error() {
     let notification_id = 100;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -454,7 +455,7 @@ async fn test_execute_transactions_send_error() {
     let notification_id = 101;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -487,7 +488,7 @@ async fn test_execute_transactions_update_error() {
     let notification_id = 100;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -522,7 +523,7 @@ async fn test_execute_transactions_update_send_error() {
     let notification_id = 100;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -556,7 +557,7 @@ async fn test_execute_transactions_commit_error() {
     let notification_id = 100;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,
@@ -608,7 +609,7 @@ async fn test_execute_transactions_commit_send_error() {
     let notification_id = 700;
     storage_synchronizer
         .execute_transactions(
-            notification_id,
+            NotificationMetadata::new_for_test(notification_id),
             create_transaction_list_with_proof(),
             create_epoch_ending_ledger_info(),
             None,


### PR DESCRIPTION
### Description
This PR adds additional metrics to track end-to-end pipeline latencies in state sync (i.e., how long a data chunk takes from the moment it is received until it moves through the entire pipeline). 

The PR offers the following commits:
1. Add a `new` method to `ResponseContext` (as a well as `creation_time`).
2. Add a `new` method to `DataNotification` (as a well as `creation_time`).
3. Add a metric to track the latency between a data chunk is received, and when it's sent along the data stream.
4. Add a metric to track the latencies of a data notification along the state-sync pipeline.
5. Small cleanups to the storage synchronizer (nothing should really change here).

### Test Plan
Existing test infrastructure.