### PR TITLE
increase thresholds for TwoTrafficsTest

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1782,9 +1782,9 @@ fn realistic_env_max_load_test(
                 if ha_proxy {
                     4600
                 } else if long_running {
-                    7500
+                    7200
                 } else {
-                    7000
+                    6700
                 },
             ),
         }))


### PR DESCRIPTION
### Description
Relax this threshold since we're seeing people run into this fairly often. [Logs](https://cloud.us.humio.com/k8s/search?columns=%5B%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40timestamp%22%2C%22format%22%3A%22datetime%22%2C%22width%22%3A180%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22level%22%2C%22format%22%3A%22text%22%2C%22width%22%3A54%7D%2C%7B%22type%22%3A%22link%22%2C%22openInNewBrowserTab%22%3Afalse%2C%22style%22%3A%22button%22%2C%22hrefTemplate%22%3A%22https%3A%2F%2Fgithub.com%2Faptos-labs%2Faptos-core%2Fpull%2F%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22textTemplate%22%3A%22%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22header%22%3A%22Forge%20PR%22%2C%22width%22%3A79%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.namespace%22%2C%22format%22%3A%22text%22%2C%22width%22%3A104%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.pod_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A126%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.container_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A85%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22message%22%2C%22format%22%3A%22text%22%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.labels.forge-username%22%2C%22format%22%3A%22text%22%2C%22width%22%3A220%7D%5D&live=false&newestAtBottom=false&query=%22TPS%20requirement%20for%20inner%20traffic%20failed.%22%20and%20%22two%20traffics%20test%22&showOnlyFirstLine=false&start=30d&tz=America%2FNew_York&widgetType=list-view)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
See forge results