### PR TITLE
[forge] revert genesis to pre-#11842

### DIFF
--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -25,6 +25,12 @@ data:
     rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
     voting_duration_secs: {{ .Values.chain.voting_duration_secs | int }}
     voting_power_increase_limit: {{ .Values.chain.voting_power_increase_limit | int }}
+    {{- with .Values.chain.on_chain_consensus_config}}
+    on_chain_consensus_config: {{ . | toJson }}
+    {{- end}}
+    {{- with .Values.chain.on_chain_execution_config}}
+    on_chain_execution_config: {{ . | toJson }}
+    {{- end}}
 
 ---
 

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -31,6 +31,10 @@ chain:
   rewards_apy_percentage: 10
   # -- Minimum price per gas unit
   min_price_per_gas_unit: 1
+  # -- Onchain Consensus Config
+  on_chain_consensus_config:
+  # -- Onchain Execution Config
+  on_chain_execution_config:
 
 # -- Default image tag to use for all tools images
 imageTag: testnet


### PR DESCRIPTION
### Description
#11842 removed consensus config and execution config so they were not applied to forge

### Test Plan
Ran ad-hoc forge test that overrides execution config and observed it is overridden: https://github.com/aptos-labs/aptos-core/actions/runs/7788659630
