### PR TITLE
[agg_v2] Allow Direct WriteSetPayload, only if it ends the block

### DIFF
--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -386,11 +386,12 @@ fn test_roundtrip_to_storage_change_set() {
     .unwrap();
 
     let storage_change_set_before = StorageChangeSet::new(write_set, vec![]);
-    let change_set = assert_ok!(VMChangeSet::try_from_storage_change_set(
-        storage_change_set_before.clone(),
-        &MockChangeSetChecker,
-        false,
-    ));
+    let change_set = assert_ok!(
+        VMChangeSet::try_from_storage_change_set_with_delayed_field_optimization_disabled(
+            storage_change_set_before.clone(),
+            &MockChangeSetChecker,
+        )
+    );
     let storage_change_set_after = assert_ok!(change_set.try_into_storage_change_set());
     assert_eq!(storage_change_set_before, storage_change_set_after)
 }

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -48,13 +48,6 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         txn: &SignatureVerifiedTransaction,
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
-        if (executor_with_group_view.is_delayed_field_optimization_capable()
-            || executor_with_group_view.is_resource_group_split_in_change_set_capable())
-            && !Self::is_transaction_dynamic_change_set_capable(txn)
-        {
-            return ExecutionStatus::DirectWriteSetTransactionNotCapableError;
-        }
-
         let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx as usize);
         let resolver = self
             .vm
@@ -90,13 +83,20 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
                     ExecutionStatus::DelayedFieldsCodeInvariantError(
                         vm_status.message().cloned().unwrap_or_default(),
                     )
-                } else if AptosVM::should_restart_execution(&vm_output) {
+                } else if AptosVM::should_restart_execution(vm_output.change_set()) {
                     speculative_info!(
                         &log_context,
                         "Reconfiguration occurred: restart required".into()
                     );
                     ExecutionStatus::SkipRest(AptosTransactionOutput::new(vm_output))
                 } else {
+                    if (executor_with_group_view.is_delayed_field_optimization_capable()
+                        || executor_with_group_view.is_resource_group_split_in_change_set_capable())
+                        && !Self::is_transaction_dynamic_change_set_capable(txn)
+                    {
+                        return ExecutionStatus::DirectWriteSetTransactionNotCapableError;
+                    }
+
                     ExecutionStatus::Success(AptosTransactionOutput::new(vm_output))
                 }
             },

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -90,13 +90,10 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
                     );
                     ExecutionStatus::SkipRest(AptosTransactionOutput::new(vm_output))
                 } else {
-                    if (executor_with_group_view.is_delayed_field_optimization_capable()
-                        || executor_with_group_view.is_resource_group_split_in_change_set_capable())
-                        && !Self::is_transaction_dynamic_change_set_capable(txn)
-                    {
-                        return ExecutionStatus::DirectWriteSetTransactionNotCapableError;
-                    }
-
+                    assert!(
+                        Self::is_transaction_dynamic_change_set_capable(txn),
+                        "DirectWriteSet should always create SkipRest transaction, validate_waypoint_change_set provides this guarantee"
+                    );
                     ExecutionStatus::Success(AptosTransactionOutput::new(vm_output))
                 }
             },

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -242,10 +242,6 @@ where
                 // Record the status indicating abort.
                 ExecutionStatus::Abort(BlockExecutionError::FatalVMError((err, idx_to_execute)))
             },
