### PR TITLE
Small aggregator v2 cleanup

### DIFF
--- a/aptos-move/aptos-aggregator/src/delayed_change.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_change.rs
@@ -76,9 +76,9 @@ impl<I: Copy + Clone> DelayedApplyChange<I> {
             SnapshotDelta { delta, .. } => {
                 DelayedFieldValue::Snapshot(delta.apply_to(base_value.into_aggregator_value()?)?)
             },
-            SnapshotDerived { formula, .. } => {
-                DelayedFieldValue::Derived(formula.apply_to(base_value.into_snapshot_value()?))
-            },
+            SnapshotDerived { formula, .. } => DelayedFieldValue::DerivedStringSnapshot(
+                formula.apply_to(base_value.into_snapshot_value()?),
+            ),
         })
     }
 }
@@ -140,7 +140,7 @@ impl<I: Copy + Clone> DelayedChange<I> {
             },
 
             // Snapshots:
-            (Some(Create(Snapshot(_) | Derived(_)) | Apply(SnapshotDelta {..} | SnapshotDerived { .. })), _) => Err(PanicOr::from(code_invariant_error(
+            (Some(Create(Snapshot(_) | DerivedStringSnapshot(_)) | Apply(SnapshotDelta {..} | SnapshotDerived { .. })), _) => Err(PanicOr::from(code_invariant_error(
                 "Snapshots are immutable, previous change cannot be any of the snapshots type",
             ))),
             (_, Apply(SnapshotDerived { .. })) => Err(PanicOr::from(code_invariant_error(
@@ -241,9 +241,9 @@ impl<I: Copy + Clone> DelayedApplyEntry<I> {
             SnapshotDelta { delta, .. } => {
                 DelayedFieldValue::Snapshot(delta.apply_to(base_value.into_aggregator_value()?)?)
             },
-            SnapshotDerived { formula, .. } => {
-                DelayedFieldValue::Derived(formula.apply_to(base_value.into_snapshot_value()?))
-            },
+            SnapshotDerived { formula, .. } => DelayedFieldValue::DerivedStringSnapshot(
+                formula.apply_to(base_value.into_snapshot_value()?),
+            ),
         })
     }
 }

--- a/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
@@ -228,7 +228,7 @@ impl DelayedFieldData {
             u32::try_from(calculate_width_for_constant_string(value.len())).map_err(|_| {
                 code_invariant_error("Calculated DerivedStringSnapshot width exceeds u32")
             })?;
-        let change = DelayedChange::Create(DelayedFieldValue::Derived(value));
+        let change = DelayedChange::Create(DelayedFieldValue::DerivedStringSnapshot(value));
         let snapshot_id = resolver.generate_delayed_field_id(width);
 
         self.delayed_fields.insert(snapshot_id, change);
@@ -274,7 +274,9 @@ impl DelayedFieldData {
         let change = match snapshot {
             // If snapshot is in Create state, we don't need to depend on it, and can just take the value.
             Some(DelayedChange::Create(DelayedFieldValue::Snapshot(value))) => {
-                DelayedChange::Create(DelayedFieldValue::Derived(formula.apply_to(*value)))
+                DelayedChange::Create(DelayedFieldValue::DerivedStringSnapshot(
+                    formula.apply_to(*value),
+                ))
             },
             Some(DelayedChange::Apply(DelayedApplyChange::SnapshotDelta { .. })) | None => {
                 DelayedChange::Apply(DelayedApplyChange::SnapshotDerived {

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -38,7 +38,7 @@ use aptos_vm_types::{
     storage::change_set_configs::ChangeSetConfigs,
 };
 use bytes::Bytes;
-use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
     language_storage::StructTag,
     value::MoveTypeLayout,
@@ -387,11 +387,7 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
             .transpose()?
             .and_then(|g| g.inner_ops().get(resource_tag))
         {
-            randomly_check_layout_matches(maybe_layout, layout.as_deref()).map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("get_resource_from_group layout check: {:?}", e))
-            })?;
-
+            randomly_check_layout_matches(maybe_layout, layout.as_deref())?;
             Ok(write_op.extract_raw_bytes())
         } else {
             self.base_resource_group_view.get_resource_from_group(

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -388,8 +388,6 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
             .and_then(|g| g.inner_ops().get(resource_tag))
         {
             randomly_check_layout_matches(maybe_layout, layout.as_deref()).map_err(|e| {
-                // TODO[agg_v2](cleanup): Push into `randomly_check_layout_matches` once Satya's
-                //                        change lands. Consider the error code as well.
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message(format!("get_resource_from_group layout check: {:?}", e))
             })?;

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -785,7 +785,6 @@ where
             .map(|(group_key, mut metadata_op, finalized_group)| {
                 let btree: BTreeMap<T::Tag, Bytes> = finalized_group
                     .into_iter()
-                    // TODO[agg_v2](fix): Should anything be done using the layout here?
                     .map(|(resource_tag, arc_v)| {
                         let bytes = arc_v
                             .extract_raw_bytes()

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -3234,14 +3234,14 @@ mod test {
         assert!(captured_reads.validate_data_reads(holder.versioned_map.data(), 1));
         let read_set_with_delayed_fields = captured_reads.get_read_values_with_delayed_fields();
 
-        // TODO[agg_v2](fix): This prints
+        // TODO[agg_v2](test): This prints
         // read: (KeyType(4, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         // read: (KeyType(2, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         for read in read_set_with_delayed_fields {
             println!("read: {:?}", read);
         }
 
-        // TODO[agg_v2](fix): This assertion fails.
+        // TODO[agg_v2](test): This assertion fails.
         // let data_read = DataRead::Versioned(Ok((1,0)), Arc::new(TransactionWrite::from_state_value(Some(state_value_4))), Some(Arc::new(layout)));
         // assert!(read_set_with_delayed_fields.any(|x| x == (&KeyType::<u32>(4, false), &data_read)));
     }

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -504,7 +504,7 @@ mod test {
 
         assert_some_eq!(
             delayed_field_changes.get(&id_from_fake_idx(3, derived_width)),
-            &DelayedChange::Create(DelayedFieldValue::Derived(
+            &DelayedChange::Create(DelayedFieldValue::DerivedStringSnapshot(
                 "prefix500suffix".as_bytes().to_vec()
             )),
         );

--- a/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
+++ b/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
@@ -600,7 +600,7 @@ impl<K: Eq + Hash + Clone + Debug + Copy> VersionedDelayedFields<K> {
 
                 if let DelayedFieldValue::Snapshot(base) = prev_value {
                     let new_value = formula.apply_to(base);
-                    DelayedFieldValue::Derived(new_value)
+                    DelayedFieldValue::DerivedStringSnapshot(new_value)
                 } else {
                     return Err(CommitError::CodeInvariantError(
                         "Cannot apply delta to non-DelayedField::Aggregator".to_string(),
@@ -759,7 +759,7 @@ mod test {
             VALUE_AGGREGATOR => Some(VersionEntry::Value(DelayedFieldValue::Aggregator(10), None)),
             VALUE_SNAPSHOT => Some(VersionEntry::Value(DelayedFieldValue::Snapshot(13), None)),
             VALUE_DERIVED => Some(VersionEntry::Value(
-                DelayedFieldValue::Derived(vec![70, 80, 90]),
+                DelayedFieldValue::DerivedStringSnapshot(vec![70, 80, 90]),
                 None,
             )),
             APPLY_AGGREGATOR => Some(VersionEntry::Apply(DelayedApplyEntry::AggregatorDelta {
@@ -808,7 +808,7 @@ mod test {
         base_snapshot: DelayedFieldID,
     ) -> VersionEntry<DelayedFieldID> {
         VersionEntry::Value(
-            DelayedFieldValue::Derived(value),
+            DelayedFieldValue::DerivedStringSnapshot(value),
             Some(DelayedApplyEntry::SnapshotDerived {
                 base_snapshot,
                 formula,
@@ -838,7 +838,7 @@ mod test {
         ($cond:expr, $expected:expr) => {
             assert_ok_eq!(
                 $cond,
-                VersionedRead::Value(DelayedFieldValue::Derived($expected))
+                VersionedRead::Value(DelayedFieldValue::DerivedStringSnapshot($expected))
             );
         };
     }
@@ -1113,7 +1113,8 @@ mod test {
 
         {
             // old value shouldn't affect derived computation, as it depends on Snapshot value.
-            let mut v = VersionedValue::new(Some(DelayedFieldValue::Derived(vec![80])));
+            let mut v =
+                VersionedValue::new(Some(DelayedFieldValue::DerivedStringSnapshot(vec![80])));
             v.insert_speculative_value(10, aggregator_entry(APPLY_DERIVED).unwrap())
                 .unwrap();
 


### PR DESCRIPTION
### Description

1. Removing a few outdated TODOs.
2. Replacing a few occurrences of "Derived" with "DerivedStringSnapshot".
