### PR TITLE
[table info][2/4] add utils for table info backup and restore and redesign the db read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,13 +2329,18 @@ dependencies = [
  "bytes",
  "chrono",
  "fail 0.5.1",
+ "flate2",
  "futures",
+ "google-cloud-storage",
  "hex",
  "hyper",
  "move-resource-viewer",
  "once_cell",
+ "rocksdb",
  "serde",
  "serde_json",
+ "tar",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -7812,6 +7817,18 @@ name = "file_diff"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "findshlibs"
@@ -15245,6 +15262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17117,6 +17145,17 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.12",
+ "rustix 0.38.28",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.10",
  "tonic 0.10.2",
  "tonic-reflection",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -674,6 +674,7 @@ strum = "0.24.1"
 strum_macros = "0.24.2"
 syn = { version = "1.0.92", features = ["derive", "extra-traits"] }
 sysinfo = "0.28.4"
+tar = "0.4.40"
 tempfile = "3.3.0"
 termcolor = "1.1.2"
 test-case = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -674,7 +674,6 @@ strum = "0.24.1"
 strum_macros = "0.24.2"
 syn = { version = "1.0.92", features = ["derive", "extra-traits"] }
 sysinfo = "0.28.4"
-tar = "0.4.40"
 tempfile = "3.3.0"
 termcolor = "1.1.2"
 test-case = "3.1.0"

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -429,7 +429,7 @@ impl<'a, R: ModuleResolver + ?Sized> MoveConverter<'a, R> {
                     "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
-                return Ok(None); // if table item not found return None anyway to avoid crash
+                return Ok(None);
             },
         };
 
@@ -456,7 +456,7 @@ impl<'a, R: ModuleResolver + ?Sized> MoveConverter<'a, R> {
                     "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
-                return Ok(None); // if table item not found return None anyway to avoid crash
+                return Ok(None);
             },
         };
 

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -429,7 +429,7 @@ impl<'a, R: ModuleResolver + ?Sized> MoveConverter<'a, R> {
                     "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
-                return Ok(None);
+                return Ok(None); // if table item not found return None anyway to avoid crash
             },
         };
 
@@ -456,7 +456,7 @@ impl<'a, R: ModuleResolver + ?Sized> MoveConverter<'a, R> {
                     "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
-                return Ok(None);
+                return Ok(None); // if table item not found return None anyway to avoid crash
             },
         };
 

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = { workspace = true }
 tar = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-reflection = { workspace = true }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/Cargo.toml
@@ -18,13 +18,16 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 fail = { workspace = true }
+flate2 = { workspace = true }
 futures = { workspace = true }
+google-cloud-storage = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
 move-resource-viewer = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tar = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
@@ -46,6 +49,10 @@ aptos-runtimes = { workspace = true }
 aptos-schemadb  = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
