### PR TITLE
Address test-and-abort attacks in the randomness module (and some clean up)

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -20,7 +20,10 @@ use crate::{
 use anyhow::{anyhow, Result};
 use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
 use aptos_crypto::HashValue;
-use aptos_framework::{natives::code::PublishRequest, RuntimeModuleMetadataV1};
+use aptos_framework::{
+    natives::{code::PublishRequest, transaction_context::NativeTransactionContext},
+    RuntimeModuleMetadataV1,
+};
 use aptos_gas_algebra::{Gas, GasQuantity, Octa};
 use aptos_gas_meter::{AptosGasMeter, GasAlgebra, StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{AptosGasParameters, VMGasParameters};
@@ -644,6 +647,18 @@ impl AptosVM {
         senders: Vec<AccountAddress>,
         script_fn: &EntryFunction,
     ) -> Result<SerializedReturnValues, VMStatus> {
+        let is_friend_or_private = session.load_function_def_is_friend_or_private(
+            script_fn.module(),
+            script_fn.function(),
+            script_fn.ty_args(),
+        )?;
+        if is_friend_or_private {
+            let txn_context = session
+                .get_native_extensions()
+                .get_mut::<NativeTransactionContext>();
+            txn_context.set_is_friend_or_private_entry_func();
+        }
+
         let function = session.load_function(
             script_fn.module(),
             script_fn.function(),

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -227,11 +227,9 @@ fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
 
     exts.add(NativeTableContext::new([0u8; 32], &*DUMMY_RESOLVER));
     exts.add(NativeCodeContext::default());
-    exts.add(NativeTransactionContext::new(
-        vec![1],
-        vec![1],
-        ChainId::test().id(),
-    )); // We use the testing environment chain ID here
+    let mut txn_context = NativeTransactionContext::new(vec![1], vec![1], ChainId::test().id());
+    txn_context.set_is_friend_or_private_entry_func();
+    exts.add(txn_context); // We use the testing environment chain ID here
     exts.add(NativeAggregatorContext::new(
         [0; 32],
         &*DUMMY_RESOLVER,

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod nft_dao;
 mod offer_rotation_capability;
 mod offer_signer_capability;
 mod per_category_gas_limits;
+mod randomness_test_and_abort;
 mod reconfig_with_dkg;
 mod resource_groups;
 mod rotate_auth_key;

--- a/aptos-move/e2e-move-tests/src/tests/randomness_test_and_abort.rs
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_test_and_abort.rs
@@ -1,0 +1,100 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{assert_abort, assert_success, build_package, tests::common, MoveHarness};
+use aptos_framework::BuiltPackage;
+use aptos_language_e2e_tests::account::{Account, TransactionBuilder};
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::OnChainConfig,
+    randomness::PerBlockRandomness,
+    transaction::{Script, TransactionStatus},
+};
+
+#[test]
+fn test_and_abort_defense_is_sound_and_correct() {
+    let mut h = MoveHarness::new();
+
+    // These scripts call a public entry function and a public function. The randomness API will reject both calls.
+    for dir in [
+        "randomness_unsafe_public_entry.data/pack",
+        "randomness_unsafe_public.data/pack",
+    ] {
+        println!("Testing {dir}");
+        // This will redeploy the package, so backwards compatibility must be maintained in these directories.
+        let (_, package) = deploy_code(AccountAddress::ONE, dir, &mut h);
+
+        let status = run_script(&mut h, &package);
+        assert_abort!(status, 1);
+    }
+
+    // The randomness module is initialized, but the randomness seed is not set.
+    let fx = h.aptos_framework_account();
+    let mut pbr = h
+        .read_resource::<PerBlockRandomness>(fx.address(), PerBlockRandomness::struct_tag())
+        .unwrap();
+    assert!(pbr.seed.is_none());
+
+    pbr.seed = Some((0..32).map(|_| 0u8).collect::<Vec<u8>>());
+    assert_eq!(pbr.seed.as_ref().unwrap().len(), 32);
+    h.set_resource(*fx.address(), PerBlockRandomness::struct_tag(), &pbr);
+
+    // This is a safe call that the randomness API should allow through.
+    let status = run_entry_func(
+        &mut h,
+        "0xa11ce",
+        "0x1::some_randapp::safe_private_entry_call",
+    );
+    assert_success!(status);
+
+    // This is a safe call that the randomness API should allow through.
+    // (I suppose that, since TXNs with private entry function payloads are okay, increasing the
+    // visibility to public(friend) should not create any problems.)
+    let status = run_entry_func(
+        &mut h,
+        "0xa11ce",
+        "0x1::some_randapp::safe_friend_entry_call",
+    );
+    assert_success!(status);
+}
+
+fn deploy_code(
+    addr: AccountAddress,
+    code_path: &str,
+    harness: &mut MoveHarness,
+) -> (Account, BuiltPackage) {
+    let account = harness.new_account_at(addr);
+
+    let package = build_package(
+        common::test_dir_path(code_path),
+        aptos_framework::BuildOptions::default(),
+    )
+    .expect("building package must succeed");
+
+    let txn = harness.create_publish_built_package(&account, &package, |_| {});
+
+    assert_success!(harness.run(txn));
+    (account, package)
+}
+
+fn run_script(h: &mut MoveHarness, package: &BuiltPackage) -> TransactionStatus {
+    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
+    let scripts = package.extract_script_code();
+    let code = scripts[0].clone();
+
+    let txn = TransactionBuilder::new(alice.clone())
+        .script(Script::new(code, vec![], vec![]))
+        .sequence_number(10)
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign();
+
+    h.run(txn)
+}
+
+fn run_entry_func(h: &mut MoveHarness, signer: &str, name: &str) -> TransactionStatus {
+    let alice = h.new_account_at(AccountAddress::from_hex_literal(signer).unwrap());
+
+    println!("Running entry function '{name}'");
+    h.run_entry_function(&alice, str::parse(name).unwrap(), vec![], vec![])
+}

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "randomness_test_and_abort"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/scripts/script.move
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/scripts/script.move
@@ -1,0 +1,5 @@
+script {
+    fun unsafe_public_entry(_attacker: &signer) {
+        0x1::some_randapp::unsafe_public_call();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/sources/some_randapp.move
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public.data/pack/sources/some_randapp.move
@@ -1,0 +1,19 @@
+module 0x1::some_randapp {
+    use aptos_std::randomness;
+
+    entry fun safe_private_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public entry fun unsafe_public_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public(friend) entry fun safe_friend_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public fun unsafe_public_call() {
+        let _ = randomness::u64_integer();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "randomness_test_and_abort"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/scripts/script.move
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/scripts/script.move
@@ -1,0 +1,5 @@
+script {
+    fun unsafe_public_entry(_attacker: &signer) {
+        0x1::some_randapp::unsafe_public_entry_call();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/sources/some_randapp.move
+++ b/aptos-move/e2e-move-tests/src/tests/randomness_unsafe_public_entry.data/pack/sources/some_randapp.move
@@ -1,0 +1,19 @@
+module 0x1::some_randapp {
+    use aptos_std::randomness;
+
+    entry fun safe_private_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public entry fun unsafe_public_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public(friend) entry fun safe_friend_entry_call() {
+        let _ = randomness::u64_integer();
+    }
+
+    public fun unsafe_public_call() {
+        let _ = randomness::u64_integer();
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/randomness.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.spec.move
@@ -1,5 +1,9 @@
 spec aptos_std::randomness {
-    spec get_and_add_txn_local_state(): vector<u8> {
+    spec fetch_and_increment_txn_counter(): vector<u8> {
+        pragma opaque;
+    }
+
+    spec is_safe_call(): bool {
         pragma opaque;
     }
 }

--- a/aptos-move/framework/src/natives/randomness.rs
+++ b/aptos-move/framework/src/natives/randomness.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
 
-use aptos_native_interface::{SafeNativeBuilder, SafeNativeContext, SafeNativeResult};
+use crate::natives::transaction_context::NativeTransactionContext;
+use aptos_native_interface::{
+    RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
+};
 use better_any::{Tid, TidAble};
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
@@ -32,23 +35,40 @@ impl RandomnessContext {
     }
 }
 
-pub fn get_and_add_txn_local_state(
+pub fn fetch_and_increment_txn_counter(
     context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    // TODO: charge gas?
     let rand_ctxt = context.extensions_mut().get_mut::<RandomnessContext>();
     let ret = rand_ctxt.txn_local_state.to_vec();
     rand_ctxt.increment();
     Ok(smallvec![Value::vector_u8(ret)])
 }
 
+pub fn is_safe_call(
+    context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    _args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    let ctx = context.extensions().get::<NativeTransactionContext>();
+    // TODO: charge gas?
+    Ok(smallvec![Value::bool(
+        ctx.get_is_friend_or_private_entry_func()
+    )])
+}
+
 pub fn make_all(
     builder: &SafeNativeBuilder,
 ) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
-    let mut natives = vec![];
-
-    natives.extend([("get_and_add_txn_local_state", get_and_add_txn_local_state)]);
+    let natives = vec![
+        (
+            "fetch_and_increment_txn_counter",
+            fetch_and_increment_txn_counter as RawSafeNative,
+        ),
+        ("is_safe_call", is_safe_call),
+    ];
 
     builder.make_named_natives(natives)
 }

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -23,6 +23,8 @@ pub struct NativeTransactionContext {
     auid_counter: u64,
     script_hash: Vec<u8>,
     chain_id: u8,
+    /// True if the current TXN's payload was an entry function marked as either public(friend) or private
+    is_friend_or_private_entry_func: bool,
 }
 
 impl NativeTransactionContext {
@@ -34,11 +36,20 @@ impl NativeTransactionContext {
             auid_counter: 0,
             script_hash,
             chain_id,
+            is_friend_or_private_entry_func: false,
         }
     }
 
     pub fn chain_id(&self) -> u8 {
         self.chain_id
+    }
+
+    pub fn set_is_friend_or_private_entry_func(&mut self) {
+        self.is_friend_or_private_entry_func = true;
+    }
+
+    pub fn get_is_friend_or_private_entry_func(&self) -> bool {
+        self.is_friend_or_private_entry_func
     }
 }
 

--- a/aptos-move/move-examples/lottery/sources/lottery_insecure.move
+++ b/aptos-move/move-examples/lottery/sources/lottery_insecure.move
@@ -1,7 +1,6 @@
 module lottery::lottery_insecure {
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
-    // NOTE: If deployed, this would be aptos_std (or aptos_framework).
     use aptos_framework::randomness;
     use aptos_std::smart_vector;
     use aptos_std::smart_vector::SmartVector;

--- a/aptos-move/move-examples/lottery/sources/lottery_secure.move
+++ b/aptos-move/move-examples/lottery/sources/lottery_secure.move
@@ -3,7 +3,6 @@ module lottery::lottery_secure {
     use std::option::Option;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
-    // NOTE: If deployed, this would be aptos_std (or aptos_framework).
     use aptos_framework::randomness;
     use aptos_std::smart_vector;
     use aptos_std::smart_vector::SmartVector;

--- a/aptos-move/move-examples/raffle/sources/raffle.move
+++ b/aptos-move/move-examples/raffle/sources/raffle.move
@@ -1,7 +1,6 @@
 module raffle::raffle {
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
-    // NOTE: If deployed, this would be aptos_std (or aptos_framework).
     use aptos_framework::randomness;
     use aptos_std::smart_vector;
     use aptos_std::smart_vector::SmartVector;
@@ -11,8 +10,7 @@ module raffle::raffle {
     // We need this friend declaration so our tests can call `init_module`.
     friend raffle::raffle_test;
 
-    /// Error code for when a user tries to initate the drawing but no users
-    /// bought any tickets.
+    /// Error code for when a user tries to initate the drawing but no users bought any tickets.
     const E_NO_TICKETS: u64 = 2;
 
     /// Error code for when the somebody tries to draw an already-closed raffle

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -349,6 +349,24 @@ impl<'r, 'l> Session<'r, 'l> {
         Ok(instantiation)
     }
 
+    /// Note: Cannot return a `Function` struct here due to its `pub(crate)` visibility.
+    pub fn load_function_def_is_friend_or_private(
+        &self,
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+        type_arguments: &[TypeTag],
+    ) -> VMResult<bool> {
+        let (_, func, _) = self.move_vm.runtime.loader().load_function(
+            module_id,
+            function_name,
+            type_arguments,
+            &self.data_cache,
+            &self.module_store,
+        )?;
+
+        Ok(func.is_friend_or_private())
+    }
+
     /// Load a module, a function, and all of its types into cache
     pub fn load_function_with_type_arg_inference(
         &self,


### PR DESCRIPTION
### Description

Test-and-abort attacks are described in [AIP-41](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-41.md#test-and-abort-attacks)

**Note:** Using similar tricks as in this [old chain ID PR](https://github.com/aptos-labs/aptos-core/pull/5288) 
