### PR TITLE
[API] reduce default max gas for view functions and simulation

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -468,7 +468,8 @@ impl TransactionsApi {
                     u64::from(gas_params.vm.txn.min_transaction_gas_units)
                         / u64::from(gas_params.vm.txn.gas_unit_scaling_factor);
                 let max_number_of_gas_units =
-                    u64::from(gas_params.vm.txn.maximum_number_of_gas_units);
+                    u64::from(gas_params.vm.txn.maximum_number_of_gas_units)
+                        .min(context.node_config.api.max_gas_simulation);
 
                 // Retrieve account balance to determine max gas available
                 let coin_store = context

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -62,6 +62,8 @@ pub struct ApiConfig {
     ///
     /// This limits the execution length of a view function to the given gas used.
     pub max_gas_view_function: u64,
+    /// This limits the execution length of simulation to the given gas used.
+    pub max_gas_simulation: u64,
     /// Optional: Maximum number of worker threads for the API.
     ///
     /// If not set, `runtime_worker_multiplier` will multiply times the number of CPU cores on the machine
@@ -83,7 +85,8 @@ pub const DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE: usize = 10;
 pub const DEFAULT_MAX_PAGE_SIZE: u16 = 100;
 const DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE: u16 = 9999;
 const DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE: u16 = 9999;
-const DEFAULT_MAX_VIEW_GAS: u64 = 2_000_000; // We keep this value the same as the max number of gas allowed for one single transaction defined in aptos-gas.
+const DEFAULT_MAX_VIEW_GAS: u64 = 500; // The value should be smaller than the max number of gas allowed for one single transaction defined in aptos-gas.
+const DEFAULT_MAX_SIMULATION_GAS: u64 = 500; // The value should be smaller than the max number of gas allowed for one single transaction defined in aptos-gas.
 
 fn default_enabled() -> bool {
     true
@@ -115,6 +118,7 @@ impl Default for ApiConfig {
             max_account_resources_page_size: DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE,
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
+            max_gas_simulation: DEFAULT_MAX_SIMULATION_GAS,
             max_runtime_workers: None,
             runtime_worker_multiplier: 2,
             gas_estimation: GasEstimationConfig::default(),


### PR DESCRIPTION
### Description

Reduce (significantly) the default max gas for potentially expensive API calls that run in the VM