### PR TITLE
[Compiler-v2] Fix type checking issue due to name conflicts between built-in functions and local variables

### DIFF
--- a/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/DiemSystem.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/DiemSystem.move
@@ -522,10 +522,10 @@ module DiemFramework::DiemSystem {
         };
         let new_validator_config = ValidatorConfig::get_config(validator_info.addr);
         // check if information is the same
-        let config_ref = &mut validator_info.config;
-        if (config_ref == &new_validator_config) {
+        if (&validator_info.config == &new_validator_config) {
             return false
         };
+        let config_ref = &mut validator_info.config;
         *config_ref = new_validator_config;
         true
     }

--- a/third_party/move/documentation/examples/diem-framework/move-packages/core/sources/configs/DiemSystem.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/core/sources/configs/DiemSystem.move
@@ -282,10 +282,10 @@ module CoreFramework::DiemSystem {
         };
         let new_validator_config = ValidatorConfig::get_config(validator_info.addr);
         // check if information is the same
-        let config_ref = &mut validator_info.config;
-        if (config_ref == &new_validator_config) {
+        if (&validator_info.config == &new_validator_config) {
             return false
         };
+        let config_ref = &mut validator_info.config;
         *config_ref = new_validator_config;
         true
     }

--- a/third_party/move/documentation/examples/diem-framework/move-packages/experimental/sources/MultiToken.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/experimental/sources/MultiToken.move
@@ -160,7 +160,7 @@ module ExperimentalFramework::MultiToken {
         let len = vector::length(gallery);
         while ({spec {
             invariant i >= 0;
-            invariant i <= len(gallery);
+            invariant i <= ::len(gallery);
             invariant forall k in 0..i: gallery[k].token_id.id != id;
         };(i < len)}) {
             if (guid::eq_id(&vector::borrow(gallery, i).token_id, id)) {

--- a/third_party/move/documentation/examples/diem-framework/move-packages/experimental/sources/MultiTokenBalance.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/experimental/sources/MultiTokenBalance.move
@@ -100,7 +100,7 @@ module ExperimentalFramework::MultiTokenBalance {
         let len = vector::length(gallery);
         while ({spec {
             invariant i >= 0;
-            invariant i <= len(gallery);
+            invariant i <= ::len(gallery);
             invariant forall k in 0..i: gallery[k].id != id;
         };(i < len)}) {
             if (MultiToken::id<TokenType>(vector::borrow(gallery, i)) == *id) {

--- a/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.exp
@@ -1,0 +1,19 @@
+// ---- Model Dump
+module 0x42::m {
+    private fun f(gallery: &vector<u64>) {
+        {
+          let len: u64 = 5;
+          spec {
+            assert Ge(Len<u64>($t0), 0);
+          }
+          ;
+          Tuple()
+        }
+    }
+    spec fun $f(gallery: vector<u64>) {
+        {
+          let len: u256 = 5;
+          Tuple()
+        }
+    }
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+
+    fun f(gallery: &vector<u64>) {
+        let len = 5;
+        spec {
+            assert len(gallery) >= 0;
+        };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/len_same_fun_name_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/len_same_fun_name_err.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: invalid call of `m::len`: argument count mismatch (expected 0 but found 1)
+   ┌─ tests/checking/specs/len_same_fun_name_err.move:10:20
+   │
+10 │             assert len(gallery) >= 0; // err is raised here because the built-in one is shadowed.
+   │                    ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/specs/len_same_fun_name_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/len_same_fun_name_err.move
@@ -1,0 +1,14 @@
+module 0x42::m {
+
+    fun len(): bool {
+        true
+    }
+
+    fun f(gallery: &vector<u64>) {
+        let len = 5;
+        spec {
+            assert len(gallery) >= 0; // err is raised here because the built-in one is shadowed.
+            assert len();
+        };
+    }
+}

--- a/third_party/move/move-compiler/tests/move_check/typing/len_err.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/len_err.exp
@@ -1,0 +1,8 @@
+error[E02010]: invalid name
+  ┌─ tests/move_check/typing/len_err.move:5:9
+  │  
+5 │ ╭         spec {
+6 │ │             assert len(gallery) >= len;
+7 │ │         };
+  │ ╰─────────^ Conflicting name 'len' is used as both a variable and a function pointer (including built-in functions) in spec
+

--- a/third_party/move/move-compiler/tests/move_check/typing/len_err.move
+++ b/third_party/move/move-compiler/tests/move_check/typing/len_err.move
@@ -1,0 +1,10 @@
+module 0x42::m {
+
+    fun f_err(gallery: &vector<u64>) {
+        let len = 5;
+        spec {
+            assert len(gallery) >= len;
+        };
+    }
+
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1943,6 +1943,15 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 if n.value.as_str() == "update_field" {
                     return Some(self.translate_update_field(expected_type, loc, generics, args));
                 }
+                let builtin_module = self.parent.parent.builtin_module();
+                let full_name = QualifiedSymbol {
+                    module_name: builtin_module,
+                    symbol: self.symbol_pool().make(&n.value),
+                };
+                // For other built-in functions, type check is performed in translate_call
+                if self.parent.parent.spec_fun_table.get(&full_name).is_some() {
+                    return None;
+                }
             }
         }
         if let EA::ModuleAccess_::Name(n) = &maccess.value {


### PR DESCRIPTION
### Description

This PR closes #11737 by returning none in `translate_fun_call_special_cases` in the spec mode when the function call is a built-in function such that no type checking will be performed between the function and a local variable with the same name.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

1) Existing tests pass;
2) Add three unit tests to show the behavior of name conflict in different cases and validate the fix;
3) Compilation of DPN will not show the error in #11737.
