### PR TITLE
[crypto] Fix CryptoHasher with multiple generics

### DIFF
--- a/crates/aptos-crypto-derive/src/lib.rs
+++ b/crates/aptos-crypto-derive/src/lib.rs
@@ -374,7 +374,7 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
         quote!()
     } else {
         let args = proc_macro2::TokenStream::from_iter(
-            std::iter::repeat(quote!(())).take(item.generics.params.len()),
+            std::iter::repeat(quote!((),)).take(item.generics.params.len()),
         );
         quote!(<#args>)
     };

--- a/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
+++ b/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
@@ -30,6 +30,13 @@ pub struct Baz<T> {
     b: u32,
 }
 
+#[derive(Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
+pub struct Duplo<A, B> {
+    a: A,
+    b: B,
+    c: u32,
+}
+
 impl CryptoHash for Bar {
     type Hasher = FooHasher;
 
@@ -105,4 +112,9 @@ fn test_cryptohasher_salt_access() {
         &prefixed_sha3(b"Foo")
     );
     assert_eq!(<Bar as CryptoHash>::Hasher::seed(), &prefixed_sha3(b"Foo"));
+
+    assert_eq!(
+        <Duplo<(), ()> as CryptoHash>::Hasher::seed(),
+        &prefixed_sha3(b"Duplo")
+    );
 }

--- a/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
+++ b/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
@@ -117,4 +117,12 @@ fn test_cryptohasher_salt_access() {
         <Duplo<(), ()> as CryptoHash>::Hasher::seed(),
         &prefixed_sha3(b"Duplo")
     );
+
+    // WARNING: There is no domain separation between `Foo<A>` and `Foo<B>`. This might be on purpose,
+    // so as to avoid changing the hash when the type of A or B needs to be changed in the code, but
+    // it means we should exercise extreme caution when using the CryptoHasher derive.
+    assert_eq!(
+        <Duplo<usize, u8> as CryptoHash>::Hasher::seed(),
+        &prefixed_sha3(b"Duplo")
+    );
 }


### PR DESCRIPTION
### Description
In the output, currently 
```
# good (baz):
let name = aptos_crypto::_serde_name::trace_name::<Baz<()>>()


# bad (duplo):
let name = aptos_crypto::_serde_name::trace_name::<()>> ()
```

To fix this, we add a `,` after the `()` for the generics. This handles both single generics, as well as multiple.

### Test Plan
Compilation works (and added test case)