### PR TITLE
[quorum store] adjust max sending rate from 2K/s to 6K/s

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -36,7 +36,7 @@ impl Default for QuorumStoreBackPressureConfig {
             increase_duration_ms: 1000,
             decrease_fraction: 0.5,
             dynamic_min_txn_per_s: 160,
-            dynamic_max_txn_per_s: 2000,
+            dynamic_max_txn_per_s: 6000,
         }
     }
 }


### PR DESCRIPTION
### Description

This allows a single validator to send more load than before. Backpressure will still kick in if txns are accumulating.

### Test Plan

Ran forge e2e perf. Things still look ok latency-wise.