### PR TITLE
[API] Add filter support for view and simulate

### DIFF
--- a/config/src/config/transaction_filter_type.rs
+++ b/config/src/config/transaction_filter_type.rs
@@ -9,7 +9,7 @@ use aptos_types::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-enum Matcher {
+pub enum Matcher {
     All,
     BlockId(HashValue),
     BlockTimeStampGreaterThan(u64),
@@ -48,9 +48,18 @@ impl Matcher {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-enum Rule {
+pub enum Rule {
     Allow(Matcher),
     Deny(Matcher),
+}
+
+impl Rule {
+    pub fn matcher(&self) -> &Matcher {
+        match self {
+            Rule::Allow(matcher) => matcher,
+            Rule::Deny(matcher) => matcher,
+        }
+    }
 }
 
 enum EvalResult {
@@ -186,6 +195,10 @@ impl Filter {
             function,
         )));
         self
+    }
+
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
     }
 
     pub fn allows(&self, block_id: HashValue, timestamp: u64, txn: &SignedTransaction) -> bool {


### PR DESCRIPTION
## Description
This is one short term solution to the overall problem of nodes being overwhelmed by computationally expensive functions to the point where they can't even state sync.

## Test Plan
### View Functions
Start local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-indexer-api
```

Stop it, add `0x1::coin::balance` to the config in the blocklist:
```
  view_filter:
    blocklist:
      - address: "0x1"
        module: "coin"
        function_name: "balance"
```

Start local testnet again:
```
cargo run -p aptos -- node run-local-testnet --with-indexer-api
```

Try to call view function from the explorer, get this response:
```
Error: {"message":"Function 0000000000000000000000000000000000000000000000000000000000000001::coin::balance is not allowed","error_code":"invalid_input","vm_error_code":null}
```

Other view functions work fine.

I also tested allowlist and the no list and it worked as expected.

## Simulation
Same procedure at first as above but we add this config:
```
  simulation_filter:
    rules:
      - Deny:
          EntryFunction:
            - "0000000000000000000000000000000000000000000000000000000000000001"
            - vesting
            - vest
```

Calling the function with the CLI you get this error:
```
{
  "Error": "API error: API error Error(InvalidInput): Transaction not allowed by simulation filter"
}
```