### PR TITLE
[cherry-pick] [API] [PFNs] improve observability of view function and simulate usage #11696

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "hyper",
  "itertools 0.10.5",
  "mime",
+ "mini-moka",
  "move-core-types",
  "move-package",
  "num_cpus",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -40,6 +40,7 @@ hex = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
 mime = { workspace = true }
+mini-moka = { workspace = true }
 move-core-types = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    metrics,
     response::{
         bcs_api_disabled, block_not_found_by_height, block_not_found_by_version,
         block_pruned_by_height, json_api_disabled, version_not_found, version_pruned,
@@ -18,7 +19,7 @@ use aptos_api_types::{
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
 use aptos_gas_schedule::{AptosGasParameters, FromOnChainGasSchedule};
-use aptos_logger::{error, warn};
+use aptos_logger::{error, info, warn, Schema};
 use aptos_mempool::{MempoolClientRequest, MempoolClientSender, SubmissionStatus};
 use aptos_state_view::TStateView;
 use aptos_storage_interface::{
@@ -45,15 +46,22 @@ use aptos_types::{
 use aptos_utils::aptos_try;
 use aptos_vm::data_cache::AsMoveResolver;
 use futures::{channel::oneshot, SinkExt};
+use mini_moka::sync::Cache;
 use move_core_types::{
+    identifier::Identifier,
     language_storage::{ModuleId, StructTag},
     move_resource::MoveResource,
     resolver::ModuleResolver,
 };
+use serde::Serialize;
 use std::{
+    cmp::Reverse,
     collections::{BTreeMap, HashMap},
     ops::{Bound::Included, Deref},
-    sync::{Arc, RwLock, RwLockWriteGuard},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock, RwLockWriteGuard,
+    },
     time::Instant,
 };
 
@@ -67,6 +75,8 @@ pub struct Context {
     gas_schedule_cache: Arc<RwLock<GasScheduleCache>>,
     gas_estimation_cache: Arc<RwLock<GasEstimationCache>>,
     gas_limit_cache: Arc<RwLock<GasLimitCache>>,
+    view_function_stats: Arc<FunctionStats>,
+    simulate_txn_stats: Arc<FunctionStats>,
 }
 
 impl std::fmt::Debug for Context {
@@ -82,6 +92,19 @@ impl Context {
         mp_sender: MempoolClientSender,
         node_config: NodeConfig,
     ) -> Self {
+        let (view_function_stats, simulate_txn_stats) = {
+            let log_per_call_stats = node_config.api.periodic_function_stats_sec.is_some();
+            (
+                Arc::new(FunctionStats::new(
+                    FunctionType::ViewFuntion,
+                    log_per_call_stats,
+                )),
+                Arc::new(FunctionStats::new(
+                    FunctionType::TxnSimulation,
+                    log_per_call_stats,
+                )),
+            )
+        };
         Self {
             chain_id,
             db,
@@ -102,6 +125,8 @@ impl Context {
                 block_executor_onchain_config: OnChainExecutionConfig::default_if_missing()
                     .block_executor_onchain_config(),
             })),
+            view_function_stats,
+            simulate_txn_stats,
         }
     }
 
@@ -1292,6 +1317,14 @@ impl Context {
             .min_inclusion_prices
             .len()
     }
+
+    pub fn view_function_stats(&self) -> &FunctionStats {
+        &self.view_function_stats
+    }
+
+    pub fn simulate_txn_stats(&self) -> &FunctionStats {
+        &self.simulate_txn_stats
+    }
 }
 
 pub struct GasScheduleCache {
@@ -1323,4 +1356,119 @@ where
     tokio::task::spawn_blocking(func)
         .await
         .map_err(|err| E::internal_with_code_no_info(err, AptosErrorCode::InternalError))?
+}
+
+#[derive(Schema)]
+pub struct LogSchema {
+    event: LogEvent,
+}
+
+impl LogSchema {
+    pub fn new(event: LogEvent) -> Self {
+        Self { event }
+    }
+}
+
+#[derive(Serialize, Copy, Clone)]
+pub enum LogEvent {
+    ViewFunction,
+    TxnSimulation,
+}
+
+pub enum FunctionType {
+    ViewFuntion,
+    TxnSimulation,
+}
+
+impl FunctionType {
+    fn log_event(&self) -> LogEvent {
+        match self {
+            FunctionType::ViewFuntion => LogEvent::ViewFunction,
+            FunctionType::TxnSimulation => LogEvent::TxnSimulation,
+        }
+    }
+
+    fn operation_id(&self) -> &'static str {
+        match self {
+            FunctionType::ViewFuntion => "view_function",
+            FunctionType::TxnSimulation => "txn_simulation",
+        }
+    }
+}
+
+pub struct FunctionStats {
+    stats: Option<Cache<String, (Arc<AtomicU64>, Arc<AtomicU64>)>>,
+    log_event: LogEvent,
+    operation_id: String,
+}
+
+impl FunctionStats {
+    fn new(function_type: FunctionType, log_per_call_stats: bool) -> Self {
+        let stats = if log_per_call_stats {
+            Some(Cache::new(100))
+        } else {
+            None
+        };
+        FunctionStats {
+            stats,
+            log_event: function_type.log_event(),
+            operation_id: function_type.operation_id().to_string(),
+        }
+    }
+
+    pub fn function_to_key(module: &ModuleId, function: &Identifier) -> String {
+        format!("{}::{}", module, function)
+    }
+
+    pub fn increment(&self, key: String, gas: u64) {
+        metrics::GAS_USED
+            .with_label_values(&[&self.operation_id])
+            .observe(gas as f64);
+        if let Some(stats) = &self.stats {
+            let (prev_gas, prev_count) = stats.get(&key).unwrap_or_else(|| {
+                // Note, race can occur on inserting new entry, resulting in some lost data, but it should be fine
+                let new_gas = Arc::new(AtomicU64::new(0));
+                let new_count = Arc::new(AtomicU64::new(0));
+                stats.insert(key.clone(), (new_gas.clone(), new_count.clone()));
+                (new_gas, new_count)
+            });
+            prev_gas.fetch_add(gas, Ordering::Relaxed);
+            prev_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn log_and_clear(&self) {
+        if let Some(stats) = &self.stats {
+            if stats.iter().next().is_none() {
+                return;
+            }
+
+            let mut sorted: Vec<_> = stats
+                .iter()
+                .map(|entry| {
+                    let (gas_used, count) = entry.value();
+                    (
+                        gas_used.load(Ordering::Relaxed),
+                        count.load(Ordering::Relaxed),
+                        entry.key().clone(),
+                    )
+                })
+                .collect();
+            sorted.sort_by_key(|(gas_used, ..)| Reverse(*gas_used));
+
+            info!(
+                LogSchema::new(self.log_event),
+                top_1 = sorted.get(0),
+                top_2 = sorted.get(1),
+                top_3 = sorted.get(2),
+                top_4 = sorted.get(3),
+                top_5 = sorted.get(4),
+                top_6 = sorted.get(5),
+                top_7 = sorted.get(6),
+                top_8 = sorted.get(7),
+            );
+
+            stats.invalidate_all();
+        }
+    }
 }

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -77,3 +77,13 @@ pub static GAS_ESTIMATE: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static GAS_USED: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_api_gas_used",
+        "Amount of gas used by each API operation",
+        &["operation_id"],
+        BYTE_BUCKETS.clone()
+    )
+    .unwrap()
+});

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -51,7 +51,7 @@ use aptos_types::{
             UserTransaction,
         },
         TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
