### PR TITLE
add CommitMessage::Nack

### DIFF
--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -25,12 +25,14 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
+use aptos_network::protocols::{rpc::error::RpcError, wire::handshake::v1::ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
 use aptos_types::{
     account_address::AccountAddress, epoch_change::EpochChangeProof, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
 };
+use bytes::Bytes;
 use futures::{
     channel::{
         mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
@@ -578,13 +580,18 @@ impl BufferManager {
                                 commit_info = commit_info,
                                 "Failed to add commit vote",
                             );
+                            reply_nack(protocol, response_sender);
                             item
                         },
                     };
                     self.buffer.set(&current_cursor, new_item);
                     if self.buffer.get(&current_cursor).is_aggregated() {
                         return Some(target_block_id);
+                    } else {
+                        return None;
                     }
+                } else {
+                    reply_nack(protocol, response_sender); // TODO: send_commit_vote() doesn't care about the response and this should be direct send not RPC
                 }
             },
             CommitMessage::Decision(commit_proof) => {
@@ -612,10 +619,14 @@ impl BufferManager {
                         return Some(target_block_id);
                     }
                 }
+                reply_nack(protocol, response_sender); // TODO: send_commit_proof() doesn't care about the response and this should be direct send not RPC
             },
             CommitMessage::Ack(_) => {
                 // It should be filtered out by verify, so we log errors here
                 error!("Unexpected ack message");
+            },
+            CommitMessage::Nack => {
+                error!("Unexpected NACK message");
             },
         }
         None
@@ -780,5 +791,12 @@ impl BufferManager {
             }
         }
         info!("Buffer manager stops.");
+    }
+}
+
+fn reply_nack(protocol: ProtocolId, response_sender: oneshot::Sender<Result<Bytes, RpcError>>) {
+    let response = ConsensusMsg::CommitMessage(Box::new(CommitMessage::Nack));
+    if let Ok(bytes) = protocol.to_bytes(&response) {
+        let _ = response_sender.send(Ok(bytes.into()));
     }
 }

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -23,6 +23,8 @@ pub enum CommitMessage {
     Decision(CommitDecision),
     /// Ack on either vote or decision
     Ack(()),
+    /// Nack is non-acknowledgement, we got your message, but it was bad/we were bad
+    Nack,
 }
 
 impl CommitMessage {
@@ -32,6 +34,7 @@ impl CommitMessage {
             CommitMessage::Vote(vote) => vote.verify(verifier),
             CommitMessage::Decision(decision) => decision.verify(verifier),
             CommitMessage::Ack(_) => bail!("Unexpected ack in incoming commit message"),
+            CommitMessage::Nack => bail!("Unexpected NACK in incoming commit message"),
         }
     }
 }

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -58,7 +58,21 @@ impl BroadcastStatus<CommitMessage> for Arc<AckState> {
     type Message = CommitMessage;
     type Response = CommitMessage;
 
-    fn add(&self, peer: Author, _ack: Self::Response) -> anyhow::Result<Option<Self::Aggregated>> {
+    fn add(&self, peer: Author, ack: Self::Response) -> anyhow::Result<Option<Self::Aggregated>> {
+        match ack {
+            CommitMessage::Vote(_) => {
+                bail!("unexected Vote reply to broadcast");
+            },
+            CommitMessage::Decision(_) => {
+                bail!("unexected Decision reply to broadcast");
+            },
+            CommitMessage::Ack(_) => {
+                // okay! continue
+            },
+            CommitMessage::Nack => {
+                bail!("unexected Nack reply to broadcast");
+            },
+        }
         let mut validators = self.validators.lock();
         if validators.remove(&peer) {
             if validators.is_empty() {

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -299,6 +299,8 @@ CommitMessage:
     2:
       Ack:
         NEWTYPE: UNIT
+    3:
+      Nack: UNIT
 CommitVote:
   STRUCT:
     - author:


### PR DESCRIPTION
### Description

add CommitMessage::Nack to reply to ::Vote and ::Decision that don't get ::Ack

The real win is that the server doesn't leave RPCs hanging to timeout. Timeout error counters and log messages will be less spammy.

### Test Plan

existing tests