### PR TITLE
[Prover] fix #11534

### DIFF
--- a/third_party/move/move-model/bytecode/src/livevar_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/livevar_analysis.rs
@@ -316,7 +316,7 @@ impl<'a> LiveVarAnalysis<'a> {
                     // that creates a root mutable reference), do not optimize it away as we need this local/global root
                     // reference for our IsParent test. An alternative (i.e., one way to get rid of this exception) is
                     // to support IsParent test against local and global directly, but that is more complicated.
-                    // 2) if the called operation is either OpaqueCallBegin or OpaqueCallEnd because they should always appear pairwise.
+                    // 2) if the called operation is either OpaqueCallBegin or OpaqueCallEnd, they should not be optimized away, because they should always appear pairwise.
                     let next_code_offset = code_offset + 1;
                     if let Bytecode::Assign(_, dest, src, _) = &code[next_code_offset] {
                         let annotation_at = &annotations[&(next_code_offset as CodeOffset)];

--- a/third_party/move/move-model/bytecode/src/livevar_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/livevar_analysis.rs
@@ -293,7 +293,13 @@ impl<'a> LiveVarAnalysis<'a> {
                 Bytecode::Call(attr_id, dests, oper, srcs, aa)
                     if code_offset + 1 < code.len()
                         && dests.len() == 1
-                        && !matches!(oper, Operation::BorrowLoc | Operation::BorrowGlobal(..)) =>
+                        && !matches!(
+                            oper,
+                            Operation::BorrowLoc
+                                | Operation::BorrowGlobal(..)
+                                | Operation::OpaqueCallBegin(..)
+                                | Operation::OpaqueCallEnd(..)
+                        ) =>
                 {
                     // Catch the common case where we have:
                     //
@@ -305,10 +311,12 @@ impl<'a> LiveVarAnalysis<'a> {
                     // Copy propagation cannot catch this case because it does not have the
                     // livevar information about $t.
                     //
-                    // With one exception: if the called operation is a BorrowLocal or BorrowGlobal (i.e., an operation
+                    // With the following exceptions:
+                    // 1) if the called operation is a BorrowLocal or BorrowGlobal (i.e., an operation
                     // that creates a root mutable reference), do not optimize it away as we need this local/global root
                     // reference for our IsParent test. An alternative (i.e., one way to get rid of this exception) is
                     // to support IsParent test against local and global directly, but that is more complicated.
+                    // 2) if the called operation is either OpaqueCallBegin or OpaqueCallEnd because they should always appear pairwise.
                     let next_code_offset = code_offset + 1;
                     if let Bytecode::Assign(_, dest, src, _) = &code[next_code_offset] {
                         let annotation_at = &annotations[&(next_code_offset as CodeOffset)];

--- a/third_party/move/move-prover/tests/sources/functional/table_option.move
+++ b/third_party/move/move-prover/tests/sources/functional/table_option.move
@@ -1,0 +1,34 @@
+module 0x42::table_option {
+    use extensions::table;
+    use std::option::{Self, Option};
+
+    struct MultisigAccount has key {
+        transactions: table::Table<u64, MultisigTransaction>,
+        last_executed_sequence_number: u64,
+    }
+
+    struct MultisigTransaction has copy, drop, store {
+        payload: Option<vector<u8>>,
+    }
+
+    public fun get_next_transaction_payload(
+        multisig_account: address, provided_payload: vector<u8>): vector<u8> acquires MultisigAccount {
+        let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
+        let sequence_number = multisig_account_resource.last_executed_sequence_number + 1;
+        let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
+
+        if (option::is_some(&transaction.payload)) {
+            *option::borrow(&transaction.payload)
+        } else {
+            provided_payload
+        }
+    }
+    spec get_next_transaction_payload(
+    multisig_account: address, provided_payload: vector<u8>
+    ): vector<u8> {
+        let multisig_account_resource = global<MultisigAccount>(multisig_account);
+        let sequence_number = multisig_account_resource.last_executed_sequence_number + 1;
+        let transaction = table::spec_get(multisig_account_resource.transactions, sequence_number);
+        ensures option::is_some(transaction.payload) ==> result == option::borrow(transaction.payload); // This should pass.
+    }
+}


### PR DESCRIPTION
### Description

This PR closes #11534 by excluding the case of OpaqueCallBegin and OpaqueCallEnd from a code optimization in live var analysis for the prover. See added comments in the code for more information.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added a new test case to validate the fix.
