### PR TITLE
[cherry-pick][consensus] reduce block size to 2500, simplify logic by removing quo…

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -11,22 +11,17 @@ use cfg_if::cfg_if;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub(crate) const MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE: u64 = 4000;
+pub(crate) const MAX_SENDING_BLOCK_TXNS: u64 = 2500;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ConsensusConfig {
     // length of inbound queue of messages
     pub max_network_channel_size: usize,
-    // Use getters to read the correct value with/without quorum store.
     pub max_sending_block_txns: u64,
-    pub max_sending_block_txns_quorum_store_override: u64,
     pub max_sending_block_bytes: u64,
-    pub max_sending_block_bytes_quorum_store_override: u64,
     pub max_receiving_block_txns: u64,
-    pub max_receiving_block_txns_quorum_store_override: u64,
     pub max_receiving_block_bytes: u64,
-    pub max_receiving_block_bytes_quorum_store_override: u64,
     pub max_pruned_blocks_in_mem: usize,
     // Timeout for consensus to get an ack from mempool for executed transactions (in milliseconds)
     pub mempool_executed_txn_timeout_ms: u64,
@@ -144,18 +139,10 @@ impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
             max_network_channel_size: 1024,
-            max_sending_block_txns: 2500,
-            max_sending_block_txns_quorum_store_override:
-                MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE,
-            // defaulting to under 0.5s to broadcast the proposal to 100 validators
-            // over 1gbps link
-            max_sending_block_bytes: 600 * 1024, // 600 KB
-            max_sending_block_bytes_quorum_store_override: 5 * 1024 * 1024, // 5MB
-            max_receiving_block_txns: 10000,
-            max_receiving_block_txns_quorum_store_override: 10000
-                .max(2 * MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE),
-            max_receiving_block_bytes: 3 * 1024 * 1024, // 3MB
-            max_receiving_block_bytes_quorum_store_override: 6 * 1024 * 1024, // 6MB
+            max_sending_block_txns: MAX_SENDING_BLOCK_TXNS,
+            max_sending_block_bytes: 3 * 1024 * 1024, // 3MB
+            max_receiving_block_txns: 10000.max(2 * MAX_SENDING_BLOCK_TXNS),
+            max_receiving_block_bytes: 6 * 1024 * 1024, // 6MB
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,
@@ -308,38 +295,6 @@ impl ConsensusConfig {
         }
     }
 
