### PR TITLE
Add move tests for compiler V2 to CI

### DIFF
--- a/.github/actions/move-tests-compiler-v2/action.yaml
+++ b/.github/actions/move-tests-compiler-v2/action.yaml
@@ -1,0 +1,37 @@
+name: Aptos Move Test for Compiler V2
+description: Runs Aptos Move tests with compiler V2
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository and setup the rust toolchain
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Install nextest
+    - uses: taiki-e/install-action@v1.5.6
+      with:
+        tool: nextest
+
+    # Run Aptos Move tests with compiler V2
+    - name: Run Aptos Move tests with compiler V2
+      run: cargo nextest run --profile ci --locked -p e2e-move-tests -p aptos-framework --retries 3 --no-fail-fast
+      shell: bash
+      env:
+        MOVE_COMPILER_EXP: no-safety
+        MOVE_COMPILER_V2: true
+        RUST_MIN_STACK: 4297152
+        MVP_TEST_ON_CI: true
+        SOLC_EXE: /home/runner/bin/solc
+        Z3_EXE: /home/runner/bin/z3
+        CVC5_EXE: /home/runner/bin/cvc5
+        DOTNET_ROOT: /home/runner/.dotnet
+        BOOGIE_EXE: /home/runner/.dotnet/tools/boogie

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -8,10 +8,14 @@ on:
     paths:
       - 'third_party/move/**'
       - 'aptos-move/e2e-move-tests/**'
+      - 'aptos-move/framework/**'
+      - '.github/workflows/coverage-move-only.yaml'
   pull_request:
     paths:
       - 'third_party/move/**'
       - 'aptos-move/e2e-move-tests/**'
+      - 'aptos-move/framework/**'
+      - '.github/workflows/coverage-move-only.yaml'
 
 env:
   CARGO_INCREMENTAL: "0"
@@ -30,12 +34,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      - name: prepare move lang prover tooling.
+        shell: bash
+        run: |
+          echo 'Z3_EXE='/home/runner/bin/z3 | tee -a $GITHUB_ENV
+          echo 'CVC5_EXE='/home/runner/bin/cvc5 | tee -a $GITHUB_ENV
+          echo 'DOTNET_ROOT='/home/runner/.dotnet/ | tee -a $GITHUB_ENV
+          echo 'BOOGIE_EXE='/home/runner/.dotnet/tools/boogie | tee -a $GITHUB_ENV
+          echo 'MVP_TEST_ON_CI'='1' | tee -a $GITHUB_ENV
+          echo "/home/runner/bin" | tee -a $GITHUB_PATH
+          echo "/home/runner/.dotnet" | tee -a $GITHUB_PATH
+          echo "/home/runner/.dotnet/tools" | tee -a $GITHUB_PATH
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@6f1ebcd9e21315fc37d7f7bc851dfcc8356d7da3 # pin@v1.5.6
         with:
           tool: nextest,cargo-llvm-cov
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
-      - run: cargo llvm-cov --ignore-run-fail -p "move*" -p e2e-move-tests --lcov --jobs 32 --output-path lcov_unit.info
+      - run: cargo llvm-cov --ignore-run-fail -p aptos-framework -p "move*" -p e2e-move-tests --lcov --jobs 32 --output-path lcov_unit.info
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/move-test-compiler-v2.yaml
+++ b/.github/workflows/move-test-compiler-v2.yaml
@@ -8,11 +8,15 @@ on:
       - 'aptos-move/e2e-move-tests/**'
       - 'aptos-move/framework/**'
       - 'third_party/move/**'
+      - '.github/workflows/move-test-compiler-v2.yaml'
+      - '.github/actions/move-tests-compiler-v2/**'
   pull_request:
     paths:
       - 'aptos-move/e2e-move-tests/**'
       - 'aptos-move/framework/**'
       - 'third_party/move/**'
+      - '.github/workflows/move-test-compiler-v2.yaml'
+      - '.github/actions/move-tests-compiler-v2/**'
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/.github/workflows/move-test-compiler-v2.yaml
+++ b/.github/workflows/move-test-compiler-v2.yaml
@@ -1,0 +1,36 @@
+name: "Aptos Move Test for Compiler V2"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aptos-move/e2e-move-tests/**'
+      - 'aptos-move/framework/**'
+      - 'third_party/move/**'
+  pull_request:
+    paths:
+      - 'aptos-move/e2e-move-tests/**'
+      - 'aptos-move/framework/**'
+      - 'third_party/move/**'
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
+# cancel redundant builds
+concurrency:
+  # cancel redundant builds on PRs (only on PR, not on branches)
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # Run Aptos Move tests.
+  rust-move-tests:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Aptos Move tests with compiler V2
+        uses: ./.github/actions/move-tests-compiler-v2
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}


### PR DESCRIPTION
### Description

This PR:

1) adds a CI action to run aptos-framework and e2e-move-tests using Compiler V2;
2) adds aptos-framework as the target when running coverage test for move.

