### PR TITLE
[comparison-testing-tool] Allow specifying target address when dumping the txn data

### DIFF
--- a/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
@@ -45,6 +45,7 @@ impl DataCollection {
         skip_publish_txns: bool,
         dump_write_set: bool,
         skip_source_code: bool,
+        target_account: Option<AccountAddress>,
     ) -> Self {
         Self {
             debugger,
@@ -55,6 +56,7 @@ impl DataCollection {
                 skip_failed_txns,
                 skip_publish_txns,
                 check_source_code: !skip_source_code,
+                target_account,
             },
         }
     }
@@ -67,6 +69,7 @@ impl DataCollection {
         skip_publish_txns: bool,
         dump_write_set: bool,
         skip_source_code: bool,
+        target_account: Option<AccountAddress>,
     ) -> Result<Self> {
         Ok(Self::new(
             Arc::new(RestDebuggerInterface::new(rest_client)),
@@ -76,6 +79,7 @@ impl DataCollection {
             skip_publish_txns,
             dump_write_set,
             skip_source_code,
+            target_account,
         ))
     }
 

--- a/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
@@ -374,7 +374,7 @@ fn generate_compiled_blob(
     if compiled_blobs.contains_key(package_info) {
         return;
     }
-    let root_modules = compiled_package.all_modules();
+    let root_modules = &compiled_package.root_compiled_units;
     let mut blob_map = HashMap::new();
     for compiled_module in root_modules {
         if let CompiledUnitEnum::Module(module) = &compiled_module.unit {

--- a/aptos-move/aptos-e2e-comparison-testing/src/main.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/main.rs
@@ -7,6 +7,7 @@ use aptos_comparison_testing::{
 };
 use aptos_rest_client::Client;
 use clap::{Parser, Subcommand};
+use move_core_types::account_address::AccountAddress;
 use std::path::PathBuf;
 use url::Url;
 
@@ -35,6 +36,9 @@ pub enum Cmd {
         /// Dump the write set of txns
         #[clap(long, default_value_t = false)]
         dump_write_set: bool,
+        /// Target account
+        #[clap(long)]
+        target_account: Option<AccountAddress>,
     },
     /// Execution of txns
     Execute {
@@ -72,6 +76,7 @@ async fn main() -> Result<()> {
             skip_publish_txns,
             skip_source_code_check: skip_source_code,
             dump_write_set,
+            target_account,
         } => {
             let batch_size = BATCH_SIZE;
             let output = if let Some(path) = output_path {
@@ -93,6 +98,7 @@ async fn main() -> Result<()> {
                 skip_publish_txns,
                 dump_write_set,
                 skip_source_code,
+                target_account,
             )?;
             data_collector
                 .dump_data(args.begin_version, args.limit)

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -34,6 +34,7 @@ pub struct FilterCondition {
     pub skip_failed_txns: bool,
     pub skip_publish_txns: bool,
     pub check_source_code: bool,
+    pub target_account: Option<AccountAddress>,
 }
 
 // TODO(skedia) Clean up this interfact to remove account specific logic and move to state store

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -298,6 +298,11 @@ impl AptosValidatorInterface for RestDebuggerInterface {
                 if let Some(entry_function) = extract_entry_fun(payload) {
                     let m = entry_function.module();
                     let addr = m.address();
+                    if filter_condition.target_account.is_some()
+                        && filter_condition.target_account.unwrap() != *addr
+                    {
+                        continue;
+                    }
                     if filter_condition.skip_publish_txns
                         && entry_function.function().as_str() == "publish_package_txn"
                     {


### PR DESCRIPTION
### Description

This PR adds a new flag `--target-account <account-address>` to the comparison testing tool such that it can dump txns with a specific target account.

usage:

`cargo run --begin-version <BEGIN_VERSION> --limit <LIMIT> dump --target-account <account-address> ... `