### PR TITLE
[Txn Emitter] Various improvements to the transaction emitter

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -176,8 +176,15 @@ pub struct EmitArgs {
     #[clap(long)]
     pub expected_gas_per_txn: Option<u64>,
 
-    #[clap(long)]
+    #[clap(long, conflicts_with = "num_accounts")]
     pub max_transactions_per_account: Option<usize>,
+
+    #[clap(long, conflicts_with = "max_transactions_per_account")]
+    pub num_accounts: Option<usize>,
+
+    #[clap(long, default_value = "false")]
+    /// Skip minting account during initialization
+    pub skip_minting_account: bool,
 
     #[clap(long)]
     pub latency_polling_interval_s: Option<f32>,

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -184,7 +184,7 @@ pub struct EmitArgs {
 
     #[clap(long, default_value = "false")]
     /// Skip minting account during initialization
-    pub skip_minting_account: bool,
+    pub skip_minting_accounts: bool,
 
     #[clap(long)]
     pub latency_polling_interval_s: Option<f32>,

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -144,7 +144,7 @@ pub async fn emit_transactions_with_cluster(
             .latency_polling_interval(Duration::from_secs_f32(latency_polling_interval_s));
     }
 
-    if args.skip_minting_account {
+    if args.skip_minting_accounts {
         emit_job_request = emit_job_request.skip_minting_accounts();
     }
 

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -5,7 +5,8 @@ use crate::{
     args::{ClusterArgs, EmitArgs},
     cluster::Cluster,
     emitter::{
-        create_accounts, parse_seed, stats::TxnStats, EmitJobMode, EmitJobRequest, TxnEmitter,
+        create_accounts, parse_seed, stats::TxnStats, EmitJobMode, EmitJobRequest, NumAccountsMode,
+        TxnEmitter,
     },
     instance::Instance,
     CreateAccountsArgs,
@@ -97,10 +98,10 @@ pub async fn emit_transactions_with_cluster(
                 args.coordination_delay_between_instances.unwrap_or(0),
             ));
 
-    if let Some(max_transactions_per_account) = args.max_transactions_per_account {
-        emit_job_request =
-            emit_job_request.max_transactions_per_account(max_transactions_per_account);
-    }
+    let num_accounts =
+        NumAccountsMode::create(args.num_accounts, args.max_transactions_per_account);
+
+    emit_job_request = emit_job_request.num_accounts_mode(num_accounts);
 
     if let Some(gas_price) = args.gas_price {
         emit_job_request = emit_job_request.gas_price(gas_price);
@@ -143,6 +144,10 @@ pub async fn emit_transactions_with_cluster(
             .latency_polling_interval(Duration::from_secs_f32(latency_polling_interval_s));
     }
 
+    if args.skip_minting_account {
+        emit_job_request = emit_job_request.skip_minting_accounts();
+    }
+
     let stats = emitter
         .emit_txn_for_with_stats(
             &mut coin_source_account,
@@ -183,6 +188,7 @@ pub async fn create_accounts_command(
         &txn_factory,
         &emit_job_request,
         DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE,
+        false,
         seed,
         create_accounts_args.count,
         4,


### PR DESCRIPTION
### Description

Various improvements as follows 

1. Add option to specify number of accounts to create - please note that the transactions per account argument is still supported and the code ensures that you specify only one of them. 
2. Add option to skip minting and funding of new accounts - this is needed to resume transaction emitter after a failure.

### Test Plan


```
cargo run -p aptos-transaction-emitter --release -- emit-tx -t https://fullnode.devnet.aptoslabs.com -t https://fullnode.devnet.aptoslabs.com -t https://fullnode.devnet.aptoslabs.com -t https://fullnode.devnet.aptoslabs.com -t https://fullnode.devnet.aptoslabs.com -t https://fullnode.devnet.aptoslabs.com --mint-key ${DEVNET_MINT_KEY} --chain-id ${CHAIN_ID} --duration 60 --txn-expiration-time-secs 60  --mempool-backlog=1000 --expected-max-txns 300000 --init-gas-price-multiplier=1 --max-gas-per-txn=10000 --expected-gas-per-txn 6 --num-accounts 200 --transaction-type coin-transfer --account-minter-seed ${DEVNET_ACCOUNT_MINTER_SEED}
```