-    pub fn max_sending_block_txns(&self, quorum_store_enabled: bool) -> u64 {
-        if quorum_store_enabled {
-            self.max_sending_block_txns_quorum_store_override
-        } else {
-            self.max_sending_block_txns
-        }
-    }
-
-    pub fn max_sending_block_bytes(&self, quorum_store_enabled: bool) -> u64 {
-        if quorum_store_enabled {
-            self.max_sending_block_bytes_quorum_store_override
-        } else {
-            self.max_sending_block_bytes
-        }
-    }
-
-    pub fn max_receiving_block_txns(&self, quorum_store_enabled: bool) -> u64 {
-        if quorum_store_enabled {
-            self.max_receiving_block_txns_quorum_store_override
-        } else {
-            self.max_receiving_block_txns
-        }
-    }
-
-    pub fn max_receiving_block_bytes(&self, quorum_store_enabled: bool) -> u64 {
-        if quorum_store_enabled {
-            self.max_receiving_block_bytes_quorum_store_override
-        } else {
-            self.max_receiving_block_bytes
-        }
-    }
-
     fn sanitize_send_recv_block_limits(
         sanitizer_name: &str,
         config: &ConsensusConfig,
@@ -354,16 +309,6 @@ impl ConsensusConfig {
                 config.max_sending_block_bytes,
                 config.max_receiving_block_bytes,
                 "bytes",
-            ),
-            (
-                config.max_sending_block_txns_quorum_store_override,
-                config.max_receiving_block_txns_quorum_store_override,
-                "txns_quorum_store_override",
-            ),
-            (
-                config.max_sending_block_bytes_quorum_store_override,
-                config.max_receiving_block_bytes_quorum_store_override,
-                "bytes_quorum_store_override",
             ),
         ];
         for (send, recv, label) in &send_recv_pairs {
@@ -385,12 +330,12 @@ impl ConsensusConfig {
         let mut recv_batch_send_block_pairs = vec![
             (
                 config.quorum_store.receiver_max_batch_txns as u64,
-                config.max_sending_block_txns_quorum_store_override,
+                config.max_sending_block_txns,
                 "txns".to_string(),
             ),
             (
                 config.quorum_store.receiver_max_batch_bytes as u64,
-                config.max_sending_block_bytes_quorum_store_override,
+                config.max_sending_block_bytes,
                 "bytes".to_string(),
             ),
         ];
@@ -543,12 +488,12 @@ mod test {
     }
 
     #[test]
-    fn test_send_recv_quorum_store_block_txn_override() {
+    fn test_send_recv_block_txn_override() {
         // Create a node config with invalid block txn limits
         let node_config = NodeConfig {
             consensus: ConsensusConfig {
-                max_sending_block_txns_quorum_store_override: 100,
-                max_receiving_block_txns_quorum_store_override: 50,
+                max_sending_block_txns: 100,
+                max_receiving_block_txns: 50,
                 ..Default::default()
             },
             ..Default::default()
@@ -565,12 +510,12 @@ mod test {
     }
 
     #[test]
-    fn test_send_recv_quorum_store_block_byte_override() {
+    fn test_send_recv_block_byte_override() {
         // Create a node config with invalid block byte limits
         let node_config = NodeConfig {
             consensus: ConsensusConfig {
-                max_sending_block_bytes_quorum_store_override: 100,
-                max_receiving_block_bytes_quorum_store_override: 50,
+                max_sending_block_bytes: 100,
+                max_receiving_block_bytes: 50,
                 ..Default::default()
             },
             ..Default::default()
@@ -591,7 +536,7 @@ mod test {
         // Create a node config with invalid batch txn limits
         let node_config = NodeConfig {
             consensus: ConsensusConfig {
-                max_sending_block_txns_quorum_store_override: 100,
+                max_sending_block_txns: 100,
                 quorum_store: QuorumStoreConfig {
                     receiver_max_batch_txns: 101,
                     ..Default::default()
@@ -612,7 +557,7 @@ mod test {
         // Create a node config with invalid batch byte limits
         let node_config = NodeConfig {
             consensus: ConsensusConfig {
-                max_sending_block_bytes_quorum_store_override: 100,
+                max_sending_block_bytes: 100,
                 quorum_store: QuorumStoreConfig {
                     receiver_max_batch_bytes: 101,
                     ..Default::default()

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -3,7 +3,6 @@
 
 use crate::config::{
     config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, Error, NodeConfig,
-    MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE,
 };
 use aptos_global_constants::DEFAULT_BUCKETS;
 use aptos_types::chain_id::ChainId;
@@ -29,7 +28,8 @@ impl Default for QuorumStoreBackPressureConfig {
     fn default() -> QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
-            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 4,
+            // Roughly, target TPS * commit latency seconds
+            backlog_txn_limit_count: 8000 * 2,
             // QS will create batches at the max rate until this number is reached
             backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -889,10 +889,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             payload_client,
             self.time_service.clone(),
             Duration::from_millis(self.config.quorum_store_poll_time_ms),
-            self.config
-                .max_sending_block_txns(self.quorum_store_enabled),
-            self.config
-                .max_sending_block_bytes(self.quorum_store_enabled),
+            self.config.max_sending_block_txns,
+            self.config.max_sending_block_bytes,
             onchain_consensus_config.max_failed_authors_to_store(),
             pipeline_backpressure_config,
             chain_health_backoff_config,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -657,24 +657,18 @@ impl RoundManager {
         let payload_size = proposal.payload().map_or(0, |payload| payload.size());
         ensure!(
             num_validator_txns as u64 + payload_len as u64
-                <= self
-                    .local_config
-                    .max_receiving_block_txns(self.onchain_config.quorum_store_enabled()),
+                <= self.local_config.max_receiving_block_txns,
             "Payload len {} exceeds the limit {}",
             payload_len,
-            self.local_config
-                .max_receiving_block_txns(self.onchain_config.quorum_store_enabled()),
+            self.local_config.max_receiving_block_txns,
         );
 
         ensure!(
             validator_txns_total_bytes as u64 + payload_size as u64
-                <= self
-                    .local_config
-                    .max_receiving_block_bytes(self.onchain_config.quorum_store_enabled()),
+                <= self.local_config.max_receiving_block_bytes,
             "Payload size {} exceeds the limit {}",
             payload_size,
-            self.local_config
-                .max_receiving_block_bytes(self.onchain_config.quorum_store_enabled()),
+            self.local_config.max_receiving_block_bytes,
         );
 
         ensure!(

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -2056,8 +2056,8 @@ fn no_vote_on_proposal_ext_when_receiving_limit_exceeded() {
         .update_extra_features(vec![ConsensusExtraFeature::ValidatorTransaction], vec![]);
 
     let local_config = ConsensusConfig {
-        max_receiving_block_txns_quorum_store_override: 10,
-        max_receiving_block_bytes_quorum_store_override: 256,
+        max_receiving_block_txns: 10,
+        max_receiving_block_bytes: 256,
         ..Default::default()
     };
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -791,18 +791,10 @@ fn run_consensus_only_realistic_env_max_tps() -> ForgeConfig {
 fn optimize_for_maximum_throughput(config: &mut NodeConfig) {
     mempool_config_practically_non_expiring(&mut config.mempool);
 
-    config
-        .consensus
-        .max_sending_block_txns_quorum_store_override = 30000;
-    config
-        .consensus
-        .max_receiving_block_txns_quorum_store_override = 40000;
-    config
-        .consensus
-        .max_sending_block_bytes_quorum_store_override = 10 * 1024 * 1024;
-    config
-        .consensus
-        .max_receiving_block_bytes_quorum_store_override = 12 * 1024 * 1024;
+    config.consensus.max_sending_block_txns = 30000;
+    config.consensus.max_receiving_block_txns = 40000;
+    config.consensus.max_sending_block_bytes = 10 * 1024 * 1024;
+    config.consensus.max_receiving_block_bytes = 12 * 1024 * 1024;
     config.consensus.pipeline_backpressure = vec![];
     config.consensus.chain_health_backoff = vec![];
 
@@ -2002,12 +1994,7 @@ fn changing_working_quorum_test_helper(
             let block_size = (target_tps / 4) as u64;
 
             config.consensus.max_sending_block_txns = block_size;
-            config
-                .consensus
-                .max_sending_block_txns_quorum_store_override = block_size;
-            config
-                .consensus
-                .max_receiving_block_txns_quorum_store_override = block_size;
+            config.consensus.max_receiving_block_txns = block_size;
             config.consensus.round_initial_timeout_ms = 500;
             config.consensus.round_timeout_backoff_exponent_base = 1.0;
             config.consensus.quorum_store_poll_time_ms = 100;

--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -26,9 +26,6 @@ pub async fn create_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
         .with_init_config(Arc::new(move |_, config, _| {
             config.api.failpoints_enabled = true;
             config.consensus.max_sending_block_txns = max_block_txns;
-            config
-                .consensus
-                .max_sending_block_txns_quorum_store_override = max_block_txns;
             config.consensus.quorum_store.sender_max_batch_txns = config
                 .consensus
                 .quorum_store

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -187,7 +187,6 @@ async fn test_gas_estimation_txns_limit() {
             conf.consensus.quorum_store_poll_time_ms = 200;
             conf.consensus.wait_for_full_blocks_above_pending_blocks = 0;
             conf.consensus.max_sending_block_txns = max_block_txns;
-            conf.consensus.max_sending_block_txns_quorum_store_override = max_block_txns;
             conf.consensus.quorum_store.sender_max_batch_txns = conf
                 .consensus
                 .quorum_store
@@ -226,7 +225,6 @@ async fn test_gas_estimation_gas_used_limit() {
             conf.consensus.quorum_store_poll_time_ms = 200;
             conf.consensus.wait_for_full_blocks_above_pending_blocks = 0;
             conf.consensus.max_sending_block_txns = max_block_txns;
-            conf.consensus.max_sending_block_txns_quorum_store_override = max_block_txns;
             conf.consensus.quorum_store.sender_max_batch_txns = conf
                 .consensus
                 .quorum_store


### PR DESCRIPTION
…rum store overrides (#11880)

### Description

With the improvements in VM load time, it's no longer necessary to have a very large block size for throughput. In fact, with the block gas limits, a large block size can be bad, because it leads to frequent block cuts.

With targeting a smaller block size, there's no more reason to have a separate quorum store enabled size. So combined into a single block size and simplified the logic.

### Test Plan

Run e2e perf test.