### PR TITLE
Improve Diagnostic ordering further for multiple diagnostics with some of the same labels

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_3.exp
@@ -11,17 +11,6 @@ error: `public(friend)` inline function `0x42::m::friend_accessible` cannot be c
 81 │       m::friend_accessible();
    │       ---------------------- called here
 
-error: `public(friend)` inline function `0x42::m::friend_accessible` cannot be called from 0x42::o_nonfriend::friend_accessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
-    ┌─ tests/checking/inlining/private_call_3.move:12:5
-    │
- 12 │ ╭     public(friend) inline fun friend_accessible(): u64 {
- 13 │ │         bar()
- 14 │ │     }
-    │ ╰─────^
-    · │
-101 │       m::friend_accessible();
-    │       ---------------------- called here
-
 error: `public(friend)` inline function `0x42::m::friend_accessible` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
    ┌─ tests/checking/inlining/private_call_3.move:12:5
    │
@@ -33,6 +22,17 @@ error: `public(friend)` inline function `0x42::m::friend_accessible` cannot be c
 91 │       m::friend_accessible();
    │       ---------------------- called here
 
+error: `public(friend)` inline function `0x42::m::friend_accessible` cannot be called from 0x42::o_nonfriend::friend_accessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
+    ┌─ tests/checking/inlining/private_call_3.move:12:5
+    │
+ 12 │ ╭     public(friend) inline fun friend_accessible(): u64 {
+ 13 │ │         bar()
+ 14 │ │     }
+    │ ╰─────^
+    · │
+101 │       m::friend_accessible();
+    │       ---------------------- called here
+
 error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_nonfriend::foofunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
    ┌─ tests/checking/inlining/private_call_3.move:16:5
    │
@@ -40,6 +40,15 @@ error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_no
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ·
 83 │     m::bar();
