### PR TITLE
Properly pin buf proto gen tools for TS

### DIFF
--- a/protos/buf.ts.gen.yaml
+++ b/protos/buf.ts.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - plugin: buf.build/community/stephenh-ts-proto
+  - plugin: buf.build/community/stephenh-ts-proto:v1.167.9
     out: typescript/src
     opt:
       # See an explanation of these options here:

--- a/protos/scripts/install_deps.sh
+++ b/protos/scripts/install_deps.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 # This assumes that cargo, pnpm, poetry, buf, and protoc are already installed.
+# The TS plugins are pulled automatically since we depend on them directly from
+# the buf.build community plugin registry.
 
 # For generating Rust code
 cargo install --version 0.2.3 protoc-gen-prost
@@ -8,10 +10,6 @@ cargo install --version 0.2.3 protoc-gen-prost-serde
 cargo install --version 0.3.1 protoc-gen-prost-crate
 cargo install --version 0.3.0 protoc-gen-tonic
 
-# For generating TS code
-pnpm install -g protoc-gen-ts@0.8.7
-
 # For generating Python code
 cd python
 poetry install
-


### PR DESCRIPTION
### Description
This properly pins the tooling so the generated code doesn't drift unintentionally.

### Test Plan
I ran the generator myself and nothing changed. CI will confirm.