### PR TITLE
[Indexer] Use spawn_blocking for converting txns in stream coordinator

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
@@ -144,7 +144,7 @@ impl IndexerStreamCoordinator {
         let mut tasks = vec![];
         for batch in task_batches {
             let context = self.context.clone();
-            let task = tokio::spawn(async move {
+            let task = tokio::task::spawn_blocking(move || {
                 let raw_txns = batch;
                 let api_txns = Self::convert_to_api_txns(context, raw_txns);
                 let pb_txns = Self::convert_to_pb_txns(api_txns);


### PR DESCRIPTION
### Description
We should use spawn_blocking for CPU bound work: https://aptos-org.slack.com/archives/C04PF1X2UKY/p1706554218137959.

### Test Plan
CI.