### PR TITLE
[Executor] [Delayed fields] Utilities clean-up / refactor

### DIFF
--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -220,7 +220,10 @@ mod test {
     };
     use aptos_types::{
         delayed_fields::PanicError,
-        state_store::{state_key::StateKey, state_value::StateValue},
+        state_store::{
+            state_key::StateKey,
+            state_value::{StateValue, StateValueMetadata},
+        },
         write_set::WriteOp,
     };
     use claims::{assert_err, assert_none, assert_ok, assert_ok_eq, assert_some_eq};
@@ -509,7 +512,6 @@ mod test {
         type Identifier = ();
         type ResourceGroupTag = ();
         type ResourceKey = ();
-        type ResourceValue = ();
 
         fn is_delayed_field_optimization_capable(&self) -> bool {
             unimplemented!("Irrelevant for the test")
@@ -548,7 +550,7 @@ mod test {
             _delayed_write_set_keys: &HashSet<Self::Identifier>,
             _skip: &HashSet<Self::ResourceKey>,
         ) -> Result<
-            BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>,
+            BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
             PanicError,
         > {
             unimplemented!("Irrelevant for the test")
@@ -558,7 +560,7 @@ mod test {
             &self,
             _delayed_write_set_keys: &HashSet<Self::Identifier>,
             _skip: &HashSet<Self::ResourceKey>,
-        ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+        ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
             unimplemented!("Irrelevant for the test")
         }
     }

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -130,7 +130,6 @@ pub trait TDelayedFieldView {
     type Identifier;
     type ResourceKey;
     type ResourceGroupTag;
-    type ResourceValue;
 
     fn is_delayed_field_optimization_capable(&self) -> bool;
 
@@ -177,34 +176,34 @@ pub trait TDelayedFieldView {
     /// 1. The resource is read during the transaction execution.
     /// 2. The resource is not present in write set of the VM Change Set.
     /// 3. The resource has a delayed field in it that is part of delayed field change set.
-    /// We get these resources and include them in the write set of the transaction output.
+    /// We get the keys of these resources and metadata to include them in the write set
+    /// of the transaction output after value exchange.
     fn get_reads_needing_exchange(
         &self,
-        delayed_write_set_keys: &HashSet<Self::Identifier>,
+        delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>;
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    >;
 
     /// Returns the list of resource groups that satisfy all the following conditions:
     /// 1. At least one of the resource in the group is read during the transaction execution.
     /// 2. The resource group is not present in the write set of the VM Change Set.
     /// 3. At least one of the resources in the group has a delayed field in it that is part.
     /// of delayed field change set.
-    /// We get these resource groups and include them in the write set of the transaction output.
-    /// For each such resource group, this function outputs (resource key, (metadata op, resource group size))
+    /// We get the keys of these resource groups and metadata to include them in the write set
+    /// of the transaction output after value exchange. For each such resource group, this function
+    /// outputs:(resource key, (metadata, resource group size))
     fn get_group_reads_needing_exchange(
         &self,
-        delayed_write_set_keys: &HashSet<Self::Identifier>,
+        delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError>;
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError>;
 }
 
 pub trait DelayedFieldResolver:
-    TDelayedFieldView<
-    Identifier = DelayedFieldID,
-    ResourceKey = StateKey,
-    ResourceGroupTag = StructTag,
-    ResourceValue = WriteOp,
->
+    TDelayedFieldView<Identifier = DelayedFieldID, ResourceKey = StateKey, ResourceGroupTag = StructTag>
 {
 }
 
@@ -213,7 +212,6 @@ impl<T> DelayedFieldResolver for T where
         Identifier = DelayedFieldID,
         ResourceKey = StateKey,
         ResourceGroupTag = StructTag,
-        ResourceValue = WriteOp,
     >
 {
 }
@@ -225,7 +223,6 @@ where
     type Identifier = DelayedFieldID;
     type ResourceGroupTag = StructTag;
     type ResourceKey = StateKey;
-    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         // For resolvers that are not capable, it cannot be enabled
@@ -264,18 +261,20 @@ where
 
     fn get_reads_needing_exchange(
         &self,
-        _delayed_write_set_keys: &HashSet<Self::Identifier>,
+        _delayed_write_set_ids: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         unimplemented!("get_reads_needing_exchange not implemented")
     }
 
     fn get_group_reads_needing_exchange(
         &self,
-        _delayed_write_set_keys: &HashSet<Self::Identifier>,
+        _delayed_write_set_ids: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         unimplemented!("get_group_reads_needing_exchange not implemented")
     }
 }

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -13,8 +13,10 @@ use crate::{
 };
 use aptos_types::{
     delayed_fields::PanicError,
-    state_store::{state_key::StateKey, state_value::StateValue},
-    write_set::WriteOp,
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueMetadata},
+    },
 };
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout};
@@ -83,7 +85,6 @@ impl TDelayedFieldView for FakeAggregatorView {
     type Identifier = DelayedFieldID;
     type ResourceGroupTag = StructTag;
     type ResourceKey = StateKey;
-    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         true
@@ -145,8 +146,10 @@ impl TDelayedFieldView for FakeAggregatorView {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         unimplemented!();
     }
 
@@ -154,7 +157,7 @@ impl TDelayedFieldView for FakeAggregatorView {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         unimplemented!();
     }
 }

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -398,9 +398,9 @@ impl VMChangeSet {
     // Called by `into_transaction_output_with_materialized_writes` only.
     pub(crate) fn extend_resource_write_set(
         &mut self,
-        patched_resource_writes: impl Iterator<Item = (StateKey, WriteOp)>,
+        materialized_resource_writes: impl Iterator<Item = (StateKey, WriteOp)>,
     ) -> Result<(), PanicError> {
-        for (key, new_write) in patched_resource_writes {
+        for (key, new_write) in materialized_resource_writes {
             let abstract_write = self.resource_write_set.get_mut(&key).ok_or_else(|| {
                 code_invariant_error(format!(
                     "Cannot patch a resource which does not exist, for: {:?}.",
@@ -429,8 +429,8 @@ impl VMChangeSet {
     }
 
     /// The events are set to the input events.
-    pub(crate) fn set_events(&mut self, patched_events: impl Iterator<Item = ContractEvent>) {
-        self.events = patched_events
+    pub(crate) fn set_events(&mut self, materialized_events: impl Iterator<Item = ContractEvent>) {
+        self.events = materialized_events
             .map(|event| (event, None))
             .collect::<Vec<_>>();
     }

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -194,7 +194,7 @@ pub trait TExecutorView<K, T, L, I, V>:
     TResourceView<Key = K, Layout = L>
     + TModuleView<Key = K>
     + TAggregatorV1View<Identifier = K>
-    + TDelayedFieldView<Identifier = I, ResourceKey = K, ResourceGroupTag = T, ResourceValue = V>
+    + TDelayedFieldView<Identifier = I, ResourceKey = K, ResourceGroupTag = T>
     + StateStorageView
 {
 }
@@ -203,7 +203,7 @@ impl<A, K, T, L, I, V> TExecutorView<K, T, L, I, V> for A where
     A: TResourceView<Key = K, Layout = L>
         + TModuleView<Key = K>
         + TAggregatorV1View<Identifier = K>
-        + TDelayedFieldView<Identifier = I, ResourceKey = K, ResourceGroupTag = T, ResourceValue = V>
+        + TDelayedFieldView<Identifier = I, ResourceKey = K, ResourceGroupTag = T>
         + StateStorageView
 {
 }

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -20,7 +20,7 @@ use aptos_aggregator::{
 use aptos_types::{
     access_path::AccessPath,
     delayed_fields::{PanicError, SnapshotToStringFormula},
-    state_store::state_key::StateKey,
+    state_store::{state_key::StateKey, state_value::StateValueMetadata},
     transaction::ChangeSet as StorageChangeSet,
     write_set::{WriteOp, WriteSetMut},
 };
@@ -622,7 +622,7 @@ fn test_resource_groups_squashing() {
             ExpandedVMChangeSetBuilder::new()
                 .with_group_reads_needing_delayed_field_exchange(vec![(
                     as_state_key!("1"),
-                    (modification_metadata.clone(), 400)
+                    (modification_metadata.metadata().clone(), 400)
                 )])
                 .build(),
             &MockChangeSetChecker
@@ -650,7 +650,8 @@ fn test_write_and_read_discrepancy_caught() {
         .with_reads_needing_delayed_field_exchange(vec![(
             as_state_key!("1"),
             (
-                WriteOp::legacy_modification(as_bytes!(1).into()),
+                StateValueMetadata::none(),
+                10,
                 Arc::new(MoveTypeLayout::U64)
             )
         )])
@@ -669,7 +670,7 @@ fn test_write_and_read_discrepancy_caught() {
         )])
         .with_group_reads_needing_delayed_field_exchange(vec![(
             as_state_key!("1"),
-            (metadata_op, group_size)
+            (metadata_op.metadata().clone(), group_size)
         )])
         .try_build());
 }

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -273,8 +273,9 @@ pub(crate) struct ExpandedVMChangeSetBuilder {
     aggregator_v1_write_set: BTreeMap<StateKey, WriteOp>,
     aggregator_v1_delta_set: BTreeMap<StateKey, DeltaOp>,
     delayed_field_change_set: BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>,
-    reads_needing_delayed_field_exchange: BTreeMap<StateKey, (WriteOp, Arc<MoveTypeLayout>)>,
-    group_reads_needing_delayed_field_exchange: BTreeMap<StateKey, (WriteOp, u64)>,
+    reads_needing_delayed_field_exchange:
+        BTreeMap<StateKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+    group_reads_needing_delayed_field_exchange: BTreeMap<StateKey, (StateValueMetadata, u64)>,
     events: Vec<(ContractEvent, Option<MoveTypeLayout>)>,
 }
 
@@ -355,7 +356,7 @@ impl ExpandedVMChangeSetBuilder {
     pub(crate) fn with_reads_needing_delayed_field_exchange(
         mut self,
         reads_needing_delayed_field_exchange: impl IntoIterator<
-            Item = (StateKey, (WriteOp, Arc<MoveTypeLayout>)),
+            Item = (StateKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)),
         >,
     ) -> Self {
         assert!(self.reads_needing_delayed_field_exchange.is_empty());
@@ -366,7 +367,9 @@ impl ExpandedVMChangeSetBuilder {
 
     pub(crate) fn with_group_reads_needing_delayed_field_exchange(
         mut self,
-        group_reads_needing_delayed_field_exchange: impl IntoIterator<Item = (StateKey, (WriteOp, u64))>,
+        group_reads_needing_delayed_field_exchange: impl IntoIterator<
+            Item = (StateKey, (StateValueMetadata, u64)),
+        >,
     ) -> Self {
         assert!(self.group_reads_needing_delayed_field_exchange.is_empty());
         self.group_reads_needing_delayed_field_exchange

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -213,7 +213,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    fn reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, Arc<MoveTypeLayout>)> {
+    fn reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata, Arc<MoveTypeLayout>)> {
         self.vm_output
             .lock()
             .as_ref()
@@ -223,7 +223,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .iter()
             .flat_map(|(key, write)| {
                 if let AbstractResourceWriteOp::InPlaceDelayedFieldChange(change) = write {
-                    Some((key.clone(), change.layout.clone()))
+                    Some((key.clone(), change.metadata.clone(), change.layout.clone()))
                 } else {
                     None
                 }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -213,7 +213,9 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
             .clone()
     }
 
-    fn reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata, Arc<MoveTypeLayout>)> {
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(StateKey, StateValueMetadata, Arc<MoveTypeLayout>)> {
         self.vm_output
             .lock()
             .as_ref()
@@ -274,8 +276,8 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     fn incorporate_materialized_txn_output(
         &self,
         aggregator_v1_writes: Vec<(StateKey, WriteOp)>,
-        patched_resource_write_set: Vec<(StateKey, WriteOp)>,
-        patched_events: Vec<ContractEvent>,
+        materialized_resource_write_set: Vec<(StateKey, WriteOp)>,
+        materialized_events: Vec<ContractEvent>,
     ) -> Result<(), PanicError> {
         assert!(
             self.committed_output
@@ -286,12 +288,12 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
                         .expect("Output must be set to incorporate materialized data")
                         .into_transaction_output_with_materialized_write_set(
                             aggregator_v1_writes,
-                            patched_resource_write_set,
-                            patched_events,
+                            materialized_resource_write_set,
+                            materialized_events,
                         )?,
                 )
                 .is_ok(),
-            "Could not combine VMOutput with the patched resource and event data"
+            "Could not combine VMOutput with the materialized resource and event data"
         );
         Ok(())
     }
@@ -308,7 +310,7 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
                         .expect("We should be able to always convert to transaction output"),
                 )
                 .is_ok(),
-            "Could not combine VMOutput with the patched resource and event data"
+            "Could not combine VMOutput with the materialized resource and event data"
         );
     }
 

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -21,10 +21,12 @@ use aptos_types::{
     delayed_fields::PanicError,
     on_chain_config::{ConfigStorage, Features, OnChainConfig},
     state_store::{
-        errors::StateviewError, state_key::StateKey, state_storage_usage::StateStorageUsage,
-        state_value::StateValue, StateView, StateViewId,
+        errors::StateviewError,
+        state_key::StateKey,
+        state_storage_usage::StateStorageUsage,
+        state_value::{StateValue, StateValueMetadata},
+        StateView, StateViewId,
     },
-    write_set::WriteOp,
 };
 use aptos_vm_types::{
     resolver::{
@@ -247,7 +249,6 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
     type Identifier = DelayedFieldID;
     type ResourceGroupTag = StructTag;
     type ResourceKey = StateKey;
-    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         self.executor_view.is_delayed_field_optimization_capable()
@@ -286,8 +287,10 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         self.executor_view
             .get_reads_needing_exchange(delayed_write_set_keys, skip)
     }
@@ -296,7 +299,7 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         self.executor_view
             .get_group_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -26,7 +26,7 @@ use aptos_types::{
         state_value::{StateValue, StateValueMetadata},
         StateViewId,
     },
-    write_set::{TransactionWrite, WriteOp},
+    write_set::TransactionWrite,
 };
 use aptos_vm_types::{
     abstract_write_op::{AbstractResourceWriteOp, WriteWithDelayedFieldsOp},
@@ -192,7 +192,6 @@ impl<'r> TDelayedFieldView for ExecutorViewWithChangeSet<'r> {
     type Identifier = DelayedFieldID;
     type ResourceGroupTag = StructTag;
     type ResourceKey = StateKey;
-    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         self.base_executor_view
@@ -279,8 +278,10 @@ impl<'r> TDelayedFieldView for ExecutorViewWithChangeSet<'r> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         self.base_executor_view
             .get_reads_needing_exchange(delayed_write_set_keys, skip)
     }
@@ -289,7 +290,7 @@ impl<'r> TDelayedFieldView for ExecutorViewWithChangeSet<'r> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         self.base_executor_view
             .get_group_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -28,8 +28,10 @@ use aptos_types::{
 use aptos_types::{
     chain_id::ChainId,
     delayed_fields::PanicError,
-    state_store::{state_key::StateKey, state_value::StateValue},
-    write_set::WriteOp,
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueMetadata},
+    },
 };
 #[cfg(feature = "testing")]
 use bytes::Bytes;
@@ -81,7 +83,6 @@ impl TDelayedFieldView for AptosBlankStorage {
     type Identifier = DelayedFieldID;
     type ResourceGroupTag = StructTag;
     type ResourceKey = StateKey;
-    type ResourceValue = WriteOp;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         false
@@ -119,8 +120,10 @@ impl TDelayedFieldView for AptosBlankStorage {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         unreachable!()
     }
 
@@ -128,7 +131,7 @@ impl TDelayedFieldView for AptosBlankStorage {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         unimplemented!()
     }
 }

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::InputOutputKey;
+use crate::{types::InputOutputKey, value_exchange::filter_value_for_exchange};
 use anyhow::bail;
 use aptos_aggregator::{
     delta_math::DeltaHistory,
@@ -32,7 +32,7 @@ use std::{
             Entry,
             Entry::{Occupied, Vacant},
         },
-        HashMap, HashSet,
+        BTreeMap, HashMap, HashSet,
     },
     sync::Arc,
 };
@@ -327,10 +327,23 @@ impl<T: Transaction> CapturedReads<T> {
     // Return an iterator over the captured reads.
     pub(crate) fn get_read_values_with_delayed_fields(
         &self,
-    ) -> impl Iterator<Item = (&T::Key, &DataRead<T::Value>)> {
+        delayed_write_set_ids: &HashSet<T::Identifier>,
+        skip: &HashSet<T::Key>,
+    ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>, PanicError> {
         self.data_reads
             .iter()
-            .filter(|(_, v)| matches!(v, DataRead::Versioned(_, _, Some(_))))
+            .filter_map(|(key, data_read)| {
+                if skip.contains(key) {
+                    return None;
+                }
+
+                if let DataRead::Versioned(_version, value, Some(layout)) = data_read {
+                    filter_value_for_exchange::<T>(value, layout, delayed_write_set_ids, key)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     // Return an iterator over the captured group reads that contain a delayed field

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -9,6 +9,7 @@ use crate::{
         TASK_VALIDATE_SECONDS, VM_INIT_SECONDS, WORK_WITH_TASK_SECONDS,
     },
     errors::*,
+    executor_utilities::*,
     explicit_sync_wrapper::ExplicitSyncWrapper,
     limit_processor::BlockGasLimitProcessor,
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
@@ -26,22 +27,21 @@ use aptos_aggregator::{
 use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_logger::{debug, error};
 use aptos_mvhashmap::{
-    types::{Incarnation, MVDataOutput, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
+    types::{Incarnation, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
     unsync_map::UnsyncMap,
     versioned_delayed_fields::CommitError,
     MVHashMap,
 };
 use aptos_types::{
     block_executor::config::BlockExecutorConfig,
-    contract_event::TransactionEvent,
     delayed_fields::PanicError,
     executable::Executable,
     on_chain_config::BlockGasLimitType,
-    state_store::TStateView,
+    state_store::{state_value::StateValue, TStateView},
     transaction::{BlockExecutableTransaction as Transaction, BlockOutput},
     write_set::{TransactionWrite, WriteOp},
 };
-use aptos_vm_logging::{alert, clear_speculative_txn_logs, init_speculative_logs, prelude::*};
+use aptos_vm_logging::{clear_speculative_txn_logs, init_speculative_logs};
 use aptos_vm_types::change_set::randomly_check_layout_matches;
 use bytes::Bytes;
 use claims::assert_none;
@@ -49,11 +49,10 @@ use core::panic;
 use fail::fail_point;
 use move_core_types::value::MoveTypeLayout;
 use num_cpus;
-use rand::{thread_rng, Rng};
 use rayon::ThreadPool;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     marker::{PhantomData, Sync},
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
@@ -127,7 +126,10 @@ where
 
         // For tracking whether the recent execution wrote outside of the previous write/delta set.
         let mut updates_outside = false;
-        let mut apply_updates = |output: &E::Output| -> Result<(), PanicError> {
+        let mut apply_updates = |output: &E::Output| -> Result<
+            Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>, // Cached resource writes
+            PanicError,
+        > {
             for (group_key, group_metadata_op, group_ops) in
                 output.resource_group_write_set().into_iter()
             {
@@ -141,7 +143,8 @@ where
                     idx_to_execute,
                     incarnation,
                     // Group metadata op needs no layout (individual resources in groups do).
-                    (group_metadata_op, None),
+                    Arc::new(group_metadata_op),
+                    None,
                 );
                 if versioned_cache.group_data().write(
                     group_key,
@@ -154,19 +157,21 @@ where
                 }
             }
 
+            let resource_write_set = output.resource_write_set();
+
             // Then, process resource & aggregator_v1 & module writes.
-            for (k, v) in output.resource_write_set().into_iter().chain(
+            for (k, v, maybe_layout) in resource_write_set.clone().into_iter().chain(
                 output
                     .aggregator_v1_write_set()
                     .into_iter()
-                    .map(|(state_key, write_op)| (state_key, (write_op, None))),
+                    .map(|(state_key, write_op)| (state_key, Arc::new(write_op), None)),
             ) {
                 if prev_modified_keys.remove(&k).is_none() {
                     updates_outside = true;
                 }
                 versioned_cache
                     .data()
-                    .write(k, idx_to_execute, incarnation, v);
+                    .write(k, idx_to_execute, incarnation, v, maybe_layout);
             }
 
             for (k, v) in output.module_write_set().into_iter() {
@@ -224,29 +229,32 @@ where
                     };
                 }
             }
-            Ok(())
+            Ok(resource_write_set)
         };
 
-        let result = match execute_result {
+        let (result, resource_write_set) = match execute_result {
             // These statuses are the results of speculative execution, so even for
             // SkipRest (skip the rest of transactions) and Abort (abort execution with
             // user defined error), no immediate action is taken. Instead the statuses
             // are recorded and (final statuses) are analyzed when the block is executed.
             ExecutionStatus::Success(output) => {
                 // Apply the writes/deltas to the versioned_data_cache.
-                apply_updates(&output)?;
-                ExecutionStatus::Success(output)
+                let resource_write_set = apply_updates(&output)?;
+                (ExecutionStatus::Success(output), resource_write_set)
             },
             ExecutionStatus::SkipRest(output) => {
                 // Apply the writes/deltas and record status indicating skip.
-                apply_updates(&output)?;
-                ExecutionStatus::SkipRest(output)
+                let resource_write_set = apply_updates(&output)?;
+                (ExecutionStatus::SkipRest(output), resource_write_set)
             },
             ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
                 read_set.capture_delayed_field_read_error(&PanicOr::Or(
                     MVDelayedFieldsError::DeltaApplicationFailure,
                 ));
-                ExecutionStatus::SpeculativeExecutionAbortError(msg)
+                (
+                    ExecutionStatus::SpeculativeExecutionAbortError(msg),
+                    Vec::new(),
+                )
             },
             ExecutionStatus::Abort(err) => {
                 // Abort indicates an unrecoverable VM failure, and should not occur
@@ -284,7 +292,7 @@ where
             versioned_cache.delayed_fields().remove(&id, idx_to_execute);
         }
 
-        if !last_input_output.record(idx_to_execute, read_set, result) {
+        if !last_input_output.record(idx_to_execute, read_set, result, resource_write_set) {
             return Err(PanicOr::Or(
                 IntentionalFallbackToSequential::module_path_read_write(
                     "Module read & write".into(),
@@ -518,67 +526,32 @@ where
                 }
             }
 
-            let process_finalized_group =
-                |finalized_group: anyhow::Result<Vec<(T::Tag, ValueWithLayout<T::Value>)>>,
-                 metadata_is_deletion: bool|
-                 -> Result<_, _> {
-                    match finalized_group {
-                        Ok(finalized_group) => {
-                            // finalize_group already applies the deletions.
-                            if finalized_group.is_empty() != metadata_is_deletion {
-                                return Err(code_invariant_error(format!(
-                                "Group is empty = {} but op is deletion = {} in parallel execution",
-                                finalized_group.is_empty(),
-                                metadata_is_deletion
-                            )));
-                            }
-                            Ok(finalized_group)
-                        },
-                        Err(e) => Err(code_invariant_error(format!(
-                            "Error committing resource group {:?}",
-                            e
-                        ))),
-                    }
-                };
-
-            let group_metadata_ops = last_input_output.group_metadata_ops(txn_idx);
-            let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
-            for (group_key, metadata_op) in group_metadata_ops.into_iter() {
-                // finalize_group copies Arc of values and the Tags (TODO: optimize as needed).
-                let finalized_result = versioned_cache
-                    .group_data()
-                    .finalize_group(&group_key, txn_idx);
-                match process_finalized_group(finalized_result, metadata_op.is_deletion()) {
-                    Ok(finalized_group) => {
-                        finalized_groups.push((group_key, metadata_op, finalized_group));
-                    },
-                    Err(err) => {
-                        return Err(err.into());
-                    },
-                }
-            }
-
-            if let Some(group_reads_needing_delayed_field_exchange) =
-                last_input_output.group_reads_needing_delayed_field_exchange(txn_idx)
-            {
-                for (group_key, metadata_op) in
-                    group_reads_needing_delayed_field_exchange.into_iter()
-                {
-                    let finalized_result = versioned_cache
-                        .group_data()
-                        .get_last_committed_group(&group_key);
-                    match process_finalized_group(finalized_result, metadata_op.is_deletion()) {
-                        Ok(finalized_group) => {
-                            finalized_groups.push((group_key, metadata_op, finalized_group));
-                        },
-                        Err(err) => {
-                            return Err(err.into());
-                        },
-                    }
-                }
-            }
-
-            last_input_output.record_finalized_group(txn_idx, finalized_groups);
+            groups_to_finalize!(last_input_output, txn_idx)
+                .map(|((group_key, metadata_op), is_read_needing_exchange)| {
+                    // finalize_group copies Arc of values and the Tags (TODO: optimize as needed).
+                    // TODO[agg_v2]: have a test that fails if we don't do the if.
+                    let finalized_result = if is_read_needing_exchange {
+                        versioned_cache
+                            .group_data()
+                            .get_last_committed_group(&group_key)
+                    } else {
+                        versioned_cache
+                            .group_data()
+                            .finalize_group(&group_key, txn_idx)
+                    };
+                    map_finalized_group::<T>(
+                        group_key,
+                        finalized_result,
+                        metadata_op,
+                        is_read_needing_exchange,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.into())
+                .and_then(|finalized_groups| {
+                    last_input_output.record_finalized_group(txn_idx, finalized_groups);
+                    last_input_output.module_rw_intersection_ok()
+                })?;
 
             // While the above propagate errors and lead to eventually halting parallel execution,
             // below we may halt the execution without an error in cases when:
@@ -608,116 +581,6 @@ where
             }
         }
         Ok(())
-    }
-
-    // For each delayed field in resource write set, replace the identifiers with values.
-    fn map_id_to_values_in_write_set(
-        resource_write_set: Option<Vec<(T::Key, (T::Value, Option<Arc<MoveTypeLayout>>))>>,
-        latest_view: &LatestView<T, S, X>,
-    ) -> BTreeMap<T::Key, T::Value> {
-        let mut patched_resource_write_set = BTreeMap::new();
-        if let Some(resource_write_set) = resource_write_set {
-            for (key, (write_op, layout)) in resource_write_set.into_iter() {
-                // layout is Some(_) if it contains a delayed field
-                if let Some(layout) = layout {
-                    if !write_op.is_deletion() {
-                        match write_op.bytes() {
-                            // TODO[agg_v2](fix): propagate error
-                            None => unreachable!(),
-                            Some(write_op_bytes) => {
-                                let patched_bytes = match latest_view
-                                    .replace_identifiers_with_values(write_op_bytes, &layout)
-                                {
-                                    Ok((bytes, _)) => bytes,
-                                    Err(_) => {
-                                        unreachable!(
-                                            "Failed to replace identifiers with values, {layout:?}"
-                                        )
-                                    },
-                                };
-                                let mut patched_write_op = write_op;
-                                patched_write_op.set_bytes(patched_bytes);
-                                patched_resource_write_set.insert(key, patched_write_op);
-                            },
-                        }
-                    }
-                }
-            }
-        }
-        patched_resource_write_set
-    }
-
-    fn map_id_to_values_in_group_writes(
-        finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, ValueWithLayout<T::Value>)>)>,
-        latest_view: &LatestView<T, S, X>,
-    ) -> Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)> {
-        let mut patched_finalized_groups = Vec::with_capacity(finalized_groups.len());
-        for (group_key, group_metadata_op, resource_vec) in finalized_groups.into_iter() {
-            let mut patched_resource_vec = Vec::with_capacity(resource_vec.len());
-            for (tag, value_with_layout) in resource_vec.into_iter() {
-                let value = match value_with_layout {
-                    ValueWithLayout::RawFromStorage(value) => value,
-                    ValueWithLayout::Exchanged(value, None) => value,
-                    ValueWithLayout::Exchanged(value, Some(layout)) => Arc::new(
-                        Self::replace_ids_with_values(&value, layout.as_ref(), latest_view),
-                    ),
-                };
-                patched_resource_vec.push((tag, value));
-            }
-            patched_finalized_groups.push((group_key, group_metadata_op, patched_resource_vec));
-        }
-        patched_finalized_groups
-    }
-
-    // Parse the input `value` and replace delayed field identifiers with
-    // corresponding values
-    fn replace_ids_with_values(
-        value: &T::Value,
-        layout: &MoveTypeLayout,
-        latest_view: &LatestView<T, S, X>,
-    ) -> T::Value {
-        if let Some(mut value) = value.convert_read_to_modification() {
-            if let Some(value_bytes) = value.bytes() {
-                let (patched_bytes, _) = latest_view
-                    .replace_identifiers_with_values(value_bytes, layout)
-                    .unwrap();
-                value.set_bytes(patched_bytes);
-                value
-            } else {
-                unreachable!("Value to be exchanged doesn't have bytes: {:?}", value)
-            }
-        } else {
-            unreachable!(
-                "Value to be exchanged cannot be transformed to modification: {:?}",
-                value
-            );
-        }
-    }
-
-    // For each delayed field in the event, replace delayed field identifier with value.
-    fn map_id_to_values_events(
-        events: Box<dyn Iterator<Item = (T::Event, Option<MoveTypeLayout>)>>,
-        latest_view: &LatestView<T, S, X>,
-    ) -> Vec<T::Event> {
-        let mut patched_events = vec![];
-        for (event, layout) in events {
-            if let Some(layout) = layout {
-                let event_data = event.get_event_data();
-                match latest_view
-                    .replace_identifiers_with_values(&Bytes::from(event_data.to_vec()), &layout)
-                {
-                    Ok((bytes, _)) => {
-                        let mut patched_event = event;
-                        patched_event.set_event_data(bytes.to_vec());
-                        patched_events.push(patched_event);
-                    },
-                    Err(_) => unreachable!("Failed to replace identifiers with values in event"),
-                }
-            } else {
-                patched_events.push(event);
-            }
-        }
-        patched_events
     }
 
     fn materialize_aggregator_v1_delta_writes(
@@ -772,55 +635,6 @@ where
         aggregator_v1_delta_writes
     }
 
-    fn serialize_groups(
-        finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
-        txn_idx: TxnIndex,
-    ) -> Result<Vec<(T::Key, T::Value)>, PanicOr<IntentionalFallbackToSequential>> {
-        fail_point!(
-            "fail-point-resource-group-serialization",
-            !finalized_groups.is_empty(),
-            |_| Err(PanicOr::Or(
-                IntentionalFallbackToSequential::ResourceGroupSerializationError
-            ))
-        );
-
-        finalized_groups
-            .into_iter()
-            .map(|(group_key, mut metadata_op, finalized_group)| {
-                let btree: BTreeMap<T::Tag, Bytes> = finalized_group
-                    .into_iter()
-                    // TODO[agg_v2](fix): Should anything be done using the layout here?
-                    .map(|(resource_tag, arc_v)| {
-                        let bytes = arc_v
-                            .extract_raw_bytes()
-                            .expect("Deletions should already be applied");
-                        (resource_tag, bytes)
-                    })
-                    .collect();
-
-                let res = bcs::to_bytes(&btree)
-                    .map_err(|e| {
-                        PanicOr::Or(
-                            IntentionalFallbackToSequential::resource_group_serialization_error(
-                                format!("Unexpected resource group error {:?}", e),
-                                txn_idx,
-                            ),
-                        )
-                    })
-                    .map(|group_bytes| {
-                        metadata_op.set_bytes(group_bytes.into());
-                        (group_key, metadata_op)
-                    });
-
-                if res.is_err() {
-                    alert!("Failed to serialize resource group");
-                }
-
-                res
-            })
-            .collect()
-    }
-
     fn materialize_txn_commit(
         &self,
         txn_idx: TxnIndex,
@@ -839,38 +653,23 @@ where
             shared_counter,
         );
         let latest_view = LatestView::new(base_view, ViewState::Sync(parallel_state), txn_idx);
-        let resource_write_set = last_input_output.resource_write_set(txn_idx);
         let finalized_groups = last_input_output.take_finalized_group(txn_idx);
+        let exchanged_finalized_groups =
+            map_id_to_values_in_group_writes(finalized_groups, &latest_view)?;
+        let serialized_groups = serialize_groups::<T>(exchanged_finalized_groups)?;
 
-        let mut patched_resource_write_set =
-            Self::map_id_to_values_in_write_set(resource_write_set, &latest_view);
-
-        if let Some(reads_needing_delayed_field_exchange) =
-            last_input_output.reads_needing_delayed_field_exchange(txn_idx)
-        {
-            for (key, layout) in reads_needing_delayed_field_exchange.into_iter() {
-                if let Ok(MVDataOutput::Versioned(
-                    _,
-                    ValueWithLayout::Exchanged(value, existing_layout),
-                )) = versioned_cache.data().fetch_data(&key, txn_idx)
-                {
-                    randomly_check_layout_matches(
-                        existing_layout.as_deref(),
-                        Some(layout.as_ref()),
-                    )?;
-                    patched_resource_write_set.insert(
-                        key,
-                        Self::replace_ids_with_values(&value, layout.as_ref(), &latest_view),
-                    );
-                }
-            }
-        }
-
-        let patched_finalized_groups =
-            Self::map_id_to_values_in_group_writes(finalized_groups, &latest_view);
+        let resource_write_set = last_input_output.take_resource_write_set(txn_idx);
+        let resource_writes_to_exchange = resource_writes_to_exchange!(
+            resource_write_set,
+            last_input_output,
+            versioned_cache.data(),
+            txn_idx
+        )?;
+        let exchanged_resource_write_set =
+            map_id_to_values_in_write_set(resource_writes_to_exchange, &latest_view)?;
 
         let events = last_input_output.events(txn_idx);
-        let patched_events = Self::map_id_to_values_events(events, &latest_view);
+        let exchanged_events = map_id_to_values_events(events, &latest_view)?;
         let aggregator_v1_delta_writes = Self::materialize_aggregator_v1_delta_writes(
             txn_idx,
             last_input_output,
@@ -878,16 +677,14 @@ where
             base_view,
         );
 
-        let serialized_groups = Self::serialize_groups(patched_finalized_groups, txn_idx)?;
-
         last_input_output.record_materialized_txn_output(
             txn_idx,
             aggregator_v1_delta_writes,
-            patched_resource_write_set
+            exchanged_resource_write_set
                 .into_iter()
                 .chain(serialized_groups)
                 .collect(),
-            patched_events,
+            exchanged_events,
         )?;
         if let Some(txn_commit_listener) = &self.transaction_commit_hook {
             let txn_output = last_input_output.txn_output(txn_idx).unwrap();
@@ -1126,8 +923,9 @@ where
     fn apply_output_sequential(
         unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         output: &E::Output,
+        resource_write_set: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
     ) -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
-        for (key, (write_op, layout)) in output.resource_write_set().into_iter() {
+        for (key, write_op, layout) in resource_write_set.into_iter() {
             unsync_map.write(key, write_op, layout);
         }
 
@@ -1139,11 +937,11 @@ where
                         code_invariant_error(format!("Unexpected resource group error {:?}", e))
                     })?;
             }
-            unsync_map.write(group_key, metadata_op, None);
+            unsync_map.write(group_key, Arc::new(metadata_op), None);
         }
 
         for (key, write_op) in output.aggregator_v1_write_set().into_iter() {
-            unsync_map.write(key, write_op, None);
+            unsync_map.write(key, Arc::new(write_op), None);
         }
 
         for (key, write_op) in output.module_write_set().into_iter() {
@@ -1358,83 +1156,46 @@ where
 
                     // Apply the writes.
                     // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
-                    Self::apply_output_sequential(&unsync_map, &output)?;
+                    let resource_write_set = output.resource_write_set();
+                    Self::apply_output_sequential(
+                        &unsync_map,
+                        &output,
+                        resource_write_set.clone(),
+                    )?;
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):
                     {
-                        let group_metadata_ops = output.resource_group_metadata_ops();
-                        let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
-                        for (group_key, group_metadata_op) in group_metadata_ops.into_iter() {
-                            let finalized_group: Vec<_> =
-                                unsync_map.finalize_group(&group_key).collect();
-                            if finalized_group.is_empty() != group_metadata_op.is_deletion() {
-                                // TODO[agg_v2](fix): code invariant error if dynamic change set optimizations disabled.
-                                // TODO[agg_v2](fix): make sure this cannot be triggered by an user transaction
-                                return Err(code_invariant_error(format!(
-                                    "Group is empty = {} but op is deletion = {} in sequential execution",
-                                    finalized_group.is_empty(),
-                                    group_metadata_op.is_deletion()
-                                )).into());
-                            }
-                            finalized_groups.push((group_key, group_metadata_op, finalized_group));
-                        }
+                        let finalized_groups = groups_to_finalize!(output,)
+                            .map(|((group_key, metadata_op), is_read_needing_exchange)| {
+                                let finalized_group =
+                                    Ok(unsync_map.finalize_group(&group_key).collect());
+                                map_finalized_group::<T>(
+                                    group_key,
+                                    finalized_group,
+                                    metadata_op,
+                                    is_read_needing_exchange,
+                                )
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+                        let exchanged_finalized_groups =
+                            map_id_to_values_in_group_writes(finalized_groups, &latest_view)?;
+                        let serialized_groups =
+                            serialize_groups::<T>(exchanged_finalized_groups, idx as TxnIndex)
+                                .map_err(BlockExecutionError::FallbackToSequential)?;
 
-                        for (group_key, group_metadata_op) in
-                            output.group_reads_needing_delayed_field_exchange()
-                        {
-                            let finalized_group: Vec<_> =
-                                unsync_map.finalize_group(&group_key).collect();
-                            if finalized_group.is_empty() != group_metadata_op.is_deletion() {
-                                return Err(code_invariant_error(format!(
-                                    "Group is empty = {} but op is deletion = {} in sequential execution",
-                                    finalized_group.is_empty(),
-                                    group_metadata_op.is_deletion()
-                                )).into());
-                            }
-                            finalized_groups.push((group_key, group_metadata_op, finalized_group));
-                        }
-
+                        let resource_writes_to_exchange =
+                            resource_writes_to_exchange!(resource_write_set, output, unsync_map,)?;
                         // Replace delayed field id with values in resource write set and read set.
-                        let resource_change_set = Some(output.resource_write_set());
-                        let mut patched_resource_write_set =
-                            Self::map_id_to_values_in_write_set(resource_change_set, &latest_view);
-
-                        for (key, layout) in
-                            output.reads_needing_delayed_field_exchange().into_iter()
-                        {
-                            if let Some(ValueWithLayout::Exchanged(value, _)) =
-                                unsync_map.fetch_data(&key)
-                            {
-                                if patched_resource_write_set
-                                    .insert(
-                                        key,
-                                        Self::replace_ids_with_values(
-                                            &value,
-                                            layout.as_ref(),
-                                            &latest_view,
-                                        ),
-                                    )
-                                    .is_some()
-                                {
-                                    return Err(BlockExecutionError::FallbackToSequential(code_invariant_error(
-                                        "reads_needing_delayed_field_exchange already in the write set for key",
-                                    ).into()));
-                                }
-                            }
-                        }
-
-                        let patched_finalized_groups =
-                            Self::map_id_to_values_in_group_writes(finalized_groups, &latest_view);
+                        let exchanged_resource_write_set = map_id_to_values_in_write_set(
+                            resource_writes_to_exchange,
+                            &latest_view,
+                        )?;
 
                         // Replace delayed field id with values in events
-                        let patched_events = Self::map_id_to_values_events(
+                        let exchanged_events = map_id_to_values_events(
                             Box::new(output.get_events().into_iter()),
                             &latest_view,
                         );
-
-                        let serialized_groups =
-                            Self::serialize_groups(patched_finalized_groups, idx as TxnIndex)
-                                .map_err(BlockExecutionError::FallbackToSequential)?;
 
                         output
                             .incorporate_materialized_txn_output(
@@ -1446,7 +1207,7 @@ where
                                     .into_iter()
                                     .chain(serialized_groups.into_iter())
                                     .collect(),
-                                patched_events,
+                                exchanged_events,
                             )
                             .map_err(PanicOr::from)
                             .map_err(BlockExecutionError::FallbackToSequential)?;
@@ -1581,15 +1342,4 @@ where
 
         ret
     }
-}
-
-fn gen_id_start_value(sequential: bool) -> u32 {
-    // IDs are ephemeral. Pick a random prefix, and different each time,
-    // in case exchange is mistakenly not performed - to more easily catch it.
-    // And in a bad case where it happens in prod, to and make sure incorrect
-    // block doesn't get committed, but chain halts.
-    // (take a different range from parallel execution, to even more easily differentiate)
-
-    let offset = if sequential { 0 } else { 1000 };
-    thread_rng().gen_range(1 + offset, 1000 + offset) * 1_000_000
 }

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -1,0 +1,299 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{errors::*, view::LatestView};
+use aptos_aggregator::types::{code_invariant_error, PanicOr};
+use aptos_logger::error;
+use aptos_mvhashmap::types::ValueWithLayout;
+use aptos_types::{
+    contract_event::TransactionEvent, delayed_fields::PanicError, executable::Executable,
+    state_store::TStateView, transaction::BlockExecutableTransaction as Transaction,
+    write_set::TransactionWrite,
+};
+use aptos_vm_logging::{alert, prelude::*};
+use bytes::Bytes;
+use move_core_types::value::MoveTypeLayout;
+use rand::{thread_rng, Rng};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+macro_rules! groups_to_finalize {
+    ($outputs:expr, $($txn_idx:expr),*) => {{
+	let group_write_ops = $outputs.resource_group_metadata_ops($($txn_idx),*);
+
+        group_write_ops.into_iter()
+            .map(|val| (val, false))
+            .chain([()].into_iter().flat_map(|_| {
+		// Lazily evaluated only after iterating over group_write_ops.
+                $outputs.group_reads_needing_delayed_field_exchange($($txn_idx),*)
+                    .into_iter()
+                    .map(|(key, metadata)|
+			 ((key, TransactionWrite::from_state_value(
+			     Some(StateValue::new_with_metadata(Bytes::new(), metadata)))), true))
+            }))
+    }};
+}
+
+// Selects and prepares resource writes that require ID replacement for delayed fields.
+// - reads needing replacement: returns the error if data is not in Exchanged format.
+// - normal resource writes: select writes that have layout set and are not a deletion.
+//
+// Since reads needing exchange also do not contain deletions (see 'does_value_need_exchange')
+// logic in value_exchange.rs, it is guaranteed that no returned values is a deletion.
+macro_rules! resource_writes_to_exchange {
+    ($writes:expr, $outputs:expr, $data_source:expr, $($txn_idx:expr),*) => {{
+	$outputs
+            .reads_needing_delayed_field_exchange($($txn_idx),*)
+            .into_iter()
+	    .map(|(key, layout)| {
+		match $data_source.fetch_exchanged_data(&key, $($txn_idx),*) {
+		    Some((value, existing_layout)) => {
+			randomly_check_layout_matches(
+			    Some(&existing_layout),
+			    Some(layout.as_ref()),
+			)?;
+
+			Ok((key, value, layout))
+		    },
+		    None => {
+			Err(code_invariant_error(
+			    "Read value needing exchange not in Exchanged format".to_string()
+			))
+		    }
+		}}).chain(
+		$writes.into_iter().filter_map(|(key, value, maybe_layout)| {
+		    // layout is Some(_) if it contains a delayed field
+		    if let Some(layout) = maybe_layout {
+			// No need to exchange anything if a resource with delayed field is deleted.
+			if !value.is_deletion() {
+			    return Some(Ok((key, value, layout)))
+			}
+		    }
+		    None
+		})).collect::<std::result::Result<Vec<_>, _>>()
+    }};
+}
+
+pub(crate) use groups_to_finalize;
+pub(crate) use resource_writes_to_exchange;
+
+pub(crate) fn map_finalized_group<T: Transaction>(
+    group_key: T::Key,
+    finalized_group: anyhow::Result<Vec<(T::Tag, ValueWithLayout<T::Value>)>>,
+    metadata_op: T::Value,
+    is_read_needing_exchange: bool,
+) -> Result<(T::Key, T::Value, Vec<(T::Tag, ValueWithLayout<T::Value>)>), PanicError> {
+    let metadata_is_deletion = metadata_op.is_deletion();
+
+    match finalized_group {
+        Ok(finalized_group) => {
+            if is_read_needing_exchange && metadata_is_deletion {
+                // Value needed exchange but was not written / modified during the txn
+                // execution: may not be empty.
+                Err(code_invariant_error(
+                    "Value only read and exchanged, but metadata op is Deletion".to_string(),
+                ))
+            } else if finalized_group.is_empty() != metadata_is_deletion {
+                // finalize_group already applies the deletions.
+                Err(code_invariant_error(format!(
+                    "Group is empty = {} but op is deletion = {} in parallel execution",
+                    finalized_group.is_empty(),
+                    metadata_is_deletion
+                )))
+            } else {
+                Ok((group_key, metadata_op, finalized_group))
+            }
+        },
+        Err(e) => Err(code_invariant_error(format!(
+            "Error committing resource group {:?}",
+            e
+        ))),
+    }
+}
+
+pub(crate) fn serialize_groups<T: Transaction>(
+    finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
+    txn_idx: TxnIndex,
+) -> Result<Vec<(T::Key, T::Value)>, PanicOr<IntentionalFallbackToSequential>> {
+    fail_point!(
+        "fail-point-resource-group-serialization",
+        !finalized_groups.is_empty(),
+        |_| Err(PanicOr::Or(
+            IntentionalFallbackToSequential::ResourceGroupSerializationError
+        ))
+    );
+
+    finalized_groups
+        .into_iter()
+        .map(|(group_key, mut metadata_op, finalized_group)| {
+            let btree: BTreeMap<T::Tag, Bytes> = finalized_group
+                .into_iter()
+                // TODO[agg_v2](fix): Should anything be done using the layout here?
+                .map(|(resource_tag, arc_v)| {
+                    let bytes = arc_v
+                        .extract_raw_bytes()
+                        .expect("Deletions should already be applied");
+                    (resource_tag, bytes)
+                })
+                .collect();
+
+            let res = bcs::to_bytes(&btree)
+                .map_err(|e| {
+                    PanicOr::Or(
+                        IntentionalFallbackToSequential::resource_group_serialization_error(
+                            format!("Unexpected resource group error {:?}", e),
+                            txn_idx,
+                        ),
+                    )
+                })
+                .map(|group_bytes| {
+                    metadata_op.set_bytes(group_bytes.into());
+                    (group_key, metadata_op)
+                });
+
+            if res.is_err() {
+                alert!("Failed to serialize resource group");
+            }
+
+            res
+        })
+        .collect()
+}
+
+pub(crate) fn gen_id_start_value(sequential: bool) -> u32 {
+    // IDs are ephemeral. Pick a random prefix, and different each time,
+    // in case exchange is mistakenly not performed - to more easily catch it.
+    // And in a bad case where it happens in prod, to and make sure incorrect
+    // block doesn't get committed, but chain halts.
+    // (take a different range from parallel execution, to even more easily differentiate)
+
+    let offset = if sequential { 0 } else { 1000 };
+    thread_rng().gen_range(1 + offset, 1000 + offset) * 1_000_000
+}
+
+pub(crate) fn map_id_to_values_in_group_writes<
+    T: Transaction,
+    S: TStateView<Key = T::Key> + Sync,
+    X: Executable + 'static,
+>(
+    finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, ValueWithLayout<T::Value>)>)>,
+    latest_view: &LatestView<T, S, X>,
+) -> ::std::result::Result<Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>, PanicError> {
+    let mut patched_finalized_groups = Vec::with_capacity(finalized_groups.len());
+    for (group_key, group_metadata_op, resource_vec) in finalized_groups.into_iter() {
+        let mut patched_resource_vec = Vec::with_capacity(resource_vec.len());
+        for (tag, value_with_layout) in resource_vec.into_iter() {
+            let value = match value_with_layout {
+                ValueWithLayout::RawFromStorage(value) => value,
+                ValueWithLayout::Exchanged(value, None) => value,
+                ValueWithLayout::Exchanged(value, Some(layout)) => Arc::new(
+                    replace_ids_with_values(&value, layout.as_ref(), latest_view)?,
+                ),
+            };
+            patched_resource_vec.push((tag, value));
+        }
+        patched_finalized_groups.push((group_key, group_metadata_op, patched_resource_vec));
+    }
+    Ok(patched_finalized_groups)
+}
+
+// For each delayed field in resource write set, replace the identifiers with values
+// (ignoring other writes). Currently also checks the keys are unique.
+pub(crate) fn map_id_to_values_in_write_set<
+    T: Transaction,
+    S: TStateView<Key = T::Key> + Sync,
+    X: Executable + 'static,
+>(
+    resource_write_set: Vec<(T::Key, Arc<T::Value>, Arc<MoveTypeLayout>)>,
+    latest_view: &LatestView<T, S, X>,
+) -> Result<Vec<(T::Key, T::Value)>, PanicError> {
+    // Note: can remove or debug-only & be less defensive in the future / check elsewhere.
+    let mut duplication_checker = HashSet::new();
+
+    let ret: Vec<_> = resource_write_set
+        .into_iter()
+        .map(|(key, write_op, layout)| {
+            duplication_checker.insert(key.clone());
+
+            Ok::<_, PanicError>((
+                key,
+                replace_ids_with_values(&write_op, &layout, latest_view)?,
+            ))
+        })
+        .collect::<std::result::Result<_, PanicError>>()?;
+
+    if duplication_checker.len() != ret.len() {
+        Err(code_invariant_error(
+            "reads_needing_delayed_field_exchange already in the write set for key".to_string(),
+        ))
+    } else {
+        Ok(ret)
+    }
+}
+
+// For each delayed field in the event, replace delayed field identifier with value.
+pub(crate) fn map_id_to_values_events<
+    T: Transaction,
+    S: TStateView<Key = T::Key> + Sync,
+    X: Executable + 'static,
+>(
+    events: Box<dyn Iterator<Item = (T::Event, Option<MoveTypeLayout>)>>,
+    latest_view: &LatestView<T, S, X>,
+) -> Result<Vec<T::Event>, PanicError> {
+    events
+        .map(|(event, layout)| {
+            if let Some(layout) = layout {
+                let event_data = event.get_event_data();
+                latest_view
+                    .replace_identifiers_with_values(&Bytes::from(event_data.to_vec()), &layout)
+                    .map(|(bytes, _)| {
+                        let mut patched_event = event;
+                        patched_event.set_event_data(bytes.to_vec());
+                        patched_event
+                    })
+                    .map_err(|_| {
+                        code_invariant_error(format!(
+                            "Failed to replace identifiers with values in an event {:?}",
+                            layout
+                        ))
+                    })
+            } else {
+                Ok(event)
+            }
+        })
+        .collect::<std::result::Result<Vec<_>, PanicError>>()
+}
+
+// Parse the input `value` and replace delayed field identifiers with corresponding values
+fn replace_ids_with_values<
+    T: Transaction,
+    S: TStateView<Key = T::Key> + Sync,
+    X: Executable + 'static,
+>(
+    value: &Arc<T::Value>,
+    layout: &MoveTypeLayout,
+    latest_view: &LatestView<T, S, X>,
+) -> Result<T::Value, PanicError> {
+    let mut value = (**value).clone();
+
+    if let Some(value_bytes) = value.bytes() {
+        let patched_bytes = latest_view
+            .replace_identifiers_with_values(value_bytes, layout)
+            .map_err(|_| {
+                code_invariant_error(format!(
+                    "Failed to replace identifiers with values in a resource {:?}",
+                    layout
+                ))
+            })?
+            .0;
+        value.set_bytes(patched_bytes);
+        Ok(value)
+    } else {
+        Err(code_invariant_error(format!(
+            "Value to be exchanged doesn't have bytes: {:?}",
+            value,
+        )))
+    }
+}

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -143,6 +143,7 @@ mod captured_reads;
 pub mod counters;
 pub mod errors;
 pub mod executor;
+mod executor_utilities;
 pub mod explicit_sync_wrapper;
 mod limit_processor;
 #[cfg(any(test, feature = "fuzzing"))]
@@ -154,4 +155,5 @@ pub mod txn_last_input_output;
 pub mod types;
 #[cfg(test)]
 mod unit_tests;
+mod value_exchange;
 pub mod view;

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1043,7 +1043,11 @@ where
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata, Arc<MoveTypeLayout>)> {
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        StateValueMetadata,
+        Arc<MoveTypeLayout>,
+    )> {
         // TODO[agg_v2](tests): add aggregators V2 to the proptest?
         Vec::new()
     }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1043,7 +1043,7 @@ where
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, Arc<MoveTypeLayout>)> {
+    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata, Arc<MoveTypeLayout>)> {
         // TODO[agg_v2](tests): add aggregators V2 to the proptest?
         Vec::new()
     }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -297,13 +297,6 @@ impl TransactionWrite for ValueType {
     fn set_bytes(&mut self, bytes: Bytes) {
         self.bytes = bytes.into();
     }
-
-    fn convert_read_to_modification(&self) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        Some(self.clone())
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -1011,12 +1004,12 @@ where
     // TODO[agg_v2](tests): Assigning MoveTypeLayout as None for all the writes for now.
     // That means, the resources do not have any DelayedFields embedded in them.
     // Change it to test resources with DelayedFields as well.
-    fn resource_write_set(&self) -> Vec<(K, (ValueType, Option<Arc<MoveTypeLayout>>))> {
+    fn resource_write_set(&self) -> Vec<(K, Arc<ValueType>, Option<Arc<MoveTypeLayout>>)> {
         self.writes
             .iter()
             .filter(|(k, _)| k.module_path().is_none())
             .cloned()
-            .map(|(k, v)| (k, (v, None)))
+            .map(|(k, v)| (k, Arc::new(v), None))
             .collect()
     }
 
@@ -1034,8 +1027,8 @@ where
         BTreeMap::new()
     }
 
-    fn aggregator_v1_delta_set(&self) -> BTreeMap<K, DeltaOp> {
-        self.deltas.iter().cloned().collect()
+    fn aggregator_v1_delta_set(&self) -> Vec<(K, DeltaOp)> {
+        self.deltas.clone()
     }
 
     fn delayed_field_change_set(
@@ -1057,10 +1050,7 @@ where
 
     fn group_reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        <Self::Txn as Transaction>::Value,
-    )> {
+    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)> {
         // TODO[agg_v2](tests): add aggregators V2 to the proptest?
         Vec::new()
     }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -121,7 +121,7 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, Arc<MoveTypeLayout>)>;
+    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata, Arc<MoveTypeLayout>)>;
 
     fn group_reads_needing_delayed_field_exchange(
         &self,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,7 +8,7 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    delayed_fields::PanicError, fee_statement::FeeStatement, fee_statement::FeeStatement,
+    delayed_fields::PanicError, fee_statement::FeeStatement,
     state_store::state_value::StateValueMetadata,
     transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
@@ -121,7 +121,11 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata, Arc<MoveTypeLayout>)>;
+    ) -> Vec<(
+        <Self::Txn as Transaction>::Key,
+        StateValueMetadata,
+        Arc<MoveTypeLayout>,
+    )>;
 
     fn group_reads_needing_delayed_field_exchange(
         &self,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,7 +8,8 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    delayed_fields::PanicError, fee_statement::FeeStatement,
+    delayed_fields::PanicError, fee_statement::FeeStatement, fee_statement::FeeStatement,
+    state_store::state_value::StateValueMetadata,
     transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
@@ -95,10 +96,8 @@ pub trait TransactionOutput: Send + Sync + Debug {
         &self,
     ) -> Vec<(
         <Self::Txn as Transaction>::Key,
-        (
-            <Self::Txn as Transaction>::Value,
-            Option<Arc<MoveTypeLayout>>,
-        ),
+        Arc<<Self::Txn as Transaction>::Value>,
+        Option<Arc<MoveTypeLayout>>,
     )>;
 
     fn module_write_set(
@@ -110,7 +109,7 @@ pub trait TransactionOutput: Send + Sync + Debug {
     ) -> BTreeMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
 
     /// Get the aggregator V1 deltas of a transaction from its output.
-    fn aggregator_v1_delta_set(&self) -> BTreeMap<<Self::Txn as Transaction>::Key, DeltaOp>;
+    fn aggregator_v1_delta_set(&self) -> Vec<(<Self::Txn as Transaction>::Key, DeltaOp)>;
 
     /// Get the delayed field changes of a transaction from its output.
     fn delayed_field_change_set(
@@ -126,10 +125,7 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     fn group_reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        <Self::Txn as Transaction>::Value,
-    )>;
+    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)>;
 
     /// Get the events of a transaction from its output.
     fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -78,6 +78,8 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: 
     // TODO: Consider breaking down the outputs when storing (avoid traversals, cache below).
     outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<O, E>>>>, // txn_idx -> output.
     // Cache to avoid expensive clones of data.
+    // TODO(clean-up): be consistent with naming resource writes: here it means specifically
+    // individual writes, but in some contexts it refers to all writes (e.g. including group writes)
     arced_resource_writes: Vec<
         CachePadded<ExplicitSyncWrapper<Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>>>,
     >,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -11,7 +11,8 @@ use crate::{
 use aptos_aggregator::types::{code_invariant_error, PanicOr};
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
 use aptos_types::{
-    delayed_fields::PanicError, fee_statement::FeeStatement,
+    delayed_fields::PanicError, fee_statement::FeeStatement, fee_statement::FeeStatement,
+    state_store::state_value::StateValueMetadata,
     transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use arc_swap::ArcSwapOption;
@@ -26,6 +27,20 @@ use std::{
 };
 
 type TxnInput<T> = CapturedReads<T>;
+
+macro_rules! forward_on_success_or_skip_rest {
+    ($self:ident, $txn_idx:ident, $f:ident) => {{
+        $self.outputs[$txn_idx as usize]
+            .load()
+            .as_ref()
+            .map_or(vec![], |txn_output| match &txn_output.output_status {
+                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.$f(),
+                ExecutionStatus::Abort(_)
+                | ExecutionStatus::SpeculativeExecutionAbortError(_)
+                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
+            })
+    }};
+}
 
 // When a transaction is committed, the output delta writes must be populated by
 // the WriteOps corresponding to the deltas in the corresponding outputs.
@@ -60,7 +75,12 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: 
         >,
     >,
 
+    // TODO: Consider breaking down the outputs when storing (avoid traversals, cache below).
     outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<O, E>>>>, // txn_idx -> output.
+    // Cache to avoid expensive clones of data.
+    arced_resource_writes: Vec<
+        CachePadded<ExplicitSyncWrapper<Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>>>,
+    >,
 
     // Record all writes and reads to access paths corresponding to modules (code) in any
     // (speculative) executions. Used to avoid a potential race with module publishing and
@@ -79,6 +99,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 .collect(),
             outputs: (0..num_txns)
                 .map(|_| CachePadded::new(ArcSwapOption::empty()))
+                .collect(),
+            arced_resource_writes: (0..num_txns)
+                .map(|_| CachePadded::new(ExplicitSyncWrapper::<Vec<_>>::new(vec![])))
                 .collect(),
             finalized_groups: (0..num_txns)
                 .map(|_| CachePadded::new(ExplicitSyncWrapper::<Vec<_>>::new(vec![])))
@@ -121,6 +144,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         txn_idx: TxnIndex,
         input: CapturedReads<T>,
         output: ExecutionStatus<O, BlockExecutionError<E>>,
+        arced_resource_writes: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
     ) -> bool {
         let written_modules = match &output {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
@@ -137,6 +161,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             return false;
         }
 
+        *self.arced_resource_writes[txn_idx as usize].acquire() = arced_resource_writes;
         self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
         self.outputs[txn_idx as usize].store(Some(Arc::new(TxnOutput::from_output_status(output))));
 
@@ -235,7 +260,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 output_status: ExecutionStatus::SkipRest(output),
             })));
         } else {
-            unreachable!("Unexpected status");
+            unreachable!("Unexpected status, must be Success");
         }
     }
 
@@ -255,9 +280,14 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => Some(
                     t.resource_write_set()
                         .into_iter()
-                        .map(|(k, _)| k)
+                        .map(|(k, _, _)| k)
                         .chain(t.aggregator_v1_write_set().into_keys())
-                        .chain(t.aggregator_v1_delta_set().into_keys())
+                        .chain(
+                            t.aggregator_v1_delta_set()
+                                .into_iter()
+                                .map(|(k, _)| k)
+                                .collect::<Vec<_>>(),
+                        )
                         .map(|k| (k, KeyKind::Resource))
                         .chain(
                             t.module_write_set()
@@ -270,22 +300,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                                 .map(|(k, _)| (k, KeyKind::Group)),
                         ),
                 ),
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
-            })
-    }
-
-    pub(crate) fn resource_write_set(
-        &self,
-        txn_idx: TxnIndex,
-    ) -> Option<Vec<(T::Key, (T::Value, Option<Arc<MoveTypeLayout>>))>> {
-        self.outputs[txn_idx as usize]
-            .load_full()
-            .and_then(|txn_output| match &txn_output.output_status {
-                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
-                    Some(t.resource_write_set())
-                },
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
                 | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
@@ -312,63 +326,26 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     pub(crate) fn reads_needing_delayed_field_exchange(
         &self,
         txn_idx: TxnIndex,
-    ) -> Option<Vec<(T::Key, Arc<MoveTypeLayout>)>> {
-        self.outputs[txn_idx as usize]
-            .load()
-            .as_ref()
-            .and_then(|txn_output| match &txn_output.output_status {
-                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
-                    Some(t.reads_needing_delayed_field_exchange())
-                },
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
-            })
+    ) -> Vec<(T::Key, Arc<MoveTypeLayout>)> {
+        forward_on_success_or_skip_rest!(self, txn_idx, reads_needing_delayed_field_exchange)
     }
 
     pub(crate) fn group_reads_needing_delayed_field_exchange(
         &self,
         txn_idx: TxnIndex,
-    ) -> Option<Vec<(T::Key, T::Value)>> {
-        self.outputs[txn_idx as usize]
-            .load()
-            .as_ref()
-            .and_then(|txn_output| match &txn_output.output_status {
-                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
-                    Some(t.group_reads_needing_delayed_field_exchange())
-                },
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => None,
-            })
+    ) -> Vec<(T::Key, StateValueMetadata)> {
+        forward_on_success_or_skip_rest!(self, txn_idx, group_reads_needing_delayed_field_exchange)
     }
 
     pub(crate) fn aggregator_v1_delta_keys(&self, txn_idx: TxnIndex) -> Vec<T::Key> {
-        self.outputs[txn_idx as usize].load().as_ref().map_or(
-            vec![],
-            |txn_output| match &txn_output.output_status {
-                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
-                    t.aggregator_v1_delta_set().into_keys().collect()
-                },
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
-            },
-        )
+        forward_on_success_or_skip_rest!(self, txn_idx, aggregator_v1_delta_set)
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect()
     }
 
-    pub(crate) fn group_metadata_ops(&self, txn_idx: TxnIndex) -> Vec<(T::Key, T::Value)> {
-        self.outputs[txn_idx as usize].load().as_ref().map_or(
-            vec![],
-            |txn_output| match &txn_output.output_status {
-                ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
-                    t.resource_group_metadata_ops()
-                },
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => vec![],
-            },
-        )
+    pub(crate) fn resource_group_metadata_ops(&self, txn_idx: TxnIndex) -> Vec<(T::Key, T::Value)> {
+        forward_on_success_or_skip_rest!(self, txn_idx, resource_group_metadata_ops)
     }
 
     pub(crate) fn events(
@@ -404,6 +381,13 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         txn_idx: TxnIndex,
     ) -> Vec<(T::Key, T::Value, Vec<(T::Tag, ValueWithLayout<T::Value>)>)> {
         std::mem::take(&mut self.finalized_groups[txn_idx as usize].acquire())
+    }
+
+    pub(crate) fn take_resource_write_set(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)> {
+        std::mem::take(&mut self.arced_resource_writes[txn_idx as usize].acquire())
     }
 
     // Called when a transaction is committed to record WriteOps for materialized aggregator values

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -326,7 +326,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     pub(crate) fn reads_needing_delayed_field_exchange(
         &self,
         txn_idx: TxnIndex,
-    ) -> Vec<(T::Key, Arc<MoveTypeLayout>)> {
+    ) -> Vec<(T::Key, StateValueMetadata, Arc<MoveTypeLayout>)> {
         forward_on_success_or_skip_rest!(self, txn_idx, reads_needing_delayed_field_exchange)
     }
 

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -11,7 +11,7 @@ use crate::{
 use aptos_aggregator::types::{code_invariant_error, PanicOr};
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
 use aptos_types::{
-    delayed_fields::PanicError, fee_statement::FeeStatement, fee_statement::FeeStatement,
+    delayed_fields::PanicError, fee_statement::FeeStatement,
     state_store::state_value::StateValueMetadata,
     transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -106,7 +106,7 @@ fn resource_group_bcs_fallback() {
             assert!(!txn_outputs[2].writes.is_empty());
             assert!(!txn_outputs[1].group_writes.is_empty());
         },
-        Err(_) => unreachable!("Must succeed: failpoint not yet set up"),
+        Err(e) => unreachable!("Must succeed, but {:?}: failpoint not yet set up", e),
     };
 
     // Set up and sanity check failpoint.

--- a/aptos-move/block-executor/src/value_exchange.rs
+++ b/aptos-move/block-executor/src/value_exchange.rs
@@ -1,0 +1,216 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::view::{LatestView, ViewState};
+use aptos_aggregator::{
+    resolver::TDelayedFieldView,
+    types::{
+        code_invariant_error, DelayedFieldValue, PanicError, ReadPosition, TryFromMoveValue,
+        TryIntoMoveValue,
+    },
+};
+use aptos_mvhashmap::{types::TxnIndex, versioned_delayed_fields::TVersionedDelayedFieldView};
+use aptos_types::{
+    executable::Executable,
+    state_store::{state_value::StateValueMetadata, TStateView},
+    transaction::BlockExecutableTransaction as Transaction,
+    write_set::TransactionWrite,
+};
+use bytes::Bytes;
+use move_core_types::value::{IdentifierMappingKind, MoveTypeLayout};
+use move_vm_types::{
+    value_transformation::{
+        deserialize_and_replace_values_with_ids, TransformationError, TransformationResult,
+        ValueToIdentifierMapping,
+    },
+    values::Value,
+};
+use std::{cell::RefCell, collections::HashSet, sync::Arc};
+
+pub(crate) struct TemporaryValueToIdentifierMapping<
+    'a,
+    T: Transaction,
+    S: TStateView<Key = T::Key>,
+    X: Executable,
+> {
+    latest_view: &'a LatestView<'a, T, S, X>,
+    txn_idx: TxnIndex,
+    // These are the delayed field keys that were touched when utilizing this mapping
+    // to replace ids with values or values with ids
+    delayed_field_ids: RefCell<HashSet<T::Identifier>>,
+}
+
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable>
+    TemporaryValueToIdentifierMapping<'a, T, S, X>
+{
+    pub fn new(latest_view: &'a LatestView<'a, T, S, X>, txn_idx: TxnIndex) -> Self {
+        Self {
+            latest_view,
+            txn_idx,
+            delayed_field_ids: RefCell::new(HashSet::new()),
+        }
+    }
+
+    fn generate_delayed_field_id(&self, width: u32) -> T::Identifier {
+        self.latest_view.generate_delayed_field_id(width)
+    }
+
+    pub fn into_inner(self) -> HashSet<T::Identifier> {
+        self.delayed_field_ids.into_inner()
+    }
+}
+
+// For aggregators V2, values are replaced with identifiers at deserialization time,
+// and are replaced back when the value is serialized. The "lifted" values are cached
+// by the `LatestView` in the aggregators multi-version data structure.
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIdentifierMapping
+    for TemporaryValueToIdentifierMapping<'a, T, S, X>
+{
+    fn value_to_identifier(
+        &self,
+        kind: &IdentifierMappingKind,
+        layout: &MoveTypeLayout,
+        value: Value,
+    ) -> TransformationResult<Value> {
+        let (base_value, width) = DelayedFieldValue::try_from_move_value(layout, value, kind)?;
+        let id = self.generate_delayed_field_id(width);
+        match &self.latest_view.latest_view {
+            ViewState::Sync(state) => state.set_delayed_field_value(id, base_value),
+            ViewState::Unsync(state) => {
+                state.set_delayed_field_value(id, base_value);
+            },
+        };
+        self.delayed_field_ids.borrow_mut().insert(id);
+        id.try_into_move_value(layout)
+            .map_err(|e| TransformationError(format!("{:?}", e)))
+    }
+
+    fn identifier_to_value(
+        &self,
+        layout: &MoveTypeLayout,
+        identifier_value: Value,
+    ) -> TransformationResult<Value> {
+        let (id, width) = T::Identifier::try_from_move_value(layout, identifier_value, &())
+            .map_err(|e| TransformationError(format!("{:?}", e)))?;
+        self.delayed_field_ids.borrow_mut().insert(id);
+        Ok(match &self.latest_view.latest_view {
+            ViewState::Sync(state) => state
+                .versioned_map
+                .delayed_fields()
+                .read_latest_committed_value(&id, self.txn_idx, ReadPosition::AfterCurrentTxn)
+                .expect("Committed value for ID must always exist"),
+            ViewState::Unsync(state) => state
+                .read_delayed_field(id)
+                .expect("Delayed field value for ID must always exist in sequential execution"),
+        }
+        .try_into_move_value(layout, width)?)
+    }
+}
+
+struct TemporaryExtractIdentifiersMapping<T: Transaction> {
+    // These are the delayed field keys that were touched when utilizing this mapping
+    // to replace ids with values or values with ids
+    delayed_field_ids: RefCell<HashSet<T::Identifier>>,
+}
+
+impl<T: Transaction> TemporaryExtractIdentifiersMapping<T> {
+    pub fn new() -> Self {
+        Self {
+            delayed_field_ids: RefCell::new(HashSet::new()),
+        }
+    }
+
+    pub fn into_inner(self) -> HashSet<T::Identifier> {
+        self.delayed_field_ids.into_inner()
+    }
+}
+
+impl<T: Transaction> ValueToIdentifierMapping for TemporaryExtractIdentifiersMapping<T> {
+    fn value_to_identifier(
+        &self,
+        _kind: &IdentifierMappingKind,
+        layout: &MoveTypeLayout,
+        value: Value,
+    ) -> TransformationResult<Value> {
+        let (id, _) = T::Identifier::try_from_move_value(layout, value, &())
+            .map_err(|e| TransformationError(format!("{:?}", e)))?;
+        self.delayed_field_ids.borrow_mut().insert(id);
+        id.try_into_move_value(layout)
+            .map_err(|e| TransformationError(format!("{:?}", e)))
+    }
+
+    fn identifier_to_value(
+        &self,
+        layout: &MoveTypeLayout,
+        identifier_value: Value,
+    ) -> TransformationResult<Value> {
+        let (id, _) = T::Identifier::try_from_move_value(layout, identifier_value, &())
+            .map_err(|e| TransformationError(format!("{:?}", e)))?;
+        self.delayed_field_ids.borrow_mut().insert(id);
+        id.try_into_move_value(layout)
+            .map_err(|e| TransformationError(format!("{:?}", e)))
+    }
+}
+
+// Given a Bytes, where values were already exchanged with identifiers,
+// return a list of identifiers present in it.
+// TODO[agg_v2](cleanup): store list of identifiers with the exchanged value (like layout),
+// and remove this method.
+fn extract_identifiers_from_value<T: Transaction>(
+    bytes: &Bytes,
+    layout: &MoveTypeLayout,
+) -> Result<HashSet<T::Identifier>, PanicError> {
+    let mapping = TemporaryExtractIdentifiersMapping::<T>::new();
+    // TODO[agg_v2](cleanup) rename deserialize_and_replace_values_with_ids to not be specific
+    // to mapping trait implementation.
+    let _patched_value = deserialize_and_replace_values_with_ids(bytes.as_ref(), layout, &mapping)
+        .ok_or_else(|| {
+            code_invariant_error("Failed to deserialize a value to extract identifiers")
+        })?;
+    Ok(mapping.into_inner())
+}
+
+// Deletion returns a PanicError.
+pub(crate) fn does_value_need_exchange<T: Transaction>(
+    value: &T::Value,
+    layout: &MoveTypeLayout,
+    delayed_write_set_ids: &HashSet<T::Identifier>,
+) -> Result<bool, PanicError> {
+    if let Some(bytes) = value.bytes() {
+        extract_identifiers_from_value::<T>(bytes, layout)
+            .map(|identifiers_in_read| !delayed_write_set_ids.is_disjoint(&identifiers_in_read))
+    } else {
+        // Deletion returns an error.
+        Err(code_invariant_error(
+            "Delete shouldn't be in values considered for exchange",
+        ))
+    }
+}
+
+// Exclude deletions, and values that do not contain any delayed field IDs that were written to.
+pub(crate) fn filter_value_for_exchange<T: Transaction>(
+    value: &T::Value,
+    layout: &Arc<MoveTypeLayout>,
+    delayed_write_set_ids: &HashSet<T::Identifier>,
+    key: &T::Key,
+) -> Option<Result<(T::Key, (StateValueMetadata, u64, Arc<MoveTypeLayout>)), PanicError>> {
+    if value.is_deletion() {
+        None
+    } else {
+        does_value_need_exchange::<T>(value, layout, delayed_write_set_ids).map_or_else(
+            |e| Some(Err(e)),
+            |needs_exchange| {
+                needs_exchange.then(|| {
+                    Ok((
+                        key.clone(),
+                        (
+                            value.as_state_value_metadata().unwrap().clone(),
+                            value.write_op_size().write_len().unwrap(),
+                            layout.clone(),
+                        ),
+                    ))
+                })
+            },
+        )
+    }
+}

--- a/aptos-move/block-executor/src/value_exchange.rs
+++ b/aptos-move/block-executor/src/value_exchange.rs
@@ -37,7 +37,7 @@ pub(crate) struct TemporaryValueToIdentifierMapping<
     txn_idx: TxnIndex,
     // These are the delayed field keys that were touched when utilizing this mapping
     // to replace ids with values or values with ids
-    delayed_field_keys: RefCell<HashSet<T::Identifier>>,
+    delayed_field_ids: RefCell<HashSet<T::Identifier>>,
 }
 
 impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable>
@@ -47,7 +47,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable>
         Self {
             latest_view,
             txn_idx,
-            delayed_field_keys: RefCell::new(HashSet::new()),
+            delayed_field_ids: RefCell::new(HashSet::new()),
         }
     }
 
@@ -56,7 +56,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable>
     }
 
     pub fn into_inner(self) -> HashSet<T::Identifier> {
-        self.delayed_field_keys.into_inner()
+        self.delayed_field_ids.into_inner()
     }
 }
 
@@ -80,7 +80,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIden
                 state.set_delayed_field_value(id, base_value);
             },
         };