-            ExecutionStatus::DirectWriteSetTransactionNotCapableError => {
-                // TODO[agg_v2](fix) decide how to handle/propagate.
-                panic!("PayloadWriteSet::Direct transaction not alone in a block");
-            },
             ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
                 read_set.capture_delayed_field_read_error(&PanicOr::Or(
                     MVDelayedFieldsError::DeltaApplicationFailure,
@@ -900,11 +896,6 @@ where
                 ExecutionStatus::Abort(_) => {
                     txn_commit_listener.on_execution_aborted(txn_idx);
                 },
-                ExecutionStatus::DirectWriteSetTransactionNotCapableError => {
-                    // This should already be handled and fallback to sequential called,
-                    // such a transaction should never reach this point.
-                    panic!("Cannot be materializing with DirectWriteSetTransactionNotCapableError");
-                },
                 ExecutionStatus::SpeculativeExecutionAbortError(msg)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
                     panic!("Cannot be materializing with {}", msg);
@@ -918,11 +909,6 @@ where
                 final_results[txn_idx as usize] = t;
             },
             ExecutionStatus::Abort(_) => (),
-            ExecutionStatus::DirectWriteSetTransactionNotCapableError => {
-                panic!("Cannot be materializing with DirectWriteSetTransactionNotCapableError");
-                // This should already be handled and fallback to sequential called,
-                // such a transaction should never reach this point.
-            },
             ExecutionStatus::SpeculativeExecutionAbortError(msg)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
                 panic!("Cannot be materializing with {}", msg);
@@ -1219,7 +1205,6 @@ where
         executor_arguments: E::Argument,
         signature_verified_block: &[T],
         base_view: &S,
-        dynamic_change_set_optimizations_enabled: bool,
     ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
         let num_txns = signature_verified_block.len();
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -1241,12 +1226,7 @@ where
         for (idx, txn) in signature_verified_block.iter().enumerate() {
             let latest_view = LatestView::<T, S, X>::new(
                 base_view,
-                ViewState::Unsync(SequentialState::new(
-                    &unsync_map,
-                    start_counter,
-                    &counter,
-                    dynamic_change_set_optimizations_capable,
-                )),
+                ViewState::Unsync(SequentialState::new(&unsync_map, start_counter, &counter)),
                 idx as TxnIndex,
             );
             let res = executor.execute_transaction(&latest_view, txn, idx as TxnIndex);
@@ -1312,8 +1292,8 @@ where
                     // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
                     Self::apply_output_sequential(&unsync_map, &output)?;
 
-                    // If dynamic change set optimizations are enabled, we might have resource groups that needs to be finalized
-                    if dynamic_change_set_optimizations_capable {
+                    // If dynamic change set materialization part (indented for clarity/variable scope):
+                    {
                         let group_metadata_ops = output.resource_group_metadata_ops();
                         let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
                         for (group_key, group_metadata_op) in group_metadata_ops.into_iter() {
@@ -1397,9 +1377,9 @@ where
                                 .collect(),
                             patched_events,
                         );
-                    } else {
-                        output.set_txn_output_for_non_dynamic_change_set();
                     }
+                    // If dynamic change set is disabled, this can be used to assert nothing needs patching instead:
+                    //   output.set_txn_output_for_non_dynamic_change_set();
 
                     if latest_view.is_incorrect_use() {
                         panic!("Incorrect use in sequential execution")
@@ -1416,9 +1396,6 @@ where
                     }
                     // Record the status indicating abort.
                     return Err(BlockExecutionError::FatalVMError((err, idx as TxnIndex)));
-                },
-                ExecutionStatus::DirectWriteSetTransactionNotCapableError => {
-                    panic!("PayloadWriteSet::Direct transaction not alone in a block, in sequential execution")
                 },
                 ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
                     panic!(
@@ -1474,7 +1451,6 @@ where
                 executor_arguments,
                 signature_verified_block,
                 base_view,
-                true,
             )
         };
 
@@ -1510,7 +1486,6 @@ where
                     executor_arguments,
                     signature_verified_block,
                     base_view,
-                    true,
                 );
             }
         }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -573,7 +573,7 @@ fn non_empty_group(
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_sequential((), &transactions, &data_view, true);
+        .execute_transactions_sequential((), &transactions, &data_view);
         // TODO: test dynamic disabled as well.
 
         BaselineOutput::generate(&transactions, None).assert_output(&output);

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -30,8 +30,6 @@ pub enum ExecutionStatus<O, E> {
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list
     SkipRest(O),
-    /// There is a DirectWriteTransaction with resolver not capable to handle it.
-    DirectWriteSetTransactionNotCapableError,
     /// Transaction detected that it is in inconsistent state due to speculative
     /// reads it did, and needs to be re-executed.
     SpeculativeExecutionAbortError(String),

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -133,7 +133,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 output.module_write_set()
             },
             ExecutionStatus::Abort(_)
-            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => BTreeMap::new(),
         };
