### PR TITLE
[NFT Metadata Crawler] Add column to mark URIs to not be parsed

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/migrations/2024-01-31-221845_add_not_parsable_column/down.sql
+++ b/ecosystem/nft-metadata-crawler-parser/migrations/2024-01-31-221845_add_not_parsable_column/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nft_metadata_crawler.parsed_asset_uris DROP COLUMN do_not_parse;

--- a/ecosystem/nft-metadata-crawler-parser/migrations/2024-01-31-221845_add_not_parsable_column/up.sql
+++ b/ecosystem/nft-metadata-crawler-parser/migrations/2024-01-31-221845_add_not_parsable_column/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nft_metadata_crawler.parsed_asset_uris ADD COLUMN do_not_parse BOOLEAN NOT NULL DEFAULT FALSE;

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
@@ -19,6 +19,7 @@ pub struct NFTMetadataCrawlerURIs {
     json_parser_retry_count: i32,
     image_optimizer_retry_count: i32,
     animation_optimizer_retry_count: i32,
+    do_not_parse: bool,
 }
 
 impl NFTMetadataCrawlerURIs {
@@ -33,6 +34,7 @@ impl NFTMetadataCrawlerURIs {
             json_parser_retry_count: 0,
             image_optimizer_retry_count: 0,
             animation_optimizer_retry_count: 0,
+            do_not_parse: false,
         }
     }
 
@@ -141,5 +143,13 @@ impl NFTMetadataCrawlerURIs {
 
     pub fn increment_animation_optimizer_retry_count(&mut self) {
         self.animation_optimizer_retry_count += 1;
+    }
+
+    pub fn get_do_not_parse(&self) -> bool {
+        self.do_not_parse
+    }
+
+    pub fn set_do_not_parse(&mut self, do_not_parse: bool) {
+        self.do_not_parse = do_not_parse;
     }
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
@@ -26,6 +26,7 @@ pub struct NFTMetadataCrawlerURIsQuery {
     pub image_optimizer_retry_count: i32,
     pub animation_optimizer_retry_count: i32,
     pub inserted_at: chrono::NaiveDateTime,
+    pub do_not_parse: bool,
 }
 
 impl NFTMetadataCrawlerURIsQuery {
@@ -100,5 +101,23 @@ impl NFTMetadataCrawlerURIsQuery {
             error!(asset_uri = asset_uri, error=?e, "Failed to get_by_raw_animation_uri");
             None
         })
+    }
+}
+
+impl Default for NFTMetadataCrawlerURIsQuery {
+    fn default() -> Self {
+        Self {
+            asset_uri: "".to_string(),
+            raw_image_uri: None,
+            raw_animation_uri: None,
+            cdn_json_uri: None,
+            cdn_image_uri: None,
+            cdn_animation_uri: None,
+            json_parser_retry_count: 0,
+            image_optimizer_retry_count: 0,
+            animation_optimizer_retry_count: 0,
+            inserted_at: chrono::NaiveDateTime::default(),
+            do_not_parse: false,
+        }
     }
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/schema.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/schema.rs
@@ -21,6 +21,7 @@ pub mod nft_metadata_crawler {
             image_optimizer_retry_count -> Int4,
             animation_optimizer_retry_count -> Int4,
             inserted_at -> Timestamp,
+            do_not_parse -> Bool,
         }
     }
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/counters.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/counters.rs
@@ -34,6 +34,15 @@ pub static PARSER_FAIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Number of times the NFT Metadata Crawler Parser has received a URI marked as not to parse
+pub static DO_NOT_PARSE_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "nft_metadata_crawler_parser_do_not_parse_count",
+        "Number of times the parser received a URI marked as not to parse",
+    )
+    .unwrap()
+});
+
 // PUBSUB METRICS
 
 /// Number of times a PubSub message has successfully been ACK'd

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
@@ -34,12 +34,12 @@ pub fn run_migrations(pool: &Pool<ConnectionManager<PgConnection>>) {
 /// Upserts URIs into database
 pub fn upsert_uris(
     conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
-    entry: NFTMetadataCrawlerURIs,
+    entry: &NFTMetadataCrawlerURIs,
 ) -> anyhow::Result<usize> {
     use schema::nft_metadata_crawler::parsed_asset_uris::dsl::*;
 
     let query = diesel::insert_into(schema::nft_metadata_crawler::parsed_asset_uris::table)
-        .values(&entry)
+        .values(entry)
         .on_conflict(asset_uri)
         .do_update()
         .set((
@@ -51,6 +51,7 @@ pub fn upsert_uris(
             image_optimizer_retry_count.eq(excluded(image_optimizer_retry_count)),
             json_parser_retry_count.eq(excluded(json_parser_retry_count)),
             animation_optimizer_retry_count.eq(excluded(animation_optimizer_retry_count)),
+            do_not_parse.eq(excluded(do_not_parse)),
         ));
 
     let debug_query = diesel::debug_query::<diesel::pg::Pg, _>(&query).to_string();

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 pub async fn write_json_to_gcs(
     bucket: String,
     id: String,
-    json: Value,
+    json: &Value,
     client: &Client,
 ) -> anyhow::Result<String> {
     GCS_UPLOAD_INVOCATION_COUNT.inc();


### PR DESCRIPTION
### Description
Many submitted tokens do not have proper JSON or image NFT metadata URIs. This column flags that so that they are not reprocessed and lets us have more accurate metrics regarding the success rate of the parser. 

### Test Plan
Tested locally + existing unit tests
