### PR TITLE
[Compiler V2] Critical edge elimination

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -26,5 +26,7 @@ impl Experiment {
     /// A flag which allows to turn off safety checks, like reference safety.
     /// Retention: permanent.
     pub const NO_SAFETY: &'static str = "no-safety";
+    /// A flag which allows to turn on the critical edge splitting pass.
+    /// Retention: temporary. This should be removed after the pass can be tested.
     pub const SPLIT_CRITICAL_EDGES: &'static str = "split-critical-edges";
 }

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -26,4 +26,5 @@ impl Experiment {
     /// A flag which allows to turn off safety checks, like reference safety.
     /// Retention: permanent.
     pub const NO_SAFETY: &'static str = "no-safety";
+    pub const SPLIT_CRITICAL_EDGES: &'static str = "split-critical-edges";
 }

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -208,7 +208,9 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     let options = env.get_extension::<Options>().expect("options");
     let safety_on = !options.experiment_on(Experiment::NO_SAFETY);
     let mut pipeline = FunctionTargetPipeline::default();
-    pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
+    if options.experiment_on(Experiment::SPLIT_CRITICAL_EDGES) {
+        pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
+    }
     if safety_on {
         pipeline.add_processor(Box::new(UninitializedUseChecker {}));
     }

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -18,6 +18,7 @@ use crate::pipeline::{
     exit_state_analysis::ExitStateAnalysisProcessor, explicit_drop::ExplicitDrop,
     livevar_analysis_processor::LiveVarAnalysisProcessor,
     reference_safety_processor::ReferenceSafetyProcessor,
+    split_critical_edges_processor::SplitCriticalEdgesProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
     unreachable_code_analysis::UnreachableCodeProcessor,
     unreachable_code_remover::UnreachableCodeRemover,
@@ -207,6 +208,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     let options = env.get_extension::<Options>().expect("options");
     let safety_on = !options.experiment_on(Experiment::NO_SAFETY);
     let mut pipeline = FunctionTargetPipeline::default();
+    pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
     if safety_on {
         pipeline.add_processor(Box::new(UninitializedUseChecker {}));
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -20,6 +20,7 @@ pub mod exit_state_analysis;
 pub mod explicit_drop;
 pub mod livevar_analysis_processor;
 pub mod reference_safety_processor;
+pub mod split_critical_edges_processor;
 pub mod uninitialized_use_checker;
 pub mod unreachable_code_analysis;
 pub mod unreachable_code_remover;

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -68,8 +68,9 @@ impl SplitCriticalEdgesTransformation {
     }
 
     /// Runs the transformation, which breaks critical edges with empty blocks.
-    fn transform(&mut self) {
-        self.code = self.transform_bytecode_vec(self.code)
+    pub fn transform(&mut self) {
+        let code = std::mem::take(&mut self.code);
+        self.code = self.transform_bytecode_vec(code)
     }
 
     /// Transforms the given code and returns the transformed code

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -115,6 +115,7 @@ impl SplitCriticalEdgesTransformation {
     ) -> Option<(Label, Vec<Bytecode>)> {
         // label is in `srcs_count` by construction
         if *self.srcs_count.get(&label).expect("srcs count") > 1 {
+
             Some(self.split_edge(attr_id, label))
         } else {
             None
@@ -141,7 +142,8 @@ impl SplitCriticalEdgesTransformation {
             if self.labels.is_empty() {
                 0
             } else {
-                self.labels.iter().next_back().expect("label").as_usize() + 1
+                let max_label = self.labels.iter().next_back().expect("label");
+                max_label.as_usize() + 1
             },
         );
         self.labels.insert(new_label);

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -185,7 +185,7 @@ fn count_srcs(code: &[Bytecode]) -> BTreeMap<Label, usize> {
                         map_inc(&mut srcs_count, *label)
                     }
                 }
-            }
+            },
             _ => {},
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -7,7 +7,7 @@
 //!
 //! Side effects: clear existing annotations.
 //!
-//! Prerequisites: none.
+//! Prerequisites: no call instructions have abort actions.
 //!
 //! Postconditions: no critical edges in the control flow graph.
 

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -50,6 +50,8 @@ struct SplitCriticalEdgesTransformation {
     labels: BTreeSet<Label>,
     /// Maps label to its number of incoming edges, including explicit goto/branch or fall throughs.
     /// If a label is not in the map, it doesn't have any incoming edges.
+    /// The count for lables generated in the transformation is not tracked,
+    /// but this map will not be invalidated during the transformation.
     incoming_edge_count: BTreeMap<Label, usize>,
 }
 
@@ -81,7 +83,9 @@ impl SplitCriticalEdgesTransformation {
         }
     }
 
-    /// Transforms a branch instruction by splitting the critical out edges
+    /// Transforms a branch instruction by splitting the critical out edges.
+    /// Note that this will not invalidate `incoming_edge_count`, since the incoming edge of a branch
+    /// is replaced by the goto in the generated empty block
     pub fn transform_branch(&mut self, attr_id: AttrId, l0: Label, l1: Label, t: TempIndex) {
         match (
             self.split_critical_edge(attr_id, l0),

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -1,0 +1,193 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This pass splits critical edges with empty blocks.
+//! A critical edge is an edge where the source node has multiple successors,
+//! and the target node has multiple predecessors.
+
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    function_target::FunctionData,
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{AttrId, Bytecode, Label},
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub struct SplitCriticalEdgesProcessor {}
+
+impl FunctionTargetProcessor for SplitCriticalEdgesProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv,
+        data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if fun_env.is_native() {
+            return data;
+        }
+        let mut transformer = SplitCriticalEdgesTransformation::new(data);
+        transformer.transform();
+        transformer.data
+    }
+
+    fn name(&self) -> String {
+        "SplitCriticalEdgesProcessor".to_owned()
+    }
+}
+
+struct SplitCriticalEdgesTransformation {
+    data: FunctionData,
+    // labels used in the original code and in the generated code
+    labels: BTreeSet<Label>,
+    srcs_count: BTreeMap<Label, usize>,
+}
+
+impl SplitCriticalEdgesTransformation {
+    pub fn new(data: FunctionData) -> Self {
+        let labels = Bytecode::labels(&data.code);
+        let srcs_count = count_srcs(&data.code);
+        Self {
+            data,
+            labels,
+            srcs_count,
+        }
+    }
+
+    /// Runs the transformation, which breaks critical edges with empty blocks.
+    fn transform(&mut self) {
+        let bytecodes = std::mem::take(&mut self.data.code);
+        for bytecode in bytecodes {
+            self.transform_bytecode(bytecode)
+        }
+    }
+
+    /// Transforms a bytecode
+    fn transform_bytecode(&mut self, bytecode: Bytecode) {
+        match bytecode {
+            Bytecode::Branch(attr_id, l0, l1, t) => self.transform_branch(attr_id, l0, l1, t),
+            // Edge of a `Jump` can never be critical since the source node only have one out edge
+            _ => self.emit(bytecode),
+        }
+    }
+
+    /// Transforms a branch instruction by splitting the critical out edges
+    pub fn transform_branch(&mut self, attr_id: AttrId, l0: Label, l1: Label, t: TempIndex) {
+        match (
+            self.split_critical_edge(attr_id, l0),
+            self.split_critical_edge(attr_id, l1),
+        ) {
+            (None, None) => self.emit(Bytecode::Branch(attr_id, l0, l1, t)),
+            (None, Some((l1_new, code))) => {
+                self.emit(Bytecode::Branch(attr_id, l0, l1_new, t));
+                self.emit_codes(code)
+            },
+            (Some((l0_new, code)), None) => {
+                self.emit(Bytecode::Branch(attr_id, l0_new, l1, t));
+                self.emit_codes(code)
+            },
+            (Some((l0_new, code0)), Some((l1_new, code1))) => {
+                self.emit(Bytecode::Branch(attr_id, l0_new, l1_new, t));
+                self.emit_codes(code0);
+                self.emit_codes(code1);
+            },
+        }
+    }
+
+    /// `label` is the target of some branch instruction
+    /// If label has multiple sources, returns
+    /// - a fresh label
+    /// - a new empty block that
+    ///     - starts with the fresh label
+    ///     - jumps to `label`
+    /// otherwise returns `None`
+    fn split_critical_edge(
+        &mut self,
+        attr_id: AttrId,
+        label: Label,
+    ) -> Option<(Label, Vec<Bytecode>)> {
+        // label is in `srcs_count` by construction
+        if *self.srcs_count.get(&label).expect("srcs count") > 1 {
+            Some(self.split_edge(attr_id, label))
+        } else {
+            None
+        }
+    }
+
+    /// Returns
+    /// - a fresh label
+    /// - a new empty block that
+    ///     - starts with the fresh label
+    ///     - jumps to `label`
+    fn split_edge(&mut self, attr_id: AttrId, label: Label) -> (Label, Vec<Bytecode>) {
+        let new_label = self.gen_fresh_label();
+        let code = vec![
+            Bytecode::Label(attr_id, new_label),
+            Bytecode::Jump(attr_id, label),
+        ];
+        (new_label, code)
+    }
+
+    /// Generates a fresh label
+    fn gen_fresh_label(&mut self) -> Label {
+        let new_label = Label::new(
+            if self.labels.is_empty() {
+                0
+            } else {
+                self.labels.iter().next_back().expect("label").as_usize() + 1
+            },
+        );
+        self.labels.insert(new_label);
+        new_label
+    }
+
+    fn emit(&mut self, bytecode: Bytecode) {
+        self.data.code.push(bytecode)
+    }
+
+    fn emit_codes(&mut self, code: Vec<Bytecode>) {
+        for instr in code {
+            self.emit(instr)
+        }
+    }
+}
+
+/// If key present in `map`, add 1 to its value; else insert 1
+fn map_inc<Key: Ord>(map: &mut BTreeMap<Key, usize>, key: Key) {
+    map.entry(key)
+        .and_modify(|n: &mut usize| {
+            let (n_suc, overflows) = n.overflowing_add(1);
+            if overflows {
+                panic!("`count_srcs` overflows")
+            } else {
+                *n = n_suc;
+            }
+        })
+        .or_insert(1usize);
+}
+
+/// Count the number of sources of labels
+/// labels with no sources are not included
+fn count_srcs(code: &[Bytecode]) -> BTreeMap<Label, usize> {
+    let mut srcs_count = BTreeMap::new();
+    for (code_offset, instr) in code.iter().enumerate() {
+        match instr {
+            Bytecode::Jump(_, label) => map_inc(&mut srcs_count, *label),
+            Bytecode::Branch(_, l0, l1, _) => {
+                map_inc(&mut srcs_count, *l0);
+                map_inc(&mut srcs_count, *l1);
+            },
+            Bytecode::Label(_, label) => {
+                if code_offset != 0 {
+                    let prev_instr = code.get(code_offset - 1).unwrap();
+                    // treat fall-through's to the label
+                    if !prev_instr.is_branch() {
+                        map_inc(&mut srcs_count, *label)
+                    }
+                }
+            }
+            _ => {},
+        }
+    }
+    srcs_count
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -11,7 +11,7 @@
 //!
 //! Postconditions: no critical edges in the control flow graph.
 
-use log::log_enabled;
+use log::{log_enabled, Level};
 use move_model::{ast::TempIndex, model::FunctionEnv};
 use move_stackless_bytecode::{
     function_target::FunctionData,

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -73,7 +73,7 @@ impl SplitCriticalEdgesTransformation {
     fn transform_bytecode(&mut self, bytecode: Bytecode) {
         match bytecode {
             Bytecode::Branch(attr_id, l0, l1, t) => self.transform_branch(attr_id, l0, l1, t),
-            // Edge of a `Jump` can never be critical since the source node only have one out edge
+            // Edge of a `Jump` is never critical because the source node only has one out edge.
             _ => self.emit(bytecode),
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -52,7 +52,6 @@ impl FunctionTargetProcessor for SplitCriticalEdgesProcessor {
 
 impl SplitCriticalEdgesProcessor {
     /// Checks the precondition of the transformaiton; cf. module documentation.
-    #[cfg(debug_assertions)]
     fn check_precondition(data: &FunctionData) {
         for instr in &data.code {
             if matches!(instr, Bytecode::Call(_, _, _, _, Some(_))) {
@@ -62,7 +61,6 @@ impl SplitCriticalEdgesProcessor {
     }
 
     /// Checks the postcondition of the transformation; cf. module documentation.
-    #[cfg(debug_assertions)]
     fn check_postcondition(code: &[Bytecode]) {
         use move_stackless_bytecode::stackless_control_flow_graph::{
             BlockId, StacklessControlFlowGraph,

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -11,6 +11,7 @@
 //!
 //! Postconditions: no critical edges in the control flow graph.
 
+use log::log_enabled;
 use move_model::{ast::TempIndex, model::FunctionEnv};
 use move_stackless_bytecode::{
     function_target::FunctionData,
@@ -30,7 +31,7 @@ impl FunctionTargetProcessor for SplitCriticalEdgesProcessor {
         mut data: FunctionData,
         _scc_opt: Option<&[FunctionEnv]>,
     ) -> FunctionData {
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) || log_enabled!(Level::Debug) {
             Self::check_precondition(&data);
         }
         if fun_env.is_native() {
@@ -40,7 +41,7 @@ impl FunctionTargetProcessor for SplitCriticalEdgesProcessor {
         transformer.transform();
         data.code = transformer.code;
         data.annotations.clear();
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) || log_enabled!(Level::Debug) {
             Self::check_postcondition(&data.code);
         }
         data

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -186,7 +186,7 @@ fn count_srcs(code: &[Bytecode]) -> BTreeMap<Label, usize> {
             },
             Bytecode::Label(_, label) => {
                 if code_offset != 0 {
-                    let prev_instr = code.get(code_offset - 1).unwrap();
+                    let prev_instr = code.get(code_offset - 1).expect("instruction");
                     // treat fall-through's to the label
                     if !prev_instr.is_branch() {
                         map_inc(&mut srcs_count, *label)

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -118,7 +118,6 @@ impl SplitCriticalEdgesTransformation {
     ) -> Option<(Label, Vec<Bytecode>)> {
         // label is in `srcs_count` by construction
         if *self.incoming_edge_count.get(&label).expect("srcs count") > 1 {
-
             Some(self.split_edge(attr_id, label))
         } else {
             None
@@ -168,12 +167,7 @@ impl SplitCriticalEdgesTransformation {
 fn increment_key_count<Key: Ord>(map: &mut BTreeMap<Key, usize>, key: Key) {
     map.entry(key)
         .and_modify(|n: &mut usize| {
-            let (n_suc, overflows) = n.overflowing_add(1);
-            if overflows {
-                panic!("`count_srcs` overflows")
-            } else {
-                *n = n_suc;
-            }
+            *n += 1;
         })
         .or_insert(1usize);
 }

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -16,6 +16,7 @@ use move_stackless_bytecode::{
     function_target::FunctionData,
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::{AttrId, Bytecode, Label},
+    stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -62,9 +63,6 @@ impl SplitCriticalEdgesProcessor {
 
     /// Checks the postcondition of the transformation; cf. module documentation.
     fn check_postcondition(code: &[Bytecode]) {
-        use move_stackless_bytecode::stackless_control_flow_graph::{
-            BlockId, StacklessControlFlowGraph,
-        };
         let cfg = StacklessControlFlowGraph::new_forward(code);
         let blocks = cfg.blocks();
         let mut pred_count: BTreeMap<BlockId, usize> =

--- a/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/split_critical_edges_processor.rs
@@ -4,6 +4,12 @@
 //! This pass splits critical edges with empty blocks.
 //! A critical edge is an edge where the source node has multiple successors,
 //! and the target node has multiple predecessors.
+//!
+//! Side effects: clear existing annotations.
+//!
+//! Prerequisites: none.
+//!
+//! Postconditions: no critical edges in the control flow graph.
 
 use move_model::{ast::TempIndex, model::FunctionEnv};
 use move_stackless_bytecode::{
@@ -28,6 +34,7 @@ impl FunctionTargetProcessor for SplitCriticalEdgesProcessor {
         }
         let mut transformer = SplitCriticalEdgesTransformation::new(data);
         transformer.transform();
+        transformer.data.annotations.clear();
         transformer.data
     }
 

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -13,6 +13,7 @@ use move_compiler_v2::{
         exit_state_analysis::ExitStateAnalysisProcessor, explicit_drop::ExplicitDrop,
         livevar_analysis_processor::LiveVarAnalysisProcessor,
         reference_safety_processor::ReferenceSafetyProcessor,
+        split_critical_edges_processor::SplitCriticalEdgesProcessor,
         uninitialized_use_checker::UninitializedUseChecker,
         unreachable_code_analysis::UnreachableCodeProcessor,
         unreachable_code_remover::UnreachableCodeRemover,
@@ -223,6 +224,7 @@ impl TestConfig {
                 dump_for_only_some_stages: None,
             }
         } else if path.contains("/ability-checker/") {
+            pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
                 with_copy_inference: true,
             }));

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -224,7 +224,6 @@ impl TestConfig {
                 dump_for_only_some_stages: None,
             }
         } else if path.contains("/ability-checker/") {
-            pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
                 with_copy_inference: true,
             }));

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -13,7 +13,6 @@ use move_compiler_v2::{
         exit_state_analysis::ExitStateAnalysisProcessor, explicit_drop::ExplicitDrop,
         livevar_analysis_processor::LiveVarAnalysisProcessor,
         reference_safety_processor::ReferenceSafetyProcessor,
-        split_critical_edges_processor::SplitCriticalEdgesProcessor,
         uninitialized_use_checker::UninitializedUseChecker,
         unreachable_code_analysis::UnreachableCodeProcessor,
         unreachable_code_remover::UnreachableCodeRemover,

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -14,7 +14,7 @@ use move_model::{
     model::{FunId, GlobalEnv, ModuleId, NodeId, QualifiedInstId, SpecVarId, StructId},
     ty::{Type, TypeDisplayContext},
 };
-use std::{collections::BTreeMap, fmt, fmt::Formatter};
+use std::{collections::{BTreeMap, BTreeSet}, fmt, fmt::Formatter};
 
 /// A label for a branch destination.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
@@ -574,6 +574,19 @@ impl Bytecode {
             }
         }
         res
+    }
+
+    /// Returns the set of labels in `code`.
+    pub fn labels(code: &[Bytecode]) -> BTreeSet<Label> {
+        code.iter()
+            .filter_map(|code| {
+                if let Bytecode::Label(_, label) = code {
+                    Some(*label)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Return the successor offsets of this instruction. In addition to the code, a map

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -14,7 +14,11 @@ use move_model::{
     model::{FunId, GlobalEnv, ModuleId, NodeId, QualifiedInstId, SpecVarId, StructId},
     ty::{Type, TypeDisplayContext},
 };
-use std::{collections::{BTreeMap, BTreeSet}, fmt, fmt::Formatter};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    fmt::Formatter,
+};
 
 /// A label for a branch destination.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]


### PR DESCRIPTION
### Description

Implements a compiler pass that eliminates critical edges by splitting them with empty blocks, making it easier for later passes to add code along control flow graph edges. 

After critical edges are eliminated, to add a new code block between `BB0` and `BB1`:

- If the edge `BB0 -> BB1` is a conditional jump, prepend the new block to `BB1`. This is because `BB0` has multiple successors so `BB1` cannot have multiple predecessors.

- Otherwise append the new block to `BB0`, since unconditional jumps have only one successor.

The pass can be turned on with the experiment flag `"split-critical-edges"`.

### Test Plan

There is currently no way to directly test for this pass, since the bytecode generator doesn't seem to create any critical edges. (I've tested it personally where I modified the bytecode generator so that it creates critical edges. The transactional tests are passed where 20 critical edges were found.)
