### PR TITLE
[API] Add tests for view function and txn simulation filters

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_simulation_filter_allow_sender.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_simulation_filter_allow_sender.json
@@ -1,0 +1,5 @@
+{
+  "message": "Transaction not allowed by simulation filter",
+  "error_code": "invalid_input",
+  "vm_error_code": null
+}

--- a/api/goldens/aptos_api__tests__transactions_test__test_simulation_filter_deny.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_simulation_filter_deny.json
@@ -1,0 +1,5 @@
+{
+  "message": "Transaction not allowed by simulation filter",
+  "error_code": "invalid_input",
+  "vm_error_code": null
+}

--- a/api/goldens/aptos_api__tests__view_function__test_view_allowlist.json
+++ b/api/goldens/aptos_api__tests__view_function__test_view_allowlist.json
@@ -1,0 +1,1 @@
+[["100000"],{"message":"Function 0000000000000000000000000000000000000000000000000000000000000001::coin::decimals is not allowed","error_code":"invalid_input","vm_error_code":null}]

--- a/api/goldens/aptos_api__tests__view_function__test_view_blocklist.json
+++ b/api/goldens/aptos_api__tests__view_function__test_view_blocklist.json
@@ -1,0 +1,1 @@
+[{"message":"Function 0000000000000000000000000000000000000000000000000000000000000001::coin::balance is not allowed","error_code":"invalid_input","vm_error_code":null},[8]]


### PR DESCRIPTION
### Description
Before we roll out the feature to prod we should have tests confirming the filtering works and that it doesn't regress. This PR adds those tests.

Related to https://github.com/aptos-labs/aptos-core/pull/11666 and https://github.com/aptos-labs/aptos-core/pull/11714.

### Test Plan
```
cargo test -p aptos-api
```