### PR TITLE
FairnessShuffler

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -57,7 +57,6 @@ mod execution_pipeline;
 pub mod network_interface;
 mod payload_manager;
 mod qc_aggregator;
-mod sender_aware_shuffler;
 mod transaction_deduper;
 mod transaction_filter;
 mod transaction_shuffler;

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun.rs
@@ -1,0 +1,41 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::conflict_key::ConflictKey;
+use aptos_types::transaction::{SignedTransaction, TransactionPayload};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum EntryFunKey {
+    EntryFun {
+        module: ModuleId,
+        function: Identifier,
+    },
+    Exempt,
+}
+
+impl ConflictKey<SignedTransaction> for EntryFunKey {
+    fn extract_from(txn: &SignedTransaction) -> Self {
+        match txn.payload() {
+            TransactionPayload::EntryFunction(entry_fun) => {
+                // FIXME(aldenhu): exempt framework modules
+                // n.b. Generics ignored.
+                Self::EntryFun {
+                    module: entry_fun.module().clone(),
+                    function: entry_fun.function().to_owned(),
+                }
+            },
+            // FIXME(aldenhu): deal with multisig
+            TransactionPayload::Multisig(_)
+            | TransactionPayload::Script(_)
+            | TransactionPayload::ModuleBundle(_) => Self::Exempt,
+        }
+    }
+
+    fn conflict_exempt(&self) -> bool {
+        match self {
+            Self::Exempt => true,
+            Self::EntryFun { .. } => false,
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun.rs
@@ -18,14 +18,18 @@ impl ConflictKey<SignedTransaction> for EntryFunKey {
     fn extract_from(txn: &SignedTransaction) -> Self {
         match txn.payload() {
             TransactionPayload::EntryFunction(entry_fun) => {
-                // FIXME(aldenhu): exempt framework modules
-                // n.b. Generics ignored.
-                Self::EntryFun {
-                    module: entry_fun.module().clone(),
-                    function: entry_fun.function().to_owned(),
+                let module_id = entry_fun.module();
+                if module_id.address().is_special() {
+                    // Exempt framework modules
+                    Self::Exempt
+                } else {
+                    // n.b. Generics ignored.
+                    Self::EntryFun {
+                        module: module_id.clone(),
+                        function: entry_fun.function().to_owned(),
+                    }
                 }
             },
-            // FIXME(aldenhu): deal with multisig
             TransactionPayload::Multisig(_)
             | TransactionPayload::Script(_)
             | TransactionPayload::ModuleBundle(_) => Self::Exempt,

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun_module.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/entry_fun_module.rs
@@ -1,0 +1,37 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::conflict_key::ConflictKey;
+use aptos_types::transaction::{SignedTransaction, TransactionPayload};
+use move_core_types::language_storage::ModuleId;
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum EntryFunModuleKey {
+    Module(ModuleId),
+    AnyScriptOrModuleBundle,
+    AnyMultiSig,
+    Exempt,
+}
+
+impl ConflictKey<SignedTransaction> for EntryFunModuleKey {
+    fn extract_from(txn: &SignedTransaction) -> Self {
+        match txn.payload() {
+            TransactionPayload::EntryFunction(entry_fun) => {
+                // FIXME(aldenhu): exempt framework modules
+                Self::Module(entry_fun.module().clone())
+            },
+            // FIXME(aldenhu): deal with multisig
+            TransactionPayload::Multisig(..) => Self::AnyMultiSig,
+            TransactionPayload::Script(_) | TransactionPayload::ModuleBundle(_) => {
+                Self::AnyScriptOrModuleBundle
+            },
+        }
+    }
+
+    fn conflict_exempt(&self) -> bool {
+        match self {
+            Self::Exempt => true,
+            Self::Module(..) | Self::AnyScriptOrModuleBundle | Self::AnyMultiSig => false,
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
@@ -1,0 +1,103 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::TxnIdx;
+use std::{collections::HashMap, hash::Hash};
+
+pub(crate) mod entry_fun;
+pub(crate) mod entry_fun_module;
+pub(crate) mod txn_sender;
+
+#[cfg(test)]
+pub(crate) mod test_utils;
+
+pub(crate) trait ConflictKey<Txn>: Eq + Hash + PartialEq {
+    fn extract_from(txn: &Txn) -> Self;
+
+    fn conflict_exempt(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ConflictKeyId(usize);
+
+impl ConflictKeyId {
+    pub fn as_idx(&self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConflictKeyRegistry {
+    id_by_txn: Vec<ConflictKeyId>,
+    is_exempt_by_id: Vec<bool>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct MapByKeyId<T> {
+    inner: Vec<T>,
+}
+
+impl<T: Default> MapByKeyId<T> {
+    pub fn new(size: usize) -> Self {
+        let mut inner = Vec::with_capacity(size);
+        inner.resize_with(size, Default::default);
+
+        Self { inner }
+    }
+
+    pub fn get(&self, key_id: ConflictKeyId) -> &T {
+        &self.inner[key_id.as_idx()]
+    }
+
+    pub fn get_mut(&mut self, key_id: ConflictKeyId) -> &mut T {
+        &mut self.inner[key_id.as_idx()]
+    }
+}
+
+impl ConflictKeyRegistry {
+    pub fn build<K: ConflictKey<Txn>, Txn>(txns: &[Txn]) -> Self
+    where
+        K: ConflictKey<Txn>,
+    {
+        let mut registry = HashMap::<K, ConflictKeyId>::new();
+        let mut is_exempt_by_id = Vec::new();
+
+        let id_by_txn = txns
+            .iter()
+            .map(|txn| {
+                let key = K::extract_from(txn);
+                *registry.entry(key).or_insert_with_key(|key| {
+                    is_exempt_by_id.push(key.conflict_exempt());
+                    ConflictKeyId(is_exempt_by_id.len() - 1)
+                })
+            })
+            .collect();
+
+        Self {
+            id_by_txn,
+            is_exempt_by_id,
+        }
+    }
+
+    fn num_ids(&self) -> usize {
+        self.is_exempt_by_id.len()
+    }
+
+    pub fn num_txns(&self) -> usize {
+        self.id_by_txn.len()
+    }
+
+    pub fn new_map_by_id<T: Default>(&self) -> MapByKeyId<T> {
+        MapByKeyId::new(self.num_ids())
+    }
+
+    pub fn key_id_for_txn(&self, txn_idx: TxnIdx) -> ConflictKeyId {
+        self.id_by_txn[txn_idx]
+    }
+
+    pub fn is_conflict_exempt(&self, key_id: ConflictKeyId) -> bool {
+        self.is_exempt_by_id[key_id.0]
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
@@ -11,6 +11,13 @@ pub(crate) mod txn_sender;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+/// `ConflictKey::extract_from(txn)` extracts a key from a transaction. For example,
+/// `TxnSenderKey::extract_from(txn)` returns the transaction sender's address. The key is used by
+/// the shuffler to determine whether two close by transactions conflict with each other.
+///
+/// `ConflictKey::conflict_exempt(&key)` returns if this specific key is exempt from conflict.
+/// For example, we can exempt transaction sender 0x1, so that consecutive transactions sent by
+/// 0x1 are not seen as a conflict by the shuffler.
 pub(crate) trait ConflictKey<Txn>: Eq + Hash + PartialEq {
     fn extract_from(txn: &Txn) -> Self;
 
@@ -28,12 +35,21 @@ impl ConflictKeyId {
     }
 }
 
+/// `ConflictKeyRegistry::build::<K: ConflictKey>()` goes through a block of transactions and
+/// extract the conflict keys from each transaction. In that process, each unique conflict key is
+/// assigned a unique `ConflictKeyId`, essentially a sequence number, and the registry remembers which
+/// key was extracted from each transaction. After that, we can query the registry to get the key
+/// represented by the id, which is 1. cheaper than calling `ConflictKey::extract_from(txn)` again;
+/// 2. enables vector based `MapByKeyId` which is cheaper than a `HashMap`; and 3. eliminates the typing
+/// information and easier to use in the shuffler.
 #[derive(Debug)]
 pub(crate) struct ConflictKeyRegistry {
     id_by_txn: Vec<ConflictKeyId>,
     is_exempt_by_id: Vec<bool>,
 }
 
+// Provided `ConflictKeyId`s managed by `ConflictKeyRegistry`s are consecutive integers starting
+// from 0, a map can be implemented based on a vector, which is cheapter than a hash map.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct MapByKeyId<T> {
     inner: Vec<T>,

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/mod.rs
@@ -21,9 +21,7 @@ pub(crate) mod test_utils;
 pub(crate) trait ConflictKey<Txn>: Eq + Hash + PartialEq {
     fn extract_from(txn: &Txn) -> Self;
 
-    fn conflict_exempt(&self) -> bool {
-        false
-    }
+    fn conflict_exempt(&self) -> bool;
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/test_utils.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/test_utils.rs
@@ -1,0 +1,186 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::conflict_key::{
+    ConflictKey, ConflictKeyId, ConflictKeyRegistry,
+};
+use proptest::prelude::*;
+use std::hash::Hash;
+
+impl ConflictKeyId {
+    pub fn new_for_test(idx: usize) -> Self {
+        Self(idx)
+    }
+}
+
+impl ConflictKeyRegistry {
+    pub fn all_exempt(num_txns: usize) -> Self {
+        ConflictKeyRegistry {
+            id_by_txn: vec![ConflictKeyId::new_for_test(0); num_txns],
+            is_exempt_by_id: vec![true],
+        }
+    }
+
+    pub fn non_conflict(num_txns: usize) -> Self {
+        ConflictKeyRegistry {
+            id_by_txn: (0..num_txns).map(ConflictKeyId::new_for_test).collect(),
+            is_exempt_by_id: vec![false; num_txns],
+        }
+    }
+
+    pub fn full_conflict(num_txns: usize) -> Self {
+        ConflictKeyRegistry {
+            id_by_txn: vec![ConflictKeyId::new_for_test(0); num_txns],
+            is_exempt_by_id: vec![false],
+        }
+    }
+
+    pub fn nums_per_key<const NUM_KEYS: usize>(nums_per_key: [usize; NUM_KEYS]) -> Self {
+        Self::nums_per_round_per_key([nums_per_key])
+    }
+
+    pub fn nums_per_round_per_key<const NUM_KEYS: usize, const NUM_ROUNDS: usize>(
+        nums_per_round_per_key: [[usize; NUM_KEYS]; NUM_ROUNDS],
+    ) -> Self {
+        let mut seq = (0..NUM_ROUNDS).flat_map(|_| 0..NUM_KEYS);
+        let nums_per_key = nums_per_round_per_key.into_iter().flatten();
+
+        ConflictKeyRegistry {
+            id_by_txn: nums_per_key
+                .flat_map(|num| {
+                    let s = seq.next().unwrap();
+                    vec![ConflictKeyId::new_for_test(s); num]
+                })
+                .collect(),
+            is_exempt_by_id: vec![false; NUM_KEYS],
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FakeAccount {
+    id: usize,
+}
+
+impl Arbitrary for FakeAccount {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (0..10usize).prop_map(|id| FakeAccount { id }).boxed()
+    }
+}
+
+#[derive(Debug)]
+struct FakeModule {
+    id: usize,
+}
+
+impl FakeModule {
+    pub fn exempt(&self) -> bool {
+        self.id % 3 == 0
+    }
+}
+
+impl Arbitrary for FakeModule {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (0..10usize).prop_map(|id| FakeModule { id }).boxed()
+    }
+}
+
+#[derive(Debug)]
+struct FakeEntryFun {
+    module: FakeModule,
+    id: usize,
+}
+
+impl Arbitrary for FakeEntryFun {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (any::<FakeModule>(), 0..3usize)
+            .prop_map(|(module, id)| FakeEntryFun { module, id })
+            .boxed()
+    }
+}
+
+#[derive(Debug)]
+pub struct FakeTxn {
+    sender: FakeAccount,
+    entry_fun: FakeEntryFun,
+}
+
+impl Arbitrary for FakeTxn {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (any::<FakeAccount>(), any::<FakeEntryFun>())
+            .prop_map(|(sender, entry_fun)| FakeTxn { sender, entry_fun })
+            .boxed()
+    }
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub(crate) struct FakeSenderKey {
+    id: usize,
+}
+
+impl ConflictKey<FakeTxn> for FakeSenderKey {
+    fn extract_from(txn: &FakeTxn) -> Self {
+        Self { id: txn.sender.id }
+    }
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub(crate) enum FakeEntryFunModuleKey {
+    Module(usize),
+    Exempt,
+}
+
+impl ConflictKey<FakeTxn> for FakeEntryFunModuleKey {
+    fn extract_from(txn: &FakeTxn) -> Self {
+        if txn.entry_fun.module.exempt() {
+            Self::Exempt
+        } else {
+            Self::Module(txn.entry_fun.module.id)
+        }
+    }
+
+    fn conflict_exempt(&self) -> bool {
+        match self {
+            Self::Exempt => true,
+            Self::Module(..) => false,
+        }
+    }
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub(crate) enum FakeEntryFunKey {
+    EntryFun { module: usize, function: usize },
+    Exempt,
+}
+
+impl ConflictKey<FakeTxn> for FakeEntryFunKey {
+    fn extract_from(txn: &FakeTxn) -> Self {
+        if txn.entry_fun.module.exempt() {
+            Self::Exempt
+        } else {
+            Self::EntryFun {
+                module: txn.entry_fun.module.id,
+                function: txn.entry_fun.id,
+            }
+        }
+    }
+
+    fn conflict_exempt(&self) -> bool {
+        match self {
+            Self::Exempt => true,
+            Self::EntryFun { .. } => false,
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/test_utils.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/test_utils.rs
@@ -134,6 +134,10 @@ impl ConflictKey<FakeTxn> for FakeSenderKey {
     fn extract_from(txn: &FakeTxn) -> Self {
         Self { id: txn.sender.id }
     }
+
+    fn conflict_exempt(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Eq, Hash, PartialEq)]

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/txn_sender.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/txn_sender.rs
@@ -12,4 +12,8 @@ impl ConflictKey<SignedTransaction> for TxnSenderKey {
     fn extract_from(txn: &SignedTransaction) -> Self {
         TxnSenderKey(txn.sender())
     }
+
+    fn conflict_exempt(&self) -> bool {
+        false
+    }
 }

--- a/consensus/src/transaction_shuffler/fairness/conflict_key/txn_sender.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_key/txn_sender.rs
@@ -1,0 +1,15 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::conflict_key::ConflictKey;
+use aptos_types::transaction::SignedTransaction;
+use move_core_types::account_address::AccountAddress;
+
+#[derive(Eq, Hash, PartialEq)]
+pub struct TxnSenderKey(AccountAddress);
+
+impl ConflictKey<SignedTransaction> for TxnSenderKey {
+    fn extract_from(txn: &SignedTransaction) -> Self {
+        TxnSenderKey(txn.sender())
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_zone.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_zone.rs
@@ -1,0 +1,65 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::{
+    conflict_key::{ConflictKeyId, ConflictKeyRegistry, MapByKeyId},
+    TxnIdx,
+};
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub(crate) struct ConflictZone<'a> {
+    sliding_window_size: usize,
+    sliding_window: VecDeque<ConflictKeyId>,
+    counts_by_id: MapByKeyId<usize>,
+    key_registry: &'a ConflictKeyRegistry,
+}
+
+impl<'a> ConflictZone<'a> {
+    pub fn build_zones<const NUM_CONFLICT_ZONES: usize>(
+        key_registries: &'a [ConflictKeyRegistry; NUM_CONFLICT_ZONES],
+        window_sizes: [usize; NUM_CONFLICT_ZONES],
+    ) -> [Self; NUM_CONFLICT_ZONES] {
+        itertools::zip_eq(key_registries.iter(), window_sizes)
+            .map(|(registry, window_size)| Self::new(registry, window_size))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("Impossible to fail.")
+    }
+
+    fn new(key_registry: &'a ConflictKeyRegistry, sliding_window_size: usize) -> Self {
+        Self {
+            sliding_window_size,
+            sliding_window: VecDeque::with_capacity(sliding_window_size + 1),
+            counts_by_id: key_registry.new_map_by_id(),
+            key_registry,
+        }
+    }
+
+    pub fn is_conflict(&self, txn_idx: TxnIdx) -> bool {
+        let key_id = self.key_registry.key_id_for_txn(txn_idx);
+        if self.key_registry.is_conflict_exempt(key_id) {
+            false
+        } else {
+            *self.counts_by_id.get(key_id) > 0
+        }
+    }
+
+    /// Append a new transaction to the sliding window and
+    /// return the key_id that's no longer in conflict as a result if there is one.
+    pub fn add(&mut self, txn_idx: TxnIdx) -> Option<ConflictKeyId> {
+        let key_id = self.key_registry.key_id_for_txn(txn_idx);
+
+        *self.counts_by_id.get_mut(key_id) += 1;
+        self.sliding_window.push_back(key_id);
+        if self.sliding_window.len() > self.sliding_window_size {
+            let removed_key_id = self.sliding_window.pop_front().unwrap();
+            let count = self.counts_by_id.get_mut(removed_key_id);
+            *count -= 1;
+            if *count == 0 && !self.key_registry.is_conflict_exempt(removed_key_id) {
+                return Some(removed_key_id);
+            }
+        }
+        None
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/conflict_zone.rs
+++ b/consensus/src/transaction_shuffler/fairness/conflict_zone.rs
@@ -7,10 +7,14 @@ use crate::transaction_shuffler::fairness::{
 };
 use std::collections::VecDeque;
 
+/// A sliding window of transactions (TxnIds), represented by `ConflictKeyId`s extracted from a
+/// specific `ConflictKey`, managed by a specific `ConflictKeyRegistry`.
 #[derive(Debug)]
 pub(crate) struct ConflictZone<'a> {
     sliding_window_size: usize,
     sliding_window: VecDeque<ConflictKeyId>,
+    /// Number of transactions in the sliding window for each key_id. `ConflictZone::is_conflict(key)`
+    /// returns true is the count for `key` is greater than 0, unless the key is exempt from conflict.
     counts_by_id: MapByKeyId<usize>,
     key_registry: &'a ConflictKeyRegistry,
 }
@@ -24,7 +28,7 @@ impl<'a> ConflictZone<'a> {
             .map(|(registry, window_size)| Self::new(registry, window_size))
             .collect::<Vec<_>>()
             .try_into()
-            .expect("Impossible to fail.")
+            .expect("key_registries and window_sizes must have the same length.")
     }
 
     fn new(key_registry: &'a ConflictKeyRegistry, sliding_window_size: usize) -> Self {

--- a/consensus/src/transaction_shuffler/fairness/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/mod.rs
@@ -1,0 +1,206 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::{
+    fairness::{
+        conflict_key::{
+            entry_fun::EntryFunKey, entry_fun_module::EntryFunModuleKey, txn_sender::TxnSenderKey,
+            ConflictKeyRegistry,
+        },
+        conflict_zone::ConflictZone,
+        pending_zone::PendingZone,
+    },
+    TransactionShuffler,
+};
+use aptos_types::transaction::SignedTransaction;
+use itertools::zip_eq;
+use selection_tracker::SelectionTracker;
+use std::collections::BTreeSet;
+
+pub(crate) mod conflict_key;
+mod conflict_zone;
+mod pending_zone;
+mod selection_tracker;
+
+#[cfg(test)]
+mod tests;
+
+type TxnIdx = usize;
+
+#[derive(Debug)]
+struct FairnessShuffler {
+    sender_conflict_window_size: usize,
+    module_conflict_window_size: usize,
+    entry_fun_conflict_window_size: usize,
+}
+
+impl FairnessShuffler {
+    fn conflict_key_registries(txns: &[SignedTransaction]) -> [ConflictKeyRegistry; 3] {
+        [
+            ConflictKeyRegistry::build::<TxnSenderKey, SignedTransaction>(txns),
+            ConflictKeyRegistry::build::<EntryFunModuleKey, SignedTransaction>(txns),
+            ConflictKeyRegistry::build::<EntryFunKey, SignedTransaction>(txns),
+        ]
+    }
+
+    fn window_sizes(&self) -> [usize; 3] {
+        [
+            self.sender_conflict_window_size,
+            self.module_conflict_window_size,
+            self.entry_fun_conflict_window_size,
+        ]
+    }
+}
+
+impl TransactionShuffler for FairnessShuffler {
+    fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        let conflict_key_registries = Self::conflict_key_registries(&txns);
+        let order =
+            FairnessShufflerImpl::new(&conflict_key_registries, self.window_sizes()).shuffle();
+        reorder(txns, &order)
+    }
+}
+
+fn reorder<T: Clone>(txns: Vec<T>, order: &[TxnIdx]) -> Vec<T> {
+    assert_eq!(txns.len(), order.len());
+    order.iter().map(|idx| txns[*idx].clone()).collect()
+}
+
+struct FairnessShufflerImpl<'a, const NUM_CONFLICT_ZONES: usize> {
+    conflict_zones: [ConflictZone<'a>; NUM_CONFLICT_ZONES],
+    pending_zones: [PendingZone<'a>; NUM_CONFLICT_ZONES],
+    selected_order: Vec<TxnIdx>,
+    selection_tracker: SelectionTracker,
+}
+
+impl<'a, const NUM_CONFLICT_ZONES: usize> FairnessShufflerImpl<'a, NUM_CONFLICT_ZONES> {
+    pub fn new(
+        conflict_key_registries: &'a [ConflictKeyRegistry; NUM_CONFLICT_ZONES],
+        window_sizes: [usize; NUM_CONFLICT_ZONES],
+    ) -> Self {
+        let num_txns = conflict_key_registries[0].num_txns();
+        assert!(conflict_key_registries
+            .iter()
+            .skip(1)
+            .all(|r| r.num_txns() == num_txns));
+
+        Self {
+            selected_order: Vec::with_capacity(num_txns),
+            selection_tracker: SelectionTracker::new(num_txns),
+            conflict_zones: ConflictZone::build_zones(conflict_key_registries, window_sizes),
+            pending_zones: PendingZone::build_zones(conflict_key_registries),
+        }
+    }
+
+    pub fn shuffle(mut self) -> Vec<TxnIdx> {
+        // First pass, only select transactions with no conflicts in all conflict zones
+        while let Some(txn_idx) = self.selection_tracker.next_unselected() {
+            if !self.is_conflict(txn_idx) && !self.is_head_of_line_blocked(txn_idx) {
+                self.select_and_select_unconflicted(txn_idx, false /* is_pending */)
+            } else {
+                self.add_pending(txn_idx);
+            }
+        }
+
+        // Second pass, select previously pending txns in order,
+        //   with newly un-conflicted txns jumping the line
+        self.selection_tracker.new_pass();
+        while let Some(txn_idx) = self.selection_tracker.next_unselected() {
+            self.select_and_select_unconflicted(txn_idx, true /* is_pending */);
+        }
+
+        self.selected_order
+    }
+
+    fn select_and_select_unconflicted(&mut self, txn_idx: TxnIdx, is_pending: bool) {
+        let mut maybe_unconflicted = self.select(txn_idx, is_pending);
+        while let Some(txn_idx) = maybe_unconflicted.pop_first() {
+            if !self.is_conflict(txn_idx) && !self.is_head_of_line_blocked(txn_idx) {
+                maybe_unconflicted.extend(self.select(txn_idx, true /* is_pending */))
+            }
+        }
+    }
+
+    /// Select a transaction and return potentially un-conflicted transactions
+    fn select(&mut self, txn_idx: TxnIdx, is_pending: bool) -> BTreeSet<TxnIdx> {
+        self.selection_tracker.mark_selected(txn_idx);
+        self.selected_order.push(txn_idx);
+        if is_pending {
+            self.pop_pending(txn_idx);
+        }
+
+        let mut maybe_unconflicted = BTreeSet::new();
+        for (conflict_zone, pending_zone) in
+            zip_eq(&mut self.conflict_zones, &mut self.pending_zones)
+        {
+            if let Some(key_id) = conflict_zone.add(txn_idx) {
+                if let Some(pending) = pending_zone.first_pending_on_key(key_id) {
+                    maybe_unconflicted.insert(pending);
+                }
+            }
+        }
+
+        maybe_unconflicted
+    }
+
+    fn is_conflict(&self, txn_idx: TxnIdx) -> bool {
+        self.conflict_zones.iter().any(|z| z.is_conflict(txn_idx))
+    }
+
+    fn is_head_of_line_blocked(&self, txn_idx: TxnIdx) -> bool {
+        self.pending_zones
+            .iter()
+            .any(|z| z.head_of_line_blocked(txn_idx))
+    }
+
+    fn add_pending(&mut self, txn_idx: TxnIdx) {
+        self.pending_zones.iter_mut().for_each(|z| z.add(txn_idx));
+    }
+
+    fn pop_pending(&mut self, txn_idx: TxnIdx) {
+        self.pending_zones.iter_mut().for_each(|z| z.pop(txn_idx));
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use crate::transaction_shuffler::fairness::FairnessShuffler;
+    use proptest::prelude::*;
+
+    impl FairnessShuffler {
+        pub fn new_for_test(
+            sender_conflict_window_size: usize,
+            module_conflict_window_size: usize,
+            entry_fun_conflict_window_size: usize,
+        ) -> Self {
+            Self {
+                sender_conflict_window_size,
+                module_conflict_window_size,
+                entry_fun_conflict_window_size,
+            }
+        }
+    }
+
+    impl Arbitrary for FairnessShuffler {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (0..10usize, 0..10usize, 0..10usize)
+                .prop_map(
+                    |(
+                        sender_conflict_window_size,
+                        module_conflict_window_size,
+                        entry_fun_conflict_window_size,
+                    )| {
+                        FairnessShuffler {
+                            sender_conflict_window_size,
+                            module_conflict_window_size,
+                            entry_fun_conflict_window_size,
+                        }
+                    },
+                )
+                .boxed()
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/mod.rs
@@ -28,10 +28,10 @@ mod tests;
 type TxnIdx = usize;
 
 #[derive(Debug)]
-struct FairnessShuffler {
-    sender_conflict_window_size: usize,
-    module_conflict_window_size: usize,
-    entry_fun_conflict_window_size: usize,
+pub struct FairnessShuffler {
+    pub sender_conflict_window_size: usize,
+    pub module_conflict_window_size: usize,
+    pub entry_fun_conflict_window_size: usize,
 }
 
 impl FairnessShuffler {

--- a/consensus/src/transaction_shuffler/fairness/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/mod.rs
@@ -92,6 +92,20 @@ impl<'a, const NUM_CONFLICT_ZONES: usize> FairnessShufflerImpl<'a, NUM_CONFLICT_
         }
     }
 
+    /// Spread (delay) transactions that have conflicts with adjacent previous transactions
+    /// according to multiple dimensions (`ConflictKey`s). Invariant is held that for each conflict
+    /// key, i.e. the transaction sender, the module, and the entry function, etc., the order of
+    /// transactions with the same key is preserved -- unless the key is exempt from conflict.
+    ///
+    /// For example, all transactions from a single sender will preserve their order; all transactions
+    /// from the same module will preserve their order, unless they are of the aptos framework
+    /// module -- p2p transfers of APT can violate this invariant.
+    ///
+    /// Each transaction comes at most once out of `self.selection_tracker.next_unselected()` for
+    /// both passes, that's O(2n). And each transaction comes out of each conflict zones at most
+    /// once, that's O(3n). In either case, the transaction is examined by going through all 3
+    /// conflict zones and all 3 pending zones. So the time complexity is O(9n) = O(n). Or if we
+    /// consider `NUM_CONFLICT_ZONES = m`, the time complexity is O(mn).
     pub fn shuffle(mut self) -> Vec<TxnIdx> {
         // First pass, only select transactions with no conflicts in all conflict zones
         while let Some(txn_idx) = self.selection_tracker.next_unselected() {

--- a/consensus/src/transaction_shuffler/fairness/pending_zone.rs
+++ b/consensus/src/transaction_shuffler/fairness/pending_zone.rs
@@ -7,6 +7,7 @@ use crate::transaction_shuffler::fairness::{
 };
 use std::collections::VecDeque;
 
+/// A queue for each confclit Key, represented by `ConflictKeyId`s managed by `ConflictKeyRegistry`.
 #[derive(Debug)]
 pub(crate) struct PendingZone<'a> {
     key_registry: &'a ConflictKeyRegistry,
@@ -22,7 +23,7 @@ impl<'a> PendingZone<'a> {
             .map(Self::new)
             .collect::<Vec<_>>()
             .try_into()
-            .expect("Impossible to fail.")
+            .expect("key_registries and the return type must have the same length.")
     }
 
     fn new(key_registry: &'a ConflictKeyRegistry) -> Self {

--- a/consensus/src/transaction_shuffler/fairness/pending_zone.rs
+++ b/consensus/src/transaction_shuffler/fairness/pending_zone.rs
@@ -1,0 +1,69 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::{
+    conflict_key::{ConflictKeyId, ConflictKeyRegistry, MapByKeyId},
+    TxnIdx,
+};
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub(crate) struct PendingZone<'a> {
+    key_registry: &'a ConflictKeyRegistry,
+    pending_by_key: MapByKeyId<VecDeque<TxnIdx>>,
+}
+
+impl<'a> PendingZone<'a> {
+    pub fn build_zones<const NUM_CONFLICT_ZONES: usize>(
+        key_registries: &'a [ConflictKeyRegistry; NUM_CONFLICT_ZONES],
+    ) -> [Self; NUM_CONFLICT_ZONES] {
+        key_registries
+            .iter()
+            .map(Self::new)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("Impossible to fail.")
+    }
+
+    fn new(key_registry: &'a ConflictKeyRegistry) -> Self {
+        Self {
+            key_registry,
+            pending_by_key: key_registry.new_map_by_id(),
+        }
+    }
+
+    pub fn add(&mut self, txn_idx: TxnIdx) {
+        let key_id = self.key_registry.key_id_for_txn(txn_idx);
+        if !self.key_registry.is_conflict_exempt(key_id) {
+            self.pending_by_key.get_mut(key_id).push_back(txn_idx);
+        }
+    }
+
+    pub fn pop(&mut self, txn_idx: TxnIdx) {
+        let key_id = self.key_registry.key_id_for_txn(txn_idx);
+        if !self.key_registry.is_conflict_exempt(key_id) {
+            let popped = self
+                .pending_by_key
+                .get_mut(key_id)
+                .pop_front()
+                .expect("Must exist");
+            assert_eq!(popped, txn_idx);
+        }
+    }
+
+    pub fn head_of_line_blocked(&self, txn_idx: TxnIdx) -> bool {
+        let key_id = self.key_registry.key_id_for_txn(txn_idx);
+        if self.key_registry.is_conflict_exempt(key_id) {
+            false
+        } else {
+            match self.pending_by_key.get(key_id).front() {
+                Some(front) => *front < txn_idx,
+                None => false,
+            }
+        }
+    }
+
+    pub fn first_pending_on_key(&self, key_id: ConflictKeyId) -> Option<TxnIdx> {
+        self.pending_by_key.get(key_id).front().cloned()
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/selection_tracker.rs
+++ b/consensus/src/transaction_shuffler/fairness/selection_tracker.rs
@@ -1,0 +1,43 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::TxnIdx;
+
+pub struct SelectionTracker {
+    selected_markers: Vec<bool>,
+    cur_idx: usize,
+}
+
+impl SelectionTracker {
+    pub fn new(num_txns: usize) -> Self {
+        Self {
+            selected_markers: vec![false; num_txns],
+            cur_idx: 0,
+        }
+    }
+
+    pub fn next_unselected(&mut self) -> Option<TxnIdx> {
+        while self.cur_idx < self.selected_markers.len() {
+            let idx = self.cur_idx;
+            self.cur_idx += 1;
+
+            if !self.is_selected(idx) {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
+    pub fn new_pass(&mut self) {
+        self.cur_idx = 0
+    }
+
+    pub fn mark_selected(&mut self, idx: TxnIdx) {
+        assert!(!self.selected_markers[idx]);
+        self.selected_markers[idx] = true;
+    }
+
+    fn is_selected(&self, idx: TxnIdx) -> bool {
+        self.selected_markers[idx]
+    }
+}

--- a/consensus/src/transaction_shuffler/fairness/tests/manual.rs
+++ b/consensus/src/transaction_shuffler/fairness/tests/manual.rs
@@ -1,0 +1,169 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::{
+    conflict_key::ConflictKeyRegistry, FairnessShuffler, FairnessShufflerImpl,
+};
+
+struct TestCase {
+    shuffler: FairnessShuffler,
+    conflict_key_registries: [ConflictKeyRegistry; 3],
+    expected_order: Vec<usize>,
+}
+
+impl TestCase {
+    fn run(self) {
+        let Self {
+            shuffler,
+            conflict_key_registries,
+            expected_order,
+        } = self;
+
+        let order =
+            FairnessShufflerImpl::new(&conflict_key_registries, shuffler.window_sizes()).shuffle();
+        assert_eq!(order, expected_order);
+    }
+}
+
+#[test]
+fn test_all_exempt() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(2, 2, 2),
+        conflict_key_registries: [
+            ConflictKeyRegistry::all_exempt(9),
+            ConflictKeyRegistry::all_exempt(9),
+            ConflictKeyRegistry::all_exempt(9),
+        ],
+        expected_order: (0..9).collect(),
+    }
+    .run()
+}
+
+#[test]
+fn test_non_conflict() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(2, 2, 2),
+        conflict_key_registries: [
+            ConflictKeyRegistry::non_conflict(9),
+            ConflictKeyRegistry::non_conflict(9),
+            ConflictKeyRegistry::non_conflict(9),
+        ],
+        expected_order: (0..9).collect(),
+    }
+    .run()
+}
+
+#[test]
+fn test_full_conflict() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(2, 2, 2),
+        conflict_key_registries: [
+            ConflictKeyRegistry::full_conflict(9),
+            ConflictKeyRegistry::full_conflict(9),
+            ConflictKeyRegistry::full_conflict(9),
+        ],
+        expected_order: (0..9).collect(),
+    }
+    .run()
+}
+
+#[test]
+fn test_modules_ignored_by_window_size() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(2, 0, 2),
+        conflict_key_registries: [
+            // [A0, A1, A2, ...]
+            ConflictKeyRegistry::non_conflict(8),
+            // [M0, M0, M0, M0, M1, M1, M2, M2]
+            ConflictKeyRegistry::nums_per_key([4, 2, 2]),
+            // [M0::E0, M0::E1, M0::E0, M0::E1, M1::E0, M1::E0, M2::E0, M2::E0]
+            ConflictKeyRegistry::nums_per_round_per_key([[1, 1, 0], [1, 1, 4]]),
+        ],
+        // [M0::E0, M0::E1, M1::E0, M0::E0, M0::E1, M1::E0, M2::E0, M2::E0]
+        expected_order: vec![0, 1, 4, 2, 3, 5, 6, 7],
+    }
+    .run()
+}
+
+#[test]
+fn test_modules_and_entry_funs_ignored_by_window_size() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(2, 0, 0),
+        conflict_key_registries: [
+            // [A0, A1, A2, ...]
+            ConflictKeyRegistry::non_conflict(8),
+            // [M0, M0, M0, M0, M1, M1, M1, M1]
+            ConflictKeyRegistry::nums_per_key([4, 4]),
+            // [M0::E0, M0::E0, M0::E1, M0::E1, M1::E0, M1::E0, M1::E1, M1::E1]
+            ConflictKeyRegistry::nums_per_key([2, 2, 2, 2]),
+        ],
+        expected_order: (0..8).collect(),
+    }
+    .run()
+}
+
+#[test]
+fn test_exempted_modules() {
+    // think "full block of p2p txns"
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(3, 2, 2),
+        conflict_key_registries: [
+            // [0:A0, 1:A0, 2:A0, 3:A0, 4:A1, 5:A1, 6:A1, 7:A2, 8:A2, 9:A3]
+            ConflictKeyRegistry::nums_per_key([4, 3, 2, 1]),
+            ConflictKeyRegistry::all_exempt(10),
+            ConflictKeyRegistry::all_exempt(10),
+        ],
+        // [A0, A1, A2, A3, A0, A1, A2, A0, A1]
+        expected_order: vec![0, 4, 7, 9, 1, 5, 8, 2, 3, 6],
+    }
+    .run()
+}
+
+#[test]
+fn test_dominating_module() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(4, 1, 1),
+        conflict_key_registries: [
+            ConflictKeyRegistry::non_conflict(7),
+            // [M0, M0, M0, M1, M2, M3, M4]
+            ConflictKeyRegistry::nums_per_key([3, 1, 1, 1, 1]),
+            ConflictKeyRegistry::nums_per_key([3, 1, 1, 1, 1]),
+        ],
+        // [M0, M1, M0, M2, M0, M3, M4]
+        expected_order: vec![0, 3, 1, 4, 2, 5, 6],
+    }
+    .run()
+}
+
+#[test]
+fn test_dominating_module2() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(4, 1, 1),
+        conflict_key_registries: [
+            ConflictKeyRegistry::non_conflict(8),
+            // [M0, M0, M0, M1, M2, M3, M4, M0]
+            ConflictKeyRegistry::nums_per_round_per_key([[3, 1, 1, 1, 1], [1, 0, 0, 0, 0]]),
+            ConflictKeyRegistry::nums_per_round_per_key([[3, 1, 1, 1, 1], [1, 0, 0, 0, 0]]),
+        ],
+        // [M0, M1, M0, M2, M0, M3, M4, M0]
+        expected_order: vec![0, 3, 1, 4, 2, 5, 6, 7],
+    }
+    .run()
+}
+
+#[test]
+fn test_multiple_entry_funs() {
+    TestCase {
+        shuffler: FairnessShuffler::new_for_test(4, 1, 2),
+        conflict_key_registries: [
+            ConflictKeyRegistry::non_conflict(10),
+            // [M0, M0, M0, M0, M1, M1, M1, M1, M2, M2]
+            ConflictKeyRegistry::nums_per_key([4, 4, 2]),
+            // [M0::E0, M0::E1, M0::E0, M0::E1, M1::E0, M1::E0, M1::E0, M1::E0, M2::E0, M2::E0]
+            ConflictKeyRegistry::nums_per_round_per_key([[1, 1, 0, 0], [1, 1, 4, 2]]),
+        ],
+        // [M0::E0, M1::E0, M0::E1, M2::E0, M0::E0, M1::E0, M0:E1, M2::E0, M1::E0, M1::E0]
+        expected_order: vec![0, 4, 1, 8, 2, 5, 3, 9, 6, 7],
+    }
+    .run()
+}

--- a/consensus/src/transaction_shuffler/fairness/tests/mod.rs
+++ b/consensus/src/transaction_shuffler/fairness/tests/mod.rs
@@ -1,0 +1,5 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod manual;
+mod proptests;

--- a/consensus/src/transaction_shuffler/fairness/tests/proptests.rs
+++ b/consensus/src/transaction_shuffler/fairness/tests/proptests.rs
@@ -1,0 +1,104 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction_shuffler::fairness::{
+    conflict_key::{
+        test_utils::{FakeEntryFunKey, FakeEntryFunModuleKey, FakeSenderKey, FakeTxn},
+        ConflictKeyRegistry, MapByKeyId,
+    },
+    reorder, FairnessShuffler, FairnessShufflerImpl, TxnIdx,
+};
+use proptest::{collection::vec, prelude::*};
+use std::collections::BTreeSet;
+
+fn arb_order(num_txns: usize) -> impl Strategy<Value = Vec<TxnIdx>> {
+    Just((0..num_txns).collect::<Vec<_>>()).prop_shuffle()
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+enum OrderOrSet {
+    #[default]
+    Empty,
+    Order(Vec<TxnIdx>),
+    Set(BTreeSet<TxnIdx>),
+}
+
+impl OrderOrSet {
+    fn add(&mut self, idx: TxnIdx, is_conflict_exempt: bool) {
+        if self.is_empty() {
+            *self = if is_conflict_exempt {
+                Self::Set(BTreeSet::new())
+            } else {
+                Self::Order(Vec::new())
+            };
+        }
+
+        match self {
+            Self::Order(order) => order.push(idx),
+            Self::Set(set) => {
+                set.insert(idx);
+            },
+            Self::Empty => unreachable!(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+}
+
+fn sort_by_key(
+    order: impl IntoIterator<Item = TxnIdx>,
+    registry: &ConflictKeyRegistry,
+) -> MapByKeyId<OrderOrSet> {
+    let mut map: MapByKeyId<OrderOrSet> = registry.new_map_by_id();
+
+    for txn_idx in order {
+        let key_id = registry.key_id_for_txn(txn_idx);
+        let is_exempt = registry.is_conflict_exempt(key_id);
+
+        map.get_mut(key_id).add(txn_idx, is_exempt);
+    }
+
+    map
+}
+
+fn assert_invariants(txns: &[FakeTxn], order: Vec<TxnIdx>, registry: &ConflictKeyRegistry) {
+    let num_txns = txns.len();
+    let original_sorted = sort_by_key(0..num_txns, registry);
+    let result_sorted = sort_by_key(order, registry);
+
+    assert_eq!(result_sorted, original_sorted);
+}
+
+fn registries(txns: &[FakeTxn]) -> [ConflictKeyRegistry; 3] {
+    [
+        ConflictKeyRegistry::build::<FakeSenderKey, FakeTxn>(txns),
+        ConflictKeyRegistry::build::<FakeEntryFunModuleKey, FakeTxn>(txns),
+        ConflictKeyRegistry::build::<FakeEntryFunKey, FakeTxn>(txns),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn test_reorder( order in (0..1000usize).prop_flat_map(arb_order) ) {
+        let num_txns = order.len();
+        let txns = (0..num_txns).collect::<Vec<_>>();
+
+        let reordered = reorder(txns, &order);
+        prop_assert_eq!(reordered, order);
+    }
+
+    #[test]
+    fn test_fairness_shuffler(
+        txns in vec(any::<FakeTxn>(), 0..1000),
+        shuffler in any::<FairnessShuffler>(),
+    ) {
+        let registries = registries(&txns);
+        let order = FairnessShufflerImpl::new(&registries, shuffler.window_sizes()).shuffle();
+
+        for registry in &registries {
+            assert_invariants(&txns, order.clone(), registry);
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/mod.rs
+++ b/consensus/src/transaction_shuffler/mod.rs
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sender_aware_shuffler::SenderAwareShuffler;
 use aptos_logger::info;
 use aptos_types::{
     on_chain_config::{
@@ -10,7 +9,10 @@ use aptos_types::{
     },
     transaction::SignedTransaction,
 };
+use sender_aware::SenderAwareShuffler;
 use std::sync::Arc;
+
+mod sender_aware;
 
 /// Interface to shuffle transactions
 pub trait TransactionShuffler: Send + Sync {

--- a/consensus/src/transaction_shuffler/mod.rs
+++ b/consensus/src/transaction_shuffler/mod.rs
@@ -12,6 +12,7 @@ use aptos_types::{
 use sender_aware::SenderAwareShuffler;
 use std::sync::Arc;
 
+mod fairness;
 mod sender_aware;
 
 /// Interface to shuffle transactions

--- a/consensus/src/transaction_shuffler/mod.rs
+++ b/consensus/src/transaction_shuffler/mod.rs
@@ -48,5 +48,22 @@ pub fn create_transaction_shuffler(
             );
             Arc::new(SenderAwareShuffler::new(conflict_window_size as usize))
         },
+        TransactionShufflerType::Fairness {
+            sender_conflict_window_size,
+            module_conflict_window_size,
+            entry_fun_conflict_window_size,
+        } => {
+            info!(
+                "Using fairness transaction shuffling with conflict window sizes: sender {}, module {}, entry fun {}",
+                sender_conflict_window_size,
+                module_conflict_window_size,
+                entry_fun_conflict_window_size
+            );
+            Arc::new(fairness::FairnessShuffler {
+                sender_conflict_window_size: sender_conflict_window_size as usize,
+                module_conflict_window_size: module_conflict_window_size as usize,
+                entry_fun_conflict_window_size: entry_fun_conflict_window_size as usize,
+            })
+        },
     }
 }

--- a/consensus/src/transaction_shuffler/sender_aware.rs
+++ b/consensus/src/transaction_shuffler/sender_aware.rs
@@ -1,10 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    counters::{NUM_SENDERS_IN_BLOCK, TXN_SHUFFLE_SECONDS},
-    transaction_shuffler::TransactionShuffler,
-};
+use crate::{counters::NUM_SENDERS_IN_BLOCK, transaction_shuffler::TransactionShuffler};
 use aptos_types::transaction::SignedTransaction;
 use move_core_types::account_address::AccountAddress;
 use std::collections::{HashMap, VecDeque};
@@ -39,8 +36,6 @@ pub struct SenderAwareShuffler {
 
 impl TransactionShuffler for SenderAwareShuffler {
     fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
-        let _timer = TXN_SHUFFLE_SECONDS.start_timer();
-
         // Early return for performance reason if there are no transactions to shuffle
         if txns.is_empty() {
             return txns;

--- a/consensus/src/transaction_shuffler/sender_aware.rs
+++ b/consensus/src/transaction_shuffler/sender_aware.rs
@@ -1,5 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     counters::{NUM_SENDERS_IN_BLOCK, TXN_SHUFFLE_SECONDS},
     transaction_shuffler::TransactionShuffler,
@@ -223,9 +224,7 @@ impl SlidingWindowState {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        sender_aware_shuffler::SenderAwareShuffler, transaction_shuffler::TransactionShuffler,
-    };
+    use crate::transaction_shuffler::{sender_aware::SenderAwareShuffler, TransactionShuffler};
     use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, SigningKey, Uniform};
     use aptos_types::{
         chain_id::ChainId,

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1883,7 +1883,11 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                 }
                 OnChainExecutionConfig::V4(config_v4) => {
                     config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
-                    config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+                    config_v4.transaction_shuffler_type = TransactionShufflerType::Fairness {
+                        sender_conflict_window_size: 256,
+                        module_conflict_window_size: 2,
+                        entry_fun_conflict_window_size: 3,
+                    };
                 }
             }
             helm_values["chain"]["on_chain_execution_config"] =

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -70,7 +70,11 @@ impl OnChainExecutionConfig {
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
         OnChainExecutionConfig::V4(ExecutionConfigV4 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            transaction_shuffler_type: TransactionShufflerType::Fairness {
+                sender_conflict_window_size: 32,
+                module_conflict_window_size: 2,
+                entry_fun_conflict_window_size: 3,
+            },
             block_gas_limit_type: BlockGasLimitType::ComplexLimitV1 {
                 effective_block_gas_limit: 20000,
                 execution_gas_effective_multiplier: 1,
@@ -142,6 +146,11 @@ pub enum TransactionShufflerType {
     NoShuffling,
     DeprecatedSenderAwareV1(u32),
     SenderAwareV2(u32),
+    Fairness {
+        sender_conflict_window_size: u32,
+        module_conflict_window_size: u32,
+        entry_fun_conflict_window_size: u32,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
### Description

FairnessShuffler that tries to spread out (delay) transactions from dominant modules in a block.  

See inline documents and tests.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Unittests
