### PR TITLE
Enable CONCURRENT_TOKEN_V2 flag

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -438,6 +438,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::SINGLE_SENDER_AUTHENTICATOR,
         FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         FeatureFlag::FEE_PAYER_ACCOUNT_OPTIONAL,
+        FeatureFlag::CONCURRENT_TOKEN_V2,
         FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
         FeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
         FeatureFlag::BN254_STRUCTURES,


### PR DESCRIPTION
### Description

Enable concurrent Token V2 structs from AIP-43.

We can do this now, that indexer change has landed. (which was blocking it)

(they will all be sequential until aggregator flag itself is enabled,
but this allows for new codepath to be executed and tested, and replay-verify to test aggregators)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
