### PR TITLE
Update .gitignore to not include .bytecode and .dot files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ run_*
 # test files for indexer GRPC
 test_indexer_grpc_*.yaml
 test_indexer_grpc/*
+
+# ignore compiler artifacts
+*.dot
+*.bytecode
+!third_party/move/move-prover/tests/xsources/design/*.bytecode


### PR DESCRIPTION
### Description
Prevents accidental commits of compiler artifacts to the repo. 
Related to, but doesn't completely fix https://github.com/aptos-labs/aptos-core/issues/11636
### Test Plan
Commits after compilation should not include artifacts, except for the pre-existing test directory.
