### PR TITLE
Add GCD algorithm to math library

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -10,6 +10,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `max`](#0x1_math128_max)
 -  [Function `min`](#0x1_math128_min)
 -  [Function `average`](#0x1_math128_average)
+-  [Function `gcd`](#0x1_math128_gcd)
 -  [Function `mul_div`](#0x1_math128_mul_div)
 -  [Function `clamp`](#0x1_math128_clamp)
 -  [Function `pow`](#0x1_math128_pow)
@@ -122,6 +123,37 @@ Return the average of two.
     } <b>else</b> {
         b + (a - b) / 2
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math128_gcd"></a>
+
+## Function `gcd`
+
+Return greatest common divisor of <code>a</code> & <code>b</code>, via the Euclidean algorithm.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_gcd">gcd</a>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_gcd">gcd</a>(a: u128, b: u128): u128 {
+    <b>let</b> (large, small) = <b>if</b> (a &gt; b) (a, b) <b>else</b> (b, a);
+    <b>while</b> (small != 0) {
+        <b>let</b> tmp = small;
+        small = large % small;
+        large = tmp;
+    };
+    large
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -10,6 +10,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `max`](#0x1_math64_max)
 -  [Function `min`](#0x1_math64_min)
 -  [Function `average`](#0x1_math64_average)
+-  [Function `gcd`](#0x1_math64_gcd)
 -  [Function `mul_div`](#0x1_math64_mul_div)
 -  [Function `clamp`](#0x1_math64_clamp)
 -  [Function `pow`](#0x1_math64_pow)
@@ -120,6 +121,37 @@ Return the average of two.
     } <b>else</b> {
         b + (a - b) / 2
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math64_gcd"></a>
+
+## Function `gcd`
+
+Return greatest common divisor of <code>a</code> & <code>b</code>, via the Euclidean algorithm.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_gcd">gcd</a>(a: u64, b: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_gcd">gcd</a>(a: u64, b: u64): u64 {
+    <b>let</b> (large, small) = <b>if</b> (a &gt; b) (a, b) <b>else</b> (b, a);
+    <b>while</b> (small != 0) {
+        <b>let</b> tmp = small;
+        small = large % small;
+        large = tmp;
+    };
+    large
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -28,6 +28,17 @@ module aptos_std::math128 {
         }
     }
 
+    /// Return greatest common divisor of `a` & `b`, via the Euclidean algorithm.
+    public inline fun gcd(a: u128, b: u128): u128 {
+        let (large, small) = if (a > b) (a, b) else (b, a);
+        while (small != 0) {
+            let tmp = small;
+            small = large % small;
+            large = tmp;
+        };
+        large
+    }
+
     /// Returns a * b / c going through u256 to prevent intermediate overflow
     public inline fun mul_div(a: u128, b: u128, c: u128): u128 {
         // Inline functions cannot take constants, as then every module using it needs the constant
@@ -161,6 +172,27 @@ module aptos_std::math128 {
         // No overflow
         assert!(ceil_div((((1u256<<128) - 9) as u128), 11) == 30934760629176223951215873402888019223, 0);
     }
+
+    #[test]
+    fun test_gcd() {
+        assert!(gcd(20, 8) == 4, 0);
+        assert!(gcd(8, 20) == 4, 0);
+        assert!(gcd(1, 100) == 1, 0);
+        assert!(gcd(100, 1) == 1, 0);
+        assert!(gcd(210, 45) == 15, 0);
+        assert!(gcd(45, 210) == 15, 0);
+        assert!(gcd(0, 0) == 0, 0);
+        assert!(gcd(1, 0) == 1, 0);
+        assert!(gcd(50, 0) == 50, 0);
+        assert!(gcd(0, 1) == 1, 0);
+        assert!(gcd(0, 50) == 50, 0);
+        assert!(gcd(54, 24) == 6, 0);
+        assert!(gcd(24, 54) == 6, 0);
+        assert!(gcd(10, 10) == 10, 0);
+        assert!(gcd(1071, 462) == 21, 0);
+        assert!(gcd(462, 1071) == 21, 0);
+    }
+
     #[test]
     public entry fun test_max() {
         let result = max(3u128, 6u128);

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -29,17 +29,12 @@ module aptos_std::math64 {
     /// Return greatest common divisor of `a` & `b`, via the Euclidean algorithm.
     public inline fun gcd(a: u64, b: u64): u64 {
         let (large, small) = if (a > b) (a, b) else (b, a);
-        if (small == 0) {
-            0
-        } else {
-            loop {
-                let remainder = large % small;
-                if (remainder == 0) break;
-                large = small;
-                small = remainder;
-            };
-            small
-        }
+        while (small != 0) {
+            let tmp = small;
+            small = large % small;
+            large = tmp;
+        };
+        large
     }
 
     /// Returns a * b / c going through u128 to prevent intermediate overflow
@@ -161,11 +156,15 @@ module aptos_std::math64 {
         assert!(gcd(210, 45) == 15, 0);
         assert!(gcd(45, 210) == 15, 0);
         assert!(gcd(0, 0) == 0, 0);
-        assert!(gcd(1, 0) == 0, 0);
-        assert!(gcd(0, 1) == 0, 0);
+        assert!(gcd(1, 0) == 1, 0);
+        assert!(gcd(50, 0) == 50, 0);
+        assert!(gcd(0, 1) == 1, 0);
+        assert!(gcd(0, 50) == 50, 0);
         assert!(gcd(54, 24) == 6, 0);
         assert!(gcd(24, 54) == 6, 0);
         assert!(gcd(10, 10) == 10, 0);
+        assert!(gcd(1071, 462) == 21, 0);
+        assert!(gcd(462, 1071) == 21, 0);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -26,6 +26,22 @@ module aptos_std::math64 {
         }
     }
 
+    /// Return greatest common divisor of `a` & `b`, via the Euclidean algorithm.
+    public inline fun gcd(a: u64, b: u64): u64 {
+        let (large, small) = if (a > b) (a, b) else (b, a);
+        if (small == 0) {
+            0
+        } else {
+            loop {
+                let remainder = large % small;
+                if (remainder == 0) break;
+                large = small;
+                small = remainder;
+            };
+            small
+        }
+    }
+
     /// Returns a * b / c going through u128 to prevent intermediate overflow
     public inline fun mul_div(a: u64, b: u64, c: u64): u64 {
         // Inline functions cannot take constants, as then every module using it needs the constant
@@ -134,6 +150,22 @@ module aptos_std::math64 {
 
         // No overflow
         assert!(ceil_div((((1u128<<64) - 9) as u64), 11) == 1676976733973595601, 0);
+    }
+
+    #[test]
+    fun test_gcd() {
+        assert!(gcd(20, 8) == 4, 0);
+        assert!(gcd(8, 20) == 4, 0);
+        assert!(gcd(1, 100) == 1, 0);
+        assert!(gcd(100, 1) == 1, 0);
+        assert!(gcd(210, 45) == 15, 0);
+        assert!(gcd(45, 210) == 15, 0);
+        assert!(gcd(0, 0) == 0, 0);
+        assert!(gcd(1, 0) == 0, 0);
+        assert!(gcd(0, 1) == 0, 0);
+        assert!(gcd(54, 24) == 6, 0);
+        assert!(gcd(24, 54) == 6, 0);
+        assert!(gcd(10, 10) == 10, 0);
     }
 
     #[test]


### PR DESCRIPTION
@davidiw @movekevin @junkil-park 

Add to the `u64` and `u128` math libraries an implementation of Euclid's algorithm for computing the greatest common divisor, along with tests