-        WriteSetPayload,
+        ViewFunctionOutput, WriteSetPayload,
     },
     validator_txn::ValidatorTransaction,
     vm_status::{AbortLocation, StatusCode, VMStatus},
@@ -1801,26 +1801,71 @@ impl AptosVM {
         type_args: Vec<TypeTag>,
         arguments: Vec<Vec<u8>>,
         gas_budget: u64,
-    ) -> Result<Vec<Vec<u8>>> {
+    ) -> ViewFunctionOutput {
         let resolver = state_view.as_move_resolver();
         let vm = AptosVM::new(&resolver);
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
-        let mut gas_meter =
-            MemoryTrackedGasMeter::new(StandardGasMeter::new(StandardGasAlgebra::new(
-                vm.gas_feature_version,
-                get_or_vm_startup_failure(&vm.gas_params, &log_context)?
-                    .vm
-                    .clone(),
-                get_or_vm_startup_failure(&vm.storage_gas_params, &log_context)?.clone(),
-                gas_budget,
-            )));
+        let mut gas_meter = match Self::memory_tracked_gas_meter(&vm, &log_context, gas_budget) {
+            Ok(gas_meter) => gas_meter,
+            Err(e) => return ViewFunctionOutput::new(Err(e), 0),
+        };
 
         let mut session = vm.new_session(&resolver, SessionId::Void);
+        match Self::execute_view_function_in_vm(
+            &mut session,
+            &vm,
+            module_id,
+            func_name,
+            type_args,
+            arguments,
+            &mut gas_meter,
+        ) {
+            Ok(result) => {
+                ViewFunctionOutput::new(Ok(result), Self::gas_used(gas_budget, &gas_meter))
+            },
+            Err(e) => ViewFunctionOutput::new(Err(e), Self::gas_used(gas_budget, &gas_meter)),
+        }
+    }
 
