### PR TITLE
cache build artifacts and run partitioned tests

### DIFF
--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -4,6 +4,9 @@ inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
     required: false
+  partition:
+    description: "The partition number for the tests"
+    required: true
 
 runs:
   using: composite
@@ -13,16 +16,6 @@ runs:
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
-
-    # Check the VM features
-    - name: Check VM features
-      run: cargo test --profile ci --locked --features check-vm-features -p aptos-node
-      shell: bash
-
-    # Run the rust doc tests
-    - name: Run rust doc tests
-      run: cargo test --profile ci --locked --doc --workspace --exclude aptos-node-checker
-      shell: bash
 
     # Install nextest
     - uses: taiki-e/install-action@v1.5.6
@@ -34,10 +27,15 @@ runs:
       run: docker run --detach -p 5432:5432 cimg/postgres:14.2
       shell: bash
 
+    - name: Download test artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: nextest-archive
+
     # Run the rust unit tests
-    - name: Run all unit tests
-      run: cargo nextest run --profile ci --cargo-profile ci --locked --workspace --exclude smoke-test --exclude aptos-testcases --retries 3 --no-fail-fast
+    - name: Run rust unit tests (partitioned)
       shell: bash
+      run: cargo nextest run --archive-file /runner/_work/aptos-core/aptos-core/nextest-archive.tar.zst --partition hash:${{ inputs.partition }}/3  --retries 3 --no-fail-fast
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
         RUST_MIN_STACK: "4297152"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -106,10 +106,42 @@ jobs:
       - run: echo "Skipping rust smoke tests! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
-  # Run all rust unit tests. This is a PR required job.
-  rust-unit-tests:
-    needs: file_change_determinator
+  build-test-artifacts:
     runs-on: high-perf-docker
+    outputs:
+      test-artifacts-path: ${{ steps.build.outputs.artifacts-path }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - name: Check VM features
+        run: cargo test --profile ci --locked --features check-vm-features -p aptos-node
+        shell: bash
+      - name: Run rust doc tests
+        run: cargo test --profile ci --locked --doc --workspace --exclude aptos-node-checker
+        shell: bash
+      - uses: taiki-e/install-action@v1.5.6
+        with:
+          tool: nextest
+      - name: Build and archive tests
+        id: build
+        run: |
+          cargo nextest archive --cargo-profile ci --locked --workspace --exclude aptos-testcases --exclude smoke-test --exclude move-cli --archive-file nextest-archive.tar.zst
+          echo "::set-output name=artifacts-path::$(pwd)/nextest-archive.tar.zst"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive
+          path: ${{ steps.build.outputs.artifacts-path }}
+
+  # Run all rust unit tests. This is a PR required job.
+  rust-unit-tests-partitioned:
+    needs: [file_change_determinator, build-test-artifacts]
+    runs-on: high-perf-docker
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -117,6 +149,7 @@ jobs:
         uses: ./.github/actions/rust-unit-tests
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
+          partition: ${{ matrix.partition }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: echo "Skipping rust unit tests! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -780,7 +780,7 @@ codegen-units = 1
 
 [profile.ci]
 inherits = "release"
-debug = true
+debug = "line-tables-only"
 overflow-checks = true
 debug-assertions = true
 


### PR DESCRIPTION
### Description
Partition unit tests so they can execute in parallel across multiple runners.

This is building a nextest archive file and caching it so can be reused for multiple jobs. The cache key is unique to each workflow run. I [originally tried this](https://github.com/aptos-labs/aptos-core/pull/11823/files) using the upload-artifacts action which is intended for sharing data between jobs in a workflow but it was taking 20 mins just to upload the artifacts.

The unpartitioned unit test job takes about 29 mins to run. [With 3 partitions](https://github.com/aptos-labs/aptos-core/actions/runs/7734633384), each of the jobs takes about 15 mins to run. It looks like the `rust-setup` action is adding some overhead to each of the job runs.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
[See workflow run](https://github.com/aptos-labs/aptos-core/actions/runs/7734633384)