@@ -281,7 +280,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                         ),
                 ),
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
             })
@@ -298,7 +296,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     Some(t.resource_write_set())
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
             })
@@ -316,7 +313,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     Some(t.delayed_field_change_set().into_keys())
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
             })
@@ -334,7 +330,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     Some(t.reads_needing_delayed_field_exchange())
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
             })
@@ -352,7 +347,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     Some(t.group_reads_needing_delayed_field_exchange())
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
             })
@@ -366,7 +360,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     t.aggregator_v1_delta_set().into_keys().collect()
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
             },
@@ -381,7 +374,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     t.resource_group_metadata_ops()
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
             },
@@ -400,7 +392,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                     Box::new(events.into_iter())
                 },
                 ExecutionStatus::Abort(_)
-                | ExecutionStatus::DirectWriteSetTransactionNotCapableError
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {
                     Box::new(empty::<(T::Event, Option<MoveTypeLayout>)>())
@@ -447,7 +438,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 );
             },
             ExecutionStatus::Abort(_)
-            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => {},
         };
@@ -472,7 +462,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         {
             ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
             ExecutionStatus::Abort(_)
-            | ExecutionStatus::DirectWriteSetTransactionNotCapableError
             | ExecutionStatus::SpeculativeExecutionAbortError(_)
             | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => HashSet::new(),
         }

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -7,9 +7,10 @@ use aptos_language_e2e_tests::{
     executor::FakeExecutor,
 };
 use aptos_types::{
-    transaction::{Transaction, TransactionStatus, WriteSetPayload},
+    transaction::{Transaction, TransactionStatus, WriteSetPayload, ChangeSet},
     write_set::TransactionWrite,
 };
+use move_core_types::vm_status::StatusCode;
 
 #[test]
 fn no_deletion_in_genesis() {
@@ -30,9 +31,7 @@ fn execute_genesis_write_set() {
     assert!(!output.pop().unwrap().status().is_discarded())
 }
 
-// TODO[agg_v2](fix) - investigate/make BlockSTM discard instead of fail if WriteSetPayload::Direct is in the block
-// #[test]
-#[allow(unused)]
+#[test]
 fn execute_genesis_and_drop_other_transaction() {
     let mut executor = FakeExecutor::no_genesis();
     let txn =
@@ -49,4 +48,20 @@ fn execute_genesis_and_drop_other_transaction() {
     // Transaction that comes after genesis should be dropped.
     assert_eq!(output.len(), 2);
     assert_eq!(output.pop().unwrap().status(), &TransactionStatus::Retry)
+}
+
+#[test]
+fn fail_no_epoch_change_write_set() {
+    let mut executor = FakeExecutor::no_genesis();
+    let txn =
+        Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::empty()));
+
+    let sender = executor.create_raw_account_data(1_000_000, 10);
+    let receiver = executor.create_raw_account_data(100_000, 10);
+    let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000, 0);
+
+    let output_err = executor
+        .execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)])
+        .unwrap_err();
+    assert_eq!(StatusCode::INVALID_WRITE_SET, output_err.status_code());
 }

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -7,7 +7,7 @@ use aptos_language_e2e_tests::{
     executor::FakeExecutor,
 };
 use aptos_types::{
-    transaction::{Transaction, TransactionStatus, WriteSetPayload, ChangeSet},
+    transaction::{ChangeSet, Transaction, TransactionStatus, WriteSetPayload},
     write_set::TransactionWrite,
 };
 use move_core_types::vm_status::StatusCode;
@@ -53,8 +53,7 @@ fn execute_genesis_and_drop_other_transaction() {
 #[test]
 fn fail_no_epoch_change_write_set() {
     let mut executor = FakeExecutor::no_genesis();
-    let txn =
-        Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::empty()));
+    let txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::empty()));
 
     let sender = executor.create_raw_account_data(1_000_000, 10);
     let receiver = executor.create_raw_account_data(100_000, 10);


### PR DESCRIPTION
Direct WriteSetPayload modifies state directly, without knowing if there are resource groups or aggregators inside. 

No transactions can be executed correctly, within same BlockSTM context, after it. So allow it to be in the block, and expect it to end the block if successfully executed.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
