### PR TITLE
Parallel fetching for GCS 

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -27,7 +27,7 @@ use aptos_protos::{
     indexer::v1::{raw_data_server::RawData, GetTransactionsRequest, TransactionsResponse},
     transaction::v1::Transaction,
 };
-use futures::{future::join_all, Stream};
+use futures::Stream;
 use prost::Message;
 use redis::Client;
 use std::{

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -666,7 +666,7 @@ async fn deserialize_cached_transactions(
     transactions: Vec<Vec<u8>>,
     storage_format: StorageFormat,
 ) -> anyhow::Result<Vec<Transaction>> {
-    let task = tokio::task::spawn_blocking( move || {
+    let task = tokio::task::spawn_blocking(move || {
         transactions
             .into_iter()
             .map(|transaction| {
@@ -738,7 +738,9 @@ async fn data_fetch(
             Ok(TransactionsDataStatus::Success(transactions))
         },
         Ok(CacheBatchGetStatus::EvictedFromCache) => {
-            let transactions = data_fetch_from_filestore(starting_version, file_store_operator, request_metadata).await?;
+            let transactions =
+                data_fetch_from_filestore(starting_version, file_store_operator, request_metadata)
+                    .await?;
             Ok(TransactionsDataStatus::Success(transactions))
         },
         Err(e) => Err(e),
@@ -750,7 +752,6 @@ async fn data_fetch_from_filestore(
     file_store_operator: Arc<Box<dyn FileStoreOperator>>,
     request_metadata: Arc<IndexerGrpcRequestMetadata>,
 ) -> anyhow::Result<Vec<Transaction>> {
-
     // Data is evicted from the cache. Fetch from file store.
     let (transactions, io_duration, decoding_duration) = file_store_operator
         .get_transactions_with_durations(starting_version, NUM_DATA_FETCH_RETRIES)

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -242,7 +242,11 @@ async fn get_data_with_threads(
             }
         });
         threads.push(thread);
+        // requested vresion = 1
+        // next requested version = 1000
+
         current_version += TRANSACTIONS_PER_STORAGE_BLOCK;
+        current_version -= current_version % TRANSACTIONS_PER_STORAGE_BLOCK;
     }
 
     let mut transactions: Vec<Vec<Transaction>> = vec![];

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
@@ -11,7 +11,7 @@ use redis::{AsyncCommands, RedisResult};
 
 // Configurations for cache.
 // Cache entries that are present.
-const CACHE_SIZE_ESTIMATION: u64 = 250_000_u64;
+pub const CACHE_SIZE_ESTIMATION: u64 = 250_000_u64;
 
 pub const MAX_CACHE_FETCH_SIZE: u64 = 1000_u64;
 
@@ -77,7 +77,7 @@ pub enum CacheUpdateStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CacheCoverageStatus {
+pub enum CacheCoverageStatus {
     /// Requested version is not processed by cache worker yet.
     DataNotReady,
     /// Requested version is cached.
@@ -188,7 +188,7 @@ impl<T: redis::aio::ConnectionLike + Send + Clone> CacheOperator<T> {
     }
 
     // Internal function to get the latest version from cache.
-    pub(crate) async fn check_cache_coverage_status(
+    pub async fn check_cache_coverage_status(
         &mut self,
         requested_version: u64,
     ) -> anyhow::Result<CacheCoverageStatus> {
@@ -312,6 +312,10 @@ impl<T: redis::aio::ConnectionLike + Send + Clone> CacheOperator<T> {
             Err(err) => Err(err.into()),
         }
     }
+
+    // Fetching from cache
+    // Requested version x
+    // Cache hit x +
 
     // TODO: Remove this
     pub async fn batch_get_encoded_proto_data(

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -169,7 +169,17 @@ pub static NUM_MULTI_FETCH_OVERLAPPED_VERSIONS: Lazy<IntCounterVec> = Lazy::new(
     register_int_counter_vec!(
         "indexer_grpc_num_multi_thread_fetch_overlapped_versions",
         "Number of versions that were overlapped in a multi thread fetch pull",
-        &["service_type"],
+        &["service_type", "overlap_type"],
+    )
+    .unwrap()
+});
+
+/// Number of times we internally retry fetching a transaction/block
+pub static TRANSACTION_STORE_FETCH_RETRIES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "indexer_grpc_num_transaction_store_fetch_retries",
+        "Number of times we internally retry fetching a transaction/block",
+        &["store"],
     )
     .unwrap()
 });

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -164,6 +164,16 @@ pub static NUM_TRANSACTIONS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Number of versions that were overlapped in a multi thread fetch pull
+pub static NUM_MULTI_FETCH_OVERLAPPED_VERSIONS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "indexer_grpc_num_multi_thread_fetch_overlapped_versions",
+        "Number of versions that were overlapped in a multi thread fetch pull",
+        &["service_type"],
+    )
+    .unwrap()
+});
+
 /// Generic duration metric
 pub static DURATION_IN_SECS: Lazy<GaugeVec> = Lazy::new(|| {
     register_gauge_vec!("indexer_grpc_duration_in_secs", "Duration in seconds", &[

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -196,7 +196,7 @@ pub fn log_grpc_step(
     duration_in_secs: Option<f64>,
     size_in_bytes: Option<usize>,
     num_transactions: Option<i64>,
-    request_metadata: Option<IndexerGrpcRequestMetadata>,
+    request_metadata: Option<&IndexerGrpcRequestMetadata>,
 ) {
     if let Some(duration_in_secs) = duration_in_secs {
         DURATION_IN_SECS

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -164,11 +164,11 @@ pub static NUM_TRANSACTIONS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Number of versions that were overlapped in a multi thread fetch pull
+/// Number of versions that were overlapped in a multi-task fetch pull
 pub static NUM_MULTI_FETCH_OVERLAPPED_VERSIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "indexer_grpc_num_multi_thread_fetch_overlapped_versions",
-        "Number of versions that were overlapped in a multi thread fetch pull",
+        "Number of versions that were overlapped in a multi-task fetch pull",
         &["service_type", "overlap_type"],
     )
     .unwrap()

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -262,7 +262,7 @@ pub fn log_grpc_step(
             step.get_label(),
         );
     } else {
-        let request_metadata = request_metadata.clone().unwrap();
+        let request_metadata = request_metadata.unwrap();
         tracing::info!(
             start_version,
             end_version,
@@ -272,12 +272,12 @@ pub fn log_grpc_step(
             duration_in_secs,
             size_in_bytes,
             // Request metadata variables
-            request_name = request_metadata.processor_name.as_str(),
-            request_email = request_metadata.request_email.as_str(),
-            request_api_key_name = request_metadata.request_api_key_name.as_str(),
-            processor_name = request_metadata.processor_name.as_str(),
-            connection_id = request_metadata.request_connection_id.as_str(),
-            request_user_classification = request_metadata.request_user_classification.as_str(),
+            request_name = &request_metadata.processor_name,
+            request_email = &request_metadata.request_email,
+            request_api_key_name = &request_metadata.request_api_key_name,
+            processor_name = &request_metadata.processor_name,
+            connection_id = &request_metadata.request_connection_id,
+            request_user_classification = &request_metadata.request_user_classification,
             service_type,
             step = step.get_step(),
             "{}",

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
@@ -62,7 +62,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
     }
 
     fn store_name(&self) -> &str {
-        "GSC"
+        "GCS"
     }
 
     async fn get_raw_file(&self, version: u64) -> anyhow::Result<Vec<u8>> {

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
@@ -61,6 +61,10 @@ impl FileStoreOperator for GcsFileStoreOperator {
         self.storage_format
     }
 
+    fn store_name(&self) -> &str {
+        "GSC"
+    }
+
     async fn get_raw_file(&self, version: u64) -> anyhow::Result<Vec<u8>> {
         let file_entry_key = FileEntry::build_key(version, self.storage_format).to_string();
         match Object::download(&self.bucket_name, file_entry_key.as_str()).await {
@@ -70,7 +74,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
                     anyhow::bail!("[Indexer File] Transactions file not found. Gap might happen between cache and file store. {}", err)
                 } else {
                     anyhow::bail!(
-                        "[Indexer File] Error happens when transaction file. {}",
+                        "[Indexer File] Error happens when downloading transaction file. {}",
                         err
                     );
                 }

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/local.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/local.rs
@@ -51,6 +51,10 @@ impl FileStoreOperator for LocalFileStoreOperator {
         self.storage_format
     }
 
+    fn store_name(&self) -> &str {
+        "local"
+    }
+
     async fn get_raw_file(&self, version: u64) -> anyhow::Result<Vec<u8>> {
         let file_entry_key = FileEntry::build_key(version, self.storage_format).to_string();
         let file_path = self.path.join(file_entry_key);


### PR DESCRIPTION
### Description
Previously, fetching from GCS cold storage was single-threaded; this increases the thread count, which in turn increases max backfill TPS

To reduce gaps due to network blips, this also adds internal retries to the `FileStoreOperator`

(also adds `spawn_blocking` whenever we do cpu bound transformations on the data, because why not)

### Test Plan
Tested in cdb-testnet, devnet