### PR TITLE
[Block Executor] Fix committed status checks / skip rest

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -483,6 +483,9 @@ where
                 scheduler.add_to_commit_queue(txn_idx);
             }
 
+            // An invariant check on the recorded outputs.
+            last_input_output.check_execution_status_during_commit(txn_idx)?;
+
             if let Some(fee_statement) = last_input_output.fee_statement(txn_idx) {
                 let approx_output_size = block_gas_limit_type.block_output_limit().and_then(|_| {
                     last_input_output
@@ -574,13 +577,6 @@ where
                     }
                 }
             }
-
-            // Note that module read/write intersection would be detected on record, and directly
-            // propagated as an error. Similarly, an unrecoverable VM failure, would also be
-            // directly propagated as error even from a speculative transaction execution.
-
-            // An additional invariant check on the recorded outputs.
-            last_input_output.check_execution_status_during_commit(txn_idx)?;
 
             last_input_output.record_finalized_group(txn_idx, finalized_groups);
 

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -114,11 +114,14 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                     status = BaselineStatus::Aborted;
                     break;
                 },
-                MockTransaction::SkipRest => {
+                MockTransaction::SkipRest(gas) => {
                     // In executor, SkipRest skips from the next index. Test assumes it's an empty
                     // transaction, so create a successful empty reads and deltas.
                     read_values.push(Ok(vec![]));
                     resolved_deltas.push(Ok(HashMap::new()));
+
+                    // gas in SkipRest is used for unit tests for now (can generalize when needed).
+                    assert_eq!(*gas, 0);
 
                     status = BaselineStatus::SkipRest;
                     break;

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -57,7 +57,7 @@ fn run_transactions<K, V, E>(
         *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::Abort;
     }
     for i in skip_rest_transactions {
-        *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::SkipRest;
+        *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::SkipRest(0);
     }
 
     let data_view = EmptyDataView::<KeyType<K>> {

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -413,7 +413,7 @@ pub(crate) enum MockTransaction<K, E> {
         incarnation_behaviors: Vec<MockIncarnation<K, E>>,
     },
     /// Skip the execution of trailing transactions.
-    SkipRest,
+    SkipRest(u64),
     /// Abort the execution.
     Abort,
 }
@@ -439,7 +439,7 @@ impl<K, E> MockTransaction<K, E> {
                 incarnation_behaviors,
                 ..
             } => incarnation_behaviors,
-            Self::SkipRest => unreachable!("SkipRest does not contain incarnation behaviors"),
+            Self::SkipRest(_) => unreachable!("SkipRest does not contain incarnation behaviors"),
             Self::Abort => unreachable!("Abort does not contain incarnation behaviors"),
         }
     }
@@ -968,7 +968,11 @@ where
                     total_gas: behavior.gas,
                 })
             },
-            MockTransaction::SkipRest => ExecutionStatus::SkipRest(MockOutput::skip_output()),
+            MockTransaction::SkipRest(gas) => {
+                let mut mock_output = MockOutput::skip_output();
+                mock_output.total_gas = *gas;
+                ExecutionStatus::SkipRest(mock_output)
+            },
             MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
     }


### PR DESCRIPTION
Thanks to @danielxiangzl for finding a status overwrite issue during commit.
It used to be for Abort, but now abort short-circuits and would not be an issue. However, if might already be a SkipRest.

Moved the checks earlier for status invariants, and made sure it errors out if status isn't recorded, warn wouldn't do much because some later operations would anyway assert. So this way we can utilize the new fallback flow if somehow there is an issue with the status.
I'm not sure if it's also worth doing that before the first delayed fields check.