+   │     -------- called here
+
+error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
+   ┌─ tests/checking/inlining/private_call_3.move:16:5
+   │
+16 │     public(friend) fun bar(): u64 { 42 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   ·
+93 │     m::bar();
    │     -------- called here
 
 error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_nonfriend::friend_accessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
@@ -51,15 +60,6 @@ error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_no
 103 │     m::bar();
     │     -------- called here
 
-error: `public(friend)` function `0x42::m::bar` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m`
-   ┌─ tests/checking/inlining/private_call_3.move:16:5
-   │
-16 │     public(friend) fun bar(): u64 { 42 }
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   ·
-93 │     m::bar();
-   │     -------- called here
-
 error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o::foofunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:28:5
    │
@@ -69,17 +69,6 @@ error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` c
    │ ╰─────^
    · │
 45 │       m_nonfriend::friend_accessible();
-   │       -------------------------------- called here
-
-error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o::friend_accessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
-   ┌─ tests/checking/inlining/private_call_3.move:28:5
-   │
-28 │ ╭     public(friend) inline fun friend_accessible(): u64 {
-29 │ │         bar()
-30 │ │     }
-   │ ╰─────^
-   · │
-65 │       m_nonfriend::friend_accessible();
    │       -------------------------------- called here
 
 error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o::inaccessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
@@ -93,6 +82,17 @@ error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` c
 55 │       m_nonfriend::friend_accessible();
    │       -------------------------------- called here
 
+error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o::friend_accessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:28:5
+   │
+28 │ ╭     public(friend) inline fun friend_accessible(): u64 {
+29 │ │         bar()
+30 │ │     }
+   │ ╰─────^
+   · │
+65 │       m_nonfriend::friend_accessible();
+   │       -------------------------------- called here
+
 error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o_nonfriend::foofunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:28:5
    │
@@ -102,6 +102,17 @@ error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` c
    │ ╰─────^
    · │
 82 │       m_nonfriend::friend_accessible();
+   │       -------------------------------- called here
+
+error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:28:5
+   │
+28 │ ╭     public(friend) inline fun friend_accessible(): u64 {
+29 │ │         bar()
+30 │ │     }
+   │ ╰─────^
+   · │
+92 │       m_nonfriend::friend_accessible();
    │       -------------------------------- called here
 
 error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o_nonfriend::friend_accessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
@@ -115,17 +126,6 @@ error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` c
 102 │       m_nonfriend::friend_accessible();
     │       -------------------------------- called here
 
-error: `public(friend)` inline function `0x42::m_nonfriend::friend_accessible` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
-   ┌─ tests/checking/inlining/private_call_3.move:28:5
-   │
-28 │ ╭     public(friend) inline fun friend_accessible(): u64 {
-29 │ │         bar()
-30 │ │     }
-   │ ╰─────^
-   · │
-92 │       m_nonfriend::friend_accessible();
-   │       -------------------------------- called here
-
 error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o::foofunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:32:5
    │
@@ -133,15 +133,6 @@ error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ·
 47 │     m_nonfriend::bar()
-   │     ------------------ called here
-
-error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o::friend_accessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
-   ┌─ tests/checking/inlining/private_call_3.move:32:5
-   │
-32 │     public(friend) fun bar(): u64 { 42 }
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   ·
-67 │     m_nonfriend::bar()
    │     ------------------ called here
 
 error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o::inaccessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
@@ -153,6 +144,15 @@ error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 
 57 │     m_nonfriend::bar()
    │     ------------------ called here
 
+error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o::friend_accessiblefunction `inline ` because module `0x42::o` is not a `friend` of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:32:5
+   │
+32 │     public(friend) fun bar(): u64 { 42 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   ·
+67 │     m_nonfriend::bar()
+   │     ------------------ called here
+
 error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o_nonfriend::foofunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
    ┌─ tests/checking/inlining/private_call_3.move:32:5
    │
@@ -160,6 +160,15 @@ error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ·
 84 │     m_nonfriend::bar()
+   │     ------------------ called here
+
+error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
+   ┌─ tests/checking/inlining/private_call_3.move:32:5
+   │
+32 │     public(friend) fun bar(): u64 { 42 }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   ·
+94 │     m_nonfriend::bar()
    │     ------------------ called here
 
 error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o_nonfriend::friend_accessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
@@ -170,15 +179,6 @@ error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 
     ·
 104 │     m_nonfriend::bar()
     │     ------------------ called here
-
-error: `public(friend)` function `0x42::m_nonfriend::bar` cannot be called from 0x42::o_nonfriend::inaccessiblefunction `inline ` because module `0x42::o_nonfriend` is not a `friend` of `0x42::m_nonfriend`
-   ┌─ tests/checking/inlining/private_call_3.move:32:5
-   │
-32 │     public(friend) fun bar(): u64 { 42 }
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   ·
-94 │     m_nonfriend::bar()
-   │     ------------------ called here
 
 error: inline function `0x42::o::inaccessible` cannot be called from function `0x42::n::test` because it is private to module `0x42::o`
     ┌─ tests/checking/inlining/private_call_3.move:50:5

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_const.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_const.exp
@@ -6,14 +6,6 @@ error: type argument count mismatch (expected 1 but got 0)
 6 │     const S1: S = S { f: 0 };
   │               ^
 
-error: Invalid type for constant
-  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:6:19
-  │
-6 │     const S1: S = S { f: 0 };
-  │     --------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
-
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:6:19
   │
@@ -22,19 +14,19 @@ error: Not a valid constant expression.
   │                   │
   │                   Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:6:19
+  │
+6 │     const S1: S = S { f: 0 };
+  │     --------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 0)
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:7:15
   │
 7 │     const S2: S<> = S { f: 0 };
   │               ^
-
-error: Invalid type for constant
-  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:7:21
-  │
-7 │     const S2: S<> = S { f: 0 };
-  │     ----------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:7:21
@@ -44,19 +36,19 @@ error: Not a valid constant expression.
   │                     │
   │                     Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:7:21
+  │
+7 │     const S2: S<> = S { f: 0 };
+  │     ----------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 2)
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:8:15
   │
 8 │     const S3: S<u64, bool> = S { f: 0 };
   │               ^
-
-error: Invalid type for constant
-  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:8:30
-  │
-8 │     const S3: S<u64, bool> = S { f: 0 };
-  │     -------------------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:8:30
@@ -66,19 +58,19 @@ error: Not a valid constant expression.
   │                              │
   │                              Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:8:30
+  │
+8 │     const S3: S<u64, bool> = S { f: 0 };
+  │     -------------------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 2)
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:9:17
   │
 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
   │                 ^
-
-error: Invalid type for constant
-  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:9:33
-  │
-9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
-  │     ----------------------------^^^^^^^^^^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:9:33
@@ -88,3 +80,11 @@ error: Not a valid constant expression.
   │                                 │      │
   │                                 │      Invalid call or operation in constant
   │                                 Invalid call or operation in constant
+
+error: Invalid type for constant
+  ┌─ tests/checking/typing/bad_type_argument_arity_const.move:9:33
+  │
+9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+  │     ----------------------------^^^^^^^^^^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_base_type.exp
@@ -1,13 +1,5 @@
 
 Diagnostics:
-error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_invalid_base_type.move:6:24
-  │
-6 │     const C1: signer = abort 0;
-  │     -------------------^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
-
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/constant_invalid_base_type.move:6:24
   │
@@ -17,10 +9,10 @@ error: Not a valid constant expression.
   │                        Invalid call or operation in constant
 
 error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_invalid_base_type.move:7:19
+  ┌─ tests/checking/typing/constant_invalid_base_type.move:6:24
   │
-7 │     const C2: S = S{};
-  │     --------------^^^-
+6 │     const C1: signer = abort 0;
+  │     -------------------^^^^^^^-
   │     │
   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
@@ -33,9 +25,9 @@ error: Not a valid constant expression.
   │                   Invalid call or operation in constant
 
 error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_invalid_base_type.move:8:19
+  ┌─ tests/checking/typing/constant_invalid_base_type.move:7:19
   │
-8 │     const C3: R = R{};
+7 │     const C2: S = S{};
   │     --------------^^^-
   │     │
   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
@@ -49,10 +41,10 @@ error: Not a valid constant expression.
   │                   Invalid call or operation in constant
 
 error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_invalid_base_type.move:9:27
+  ┌─ tests/checking/typing/constant_invalid_base_type.move:8:19
   │
-9 │     const C4: vector<S> = abort 0;
-  │     ----------------------^^^^^^^-
+8 │     const C3: R = R{};
+  │     --------------^^^-
   │     │
   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
@@ -65,12 +57,12 @@ error: Not a valid constant expression.
   │                           Invalid call or operation in constant
 
 error: Invalid type for constant
-   ┌─ tests/checking/typing/constant_invalid_base_type.move:10:27
-   │
-10 │     const C5: vector<R> = abort 0;
-   │     ----------------------^^^^^^^-
-   │     │
-   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  ┌─ tests/checking/typing/constant_invalid_base_type.move:9:27
+  │
+9 │     const C4: vector<S> = abort 0;
+  │     ----------------------^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/checking/typing/constant_invalid_base_type.move:10:27
@@ -81,10 +73,10 @@ error: Not a valid constant expression.
    │                           Invalid call or operation in constant
 
 error: Invalid type for constant
-   ┌─ tests/checking/typing/constant_invalid_base_type.move:11:35
+   ┌─ tests/checking/typing/constant_invalid_base_type.move:10:27
    │
-11 │     const C6: vector<vector<S>> = abort 0;
-   │     ------------------------------^^^^^^^-
+10 │     const C5: vector<R> = abort 0;
+   │     ----------------------^^^^^^^-
    │     │
    │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
@@ -97,9 +89,9 @@ error: Not a valid constant expression.
    │                                   Invalid call or operation in constant
 
 error: Invalid type for constant
-   ┌─ tests/checking/typing/constant_invalid_base_type.move:12:35
+   ┌─ tests/checking/typing/constant_invalid_base_type.move:11:35
    │
-12 │     const C7: vector<vector<R>> = abort 0;
+11 │     const C6: vector<vector<S>> = abort 0;
    │     ------------------------------^^^^^^^-
    │     │
    │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
@@ -111,3 +103,11 @@ error: Not a valid constant expression.
    │                                   ^^^^^^^
    │                                   │
    │                                   Invalid call or operation in constant
+
+error: Invalid type for constant
+   ┌─ tests/checking/typing/constant_invalid_base_type.move:12:35
+   │
+12 │     const C7: vector<vector<R>> = abort 0;
+   │     ------------------------------^^^^^^^-
+   │     │
+   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
@@ -1,13 +1,5 @@
 
 Diagnostics:
-error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_non_base_type.move:3:22
-  │
-3 │     const C1: &u64 = &0;
-  │     -----------------^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
-
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/constant_non_base_type.move:3:22
   │
@@ -17,10 +9,10 @@ error: Not a valid constant expression.
   │                      Invalid call or operation in constant
 
 error: Invalid type for constant
-  ┌─ tests/checking/typing/constant_non_base_type.move:4:26
+  ┌─ tests/checking/typing/constant_non_base_type.move:3:22
   │
-4 │     const C2: &mut u64 = &0;
-  │     ---------------------^^-
+3 │     const C1: &u64 = &0;
+  │     -----------------^^-
   │     │
   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
@@ -31,6 +23,14 @@ error: Not a valid constant expression.
   │                          ^^
   │                          │
   │                          Invalid call or operation in constant
+
+error: Invalid type for constant
+  ┌─ tests/checking/typing/constant_non_base_type.move:4:26
+  │
+4 │     const C2: &mut u64 = &0;
+  │     ---------------------^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: mutability mismatch (&mut != &)
   ┌─ tests/checking/typing/constant_non_base_type.move:4:26

--- a/third_party/move/move-compiler-v2/tests/folding/bad_type_argument_arity_const.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/bad_type_argument_arity_const.exp
@@ -6,14 +6,6 @@ error: type argument count mismatch (expected 1 but got 0)
 6 │     const S1: S = S { f: 0 };
   │               ^
 
-error: Invalid type for constant
-  ┌─ tests/folding/bad_type_argument_arity_const.move:6:19
-  │
-6 │     const S1: S = S { f: 0 };
-  │     --------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
-
 error: Not a valid constant expression.
   ┌─ tests/folding/bad_type_argument_arity_const.move:6:19
   │
@@ -22,19 +14,19 @@ error: Not a valid constant expression.
   │                   │
   │                   Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/folding/bad_type_argument_arity_const.move:6:19
+  │
+6 │     const S1: S = S { f: 0 };
+  │     --------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 0)
   ┌─ tests/folding/bad_type_argument_arity_const.move:7:15
   │
 7 │     const S2: S<> = S { f: 0 };
   │               ^
-
-error: Invalid type for constant
-  ┌─ tests/folding/bad_type_argument_arity_const.move:7:21
-  │
-7 │     const S2: S<> = S { f: 0 };
-  │     ----------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/folding/bad_type_argument_arity_const.move:7:21
@@ -44,19 +36,19 @@ error: Not a valid constant expression.
   │                     │
   │                     Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/folding/bad_type_argument_arity_const.move:7:21
+  │
+7 │     const S2: S<> = S { f: 0 };
+  │     ----------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 2)
   ┌─ tests/folding/bad_type_argument_arity_const.move:8:15
   │
 8 │     const S3: S<u64, bool> = S { f: 0 };
   │               ^
-
-error: Invalid type for constant
-  ┌─ tests/folding/bad_type_argument_arity_const.move:8:30
-  │
-8 │     const S3: S<u64, bool> = S { f: 0 };
-  │     -------------------------^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/folding/bad_type_argument_arity_const.move:8:30
@@ -66,19 +58,19 @@ error: Not a valid constant expression.
   │                              │
   │                              Invalid call or operation in constant
 
+error: Invalid type for constant
+  ┌─ tests/folding/bad_type_argument_arity_const.move:8:30
+  │
+8 │     const S3: S<u64, bool> = S { f: 0 };
+  │     -------------------------^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+
 error: type argument count mismatch (expected 1 but got 2)
   ┌─ tests/folding/bad_type_argument_arity_const.move:9:17
   │
 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
   │                 ^
-
-error: Invalid type for constant
-  ┌─ tests/folding/bad_type_argument_arity_const.move:9:33
-  │
-9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
-  │     ----------------------------^^^^^^^^^^^^^^^^^^^-
-  │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/folding/bad_type_argument_arity_const.move:9:33
@@ -88,3 +80,11 @@ error: Not a valid constant expression.
   │                                 │      │
   │                                 │      Invalid call or operation in constant
   │                                 Invalid call or operation in constant
+
+error: Invalid type for constant
+  ┌─ tests/folding/bad_type_argument_arity_const.move:9:33
+  │
+9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
+  │     ----------------------------^^^^^^^^^^^^^^^^^^^-
+  │     │
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/folding/constants_blocks.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/constants_blocks.exp
@@ -32,18 +32,6 @@ error: Not a valid constant expression.
   │                                        │
   │                                        Invalid call or operation in constant
 
-error: Invalid type for constant
-   ┌─ tests/folding/constants_blocks.move:11:20
-   │
-11 │   ╭     const C7: () = {
-   │ ╭──────────────────────^
-12 │ │ │         let x = 0;
-13 │ │ │         let y = 1;
-14 │ │ │         x + y;
-15 │ │ │     };
-   │ ╰─│─────^
-   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
-
 error: Not a valid constant expression.
    ┌─ tests/folding/constants_blocks.move:11:20
    │
@@ -61,6 +49,18 @@ error: Not a valid constant expression.
    │ ╰─│─│─────^
    │   ╰─│─────' Invalid statement or expression in constant
    │     ╰─────' Invalid statement or expression in constant
+
+error: Invalid type for constant
+   ┌─ tests/folding/constants_blocks.move:11:20
+   │
+11 │   ╭     const C7: () = {
+   │ ╭──────────────────────^
+12 │ │ │         let x = 0;
+13 │ │ │         let y = 1;
+14 │ │ │         x + y;
+15 │ │ │     };
+   │ ╰─│─────^
+   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/folding/constants_blocks.move:16:25

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local_invalid.exp
@@ -1,5 +1,63 @@
 
 Diagnostics:
+error: cannot return a reference derived from local `v1` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+   │            ------- previous mutable local borrow
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v2` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+   │ │         --- previous local borrow
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v3` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+   │ │         ---------------
+   │ │         │      │
+   │ │         │      previous mutable local borrow
+   │ │         used by mutable call result
+22 │ │         id(&v4),
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
+error: cannot return a reference derived from local `v4` since it is not a parameter
+   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
+   │
+19 │ ╭         (&mut v1,
+20 │ │         &v2,
+21 │ │         id_mut(&mut v3),
+22 │ │         id(&v4),
+   │ │         -------
+   │ │         │  │
+   │ │         │  previous local borrow
+   │ │         used by call result
+   · │
+25 │ │         id_mut(&mut s3.f),
+26 │ │         id(&s4.f))
+   │ ╰──────────────────^ returned here
+
 error: cannot return a reference derived from local `s1` since it is not a parameter
    ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
    │
@@ -64,62 +122,4 @@ error: cannot return a reference derived from local `s4` since it is not a param
    │ │            ││
    │ │            │previous local borrow
    │ │            used by field borrow
-   │ ╰──────────────────^ returned here
-
-error: cannot return a reference derived from local `v1` since it is not a parameter
-   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
-   │
-19 │ ╭         (&mut v1,
-   │            ------- previous mutable local borrow
-20 │ │         &v2,
-21 │ │         id_mut(&mut v3),
-22 │ │         id(&v4),
-   · │
-25 │ │         id_mut(&mut s3.f),
-26 │ │         id(&s4.f))
-   │ ╰──────────────────^ returned here
-
-error: cannot return a reference derived from local `v2` since it is not a parameter
-   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
-   │
-19 │ ╭         (&mut v1,
-20 │ │         &v2,
-   │ │         --- previous local borrow
-21 │ │         id_mut(&mut v3),
-22 │ │         id(&v4),
-   · │
-25 │ │         id_mut(&mut s3.f),
-26 │ │         id(&s4.f))
-   │ ╰──────────────────^ returned here
-
-error: cannot return a reference derived from local `v3` since it is not a parameter
-   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
-   │
-19 │ ╭         (&mut v1,
-20 │ │         &v2,
-21 │ │         id_mut(&mut v3),
-   │ │         ---------------
-   │ │         │      │
-   │ │         │      previous mutable local borrow
-   │ │         used by mutable call result
-22 │ │         id(&v4),
-   · │
-25 │ │         id_mut(&mut s3.f),
-26 │ │         id(&s4.f))
-   │ ╰──────────────────^ returned here
-
-error: cannot return a reference derived from local `v4` since it is not a parameter
-   ┌─ tests/reference-safety/v1-tests/return_borrowed_local_invalid.move:19:9
-   │
-19 │ ╭         (&mut v1,
-20 │ │         &v2,
-21 │ │         id_mut(&mut v3),
-22 │ │         id(&v4),
-   │ │         -------
-   │ │         │  │
-   │ │         │  previous local borrow
-   │ │         used by call result
-   · │
-25 │ │         id_mut(&mut s3.f),
-26 │ │         id(&s4.f))
    │ ╰──────────────────^ returned here

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1531,15 +1531,12 @@ impl GlobalEnv {
         let field_name = self.symbol_pool.make("v");
         let mut field_data = BTreeMap::new();
         let field_id = FieldId::new(field_name);
-        field_data.insert(
-            field_id,
-            FieldData {
-                name: field_name,
-                loc: loc.clone(),
-                offset: 0,
-                ty,
-            },
-        );
+        field_data.insert(field_id, FieldData {
+            name: field_name,
+            loc: loc.clone(),
+            offset: 0,
+            ty,
+        });
         StructData {
             name: self.ghost_memory_name(var_name),
             loc,

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1146,9 +1146,9 @@ impl GlobalEnv {
     // are ignored, but if all are `Secondary` then the earliest of those is used in
     // the ordering.
     fn cmp_labels(labels1: &[Label<FileId>], labels2: &[Label<FileId>]) -> Ordering {
-        let mut sorted_labels1: Vec<_> = labels1.iter().collect();
+        let mut sorted_labels1 = labels1.iter().collect_vec();
         sorted_labels1.sort_by(|l1, l2| GlobalEnv::cmp_label_priority(l1, l2));
-        let mut sorted_labels2: Vec<_> = labels2.iter().collect();
+        let mut sorted_labels2 = labels2.iter().collect_vec();
         sorted_labels2.sort_by(|l1, l2| GlobalEnv::cmp_label_priority(l1, l2));
         std::iter::zip(sorted_labels1, sorted_labels2)
             .map(|(l1, l2)| GlobalEnv::cmp_label(l1, l2))

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1130,48 +1130,30 @@ impl GlobalEnv {
         }
     }
 
+    // Label comparison within a list of labels for a given diagnostic, which orders by priority
+    // first, then files and line numbers.
+    fn cmp_label_priority(label1: &Label<FileId>, label2: &Label<FileId>) -> Ordering {
+        use LabelStyle::*;
+        match (label1.style, label2.style) {
+            (Primary, Secondary) => Ordering::Less,
+            (Secondary, Primary) => Ordering::Greater,
+            (_, _) => GlobalEnv::cmp_label(label1, label2),
+        }
+    }
+
     // Comparison for sets of labels that orders them based on program ordering, using
     // the earliest label found.  If a `Primary` label is found then `Secondary` labels
     // are ignored, but if all are `Secondary` then the earliest of those is used in
     // the ordering.
     fn cmp_labels(labels1: &[Label<FileId>], labels2: &[Label<FileId>]) -> Ordering {
-        let primary1 = labels1
-            .iter()
-            .filter(|l| l.style == LabelStyle::Primary)
-            .min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-        let primary2 = labels2
-            .iter()
-            .filter(|l| l.style == LabelStyle::Primary)
-            .min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-        match (primary1, primary2) {
-            (Some(prim1), Some(prim2)) => GlobalEnv::cmp_label(prim1, prim2),
-            (Some(prim1), None) => {
-                let second2 = labels2.iter().min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-                if let Some(sec2) = second2 {
-                    GlobalEnv::cmp_label(prim1, sec2)
-                } else {
-                    Ordering::Less // Label beats none
-                }
-            },
-            (None, Some(prim2)) => {
-                let second1 = labels1.iter().min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-                if let Some(sec1) = second1 {
-                    GlobalEnv::cmp_label(sec1, prim2)
-                } else {
-                    Ordering::Greater // None is beaten by Label
-                }
-            },
-            (None, None) => {
-                let second1 = labels1.iter().min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-                let second2 = labels2.iter().min_by(|l1, l2| GlobalEnv::cmp_label(l1, l2));
-                match (second1, second2) {
-                    (Some(sec1), Some(sec2)) => GlobalEnv::cmp_label(sec1, sec2),
-                    (Some(_), None) => Ordering::Less, // Label beats None
-                    (None, Some(_)) => Ordering::Greater, // None is beaten by Label
-                    (None, None) => Ordering::Equal,
-                }
-            },
-        }
+        let mut sorted_labels1: Vec<_> = labels1.iter().collect();
+        sorted_labels1.sort_by(|l1, l2| GlobalEnv::cmp_label_priority(l1, l2));
+        let mut sorted_labels2: Vec<_> = labels2.iter().collect();
+        sorted_labels2.sort_by(|l1, l2| GlobalEnv::cmp_label_priority(l1, l2));
+        std::iter::zip(sorted_labels1, sorted_labels2)
+            .map(|(l1, l2)| GlobalEnv::cmp_label(l1, l2))
+            .find(|r| Ordering::Equal != *r)
+            .unwrap_or(Ordering::Equal)
     }
 
     /// Writes accumulated diagnostics that pass through `filter`
@@ -1549,12 +1531,15 @@ impl GlobalEnv {
         let field_name = self.symbol_pool.make("v");
         let mut field_data = BTreeMap::new();
         let field_id = FieldId::new(field_name);
-        field_data.insert(field_id, FieldData {
-            name: field_name,
-            loc: loc.clone(),
-            offset: 0,
-            ty,
-        });
+        field_data.insert(
+            field_id,
+            FieldData {
+                name: field_name,
+                loc: loc.clone(),
+                offset: 0,
+                ty,
+            },
+        );
         StructData {
             name: self.ghost_memory_name(var_name),
             loc,


### PR DESCRIPTION
### Description

Improve ordering of Errors/Warnings shown to user by comparing more than one Label/location when there are multiple locations in two diagnostics.

Fixes https://github.com/aptos-labs/aptos-core/issues/10935

### Test Plan
Testing on existing move-compiler-v2 tests shows a change in 7 cases, manually checked they are an improvement.

