### PR TITLE
[compiler-v2] Implement uninitialized use checker.

### DIFF
--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -14,7 +14,8 @@ use crate::pipeline::{
     ability_checker::AbilityChecker, avail_copies_analysis::AvailCopiesAnalysisProcessor,
     copy_propagation::CopyPropagation, dead_store_elimination::DeadStoreElimination,
     explicit_drop::ExplicitDrop, livevar_analysis_processor::LiveVarAnalysisProcessor,
-    reference_safety_processor::ReferenceSafetyProcessor, visibility_checker::VisibilityChecker,
+    reference_safety_processor::ReferenceSafetyProcessor,
+    uninitialized_use_checker::UninitializedUseChecker, visibility_checker::VisibilityChecker,
 };
 use anyhow::bail;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
@@ -175,6 +176,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     let safety_on = !options.experiment_on(Experiment::NO_SAFETY);
     let mut pipeline = FunctionTargetPipeline::default();
     if safety_on {
+        pipeline.add_processor(Box::new(UninitializedUseChecker {}));
         pipeline.add_processor(Box::new(VisibilityChecker()));
     }
     pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -9,4 +9,5 @@ pub mod dead_store_elimination;
 pub mod explicit_drop;
 pub mod livevar_analysis_processor;
 pub mod reference_safety_processor;
+pub mod uninitialized_use_checker;
 pub mod visibility_checker;