-        self.delayed_field_keys.borrow_mut().insert(id);
+        self.delayed_field_ids.borrow_mut().insert(id);
         id.try_into_move_value(layout)
             .map_err(|e| TransformationError(format!("{:?}", e)))
     }
@@ -92,7 +92,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIden
     ) -> TransformationResult<Value> {
         let (id, width) = T::Identifier::try_from_move_value(layout, identifier_value, &())
             .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
+        self.delayed_field_ids.borrow_mut().insert(id);
         Ok(match &self.latest_view.latest_view {
             ViewState::Sync(state) => state
                 .versioned_map
@@ -110,18 +110,18 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIden
 struct TemporaryExtractIdentifiersMapping<T: Transaction> {
     // These are the delayed field keys that were touched when utilizing this mapping
     // to replace ids with values or values with ids
-    delayed_field_keys: RefCell<HashSet<T::Identifier>>,
+    delayed_field_ids: RefCell<HashSet<T::Identifier>>,
 }
 
 impl<T: Transaction> TemporaryExtractIdentifiersMapping<T> {
     pub fn new() -> Self {
         Self {
-            delayed_field_keys: RefCell::new(HashSet::new()),
+            delayed_field_ids: RefCell::new(HashSet::new()),
         }
     }
 
     pub fn into_inner(self) -> HashSet<T::Identifier> {
-        self.delayed_field_keys.into_inner()
+        self.delayed_field_ids.into_inner()
     }
 }
 
@@ -134,7 +134,7 @@ impl<T: Transaction> ValueToIdentifierMapping for TemporaryExtractIdentifiersMap
     ) -> TransformationResult<Value> {
         let (id, _) = T::Identifier::try_from_move_value(layout, value, &())
             .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
+        self.delayed_field_ids.borrow_mut().insert(id);
         id.try_into_move_value(layout)
             .map_err(|e| TransformationError(format!("{:?}", e)))
     }
@@ -146,7 +146,7 @@ impl<T: Transaction> ValueToIdentifierMapping for TemporaryExtractIdentifiersMap
     ) -> TransformationResult<Value> {
         let (id, _) = T::Identifier::try_from_move_value(layout, identifier_value, &())
             .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
+        self.delayed_field_ids.borrow_mut().insert(id);
         id.try_into_move_value(layout)
             .map_err(|e| TransformationError(format!("{:?}", e)))
     }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -10,6 +10,9 @@ use crate::{
     },
     counters,
     scheduler::{DependencyResult, DependencyStatus, Scheduler, TWaitForDependency},
+    value_exchange::{
+        does_value_need_exchange, filter_value_for_exchange, TemporaryValueToIdentifierMapping,
+    },
 };
 use aptos_aggregator::{
     bounded_math::{ok_overflow, BoundedMath, SignedU128},
@@ -18,7 +21,7 @@ use aptos_aggregator::{
     resolver::{TAggregatorV1View, TDelayedFieldView},
     types::{
         code_invariant_error, expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr,
-        ReadPosition, TryFromMoveValue, TryIntoMoveValue,
+        ReadPosition,
     },
 };
 use aptos_logger::error;
@@ -51,14 +54,10 @@ use aptos_vm_types::resolver::{
 use bytes::Bytes;
 use claims::assert_ok;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_core_types::{
-    value::{IdentifierMappingKind, MoveTypeLayout},
-    vm_status::StatusCode,
-};
+use move_core_types::{value::MoveTypeLayout, vm_status::StatusCode};
 use move_vm_types::{
     value_transformation::{
         deserialize_and_replace_values_with_ids, serialize_and_replace_ids_with_values,
-        TransformationError, TransformationResult, ValueToIdentifierMapping,
     },
     values::Value,
 };
@@ -156,7 +155,7 @@ trait ResourceGroupState<T: Transaction> {
 }
 
 pub(crate) struct ParallelState<'a, T: Transaction, X: Executable> {
-    versioned_map: &'a MVHashMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
+    pub(crate) versioned_map: &'a MVHashMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
     scheduler: &'a Scheduler,
     start_counter: u32,
     counter: &'a AtomicU32,
@@ -453,7 +452,7 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
         }
     }
 
