### PR TITLE
[NFT Metadata Crawler] SHA256 file names + last_transaction_version migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha256",
  "tokio",
  "tracing",
  "url",

--- a/ecosystem/nft-metadata-crawler-parser/Cargo.toml
+++ b/ecosystem/nft-metadata-crawler-parser/Cargo.toml
@@ -39,9 +39,9 @@ image = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-sha256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha256 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/ecosystem/nft-metadata-crawler-parser/Cargo.toml
+++ b/ecosystem/nft-metadata-crawler-parser/Cargo.toml
@@ -39,6 +39,7 @@ image = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+sha256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/ecosystem/nft-metadata-crawler-parser/migrations/2024-02-08-013147_add_last_transaction_version/down.sql
+++ b/ecosystem/nft-metadata-crawler-parser/migrations/2024-02-08-013147_add_last_transaction_version/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS nft_metadata_crawler.parsed_asset_uris DROP COLUMN last_transaction_version;

--- a/ecosystem/nft-metadata-crawler-parser/migrations/2024-02-08-013147_add_last_transaction_version/up.sql
+++ b/ecosystem/nft-metadata-crawler-parser/migrations/2024-02-08-013147_add_last_transaction_version/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS nft_metadata_crawler.parsed_asset_uris ADD COLUMN last_transaction_version BIGINT NOT NULL DEFAULT 0;

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
@@ -23,6 +23,7 @@ pub struct NFTMetadataCrawlerURIs {
     image_optimizer_retry_count: i32,
     animation_optimizer_retry_count: i32,
     do_not_parse: bool,
+    last_transaction_version: i64,
 }
 
 impl NFTMetadataCrawlerURIs {
@@ -38,6 +39,7 @@ impl NFTMetadataCrawlerURIs {
             image_optimizer_retry_count: 0,
             animation_optimizer_retry_count: 0,
             do_not_parse: false,
+            last_transaction_version: 0,
         }
     }
 
@@ -155,6 +157,14 @@ impl NFTMetadataCrawlerURIs {
     pub fn set_do_not_parse(&mut self, do_not_parse: bool) {
         self.do_not_parse = do_not_parse;
     }
+
+    pub fn get_last_transaction_version(&self) -> i64 {
+        self.last_transaction_version
+    }
+
+    pub fn set_last_transaction_version(&mut self, last_transaction_version: i64) {
+        self.last_transaction_version = last_transaction_version;
+    }
 }
 
 impl From<NFTMetadataCrawlerURIsQuery> for NFTMetadataCrawlerURIs {
@@ -170,6 +180,7 @@ impl From<NFTMetadataCrawlerURIsQuery> for NFTMetadataCrawlerURIs {
             image_optimizer_retry_count: query.image_optimizer_retry_count,
             animation_optimizer_retry_count: query.animation_optimizer_retry_count,
             do_not_parse: query.do_not_parse,
+            last_transaction_version: query.last_transaction_version,
         }
     }
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
@@ -27,6 +27,7 @@ pub struct NFTMetadataCrawlerURIsQuery {
     pub animation_optimizer_retry_count: i32,
     pub inserted_at: chrono::NaiveDateTime,
     pub do_not_parse: bool,
+    pub last_transaction_version: i64,
 }
 
 impl NFTMetadataCrawlerURIsQuery {
@@ -120,6 +121,7 @@ impl Default for NFTMetadataCrawlerURIsQuery {
             animation_optimizer_retry_count: 0,
             inserted_at: chrono::NaiveDateTime::default(),
             do_not_parse: false,
+            last_transaction_version: 0,
         }
     }
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/schema.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/schema.rs
@@ -22,8 +22,12 @@ pub mod nft_metadata_crawler {
             animation_optimizer_retry_count -> Int4,
             inserted_at -> Timestamp,
             do_not_parse -> Bool,
+            last_transaction_version -> Int8,
         }
     }
 
-    diesel::allow_tables_to_appear_in_same_query!(ledger_infos, parsed_asset_uris,);
+    diesel::allow_tables_to_appear_in_same_query!(
+        ledger_infos,
+        parsed_asset_uris,
+    );
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/schema.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/schema.rs
@@ -26,8 +26,5 @@ pub mod nft_metadata_crawler {
         }
     }
 
-    diesel::allow_tables_to_appear_in_same_query!(
-        ledger_infos,
-        parsed_asset_uris,
-    );
+    diesel::allow_tables_to_appear_in_same_query!(ledger_infos, parsed_asset_uris,);
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
@@ -52,6 +52,7 @@ pub fn upsert_uris(
             json_parser_retry_count.eq(excluded(json_parser_retry_count)),
             animation_optimizer_retry_count.eq(excluded(animation_optimizer_retry_count)),
             do_not_parse.eq(excluded(do_not_parse)),
+            last_transaction_version.eq(excluded(last_transaction_version)),
         ));
 
     let debug_query = diesel::debug_query::<diesel::pg::Pg, _>(&query).to_string();

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -361,6 +361,8 @@ impl Worker {
             }
         }
 
+        self.model
+            .set_last_transaction_version(self.last_transaction_version as i64);
         if self.model.get_json_parser_retry_count() > MAX_NUM_PARSE_RETRIES
             || self.model.get_image_optimizer_retry_count() > MAX_NUM_PARSE_RETRIES
             || self.model.get_animation_optimizer_retry_count() > MAX_NUM_PARSE_RETRIES


### PR DESCRIPTION
### Description
Found a bug where the wrong image is being shown due to overwriting images with the same `token_data_id`. These changes make the file names the SHA256 hash of their corresponding URI instead of its corresponding `token_data_id`. 

### Test Plan
Works locally + unit tests
