### PR TITLE
[Compiler-V2] add constraints when type checking the cast operation

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.exp
@@ -1,0 +1,74 @@
+// ---- Model Dump
+module 0x12391283::M {
+    use std::vector;
+    private fun test_1(): u64 {
+        {
+          let gas_schedule_blob: vector<u8> = Vector<u8>(115, 115, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0, 0, 0, 0);
+          {
+            let (v: vector<u8>, init: u64) = Tuple(gas_schedule_blob, Cast(0));
+            {
+              let accu: u64 = init;
+              {
+                let (v: vector<u8>) = Tuple(v);
+                vector::reverse<u8>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u8>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u8 = vector::pop_back<u8>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u8) = Tuple(e);
+                        accu: u64 = {
+                          let (sum: u64, addend: u8) = Tuple(accu, elem);
+                          Add<u64>(sum, Cast(addend))
+                        }
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              accu
+            }
+          }
+        }
+    }
+    private fun test_2(): u64 {
+        {
+          let gas_schedule_blob: vector<u8> = Vector<u8>(115, 115, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0, 0, 0, 0);
+          {
+            let (v: vector<u8>, init: u64) = Tuple(gas_schedule_blob, Cast(0));
+            {
+              let accu: u64 = init;
+              {
+                let (v: vector<u8>) = Tuple(v);
+                vector::reverse<u8>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u8>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u8 = vector::pop_back<u8>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u8) = Tuple(e);
+                        accu: u64 = {
+                          let (sum: u64, addend: u8) = Tuple(accu, elem);
+                          Add<u64>(sum, Cast(addend))
+                        }
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              accu
+            }
+          }
+        }
+    }
+    spec fun $test_1(): u64;
+    spec fun $test_2(): u64;
+} // end 0x12391283::M

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.move
@@ -1,0 +1,16 @@
+module 0x12391283::M {
+    use std::vector;
+    fun test_1() : u64 {
+        let gas_schedule_blob: vector<u8> = vector[
+            115, 115, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        vector::fold<u64, u8>(gas_schedule_blob, (0 as u64), |sum, addend| sum + (addend as u64))
+    }
+
+    fun test_2() : u64 {
+        let gas_schedule_blob: vector<u8> = vector[
+            115, 115, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        vector::fold(gas_schedule_blob, (0 as u64), |sum, addend| sum + (addend as u64))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: invalid call of `vector::fold`: expected `integer` but found `vector<u8>` for argument 3
+  ┌─ tests/checking/inlining/lambda_cast_err.move:7:53
+  │
+7 │         vector::fold(gas_schedule_blob, (0 as u64), |sum, addend| sum + (addend as u64))
+  │                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.move
@@ -1,0 +1,9 @@
+module 0x12391283::M {
+    use std::vector;
+    fun test(gas_schedule_blob: vector<u8>) : u64 {
+        let gas_schedule_blob: vector<vector<u8>> = vector[
+            vector[115], vector[115], vector[95],
+        ];
+        vector::fold(gas_schedule_blob, (0 as u64), |sum, addend| sum + (addend as u64))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/len_ok.exp
@@ -1,3 +1,11 @@
+
+Diagnostics:
+warning: Unused local variable `len`. Consider removing or prefixing with an underscore: `_len`
+  ┌─ tests/checking/specs/len_ok.move:4:13
+  │
+4 │         let len = 5;
+  │             ^^^
+
 // ---- Model Dump
 module 0x42::m {
     private fun f(gallery: &vector<u64>) {

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1406,17 +1406,31 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let (exp_ty, exp) = self.translate_exp_free(exp);
                 if !ty.is_number() {
                     self.error(&loc, "cast target type must be a number");
-                    self.new_error_exp()
-                } else if !self.subs.is_some_number(&exp_ty) {
+                    return self.new_error_exp();
+                } else if !self.subs.is_some_number(&exp_ty)
+                    && !self.subs.is_free_var_without_constraints(&exp_ty)
+                {
                     self.error(&loc, "operand of cast must be a number");
-                    self.new_error_exp()
-                } else {
-                    ExpData::Call(
-                        self.new_node_id_with_type_loc(&ty, &loc),
-                        Operation::Cast,
-                        vec![exp.into_exp()],
-                    )
+                    return self.new_error_exp();
+                } else if let Type::Var(idx) = exp_ty {
+                    let all_ints = PrimitiveType::all_int_types()
+                        .into_iter()
+                        .collect::<BTreeSet<_>>();
+                    self.subs
+                        .add_constraint(
+                            &self.unification_context,
+                            idx,
+                            loc.clone(),
+                            WideningOrder::LeftToRight,
+                            Constraint::SomeNumber(all_ints),
+                        )
+                        .expect("success on var");
                 }
+                ExpData::Call(
+                    self.new_node_id_with_type_loc(&ty, &loc),
+                    Operation::Cast,
+                    vec![exp.into_exp()],
+                )
             },
             EA::Exp_::Annotate(exp, typ) => {
                 let ty = self.translate_type(typ);


### PR DESCRIPTION
### Description

This PR closes #11810 by adding number type constraint to the expression type if it is not fully instantiated.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added two test cases to validate the fix.