+    fn memory_tracked_gas_meter(
+        vm: &AptosVM,
+        log_context: &AdapterLogSchema,
+        gas_budget: u64,
+    ) -> Result<MemoryTrackedGasMeter<StandardGasMeter<StandardGasAlgebra>>> {
+        let gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(StandardGasAlgebra::new(
+            vm.gas_feature_version,
+            get_or_vm_startup_failure(&vm.gas_params, log_context)?
+                .vm
+                .clone(),
+            get_or_vm_startup_failure(&vm.storage_gas_params, log_context)?.clone(),
+            gas_budget,
+        )));
+        Ok(gas_meter)
+    }
+
+    fn gas_used(
+        gas_budget: u64,
+        gas_meter: &MemoryTrackedGasMeter<StandardGasMeter<StandardGasAlgebra>>,
+    ) -> u64 {
+        GasQuantity::new(gas_budget)
+            .checked_sub(gas_meter.balance())
+            .expect("Balance should always be less than or equal to max gas amount")
+            .into()
+    }
+
+    fn execute_view_function_in_vm(
+        session: &mut SessionExt,
+        vm: &AptosVM,
+        module_id: ModuleId,
+        func_name: Identifier,
+        type_args: Vec<TypeTag>,
+        arguments: Vec<Vec<u8>>,
+        gas_meter: &mut MemoryTrackedGasMeter<StandardGasMeter<StandardGasAlgebra>>,
+    ) -> Result<Vec<Vec<u8>>> {
         let func_inst = session.load_function(&module_id, &func_name, &type_args)?;
         let metadata = vm.extract_module_metadata(&module_id);
         let arguments = verifier::view_function::validate_view_function(
-            &mut session,
+            session,
             arguments,
             func_name.as_ident_str(),
             &func_inst,
@@ -1834,7 +1879,7 @@ impl AptosVM {
                 func_name.as_ident_str(),
                 type_args,
                 arguments,
-                &mut gas_meter,
+                gas_meter,
             )
             .map_err(|err| anyhow!("Failed to execute function: {:?}", err))?
             .return_values

--- a/aptos-move/e2e-move-tests/src/aptos_governance.rs
+++ b/aptos-move/e2e-move-tests/src/aptos_governance.rs
@@ -78,6 +78,7 @@ pub fn get_remaining_voting_power(
             bcs::to_bytes(&stake_pool).unwrap(),
             bcs::to_bytes(&proposal_id).unwrap(),
         ])
+        .values
         .unwrap();
     bcs::from_bytes::<u64>(&res[0]).unwrap()
 }

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{assert_success, build_package, AptosPackageHooks};
-use anyhow::Error;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_framework::{natives::code::PackageMetadata, BuildOptions, BuiltPackage};
@@ -27,7 +26,7 @@ use aptos_types::{
     },
     transaction::{
         EntryFunction, Script, SignedTransaction, TransactionArgument, TransactionOutput,
-        TransactionPayload, TransactionStatus,
+        TransactionPayload, TransactionStatus, ViewFunctionOutput,
     },
 };
 use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
