### PR TITLE
[minor] Removing profile causing build warnings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -108,4 +108,7 @@
 # Owners for the `/terraform` directory and all its subdirectories.
 /terraform/ @aptos-labs/prod-eng
 
+# Owners for the `aptos-dkg` crate.
+/crates/aptos-dkg @alinush
+
 /types/src/transaction/authenticator.rs @alinush

--- a/crates/aptos-dkg/Cargo.toml
+++ b/crates/aptos-dkg/Cargo.toml
@@ -48,6 +48,3 @@ harness = false
 [[bench]]
 name = "lagrange"
 harness = false
-
-[profile.bench]
-debug = true    # for running cargo flamegraph on benchmarks


### PR DESCRIPTION
### Description

Removing a profile causing the warning: `profiles for the non root package will be ignored, specify profiles at the workspace root` when building the crate `aptos-dkg`. Also updating code owners on @alinush's request. 

### Test Plan
N/A