### PR TITLE
aptos-dkg extra benchmarking

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,16 +11,15 @@
 /aptos-move/aptos-gas/ @vgao1996
 /aptos-move/aptos-vm/ @davidiw @wrwg @zekun000 @vgao1996 @georgemitenkov
 /aptos-move/aptos-vm-types/ @georgemitenkov @gelash @vgao1996
-/aptos-move/e2e-tests/src/account.rs @alinush
 /aptos-move/framework/ @davidiw @movekevin @wrwg
 /aptos-move/framework/aptos-framework/sources/account.move @alinush
-/aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush
+/aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush @zjma @mstraka100
 /aptos-move/framework/**/*.spec.move @junkil-park
 /aptos-move/framework/aptos-stdlib/sources/hash.move @alinush
 
 # Owner for aptos-token, cryptography natives, parallel-executor and vm-genesis.
 /aptos-move/framework/aptos-token @areshand
-/aptos-move/framework/src/natives/cryptography/ @alinush
+/aptos-move/framework/src/natives/cryptography/ @alinush @zjma @mstraka100
 /aptos-move/framework/src/natives/aggregator_natives/ @georgemitenkov @gelash @zekun000
 /aptos-move/block-executor/ @gelash @zekun000 @sasha8 @danielxiangzl
 /aptos-move/sharded_block-executor/ @sitalkedia
@@ -43,8 +42,8 @@
 /crates/aptos @gregnazario @0xjinn @banool
 
 # Owners for the `/crates/aptos-crypto*` directories.
-/crates/aptos-crypto-derive/ @alinush
-/crates/aptos-crypto/ @alinush
+/crates/aptos-crypto-derive/ @alinush @zjma @mstraka100 @rex1fernando
+/crates/aptos-crypto/ @alinush @zjma @mstraka100 @rex1fernando
 
 # Owners for the `/crates/aptos-faucet` directory and all its subdirectories. And other faucet, genesis, and OpenAPI-related crates.
 /crates/aptos-faucet @banool @gregnazario
@@ -109,6 +108,6 @@
 /terraform/ @aptos-labs/prod-eng
 
 # Owners for the `aptos-dkg` crate.
-/crates/aptos-dkg @alinush
+/crates/aptos-dkg @alinush @rex1fernando
 
-/types/src/transaction/authenticator.rs @alinush
+/types/src/transaction/authenticator.rs @alinush @mstraka100

--- a/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
@@ -220,7 +220,7 @@ impl WeightedVUF for PinkasWUF {
         Ok(multi_pairing(lhs.iter().map(|r| r), rhs.into_iter()))
     }
 
-    /// Verifies the proof shares one by one
+    /// Verifies the proof shares (using batch verification)
     fn verify_proof(
         pp: &Self::PublicParameters,
         _pk: &Self::PubKey,

--- a/crates/aptos-dkg/tests/dkg.rs
+++ b/crates/aptos-dkg/tests/dkg.rs
@@ -44,8 +44,7 @@ fn test_dkg_all_weighted() {
 fn aggregatable_dkg<T: Transcript + CryptoHash>(sc: &T::SecretSharingConfig, seed_bytes: [u8; 32]) {
     let mut rng = StdRng::from_seed(seed_bytes);
 
-    let (pp, ssks, spks, dks, eks, iss, _, sk) =
-        test_utils::setup_dealing::<T, StdRng>(sc, &mut rng);
+    let d = test_utils::setup_dealing::<T, StdRng>(sc, &mut rng);
 
     let mut trxs = vec![];
 
@@ -53,10 +52,10 @@ fn aggregatable_dkg<T: Transcript + CryptoHash>(sc: &T::SecretSharingConfig, see
     for i in 0..sc.get_total_num_players() {
         trxs.push(T::deal(
             sc,
-            &pp,
-            &ssks[i],
-            &eks,
-            &iss[i],
+            &d.pp,
+            &d.ssks[i],
+            &d.eks,
+            &d.iss[i],
             &NoAux,
             &sc.get_player(i),
             &mut rng,
@@ -69,16 +68,16 @@ fn aggregatable_dkg<T: Transcript + CryptoHash>(sc: &T::SecretSharingConfig, see
     // Verify the aggregated transcript
     trx.verify(
         sc,
-        &pp,
-        &spks,
-        &eks,
+        &d.pp,
+        &d.spks,
+        &d.eks,
         &(0..sc.get_total_num_players())
             .map(|_| NoAux)
             .collect::<Vec<NoAux>>(),
     )
     .expect("aggregated PVSS transcript failed verification");
 
-    if sk != reconstruct_dealt_secret_key_randomly::<StdRng, T>(sc, &mut rng, &dks, trx) {
+    if d.dsk != reconstruct_dealt_secret_key_randomly::<StdRng, T>(sc, &mut rng, &d.dks, trx) {
         panic!("Reconstructed SK did not match");
     }
 }


### PR DESCRIPTION
### Description

Some bureaucratic fixes to our benchmarking infrastructure.

Plus, fixed the BLS WVUF `verify_share` implementation to use the [BDN18] multisig verification, since we need to ensure individual shares are correct, not just their aggregation. Otherwise, an adversary can tweak two shares $(\sigma_1, \sigma_2)$ into $(\sigma_1 + \delta, \sigma_2 - \delta)$ and break the correctness of aggregation later on.