--- a/third_party/move/move-compiler-v2/src/pipeline/uninitialized_use_checker.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/uninitialized_use_checker.rs
@@ -1,0 +1,386 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements a checker which verifies that all locals are initialized before any use.
+//! This intra-procedural checker does not require any other analysis to be run before.
+//! As a side effect of running this checker, function targets are annotated with
+//! the initialized state (yes, no, maybe) of all locals at each reachable program point.
+//!
+//! There are two parts to this checker:
+//! * `InitializedStateAnalysis` which computes the initialized state of all locals at each
+//!   program point via a forward dataflow analysis.
+//! * `UninitializedUseChecker` which checks that all locals are initialized before use.
+
+use im::Vector;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::collections::BTreeMap;
+
+/// State of initialization of a local at a given program point.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Initialized {
+    No,    // definitely not initialized
+    Maybe, // maybe initialized
+    Yes,   // definitely initialized
+}
+
+impl AbstractDomain for Initialized {
+    /// Implements `join` for the initialized state lattice:
+    ///
+    ///             +-------+
+    ///             | Maybe |
+    ///             +-------+
+    ///               /   \
+    ///              /     \
+    ///      +-----+/       \+----+
+    ///      | Yes |         | No |
+    ///      +-----+\       /+----+
+    ///              \     /
+    ///               \   /
+    ///            +--------+
+    ///            | bottom |
+    ///            +--------+
+    /// Note that bottom is not explicitly represented in the enum `Initialized`.
+    /// Instead, it is implicit: it represents the initialized state for locals at unreachable program points.
+    fn join(&mut self, other: &Self) -> JoinResult {
+        if *self == *other {
+            return JoinResult::Unchanged;
+        }
+        if *self != Initialized::Maybe {
+            *self = Initialized::Maybe;
+            JoinResult::Changed
+        } else {
+            JoinResult::Unchanged
+        }
+    }
+}
+
+/// Initialization state of all the locals at a program point.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InitializedState(Vector<Initialized>);
+
+impl InitializedState {
+    /// Create a new initialized state with:
+    /// * all param locals set to `Yes`
+    /// * all other locals set to `No`.
+    /// Note: `num_locals` is the total number of locals, including params.
+    pub fn new(num_params: usize, num_locals: usize) -> Self {
+        if num_locals < num_params {
+            panic!("ICE: num_locals must be >= num_params");
+        }
+        Self(Vector::from_iter(
+            std::iter::repeat(Initialized::Yes)
+                .take(num_params)
+                .chain(std::iter::repeat(Initialized::No).take(num_locals - num_params)),
+        ))
+    }
+
+    /// Mark `local` as initialized.
+    fn mark_as_initialized(&mut self, local: usize) {
+        self.0.set(local, Initialized::Yes);
+    }
+
+    /// Get the initialization state of `local`.
+    /// Panics if `local` does not exist in this state.
+    fn get_initialized_state(&self, local: usize) -> Initialized {
+        self.0.get(local).expect("local must exist").clone()
+    }
+}
+
+impl AbstractDomain for InitializedState {
+    /// `join` of two initialized states is the point-wise join for each local.
+    /// The result is `JoinResult::Changed` if any of the local joins causes a change.
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut result = JoinResult::Unchanged;
+        // Do a shallow check if the two states are the same.
+        if self.0.ptr_eq(&other.0) {
+            return result;
+        }
+        // Otherwise, join each element.
+        for (l, r) in self.0.iter_mut().zip(other.0.iter()) {
+            result = result.combine(l.join(r));
+        }
+        result
+    }
+}
+
+/// Initialized state of all locals, both before and after various program points.
+#[derive(Clone)]
+struct InitializedStateAnnotation(
+    BTreeMap<
+        CodeOffset, // program point
+        (
+            /*before*/ InitializedState,
+            /*after*/ InitializedState,
+        ),
+    >,
+);
+
+impl InitializedStateAnnotation {
+    /// Get the initialized state of `local` just before the instruction at `offset`, if available.
+    fn get_initialized_state(&self, local: TempIndex, offset: CodeOffset) -> Option<Initialized> {
+        self.0
+            .get(&offset)
+            .map(|(before, _)| before.get_initialized_state(local))
+    }
+}
+
+/// Analysis to compute the initialized state of all locals at each reachable program point.
+/// This is an intra-procedural forward dataflow analysis.
+pub struct InitializedStateAnalysis {
+    num_params: usize, // number of parameters in the analyzed function
+    num_locals: usize, // number of locals in the analyzed function, including parameters
+}
+
+impl InitializedStateAnalysis {
+    /// Create a new instance of the initialized state analysis for a function.
+    /// The function's `num_params` and `num_locals` are provided.
+    ///
+    /// Note: `num_locals` is the total number of locals, including params.
+    /// Thus, `num_locals` must be >= `num_params`.
+    pub fn new(num_params: usize, num_locals: usize) -> Self {
+        Self {
+            num_params,
+            num_locals,
+        }
+    }
+
+    /// Analyze the given function and return the initialized state of all locals before and
+    /// after each reachable program point.
+    fn analyze(&self, func_target: &FunctionTarget) -> InitializedStateAnnotation {
+        let code = func_target.get_bytecode();
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        let block_state_map = self.analyze_function(
+            InitializedState::new(self.num_params, self.num_locals),
+            code,
+            &cfg,
+        );
+        let per_bytecode_state =
+            self.state_per_instruction(block_state_map, code, &cfg, |before, after| {
+                (before.clone(), after.clone())
+            });
+        InitializedStateAnnotation(per_bytecode_state)
+    }
+}
+
+impl TransferFunctions for InitializedStateAnalysis {
+    type State = InitializedState;
+
+    // This is a forward analysis.
+    const BACKWARD: bool = false;
+
+    fn execute(&self, state: &mut Self::State, instr: &Bytecode, _offset: CodeOffset) {
+        // Once you write to a local, it is considered initialized.
+        instr.dests().iter().for_each(|dst| {
+            state.mark_as_initialized(*dst);
+        });
+    }
+}
+
+impl DataflowAnalysis for InitializedStateAnalysis {}
+
+/// Checker which verifies that all locals are definitely initialized before use.
+/// Violations are reported as errors.
+pub struct UninitializedUseChecker {}
+
+impl UninitializedUseChecker {
+    /// Check whether all locals are definitely initialized before use in the function `target`.
+    /// Information about initialized state is provided in `annotation`.
+    /// Violations are reported as errors in the `target`'s global environment.
+    fn perform_checks(&self, target: &FunctionTarget, annotation: &InitializedStateAnnotation) {
+        for (offset, bc) in target.get_bytecode().iter().enumerate() {
+            if bc.is_spec_only() {
+                // We don't check spec-only instructions here.
+                continue;
+            }
+            bc.sources().iter().for_each(|src| {
+                if let Some(state @ (Initialized::Maybe | Initialized::No)) =
+                    annotation.get_initialized_state(*src, offset as CodeOffset)
+                {
+                    target.global_env().error(
+                        &target.get_bytecode_loc(bc.get_attr_id()),
+                        &format!(
+                            "use of {}unassigned {}",
+                            match state {
+                                Initialized::No => "",
+                                Initialized::Maybe => "possibly ",
+                                Initialized::Yes => panic!("ICE: should be unreachable"),
+                            },
+                            target.get_local_name_for_error_message(*src)
+                        ),
+                    );
+                }
+            });
+        }
+    }
+
+    /// Registers initialized state annotation formatter at the given function target.
+    /// Helps with testing and debugging.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_initialized_state_annotation));
+    }
+}
+
+impl FunctionTargetProcessor for UninitializedUseChecker {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            // We don't have to look inside native functions.
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        let analysis =
+            InitializedStateAnalysis::new(target.get_parameter_count(), target.get_local_count());
+        let annotation = analysis.analyze(&target);
+        self.perform_checks(&target, &annotation);
+        data.annotations.set(annotation, true); // for testing.
+        data
+    }
+
+    fn name(&self) -> String {
+        "uninitialized_use_checker".to_string()
+    }
+}
+
+// ====================================================================
+// Formatting functionality for initialized state annotation.
+
+/// Format the initialized state annotation for a given function target.
+pub fn format_initialized_state_annotation(
+    target: &FunctionTarget,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    let InitializedStateAnnotation(map) = target
+        .get_annotations()
+        .get::<InitializedStateAnnotation>()?;
+    let (before, after) = map.get(&code_offset)?;
+    let mut s = String::new();
+    s.push_str("before: ");
+    s.push_str(&format_initialized_state(before, target));
+    s.push_str(", after: ");
+    s.push_str(&format_initialized_state(after, target));
+    Some(s)
+}
+
+/// Format a vector of `locals`.
+/// `header` is added as a prefix.
+/// `target` is used to get the name of each local symbol.
+fn format_vector_of_locals(
+    header: &str,
+    locals: Vec<TempIndex>,
+    target: &FunctionTarget,
+) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("{{ {}: ", header));
+    s.push_str(
+        &locals
+            .into_iter()
+            .map(|tmp| {
+                let name = target.get_local_raw_name(tmp);
+                name.display(target.symbol_pool()).to_string()
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    s.push_str(" }");
+    s
+}
+
+/// Format the initialized state for a given function `target`.
+fn format_initialized_state(state: &InitializedState, target: &FunctionTarget) -> String {
+    let mut s = String::new();
+    let mut nos = vec![];
+    let mut maybes = vec![];
+    for (i, v) in state.0.iter().enumerate() {
+        match v {
+            Initialized::No => nos.push(i),
+            Initialized::Maybe => maybes.push(i),
+            Initialized::Yes => {},
+        }
+    }
+    let mut all_initialized = true;
+    if !nos.is_empty() {
+        s.push_str(&format_vector_of_locals("no", nos, target));
+        all_initialized = false;
+    }
+    if !maybes.is_empty() {
+        s.push_str(&format_vector_of_locals("maybe", maybes, target));
+        all_initialized = false;
+    }
+    if all_initialized {
+        s.push_str("all initialized");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initialized_join() {
+        let mut state = Initialized::No;
+        assert_eq!(state.join(&Initialized::No), JoinResult::Unchanged);
+        assert_eq!(state, Initialized::No);
+
+        state = Initialized::No;
+        assert_eq!(state.join(&Initialized::Maybe), JoinResult::Changed);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::No;
+        assert_eq!(state.join(&Initialized::Yes), JoinResult::Changed);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Maybe;
+        assert_eq!(state.join(&Initialized::No), JoinResult::Unchanged);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Maybe;
+        assert_eq!(state.join(&Initialized::Maybe), JoinResult::Unchanged);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Maybe;
+        assert_eq!(state.join(&Initialized::Yes), JoinResult::Unchanged);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Yes;
+        assert_eq!(state.join(&Initialized::No), JoinResult::Changed);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Yes;
+        assert_eq!(state.join(&Initialized::Maybe), JoinResult::Changed);
+        assert_eq!(state, Initialized::Maybe);
+
+        state = Initialized::Yes;
+        assert_eq!(state.join(&Initialized::Yes), JoinResult::Unchanged);
+        assert_eq!(state, Initialized::Yes);
+    }
+
+    #[test]
+    fn test_initialized_state_join() {
+        let mut state = InitializedState::new(1, 2);
+        let mut other = InitializedState::new(1, 2);
+        assert_eq!(state.join(&other), JoinResult::Unchanged);
+        assert_eq!(state, InitializedState::new(1, 2));
+
+        state.mark_as_initialized(1);
+        assert_eq!(state.join(&other), JoinResult::Changed);
+
+        state = InitializedState::new(1, 2);
+        other.mark_as_initialized(1);
+        assert_eq!(state.join(&other), JoinResult::Changed);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -13,7 +13,7 @@ use move_compiler_v2::{
         copy_propagation::CopyPropagation, dead_store_elimination::DeadStoreElimination,
         explicit_drop::ExplicitDrop, livevar_analysis_processor::LiveVarAnalysisProcessor,
         reference_safety_processor::ReferenceSafetyProcessor,
-        visibility_checker::VisibilityChecker,
+        uninitialized_use_checker::UninitializedUseChecker, visibility_checker::VisibilityChecker,
     },
     run_file_format_gen, Options,
 };
@@ -263,6 +263,16 @@ impl TestConfig {
                 // Only dump with annotations after these pipeline stages.
                 dump_for_only_some_stages: Some(vec![0, 1, 3]),
             }
+        } else if path.contains("/uninit-use-checker/") {
+            pipeline.add_processor(Box::new(UninitializedUseChecker {}));
+            Self {
+                type_check_only: false,
+                dump_ast: false,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: true,
+                dump_for_only_some_stages: None,
+            }
         } else {
             panic!(
                 "unexpected test path `{}`, cannot derive configuration",
@@ -396,6 +406,7 @@ impl TestConfig {
         LiveVarAnalysisProcessor::register_formatters(target);
         ReferenceSafetyProcessor::register_formatters(target);
         AvailCopiesAnalysisProcessor::register_formatters(target);
+        UninitializedUseChecker::register_formatters(target);
     }
 
     fn check_diags(baseline: &mut String, env: &GlobalEnv) -> bool {

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.exp
@@ -1,0 +1,52 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t3 := 1
+  3: $t2 := infer($t3)
+  4: goto 8
+  5: label L1
+  6: $t4 := 2
+  7: $t2 := infer($t4)
+  8: label L2
+  9: $t1 := infer($t2)
+ 10: return $t1
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  0: if ($t0) goto 1 else goto 5
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t4 }
+  2: $t3 := 1
+     # before: { no: $t1, $t2, $t4 }, after: { no: $t1, $t4 }
+  3: $t2 := infer($t3)
+     # before: { no: $t1, $t4 }, after: { no: $t1, $t4 }
+  4: goto 8
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  5: label L1
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3 }
+  6: $t4 := 2
+     # before: { no: $t1, $t2, $t3 }, after: { no: $t1, $t3 }
+  7: $t2 := infer($t4)
+     # before: { no: $t1 }{ maybe: $t3, $t4 }, after: { no: $t1 }{ maybe: $t3, $t4 }
+  8: label L2
+     # before: { no: $t1 }{ maybe: $t3, $t4 }, after: { maybe: $t3, $t4 }
+  9: $t1 := infer($t2)
+     # before: { maybe: $t3, $t4 }, after: { maybe: $t3, $t4 }
+ 10: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun test(cond: bool): u64 {
+        let x: u64;
+        if (cond) {
+            x = 1;
+        } else {
+            x = 2;
+        };
+        x
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_in_one_if_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_in_one_if_branch.exp
@@ -1,0 +1,93 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: bool
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 5
+  4: $t0 := infer($t3)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t4 := true
+  9: if ($t4) goto 10 else goto 14
+ 10: label L3
+ 11: $t5 := 5
+ 12: $t1 := infer($t5)
+ 13: goto 15
+ 14: label L4
+ 15: label L5
+ 16: $t6 := ==($t0, $t1)
+ 17: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/assign_in_one_if_branch.move:7:5
+  │
+7 │     x == y;
+  │     ^^^^^^
+
+error: use of possibly unassigned local `y`
+  ┌─ tests/uninit-use-checker/assign_in_one_if_branch.move:7:5
+  │
+7 │     x == y;
+  │     ^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: bool
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  0: $t2 := true
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  1: if ($t2) goto 2 else goto 6
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  2: label L0
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t4, $t5, $t6 }
+  3: $t3 := 5
+     # before: { no: $t0, $t1, $t4, $t5, $t6 }, after: { no: $t1, $t4, $t5, $t6 }
+  4: $t0 := infer($t3)
+     # before: { no: $t1, $t4, $t5, $t6 }, after: { no: $t1, $t4, $t5, $t6 }
+  5: goto 7
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  6: label L1
+     # before: { no: $t1, $t4, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t4, $t5, $t6 }{ maybe: $t0, $t3 }
+  7: label L2
+     # before: { no: $t1, $t4, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }
+  8: $t4 := true
+     # before: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }
+  9: if ($t4) goto 10 else goto 14
+     # before: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }
+ 10: label L3
+     # before: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t6 }{ maybe: $t0, $t3 }
+ 11: $t5 := 5
+     # before: { no: $t1, $t6 }{ maybe: $t0, $t3 }, after: { no: $t6 }{ maybe: $t0, $t3 }
+ 12: $t1 := infer($t5)
+     # before: { no: $t6 }{ maybe: $t0, $t3 }, after: { no: $t6 }{ maybe: $t0, $t3 }
+ 13: goto 15
+     # before: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }, after: { no: $t1, $t5, $t6 }{ maybe: $t0, $t3 }
+ 14: label L4
+     # before: { no: $t6 }{ maybe: $t0, $t1, $t3, $t5 }, after: { no: $t6 }{ maybe: $t0, $t1, $t3, $t5 }
+ 15: label L5
+     # before: { no: $t6 }{ maybe: $t0, $t1, $t3, $t5 }, after: { maybe: $t0, $t1, $t3, $t5 }
+ 16: $t6 := ==($t0, $t1)
+     # before: { maybe: $t0, $t1, $t3, $t5 }, after: { maybe: $t0, $t1, $t3, $t5 }
+ 17: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_in_one_if_branch.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_in_one_if_branch.move
@@ -1,0 +1,11 @@
+script {
+fun main() {
+    let x;
+    let y;
+    if (true) x = 5 else ();
+    if (true) y = 5;
+    x == y;
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch.exp
@@ -1,0 +1,85 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := true
+  1: if ($t1) goto 2 else goto 4
+  2: label L0
+  3: goto 7
+  4: label L1
+  5: $t2 := 100
+  6: $t0 := infer($t2)
+  7: label L2
+  8: $t4 := 100
+  9: $t3 := ==($t0, $t4)
+ 10: if ($t3) goto 11 else goto 13
+ 11: label L3
+ 12: goto 16
+ 13: label L4
+ 14: $t5 := 42
+ 15: abort($t5)
+ 16: label L5
+ 17: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/assign_wrong_if_branch.move:5:13
+  │
+5 │     assert!(x == 100, 42);
+  │             ^^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  0: $t1 := true
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  1: if ($t1) goto 2 else goto 4
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  2: label L0
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  3: goto 7
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  4: label L1
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4, $t5 }
+  5: $t2 := 100
+     # before: { no: $t0, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  6: $t0 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }
+  7: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t5 }{ maybe: $t0, $t2 }
+  8: $t4 := 100
+     # before: { no: $t3, $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+  9: $t3 := ==($t0, $t4)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 10: if ($t3) goto 11 else goto 13
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 11: label L3
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 12: goto 16
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 13: label L4
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 14: $t5 := 42
+     # before: { maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 15: abort($t5)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 16: label L5
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 17: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch.move
@@ -1,0 +1,9 @@
+script {
+fun main() {
+    let x: u64;
+    if (true) () else x = 100;
+    assert!(x == 100, 42);
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch_no_else.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch_no_else.exp
@@ -1,0 +1,85 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := false
+  1: if ($t1) goto 2 else goto 6
+  2: label L0
+  3: $t2 := 100
+  4: $t0 := infer($t2)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t4 := 100
+  9: $t3 := ==($t0, $t4)
+ 10: if ($t3) goto 11 else goto 13
+ 11: label L3
+ 12: goto 16
+ 13: label L4
+ 14: $t5 := 42
+ 15: abort($t5)
+ 16: label L5
+ 17: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/assign_wrong_if_branch_no_else.move:5:13
+  │
+5 │     assert!(x == 100, 42);
+  │             ^^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  0: $t1 := false
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  1: if ($t1) goto 2 else goto 6
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  2: label L0
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4, $t5 }
+  3: $t2 := 100
+     # before: { no: $t0, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  4: $t0 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  5: goto 7
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  6: label L1
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }
+  7: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t5 }{ maybe: $t0, $t2 }
+  8: $t4 := 100
+     # before: { no: $t3, $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+  9: $t3 := ==($t0, $t4)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 10: if ($t3) goto 11 else goto 13
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 11: label L3
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 12: goto 16
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 13: label L4
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 14: $t5 := 42
+     # before: { maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 15: abort($t5)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 16: label L5
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 17: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch_no_else.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_wrong_if_branch_no_else.move
@@ -1,0 +1,9 @@
+script {
+fun main() {
+    let x: u64;
+    if (false) x = 100;
+    assert!(x == 100, 42);
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/borrow_if.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/borrow_if.exp
@@ -1,0 +1,105 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: bool
+     var $t4: &u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: u64
+  0: $t1 := 5
+  1: $t0 := infer($t1)
+  2: $t3 := true
+  3: if ($t3) goto 4 else goto 8
+  4: label L0
+  5: $t4 := borrow_local($t0)
+  6: $t2 := infer($t4)
+  7: goto 9
+  8: label L1
+  9: label L2
+ 10: $t7 := move($t2)
+ 11: $t6 := read_ref($t7)
+ 12: $t8 := 5
+ 13: $t5 := ==($t6, $t8)
+ 14: if ($t5) goto 15 else goto 17
+ 15: label L3
+ 16: goto 20
+ 17: label L4
+ 18: $t9 := 42
+ 19: abort($t9)
+ 20: label L5
+ 21: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `ref`
+  ┌─ tests/uninit-use-checker/borrow_if.move:8:14
+  │
+8 │     assert!(*move ref == 5, 42);
+  │              ^^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: bool
+     var $t4: &u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t0, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9 }
+  0: $t1 := 5
+     # before: { no: $t0, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9 }
+  1: $t0 := infer($t1)
+     # before: { no: $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }
+  2: $t3 := true
+     # before: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }
+  3: if ($t3) goto 4 else goto 8
+     # before: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }
+  4: label L0
+     # before: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t5, $t6, $t7, $t8, $t9 }
+  5: $t4 := borrow_local($t0)
+     # before: { no: $t2, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t5, $t6, $t7, $t8, $t9 }
+  6: $t2 := infer($t4)
+     # before: { no: $t5, $t6, $t7, $t8, $t9 }, after: { no: $t5, $t6, $t7, $t8, $t9 }
+  7: goto 9
+     # before: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }, after: { no: $t2, $t4, $t5, $t6, $t7, $t8, $t9 }
+  8: label L1
+     # before: { no: $t5, $t6, $t7, $t8, $t9 }{ maybe: $t2, $t4 }, after: { no: $t5, $t6, $t7, $t8, $t9 }{ maybe: $t2, $t4 }
+  9: label L2
+     # before: { no: $t5, $t6, $t7, $t8, $t9 }{ maybe: $t2, $t4 }, after: { no: $t5, $t6, $t8, $t9 }{ maybe: $t2, $t4 }
+ 10: $t7 := move($t2)
+     # before: { no: $t5, $t6, $t8, $t9 }{ maybe: $t2, $t4 }, after: { no: $t5, $t8, $t9 }{ maybe: $t2, $t4 }
+ 11: $t6 := read_ref($t7)
+     # before: { no: $t5, $t8, $t9 }{ maybe: $t2, $t4 }, after: { no: $t5, $t9 }{ maybe: $t2, $t4 }
+ 12: $t8 := 5
+     # before: { no: $t5, $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 13: $t5 := ==($t6, $t8)
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 14: if ($t5) goto 15 else goto 17
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 15: label L3
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 16: goto 20
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 17: label L4
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { maybe: $t2, $t4 }
+ 18: $t9 := 42
+     # before: { maybe: $t2, $t4 }, after: { maybe: $t2, $t4 }
+ 19: abort($t9)
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 20: label L5
+     # before: { no: $t9 }{ maybe: $t2, $t4 }, after: { no: $t9 }{ maybe: $t2, $t4 }
+ 21: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/borrow_if.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/borrow_if.move
@@ -1,0 +1,12 @@
+script {
+fun main() {
+    let x = 5;
+    let ref;
+    if (true) {
+        ref = &x;
+    };
+    assert!(*move ref == 5, 42);
+}
+}
+
+// check: MOVELOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/else_assigns_if_doesnt.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/else_assigns_if_doesnt.exp
@@ -1,0 +1,100 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 0
+  4: $t1 := infer($t3)
+  5: goto 10
+  6: label L1
+  7: $t4 := 42
+  8: $t0 := infer($t4)
+  9: $t5 := infer($t0)
+ 10: label L2
+ 11: $t7 := 0
+ 12: $t6 := ==($t1, $t7)
+ 13: if ($t6) goto 14 else goto 16
+ 14: label L3
+ 15: goto 19
+ 16: label L4
+ 17: $t8 := 42
+ 18: abort($t8)
+ 19: label L5
+ 20: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `y`
+   ┌─ tests/uninit-use-checker/else_assigns_if_doesnt.move:11:13
+   │
+11 │     assert!(y == 0, 42);
+   │             ^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  0: $t2 := true
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  1: if ($t2) goto 2 else goto 6
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  2: label L0
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t4, $t5, $t6, $t7, $t8 }
+  3: $t3 := 0
+     # before: { no: $t0, $t1, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t4, $t5, $t6, $t7, $t8 }
+  4: $t1 := infer($t3)
+     # before: { no: $t0, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t4, $t5, $t6, $t7, $t8 }
+  5: goto 10
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  6: label L1
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t5, $t6, $t7, $t8 }
+  7: $t4 := 42
+     # before: { no: $t0, $t1, $t3, $t5, $t6, $t7, $t8 }, after: { no: $t1, $t3, $t5, $t6, $t7, $t8 }
+  8: $t0 := infer($t4)
+     # before: { no: $t1, $t3, $t5, $t6, $t7, $t8 }, after: { no: $t1, $t3, $t6, $t7, $t8 }
+  9: $t5 := infer($t0)
+     # before: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 10: label L2
+     # before: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t6, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 11: $t7 := 0
+     # before: { no: $t6, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 12: $t6 := ==($t1, $t7)
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 13: if ($t6) goto 14 else goto 16
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 14: label L3
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 15: goto 19
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 16: label L4
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t3, $t4, $t5 }
+ 17: $t8 := 42
+     # before: { maybe: $t0, $t1, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t3, $t4, $t5 }
+ 18: abort($t8)
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 19: label L5
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 20: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/else_assigns_if_doesnt.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/else_assigns_if_doesnt.move
@@ -1,0 +1,15 @@
+script {
+fun main() {
+    let x;
+    let y;
+    if (true) {
+        y = 0;
+    } else {
+        x = 42;
+        x;
+    };
+    assert!(y == 0, 42);
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/eq_unassigned_local.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/eq_unassigned_local.exp
@@ -1,0 +1,44 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: bool
+     var $t4: &u64
+  0: $t1 := 5
+  1: $t0 := infer($t1)
+  2: $t4 := borrow_local($t0)
+  3: $t3 := ==($t2, $t4)
+  4: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `ref`
+  ┌─ tests/uninit-use-checker/eq_unassigned_local.move:5:9
+  │
+5 │         ref == &x;
+  │         ^^^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: bool
+     var $t4: &u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4 }, after: { no: $t0, $t2, $t3, $t4 }
+  0: $t1 := 5
+     # before: { no: $t0, $t2, $t3, $t4 }, after: { no: $t2, $t3, $t4 }
+  1: $t0 := infer($t1)
+     # before: { no: $t2, $t3, $t4 }, after: { no: $t2, $t3 }
+  2: $t4 := borrow_local($t0)
+     # before: { no: $t2, $t3 }, after: { no: $t2 }
+  3: $t3 := ==($t2, $t4)
+     # before: { no: $t2 }, after: { no: $t2 }
+  4: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/eq_unassigned_local.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/eq_unassigned_local.move
@@ -1,0 +1,7 @@
+script {
+    fun main() {
+        let x = 5;
+        let ref;
+        ref == &x;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_else_doesnt.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_else_doesnt.exp
@@ -1,0 +1,100 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 42
+  4: $t0 := infer($t3)
+  5: goto 10
+  6: label L1
+  7: $t4 := 0
+  8: $t1 := infer($t4)
+  9: $t5 := infer($t1)
+ 10: label L2
+ 11: $t7 := 42
+ 12: $t6 := ==($t0, $t7)
+ 13: if ($t6) goto 14 else goto 16
+ 14: label L3
+ 15: goto 19
+ 16: label L4
+ 17: $t8 := 42
+ 18: abort($t8)
+ 19: label L5
+ 20: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/if_assigns_else_doesnt.move:11:13
+   │
+11 │     assert!(x == 42, 42);
+   │             ^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  0: $t2 := true
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  1: if ($t2) goto 2 else goto 6
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  2: label L0
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t4, $t5, $t6, $t7, $t8 }
+  3: $t3 := 42
+     # before: { no: $t0, $t1, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t1, $t4, $t5, $t6, $t7, $t8 }
+  4: $t0 := infer($t3)
+     # before: { no: $t1, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t1, $t4, $t5, $t6, $t7, $t8 }
+  5: goto 10
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }
+  6: label L1
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t1, $t3, $t5, $t6, $t7, $t8 }
+  7: $t4 := 0
+     # before: { no: $t0, $t1, $t3, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t3, $t5, $t6, $t7, $t8 }
+  8: $t1 := infer($t4)
+     # before: { no: $t0, $t3, $t5, $t6, $t7, $t8 }, after: { no: $t0, $t3, $t6, $t7, $t8 }
+  9: $t5 := infer($t1)
+     # before: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 10: label L2
+     # before: { no: $t6, $t7, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t6, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 11: $t7 := 42
+     # before: { no: $t6, $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 12: $t6 := ==($t0, $t7)
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 13: if ($t6) goto 14 else goto 16
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 14: label L3
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 15: goto 19
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 16: label L4
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t3, $t4, $t5 }
+ 17: $t8 := 42
+     # before: { maybe: $t0, $t1, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t3, $t4, $t5 }
+ 18: abort($t8)
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 19: label L5
+     # before: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t8 }{ maybe: $t0, $t1, $t3, $t4, $t5 }
+ 20: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_else_doesnt.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_else_doesnt.move
@@ -1,0 +1,15 @@
+script {
+fun main() {
+    let x;
+    let y;
+    if (true) {
+        x = 42;
+    } else {
+        y = 0;
+        y;
+    };
+    assert!(x == 42, 42);
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_no_else.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_no_else.exp
@@ -1,0 +1,85 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := true
+  1: if ($t1) goto 2 else goto 6
+  2: label L0
+  3: $t2 := 42
+  4: $t0 := infer($t2)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t4 := 42
+  9: $t3 := ==($t0, $t4)
+ 10: if ($t3) goto 11 else goto 13
+ 11: label L3
+ 12: goto 16
+ 13: label L4
+ 14: $t5 := 42
+ 15: abort($t5)
+ 16: label L5
+ 17: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/if_assigns_no_else.move:5:13
+  │
+5 │     assert!(x == 42, 42);
+  │             ^^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  0: $t1 := true
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  1: if ($t1) goto 2 else goto 6
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  2: label L0
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4, $t5 }
+  3: $t2 := 42
+     # before: { no: $t0, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  4: $t0 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  5: goto 7
+     # before: { no: $t0, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t2, $t3, $t4, $t5 }
+  6: label L1
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }
+  7: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t0, $t2 }, after: { no: $t3, $t5 }{ maybe: $t0, $t2 }
+  8: $t4 := 42
+     # before: { no: $t3, $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+  9: $t3 := ==($t0, $t4)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 10: if ($t3) goto 11 else goto 13
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 11: label L3
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 12: goto 16
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 13: label L4
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 14: $t5 := 42
+     # before: { maybe: $t0, $t2 }, after: { maybe: $t0, $t2 }
+ 15: abort($t5)
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 16: label L5
+     # before: { no: $t5 }{ maybe: $t0, $t2 }, after: { no: $t5 }{ maybe: $t0, $t2 }
+ 17: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_no_else.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/if_assigns_no_else.move
@@ -1,0 +1,9 @@
+script {
+fun main() {
+    let x;
+    if (true) x = 42;
+    assert!(x == 42, 42);
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/move_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/move_before_assign.exp
@@ -1,0 +1,34 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+  0: $t2 := move($t0)
+  1: $t1 := infer($t2)
+  2: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/uninit-use-checker/move_before_assign.move:4:13
+  │
+4 │     let y = move x;
+  │             ^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
+  0: $t2 := move($t0)
+     # before: { no: $t0, $t1 }, after: { no: $t0 }
+  1: $t1 := infer($t2)
+     # before: { no: $t0 }, after: { no: $t0 }
+  2: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/move_before_assign.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/move_before_assign.move
@@ -1,0 +1,8 @@
+script {
+fun main() {
+    let x: u64;
+    let y = move x;
+}
+}
+
+// check: MOVELOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
@@ -1,0 +1,59 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+  0: $t4 := +($t0, $t1)
+  1: $t3 := infer($t4)
+  2: $t7 := 1
+  3: $t6 := +($t3, $t7)
+  4: $t5 := infer($t6)
+  5: $t10 := 1
+  6: $t9 := +($t5, $t10)
+  7: $t8 := infer($t9)
+  8: $t2 := infer($t8)
+  9: return $t2
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     # before: { no: $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t3, $t5, $t6, $t7, $t8, $t9, $t10 }
+  0: $t4 := +($t0, $t1)
+     # before: { no: $t2, $t3, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t6, $t7, $t8, $t9, $t10 }
+  1: $t3 := infer($t4)
+     # before: { no: $t2, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t6, $t8, $t9, $t10 }
+  2: $t7 := 1
+     # before: { no: $t2, $t5, $t6, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t8, $t9, $t10 }
+  3: $t6 := +($t3, $t7)
+     # before: { no: $t2, $t5, $t8, $t9, $t10 }, after: { no: $t2, $t8, $t9, $t10 }
+  4: $t5 := infer($t6)
+     # before: { no: $t2, $t8, $t9, $t10 }, after: { no: $t2, $t8, $t9 }
+  5: $t10 := 1
+     # before: { no: $t2, $t8, $t9 }, after: { no: $t2, $t8 }
+  6: $t9 := +($t5, $t10)
+     # before: { no: $t2, $t8 }, after: { no: $t2 }
+  7: $t8 := infer($t9)
+     # before: { no: $t2 }, after: all initialized
+  8: $t2 := infer($t8)
+     # before: all initialized, after: all initialized
+  9: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.move
@@ -1,0 +1,8 @@
+module 0xc0::m {
+    fun foo(p: u64, q: u64): u64 {
+        let x = p + q;
+        let y = x + 1;
+        let z = y + 1;
+        z
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign.exp
@@ -1,0 +1,29 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign.move:4:9
+  │
+4 │     let y = x;
+  │         ^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     # before: { no: $t0, $t1 }, after: { no: $t0 }
+  0: $t1 := infer($t0)
+     # before: { no: $t0 }, after: { no: $t0 }
+  1: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign.move
@@ -1,0 +1,8 @@
+script {
+fun main() {
+    let x: u64;
+    let y = x;
+}
+}
+
+// check: COPYLOC_UNAVAILABLE_ERROR

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if.exp
@@ -1,0 +1,165 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun M::tborrow($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t2 := 0
+  3: $t1 := infer($t2)
+  4: goto 6
+  5: label L1
+  6: label L2
+  7: $t3 := borrow_local($t1)
+  8: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t2 := 0
+  3: $t1 := infer($t2)
+  4: goto 6
+  5: label L1
+  6: label L2
+  7: $t4 := 1
+  8: $t3 := +($t1, $t4)
+  9: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t2 := 0
+  3: $t1 := infer($t2)
+  4: goto 6
+  5: label L1
+  6: label L2
+  7: $t4 := move($t1)
+  8: $t5 := 1
+  9: $t3 := +($t4, $t5)
+ 10: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_if.move:5:17
+  │
+5 │         let _ = move x + 1;
+  │                 ^^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_if.move:11:17
+   │
+11 │         let _ = x + 1;
+   │                 ^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_if.move:17:17
+   │
+17 │         let _ = &x;
+   │                 ^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun M::tborrow($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &u64
+     # before: { no: $t1, $t2, $t3 }, after: { no: $t1, $t2, $t3 }
+  0: if ($t0) goto 1 else goto 5
+     # before: { no: $t1, $t2, $t3 }, after: { no: $t1, $t2, $t3 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3 }, after: { no: $t1, $t3 }
+  2: $t2 := 0
+     # before: { no: $t1, $t3 }, after: { no: $t3 }
+  3: $t1 := infer($t2)
+     # before: { no: $t3 }, after: { no: $t3 }
+  4: goto 6
+     # before: { no: $t1, $t2, $t3 }, after: { no: $t1, $t2, $t3 }
+  5: label L1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  7: $t3 := borrow_local($t1)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  8: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  0: if ($t0) goto 1 else goto 5
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t3, $t4 }
+  2: $t2 := 0
+     # before: { no: $t1, $t3, $t4 }, after: { no: $t3, $t4 }
+  3: $t1 := infer($t2)
+     # before: { no: $t3, $t4 }, after: { no: $t3, $t4 }
+  4: goto 6
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  5: label L1
+     # before: { no: $t3, $t4 }{ maybe: $t1, $t2 }, after: { no: $t3, $t4 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3, $t4 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  7: $t4 := 1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  8: $t3 := +($t1, $t4)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  9: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  0: if ($t0) goto 1 else goto 5
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t3, $t4, $t5 }
+  2: $t2 := 0
+     # before: { no: $t1, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  3: $t1 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  4: goto 6
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  5: label L1
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t5 }{ maybe: $t1, $t2 }
+  7: $t4 := move($t1)
+     # before: { no: $t3, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  8: $t5 := 1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  9: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if.move
@@ -1,0 +1,20 @@
+module 0x8675309::M {
+    fun tmove(cond: bool) {
+        let x: u64;
+        if (cond) { x = 0 };
+        let _ = move x + 1;
+    }
+
+    fun tcopy(cond: bool) {
+        let x: u64;
+        if (cond) { x = 0 };
+        let _ = x + 1;
+    }
+
+    fun tborrow(cond: bool) {
+        let x: u64;
+        if (cond) { x = 0 };
+        let _ = &x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if_else.exp
@@ -1,0 +1,180 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun M::tborrow($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: if ($t0) goto 1 else goto 3
+  1: label L0
+  2: goto 6
+  3: label L1
+  4: $t2 := 0
+  5: $t1 := infer($t2)
+  6: label L2
+  7: $t4 := move($t1)
+  8: $t5 := 1
+  9: $t3 := +($t4, $t5)
+ 10: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: if ($t0) goto 1 else goto 3
+  1: label L0
+  2: goto 6
+  3: label L1
+  4: $t2 := 0
+  5: $t1 := infer($t2)
+  6: label L2
+  7: $t4 := move($t1)
+  8: $t5 := 1
+  9: $t3 := +($t4, $t5)
+ 10: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: if ($t0) goto 1 else goto 3
+  1: label L0
+  2: goto 6
+  3: label L1
+  4: $t2 := 0
+  5: $t1 := infer($t2)
+  6: label L2
+  7: $t4 := move($t1)
+  8: $t5 := 1
+  9: $t3 := +($t4, $t5)
+ 10: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_if_else.move:5:17
+  │
+5 │         let _ = move x + 1;
+  │                 ^^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_if_else.move:11:17
+   │
+11 │         let _ = move x + 1;
+   │                 ^^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_if_else.move:17:17
+   │
+17 │         let _ = move x + 1;
+   │                 ^^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun M::tborrow($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  0: if ($t0) goto 1 else goto 3
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  2: goto 6
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  3: label L1
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t3, $t4, $t5 }
+  4: $t2 := 0
+     # before: { no: $t1, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  5: $t1 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t5 }{ maybe: $t1, $t2 }
+  7: $t4 := move($t1)
+     # before: { no: $t3, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  8: $t5 := 1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  9: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+ 10: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  0: if ($t0) goto 1 else goto 3
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  2: goto 6
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  3: label L1
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t3, $t4, $t5 }
+  4: $t2 := 0
+     # before: { no: $t1, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  5: $t1 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t5 }{ maybe: $t1, $t2 }
+  7: $t4 := move($t1)
+     # before: { no: $t3, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  8: $t5 := 1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  9: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+ 10: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  0: if ($t0) goto 1 else goto 3
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  1: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  2: goto 6
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  3: label L1
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t3, $t4, $t5 }
+  4: $t2 := 0
+     # before: { no: $t1, $t3, $t4, $t5 }, after: { no: $t3, $t4, $t5 }
+  5: $t1 := infer($t2)
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }
+  6: label L2
+     # before: { no: $t3, $t4, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3, $t5 }{ maybe: $t1, $t2 }
+  7: $t4 := move($t1)
+     # before: { no: $t3, $t5 }{ maybe: $t1, $t2 }, after: { no: $t3 }{ maybe: $t1, $t2 }
+  8: $t5 := 1
+     # before: { no: $t3 }{ maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+  9: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2 }, after: { maybe: $t1, $t2 }
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if_else.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_if_else.move
@@ -1,0 +1,20 @@
+module 0x8675309::M {
+    fun tmove(cond: bool) {
+        let x: u64;
+        if (cond) { } else { x = 0 };
+        let _ = move x + 1;
+    }
+
+    fun tcopy(cond: bool) {
+        let x: u64;
+        if (cond) { } else { x = 0 };
+        let _ = move x + 1;
+    }
+
+    fun tborrow(cond: bool) {
+        let x: u64;
+        if (cond) { } else { x = 0 };
+        let _ = move x + 1;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_loop.exp
@@ -1,0 +1,269 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun M::tborrow1() {
+     var $t0: u64
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+  0: label L0
+  1: $t2 := borrow_local($t0)
+  2: $t1 := infer($t2)
+  3: $t3 := move($t1)
+  4: $t4 := 0
+  5: $t0 := infer($t4)
+  6: goto 0
+  7: label L1
+  8: return ()
+}
+
+
+[variant baseline]
+fun M::tborrow2($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+  0: label L0
+  1: $t3 := borrow_local($t1)
+  2: $t2 := infer($t3)
+  3: $t4 := move($t2)
+  4: if ($t0) goto 5 else goto 9
+  5: label L2
+  6: $t5 := 0
+  7: $t1 := infer($t5)
+  8: goto 10
+  9: label L3
+ 10: label L4
+ 11: goto 13
+ 12: goto 0
+ 13: label L1
+ 14: $t6 := infer($t1)
+ 15: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: label L0
+  1: $t4 := 1
+  2: $t3 := +($t1, $t4)
+  3: $t2 := infer($t3)
+  4: if ($t0) goto 5 else goto 8
+  5: label L2
+  6: goto 0
+  7: goto 9
+  8: label L3
+  9: label L4
+ 10: $t5 := 0
+ 11: $t1 := infer($t5)
+ 12: $t6 := infer($t2)
+ 13: goto 0
+ 14: label L1
+ 15: return ()
+}
+
+
+[variant baseline]
+fun M::tmove() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: label L0
+  1: $t3 := move($t0)
+  2: $t4 := 1
+  3: $t2 := +($t3, $t4)
+  4: $t1 := infer($t2)
+  5: $t5 := 0
+  6: $t0 := infer($t5)
+  7: $t6 := infer($t1)
+  8: goto 0
+  9: label L1
+ 10: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_loop.move:4:24
+  │
+4 │         loop { let y = move x + 1; x = 0; y; }
+  │                        ^^^^^^
+
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_loop.move:9:24
+  │
+9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
+  │                        ^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_loop.move:14:24
+   │
+14 │         loop { let y = &x; _ = move y; x = 0 }
+   │                        ^^
+
+error: use of unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_loop.move:19:24
+   │
+19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+   │                        ^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_loop.move:20:9
+   │
+20 │         x;
+   │         ^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun M::tborrow1() {
+     var $t0: u64
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4 }, after: { maybe: $t0, $t1, $t2, $t3, $t4 }
+  0: label L0
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4 }, after: { maybe: $t0, $t1, $t3, $t4 }
+  1: $t2 := borrow_local($t0)
+     # before: { maybe: $t0, $t1, $t3, $t4 }, after: { maybe: $t0, $t3, $t4 }
+  2: $t1 := infer($t2)
+     # before: { maybe: $t0, $t3, $t4 }, after: { maybe: $t0, $t4 }
+  3: $t3 := move($t1)
+     # before: { maybe: $t0, $t4 }, after: { maybe: $t0 }
+  4: $t4 := 0
+     # before: { maybe: $t0 }, after: all initialized
+  5: $t0 := infer($t4)
+     # before: all initialized, after: all initialized
+  6: goto 0
+  7: label L1
+  8: return ()
+}
+
+
+[variant baseline]
+fun M::tborrow2($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t1, $t2, $t3, $t4, $t5, $t6 }
+  0: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t1, $t2, $t4, $t5, $t6 }
+  1: $t3 := borrow_local($t1)
+     # before: { no: $t1, $t2, $t4, $t5, $t6 }, after: { no: $t1, $t4, $t5, $t6 }
+  2: $t2 := infer($t3)
+     # before: { no: $t1, $t4, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
+  3: $t4 := move($t2)
+     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
+  4: if ($t0) goto 5 else goto 9
+     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
+  5: label L2
+     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t6 }
+  6: $t5 := 0
+     # before: { no: $t1, $t6 }, after: { no: $t6 }
+  7: $t1 := infer($t5)
+     # before: { no: $t6 }, after: { no: $t6 }
+  8: goto 10
+     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
+  9: label L3
+     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
+ 10: label L4
+     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
+ 11: goto 13
+ 12: goto 0
+     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
+ 13: label L1
+     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
+ 14: $t6 := infer($t1)
+     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
+ 15: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+  0: label L0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t5, $t6 }
+  1: $t4 := 1
+     # before: { maybe: $t1, $t2, $t3, $t5, $t6 }, after: { maybe: $t1, $t2, $t5, $t6 }
+  2: $t3 := +($t1, $t4)
+     # before: { maybe: $t1, $t2, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  3: $t2 := infer($t3)
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  4: if ($t0) goto 5 else goto 8
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  5: label L2
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  6: goto 0
+  7: goto 9
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  8: label L3
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  9: label L4
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t6 }
+ 10: $t5 := 0
+     # before: { maybe: $t1, $t6 }, after: { maybe: $t6 }
+ 11: $t1 := infer($t5)
+     # before: { maybe: $t6 }, after: all initialized
+ 12: $t6 := infer($t2)
+     # before: all initialized, after: all initialized
+ 13: goto 0
+ 14: label L1
+ 15: return ()
+}
+
+
+[variant baseline]
+fun M::tmove() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }
+  0: label L0
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t4, $t5, $t6 }
+  1: $t3 := move($t0)
+     # before: { maybe: $t0, $t1, $t2, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t5, $t6 }
+  2: $t4 := 1
+     # before: { maybe: $t0, $t1, $t2, $t5, $t6 }, after: { maybe: $t0, $t1, $t5, $t6 }
+  3: $t2 := +($t3, $t4)
+     # before: { maybe: $t0, $t1, $t5, $t6 }, after: { maybe: $t0, $t5, $t6 }
+  4: $t1 := infer($t2)
+     # before: { maybe: $t0, $t5, $t6 }, after: { maybe: $t0, $t6 }
+  5: $t5 := 0
+     # before: { maybe: $t0, $t6 }, after: { maybe: $t6 }
+  6: $t0 := infer($t5)
+     # before: { maybe: $t6 }, after: all initialized
+  7: $t6 := infer($t1)
+     # before: all initialized, after: all initialized
+  8: goto 0
+  9: label L1
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_loop.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_loop.move
@@ -1,0 +1,23 @@
+module 0x8675309::M {
+    fun tmove() {
+        let x: u64;
+        loop { let y = move x + 1; x = 0; y; }
+    }
+
+    fun tcopy(cond: bool) {
+        let x: u64;
+        loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
+    }
+
+    fun tborrow1() {
+        let x: u64;
+        loop { let y = &x; _ = move y; x = 0 }
+    }
+
+    fun tborrow2(cond: bool) {
+        let x: u64;
+        loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+        x;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_simple.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_simple.exp
@@ -1,0 +1,145 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun M::tborrow() {
+     var $t0: u64
+     var $t1: &u64
+     var $t2: M::S
+     var $t3: &M::S
+     var $t4: &M::S
+  0: $t1 := borrow_local($t0)
+  1: $t4 := borrow_local($t2)
+  2: $t3 := infer($t4)
+  3: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: M::S
+     var $t4: M::S
+     var $t5: M::S
+  0: $t2 := 1
+  1: $t1 := +($t0, $t2)
+  2: $t5 := copy($t3)
+  3: $t4 := infer($t5)
+  4: return ()
+}
+
+
+[variant baseline]
+fun M::tmove() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: M::S
+     var $t5: M::S
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: $t5 := infer($t4)
+  4: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_simple.move:6:17
+  │
+6 │         let _ = move x + 1;
+  │                 ^^^^^^
+
+error: use of unassigned local `s`
+  ┌─ tests/uninit-use-checker/use_before_assign_simple.move:9:13
+  │
+9 │         let _s2 = s;
+  │             ^^^
+
+error: use of unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_simple.move:14:17
+   │
+14 │         let _ = x + 1;
+   │                 ^^^^^
+
+error: use of unassigned local `s`
+   ┌─ tests/uninit-use-checker/use_before_assign_simple.move:17:19
+   │
+17 │         let _s3 = copy s;
+   │                   ^^^^^^
+
+error: use of unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_simple.move:22:17
+   │
+22 │         let _ = &x;
+   │                 ^^
+
+error: use of unassigned local `s`
+   ┌─ tests/uninit-use-checker/use_before_assign_simple.move:25:19
+   │
+25 │         let _s2 = &s;
+   │                   ^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun M::tborrow() {
+     var $t0: u64
+     var $t1: &u64
+     var $t2: M::S
+     var $t3: &M::S
+     var $t4: &M::S
+     # before: { no: $t0, $t1, $t2, $t3, $t4 }, after: { no: $t0, $t2, $t3, $t4 }
+  0: $t1 := borrow_local($t0)
+     # before: { no: $t0, $t2, $t3, $t4 }, after: { no: $t0, $t2, $t3 }
+  1: $t4 := borrow_local($t2)
+     # before: { no: $t0, $t2, $t3 }, after: { no: $t0, $t2 }
+  2: $t3 := infer($t4)
+     # before: { no: $t0, $t2 }, after: { no: $t0, $t2 }
+  3: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: M::S
+     var $t4: M::S
+     var $t5: M::S
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t1, $t3, $t4, $t5 }
+  0: $t2 := 1
+     # before: { no: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4, $t5 }
+  1: $t1 := +($t0, $t2)
+     # before: { no: $t0, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4 }
+  2: $t5 := copy($t3)
+     # before: { no: $t0, $t3, $t4 }, after: { no: $t0, $t3 }
+  3: $t4 := infer($t5)
+     # before: { no: $t0, $t3 }, after: { no: $t0, $t3 }
+  4: return ()
+}
+
+
+[variant baseline]
+fun M::tmove() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: M::S
+     var $t5: M::S
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t1, $t3, $t4, $t5 }
+  0: $t2 := move($t0)
+     # before: { no: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t0, $t1, $t4, $t5 }
+  1: $t3 := 1
+     # before: { no: $t0, $t1, $t4, $t5 }, after: { no: $t0, $t4, $t5 }
+  2: $t1 := +($t2, $t3)
+     # before: { no: $t0, $t4, $t5 }, after: { no: $t0, $t4 }
+  3: $t5 := infer($t4)
+     # before: { no: $t0, $t4 }, after: { no: $t0, $t4 }
+  4: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_simple.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_simple.move
@@ -1,0 +1,28 @@
+module 0x8675309::M {
+    struct S has copy, drop {}
+
+    fun tmove() {
+        let x: u64;
+        let _ = move x + 1;
+
+        let s: S;
+        let _s2 = s;
+    }
+
+    fun tcopy() {
+        let x: u64;
+        let _ = x + 1;
+
+        let s: S;
+        let _s3 = copy s;
+    }
+
+    fun tborrow() {
+        let x: u64;
+        let _ = &x;
+
+        let s: S;
+        let _s2 = &s;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_while.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_while.exp
@@ -1,0 +1,339 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun M::tborrow1($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+  0: label L0
+  1: if ($t0) goto 2 else goto 9
+  2: label L2
+  3: $t3 := borrow_local($t1)
+  4: $t2 := infer($t3)
+  5: $t4 := move($t2)
+  6: $t5 := 0
+  7: $t1 := infer($t5)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 0
+ 13: label L1
+ 14: return ()
+}
+
+
+[variant baseline]
+fun M::tborrow2($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+  0: label L0
+  1: if ($t0) goto 2 else goto 15
+  2: label L2
+  3: $t3 := borrow_local($t1)
+  4: $t2 := infer($t3)
+  5: $t4 := move($t2)
+  6: if ($t0) goto 7 else goto 11
+  7: label L5
+  8: $t5 := 0
+  9: $t1 := infer($t5)
+ 10: goto 12
+ 11: label L6
+ 12: label L7
+ 13: goto 19
+ 14: goto 17
+ 15: label L3
+ 16: goto 19
+ 17: label L4
+ 18: goto 0
+ 19: label L1
+ 20: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: label L0
+  1: if ($t0) goto 2 else goto 17
+  2: label L2
+  3: $t4 := move($t1)
+  4: $t5 := 1
+  5: $t3 := +($t4, $t5)
+  6: $t2 := infer($t3)
+  7: if ($t0) goto 8 else goto 11
+  8: label L5
+  9: goto 0
+ 10: goto 12
+ 11: label L6
+ 12: label L7
+ 13: $t6 := 0
+ 14: $t1 := infer($t6)
+ 15: $t7 := infer($t2)
+ 16: goto 19
+ 17: label L3
+ 18: goto 21
+ 19: label L4
+ 20: goto 0
+ 21: label L1
+ 22: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: label L0
+  1: if ($t0) goto 2 else goto 11
+  2: label L2
+  3: $t4 := move($t1)
+  4: $t5 := 1
+  5: $t3 := +($t4, $t5)
+  6: $t2 := infer($t3)
+  7: $t6 := 0
+  8: $t1 := infer($t6)
+  9: $t7 := infer($t2)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 0
+ 15: label L1
+ 16: return ()
+}
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_while.move:4:32
+  │
+4 │         while (cond) { let y = move x + 1; x = 0; y; }
+  │                                ^^^^^^
+
+error: use of possibly unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_before_assign_while.move:9:32
+  │
+9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
+  │                                ^^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_while.move:14:32
+   │
+14 │         while (cond) { let y = &x; _ = move y; x = 0 }
+   │                                ^^
+
+error: use of unassigned local `x`
+   ┌─ tests/uninit-use-checker/use_before_assign_while.move:19:32
+   │
+19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+   │                                ^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun M::tborrow1($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+  0: label L0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+  1: if ($t0) goto 2 else goto 9
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+  2: label L2
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t4, $t5 }
+  3: $t3 := borrow_local($t1)
+     # before: { maybe: $t1, $t2, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  4: $t2 := infer($t3)
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t5 }
+  5: $t4 := move($t2)
+     # before: { maybe: $t1, $t5 }, after: { maybe: $t1 }
+  6: $t5 := 0
+     # before: { maybe: $t1 }, after: all initialized
+  7: $t1 := infer($t5)
+     # before: all initialized, after: all initialized
+  8: goto 11
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+  9: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+ 10: goto 13
+     # before: all initialized, after: all initialized
+ 11: label L4
+     # before: all initialized, after: all initialized
+ 12: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+ 13: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+ 14: return ()
+}
+
+
+[variant baseline]
+fun M::tborrow2($t0: bool) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  0: label L0
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  1: if ($t0) goto 2 else goto 15
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+  2: label L2
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t4, $t5 }
+  3: $t3 := borrow_local($t1)
+     # before: { no: $t1, $t2, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
+  4: $t2 := infer($t3)
+     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t5 }
+  5: $t4 := move($t2)
+     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
+  6: if ($t0) goto 7 else goto 11
+     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
+  7: label L5
+     # before: { no: $t1, $t5 }, after: { no: $t1 }
+  8: $t5 := 0
+     # before: { no: $t1 }, after: all initialized
+  9: $t1 := infer($t5)
+     # before: all initialized, after: all initialized
+ 10: goto 12
+     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
+ 11: label L6
+     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
+ 12: label L7
+     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
+ 13: goto 19
+ 14: goto 17
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+ 15: label L3
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+ 16: goto 19
+ 17: label L4
+ 18: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+ 19: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+ 20: return ()
+}
+
+
+[variant baseline]
+fun M::tcopy($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  0: label L0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  1: if ($t0) goto 2 else goto 17
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  2: label L2
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }
+  3: $t4 := move($t1)
+     # before: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t6, $t7 }
+  4: $t5 := 1
+     # before: { maybe: $t1, $t2, $t3, $t6, $t7 }, after: { maybe: $t1, $t2, $t6, $t7 }
+  5: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+  6: $t2 := infer($t3)
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+  7: if ($t0) goto 8 else goto 11
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+  8: label L5
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+  9: goto 0
+ 10: goto 12
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+ 11: label L6
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+ 12: label L7
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t7 }
+ 13: $t6 := 0
+     # before: { maybe: $t1, $t7 }, after: { maybe: $t7 }
+ 14: $t1 := infer($t6)
+     # before: { maybe: $t7 }, after: all initialized
+ 15: $t7 := infer($t2)
+     # before: all initialized, after: all initialized
+ 16: goto 19
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 17: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 18: goto 21
+     # before: all initialized, after: all initialized
+ 19: label L4
+     # before: all initialized, after: all initialized
+ 20: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 21: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 22: return ()
+}
+
+
+[variant baseline]
+fun M::tmove($t0: bool) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  0: label L0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  1: if ($t0) goto 2 else goto 11
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+  2: label L2
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }
+  3: $t4 := move($t1)
+     # before: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t6, $t7 }
+  4: $t5 := 1
+     # before: { maybe: $t1, $t2, $t3, $t6, $t7 }, after: { maybe: $t1, $t2, $t6, $t7 }
+  5: $t3 := +($t4, $t5)
+     # before: { maybe: $t1, $t2, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
+  6: $t2 := infer($t3)
+     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t7 }
+  7: $t6 := 0
+     # before: { maybe: $t1, $t7 }, after: { maybe: $t7 }
+  8: $t1 := infer($t6)
+     # before: { maybe: $t7 }, after: all initialized
+  9: $t7 := infer($t2)
+     # before: all initialized, after: all initialized
+ 10: goto 13
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 11: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 12: goto 15
+     # before: all initialized, after: all initialized
+ 13: label L4
+     # before: all initialized, after: all initialized
+ 14: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 15: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+ 16: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_while.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_before_assign_while.move
@@ -1,0 +1,22 @@
+module 0x8675309::M {
+    fun tmove(cond: bool) {
+        let x: u64;
+        while (cond) { let y = move x + 1; x = 0; y; }
+    }
+
+    fun tcopy(cond: bool) {
+        let x: u64;
+        while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
+    }
+
+    fun tborrow1(cond: bool) {
+        let x: u64;
+        while (cond) { let y = &x; _ = move y; x = 0 }
+    }
+
+    fun tborrow2(cond: bool) {
+        let x: u64;
+        while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.exp
@@ -1,0 +1,34 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+  0: $t2 := +($t0, $t0)
+  1: $t1 := infer($t2)
+  2: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/uninit-use-checker/use_twice_before_assign.move:4:13
+  │
+4 │     let y = x + x;
+  │             ^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
+  0: $t2 := +($t0, $t0)
+     # before: { no: $t0, $t1 }, after: { no: $t0 }
+  1: $t1 := infer($t2)
+     # before: { no: $t0 }, after: { no: $t0 }
+  2: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.move
@@ -1,0 +1,6 @@
+script {
+fun main() {
+    let x: u64;
+    let y = x + x;
+}
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.exp
@@ -1,0 +1,42 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := +($t0, $t1)
+  1: $t2 := infer($t3)
+  2: return ()
+}
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/uninit-use-checker/uses_before_assign.move:5:13
+  │
+5 │     let z = x + y;
+  │             ^^^^^
+
+error: use of unassigned local `y`
+  ┌─ tests/uninit-use-checker/uses_before_assign.move:5:13
+  │
+5 │     let z = x + y;
+  │             ^^^^^
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # before: { no: $t0, $t1, $t2, $t3 }, after: { no: $t0, $t1, $t2 }
+  0: $t3 := +($t0, $t1)
+     # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
+  1: $t2 := infer($t3)
+     # before: { no: $t0, $t1 }, after: { no: $t0, $t1 }
+  2: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.move
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.move
@@ -1,0 +1,7 @@
+script {
+fun main() {
+    let x: u64;
+    let y: u64;
+    let z = x + y;
+}
+}

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -409,6 +409,7 @@ pub enum Bytecode {
     Abort(AttrId, TempIndex),
     Nop(AttrId),
 
+    // Extended bytecode: spec-only.
     SaveMem(AttrId, MemoryLabel, QualifiedInstId<StructId>),
     SaveSpecVar(AttrId, MemoryLabel, QualifiedInstId<SpecVarId>),
     Prop(AttrId, PropKind, Exp),
@@ -482,6 +483,12 @@ impl Bytecode {
 
     pub fn is_branch(&self) -> bool {
         self.is_conditional_branch() || self.is_unconditional_branch()
+    }
+
+    /// Returns true if the bytecode is spec-only.
+    pub fn is_spec_only(&self) -> bool {
+        use Bytecode::*;
+        matches!(self, SaveMem(..) | SaveSpecVar(..) | Prop(..))
     }
 
     /// Return the sources of the instruction (for non-spec-only instructions).


### PR DESCRIPTION
### Description

This PR adds the "uninitialized use checker" for compiler v2, which checks and warns on the use of uninitialized locals. It is performed on the stackless bytecode. It performs initialization state analysis to do these checks. This is enabled in compiler v2 as long as safety checks are enabled (which they are, unless explicitly disabled).

#### Initialization state analysis

This analysis computes for each local at each reachable program point, is it:

- definitely initialized
- definitely not initialized
- maybe initialized

It is implemented as a "forwards may" analysis. These analysis results are used by "uninitialized use checker" to see if any uses of locals (in non spec-only code) are not "definitely initialized".

### Test Plan

- Ported uninitialized use check related tests from compiler v1 tests as well as added some new ones.
- All other tests run as before.
