### PR TITLE
[Data Streaming Service] Add support for dynamic prefetching

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -136,7 +136,7 @@ impl Default for StateSyncDriverConfig {
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,
             max_num_stream_timeouts: 12,
-            max_pending_data_chunks: 100,
+            max_pending_data_chunks: 50,
             max_pending_mempool_notifications: 100,
             max_stream_wait_time_ms: 5000,
             num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.
@@ -219,9 +219,7 @@ pub struct DataStreamingServiceConfig {
     /// Maximum number of concurrent data client requests (per stream) for state keys/values.
     pub max_concurrent_state_requests: u64,
 
-    /// Maximum channel sizes for each data stream listener. If messages are not
-    /// consumed, they will be dropped (oldest messages first). The remaining
-    /// messages will be retrieved using FIFO ordering.
+    /// Maximum channel sizes for each data stream listener (per stream).
     pub max_data_stream_channel_sizes: u64,
 
     /// Maximum number of notification ID to response context mappings held in
@@ -256,7 +254,7 @@ impl Default for DataStreamingServiceConfig {
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,
-            max_data_stream_channel_sizes: 300,
+            max_data_stream_channel_sizes: 50,
             max_notification_id_mappings: 300,
             max_num_consecutive_subscriptions: 40, // At ~4 blocks per second, this should last 10 seconds
             max_pending_requests: 50,
@@ -297,7 +295,7 @@ impl Default for DynamicPrefetchingConfig {
         Self {
             enable_dynamic_prefetching: true,
             initial_prefetching_value: 3,
-            max_prefetching_value: 50,
+            max_prefetching_value: 30,
             min_prefetching_value: 3,
             prefetching_value_increase: 1,
             prefetching_value_decrease: 2,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -204,6 +204,9 @@ impl Default for StorageServiceConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct DataStreamingServiceConfig {
+    /// The dynamic prefetching config for the data streaming service
+    pub dynamic_prefetching: DynamicPrefetchingConfig,
+
     /// Whether or not to enable data subscription streaming.
     pub enable_subscription_streaming: bool,
 
@@ -248,6 +251,7 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
+            dynamic_prefetching: DynamicPrefetchingConfig::default(),
             enable_subscription_streaming: false,
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
@@ -259,6 +263,45 @@ impl Default for DataStreamingServiceConfig {
             max_request_retry: 5,
             max_subscription_stream_lag_secs: 15, // 15 seconds
             progress_check_interval_ms: 50,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DynamicPrefetchingConfig {
+    /// Whether or not to enable dynamic prefetching
+    pub enable_dynamic_prefetching: bool,
+
+    /// The initial number of concurrent prefetching requests
+    pub initial_prefetching_value: u64,
+
+    /// The maximum number of concurrent prefetching requests
+    pub max_prefetching_value: u64,
+
+    /// The minimum number of concurrent prefetching requests
+    pub min_prefetching_value: u64,
+
+    /// The amount by which to increase the concurrent prefetching value (i.e., on a successful response)
+    pub prefetching_value_increase: u64,
+
+    /// The amount by which to decrease the concurrent prefetching value (i.e., on a timeout)
+    pub prefetching_value_decrease: u64,
+
+    /// The duration by which to freeze the prefetching value on a timeout
+    pub timeout_freeze_duration_secs: u64,
+}
+
+impl Default for DynamicPrefetchingConfig {
+    fn default() -> Self {
+        Self {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value: 3,
+            max_prefetching_value: 50,
+            min_prefetching_value: 3,
+            prefetching_value_increase: 1,
+            prefetching_value_decrease: 2,
+            timeout_freeze_duration_secs: 30,
         }
     }
 }

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -88,6 +88,11 @@ impl DataClientRequest {
         }
     }
 
+    /// Returns true iff the request is a new data request
+    pub fn is_new_data_request(&self) -> bool {
+        self.is_optimistic_fetch_request() || self.is_subscription_request()
+    }
+
     /// Returns true iff the request is an optimistic fetch request
     pub fn is_optimistic_fetch_request(&self) -> bool {
         matches!(self, DataClientRequest::NewTransactionsWithProof(_))

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -13,6 +13,7 @@ use crate::{
         TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
         TransactionsWithProofRequest,
     },
+    dynamic_prefetching::DynamicPrefetchingState,
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
     metrics,
@@ -119,6 +120,9 @@ pub struct DataStream<T> {
 
     // The time service to track elapsed time (e.g., during stream lag checks)
     time_service: TimeService,
+
+    // The dynamic prefetching state (if enabled)
+    dynamic_prefetching_state: DynamicPrefetchingState,
 }
 
 impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
@@ -141,6 +145,10 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         // Create a new stream engine
         let stream_engine = StreamEngine::new(data_stream_config, stream_request, advertised_data)?;
 
+        // Create the dynamic prefetching state
+        let dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_stream_config, time_service.clone());
+
         // Create a new data stream
         let data_stream = Self {
             data_client_config,
@@ -159,6 +167,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
             send_failure: false,
             subscription_stream_lag: None,
             time_service,
+            dynamic_prefetching_state,
         };
 
         Ok((data_stream, data_stream_listener))
@@ -255,17 +264,6 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         Ok(())
     }
 
-    /// Returns the maximum number of concurrent requests that can be executing
-    /// at any given time.
-    fn get_max_concurrent_requests(&self) -> u64 {
-        match self.stream_engine {
-            StreamEngine::StateStreamEngine(_) => {
-                self.streaming_service_config.max_concurrent_state_requests
-            },
-            _ => self.streaming_service_config.max_concurrent_requests,
-        }
-    }
-
     /// Creates and sends a batch of aptos data client requests to the network
     fn create_and_send_client_requests(
         &mut self,
@@ -285,7 +283,8 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
             // Otherwise, calculate the max number of requests to send based on
             // the max concurrent requests and the number of pending request slots.
             let remaining_concurrent_requests = self
-                .get_max_concurrent_requests()
+                .dynamic_prefetching_state
+                .get_max_concurrent_requests(&self.stream_engine)
                 .saturating_sub(num_in_flight_requests);
             let remaining_request_slots = max_pending_requests.saturating_sub(num_pending_requests);
             min(remaining_concurrent_requests, remaining_request_slots)
@@ -453,85 +452,89 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
             return Ok(()); // There's nothing left to do
         }
 
-        // Process any ready data responses
-        for _ in 0..self.get_num_pending_data_requests()? {
-            if let Some(pending_response) = self.pop_pending_response_queue()? {
-                // Get the client request and response information
-                let maybe_client_response = pending_response.lock().client_response.take();
-                let client_response = maybe_client_response.ok_or_else(|| {
-                    Error::UnexpectedErrorEncountered("The client response should be ready!".into())
-                })?;
-                let client_request = &pending_response.lock().client_request.clone();
+        // Continuously process any ready data responses
+        while let Some(pending_response) = self.pop_pending_response_queue()? {
+            // Get the client request and response information
+            let maybe_client_response = pending_response.lock().client_response.take();
+            let client_response = maybe_client_response.ok_or_else(|| {
+                Error::UnexpectedErrorEncountered("The client response should be ready!".into())
+            })?;
+            let client_request = &pending_response.lock().client_request.clone();
 
-                // Process the client response
-                match client_response {
-                    Ok(client_response) => {
-                        // Sanity check and process the response
-                        if sanity_check_client_response_type(client_request, &client_response) {
-                            // The response is valid, send the data notification to the client
-                            let client_response_payload = client_response.payload.clone();
-                            self.send_data_notification_to_client(client_request, client_response)
-                                .await?;
-
-                            // If the response wasn't enough to satisfy the original request (e.g.,
-                            // it was truncated), missing data should be requested.
-                            match self
-                                .request_missing_data(client_request, &client_response_payload)
-                            {
-                                Ok(missing_data_requested) => {
-                                    if missing_data_requested {
-                                        break; // We're now head of line blocked on the missing data
-                                    }
-                                },
-                                Err(error) => {
-                                    warn!(LogSchema::new(LogEntry::ReceivedDataResponse)
-                                        .stream_id(self.data_stream_id)
-                                        .event(LogEvent::Error)
-                                        .error(&error)
-                                        .message(
-                                            "Failed to determine if missing data was requested!"
-                                        ));
-                                },
-                            }
-
-                            // If the request was a subscription request and the subscription
-                            // stream is lagging behind the data advertisements, the stream
-                            // engine should be notified (e.g., so that it can catch up).
-                            if client_request.is_subscription_request() {
-                                if let Err(error) = self.check_subscription_stream_lag(
-                                    &global_data_summary,
-                                    &client_response_payload,
-                                ) {
-                                    self.notify_new_data_request_error(client_request, error)?;
-                                    break; // We're now head of line blocked on the failed stream
+            // Process the client response
+            match client_response {
+                Ok(client_response) => {
+                    // Sanity check and process the response
+                    if sanity_check_client_response_type(client_request, &client_response) {
+                        // If the response wasn't enough to satisfy the original request (e.g.,
+                        // it was truncated), missing data should be requested.
+                        let mut head_of_line_blocked = false;
+                        match self.request_missing_data(client_request, &client_response.payload) {
+                            Ok(missing_data_requested) => {
+                                if missing_data_requested {
+                                    head_of_line_blocked = true; // We're now head of line blocked on the missing data
                                 }
+                            },
+                            Err(error) => {
+                                warn!(LogSchema::new(LogEntry::ReceivedDataResponse)
+                                    .stream_id(self.data_stream_id)
+                                    .event(LogEvent::Error)
+                                    .error(&error)
+                                    .message("Failed to determine if missing data was requested!"));
+                            },
+                        }
+
+                        // If the request was a subscription request and the subscription
+                        // stream is lagging behind the data advertisements, the stream
+                        // engine should be notified (e.g., so that it can catch up).
+                        if client_request.is_subscription_request() {
+                            if let Err(error) = self.check_subscription_stream_lag(
+                                &global_data_summary,
+                                &client_response.payload,
+                            ) {
+                                self.notify_new_data_request_error(client_request, error)?;
+                                head_of_line_blocked = true; // We're now head of line blocked on the failed stream
                             }
-                        } else {
-                            // The sanity check failed
-                            self.handle_sanity_check_failure(
-                                client_request,
-                                &client_response.context,
-                            )?;
-                            break; // We're now head of line blocked on the failed request
                         }
-                    },
-                    Err(error) => {
-                        // Handle the error depending on the request type
-                        if client_request.is_subscription_request()
-                            || client_request.is_optimistic_fetch_request()
-                        {
-                            // The request was for new data. We should notify the
-                            // stream engine and clear the requests queue.
-                            self.notify_new_data_request_error(client_request, error)?;
-                        } else {
-                            // Otherwise, we should handle the error and simply retry
-                            self.handle_data_client_error(client_request, &error)?;
+
+                        // The response is valid, send the data notification to the client
+                        self.send_data_notification_to_client(client_request, client_response)
+                            .await?;
+
+                        // If the request is for specific data, increase the prefetching limit.
+                        // Note: we don't increase the limit for new data requests because
+                        // those don't invoke the prefetcher (as we're already up-to-date).
+                        if !client_request.is_new_data_request() {
+                            self.dynamic_prefetching_state
+                                .increase_max_concurrent_requests();
                         }
+
+                        // If we're head of line blocked, we should return early
+                        if head_of_line_blocked {
+                            break;
+                        }
+                    } else {
+                        // The sanity check failed
+                        self.handle_sanity_check_failure(client_request, &client_response.context)?;
                         break; // We're now head of line blocked on the failed request
-                    },
-                }
-            } else {
-                break; // The first response hasn't arrived yet
+                    }
+                },
+                Err(error) => {
+                    // Handle the error depending on the request type
+                    if client_request.is_new_data_request() {
+                        // The request was for new data. We should notify the
+                        // stream engine and clear the requests queue.
+                        self.notify_new_data_request_error(client_request, error)?;
+                    } else {
+                        // Decrease the prefetching limit on an error
+                        self.dynamic_prefetching_state
+                            .decrease_max_concurrent_requests();
+
+                        // Handle the error and simply retry
+                        self.handle_data_client_error(client_request, &error)?;
+                    }
+                    break; // We're now head of line blocked on the failed request
+                },
             }
         }
 
@@ -705,6 +708,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         data_client_request: &DataClientRequest,
         data_client_error: &aptos_data_client::error::Error,
     ) -> Result<(), Error> {
+        // Log the error
         warn!(LogSchema::new(LogEntry::ReceivedDataResponse)
             .stream_id(self.data_stream_id)
             .event(LogEvent::Error)

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -393,8 +393,11 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         pending_client_response
     }
 
-    // TODO(joshlind): this function shouldn't be blocking when trying to send! If there are
-    // multiple streams, a single blocked stream could cause them all to block.
+    // TODO(joshlind): this function shouldn't be blocking when trying to send.
+    // If there are multiple streams, a single blocked stream could cause them
+    // all to block. This is acceptable for now (because there is only ever
+    // a single stream in use by the driver) but it should be fixed if we want
+    // to generalize this for multiple streams.
     async fn send_data_notification(
         &mut self,
         data_notification: DataNotification,

--- a/state-sync/data-streaming-service/src/dynamic_prefetching.rs
+++ b/state-sync/data-streaming-service/src/dynamic_prefetching.rs
@@ -1,0 +1,151 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{metrics, stream_engine::StreamEngine};
+use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use std::{
+    cmp::{max, min},
+    time::{Duration, Instant},
+};
+
+/// A simple container for the dynamic prefetching state
+#[derive(Debug)]
+pub struct DynamicPrefetchingState {
+    // The data streaming service config
+    streaming_service_config: DataStreamingServiceConfig,
+
+    // The instant the last timeout occurred (if any)
+    last_timeout_instant: Option<Instant>,
+
+    // The maximum number of concurrent requests that can be executing at any given time
+    max_dynamic_concurrent_requests: u64,
+
+    // The time service to track elapsed time (e.g., during stream lag checks)
+    time_service: TimeService,
+}
+
+impl DynamicPrefetchingState {
+    pub fn new(
+        data_streaming_service_config: DataStreamingServiceConfig,
+        time_service: TimeService,
+    ) -> Self {
+        // Get the initial prefetching value from the config
+        let max_dynamic_concurrent_requests = data_streaming_service_config
+            .dynamic_prefetching
+            .initial_prefetching_value;
+
+        // Create and return the new dynamic prefetching state
+        Self {
+            streaming_service_config: data_streaming_service_config,
+            last_timeout_instant: None,
+            max_dynamic_concurrent_requests,
+            time_service,
+        }
+    }
+
+    /// A simple helper function that returns the dynamic prefetching config
+    fn get_dynamic_prefetching_config(&self) -> &DynamicPrefetchingConfig {
+        &self.streaming_service_config.dynamic_prefetching
+    }
+
+    /// Returns true iff dynamic prefetching is enabled
+    fn is_dynamic_prefetching_enabled(&self) -> bool {
+        self.get_dynamic_prefetching_config()
+            .enable_dynamic_prefetching
+    }
+
+    /// Returns true iff the prefetching value is currently frozen (i.e.,
+    /// to avoid overly increasing the value near saturation). Freezing
+    /// occurs after a timeout and lasts for a configured duration.
+    fn is_prefetching_value_frozen(&self) -> bool {
+        match self.last_timeout_instant {
+            Some(last_failure_time) => {
+                // Get the time since the last failure and max freeze duration
+                let time_since_last_failure =
+                    self.time_service.now().duration_since(last_failure_time);
+                let max_freeze_duration = Duration::from_secs(
+                    self.get_dynamic_prefetching_config()
+                        .timeout_freeze_duration_secs,
+                );
+
+                // Check if the time since the last failure is less than the freeze duration
+                time_since_last_failure < max_freeze_duration
+            },
+            None => false, // No failures have occurred
+        }
+    }
+
+    /// Returns the number of maximum concurrent requests that can be executing
+    /// at any given time. Depending on if dynamic prefetching is enabled, this
+    /// value will be dynamic or static (i.e., config defined).
+    pub fn get_max_concurrent_requests(&self, stream_engine: &StreamEngine) -> u64 {
+        // If dynamic prefetching is disabled, use the static values defined
+        // in the config. Otherwise get the current dynamic max value.
+        let max_concurrent_requests = if !self.is_dynamic_prefetching_enabled() {
+            match stream_engine {
+                StreamEngine::StateStreamEngine(_) => {
+                    // Use the configured max for state value requests
+                    self.streaming_service_config.max_concurrent_state_requests
+                },
+                _ => {
+                    // Use the configured max for all other requests
+                    self.streaming_service_config.max_concurrent_requests
+                },
+            }
+        } else {
+            // Otherwise, return the current max value
+            self.max_dynamic_concurrent_requests
+        };
+
+        // Update the metrics for the max concurrent requests
+        metrics::set_max_concurrent_requests(max_concurrent_requests);
+
+        max_concurrent_requests
+    }
+
+    /// Increases the maximum number of concurrent requests that should be executing.
+    /// This is typically called after a successful response is received.
+    pub fn increase_max_concurrent_requests(&mut self) {
+        // If dynamic prefetching is disabled, or the value is currently frozen, do nothing
+        if !self.is_dynamic_prefetching_enabled() || self.is_prefetching_value_frozen() {
+            return;
+        }
+
+        // Otherwise, get and increase the current max
+        let dynamic_prefetching_config = self.get_dynamic_prefetching_config();
+        let amount_to_increase = dynamic_prefetching_config.prefetching_value_increase;
+        let max_dynamic_concurrent_requests = self
+            .max_dynamic_concurrent_requests
+            .saturating_add(amount_to_increase);
+
+        // Bound the value by the configured maximum
+        let max_prefetching_value = dynamic_prefetching_config.max_prefetching_value;
+        self.max_dynamic_concurrent_requests =
+            min(max_dynamic_concurrent_requests, max_prefetching_value);
+    }
+
+    /// Decreases the maximum number of concurrent requests that should be executing.
+    /// This is typically called after a timeout is received.
+    pub fn decrease_max_concurrent_requests(&mut self) {
+        // If dynamic prefetching is disabled, do nothing
+        if !self.is_dynamic_prefetching_enabled() {
+            return;
+        }
+
+        // Update the last failure time
+        self.last_timeout_instant = Some(self.time_service.now());
+
+        // Otherwise, get and decrease the current max
+        let dynamic_prefetching_config = self.get_dynamic_prefetching_config();
+        let amount_to_decrease = dynamic_prefetching_config.prefetching_value_decrease;
+        let max_dynamic_concurrent_requests = self
+            .max_dynamic_concurrent_requests
+            .saturating_sub(amount_to_decrease);
+
+        // Bound the value by the configured minimum
+        let min_prefetching_value = dynamic_prefetching_config.min_prefetching_value;
+        self.max_dynamic_concurrent_requests =
+            max(max_dynamic_concurrent_requests, min_prefetching_value);
+    }
+}

--- a/state-sync/data-streaming-service/src/dynamic_prefetching.rs
+++ b/state-sync/data-streaming-service/src/dynamic_prefetching.rs
@@ -149,3 +149,592 @@ impl DynamicPrefetchingState {
             max(max_dynamic_concurrent_requests, min_prefetching_value);
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::streaming_client::{
+        GetAllStatesRequest, GetAllTransactionsOrOutputsRequest, StreamRequest,
+    };
+    use aptos_data_client::global_summary::AdvertisedData;
+
+    #[test]
+    fn test_initialize_prefetching_state() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let initial_prefetching_value = 5;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Verify that the state was initialized correctly
+        assert_eq!(
+            dynamic_prefetching_state.streaming_service_config,
+            data_streaming_service_config
+        );
+        assert_eq!(dynamic_prefetching_state.last_timeout_instant, None);
+        assert_eq!(
+            dynamic_prefetching_state.max_dynamic_concurrent_requests,
+            initial_prefetching_value
+        );
+    }
+
+    #[test]
+    fn test_is_dynamic_prefetching_enabled() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Verify that dynamic prefetching is enabled
+        assert!(dynamic_prefetching_state.is_dynamic_prefetching_enabled());
+
+        // Create a data streaming service config with dynamic prefetching disabled
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: false,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Verify that dynamic prefetching is disabled
+        assert!(!dynamic_prefetching_state.is_dynamic_prefetching_enabled());
+    }
+
+    #[test]
+    fn test_is_prefetching_value_frozen() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let timeout_freeze_duration_secs = 10;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            timeout_freeze_duration_secs,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let time_service = TimeService::mock();
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, time_service.clone());
+
+        // Verify that the prefetching value is not frozen initially
+        assert!(!dynamic_prefetching_state.is_prefetching_value_frozen());
+
+        // Update the prefetcher state to simulate a timeout
+        dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+        // Verify that the prefetching value is frozen
+        assert!(dynamic_prefetching_state.is_prefetching_value_frozen());
+
+        // Elapse less time than the freeze duration
+        let time_service = time_service.into_mock();
+        time_service.advance_secs(timeout_freeze_duration_secs - 1);
+
+        // Verify that the prefetching value is still frozen
+        assert!(dynamic_prefetching_state.is_prefetching_value_frozen());
+
+        // Elapse more time than the freeze duration
+        time_service.advance_secs(timeout_freeze_duration_secs + 1);
+
+        // Verify that the prefetching value is no longer frozen
+        assert!(!dynamic_prefetching_state.is_prefetching_value_frozen());
+    }
+
+    #[test]
+    fn test_get_max_concurrent_requests_disabled() {
+        // Create a data streaming service config with dynamic prefetching disabled
+        let max_concurrent_requests = 10;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: false,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            max_concurrent_requests,
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Verify that dynamic prefetching is disabled
+        assert!(!dynamic_prefetching_state.is_dynamic_prefetching_enabled());
+
+        // Create a stream engine for transactions or outputs
+        let stream_engine =
+            create_transactions_or_outputs_stream_engine(data_streaming_service_config);
+
+        // Verify that the max concurrent requests is the static config value
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            max_concurrent_requests,
+        );
+
+        // Increase the max concurrent requests several times and verify the value
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests is still the static config value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                max_concurrent_requests,
+            );
+        }
+
+        // Decrease the max concurrent requests several times and verify the value
+        for _ in 0..10 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests is still the static config value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                max_concurrent_requests,
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_max_concurrent_state_requests_disabled() {
+        // Create a data streaming service config with dynamic prefetching disabled
+        let max_concurrent_state_requests = 5;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: false,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            max_concurrent_state_requests,
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Verify that dynamic prefetching is disabled
+        assert!(!dynamic_prefetching_state.is_dynamic_prefetching_enabled());
+
+        // Create a stream engine for states
+        let stream_engine = create_state_stream_engine(data_streaming_service_config);
+
+        // Verify that the max concurrent state requests is the static config value
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            max_concurrent_state_requests,
+        );
+
+        // Increase the max concurrent requests several times and verify the value
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests is still the static config value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                max_concurrent_state_requests,
+            );
+        }
+
+        // Decrease the max concurrent requests several times
+        for _ in 0..10 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests is still the static config value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                max_concurrent_state_requests,
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_max_concurrent_requests() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let initial_prefetching_value = 5;
+        let prefetching_value_increase = 1;
+        let prefetching_value_decrease = 2;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value,
+            prefetching_value_increase,
+            prefetching_value_decrease,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Create a stream engine for transactions or outputs
+        let stream_engine =
+            create_transactions_or_outputs_stream_engine(data_streaming_service_config);
+
+        // Verify that the max concurrent requests is the initial prefetching value
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            initial_prefetching_value,
+        );
+
+        // Increase the max concurrent requests several times and verify the value
+        let mut expected_max_requests = initial_prefetching_value;
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has increased correctly
+            expected_max_requests += prefetching_value_increase;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Decrease the max concurrent requests several times and verify the value
+        for _ in 0..3 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has decreased correctly
+            expected_max_requests -= prefetching_value_decrease;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_max_concurrent_requests_max_value() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let initial_prefetching_value = 10;
+        let prefetching_value_increase = 2;
+        let max_prefetching_value = 30;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value,
+            prefetching_value_increase,
+            max_prefetching_value,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Create a stream engine for states
+        let stream_engine = create_state_stream_engine(data_streaming_service_config);
+
+        // Verify that the max concurrent requests is the initial prefetching value
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            initial_prefetching_value,
+        );
+
+        // Increase the max concurrent requests several times and verify the value
+        let mut expected_max_requests = initial_prefetching_value;
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has increased correctly
+            expected_max_requests += prefetching_value_increase;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Increase the max concurrent requests many more times and verify the value
+        for _ in 0..100 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has increased to the max value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                max_prefetching_value,
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_max_concurrent_requests_min_value() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let initial_prefetching_value = 20;
+        let prefetching_value_decrease = 1;
+        let min_prefetching_value = 2;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value,
+            prefetching_value_decrease,
+            min_prefetching_value,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, TimeService::mock());
+
+        // Create a stream engine for transactions or outputs
+        let stream_engine =
+            create_transactions_or_outputs_stream_engine(data_streaming_service_config);
+
+        // Verify that the max concurrent requests is the initial prefetching value
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            initial_prefetching_value,
+        );
+
+        // Decrease the max concurrent requests several times and verify the value
+        let mut expected_max_requests = initial_prefetching_value;
+        for _ in 0..18 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has decreased correctly
+            expected_max_requests -= prefetching_value_decrease;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Decrease the max concurrent requests many more times and verify the value
+        for _ in 0..100 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has decreased to the min value
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                min_prefetching_value,
+            );
+        }
+    }
+
+    #[test]
+    fn test_prefetching_value_frozen() {
+        // Create a data streaming service config with dynamic prefetching enabled
+        let initial_prefetching_value = 5;
+        let prefetching_value_increase = 1;
+        let prefetching_value_decrease = 2;
+        let timeout_freeze_duration_secs = 10;
+        let dynamic_prefetching_config = DynamicPrefetchingConfig {
+            enable_dynamic_prefetching: true,
+            initial_prefetching_value,
+            prefetching_value_increase,
+            prefetching_value_decrease,
+            timeout_freeze_duration_secs,
+            ..Default::default()
+        };
+        let data_streaming_service_config = DataStreamingServiceConfig {
+            dynamic_prefetching: dynamic_prefetching_config,
+            ..Default::default()
+        };
+
+        // Create a new dynamic prefetching state
+        let time_service = TimeService::mock();
+        let mut dynamic_prefetching_state =
+            DynamicPrefetchingState::new(data_streaming_service_config, time_service.clone());
+
+        // Create a stream engine for transactions or outputs
+        let stream_engine =
+            create_transactions_or_outputs_stream_engine(data_streaming_service_config);
+
+        // Increase the max concurrent requests several times and verify the value
+        let mut expected_max_requests = initial_prefetching_value;
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has increased correctly
+            expected_max_requests += prefetching_value_increase;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Update the prefetcher state to simulate a timeout and verify the value is frozen
+        dynamic_prefetching_state.decrease_max_concurrent_requests();
+        assert!(dynamic_prefetching_state.is_prefetching_value_frozen());
+
+        // Verify that the max concurrent requests has decreased correctly
+        let mut expected_max_requests = expected_max_requests - prefetching_value_decrease;
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            expected_max_requests,
+        );
+
+        // Increase the max concurrent requests several more times
+        for _ in 0..100 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has not changed (the value is frozen)
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Elapse less time than the freeze duration
+        let time_service = time_service.into_mock();
+        time_service.advance_secs(timeout_freeze_duration_secs - 1);
+
+        // Increase the max concurrent requests and verify the prefetching value is still frozen
+        dynamic_prefetching_state.increase_max_concurrent_requests();
+        assert!(dynamic_prefetching_state.is_prefetching_value_frozen());
+        verify_max_concurrent_requests(
+            &mut dynamic_prefetching_state,
+            &stream_engine,
+            expected_max_requests,
+        );
+
+        // Decrease the max concurrent requests several times
+        for _ in 0..3 {
+            // Decrease the max concurrent requests
+            dynamic_prefetching_state.decrease_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has decreased correctly
+            expected_max_requests -= prefetching_value_decrease;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+
+        // Elapse more time than the freeze duration and verify the value is not frozen
+        time_service.advance_secs(timeout_freeze_duration_secs + 1);
+        assert!(!dynamic_prefetching_state.is_prefetching_value_frozen());
+
+        // Increase the max concurrent requests several times and verify the value is not frozen
+        for _ in 0..10 {
+            // Increase the max concurrent requests
+            dynamic_prefetching_state.increase_max_concurrent_requests();
+
+            // Verify that the max concurrent requests has increased correctly
+            expected_max_requests += prefetching_value_increase;
+            verify_max_concurrent_requests(
+                &mut dynamic_prefetching_state,
+                &stream_engine,
+                expected_max_requests,
+            );
+        }
+    }
+
+    /// Creates a stream engine for states
+    fn create_state_stream_engine(
+        data_streaming_service_config: DataStreamingServiceConfig,
+    ) -> StreamEngine {
+        // Create the stream request for states
+        let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
+            version: 0,
+            start_index: 0,
+        });
+
+        // Create and return the stream engine
+        StreamEngine::new(
+            data_streaming_service_config,
+            &stream_request,
+            &AdvertisedData::empty(),
+        )
+        .unwrap()
+    }
+
+    /// Creates a stream engine for transactions or outputs
+    fn create_transactions_or_outputs_stream_engine(
+        data_streaming_service_config: DataStreamingServiceConfig,
+    ) -> StreamEngine {
+        // Create the stream request for transactions or outputs
+        let stream_request =
+            StreamRequest::GetAllTransactionsOrOutputs(GetAllTransactionsOrOutputsRequest {
+                start_version: 0,
+                end_version: 100_000,
+                proof_version: 100_000,
+                include_events: true,
+            });
+
+        // Create and return the stream engine
+        StreamEngine::new(
+            data_streaming_service_config,
+            &stream_request,
+            &AdvertisedData::empty(),
+        )
+        .unwrap()
+    }
+
+    /// Verifies that the max concurrent requests is the expected value
+    fn verify_max_concurrent_requests(
+        dynamic_prefetching_state: &mut DynamicPrefetchingState,
+        stream_engine: &StreamEngine,
+        expected_max_requests: u64,
+    ) {
+        assert_eq!(
+            dynamic_prefetching_state.get_max_concurrent_requests(stream_engine),
+            expected_max_requests
+        );
+    }
+}

