### PR TITLE
[passkey] Add MAX_BYTES limit for signatures

### DIFF
--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -23,7 +23,7 @@ use aptos_types::{
             AccountAuthenticator, AnyPublicKey, AnySignature, MultiKey, MultiKeyAuthenticator,
             SingleKeyAuthenticator, TransactionAuthenticator, MAX_NUM_OF_SIGS,
         },
-        webauthn::PartialAuthenticatorAssertionResponse,
+        webauthn::{PartialAuthenticatorAssertionResponse, MAX_WEBAUTHN_SIGNATURE_BYTES},
         Script, SignedTransaction, TransactionOutput, TransactionWithProof,
     },
 };
@@ -1162,12 +1162,18 @@ pub struct WebAuthnSignature {
 impl VerifyInput for WebAuthnSignature {
     fn verify(&self) -> anyhow::Result<()> {
         let public_key_len = self.public_key.inner().len();
+        let signature_len = self.signature.inner().len();
 
         // Currently only takes Secp256r1Ecdsa. If other signature schemes are introduced, modify this to accommodate them
         if public_key_len != PUBLIC_KEY_LENGTH {
             bail!(
                 "The public key provided is an invalid number of bytes, should be {} bytes but found {}. Note WebAuthn signatures only support Secp256r1Ecdsa at this time.",
                 secp256r1_ecdsa::PUBLIC_KEY_LENGTH, public_key_len
+            )
+        } else if signature_len > MAX_WEBAUTHN_SIGNATURE_BYTES {
+            bail!(
+                "The WebAuthn signature length is greater than the maximum number of {} bytes: found {} bytes.",
+                MAX_WEBAUTHN_SIGNATURE_BYTES, signature_len
             )
         } else {
             // TODO: Check if they match / parse correctly?

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -300,7 +300,7 @@ impl TransactionAuthenticator {
 
     pub fn all_signers(&self) -> Vec<AccountAuthenticator> {
         match self {
-            // This is to ensure that any new TransactionAuthenticor variant must update this function.
+            // This is to ensure that any new TransactionAuthenticator variant must update this function.
             Self::Ed25519 { .. }
             | Self::MultiEd25519 { .. }
             | Self::MultiAgent { .. }

--- a/types/src/transaction/webauthn.rs
+++ b/types/src/transaction/webauthn.rs
@@ -9,6 +9,8 @@ use aptos_crypto::{
 use passkey_types::{crypto::sha256, webauthn::CollectedClientData, Bytes};
 use serde::{Deserialize, Serialize};
 
+pub const MAX_WEBAUTHN_SIGNATURE_BYTES: usize = 1024;
+
 /// Returns the binary concatenation of
 /// 1. [`authenticator_data_bytes`](PartialAuthenticatorAssertionResponse) and
 /// 2. SHA-256 hash of [`client_data_json`](PartialAuthenticatorAssertionResponse),


### PR DESCRIPTION
### Description
Adding a `MAX_BYTES` limit for WebAuthn signatures of 1024 bytes. WebAuthn signatures are variable length but on average should never come close to this limit. See https://github.com/aptos-labs/aptos-core/pull/10755 for previous signature size estimations

### Test Plan
lint + build