### PR TITLE
[dag] cache votes without re-counting

### DIFF
--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -40,11 +40,7 @@ use futures::{
     future::{join, AbortHandle, Abortable},
 };
 use futures_channel::oneshot;
-use std::{
-    collections::{vec_deque, HashSet, VecDeque},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub(crate) struct DagDriver {

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -28,7 +28,8 @@ use std::{
 pub enum NodeStatus {
     Unordered {
         node: Arc<CertifiedNode>,
-        accumulated_voting_power: u128,
+        votes_culumative_voting_power: u128,
+        links_cumulative_voting_power: u128,
     },
     Ordered(Arc<CertifiedNode>),
 }
@@ -55,7 +56,6 @@ pub struct InMemDag {
     epoch_state: Arc<EpochState>,
     /// The window we maintain between highest committed round and initial round
     window_size: u64,
-    voted_nodes: BTreeMap<Round, BTreeSet<NodeId>>,
 }
 
 impl InMemDag {
@@ -68,7 +68,6 @@ impl InMemDag {
             start_round,
             epoch_state,
             window_size,
-            voted_nodes: BTreeMap::new(),
         }
     }
 
@@ -117,9 +116,10 @@ impl InMemDag {
         ensure!(round_ref.is_none(), "race during insertion");
         *round_ref = Some(NodeStatus::Unordered {
             node: node.clone(),
-            accumulated_voting_power: 0,
+            votes_culumative_voting_power: 0,
+            links_cumulative_voting_power: 0,
         });
-        self.update_votes(&node);
+        self.update_votes(&node, true);
         Ok(())
     }
 
@@ -161,16 +161,7 @@ impl InMemDag {
         Ok(())
     }
 
-    pub fn update_votes(&mut self, node: &Node) {
-        if !self
-            .voted_nodes
-            .entry(node.round())
-            .or_default()
-            .insert(node.id())
-        {
-            return;
-        }
-
+    pub fn update_votes(&mut self, node: &Node, update_link_power: bool) {
         if node.round() <= self.lowest_round() {
             return;
         }
@@ -186,9 +177,16 @@ impl InMemDag {
                 .expect("must exist");
             match node_status {
                 Some(NodeStatus::Unordered {
-                    accumulated_voting_power,
+                    votes_culumative_voting_power,
+                    links_cumulative_voting_power,
                     ..
-                }) => *accumulated_voting_power += voting_power as u128,
+                }) => {
+                    if update_link_power {
+                        *links_cumulative_voting_power += voting_power as u128;
+                    } else {
+                        *votes_culumative_voting_power += voting_power as u128;
+                    }
+                },
                 Some(NodeStatus::Ordered(_)) => {},
                 None => unreachable!("parents must exist before voting for a node"),
             }
@@ -265,11 +263,17 @@ impl InMemDag {
         self.get_node_ref_by_metadata(metadata)
             .map(|node_status| match node_status {
                 NodeStatus::Unordered {
-                    accumulated_voting_power,
+                    votes_culumative_voting_power,
+                    links_cumulative_voting_power,
                     ..
-                } => validator_verifier
-                    .check_aggregated_voting_power(*accumulated_voting_power, false)
-                    .is_ok(),
+                } => {
+                    validator_verifier
+                        .check_aggregated_voting_power(*votes_culumative_voting_power, true)
+                        .is_ok()
+                        || validator_verifier
+                            .check_aggregated_voting_power(*links_cumulative_voting_power, false)
+                            .is_ok()
+                },
                 NodeStatus::Ordered(_) => {
                     error!("checking voting power for Ordered node");
                     true
@@ -387,9 +391,6 @@ impl InMemDag {
     }
 
     pub(super) fn prune(&mut self) -> BTreeMap<u64, Vec<Option<NodeStatus>>> {
-        let to_keep = self.voted_nodes.split_off(&self.start_round);
-        _ = std::mem::replace(&mut self.voted_nodes, to_keep);
-
         let to_keep = self.nodes_by_round.split_off(&self.start_round);
         let to_prune = std::mem::replace(&mut self.nodes_by_round, to_keep);
         debug!(

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -3,7 +3,7 @@
 
 use super::{
     types::{DagSnapshotBitmask, NodeMetadata},
-    Node, NodeId,
+    Node,
 };
 use crate::{
     dag::{
@@ -19,7 +19,7 @@ use aptos_infallible::RwLock;
 use aptos_logger::{debug, error, warn};
 use aptos_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::Deref,
     sync::Arc,
 };

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::{DagSnapshotBitmask, NodeMetadata};
+use super::{
+    types::{DagSnapshotBitmask, NodeMetadata},
+    Node, NodeId,
+};
 use crate::{
     dag::{
         storage::DAGStorage,
@@ -16,26 +19,29 @@ use aptos_infallible::RwLock;
 use aptos_logger::{debug, error, warn};
 use aptos_types::{epoch_state::EpochState, validator_verifier::ValidatorVerifier};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::Deref,
     sync::Arc,
 };
 
 #[derive(Clone)]
 pub enum NodeStatus {
-    Unordered(Arc<CertifiedNode>),
+    Unordered {
+        node: Arc<CertifiedNode>,
+        accumulated_voting_power: u128,
+    },
     Ordered(Arc<CertifiedNode>),
 }
 
 impl NodeStatus {
     pub fn as_node(&self) -> &Arc<CertifiedNode> {
         match self {
-            NodeStatus::Unordered(node) | NodeStatus::Ordered(node) => node,
+            NodeStatus::Unordered { node, .. } | NodeStatus::Ordered(node) => node,
         }
     }
 
     pub fn mark_as_ordered(&mut self) {
-        assert!(matches!(self, NodeStatus::Unordered(_)));
+        assert!(matches!(self, NodeStatus::Unordered { .. }));
         *self = NodeStatus::Ordered(self.as_node().clone());
     }
 }
@@ -49,6 +55,7 @@ pub struct InMemDag {
     epoch_state: Arc<EpochState>,
     /// The window we maintain between highest committed round and initial round
     window_size: u64,
+    voted_nodes: BTreeMap<Round, BTreeSet<NodeId>>,
 }
 
 impl InMemDag {
@@ -61,6 +68,7 @@ impl InMemDag {
             start_round,
             epoch_state,
             window_size,
+            voted_nodes: BTreeMap::new(),
         }
     }
 
@@ -107,7 +115,11 @@ impl InMemDag {
             .get_node_ref_mut(node.round(), node.author())
             .expect("must be present");
         ensure!(round_ref.is_none(), "race during insertion");
-        *round_ref = Some(NodeStatus::Unordered(node.clone()));
+        *round_ref = Some(NodeStatus::Unordered {
+            node: node.clone(),
+            accumulated_voting_power: 0,
+        });
+        self.update_votes(&node);
         Ok(())
     }
 
@@ -147,6 +159,40 @@ impl InMemDag {
             .or_insert_with(|| vec![None; self.author_to_index.len()]);
         ensure!(round_ref[index].is_none(), "duplicate node");
         Ok(())
+    }
+
+    pub fn update_votes(&mut self, node: &Node) {
+        if !self
+            .voted_nodes
+            .entry(node.round())
+            .or_default()
+            .insert(node.id())
+        {
+            return;
+        }
+
+        if node.round() <= self.lowest_round() {
+            return;
+        }
+
+        for parent in node.parents_metadata() {
+            let voting_power = self
+                .epoch_state
+                .verifier
+                .get_voting_power(node.author())
+                .expect("must exist");
+            let node_status = self
+                .get_node_ref_mut(parent.round(), parent.author())
+                .expect("must exist");
+            match node_status {
+                Some(NodeStatus::Unordered {
+                    accumulated_voting_power,
+                    ..
+                }) => *accumulated_voting_power += voting_power as u128,
+                Some(NodeStatus::Ordered(_)) => {},
+                None => unreachable!("parents must exist before voting for a node"),
+            }
+        }
     }
 
     pub fn exists(&self, metadata: &NodeMetadata) -> bool {
@@ -211,24 +257,23 @@ impl InMemDag {
             .map(|node_status| node_status.as_node())
     }
 
-    // TODO: I think we can cache votes in the NodeStatus::Unordered
     pub fn check_votes_for_node(
         &self,
         metadata: &NodeMetadata,
         validator_verifier: &ValidatorVerifier,
     ) -> bool {
-        self.get_round_iter(metadata.round() + 1)
-            .map(|next_round_iter| {
-                let votes = next_round_iter
-                    .filter(|node_status| {
-                        node_status
-                            .as_node()
-                            .parents()
-                            .iter()
-                            .any(|cert| cert.metadata() == metadata)
-                    })
-                    .map(|node_status| node_status.as_node().author());
-                validator_verifier.check_voting_power(votes, false).is_ok()
+        self.get_node_ref_by_metadata(metadata)
+            .map(|node_status| match node_status {
+                NodeStatus::Unordered {
+                    accumulated_voting_power,
+                    ..
+                } => validator_verifier
+                    .check_aggregated_voting_power(*accumulated_voting_power, false)
+                    .is_ok(),
+                NodeStatus::Ordered(_) => {
+                    error!("checking voting power for Ordered node");
+                    true
+                },
             })
             .unwrap_or(false)
     }
@@ -260,7 +305,7 @@ impl InMemDag {
             .flat_map(|(_, round_ref)| round_ref.iter_mut())
             .flatten()
             .filter(move |node_status| {
-                matches!(node_status, NodeStatus::Unordered(_))
+                matches!(node_status, NodeStatus::Unordered { .. })
                     && reachable_filter(node_status.as_node())
             })
     }
@@ -342,6 +387,9 @@ impl InMemDag {
     }
 
     pub(super) fn prune(&mut self) -> BTreeMap<u64, Vec<Option<NodeStatus>>> {
+        let to_keep = self.voted_nodes.split_off(&self.start_round);
+        _ = std::mem::replace(&mut self.voted_nodes, to_keep);
+
         let to_keep = self.nodes_by_round.split_off(&self.start_round);
         let to_prune = std::mem::replace(&mut self.nodes_by_round, to_keep);
         debug!(

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -136,7 +136,7 @@ impl OrderRule {
             .reachable(
                 Some(current_anchor.metadata().clone()).iter(),
                 Some(*self.lowest_unordered_anchor_round.read()),
-                |node_status| matches!(node_status, NodeStatus::Unordered(_)),
+                |node_status| matches!(node_status, NodeStatus::Unordered{ .. }),
             )
             // skip the current anchor itself
             .skip(1)

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -136,7 +136,7 @@ impl OrderRule {
             .reachable(
                 Some(current_anchor.metadata().clone()).iter(),
                 Some(*self.lowest_unordered_anchor_round.read()),
-                |node_status| matches!(node_status, NodeStatus::Unordered{ .. }),
+                |node_status| matches!(node_status, NodeStatus::Unordered { .. }),
             )
             // skip the current anchor itself
             .skip(1)

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -110,7 +110,7 @@ impl NodeBroadcastHandler {
             node.epoch(),
             self.epoch_state.epoch
         );
-        
+
         let num_vtxns = node.validator_txns().len() as u64;
         ensure!(num_vtxns <= self.vtxn_config.per_block_limit_txn_count());
         for vtxn in node.validator_txns() {

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -246,7 +246,7 @@ impl RpcHandler for NodeBroadcastHandler {
             .expect("must exist")
             .insert(*node.author(), vote.clone());
 
-        self.dag.write().update_votes(&node);
+        self.dag.write().update_votes(&node, false);
 
         debug!(LogSchema::new(LogEvent::Vote)
             .remote_peer(*node.author())

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -40,7 +40,7 @@ pub(crate) fn new_node(
     parents: Vec<NodeCertificate>,
 ) -> Node {
     Node::new(
-        0,
+        1,
         round,
         author,
         timestamp,

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -223,7 +223,7 @@ async fn test_node_broadcast_receiver_storage() {
     let sig = rb_receiver.process(node).await.expect("must succeed");
 
     assert_ok_eq!(storage.get_votes(), vec![(
-        NodeId::new(0, 1, signers[0].author()),
+        NodeId::new(1, 1, signers[0].author()),
         sig
     )],);
 

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -558,6 +558,9 @@ impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
     type Message = Node;
     type Response = Vote;
 
+    /// Processes the [Vote]s received for a given [Node]. Once a supermajority voting power
+    /// is reached, this method sends [NodeCertificate] into a channel. It will only return
+    /// successfully when [Vote]s are received from all the peers.
     fn add(&self, peer: Author, ack: Self::Response) -> anyhow::Result<Option<Self::Aggregated>> {
         ensure!(self.metadata == ack.metadata, "Digest mismatch");
         ack.verify(peer, &self.epoch_state.verifier)?;

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -30,12 +30,13 @@ use aptos_types::{
     validator_txn::ValidatorTransaction,
     validator_verifier::ValidatorVerifier,
 };
+use futures_channel::oneshot;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::min,
     collections::HashSet,
     fmt::{Display, Formatter},
-    ops::Deref,
+    ops::{Deref, DerefMut},
     sync::Arc,
 };
 
@@ -534,22 +535,26 @@ impl TryFrom<DAGRpcResult> for Vote {
 
 pub struct SignatureBuilder {
     metadata: NodeMetadata,
-    partial_signatures: Mutex<PartialSignatures>,
+    inner: Mutex<(PartialSignatures, Option<oneshot::Sender<NodeCertificate>>)>,
     epoch_state: Arc<EpochState>,
 }
 
 impl SignatureBuilder {
-    pub fn new(metadata: NodeMetadata, epoch_state: Arc<EpochState>) -> Arc<Self> {
+    pub fn new(
+        metadata: NodeMetadata,
+        epoch_state: Arc<EpochState>,
+        tx: oneshot::Sender<NodeCertificate>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             metadata,
-            partial_signatures: Mutex::new(PartialSignatures::empty()),
+            inner: Mutex::new((PartialSignatures::empty(), Some(tx))),
             epoch_state,
         })
     }
 }
 
 impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
-    type Aggregated = NodeCertificate;
+    type Aggregated = ();
     type Message = Node;
     type Response = Vote;
 
@@ -559,22 +564,33 @@ impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
         debug!(LogSchema::new(LogEvent::ReceiveVote)
             .remote_peer(peer)
             .round(self.metadata.round()));
-        let mut signatures_lock = self.partial_signatures.lock();
-        signatures_lock.add_signature(peer, ack.signature);
-        Ok(self
-            .epoch_state
-            .verifier
-            .check_voting_power(signatures_lock.signatures().keys(), true)
-            .ok()
-            .map(|_| {
-                let aggregated_signature = self
-                    .epoch_state
-                    .verifier
-                    .aggregate_signatures(&signatures_lock)
-                    .expect("Signature aggregation should succeed");
-                observe_node(self.metadata.timestamp(), NodeStage::CertAggregated);
-                NodeCertificate::new(self.metadata.clone(), aggregated_signature)
-            }))
+        let mut guard = self.inner.lock();
+        let (partial_signatures, tx) = guard.deref_mut();
+        partial_signatures.add_signature(peer, ack.signature);
+
+        if tx.is_some()
+            && self
+                .epoch_state
+                .verifier
+                .check_voting_power(partial_signatures.signatures().keys(), true)
+                .is_ok()
+        {
+            let aggregated_signature = self
+                .epoch_state
+                .verifier
+                .aggregate_signatures(&partial_signatures)
+                .expect("Signature aggregation should succeed");
+            observe_node(self.metadata.timestamp(), NodeStage::CertAggregated);
+            let certificate = NodeCertificate::new(self.metadata.clone(), aggregated_signature);
+
+            _ = tx.take().expect("must exist").send(certificate);
+        }
+
+        if partial_signatures.signatures().len() == self.epoch_state.verifier.len() {
+            Ok(Some(()))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -578,7 +578,7 @@ impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
             let aggregated_signature = self
                 .epoch_state
                 .verifier
-                .aggregate_signatures(&partial_signatures)
+                .aggregate_signatures(partial_signatures)
                 .expect("Signature aggregation should succeed");
             observe_node(self.metadata.timestamp(), NodeStage::CertAggregated);
             let certificate = NodeCertificate::new(self.metadata.clone(), aggregated_signature);

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -343,7 +343,7 @@ impl Node {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Hash, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Hash, Clone, PartialOrd, Ord)]
 pub struct NodeId {
     epoch: u64,
     round: Round,

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -381,7 +381,14 @@ impl ValidatorVerifier {
         check_super_majority: bool,
     ) -> std::result::Result<u128, VerifyError> {
         let aggregated_voting_power = self.sum_voting_power(authors)?;
+        self.check_aggregated_voting_power(aggregated_voting_power, check_super_majority)
+    }
 
+    pub fn check_aggregated_voting_power(
+        &self,
+        aggregated_voting_power: u128,
+        check_super_majority: bool,
+    ) -> std::result::Result<u128, VerifyError> {
         let target = if check_super_majority {
             self.quorum_voting_power
         } else {


### PR DESCRIPTION
### Description

Instead of counting votes each time, this PR adds caching functionality for votes.

Also, checks for epoch when handling a RB node.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Fixed existing tests.