-    fn set_delayed_field_value(&self, id: T::Identifier, base_value: DelayedFieldValue) {
+    pub(crate) fn set_delayed_field_value(&self, id: T::Identifier, base_value: DelayedFieldValue) {
         self.versioned_map
             .delayed_fields()
             .set_base_value(id, base_value)
@@ -777,11 +776,11 @@ impl<'a, T: Transaction, X: Executable> SequentialState<'a, T, X> {
         }
     }
 
-    fn set_delayed_field_value(&self, id: T::Identifier, base_value: DelayedFieldValue) {
+    pub(crate) fn set_delayed_field_value(&self, id: T::Identifier, base_value: DelayedFieldValue) {
         self.unsync_map.write_delayed_field(id, base_value)
     }
 
-    fn read_delayed_field(&self, id: T::Identifier) -> Option<DelayedFieldValue> {
+    pub(crate) fn read_delayed_field(&self, id: T::Identifier) -> Option<DelayedFieldValue> {
         self.unsync_map.fetch_delayed_field(&id)
     }
 }
@@ -948,7 +947,7 @@ impl<'a, T: Transaction, X: Executable> ViewState<'a, T, X> {
 /// must be set according to the latest transaction that the worker was / is executing.
 pub(crate) struct LatestView<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> {
     base_view: &'a S,
-    latest_view: ViewState<'a, T, X>,
+    pub(crate) latest_view: ViewState<'a, T, X>,
     txn_idx: TxnIndex,
 }
 
@@ -1115,88 +1114,35 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
         Ok((patched_bytes, mapping.into_inner()))
     }
 
-    // Given a bytes, where values were already exchanged with idnetifiers,
-    // return a list of identifiers present in it.
-    fn extract_identifiers_from_value(
-        &self,
-        bytes: &Bytes,
-        layout: &MoveTypeLayout,
-    ) -> anyhow::Result<HashSet<T::Identifier>> {
-        let mapping = TemporaryExtractIdentifiersMapping::<T>::new();
-        // TODO[agg_v2](cleanup) rename deserialize_and_replace_values_with_ids to not be specific to mapping trait implementation
-        // TODO[agg_v2](cleanup) provide traversal method, that doesn't create unnecessary patched value.
-        let _patched_value =
-            deserialize_and_replace_values_with_ids(bytes.as_ref(), layout, &mapping).ok_or_else(
-                || anyhow::anyhow!("Failed to deserialize resource during id replacement"),
-            )?;
-        Ok(mapping.into_inner())
-    }
-
-    fn does_value_need_exchange(
-        &self,
-        value: &T::Value,
-        layout: &Arc<MoveTypeLayout>,
-        delayed_write_set_keys: &HashSet<T::Identifier>,
-        key: &T::Key,
-    ) -> Option<Result<(T::Key, (T::Value, Arc<MoveTypeLayout>)), PanicError>> {
-        if let Some(bytes) = value.bytes() {
-            let identifiers_in_read_result = self.extract_identifiers_from_value(bytes, layout);
-
-            match identifiers_in_read_result {
-                Ok(identifiers_in_read) => {
-                    if !delayed_write_set_keys.is_disjoint(&identifiers_in_read) {
-                        return Some(Ok((key.clone(), (value.clone(), layout.clone()))));
-                    }
-                },
-                Err(e) => {
-                    return Some(Err(code_invariant_error(format!("Cannot extract identifiers from value that identifiers were exchanged into before {:?}", e))))
-                }
-            }
-        }
-        None
-    }
-
-    fn get_reads_needing_exchange_parallel(
-        &self,
-        read_set: &CapturedReads<T>,
-        delayed_write_set_keys: &HashSet<T::Identifier>,
-        skip: &HashSet<T::Key>,
-    ) -> Result<BTreeMap<T::Key, (T::Value, Arc<MoveTypeLayout>)>, PanicError> {
-        read_set
-            .get_read_values_with_delayed_fields()
-            .filter(|(key, _)| !skip.contains(key))
-            .flat_map(|(key, data_read)| {
-                if let DataRead::Versioned(_version, value, Some(layout)) = data_read {
-                    return self.does_value_need_exchange(
-                        value,
-                        layout,
-                        delayed_write_set_keys,
-                        key,
-                    );
-                }
-                None
-            })
-            .collect()
-    }
-
     fn get_reads_needing_exchange_sequential(
         &self,
         read_set: &HashSet<T::Key>,
         unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
-        delayed_write_set_keys: &HashSet<T::Identifier>,
+        delayed_write_set_ids: &HashSet<T::Identifier>,
         skip: &HashSet<T::Key>,
-    ) -> Result<BTreeMap<T::Key, (T::Value, Arc<MoveTypeLayout>)>, PanicError> {
+    ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>, PanicError> {
         read_set
             .iter()
-            .filter(|key| !skip.contains(key))
-            .flat_map(|key| match unsync_map.fetch_data(key) {
-                Some(ValueWithLayout::Exchanged(value, Some(layout))) => self
-                    .does_value_need_exchange(value.as_ref(), &layout, delayed_write_set_keys, key),
-                Some(ValueWithLayout::Exchanged(_, None)) => None,
-                Some(ValueWithLayout::RawFromStorage(_)) => Some(Err(code_invariant_error(
-                    "Cannot exchange value that was not exchanged before",
-                ))),
-                None => None,
+            .filter_map(|key| {
+                if skip.contains(key) {
+                    return None;
+                }
+
+                match unsync_map.fetch_data(key) {
+                    Some(ValueWithLayout::Exchanged(value, Some(layout))) => {
+                        filter_value_for_exchange::<T>(
+                            value.as_ref(),
+                            &layout,
+                            delayed_write_set_ids,
+                            key,
+                        )
+                    },
+                    Some(ValueWithLayout::Exchanged(_, None)) => None,
+                    Some(ValueWithLayout::RawFromStorage(_)) => Some(Err(code_invariant_error(
+                        "Cannot exchange value that was not exchanged before",
+                    ))),
+                    None => None,
+                }
             })
             .collect()
     }
@@ -1204,9 +1150,9 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
     fn get_group_reads_needing_exchange_parallel(
         &self,
         parallel_state: &ParallelState<'a, T, X>,
-        delayed_write_set_keys: &HashSet<T::Identifier>,
+        delayed_write_set_ids: &HashSet<T::Identifier>,
         skip: &HashSet<T::Key>,
-    ) -> Result<BTreeMap<T::Key, (T::Value, u64)>, PanicError> {
+    ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64)>, PanicError> {
         let reads_with_delayed_fields = parallel_state
             .captured_reads
             .borrow()
@@ -1218,18 +1164,27 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             .into_iter()
             .flat_map(|(key, group_read)| {
                 let GroupRead { inner_reads, .. } = group_read;
+
+                // TODO[agg_v2](clean-up): Once ids can be extracted without possible failure,
+                // the following is just an any call on iterator (same for resource reads).
                 let mut resources_needing_delayed_field_exchange = false;
                 for data_read in inner_reads.values() {
                     if let DataRead::Versioned(_version, value, Some(layout)) = data_read {
-                        if let Some(bytes) = value.bytes() {
-                            let identifiers_in_read = self
-                                .extract_identifiers_from_value(bytes, layout.as_ref())
-                                .unwrap();
-                            if !delayed_write_set_keys.is_disjoint(&identifiers_in_read) {
-                                // TODO[agg_v2](optimize): Is it possible to avoid clones here?
-                                resources_needing_delayed_field_exchange = true;
-                                break;
-                            }
+                        // TODO[agg_v2](optimize): Is it possible to avoid clones here?
+                        match does_value_need_exchange::<T>(
+                            value,
+                            layout.as_ref(),
+                            delayed_write_set_ids,
+                        ) {
+                            Ok(needs_exchange) => {
+                                if needs_exchange {
+                                    resources_needing_delayed_field_exchange = true;
+                                    break;
+                                }
+                            },
+                            Err(e) => {
+                                return Some(Err(e));
+                            },
                         }
                     }
                 }
@@ -1238,20 +1193,18 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                 }
 
                 if let Ok(Some(metadata)) = self.get_resource_state_value_metadata(&key) {
-                    let metadata = Some(StateValue::new_with_metadata(Bytes::new(), metadata));
-                    if let Ok(GroupReadResult::Size(group_size)) =
-                        parallel_state.read_group_size(&key, self.txn_idx)
-                    {
-                        let metadata_op: T::Value = TransactionWrite::from_state_value(metadata);
-                        if let Some(metadata_op) = metadata_op.convert_read_to_modification() {
-                            return Some(Ok((key.clone(), (metadata_op, group_size.get()))));
-                        }
-                    } else {
-                        return Some(Err(code_invariant_error(format!(
-                            "Cannot compute metadata op size for the group read {:?}",
-                            key
-                        ))));
-                    }
+                    return Some(
+                        if let Ok(GroupReadResult::Size(group_size)) =
+                            parallel_state.read_group_size(&key, self.txn_idx)
+                        {
+                            Ok((key.clone(), (metadata, group_size.get())))
+                        } else {
+                            Err(code_invariant_error(format!(
+                                "Cannot compute metadata op size for the group read {:?}",
+                                key
+                            )))
+                        },
+                    );
                 }
                 Some(Err(code_invariant_error(format!(
                     "Cannot compute metadata op for the group read {:?}",
@@ -1265,9 +1218,9 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
         &self,
         group_read_set: &HashMap<T::Key, HashSet<T::Tag>>,
         unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
-        delayed_write_set_keys: &HashSet<T::Identifier>,
+        delayed_write_set_ids: &HashSet<T::Identifier>,
         skip: &HashSet<T::Key>,
-    ) -> Result<BTreeMap<T::Key, (T::Value, u64)>, PanicError> {
+    ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64)>, PanicError> {
         group_read_set
             .iter()
             .filter(|(key, _tags)| !skip.contains(key))
@@ -1280,18 +1233,21 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                             if let ValueWithLayout::Exchanged(value, Some(layout)) =
                                 value_with_layout
                             {
-                                if let Some(bytes) = value.bytes() {
-                                    let identifiers_in_read = self
-                                        .extract_identifiers_from_value(bytes, layout.as_ref())
-                                        .unwrap();
-                                    if !delayed_write_set_keys.is_disjoint(&identifiers_in_read) {
-                                        resources_needing_delayed_field_exchange = true;
-                                        break;
-                                    }
-                                } else {
-                                    return Some(Err(code_invariant_error(
-                                        "Delete shouldn't be in get_group_reads_needing_exchange_sequential",
-                                    )));
+                                // TODO[agg_v2](optimize): Is it possible to avoid clones here?
+                                match does_value_need_exchange::<T>(
+                                    &value,
+                                    layout.as_ref(),
+                                    delayed_write_set_ids,
+                                ) {
+                                    Ok(needs_exchange) => {
+                                        if needs_exchange {
+                                            resources_needing_delayed_field_exchange = true;
+                                            break;
+                                        }
+                                    },
+                                    Err(e) => {
+                                        return Some(Err(e));
+                                    },
                                 }
                             }
                         }
@@ -1299,16 +1255,11 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                     if !resources_needing_delayed_field_exchange {
                         return None;
                     }
-                    if let Some(metadata) = unsync_map.fetch_data(key) {
+                    if let Ok(Some(metadata)) = self.get_resource_state_value_metadata(key) {
                         if let Ok(GroupReadResult::Size(group_size)) =
                             unsync_map.get_group_size(key)
                         {
-                            if let Some(metadata_op) = metadata
-                                .extract_value_no_layout()
-                                .convert_read_to_modification()
-                            {
-                                return Some(Ok((key.clone(), (metadata_op, group_size.get()))));
-                            }
+                            return Some(Ok((key.clone(), (metadata, group_size.get()))));
                         } else {
                             // TODO[agg_v2](fix): `get_group_size` can fail on group tag serialization. Do
                             //       we want to propagate this error? This is somewhat an invariant
@@ -1651,7 +1602,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
     type Identifier = T::Identifier;
     type ResourceGroupTag = T::Tag;
     type ResourceKey = T::Key;
-    type ResourceValue = T::Value;
 
     fn is_delayed_field_optimization_capable(&self) -> bool {
         match &self.latest_view {
@@ -1767,34 +1717,25 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
         Ok(result)
     }
 
-    // TODO[agg_v2](cleanup) - update comment.
-    // For each resource that satisfies the following conditions,
-    //     1. Resource is in read set
-    //     2. Resource is not in write set
-    // replace the delayed field identifiers in the resource with corresponding values.
-    // If any of the delayed field identifiers in the resource are part of delayed_field_write_set,
-    // then include the resource in the write set.
     fn get_reads_needing_exchange(
         &self,
-        delayed_write_set_keys: &HashSet<Self::Identifier>,
+        delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, Arc<MoveTypeLayout>)>, PanicError>
-    {
+    ) -> Result<
+        BTreeMap<Self::ResourceKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+        PanicError,
+    > {
         match &self.latest_view {
-            ViewState::Sync(state) => {
-                let captured_reads = state.captured_reads.borrow();
-                self.get_reads_needing_exchange_parallel(
-                    &captured_reads,
-                    delayed_write_set_keys,
-                    skip,
-                )
-            },
+            ViewState::Sync(state) => state
+                .captured_reads
+                .borrow()
+                .get_read_values_with_delayed_fields(delayed_write_set_ids, skip),
             ViewState::Unsync(state) => {
                 let read_set = state.read_set.borrow();
                 self.get_reads_needing_exchange_sequential(
                     &read_set.resource_reads,
                     state.unsync_map,
-                    delayed_write_set_keys,
+                    delayed_write_set_ids,
                     skip,
                 )
             },
@@ -1803,148 +1744,23 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
 
     fn get_group_reads_needing_exchange(
         &self,
-        delayed_write_set_keys: &HashSet<Self::Identifier>,
+        delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (Self::ResourceValue, u64)>, PanicError> {
+    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
         match &self.latest_view {
             ViewState::Sync(state) => {
-                self.get_group_reads_needing_exchange_parallel(state, delayed_write_set_keys, skip)
+                self.get_group_reads_needing_exchange_parallel(state, delayed_write_set_ids, skip)
             },
             ViewState::Unsync(state) => {
                 let read_set = state.read_set.borrow();
                 self.get_group_reads_needing_exchange_sequential(
                     &read_set.group_reads,
                     state.unsync_map,
-                    delayed_write_set_keys,
+                    delayed_write_set_ids,
                     skip,
                 )
             },
         }
-    }
-}
-
-struct TemporaryValueToIdentifierMapping<
-    'a,
-    T: Transaction,
-    S: TStateView<Key = T::Key>,
-    X: Executable,
-> {
-    latest_view: &'a LatestView<'a, T, S, X>,
-    txn_idx: TxnIndex,
-    // These are the delayed field keys that were touched when utilizing this mapping
-    // to replace ids with values or values with ids
-    delayed_field_keys: RefCell<HashSet<T::Identifier>>,
-}
-
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable>
-    TemporaryValueToIdentifierMapping<'a, T, S, X>
-{
-    pub fn new(latest_view: &'a LatestView<'a, T, S, X>, txn_idx: TxnIndex) -> Self {
-        Self {
-            latest_view,
-            txn_idx,
-            delayed_field_keys: RefCell::new(HashSet::new()),
-        }
-    }
-
-    fn generate_delayed_field_id(&self, width: u32) -> T::Identifier {
-        self.latest_view.generate_delayed_field_id(width)
-    }
-
-    pub fn into_inner(self) -> HashSet<T::Identifier> {
-        self.delayed_field_keys.into_inner()
-    }
-}
-
-// For aggregators V2, values are replaced with identifiers at deserialization time,
-// and are replaced back when the value is serialized. The "lifted" values are cached
-// by the `LatestView` in the aggregators multi-version data structure.
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ValueToIdentifierMapping
-    for TemporaryValueToIdentifierMapping<'a, T, S, X>
-{
-    fn value_to_identifier(
-        &self,
-        kind: &IdentifierMappingKind,
-        layout: &MoveTypeLayout,
-        value: Value,
-    ) -> TransformationResult<Value> {
-        let (base_value, width) = DelayedFieldValue::try_from_move_value(layout, value, kind)?;
-        let id = self.generate_delayed_field_id(width);
-        match &self.latest_view.latest_view {
-            ViewState::Sync(state) => state.set_delayed_field_value(id, base_value),
-            ViewState::Unsync(state) => {
-                state.set_delayed_field_value(id, base_value);
-            },
-        };
-        self.delayed_field_keys.borrow_mut().insert(id);
-        id.try_into_move_value(layout)
-            .map_err(|e| TransformationError(format!("{:?}", e)))
-    }
-
-    fn identifier_to_value(
-        &self,
-        layout: &MoveTypeLayout,
-        identifier_value: Value,
-    ) -> TransformationResult<Value> {
-        let (id, width) = T::Identifier::try_from_move_value(layout, identifier_value, &())
-            .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
-        Ok(match &self.latest_view.latest_view {
-            ViewState::Sync(state) => state
-                .versioned_map
-                .delayed_fields()
-                .read_latest_committed_value(&id, self.txn_idx, ReadPosition::AfterCurrentTxn)
-                .expect("Committed value for ID must always exist"),
-            ViewState::Unsync(state) => state
-                .read_delayed_field(id)
-                .expect("Delayed field value for ID must always exist in sequential execution"),
-        }
-        .try_into_move_value(layout, width)?)
-    }
-}
-
-struct TemporaryExtractIdentifiersMapping<T: Transaction> {
-    // These are the delayed field keys that were touched when utilizing this mapping
-    // to replace ids with values or values with ids
-    delayed_field_keys: RefCell<HashSet<T::Identifier>>,
-}
-
-impl<T: Transaction> TemporaryExtractIdentifiersMapping<T> {
-    pub fn new() -> Self {
-        Self {
-            delayed_field_keys: RefCell::new(HashSet::new()),
-        }
-    }
-
-    pub fn into_inner(self) -> HashSet<T::Identifier> {
-        self.delayed_field_keys.into_inner()
-    }
-}
-
-impl<T: Transaction> ValueToIdentifierMapping for TemporaryExtractIdentifiersMapping<T> {
-    fn value_to_identifier(
-        &self,
-        _kind: &IdentifierMappingKind,
-        layout: &MoveTypeLayout,
-        value: Value,
-    ) -> TransformationResult<Value> {
-        let (id, _) = T::Identifier::try_from_move_value(layout, value, &())
-            .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
-        id.try_into_move_value(layout)
-            .map_err(|e| TransformationError(format!("{:?}", e)))
-    }
-
-    fn identifier_to_value(
-        &self,
-        layout: &MoveTypeLayout,
-        identifier_value: Value,
-    ) -> TransformationResult<Value> {
-        let (id, _) = T::Identifier::try_from_move_value(layout, identifier_value, &())
-            .map_err(|e| TransformationError(format!("{:?}", e)))?;
-        self.delayed_field_keys.borrow_mut().insert(id);
-        id.try_into_move_value(layout)
-            .map_err(|e| TransformationError(format!("{:?}", e)))
     }
 }
 
@@ -2991,25 +2807,28 @@ mod test {
 
         fn get_reads_needing_exchange(
             &self,
-            delayed_write_set_keys: &HashSet<DelayedFieldID>,
+            delayed_write_set_ids: &HashSet<DelayedFieldID>,
             skip: &HashSet<KeyType<u32>>,
-        ) -> Result<BTreeMap<KeyType<u32>, (ValueType, Arc<MoveTypeLayout>)>, PanicError> {
+        ) -> Result<
+            BTreeMap<KeyType<u32>, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+            PanicError,
+        > {
             let seq = self
                 .latest_view_seq
-                .get_reads_needing_exchange(delayed_write_set_keys, skip);
+                .get_reads_needing_exchange(delayed_write_set_ids, skip);
             let par = self
                 .latest_view_par
-                .get_reads_needing_exchange(delayed_write_set_keys, skip);
+                .get_reads_needing_exchange(delayed_write_set_ids, skip);
 
             self.assert_res_eq(
                 seq.as_ref().map(|m| {
                     m.iter()
-                        .map(|(k, (v, l))| (*k, (v.as_state_value(), l.clone())))
+                        .map(|(k, (metadata, size, layout))| (*k, (metadata, size, layout.clone())))
                         .collect::<BTreeMap<_, _>>()
                 }),
                 par.as_ref().map(|m| {
                     m.iter()
-                        .map(|(k, (v, l))| (*k, (v.as_state_value(), l.clone())))
+                        .map(|(k, (metadata, size, layout))| (*k, (metadata, size, layout.clone())))
                         .collect::<BTreeMap<_, _>>()
                 }),
             )
@@ -3232,14 +3051,16 @@ mod test {
 
         let captured_reads = views.latest_view_par.take_parallel_reads();
         assert!(captured_reads.validate_data_reads(holder.versioned_map.data(), 1));
-        let read_set_with_delayed_fields = captured_reads.get_read_values_with_delayed_fields();
+        // TODO(aggr_v2): what's up with this test case?
+        let _read_set_with_delayed_fields =
+            captured_reads.get_read_values_with_delayed_fields(&HashSet::new(), &HashSet::new());
 
         // TODO[agg_v2](fix): This prints
         // read: (KeyType(4, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         // read: (KeyType(2, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
-        for read in read_set_with_delayed_fields {
-            println!("read: {:?}", read);
-        }
+        // for read in read_set_with_delayed_fields {
+        //     println!("read: {:?}", read);
+        // }
 
         // TODO[agg_v2](fix): This assertion fails.
         // let data_read = DataRead::Versioned(Ok((1,0)), Arc::new(TransactionWrite::from_state_value(Some(state_value_4))), Some(Arc::new(layout)));

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -179,14 +179,9 @@ impl AggV2TestHarness {
             .harness
             .run_block_in_parts_and_check(block_split, txn_block.clone());
 
-        for (idx, (h, name)) in self.comparison_harnesses.iter_mut().enumerate() {
+        for (h, name) in self.comparison_harnesses.iter_mut() {
             let new_result = h.run_block_in_parts_and_check(block_split, txn_block.clone());
-            assert_outputs_equal(
-                &result,
-                "baseline",
-                &new_result,
-                name,
-            );
+            assert_outputs_equal(&result, "baseline", &new_result, name);
         }
     }
 

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -45,7 +45,7 @@ pub fn initialize_enabled_disabled_comparison(
 
     let mut agg_harness = AggV2TestHarness {
         harness: harness_base,
-        comparison_harnesses: vec![harness_comp],
+        comparison_harnesses: vec![(harness_comp, "aggregator_execution_enabled".to_string())],
         account: account_base,
         txn_accounts: vec![],
         txn_index: 0,
@@ -87,7 +87,7 @@ fn initialize_harness(
 
 pub struct AggV2TestHarness {
     pub harness: MoveHarness,
-    pub comparison_harnesses: Vec<MoveHarness>,
+    pub comparison_harnesses: Vec<(MoveHarness, String)>,
     pub account: Account,
     pub txn_accounts: Vec<Account>,
     pub txn_index: usize,
@@ -179,13 +179,13 @@ impl AggV2TestHarness {
             .harness
             .run_block_in_parts_and_check(block_split, txn_block.clone());
 
-        for (idx, h) in self.comparison_harnesses.iter_mut().enumerate() {
+        for (idx, (h, name)) in self.comparison_harnesses.iter_mut().enumerate() {
             let new_result = h.run_block_in_parts_and_check(block_split, txn_block.clone());
             assert_outputs_equal(
                 &result,
                 "baseline",
                 &new_result,
-                &format!("comparison {}", idx),
+                name,
             );
         }
     }
@@ -204,7 +204,7 @@ impl AggV2TestHarness {
 
         let result = self.harness.store_and_fund_account(&acc, balance, seq_num);
 
-        for h in self.comparison_harnesses.iter_mut() {
+        for (h, _name) in self.comparison_harnesses.iter_mut() {
             h.store_and_fund_account(&acc, balance, seq_num);
         }
 

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -11,7 +11,8 @@ use aptos_aggregator::{
     types::DelayedFieldID,
 };
 use aptos_types::{
-    delayed_fields::PanicError, state_store::state_key::StateKey, write_set::WriteOp,
+    delayed_fields::PanicError,
+    state_store::{state_key::StateKey, state_value::StateValueMetadata},
 };
 use better_any::{Tid, TidAble};
 use move_core_types::value::MoveTypeLayout;
@@ -38,8 +39,8 @@ pub enum AggregatorChangeV1 {
 pub struct AggregatorChangeSet {
     pub aggregator_v1_changes: BTreeMap<StateKey, AggregatorChangeV1>,
     pub delayed_field_changes: BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>,
-    pub reads_needing_exchange: BTreeMap<StateKey, (WriteOp, Arc<MoveTypeLayout>)>,
-    pub group_reads_needing_exchange: BTreeMap<StateKey, (WriteOp, u64)>,
+    pub reads_needing_exchange: BTreeMap<StateKey, (StateValueMetadata, u64, Arc<MoveTypeLayout>)>,
+    pub group_reads_needing_exchange: BTreeMap<StateKey, (StateValueMetadata, u64)>,
 }
 
 /// Native context that can be attached to VM `NativeContextExtensions`.
@@ -116,7 +117,7 @@ impl<'a> NativeAggregatorContext<'a> {
         }
 
         let delayed_field_changes = delayed_field_data.into_inner().into();
-        let delayed_write_set_keys = delayed_field_changes
+        let delayed_write_set_ids = delayed_field_changes
             .keys()
             .cloned()
             .collect::<HashSet<_>>();
@@ -126,17 +127,17 @@ impl<'a> NativeAggregatorContext<'a> {
             // is_empty check covers both whether delayed fields are enabled or not, as well as whether there
             // are any changes that would require computing reads needing exchange.
             // TODO[agg_v2](optimize) we only later compute the the write set, so cannot pass the correct skip values here.
-            reads_needing_exchange: if delayed_write_set_keys.is_empty() {
+            reads_needing_exchange: if delayed_write_set_ids.is_empty() {
                 BTreeMap::new()
             } else {
                 self.delayed_field_resolver
-                    .get_reads_needing_exchange(&delayed_write_set_keys, &HashSet::new())?
+                    .get_reads_needing_exchange(&delayed_write_set_ids, &HashSet::new())?
             },
-            group_reads_needing_exchange: if delayed_write_set_keys.is_empty() {
+            group_reads_needing_exchange: if delayed_write_set_ids.is_empty() {
                 BTreeMap::new()
             } else {
                 self.delayed_field_resolver
-                    .get_group_reads_needing_exchange(&delayed_write_set_keys, &HashSet::new())?
+                    .get_group_reads_needing_exchange(&delayed_write_set_ids, &HashSet::new())?
             },
         })
     }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -364,17 +364,10 @@ pub(crate) mod test {
         fn set_bytes(&mut self, bytes: Bytes) {
             self.bytes = bytes;
         }
-
-        fn convert_read_to_modification(&self) -> Option<Self>
-        where
-            Self: Sized,
-        {
-            Some(self.clone())
-        }
     }
 
     // Generate a Vec deterministically based on txn_idx and incarnation.
-    pub(crate) fn value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> TestValue {
+    fn value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> TestValue {
         TestValue::new(vec![txn_idx * 5, txn_idx + incarnation, incarnation * 5])
     }
 

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -4,7 +4,7 @@
 
 use super::{
     types::{
-        test::{arc_value_for, u128_for, value_for, KeyType, TestValue},
+        test::{arc_value_for, u128_for, KeyType, TestValue},
         MVDataError, MVDataOutput,
     },
     unsync_map::UnsyncMap,
@@ -42,16 +42,16 @@ fn unsync_map_data_basic() {
     assert_none!(map.fetch_data(&ap));
     // Ensure write registers the new value.
     //TODO[agg_v2](tests): Hardocoding layout to None. Test when layout is Some(.) as well.
-    map.write(ap.clone(), value_for(10, 1), None);
+    map.write(ap.clone(), arc_value_for(10, 1), None);
     assert_some_eq!(
         map.fetch_data(&ap),
-        ValueWithLayout::Exchanged(Arc::new(value_for(10, 1)), None)
+        ValueWithLayout::Exchanged(arc_value_for(10, 1), None)
     );
     // Ensure the next write overwrites the value.
-    map.write(ap.clone(), value_for(14, 1), None);
+    map.write(ap.clone(), arc_value_for(14, 1), None);
     assert_some_eq!(
         map.fetch_data(&ap),
-        ValueWithLayout::Exchanged(Arc::new(value_for(14, 1)), None)
+        ValueWithLayout::Exchanged(arc_value_for(14, 1), None)
     );
 }
 
@@ -74,7 +74,7 @@ fn create_write_read_placeholder_struct() {
     // Write by txn 10.
     mvtbl
         .data()
-        .write(ap1.clone(), 10, 1, (value_for(10, 1), None));
+        .write(ap1.clone(), 10, 1, arc_value_for(10, 1), None);
 
     // Reads that should go the DB return Err(Uninitialized)
     let r_db = mvtbl.data().fetch_data(&ap1, 9);
@@ -111,10 +111,10 @@ fn create_write_read_placeholder_struct() {
     // More writes.
     mvtbl
         .data()
-        .write(ap1.clone(), 12, 0, (value_for(12, 0), None));
+        .write(ap1.clone(), 12, 0, arc_value_for(12, 0), None);
     mvtbl
         .data()
-        .write(ap1.clone(), 8, 3, (value_for(8, 3), None));
+        .write(ap1.clone(), 8, 3, arc_value_for(8, 3), None);
 
     // Verify reads.
     let r_12 = mvtbl.data().fetch_data(&ap1, 15);
@@ -151,7 +151,7 @@ fn create_write_read_placeholder_struct() {
     mvtbl.data().remove(&ap1, 10);
     mvtbl
         .data()
-        .write(ap2.clone(), 10, 2, (value_for(10, 2), None));
+        .write(ap2.clone(), 10, 2, arc_value_for(10, 2), None);
 
     // Read by txn 11 no longer observes entry from txn 10.
     let r_8 = mvtbl.data().fetch_data(&ap1, 11);
@@ -166,10 +166,10 @@ fn create_write_read_placeholder_struct() {
     // Reads, writes for ap2 and ap3.
     mvtbl
         .data()
-        .write(ap2.clone(), 5, 0, (value_for(5, 0), None));
+        .write(ap2.clone(), 5, 0, arc_value_for(5, 0), None);
     mvtbl
         .data()
-        .write(ap3.clone(), 20, 4, (value_for(20, 4), None));
+        .write(ap3.clone(), 20, 4, arc_value_for(20, 4), None);
     let r_5 = mvtbl.data().fetch_data(&ap2, 10);
     assert_eq!(
         Ok(Versioned(
@@ -216,10 +216,10 @@ fn create_write_read_placeholder_struct() {
     let r_33 = mvtbl.data().fetch_data(&ap1, 33);
     assert_eq!(Err(DeltaApplicationFailure), r_33);
 
-    let val = value_for(10, 3);
+    let val = arc_value_for(10, 3);
     // sub base sub_for for which should underflow.
     let sub_base = val.as_u128().unwrap().unwrap();
-    mvtbl.data().write(ap2.clone(), 10, 3, (val, None));
+    mvtbl.data().write(ap2.clone(), 10, 3, val, None);
     mvtbl
         .data()
         .add_delta(ap2.clone(), 30, delta_sub(30 + sub_base, u128::MAX));

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -189,6 +189,14 @@ impl<
         self.resource_map.borrow().get(key).cloned()
     }
 
+    pub fn fetch_exchanged_data(&self, key: &K) -> Option<(Arc<V>, Arc<MoveTypeLayout>)> {
+        if let Some(ValueWithLayout::Exchanged(value, Some(layout))) = self.fetch_data(key) {
+            Some((value, layout))
+        } else {
+            None
+        }
+    }
+
     pub fn fetch_group_data(&self, key: &K) -> Option<Vec<(Arc<T>, ValueWithLayout<V>)>> {
         self.group_cache.borrow().get(key).map(|group_map| {
             group_map
@@ -224,10 +232,10 @@ impl<
         self.delayed_field_map.borrow().get(id).cloned()
     }
 
-    pub fn write(&self, key: K, value: V, layout: Option<Arc<MoveTypeLayout>>) {
+    pub fn write(&self, key: K, value: Arc<V>, layout: Option<Arc<MoveTypeLayout>>) {
         self.resource_map
             .borrow_mut()
-            .insert(key, ValueWithLayout::Exchanged(Arc::new(value), layout));
+            .insert(key, ValueWithLayout::Exchanged(value, layout));
     }
 
     pub fn write_module(&self, key: K, value: V) {

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -246,7 +246,11 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
     }
 
     // Records the latest committed op for each tag in the group (removed tags ar excluded).
-    fn commit_idx(&mut self, shifted_idx: ShiftedTxnIndex, allow_new_modification: bool) -> anyhow::Result<()> {
+    fn commit_idx(
+        &mut self,
+        shifted_idx: ShiftedTxnIndex,
+        allow_new_modification: bool,
+    ) -> anyhow::Result<()> {
         use std::collections::hash_map::Entry::*;
         use WriteOpKind::*;
 
@@ -262,8 +266,10 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                 (Occupied(mut entry), Modification) => {
                     entry.insert(v.clone());
                 },
-                (Vacant(entry), Creation)
-                | (Vacant(entry), Modification) if allow_new_modification => {
+                (Vacant(entry), Creation) => {
+                    entry.insert(v.clone());
+                },
+                (Vacant(entry), Modification) if allow_new_modification => {
                     entry.insert(v.clone());
                 },
                 (Occupied(mut entry), Creation) if entry.get().write_op_kind() == Deletion => {

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -197,7 +197,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
 
         if at_base_version {
             // base version is from storage and final - immediately treat as committed.
-            self.commit_idx(zero_idx)
+            self.commit_idx(zero_idx, true)
                 .expect("Marking storage version as committed must succeed");
         }
 
@@ -246,7 +246,7 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
     }
 
     // Records the latest committed op for each tag in the group (removed tags ar excluded).
-    fn commit_idx(&mut self, shifted_idx: ShiftedTxnIndex) -> anyhow::Result<()> {
+    fn commit_idx(&mut self, shifted_idx: ShiftedTxnIndex, allow_new_modification: bool) -> anyhow::Result<()> {
         use std::collections::hash_map::Entry::*;
         use WriteOpKind::*;
 
@@ -262,17 +262,17 @@ impl<T: Hash + Clone + Debug + Eq + Serialize, V: TransactionWrite> VersionedGro
                 (Occupied(mut entry), Modification) => {
                     entry.insert(v.clone());
                 },
-                (Vacant(entry), Creation) => {
+                (Vacant(entry), Creation)
+                | (Vacant(entry), Modification) if allow_new_modification => {
                     entry.insert(v.clone());
                 },
                 (Occupied(mut entry), Creation) if entry.get().write_op_kind() == Deletion => {
                     entry.insert(v.clone());
                 },
-                (_, _) => {
+                (e, _) => {
                     bail!(
-                        "WriteOp kind {:?} not consistent with previous value at tag {:?}",
+                        "[{shifted_idx:?}] WriteOp kind {:?} not consistent with previous value at tag {tag:?}, value: {e:?}",
                         v.write_op_kind(),
-                        tag
                     );
                 },
             }
@@ -479,7 +479,7 @@ impl<
     ) -> anyhow::Result<Vec<(T, ValueWithLayout<V>)>> {
         let mut v = self.group_values.get_mut(key).expect("Path must exist");
 
-        v.commit_idx(ShiftedTxnIndex::new(txn_idx))?;
+        v.commit_idx(ShiftedTxnIndex::new(txn_idx), false)?;
         Ok(v.get_committed_group())
     }
 

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -286,21 +286,6 @@ pub enum WriteOpSize {
     Deletion,
 }
 
-impl From<&WriteOp> for WriteOpSize {
-    fn from(value: &WriteOp) -> Self {
-        use WriteOp::*;
-        match value {
-            Creation { data, .. } => WriteOpSize::Creation {
-                write_len: data.len() as u64,
-            },
-            Modification { data, .. } => WriteOpSize::Modification {
-                write_len: data.len() as u64,
-            },
-            Deletion { .. } => WriteOpSize::Deletion,
-        }
-    }
-}
-
 impl WriteOpSize {
     pub fn write_len(&self) -> Option<u64> {
         match self {
@@ -329,9 +314,10 @@ pub trait TransactionWrite: Debug {
     // Often, the contents of W:TransactionWrite are converted to Option<StateValue>, e.g.
     // to emulate reading from storage after W has been applied. However, in some contexts,
     // it is also helpful to convert a StateValue to a potential instance of W that would
-    // have the desired effect. This allows e.g. to store certain sentinel elements of
-    // type W in data-structures (happens in MVHashMap). If there are several instances of
-    // W that correspond to maybe_state_value, an arbitrary one may be provided.
+    // have the desired effect. This allows e.g. storing sentinel elements of type W in
+    // data-structures (notably in MVHashMap). The kind of W will be Modification and not
+    // Creation, but o.w. if there are several instances of W that correspond to the
+    // provided maybe_state_value, an arbitrary one may be provided.
     fn from_state_value(maybe_state_value: Option<StateValue>) -> Self;
 
     fn extract_raw_bytes(&self) -> Option<Bytes> {
@@ -361,12 +347,18 @@ pub trait TransactionWrite: Debug {
 
     fn set_bytes(&mut self, bytes: Bytes);
 
-    /// Convert a `self`, which was read (containing DelayedField exchanges) in a current
-    /// transaction, to a modification write, in which we can then exchange DelayedField
-    /// identifiers into their final values, to produce a write operation.
-    fn convert_read_to_modification(&self) -> Option<Self>
-    where
-        Self: Sized;
+    fn write_op_size(&self) -> WriteOpSize {
+        use WriteOpKind::*;
+        match self.write_op_kind() {
+            Creation => WriteOpSize::Creation {
+                write_len: self.bytes().unwrap().len() as u64,
+            },
+            Modification => WriteOpSize::Modification {
+                write_len: self.bytes().unwrap().len() as u64,
+            },
+            Deletion { .. } => WriteOpSize::Deletion,
+        }
+    }
 }
 
 impl TransactionWrite for WriteOp {
@@ -390,7 +382,7 @@ impl TransactionWrite for WriteOp {
             None => Self::legacy_deletion(),
             Some(state_value) => {
                 let (metadata, data) = state_value.unpack();
-                Self::Creation { data, metadata }
+                Self::Modification { data, metadata }
             },
         }
     }
@@ -410,18 +402,6 @@ impl TransactionWrite for WriteOp {
         match self {
             Creation { data, .. } | Modification { data, .. } => *data = bytes,
             Deletion { .. } => (),
-        }
-    }
-
-    fn convert_read_to_modification(&self) -> Option<Self> {
-        use WriteOp::*;
-
-        match self.clone() {
-            Creation { data, metadata } | Modification { data, metadata } => {
-                Some(Modification { data, metadata })
-            },
-            // Deletion don't have data to become modification.
-            Deletion { .. } => None,
         }
     }
 }


### PR DESCRIPTION
- Get rid of convert_read_to_modification, propagate metadata (for reads needing replacement) when write op isn't needed
- Between resources and resources in the groups, as well as reads needing delayed field replacement 
    - Extract, isolate and re-use common functionality
    - Make error handling uniform
- Turn some expects into fallback errors
- Start re-structure the code (from executor and view) to have more thematic and smaller files (e.g. with utilities)
- Do not clone the whole write set twice (one to put in MVHashMap and then to filter for ID replacement)

Tests pass, I'll add tests to newly extracted utilities, etc, separately.