### PR TITLE
[SDK] Remove unnecessary mut for account

### DIFF
--- a/crates/aptos-api-tester/src/tests/coin_transfer.rs
+++ b/crates/aptos-api-tester/src/tests/coin_transfer.rs
@@ -153,7 +153,7 @@ async fn check_account_data(
 async fn transfer_coins(
     client: &Client,
     coin_client: &CoinClient<'_>,
-    account: &mut LocalAccount,
+    account: &LocalAccount,
     receiver: AccountAddress,
 ) -> Result<u64, TestFailure> {
     // create transaction

--- a/sdk/examples/transfer-coin.rs
+++ b/sdk/examples/transfer-coin.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
 
     // Have Alice send Bob some coins.
     let txn_hash = coin_client
-        .transfer(&mut alice, bob.address(), 1_000, None)
+        .transfer(&alice, bob.address(), 1_000, None)
         .await
         .context("Failed to submit transaction to transfer coins")?;
     rest_client
@@ -111,7 +111,7 @@ async fn main() -> Result<()> {
     // Have Alice send Bob some more coins.
     // :!:>section_5
     let txn_hash = coin_client
-        .transfer(&mut alice, bob.address(), 1_000, None)
+        .transfer(&alice, bob.address(), 1_000, None)
         .await
         .context("Failed to submit transaction to transfer coins")?; // <:!:section_5
                                                                      // :!:>section_6

--- a/sdk/src/coin_client.rs
+++ b/sdk/src/coin_client.rs
@@ -34,7 +34,7 @@ impl<'a> CoinClient<'a> {
 
     pub async fn transfer(
         &self,
-        from_account: &mut LocalAccount,
+        from_account: &LocalAccount,
         to_account: AccountAddress,
         amount: u64,
         options: Option<TransferOptions<'_>>,


### PR DESCRIPTION
### Description
Mut reference for `LocalAccount` is unnecessary here. 

### Test Plan
run the `transfer-coin.rs` example file.
