### PR TITLE
[Block Executor] implement group serialization fallback, test

### DIFF
--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -19,6 +19,10 @@ pub enum IntentionalFallbackToSequential {
     // This is not PanicError because we need to match the error variant to provide a specialized
     // fallback logic if a resource group serialization error occurs.
     ResourceGroupSerializationError,
+    // If multiple workers encounter conditions that qualify for a sequential fallback during parallel
+    // execution, it is not clear what is the "right" one to fallback with. Instead, we use the
+    // variant below. TODO: pass a vector of all encountered conditions (mainly for tests).
+    FallbackFromParallel,
 }
 
 impl IntentionalFallbackToSequential {

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -776,6 +776,14 @@ where
         finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
         txn_idx: TxnIndex,
     ) -> Result<Vec<(T::Key, T::Value)>, PanicOr<IntentionalFallbackToSequential>> {
+        fail_point!(
+            "fail-point-resource-group-serialization",
+            !finalized_groups.is_empty(),
+            |_| Err(PanicOr::Or(
+                IntentionalFallbackToSequential::ResourceGroupSerializationError
+            ))
+        );
+
         finalized_groups
             .into_iter()
             .map(|(group_key, mut metadata_op, finalized_group)| {
@@ -806,9 +814,6 @@ where
 
                 if res.is_err() {
                     alert!("Failed to serialize resource group");
-                    // Alert first, then log an error with actual btree, to make sure
-                    // printing it can't possibly fail during alert.
-                    error!("Failed to serialize resource group BTreeMap {:?}", btree);
                 }
 
                 res
@@ -1114,11 +1119,7 @@ where
         (!shared_maybe_error.load(Ordering::SeqCst))
             .then(|| BlockOutput::new(final_results.into_inner()))
             .ok_or(PanicOr::Or(
-                // All errors (if more than one) have been logged, and here any error
-                // leads to a sequential fallback. We use serialization error for now
-                // to be defensive and avoid any scenarios where the fallback would not
-                // have the specialized logic enabled. TODO: refactor.
-                IntentionalFallbackToSequential::ResourceGroupSerializationError,
+                IntentionalFallbackToSequential::FallbackFromParallel,
             ))
     }
 
@@ -1205,6 +1206,7 @@ where
         executor_arguments: E::Argument,
         signature_verified_block: &[T],
         base_view: &S,
+        resource_group_bcs_fallback: bool,
     ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
         let num_txns = signature_verified_block.len();
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -1288,6 +1290,69 @@ where
                         "Sequential execution must materialize deltas"
                     );
 
+                    if resource_group_bcs_fallback {
+                        // Dynamic change set optimizations are enabled, and resource group serialization
+                        // previously failed in bcs serialization for preparing final transaction outputs.
+                        // TODO: remove this fallback when txn errors can be created from block executor.
+
+                        let finalize = |group_key| -> BTreeMap<_, _> {
+                            unsync_map
+                                .finalize_group(&group_key)
+                                .map(|(resource_tag, value_with_layout)| {
+                                    (
+                                        resource_tag,
+                                        value_with_layout
+                                            .extract_value_no_layout()
+                                            .extract_raw_bytes()
+                                            .expect("Deletions should already be applied"),
+                                    )
+                                })
+                                .collect()
+                        };
+
+                        // The IDs are not exchanged but it doesn't change the types (Bytes) or size.
+                        let serialization_error = output
+                            .group_reads_needing_delayed_field_exchange()
+                            .iter()
+                            .any(|(group_key, _)| {
+                                fail_point!("fail-point-resource-group-serialization", |_| {
+                                    true
+                                });
+
+                                let finalized_group = finalize(group_key.clone());
+                                bcs::to_bytes(&finalized_group).is_err()
+                            })
+                            || output.resource_group_write_set().into_iter().any(
+                                |(group_key, _, group_ops)| {
+                                    fail_point!("fail-point-resource-group-serialization", |_| {
+                                        true
+                                    });
+
+                                    let mut finalized_group = finalize(group_key);
+                                    for (value_tag, (group_op, _)) in group_ops {
+                                        if group_op.is_deletion() {
+                                            finalized_group.remove(&value_tag);
+                                        } else {
+                                            finalized_group.insert(
+                                                value_tag,
+                                                group_op
+                                                    .extract_raw_bytes()
+                                                    .expect("Not a deletion"),
+                                            );
+                                        }
+                                    }
+                                    bcs::to_bytes(&finalized_group).is_err()
+                                },
+                            );
+
+                        if serialization_error {
+                            // The corresponding error / alert must already be triggered, the goal in sequential
+                            // fallback is to just skip any transactions that would cause such serialization errors.
+                            ret.push(E::Output::skip_output());
+                            continue;
+                        }
+                    };
+
                     // Apply the writes.
                     // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
                     Self::apply_output_sequential(&unsync_map, &output)?;
@@ -1297,7 +1362,8 @@ where
                         let group_metadata_ops = output.resource_group_metadata_ops();
                         let mut finalized_groups = Vec::with_capacity(group_metadata_ops.len());
                         for (group_key, group_metadata_op) in group_metadata_ops.into_iter() {
-                            let finalized_group = unsync_map.finalize_group(&group_key);
+                            let finalized_group: Vec<_> =
+                                unsync_map.finalize_group(&group_key).collect();
                             if finalized_group.is_empty() != group_metadata_op.is_deletion() {
                                 // TODO[agg_v2](fix): code invariant error if dynamic change set optimizations disabled.
                                 // TODO[agg_v2](fix): make sure this cannot be triggered by an user transaction
@@ -1313,7 +1379,8 @@ where
                         for (group_key, group_metadata_op) in
                             output.group_reads_needing_delayed_field_exchange()
                         {
-                            let finalized_group = unsync_map.finalize_group(&group_key);
+                            let finalized_group: Vec<_> =
+                                unsync_map.finalize_group(&group_key).collect();
                             if finalized_group.is_empty() != group_metadata_op.is_deletion() {
                                 return Err(code_invariant_error(format!(
                                     "Group is empty = {} but op is deletion = {} in sequential execution",
@@ -1452,12 +1519,21 @@ where
                 executor_arguments,
                 signature_verified_block,
                 base_view,
+                false,
             )
         };
 
-        // Sequential execution fallback
-        // Only worth doing if we did parallel before, i.e. if we did a different pass.
-        if self.config.local.concurrency_level > 1 {
+        let resource_group_bcs_fallback = matches!(
+            ret,
+            Err(BlockExecutionError::FallbackToSequential(PanicOr::Or(
+                IntentionalFallbackToSequential::ResourceGroupSerializationError
+            )))
+        );
+
+        if self.config.local.concurrency_level > 1 || resource_group_bcs_fallback {
+            // Sequential execution fallback, only worth doing if we did a different pass before,
+            // i.e. parallel, or without resource group serialization fallback configured.
+
             if let Err(BlockExecutionError::FallbackToSequential(_)) = &ret {
                 // Any error logs are already written at appropriate levels.
                 debug!("Sequential_fallback occurred");
@@ -1470,6 +1546,8 @@ where
                     executor_arguments,
                     signature_verified_block,
                     base_view,
+                    // Always enable resource group serialization handling in fallback.
+                    true,
                 );
             }
         }

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -365,10 +365,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
 
                 results.iter().skip(committed).for_each(|output| {
                     // Ensure the transaction is skipped based on the output.
-                    assert!(output.writes.is_empty());
-                    assert!(output.deltas.is_empty());
-                    assert!(output.read_results.is_empty());
-                    assert_eq!(output.total_gas, 0);
+                    assert!(output.skipped);
 
                     // Implies that materialize_delta_writes was never called, as should
                     // be for skipped transactions.

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -567,7 +567,7 @@ fn non_empty_group(
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_sequential((), &transactions, &data_view);
+        .execute_transactions_sequential((), &transactions, &data_view, false);
         // TODO: test dynamic disabled as well.
 
         BaselineOutput::generate(&transactions, None).assert_output(&output);

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -966,6 +966,7 @@ where
                     read_group_sizes,
                     materialized_delta_writes: OnceCell::new(),
                     total_gas: behavior.gas,
+                    skipped: false,
                 })
             },
             MockTransaction::SkipRest(gas) => {
@@ -997,6 +998,7 @@ pub(crate) struct MockOutput<K, E> {
     pub(crate) read_group_sizes: Vec<(K, u64)>,
     pub(crate) materialized_delta_writes: OnceCell<Vec<(K, WriteOp)>>,
     pub(crate) total_gas: u64,
+    pub(crate) skipped: bool,
 }
 
 impl<K, E> TransactionOutput for MockOutput<K, E>
@@ -1100,6 +1102,7 @@ where
             read_group_sizes: vec![],
             materialized_delta_writes: OnceCell::new(),
             total_gas: 0,
+            skipped: true,
         }
     }
 

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         baseline::BaselineOutput,
         types::{
             DeltaDataView, KeyType, MockEvent, MockIncarnation, MockOutput, MockTask,
-            MockTransaction, ValueType,
+            MockTransaction, NonEmptyGroupDataView, ValueType,
         },
     },
     scheduler::{
@@ -33,8 +33,126 @@ use claims::assert_matches;
 use fail::FailScenario;
 use rand::{prelude::*, random};
 use std::{
-    cmp::min, collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc,
+    cmp::min,
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+    sync::Arc,
 };
+
+#[test]
+fn resource_group_bcs_fallback() {
+    let no_group_incarnation_1: MockIncarnation<KeyType<u32>, MockEvent> = MockIncarnation::new(
+        vec![KeyType::<u32>(1, false)],
+        vec![(
+            KeyType::<u32>(2, false),
+            ValueType::from_value(vec![5], true),
+        )],
+        vec![],
+        vec![],
+        10,
+    );
+    let no_group_incarnation_2: MockIncarnation<KeyType<u32>, MockEvent> = MockIncarnation::new(
+        vec![KeyType::<u32>(3, false), KeyType::<u32>(4, false)],
+        vec![(
+            KeyType::<u32>(1, false),
+            ValueType::from_value(vec![5], true),
+        )],
+        vec![],
+        vec![],
+        10,
+    );
+    let t_1 = MockTransaction::from_behavior(no_group_incarnation_1);
+    let t_3 = MockTransaction::from_behavior(no_group_incarnation_2);
+
+    let mut group_incarnation: MockIncarnation<KeyType<u32>, MockEvent> =
+        MockIncarnation::new(vec![KeyType::<u32>(1, false)], vec![], vec![], vec![], 10);
+    group_incarnation.group_writes.push((
+        KeyType::<u32>(100, false),
+        HashMap::from([(101, ValueType::from_value(vec![5], true))]),
+    ));
+    let t_2 = MockTransaction::from_behavior(group_incarnation);
+    let transactions = Vec::from([t_1, t_2, t_3]);
+
+    let data_view = NonEmptyGroupDataView::<KeyType<u32>> {
+        group_keys: HashSet::new(),
+    };
+    let executor_thread_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_cpus::get())
+            .build()
+            .unwrap(),
+    );
+    let block_executor = BlockExecutor::<
+        MockTransaction<KeyType<u32>, MockEvent>,
+        MockTask<KeyType<u32>, MockEvent>,
+        NonEmptyGroupDataView<KeyType<u32>>,
+        NoOpTransactionCommitHook<MockOutput<KeyType<u32>, MockEvent>, usize>,
+        ExecutableTestType,
+    >::new(
+        BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
+        executor_thread_pool,
+        None,
+    );
+
+    // Execute the block normally.
+    let output = block_executor.execute_transactions_parallel((), &transactions, &data_view);
+    match output {
+        Ok(block_output) => {
+            let txn_outputs = block_output.into_transaction_outputs_forced();
+            assert_eq!(txn_outputs.len(), 3);
+            assert!(!txn_outputs[0].writes.is_empty());
+            assert!(!txn_outputs[2].writes.is_empty());
+            assert!(!txn_outputs[1].group_writes.is_empty());
+        },
+        Err(_) => unreachable!("Must succeed: failpoint not yet set up"),
+    };
+
+    // Set up and sanity check failpoint.
+    let scenario = FailScenario::setup();
+    assert!(fail::has_failpoints());
+    fail::cfg("fail-point-resource-group-serialization", "return()").unwrap();
+    assert!(!fail::list().is_empty());
+
+    let par_output = block_executor.execute_transactions_parallel((), &transactions, &data_view);
+    assert_matches!(
+        par_output,
+        Err(PanicOr::Or(
+            IntentionalFallbackToSequential::FallbackFromParallel
+        ))
+    );
+
+    let seq_output =
+        block_executor.execute_transactions_sequential((), &transactions, &data_view, false);
+    assert_matches!(
+        seq_output,
+        Err(BlockExecutionError::FallbackToSequential(PanicOr::Or(
+            IntentionalFallbackToSequential::ResourceGroupSerializationError
+        )))
+    );
+
+    // Now execute with fallback handling for resource group serialization error:
+    let fallback_output =
+        block_executor.execute_transactions_sequential((), &transactions, &data_view, true);
+    let fallback_output_block = block_executor.execute_block((), &transactions, &data_view);
+    for output in [fallback_output, fallback_output_block] {
+        match output {
+            Ok(block_output) => {
+                let txn_outputs = block_output.into_transaction_outputs_forced();
+                assert_eq!(txn_outputs.len(), 3);
+                assert!(!txn_outputs[0].writes.is_empty());
+                assert!(!txn_outputs[2].writes.is_empty());
+
+                // But now transaction 1 must be skipped.
+                assert!(txn_outputs[1].skipped);
+            },
+            Err(_) => unreachable!("Must succeed: fallback"),
+        };
+    }
+
+    scenario.teardown();
+}
 
 #[test]
 fn block_output_err_precedence() {
@@ -82,7 +200,7 @@ fn block_output_err_precedence() {
     assert_matches!(
         output,
         Err(PanicOr::Or(
-            IntentionalFallbackToSequential::ResourceGroupSerializationError
+            IntentionalFallbackToSequential::FallbackFromParallel
         ))
     );
     scenario.teardown();

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -134,7 +134,7 @@ impl<
     }
 
     /// Contains the latest group ops for the given group key.
-    pub fn finalize_group(&self, group_key: &K) -> Vec<(T, ValueWithLayout<V>)> {
+    pub fn finalize_group(&self, group_key: &K) -> impl Iterator<Item = (T, ValueWithLayout<V>)> {
         self.group_cache
             .borrow()
             .get(group_key)
@@ -142,7 +142,6 @@ impl<
             .borrow()
             .clone()
             .into_iter()
-            .collect()
     }
 
     pub fn insert_group_op(
@@ -280,7 +279,7 @@ mod test {
         map: &UnsyncMap<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>,
         key: &KeyType<Vec<u8>>,
     ) -> HashMap<usize, ValueWithLayout<TestValue>> {
-        map.finalize_group(key).into_iter().collect()
+        map.finalize_group(key).collect()
     }
 
     // TODO[agg_v2](test) Add tests with non trivial layout
@@ -402,7 +401,7 @@ mod test {
         let ap = KeyType(b"/foo/b".to_vec());
         let map = UnsyncMap::<KeyType<Vec<u8>>, usize, TestValue, ExecutableTestType, ()>::new();
 
-        map.finalize_group(&ap);
+        let _ = map.finalize_group(&ap).collect::<Vec<_>>();
     }
 
     #[test]


### PR DESCRIPTION
- If block execution runs into bcs serialization issue, run sequential execution that pre-serializes and skips txns that have an error.
- New test to check the fallback logic, re-using existing mock executor infrastructure.

Used to fix error propagation / halting issue, but now rebased on https://github.com/aptos-labs/aptos-core/pull/11899