--- a/state-sync/data-streaming-service/src/lib.rs
+++ b/state-sync/data-streaming-service/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod data_notification;
 pub mod data_stream;
+mod dynamic_prefetching;
 pub mod error;
 mod logging;
 mod metrics;

--- a/state-sync/data-streaming-service/src/metrics.rs
+++ b/state-sync/data-streaming-service/src/metrics.rs
@@ -134,6 +134,15 @@ pub static RETRIED_DATA_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for the number of max concurrent prefetching requests
+pub static MAX_CONCURRENT_PREFETCHING_REQUESTS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_data_streaming_service_max_concurrent_prefetching_requests",
+        "The number of max concurrent prefetching requests",
+    )
+    .unwrap()
+});
+
 /// Counter for the number of pending data responses
 pub static PENDING_DATA_RESPONSES: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
@@ -250,6 +259,11 @@ pub fn observe_values(
 /// Sets the number of active data streams
 pub fn set_active_data_streams(value: usize) {
     ACTIVE_DATA_STREAMS.set(value as i64);
+}
+
+/// Sets the number of max concurrent requests
+pub fn set_max_concurrent_requests(value: u64) {
+    MAX_CONCURRENT_PREFETCHING_REQUESTS.set(value as i64);
 }
 
 /// Sets the number of complete pending data responses

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -1030,6 +1030,7 @@ impl<
         if let Err(error) = self
             .storage_synchronizer
             .save_state_values(notification_id, state_value_chunk_with_proof)
+            .await
         {
             self.reset_active_stream(Some(NotificationAndFeedback::new(
                 notification_id,

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -475,7 +475,7 @@ mock! {
 
         fn pending_storage_data(&self) -> bool;
 
-        fn save_state_values(
+        async fn save_state_values(
             &mut self,
             notification_id: NotificationId,
             state_value_chunk_with_proof: StateValueChunkWithProof,

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -750,9 +750,11 @@ async fn test_save_states_completion() {
     // Save multiple state chunks (including the last chunk)
     storage_synchronizer
         .save_state_values(0, create_state_value_chunk_with_proof(false))
+        .await
         .unwrap();
     storage_synchronizer
         .save_state_values(1, create_state_value_chunk_with_proof(true))
+        .await
         .unwrap();
 
     // Verify we get a commit notification
@@ -808,6 +810,7 @@ async fn test_save_states_dropped_error_listener() {
     let notification_id = 0;
     storage_synchronizer
         .save_state_values(notification_id, create_state_value_chunk_with_proof(true))
+        .await
         .unwrap();
 
     // The handler should panic as the commit listener was dropped
@@ -849,13 +852,14 @@ async fn test_save_states_invalid_chunk() {
     let notification_id = 0;
     storage_synchronizer
         .save_state_values(notification_id, create_state_value_chunk_with_proof(false))
+        .await
         .unwrap();
     verify_error_notification(&mut error_listener, notification_id).await;
 }
 
-#[test]
+#[tokio::test]
 #[should_panic]
-fn test_save_states_without_initialize() {
+async fn test_save_states_without_initialize() {
     // Create the storage synchronizer
     let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
@@ -864,7 +868,10 @@ fn test_save_states_without_initialize() {
 
     // Attempting to save the states should panic as the state
     // synchronizer was not initialized!
-    let _ = storage_synchronizer.save_state_values(0, create_state_value_chunk_with_proof(false));
+    storage_synchronizer
+        .save_state_values(0, create_state_value_chunk_with_proof(false))
+        .await
+        .unwrap();
 }
 
 /// Creates a storage synchronizer for testing


### PR DESCRIPTION
Note: > 80% of this PR is just unit test changes/additions.

### Description
This PR adds dynamic prefetching support to the data streaming service. Instead of having a static (config-defined) maximum number of in-flight requests, we now dynamically increase/decrease the maximum based on successful RPC responses and timeouts, i.e., for each successful response we increase the value (e.g., +1), for each timeout we decrease the value (e.g., -3), and when we see a timeout, freeze the increases for some time (e.g., 30 secs), to regain stability.

The feature is config gated, and the experiments show significant improvements for `mainnet` PFNs running in GCP, e.g., a `40%` improvement in fast syncing time when combined with latency aware peer dialing (already landed).

The PR offers several commits:
1. Add dynamic prefetching support to the data streaming service.
2. (Tests) Add simple unit tests for dynamic prefetching.
3. (Tests) Update the existing integration tests and add several new tests for dynamic prefetching.
4. Add simple back pressure to the state snapshot receiver when fast syncing (the increased aggression now actually allows us saturate storage).


### Test Plan
New and existing tests.