### PR TITLE
Fix environment variable setup in benchmark script

### DIFF
--- a/testsuite/performance_benchmark.sh
+++ b/testsuite/performance_benchmark.sh
@@ -7,18 +7,12 @@ ulimit -n 1048576
 
 # Function to run the benchmark
 run_benchmark() {
-    FLOW=$1
-    NUM_BLOCKS_PER_TEST=$2
-    HIDE_OUTPUT=$3
-    ENABLE_PRUNER=$4
-    NUMBER_OF_EXECUTION_THREADS=$5
-
-    ./testsuite/single_node_performance.py \
-        FLOW=$FLOW \
-        NUM_BLOCKS_PER_TEST=$NUM_BLOCKS_PER_TEST \
-        HIDE_OUTPUT=$HIDE_OUTPUT \
-        ENABLE_PRUNER=$ENABLE_PRUNER \
-        NUMBER_OF_EXECUTION_THREADS=$NUMBER_OF_EXECUTION_THREADS
+    FLOW=$1\
+    NUM_BLOCKS_PER_TEST=$2\
+    HIDE_OUTPUT=$3\
+    ENABLE_PRUNER=$4\
+    NUMBER_OF_EXECUTION_THREADS=$5\
+    ./testsuite/single_node_performance.py
 }
 
 # Check for the flag


### PR DESCRIPTION
### Description
single_node_performance.py uses the value from environment variable instead of the command line arguments. Setting environment variables needs to be placed in front of the command

