### PR TITLE
[compiler-v2] Invalid friend declaration warnings

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_out_of_account_addr.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_out_of_account_addr.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: friend modules of `0x3::M` must have the same address, but the declared friend module `0x2::M` has a different address
+  ┌─ tests/checking/friends/friend_decl_out_of_account_addr.move:7:5
+  │
+7 │     friend 0x2::M;
+  │     ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_out_of_account_addr.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_out_of_account_addr.move
@@ -1,0 +1,9 @@
+address 0x2 {
+module M {}
+}
+
+address 0x3 {
+module M {
+    friend 0x2::M;
+}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: cannot declare module `0x42::M` as a friend of itself
+  ┌─ tests/checking/friends/friend_decl_self.move:3:5
+  │
+3 │     friend Self;
+  │     ^^^^^^^^^^^^
+
+error: cannot declare module `0x43::M` as a friend of itself
+  ┌─ tests/checking/friends/friend_decl_self.move:9:5
+  │
+9 │     friend 0x43::M;
+  │     ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self.move
@@ -1,0 +1,11 @@
+address 0x42 {
+module M {
+    friend Self;
+}
+}
+
+address 0x43 {
+module M {
+    friend 0x43::M;
+}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self_with_use.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self_with_use.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: cannot declare module `0xc0ffee::o` as a friend of itself
+  ┌─ tests/checking/friends/friend_decl_self_with_use.move:3:5
+  │
+3 │     friend o;
+  │     ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self_with_use.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_self_with_use.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::o {
+    use 0xc0ffee::o;
+    friend o;
+
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_unbound_module.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_unbound_module.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: unbound module `0x42::Nonexistent` in friend declaration
+  ┌─ tests/checking/friends/friend_decl_unbound_module.move:3:5
+  │
+3 │     friend 0x42::Nonexistent;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_unbound_module.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_decl_unbound_module.move
@@ -1,0 +1,5 @@
+address 0x42 {
+module M {
+    friend 0x42::Nonexistent;
+}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_different_addresses.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_different_addresses.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: friend modules of `0xc0ffee::m` must have the same address, but the declared friend module `0xdeadbeef::n` has a different address
+  ┌─ tests/checking/friends/friend_different_addresses.move:2:5
+  │
+2 │     friend 0xdeadbeef::n;
+  │     ^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/friends/friend_different_addresses.move
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/friend_different_addresses.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    friend 0xdeadbeef::n;
+    public fun test() {}
+}
+
+module 0xdeadbeef::n {
+    public fun test() {}
+}

--- a/third_party/move/move-model/src/lib.rs
+++ b/third_party/move/move-model/src/lib.rs
@@ -385,8 +385,36 @@ fn run_move_checker(env: &mut GlobalEnv, program: E::Program) {
         let module_def = expansion_script_to_module(script_def);
         module_translator.translate(loc, module_def, None);
     }
+    // Perform any remaining friend-declaration checks and update friend module id information.
+    check_and_update_friend_info(builder);
+    // Compute information derived from AST (currently callgraph)
+    for module in env.module_data.iter_mut() {
+        for fun_data in module.function_data.values_mut() {
+            fun_data.called_funs = Some(
+                fun_data
+                    .def
+                    .borrow()
+                    .clone()
+                    .map(|e| e.called_funs())
+                    .unwrap_or_default(),
+            )
+        }
+    }
+}
 
+/// Checks if any friend declarations are invalid because:
+///     - they are self-friend declarations
+///     - they are out-of-address friend declarations
+/// If so, report errors.
+/// Also, update friend module id information: this function assumes all modules have been assigned ids.
+///
+/// Note: we assume (a) friend declarations of unbound modules,
+///                 (b) friend declarations creating cyclic dependencies (cycle size > 1),
+///                 (c) duplicate friend declarations
+/// have been reported already. Currently, these checks happen in the expansion phase.
+fn check_and_update_friend_info(mut builder: ModelBuilder) {
     let module_table = std::mem::take(&mut builder.module_table);
+    let env = builder.env;
     // To save (loc, name) info about self friend decls.
     let mut self_friends = vec![];
     // To save (loc, friend_module_name, current_module_name) info about out-of-address friend decls.
@@ -395,6 +423,7 @@ fn run_move_checker(env: &mut GlobalEnv, program: E::Program) {
     for module in env.module_data.iter_mut() {
         let mut friend_modules = BTreeSet::new();
         for friend_decl in module.friend_decls.iter_mut() {
+            // Save information of out-of-address friend decls to report error later.
             if friend_decl.module_name.addr() != module.name.addr() {
                 out_of_address_friends.push((
                     friend_decl.loc.clone(),
@@ -418,7 +447,7 @@ fn run_move_checker(env: &mut GlobalEnv, program: E::Program) {
         env.error(
             &loc,
             &format!(
-                "cannot declare module '{}' as a friend of itself",
+                "cannot declare module `{}` as a friend of itself",
                 module_name.display_full(env)
             ),
         );
@@ -429,9 +458,9 @@ fn run_move_checker(env: &mut GlobalEnv, program: E::Program) {
             &loc,
             &format!(
                 "friend modules of `{}` must have the same address, \
-                    but declared friend module '{}' has different address than current module '{}'",
-                friend_mod_name.display_full(env),
+                    but the declared friend module `{}` has a different address",
                 cur_mod_name.display_full(env),
+                friend_mod_name.display_full(env),
             ),
         );
     }


### PR DESCRIPTION
### Description

This PR adds some missing checks in compiler v2 when it comes to friend declarations.

As per the move book (https://aptos.dev/move/book/friends#friend-declaration-rules), the following rules are applied when checking for correctly formed friend declarations:
- no self friend decls (check implemented in this PR, and in naming phase in v1)
- friending unbound module (checked in expansion phase already)
- friends should be within the same address (check implemented in this PR, and in naming phase in v1)
- no cyclic dependencies (checked in expansion phase already)
- duplicate friends (checked in expansion phase already)

### Test Plan
- Ported relevant tests from compiler v1
- Added a couple of new ones
- Remaining tests remain as is, without changes
