### PR TITLE
[API] Allow all headers in CORS policy

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -9,7 +9,6 @@ use crate::{
     view_function::ViewFunctionApi,
 };
 use anyhow::Context as AnyhowContext;
-use aptos_api_types::X_APTOS_CLIENT;
 use aptos_config::config::{ApiConfig, NodeConfig};
 use aptos_logger::info;
 use aptos_mempool::MempoolClientSender;
@@ -17,7 +16,7 @@ use aptos_storage_interface::DbReader;
 use aptos_types::chain_id::ChainId;
 use poem::{
     handler,
-    http::{header, Method},
+    http::Method,
     listener::{Listener, RustlsCertificate, RustlsConfig, TcpListener},
     middleware::Cors,
     web::Html,
@@ -194,12 +193,7 @@ pub fn attach_poem_to_runtime(
             // routing in the LB) we must enable this:
             // https://stackoverflow.com/a/24689738/3846032
             .allow_credentials(true)
-            .allow_methods(vec![Method::GET, Method::POST])
-            .allow_headers(vec![
-                header::HeaderName::from_static(X_APTOS_CLIENT),
-                header::CONTENT_TYPE,
-                header::ACCEPT,
-            ]);
+            .allow_methods(vec![Method::GET, Method::POST]);
 
         // Build routes for the API
         let route = Route::new()


### PR DESCRIPTION
### Description
I see no reason why we should restrict the headers we accept in our CORS policy, it has only caused us grief in the past. As far as I can tell the only reason you can configure this in CORS is for auth purposes, which is irrelevant for the node API.

### Test Plan
Run local testnet on a machine behind a reverse proxy with a URL using https:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-indexer-api
```


Run explorer from https://github.com/aptos-labs/explorer/pull/661 where the mainnet URL is hacked to that new URL. See that it works using a local testnet from this PR. 