### PR TITLE
[BUG FIX]: Axios to Fetch Migration

### DIFF
--- a/ecosystem/typescript/aptos-client/src/index.browser.ts
+++ b/ecosystem/typescript/aptos-client/src/index.browser.ts
@@ -1,30 +1,50 @@
-import axios, { AxiosRequestConfig, AxiosError } from "axios";
 import { AptosClientRequest, AptosClientResponse } from "./types";
 
 export default async function aptosClient<Res>(options: AptosClientRequest): Promise<AptosClientResponse<Res>> {
-  const { params, method, url, headers, body, overrides } = options;
-  const requestConfig: AxiosRequestConfig = {
-    headers,
-    method,
-    url,
-    params,
-    data: body,
-    withCredentials: overrides?.WITH_CREDENTIALS ?? true,
+  const { params, method, url, headers, body } = options;
+
+  // Constructing the query string for POST requests
+  let queryString = '';
+  if (params && method.toUpperCase() === 'POST') {
+    queryString = `?address=${params.address}&amount=${params.amount}`
+  }
+
+  // Setting up the Request Configuration for fetch
+  const requestConfig: RequestInit = {
+    method: method,
+    headers: headers,
   };
+  if (body) {
+    if (body instanceof Uint8Array) {
+      requestConfig.body = Buffer.from(body);
+    } else {
+      requestConfig.body = Buffer.from(JSON.stringify(body));
+    }
+  }
 
   try {
-    const response = await axios(requestConfig);
+    const response = await fetch(url + queryString, requestConfig);
+    const responseData = await response.json();
+
     return {
       status: response.status,
-      statusText: response.statusText!,
-      data: response.data,
+      statusText: response.statusText,
+      data: responseData as Res,
       headers: response.headers,
-      config: response.config,
+      request: requestConfig,
+      response: response,
     };
   } catch (error) {
-    const axiosError = error as AxiosError<Res>;
-    if (axiosError.response) {
-      return axiosError.response;
+    if (error instanceof Response) {
+      const errorResponse = await error.json();
+      return {
+        status: error.status,
+        statusText: error.statusText,
+        data: errorResponse,
+        headers: error.headers,
+        request: requestConfig,
+        response: error,
+      };
     }
     throw error;
   }


### PR DESCRIPTION
### What?

Migrated to use Fetch for making network calls instead of [Axios](https://github.com/axios/axios). This is the fix which allows the creation of Metamask Snaps.

### Why?

> https://docs.metamask.io/snaps/how-to/troubleshoot/#axios

As mentioned clearly in the above section of official documentation of Metamask Snaps, they run in a sandboxed environment in which axios doesn't work, always leading to [this](https://github.com/axios/axios/issues/2968) very error. In addition, none of the solution provided in that issue thread works in this case either.

### Test Plan

Can be tested on a template snap