### PR TITLE
[docs] update links in markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Refer to our Coding Guidelines for the [Move](./developer-docs-site/docs/move/bo
 
 ### Documentation
 
-Aptos Core's developer website is also open source (the code can be found in this [repository](https://github.com/aptos-labs/aptos-core/tree/main/developers-docs-site/).  It is built using [Docusaurus](https://docusaurus.io/):
+Aptos Core's developer website is also open source (the code can be found in this [repository](https://github.com/aptos-labs/developer-docs).  It is built using [Docusaurus](https://docusaurus.io/):
 
 If you know Markdown, you can already contribute!
 

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -2,4 +2,4 @@
 
 The `aptos` tool is a command line interface (CLI) for debugging, development, and node operation.
 
-See [Aptos CLI Documentation](https://aptos.dev/cli-tools/aptos-cli/use-cli/install-aptos-cli) for how to install the `aptos` CLI tool and how to use it.
+See [Aptos CLI Documentation](https://aptos.dev/tools/aptos-cli/) for how to install the `aptos` CLI tool and how to use it.

--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -3,7 +3,7 @@
 Homebrew is a package manager that works for MacOS Silicon and Intel chips as well as Linux distributions like Debian
 and Ubuntu.
 
-The [Aptos command line interface (CLI)](https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli) may be installed
+The [Aptos command line interface (CLI)](https://aptos.dev/tools/aptos-cli/install-cli/) may be installed
 via [Homebrew](https://brew.sh/) for simplicity. This is an in-depth overview of Homebrew and the Aptos formula. In this
 guide, we go over each section of the Homebrew formula and steps to implement changes in the future.
 


### PR DESCRIPTION
### Description
Updated links for the cli-tools and developer-docs. 

### Test Plan
Markdown doc link fixes, in case if needed to test, just click on the old and new links. 😄