@@ -722,7 +721,7 @@ impl MoveHarness {
         fun: MemberId,
         type_args: Vec<TypeTag>,
         arguments: Vec<Vec<u8>>,
-    ) -> Result<Vec<Vec<u8>>, Error> {
+    ) -> ViewFunctionOutput {
         self.executor
             .execute_view_function(fun.module_id, fun.member_id, type_args, arguments)
     }

--- a/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/constructor_args.rs
@@ -85,8 +85,12 @@ fn success_generic_view(
 
     for (entry, args, expected) in tests {
         let res = h.execute_view_function(str::parse(entry).unwrap(), ty_args.clone(), args);
-        assert!(res.is_ok(), "{}", res.err().unwrap().to_string());
-        let bcs = res.unwrap().pop().unwrap();
+        assert!(
+            res.values.is_ok(),
+            "{}",
+            res.values.err().unwrap().to_string()
+        );
+        let bcs = res.values.unwrap().pop().unwrap();
         let res = bcs::from_bytes::<String>(&bcs).unwrap();
         assert_eq!(res, expected);
     }

--- a/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
@@ -49,6 +49,7 @@ fn test_basic_fungible_token() {
             vec![],
             vec![],
         )
+        .values
         .unwrap()
         .pop()
         .unwrap();

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     golden_outputs::GoldenOutputs,
 };
-use anyhow::Error;
 use aptos_abstract_gas_usage::CalibrationAlgebra;
 use aptos_bitvec::BitVec;
 use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
@@ -50,6 +49,7 @@ use aptos_types::{
         },
         BlockOutput, EntryFunction, ExecutionStatus, SignedTransaction, Transaction,
         TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
+        ViewFunctionOutput,
     },
     vm_status::VMStatus,
     write_set::WriteSet,
@@ -1096,7 +1096,7 @@ impl FakeExecutor {
         func_name: Identifier,
         type_args: Vec<TypeTag>,
         arguments: Vec<Vec<u8>>,
-    ) -> Result<Vec<Vec<u8>>, Error> {
+    ) -> ViewFunctionOutput {
         // No gas limit
         AptosVM::execute_view_function(
             self.get_state_view(),

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -79,6 +79,8 @@ pub struct ApiConfig {
     pub simulation_filter: Filter,
     /// Configuration to filter view function requests.
     pub view_filter: ViewFilter,
+    /// Periodically log stats for view function and simulate transaction usage
+    pub periodic_function_stats_sec: Option<u64>,
 }
 
 const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -126,6 +128,7 @@ impl Default for ApiConfig {
             periodic_gas_estimation_ms: Some(30_000),
             simulation_filter: Filter::default(),
             view_filter: ViewFilter::default(),
+            periodic_function_stats_sec: Some(60),
         }
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1917,3 +1917,14 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
     /// Size of the user transaction in bytes, 0 otherwise
     fn user_txn_bytes_len(&self) -> usize;
 }
+
+pub struct ViewFunctionOutput {
+    pub values: Result<Vec<Vec<u8>>>,
+    pub gas_used: u64,
+}
+
+impl ViewFunctionOutput {
+    pub fn new(values: Result<Vec<Vec<u8>>>, gas_used: u64) -> Self {
+        Self { values, gas_used }
+    }
+}


### PR DESCRIPTION
### Description

On PFNs, periodically (every minute) log the top-9 gas-using view functions and simulate transactions. This gives observability to the PFNs usage.

Utilizes a small cache that is reset every minute. Alternatively, such high-cardinality data would not work with prometheus.

Requires minimal changes to propagate gas usage.

### Test Plan

Deploy PFN locally, observe log messages.