+
+[dev-dependencies]
+rocksdb = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 failpoints = ["fail/failpoints"]

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
@@ -1,0 +1,257 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use std::{
+    fs,
+    fs::File,
+    io::{BufWriter, Error, Write},
+    path::PathBuf,
+};
+use tar::{Archive, Builder};
+
+pub fn rename_db_folders_and_cleanup(
+    original_db_path: &PathBuf,
+    temp_old_db_path: &PathBuf,
+    restored_db_path: &PathBuf,
+) -> Result<(), Error> {
+    // Rename the original DB path to a temporary old DB path
+    fs::rename(original_db_path, temp_old_db_path).map_err(|e| {
+        Error::new(
+            e.kind(),
+            format!(
+                "Failed to rename original DB folder from {:?} to {:?}: {}",
+                original_db_path, temp_old_db_path, e
+            ),
+        )
+    })?;
+
+    // Rename the restored DB path to the original DB path
+    fs::rename(restored_db_path, original_db_path).map_err(|e| {
+        Error::new(
+            e.kind(),
+            format!(
+                "Failed to rename restored DB folder from {:?} to {:?}: {}",
+                restored_db_path, original_db_path, e
+            ),
+        )
+    })?;
+
+    // Remove the temporary old DB folder
+    fs::remove_dir_all(temp_old_db_path).map_err(|e| {
+        Error::new(
+            e.kind(),
+            format!(
+                "Failed to remove old DB folder {:?}: {}",
+                temp_old_db_path, e
+            ),
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Creates a tar.gz archive from the db snapshot directory
+pub fn create_tar_gz(
+    dir_path: PathBuf,
+    backup_file_name: &str,
+) -> Result<(PathBuf, String), anyhow::Error> {
+    let tar_file_name = format!("{}.tar.gz", backup_file_name);
+    let tar_file_path = dir_path.join(&tar_file_name);
+    let temp_tar_file_path = dir_path.join(format!("{}.tmp", tar_file_name));
+
+    let tar_file = File::create(&temp_tar_file_path)?;
+    let gz_encoder = GzEncoder::new(tar_file, Compression::default());
+    let tar_data = BufWriter::new(gz_encoder);
+    let mut tar_builder = Builder::new(tar_data);
+
+    tar_builder.append_dir_all(".", &dir_path)?;
+    tar_builder.into_inner()?;
+
+    std::fs::rename(&temp_tar_file_path, &tar_file_path)?;
+
+    Ok((tar_file_path, tar_file_name))
+}
+
+pub fn write_snapshot_to_file(snapshot: &[u8], target_path: &PathBuf) -> anyhow::Result<()> {
+    let temp_file_path = target_path.with_extension("tmp");
+    let mut temp_file = File::create(&temp_file_path)?;
+    temp_file.write_all(snapshot)?;
+    temp_file.sync_all()?; // Ensure all data is written to disk
+    fs::rename(&temp_file_path, target_path)?; // Atomically move the temp file to the target path
+    Ok(())
+}
+
+/// Unpack a tar.gz archive to a specified directory
+pub fn unpack_tar_gz(temp_file_path: &PathBuf, target_db_path: &PathBuf) -> anyhow::Result<()> {
+    let temp_dir_path = target_db_path.with_extension("tmp");
+    fs::create_dir(&temp_dir_path)?;
+
+    let file = File::open(temp_file_path)?;
+    let gz_decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(gz_decoder);
+    archive.unpack(&temp_dir_path)?;
+
+    fs::remove_dir_all(target_db_path).unwrap_or(());
+    fs::rename(&temp_dir_path, target_db_path)?; // Atomically replace the directory
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocksdb::{
+        ColumnFamilyDescriptor, DBWithThreadMode, IteratorMode, Options, SingleThreaded, DB,
+    };
+    use std::{
+        fs::File,
+        io::{Read, Write},
+    };
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_rename_db_folders_and_cleanup() {
+        // Create temporary directories to simulate the original, temp old, and restored DB paths
+        let original_db_dir = tempdir().unwrap();
+        let temp_old_db_dir = tempdir().unwrap();
+        let restored_db_dir = tempdir().unwrap();
+
+        // Create a mock file in each directory to simulate DB contents
+        File::create(original_db_dir.path().join("original_db_file")).unwrap();
+        File::create(restored_db_dir.path().join("restored_db_file")).unwrap();
+
+        // Call the function with the paths
+        let result = rename_db_folders_and_cleanup(
+            &original_db_dir.path().to_path_buf(),
+            &temp_old_db_dir.path().to_path_buf(),
+            &restored_db_dir.path().to_path_buf(),
+        );
+
+        // Check if the function executed successfully
+        assert!(result.is_ok());
+
+        // Check if the original DB directory now contains the restored DB file
+        assert!(original_db_dir.path().join("restored_db_file").exists());
+
+        // Check if the temp old DB directory has been removed
+        assert!(!temp_old_db_dir.path().exists());
+    }
+
+    #[test]
+    fn test_create_unpack_tar_gz_and_preserves_content() -> anyhow::Result<()> {
+        // Create a temporary directory and a file within it
+        let dir_to_compress = tempdir()?;
+        let file_path = dir_to_compress.path().join("testfile.txt");
+        let test_content = "Sample content";
+        let mut file = File::create(file_path)?;
+        writeln!(file, "{}", test_content)?;
+
+        // Create a tar.gz file from the directory
+        let (tar_gz_path, _) = create_tar_gz(dir_to_compress.path().to_path_buf(), "testbackup")?;
+        assert!(tar_gz_path.exists());
+
+        // Create a new temporary directory to unpack the tar.gz file
+        let unpack_dir = tempdir()?;
+        unpack_tar_gz(&tar_gz_path, &unpack_dir.path().to_path_buf())?;
+
+        // Verify the file is correctly unpacked
+        let unpacked_file_path = unpack_dir.path().join("testfile.txt");
+        assert!(unpacked_file_path.exists());
+
+        // Read content from the unpacked file
+        let mut unpacked_file = File::open(unpacked_file_path)?;
+        let mut unpacked_content = String::new();
+        unpacked_file.read_to_string(&mut unpacked_content)?;
+
+        // Assert that the original content is equal to the unpacked content
+        assert_eq!(unpacked_content.trim_end(), test_content);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pack_unpack_compare_rocksdb() -> anyhow::Result<()> {
+        // Create a temporary directory for the original RocksDB
+        let original_db_dir = tempdir()?;
+        let original_db_path = original_db_dir.path();
+
+        // Initialize RocksDB with some data
+        {
+            let db = DB::open_default(original_db_path)?;
+            db.put(b"key1", b"value1")?;
+            db.put(b"key2", b"value2")?;
+            db.flush()?;
+        }
+
+        // Pack the original RocksDB into a tar.gz file
+        let (tar_gz_path, _) = create_tar_gz(original_db_path.to_path_buf(), "testbackup")?;
+        assert!(tar_gz_path.exists(), "Tar.gz file was not created.");
+
+        // Create a temporary directory for the unpacked RocksDB
+        let unpacked_db_dir = tempdir()?;
+        let unpacked_db_path = unpacked_db_dir.path();
+
+        // Unpack the tar.gz file to the new directory
+        unpack_tar_gz(&tar_gz_path, &unpacked_db_path.to_path_buf())?;
+
+        // Compare the original and unpacked databases
+        let comparison_result = compare_rocksdb(
+            original_db_path.to_str().unwrap(),
+            unpacked_db_path.to_str().unwrap(),
+        )?;
+        assert!(
+            comparison_result,
+            "Databases are not the same after packing and unpacking."
+        );
+
+        Ok(())
+    }
+
+    fn compare_rocksdb(db1_path: &str, db2_path: &str) -> Result<bool, anyhow::Error> {
+        let db1 = open_db_with_column_families(db1_path)?;
+        let db2 = open_db_with_column_families(db2_path)?;
+
+        let iter1 = db1.iterator(IteratorMode::Start); // Iterate from the start of db1
+        let mut iter2 = db2.iterator(IteratorMode::Start); // Iterate from the start of db2
+
+        for result1 in iter1 {
+            let (key1, value1) = result1?;
+
+            match iter2.next() {
+                Some(result2) => {
+                    let (key2, value2) = result2?;
+                    if key1 != key2 || value1 != value2 {
+                        // If keys or values differ, the databases are not identical
+                        return Ok(false);
+                    }
+                },
+                None => {
+                    // db2 has fewer elements than db1
+                    return Ok(false);
+                },
+            }
+        }
+
+        // Check if db2 has more elements than db1
+        if iter2.next().is_some() {
+            return Ok(false);
+        }
+
+        Ok(true) // Databases are identical
+    }
+
+    fn open_db_with_column_families(
+        db_path: &str,
+    ) -> anyhow::Result<DBWithThreadMode<SingleThreaded>> {
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(false);
+
+        let cfs = DB::list_cf(&db_opts, db_path).map_err(anyhow::Error::new)?; // Convert rocksdb::Error to anyhow::Error
+        let cf_descriptors = cfs
+            .into_iter()
+            .map(|cf| ColumnFamilyDescriptor::new(cf, Options::default()))
+            .collect::<Vec<_>>();
+
+        DB::open_cf_descriptors(&db_opts, db_path, cf_descriptors).map_err(anyhow::Error::new)
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
@@ -5,7 +5,7 @@ use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use std::{
     fs,
     fs::File,
-    io::{BufWriter, Error, Write},
+    io::{BufWriter, Error},
     path::PathBuf,
 };
 use tar::{Archive, Builder};
@@ -52,10 +52,7 @@ pub fn rename_db_folders_and_cleanup(
 }
 
 /// Creates a tar.gz archive from the db snapshot directory
-pub fn create_tar_gz(
-    dir_path: PathBuf,
-    backup_file_name: &str,
-) -> Result<(PathBuf, String), anyhow::Error> {
+pub fn create_tar_gz(dir_path: PathBuf, backup_file_name: &str) -> Result<PathBuf, anyhow::Error> {
     let tar_file_name = format!("{}.tar.gz", backup_file_name);
     let tar_file_path = dir_path.join(&tar_file_name);
     let temp_tar_file_path = dir_path.join(format!("{}.tmp", tar_file_name));
@@ -70,16 +67,7 @@ pub fn create_tar_gz(
 
     std::fs::rename(&temp_tar_file_path, &tar_file_path)?;
 
-    Ok((tar_file_path, tar_file_name))
-}
-
-pub fn write_snapshot_to_file(snapshot: &[u8], target_path: &PathBuf) -> anyhow::Result<()> {
-    let temp_file_path = target_path.with_extension("tmp");
-    let mut temp_file = File::create(&temp_file_path)?;
-    temp_file.write_all(snapshot)?;
-    temp_file.sync_all()?; // Ensure all data is written to disk
-    fs::rename(&temp_file_path, target_path)?; // Atomically move the temp file to the target path
-    Ok(())
+    Ok(tar_file_path)
 }
 
 /// Unpack a tar.gz archive to a specified directory
@@ -147,7 +135,7 @@ mod tests {
         writeln!(file, "{}", test_content)?;
 
         // Create a tar.gz file from the directory
-        let (tar_gz_path, _) = create_tar_gz(dir_to_compress.path().to_path_buf(), "testbackup")?;
+        let tar_gz_path = create_tar_gz(dir_to_compress.path().to_path_buf(), "testbackup")?;
         assert!(tar_gz_path.exists());
 
         // Create a new temporary directory to unpack the tar.gz file
@@ -184,7 +172,7 @@ mod tests {
         }
 
         // Pack the original RocksDB into a tar.gz file
-        let (tar_gz_path, _) = create_tar_gz(original_db_path.to_path_buf(), "testbackup")?;
+        let tar_gz_path = create_tar_gz(original_db_path.to_path_buf(), "testbackup")?;
         assert!(tar_gz_path.exists(), "Tar.gz file was not created.");
 
         // Create a temporary directory for the unpacked RocksDB

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/gcs.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/gcs.rs
@@ -1,0 +1,270 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    fs_ops::create_tar_gz, generate_blob_name, BackupRestoreMetadata, JSON_FILE_TYPE,
+    METADATA_FILE_NAME, TAR_FILE_TYPE,
+};
+use crate::backup_restore::fs_ops::{unpack_tar_gz, write_snapshot_to_file};
+use anyhow::Context;
+use aptos_db_indexer::db_v2::IndexerAsyncV2;
+use aptos_logger::{error, info};
+use google_cloud_storage::{
+    client::{Client, ClientConfig},
+    http::{
+        buckets::get::GetBucketRequest,
+        objects::{
+            download::Range,
+            get::GetObjectRequest,
+            upload::{Media, UploadObjectRequest, UploadType},
+        },
+        Error,
+    },
+};
+use hyper::StatusCode;
+use std::{
+    borrow::Cow::Borrowed,
+    env, fs,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+pub struct GcsBackupRestoreOperator {
+    bucket_name: String,
+    metadata_epoch: AtomicU64,
+    gcs_client: Client,
+}
+
+impl GcsBackupRestoreOperator {
+    pub async fn new(bucket_name: String) -> Self {
+        let gcs_config = ClientConfig::default()
+            .with_auth()
+            .await
+            .expect("Failed to create GCS client.");
+        let gcs_client = Client::new(gcs_config);
+        Self {
+            bucket_name,
+            metadata_epoch: AtomicU64::new(0),
+            gcs_client,
+        }
+    }
+}
+
+impl GcsBackupRestoreOperator {
+    pub async fn verify_storage_bucket_existence(&self) {
+        info!(
+            bucket_name = self.bucket_name,
+            "Before gcs backup restore operator starts, verify the bucket exists."
+        );
+
+        self.gcs_client
+            .get_bucket(&GetBucketRequest {
+                bucket: self.bucket_name.to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_or_else(|_| panic!("Failed to get the bucket with name: {}", self.bucket_name));
+    }
+
+    pub async fn get_metadata(&self) -> Option<BackupRestoreMetadata> {
+        match self.download_metadata_object().await {
+            Ok(metadata) => Some(metadata),
+            Err(Error::HttpClient(err)) => {
+                if err.status() == Some(StatusCode::NOT_FOUND) {
+                    None
+                } else {
+                    panic!("Error happens when accessing metadata file. {}", err);
+                }
+            },
+            Err(e) => {
+                panic!("Error happens when accessing metadata file. {}", e);
+            },
+        }
+    }
+
+    pub async fn create_default_metadata_if_absent(
+        &self,
+        expected_chain_id: u64,
+    ) -> anyhow::Result<BackupRestoreMetadata> {
+        match self.download_metadata_object().await {
+            Ok(metadata) => {
+                assert!(metadata.chain_id == expected_chain_id, "Chain ID mismatch.");
+                self.set_metadata_epoch(metadata.epoch);
+                Ok(metadata)
+            },
+            Err(Error::HttpClient(err)) => {
+                let is_file_missing = err.status() == Some(StatusCode::NOT_FOUND);
+                if is_file_missing {
+                    self.update_metadata(expected_chain_id, 0)
+                        .await
+                        .expect("Update metadata failed.");
+                    self.set_metadata_epoch(0);
+                    Ok(BackupRestoreMetadata::new(expected_chain_id, 0))
+                } else {
+                    Err(anyhow::Error::msg(format!(
+                        "Metadata not found or gcs operator is not in write mode. {}",
+                        err
+                    )))
+                }
+            },
+            Err(err) => Err(anyhow::Error::from(err)),
+        }
+    }
+
+    async fn download_metadata_object(&self) -> Result<BackupRestoreMetadata, Error> {
+        self.gcs_client
+            .download_object(
+                &GetObjectRequest {
+                    bucket: self.bucket_name.clone(),
+                    object: METADATA_FILE_NAME.to_string(),
+                    ..Default::default()
+                },
+                &Range::default(),
+            )
+            .await
+            .map(BackupRestoreMetadata::from)
+    }
+
+    pub async fn update_metadata(&self, chain_id: u64, epoch: u64) -> anyhow::Result<()> {
+        let metadata = BackupRestoreMetadata::new(chain_id, epoch);
+        loop {
+            match self
+                .gcs_client
+                .upload_object(
+                    &UploadObjectRequest {
+                        bucket: self.bucket_name.clone(),
+                        ..Default::default()
+                    },
+                    serde_json::to_vec(&metadata).unwrap(),
+                    &UploadType::Simple(Media {
+                        name: Borrowed(METADATA_FILE_NAME),
+                        content_type: Borrowed(JSON_FILE_TYPE),
+                        content_length: None,
+                    }),
+                )
+                .await
+            {
+                Ok(_) => {
+                    return Ok(());
+                },
+                // https://cloud.google.com/storage/quotas
+                // add retry logic due to: "Maximum rate of writes to the same object name: One write per second"
+                Err(Error::Response(err)) if (err.is_retriable() && err.code == 429) => {
+                    info!("Retried with rateLimitExceeded on gcs single object at epoch {} when updating the metadata", epoch);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                },
+                Err(err) => {
+                    anyhow::bail!("Failed to update metadata: {}", err);
+                },
+            }
+        }
+    }
+
+    pub async fn backup_db_snapshot(
+        &self,
+        chain_id: u64,
+        epoch: u64,
+        indexer_async_v2: Arc<IndexerAsyncV2>,
+        snapshot_path: PathBuf,
+    ) -> anyhow::Result<()> {
+        // reading epoch from gcs metadata is too slow, so updating the local var first so that every previous
+        // new epoch based backup will be observed correctly by the next backup
+        self.set_metadata_epoch(epoch);
+
+        // rocksdb will create a checkpoint to take a snapshot of full db and then save it to snapshot_path
+        indexer_async_v2
+            .create_checkpoint(&snapshot_path)
+            .context(format!("DB checkpoint failed at epoch {}", epoch))?;
+
+        // create a gzipped tar file by compressing a folder into a single file
+        let (tar_file, _tar_file_name) = create_tar_gz(snapshot_path.clone(), &epoch.to_string())?;
+        let buffer = std::fs::read(&tar_file).context("Failed to read gzipped tar file")?;
+
+        let filename = generate_blob_name(epoch);
+
+        match self
+            .gcs_client
+            .upload_object(
+                &UploadObjectRequest {
+                    bucket: self.bucket_name.clone(),
+                    ..Default::default()
+                },
+                buffer.clone(),
+                &UploadType::Simple(Media {
+                    name: filename.clone().into(),
+                    content_type: Borrowed(TAR_FILE_TYPE),
+                    content_length: None,
+                }),
+            )
+            .await
+        {
+            Ok(_) => {
+                self.update_metadata(chain_id, epoch).await?;
+
+                std::fs::remove_file(&tar_file)
+                    .and_then(|_| fs::remove_dir_all(&snapshot_path))
+                    .expect("Failed to clean up after db snapshot upload");
+            },
+            Err(err) => {
+                error!("Failed to upload snapshot: {}", err);
+            },
+        };
+
+        Ok(())
+    }
+
+    /// When fullnode is getting started, it will first restore its table info db by restoring most recent snapshot from gcs buckets.
+    /// Download the right snapshot based on epoch to a local file and then unzip it and write to the indexer async v2 db.
+    pub async fn restore_db_snapshot(
+        &self,
+        chain_id: u64,
+        metadata: BackupRestoreMetadata,
+        db_path: PathBuf,
+        base_path: PathBuf,
+    ) -> anyhow::Result<()> {
+        assert!(metadata.chain_id == chain_id, "Chain ID mismatch.");
+
+        let epoch = metadata.epoch;
+        let epoch_based_filename = generate_blob_name(epoch);
+
+        match self
+            .gcs_client
+            .download_object(
+                &GetObjectRequest {
+                    bucket: self.bucket_name.clone(),
+                    object: epoch_based_filename.clone(),
+                    ..Default::default()
+                },
+                &Range::default(),
+            )
+            .await
+        {
+            Ok(snapshot) => {
+                let temp_file_name = "snapshot.tar.gz";
+                let temp_file_path = base_path.join(temp_file_name);
+                write_snapshot_to_file(&snapshot, &temp_file_path)?;
+
+                unpack_tar_gz(&temp_file_path, &db_path)?;
+                fs::remove_file(&temp_file_path).context("Failed to remove temporary file")?;
+
+                self.set_metadata_epoch(epoch);
+
+                Ok(())
+            },
+            Err(e) => Err(anyhow::Error::new(e)),
+        }
+    }
+
+    pub fn set_metadata_epoch(&self, epoch: u64) {
+        self.metadata_epoch.store(epoch, Ordering::Relaxed)
+    }
+
+    pub fn get_metadata_epoch(&self) -> u64 {
+        self.metadata_epoch.load(Ordering::Relaxed)
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/mod.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/mod.rs
@@ -1,0 +1,36 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+pub mod fs_ops;
+pub mod gcs;
+
+pub const FILE_FOLDER_NAME: &str = "files";
+pub const METADATA_FILE_NAME: &str = "metadata.json";
+pub const JSON_FILE_TYPE: &str = "application/json";
+pub const TAR_FILE_TYPE: &str = "application/gzip";
+
+#[inline]
+pub fn generate_blob_name(epoch: u64) -> String {
+    format!("{}/{}.tar.gz", FILE_FOLDER_NAME, epoch)
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug)]
+pub struct BackupRestoreMetadata {
+    pub chain_id: u64,
+    pub epoch: u64,
+}
+
+impl BackupRestoreMetadata {
+    pub fn new(chain_id: u64, epoch: u64) -> Self {
+        Self { chain_id, epoch }
+    }
+}
+
+impl From<Vec<u8>> for BackupRestoreMetadata {
+    fn from(bytes: Vec<u8>) -> Self {
+        serde_json::from_slice(bytes.as_slice())
+            .expect("Failed to deserialize BackupRestoreMetadata file.")
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod backup_restore;
 pub mod runtime;
 pub mod table_info_service;


### PR DESCRIPTION
### This PR
1. add gcs operator utils

### Overview
**[1/4] separate indexer async v2 db from aptosdb : https://github.com/aptos-labs/aptos-core/pull/11799
[2/4] add gcs operational utils to set up for backup and restore to gcs: https://github.com/aptos-labs/aptos-core/pull/11793
[3/4] add epoch based backup logic: https://github.com/aptos-labs/aptos-core/pull/11794
[4/4] add db snapshot restore logic: https://github.com/aptos-labs/aptos-core/pull/11795**

### Goal
https://www.notion.so/aptoslabs/Internal-Indexer-Deprecation-Next-Steps-824d5af7f16a4ff3aeccc4a4edee2763?pvs=4
1. Migrating internal indexer off of aptos db critical path, move it into its own standalone runtime service.
7. Still provide the table info mapping to both API and indexer services.
8. improve table info parsing performance to unblock indexer perf bottleneck

### Context
This effort is broken down into two parts:
1. part 1: https://github.com/aptos-labs/aptos-core/pull/10783. Add moving the table info service out of the critical path and convert it into multithread to concurrently process the request.
3. part 2 is this PR. Now we have the table info service, but this service will only be enabled by a handful FNs, so when a new FN wants to join the network but they don't want to sync from the genesis, they should be able to restore the db from a cloud service. In order to provide such a cloud service for others to download the db snapshot, this pr focuses on two things: backup and restore. backup is optional in the config, but restore logic is written in the code.

| before | after |
| --- | --- |
| <img width="1371" alt="Screenshot 2023-11-15 at 10 15 01 PM" src="https://github.com/aptos-labs/aptos-core/assets/121921928/e2e46022-3e7b-4994-bc7f-a4b5b2137a7b"> | <img width="701" alt="Screenshot 2024-01-25 at 11 14 05 AM" src="https://github.com/aptos-labs/aptos-core/assets/121921928/96e9ccdc-487e-4bf6-ad2f-9482b17454e6"> |

### Detailed Changes
<img width="1094" alt="Screenshot 2024-01-25 at 11 56 53 AM" src="https://github.com/aptos-labs/aptos-core/assets/121921928/431987b4-45e6-44e9-8fef-e85e59492e7a">

### Tradeoffs
#### backup based on epoch or transaction version? what frequency?
Pros of backup using version:
1. We have more control over the backup frequency as frequency is tunable. 
Cons of backup using version:
1. Overhead of managing and comparing backed up versions and current processing versions

Pros of backup using epoch:
1. When to backup logic is much cleaner and less error prone
Cons of backup using epoch:
1. not very configurable but still tunable by setting frequency on how many epochs behind

Decided to use epoch, because on testnet we have little over 10k epoch, divided by total txns, it gives us on average 70k txns per epoch, this sounds about the frequency of txns we'd like to backup.

#### when to restore
Decided to restore when both conditions are met: 
1. the difference btw next versions to be processed and current version from ledger is greater than a `version_diff`.
2. and time difference btw last restored timestamp in db and current timestamp is greater than a `RESTORE_TIME_DIFF_SECS`.
This is to prevent fullnode crashlooping and constantly try to restore without luck, and when version difference is not that big we don't need to spam the gcs service but rather directly state syncing from that close to head version.

#### structure of the gcs bucket
I followed the similar structure as of indexer's filestore, where we keep a `metadata.json` file in the bucket to keep track of the chain id and newest backed up epoch. and then a files folder to keep all the epoch based backup. Each db snapshot is first compressed into a tar file from folder, and then gzipped to compress to the best size possible. based on larry's point, alternative compression like bzip2 is less performant.

#### threads
Using a separate thread for backup only, base on the past experience, gcs upload could be as slow as minutes.

#### gcs prunning
Couple options we could pursue, since each backup file is a full db backup, 
1. create another service to constantly clean up the backup files
2. use gcs own policy to delete files based on time, and other conditions
4. programmatically delete old files while upload
9. constantly writing to the same file

Decided to go with gcs own policy with the proper configuration setup in the gcs deployment. Reason behind is that deploying and maintaining another service is overhead and costs more money, especially this service's responsibility is very singular; writing code for gcs object deletion is not ideal, since we're writing and deleting, need to handle different multitude of edge cases; constantly writing to the same file is def not gonna work, since gcs has strict limitation on single object write limit, only once per second.

### Test Plan
1. passing all the written unit tests on file system operation
10. locally tested and verified backup and restore, as well as table info read

### Concerns
There's a bottleneck on the size of db snapshot. Currently this db on testnet is around 250mb, based on the nature of db, the compression could get it to be 50-150mb per db snapshot. It's still too big to upload to gcs as its too slow. 

### TODO
#### E2E test
from rustie:
1. set up a long-running fullnode in a new k8s project. We can use the same data-staging-us-central1 cluster, but use a new namespace, like indexer-fullnode-testnet-test  or something. This is to isolate it from everything else, but we can use the same cluster for simplicity
11. Set up a job in the same namespace that does the backup to GCS.
12. We can set up a continuous job in aptos-core CI that:
5.1. Spins up a fullnode based on the latest build. This would be the latest main nightly for instance
3.2. We can quit immediately after verifying that the restore was successful
3.3. The cost should be manageable, assuming that the restore process is quick.

#### integration test

#### load test
Couple things i want to verify with load testing
1. 10 fns boostrapping, can restore work for all of them
2. fns keep crashlooping, is gcs spammed based on egress & ingress
3. when file gets bigger, will backup still work and how long it could take