### PR TITLE
Addressing minor aggregator TODOs

### DIFF
--- a/aptos-move/aptos-aggregator/src/delayed_change.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_change.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     delta_change_set::{DeltaOp, DeltaWithMax},
-    types::{code_invariant_error, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
+    types::{DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
-use aptos_types::delayed_fields::SnapshotToStringFormula;
+use aptos_types::delayed_fields::{code_invariant_error, SnapshotToStringFormula};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DelayedApplyChange<I: Clone> {
@@ -251,7 +251,8 @@ impl<I: Copy + Clone> DelayedApplyEntry<I> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{bounded_math::SignedU128, types::DelayedFieldID};
+    use crate::bounded_math::SignedU128;
+    use aptos_types::delayed_fields::DelayedFieldID;
     use claims::{assert_err, assert_ok};
     use DelayedApplyChange::*;
     use DelayedChange::*;

--- a/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
+++ b/aptos-move/aptos-aggregator/src/delayed_field_extension.rs
@@ -6,14 +6,11 @@ use crate::{
     delayed_change::{ApplyBase, DelayedApplyChange, DelayedChange},
     delta_change_set::DeltaWithMax,
     resolver::DelayedFieldResolver,
-    types::{
-        code_invariant_error, expect_ok, DelayedFieldID, DelayedFieldValue,
-        DelayedFieldsSpeculativeError, PanicOr, ReadPosition,
-    },
+    types::{expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr, ReadPosition},
 };
 use aptos_types::delayed_fields::{
     calculate_width_for_constant_string, calculate_width_for_integer_embeded_string,
-    SnapshotToStringFormula,
+    code_invariant_error, DelayedFieldID, SnapshotToStringFormula,
 };
 use move_binary_format::errors::PartialVMResult;
 use std::collections::{btree_map::Entry, BTreeMap};

--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -8,10 +8,9 @@
 use crate::{
     bounded_math::{BoundedMath, SignedU128},
     delta_math::{merge_data_and_delta, merge_two_deltas, DeltaHistory},
-    types::{
-        code_invariant_error, DelayedFieldsSpeculativeError, DeltaApplicationFailureReason, PanicOr,
-    },
+    types::{DelayedFieldsSpeculativeError, DeltaApplicationFailureReason, PanicOr},
 };
+use aptos_types::delayed_fields::code_invariant_error;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct DeltaWithMax {

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -6,12 +6,11 @@ use crate::{
     bounded_math::SignedU128,
     delta_change_set::{serialize, DeltaOp},
     types::{
-        code_invariant_error, DelayedFieldID, DelayedFieldValue, DelayedFieldsSpeculativeError,
-        DeltaApplicationFailureReason, PanicOr,
+        DelayedFieldValue, DelayedFieldsSpeculativeError, DeltaApplicationFailureReason, PanicOr,
     },
 };
 use aptos_types::{
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, DelayedFieldID, PanicError},
     state_store::{
         state_key::StateKey,
         state_value::{StateValue, StateValueMetadata},

--- a/aptos-move/aptos-aggregator/src/tests/identifier_mappings.rs
+++ b/aptos-move/aptos-aggregator/src/tests/identifier_mappings.rs
@@ -1,8 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{DelayedFieldID, DelayedFieldValue, TryFromMoveValue, TryIntoMoveValue};
-use aptos_types::delayed_fields::bytes_and_width_to_derived_string_struct;
+use crate::types::DelayedFieldValue;
+use aptos_types::delayed_fields::{
+    bytes_and_width_to_derived_string_struct, DelayedFieldID, TryFromMoveValue, TryIntoMoveValue,
+};
 use claims::{assert_err, assert_ok};
 use move_core_types::value::{
     IdentifierMappingKind,

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -6,13 +6,10 @@ use crate::{
     bounded_math::{BoundedMath, SignedU128},
     delta_change_set::serialize,
     resolver::{TAggregatorV1View, TDelayedFieldView},
-    types::{
-        code_invariant_error, expect_ok, DelayedFieldID, DelayedFieldValue,
-        DelayedFieldsSpeculativeError, PanicOr,
-    },
+    types::{expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
 use aptos_types::{
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, DelayedFieldID, PanicError},
     state_store::{state_key::StateKey, state_value::StateValue},
     write_set::WriteOp,
 };

--- a/aptos-move/aptos-aggregator/src/types.rs
+++ b/aptos-move/aptos-aggregator/src/types.rs
@@ -7,7 +7,6 @@ use aptos_types::delayed_fields::{
     bytes_and_width_to_derived_string_struct, derived_string_struct_to_bytes_and_length,
     is_derived_string_struct_layout,
 };
-// TODO[agg_v2](cleanup): After aggregators_v2 branch land, consolidate these, instead of using alias here
 pub use aptos_types::delayed_fields::{
     DelayedFieldID, PanicError, TryFromMoveValue, TryIntoMoveValue,
 };

--- a/aptos-move/aptos-aggregator/src/types.rs
+++ b/aptos-move/aptos-aggregator/src/types.rs
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bounded_math::SignedU128;
-use aptos_logger::error;
 use aptos_types::delayed_fields::{
-    bytes_and_width_to_derived_string_struct, derived_string_struct_to_bytes_and_length,
-    is_derived_string_struct_layout,
-};
-pub use aptos_types::delayed_fields::{
-    DelayedFieldID, PanicError, TryFromMoveValue, TryIntoMoveValue,
+    bytes_and_width_to_derived_string_struct, code_invariant_error,
+    derived_string_struct_to_bytes_and_length, is_derived_string_struct_layout, DelayedFieldID,
+    PanicError, TryFromMoveValue,
 };
 use move_binary_format::errors::PartialVMError;
 use move_core_types::{
@@ -34,15 +31,6 @@ impl<T: std::fmt::Debug> PanicOr<T> {
             PanicOr::Or(value) => PanicOr::Or(f(value)),
         }
     }
-}
-
-pub fn code_invariant_error<M: std::fmt::Debug>(message: M) -> PanicError {
-    let msg = format!(
-        "Delayed materialization code invariant broken (there is a bug in the code), {:?}",
-        message
-    );
-    error!("{}", msg);
-    PanicError::CodeInvariantError(msg)
 }
 
 pub fn expect_ok<V, E: std::fmt::Debug>(value: Result<V, E>) -> Result<V, PanicError> {

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -12,11 +12,10 @@ use aptos_aggregator::{
     delayed_change::DelayedChange,
     delta_change_set::{serialize, DeltaOp},
     resolver::AggregatorV1Resolver,
-    types::{code_invariant_error, DelayedFieldID},
 };
 use aptos_types::{
     contract_event::ContractEvent,
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, DelayedFieldID, PanicError},
     state_store::{
         state_key::{StateKey, StateKeyInner},
         state_value::StateValueMetadata,

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::change_set::VMChangeSet;
-use aptos_aggregator::{resolver::AggregatorV1Resolver, types::code_invariant_error};
+use aptos_aggregator::resolver::AggregatorV1Resolver;
 use aptos_types::{
     contract_event::ContractEvent, //contract_event::ContractEvent,
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, PanicError},
     fee_statement::FeeStatement,
     state_store::state_key::StateKey,
     transaction::{TransactionOutput, TransactionStatus},

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -1,11 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::{
-    resolver::{TAggregatorV1View, TDelayedFieldView},
-    types::DelayedFieldID,
-};
+use aptos_aggregator::resolver::{TAggregatorV1View, TDelayedFieldView};
 use aptos_types::{
+    delayed_fields::DelayedFieldID,
     serde_helper::bcs_utils::size_u32_as_uleb128,
     state_store::{
         errors::StateviewError,

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -17,11 +17,10 @@ mod tests {
         bounded_math::SignedU128,
         delayed_change::{DelayedApplyChange, DelayedChange},
         delta_change_set::DeltaWithMax,
-        types::DelayedFieldID,
     };
     use aptos_types::{
         access_path::AccessPath,
-        delayed_fields::{PanicError, SnapshotToStringFormula},
+        delayed_fields::{DelayedFieldID, PanicError, SnapshotToStringFormula},
         state_store::state_key::StateKey,
         transaction::ChangeSet as StorageChangeSet,
         write_set::{WriteOp, WriteSetMut},

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -1,690 +1,678 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::utils::{mock_tag_0, VMChangeSetBuilder};
-use crate::{
-    abstract_write_op::{AbstractResourceWriteOp, GroupWrite},
-    change_set::VMChangeSet,
-    tests::utils::{
-        as_bytes, as_state_key, mock_add, mock_create, mock_create_with_layout, mock_delete,
-        mock_delete_with_layout, mock_modify, mock_modify_with_layout, mock_tag_1, raw_metadata,
-        ExpandedVMChangeSetBuilder, MockChangeSetChecker,
-    },
-};
-use aptos_aggregator::{
-    bounded_math::SignedU128,
-    delayed_change::{DelayedApplyChange, DelayedChange},
-    delta_change_set::DeltaWithMax,
-    types::DelayedFieldID,
-};
-use aptos_types::{
-    access_path::AccessPath,
-    delayed_fields::{PanicError, SnapshotToStringFormula},
-    state_store::state_key::StateKey,
-    transaction::ChangeSet as StorageChangeSet,
-    write_set::{WriteOp, WriteSetMut},
-};
-use bytes::Bytes;
-use claims::{assert_err, assert_matches, assert_ok, assert_some_eq};
-use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    account_address::AccountAddress,
-    ident_str,
-    language_storage::{ModuleId, StructTag},
-    value::MoveTypeLayout,
-    vm_status::StatusCode,
-};
-use std::{collections::BTreeMap, sync::Arc};
-
-/// Testcases:
-/// ```text
-/// *--------------*----------------*----------------*-----------------*
-/// |   state key  |  change set 1  |  change set 2  |    squashed     |
-/// +--------------*----------------*----------------*-----------------*
-/// |      0       |    create 0    |                |    create 0     |
-/// |      1       |    modify 1    |                |    modify 1     |
-/// |      2       |    delete      |                |    delete       |
-/// |      3       |                |    create 103  |    create 103   |
-/// |      4       |                |    modify 104  |    modify 104   |
-/// |      5       |                |    delete      |    delete       |
-/// |      6       |    create 6    |    create 106  |    ERROR        |
-/// |      7       |    create 7    |    modify 107  |    create 107   |
-/// |      8       |    create 8    |    delete      |                 |
-/// |      9       |    modify 9    |    create 109  |    ERROR        |
-/// |      10      |    modify 10   |    modify 110  |    modify 110   |
-/// |      11      |    modify 11   |    delete      |    delete       |
-/// |      12      |    delete      |    create 112  |    modify 112   |
-/// |      13      |    delete      |    modify 113  |    ERROR        |
-/// |      14      |    delete      |    delete      |    ERROR        |
-/// *--------------*----------------*----------------*-----------------*
-/// |      15      |    +15         |                |    +15          |
-/// |      16      |                |    +116        |    +116         |
-/// |      17      |    +17         |    +117        |    +134         |
-/// *--------------*----------------*----------------*-----------------*
-/// |      18      |    create 18   |    +118        |    create 136   |
-/// |      19      |    modify 19   |    +119        |    modify 138   |
-/// |      20      |    delete      |    +120        |    ERROR        |
-/// *--------------*----------------*----------------*-----------------*
-/// |      21      |    +21         |    create 121  |    ERROR        |
-/// |      22      |    +22         |    modify 122  |    modify 122   |
-/// |      23      |    +23         |    delete      |    delete       |
-/// *--------------*----------------*----------------*-----------------*
-/// ```
-
-macro_rules! resource_write_set_1 {
-    ($d:ident) => {
-        vec![
-            mock_create_with_layout(format!("0{}", $d), 0, None),
-            mock_modify_with_layout(format!("1{}", $d), 1, None),
-            mock_delete_with_layout(format!("2{}", $d)),
-            mock_create_with_layout(format!("7{}", $d), 7, None),
-            mock_create_with_layout(format!("8{}", $d), 8, None),
-            mock_modify_with_layout(format!("10{}", $d), 10, None),
-            mock_modify_with_layout(format!("11{}", $d), 11, None),
-            mock_delete_with_layout(format!("12{}", $d)),
-        ]
+#[cfg(test)]
+mod tests {
+    use crate::{
+        abstract_write_op::{AbstractResourceWriteOp, GroupWrite},
+        change_set::VMChangeSet,
+        tests::utils::{
+            as_bytes, as_state_key, mock_add, mock_create, mock_create_with_layout, mock_delete,
+            mock_delete_with_layout, mock_modify, mock_modify_with_layout, mock_tag_0, mock_tag_1,
+            mock_tag_2, raw_metadata, ExpandedVMChangeSetBuilder, MockChangeSetChecker,
+            VMChangeSetBuilder,
+        },
     };
-}
-
-macro_rules! module_write_set_1 {
-    ($d:ident) => {
-        vec![
-            mock_create(format!("0{}", $d), 0),
-            mock_modify(format!("1{}", $d), 1),
-            mock_delete(format!("2{}", $d)),
-            mock_create(format!("7{}", $d), 7),
-            mock_create(format!("8{}", $d), 8),
-            mock_modify(format!("10{}", $d), 10),
-            mock_modify(format!("11{}", $d), 11),
-            mock_delete(format!("12{}", $d)),
-        ]
+    use aptos_aggregator::{
+        bounded_math::SignedU128,
+        delayed_change::{DelayedApplyChange, DelayedChange},
+        delta_change_set::DeltaWithMax,
+        types::DelayedFieldID,
     };
-}
-
-macro_rules! resource_write_set_2 {
-    ($d:ident) => {
-        vec![
-            mock_create_with_layout(format!("3{}", $d), 103, None),
-            mock_modify_with_layout(format!("4{}", $d), 104, None),
-            mock_delete_with_layout(format!("5{}", $d)),
-            mock_modify_with_layout(format!("7{}", $d), 107, None),
-            mock_delete_with_layout(format!("8{}", $d)),
-            mock_modify_with_layout(format!("10{}", $d), 110, None),
-            mock_delete_with_layout(format!("11{}", $d)),
-            mock_create_with_layout(format!("12{}", $d), 112, None),
-        ]
+    use aptos_types::{
+        access_path::AccessPath,
+        delayed_fields::{PanicError, SnapshotToStringFormula},
+        state_store::state_key::StateKey,
+        transaction::ChangeSet as StorageChangeSet,
+        write_set::{WriteOp, WriteSetMut},
     };
-}
-
-macro_rules! module_write_set_2 {
-    ($d:ident) => {
-        vec![
-            mock_create(format!("3{}", $d), 103),
-            mock_modify(format!("4{}", $d), 104),
-            mock_delete(format!("5{}", $d)),
-            mock_modify(format!("7{}", $d), 107),
-            mock_delete(format!("8{}", $d)),
-            mock_modify(format!("10{}", $d), 110),
-            mock_delete(format!("11{}", $d)),
-            mock_create(format!("12{}", $d), 112),
-        ]
+    use bytes::Bytes;
+    use claims::{assert_err, assert_matches, assert_ok, assert_some_eq};
+    use move_binary_format::errors::PartialVMResult;
+    use move_core_types::{
+        account_address::AccountAddress,
+        ident_str,
+        language_storage::{ModuleId, StructTag},
+        value::MoveTypeLayout,
+        vm_status::StatusCode,
     };
-}
-macro_rules! expected_resource_write_set {
-    ($d:ident) => {
-        BTreeMap::from([
-            mock_create_with_layout(format!("0{}", $d), 0, None),
-            mock_modify_with_layout(format!("1{}", $d), 1, None),
-            mock_delete_with_layout(format!("2{}", $d)),
-            mock_create_with_layout(format!("3{}", $d), 103, None),
-            mock_modify_with_layout(format!("4{}", $d), 104, None),
-            mock_delete_with_layout(format!("5{}", $d)),
-            mock_create_with_layout(format!("7{}", $d), 107, None),
-            mock_modify_with_layout(format!("10{}", $d), 110, None),
-            mock_delete_with_layout(format!("11{}", $d)),
-            mock_modify_with_layout(format!("12{}", $d), 112, None),
-        ])
-    };
-}
+    use std::{collections::BTreeMap, sync::Arc};
+    use test_case::test_case;
 
-macro_rules! expected_module_write_set {
-    ($d:ident) => {
-        BTreeMap::from([
-            mock_create(format!("0{}", $d), 0),
-            mock_modify(format!("1{}", $d), 1),
-            mock_delete(format!("2{}", $d)),
-            mock_create(format!("3{}", $d), 103),
-            mock_modify(format!("4{}", $d), 104),
-            mock_delete(format!("5{}", $d)),
-            mock_create(format!("7{}", $d), 107),
-            mock_modify(format!("10{}", $d), 110),
-            mock_delete(format!("11{}", $d)),
-            mock_modify(format!("12{}", $d), 112),
-        ])
-    };
-}
-
-// Populate sets according to the spec. Skip keys which lead to
-// errors because we test them separately.
-fn build_change_sets_for_test() -> (VMChangeSet, VMChangeSet) {
-    let mut descriptor = "r";
-    let resource_write_set_1 = resource_write_set_1!(descriptor);
-    descriptor = "m";
-    let module_write_set_1 = module_write_set_1!(descriptor);
-    let aggregator_write_set_1 = vec![mock_create("18a", 18), mock_modify("19a", 19)];
-    let aggregator_delta_set_1 = vec![
-        mock_add("15a", 15),
-        mock_add("17a", 17),
-        mock_add("22a", 22),
-        mock_add("23a", 23),
-    ];
-    let change_set_1 = VMChangeSetBuilder::new()
-        .with_resource_write_set(resource_write_set_1)
-        .with_module_write_set(module_write_set_1)
-        .with_aggregator_v1_write_set(aggregator_write_set_1)
-        .with_aggregator_v1_delta_set(aggregator_delta_set_1)
-        .build();
-
-    descriptor = "r";
-    let resource_write_set_2 = resource_write_set_2!(descriptor);
-    descriptor = "m";
-    let module_write_set_2 = module_write_set_2!(descriptor);
-    let aggregator_write_set_2 = vec![mock_modify("22a", 122), mock_delete("23a")];
-    let aggregator_delta_set_2 = vec![
-        mock_add("16a", 116),
-        mock_add("17a", 117),
-        mock_add("18a", 118),
-        mock_add("19a", 119),
-    ];
-    let change_set_2 = VMChangeSetBuilder::new()
-        .with_resource_write_set(resource_write_set_2)
-        .with_module_write_set(module_write_set_2)
-        .with_aggregator_v1_write_set(aggregator_write_set_2)
-        .with_aggregator_v1_delta_set(aggregator_delta_set_2)
-        .build();
-
-    (change_set_1, change_set_2)
-}
-
-#[test]
-fn test_successful_squash() {
-    let (mut change_set, additional_change_set) = build_change_sets_for_test();
-    assert_ok!(
-        change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker)
-    );
-
-    let mut descriptor = "r";
-    assert_eq!(
-        change_set.resource_write_set(),
-        &expected_resource_write_set!(descriptor)
-    );
-    descriptor = "m";
-    assert_eq!(
-        change_set.module_write_set(),
-        &expected_module_write_set!(descriptor)
-    );
-
-    let expected_aggregator_write_set = BTreeMap::from([
-        mock_create("18a", 136),
-        mock_modify("19a", 138),
-        mock_modify("22a", 122),
-        mock_delete("23a"),
-    ]);
-    let expected_aggregator_delta_set = BTreeMap::from([
-        mock_add("15a", 15),
-        mock_add("16a", 116),
-        mock_add("17a", 134),
-    ]);
-    assert_eq!(
-        change_set.aggregator_v1_write_set(),
-        &expected_aggregator_write_set
-    );
-    assert_eq!(
-        change_set.aggregator_v1_delta_set(),
-        &expected_aggregator_delta_set
-    );
-}
-
-macro_rules! assert_invariant_violation {
-    ($w1:ident, $w2:ident, $w3:ident, $w4:ident) => {
-        let check = |res: PartialVMResult<()>| {
-            let err = assert_err!(res);
-
-            // TODO[agg_v2](test): Uniformize errors for write op squashing.
-            assert!(
-                err.major_status() == StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
-                    || err.major_status()
-                        == StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR
-            );
+    /// Testcases:
+    /// ```text
+    /// *--------------*----------------*----------------*-----------------*
+    /// |   state key  |  change set 1  |  change set 2  |    squashed     |
+    /// +--------------*----------------*----------------*-----------------*
+    /// |      0       |    create 0    |                |    create 0     |
+    /// |      1       |    modify 1    |                |    modify 1     |
+    /// |      2       |    delete      |                |    delete       |
+    /// |      3       |                |    create 103  |    create 103   |
+    /// |      4       |                |    modify 104  |    modify 104   |
+    /// |      5       |                |    delete      |    delete       |
+    /// |      6       |    create 6    |    create 106  |    ERROR        |
+    /// |      7       |    create 7    |    modify 107  |    create 107   |
+    /// |      8       |    create 8    |    delete      |                 |
+    /// |      9       |    modify 9    |    create 109  |    ERROR        |
+    /// |      10      |    modify 10   |    modify 110  |    modify 110   |
+    /// |      11      |    modify 11   |    delete      |    delete       |
+    /// |      12      |    delete      |    create 112  |    modify 112   |
+    /// |      13      |    delete      |    modify 113  |    ERROR        |
+    /// |      14      |    delete      |    delete      |    ERROR        |
+    /// *--------------*----------------*----------------*-----------------*
+    /// |      15      |    +15         |                |    +15          |
+    /// |      16      |                |    +116        |    +116         |
+    /// |      17      |    +17         |    +117        |    +134         |
+    /// *--------------*----------------*----------------*-----------------*
+    /// |      18      |    create 18   |    +118        |    create 136   |
+    /// |      19      |    modify 19   |    +119        |    modify 138   |
+    /// |      20      |    delete      |    +120        |    ERROR        |
+    /// *--------------*----------------*----------------*-----------------*
+    /// |      21      |    +21         |    create 121  |    ERROR        |
+    /// |      22      |    +22         |    modify 122  |    modify 122   |
+    /// |      23      |    +23         |    delete      |    delete       |
+    /// *--------------*----------------*----------------*-----------------*
+    /// ```
+    macro_rules! resource_write_set_1 {
+        ($d:ident) => {
+            vec![
+                mock_create_with_layout(format!("0{}", $d), 0, None),
+                mock_modify_with_layout(format!("1{}", $d), 1, None),
+                mock_delete_with_layout(format!("2{}", $d)),
+                mock_create_with_layout(format!("7{}", $d), 7, None),
+                mock_create_with_layout(format!("8{}", $d), 8, None),
+                mock_modify_with_layout(format!("10{}", $d), 10, None),
+                mock_modify_with_layout(format!("11{}", $d), 11, None),
+                mock_delete_with_layout(format!("12{}", $d)),
+            ]
         };
+    }
 
-        let mut cs1 = VMChangeSetBuilder::new()
-            .with_resource_write_set($w1.clone())
+    macro_rules! module_write_set_1 {
+        ($d:ident) => {
+            vec![
+                mock_create(format!("0{}", $d), 0),
+                mock_modify(format!("1{}", $d), 1),
+                mock_delete(format!("2{}", $d)),
+                mock_create(format!("7{}", $d), 7),
+                mock_create(format!("8{}", $d), 8),
+                mock_modify(format!("10{}", $d), 10),
+                mock_modify(format!("11{}", $d), 11),
+                mock_delete(format!("12{}", $d)),
+            ]
+        };
+    }
+
+    macro_rules! resource_write_set_2 {
+        ($d:ident) => {
+            vec![
+                mock_create_with_layout(format!("3{}", $d), 103, None),
+                mock_modify_with_layout(format!("4{}", $d), 104, None),
+                mock_delete_with_layout(format!("5{}", $d)),
+                mock_modify_with_layout(format!("7{}", $d), 107, None),
+                mock_delete_with_layout(format!("8{}", $d)),
+                mock_modify_with_layout(format!("10{}", $d), 110, None),
+                mock_delete_with_layout(format!("11{}", $d)),
+                mock_create_with_layout(format!("12{}", $d), 112, None),
+            ]
+        };
+    }
+
+    macro_rules! module_write_set_2 {
+        ($d:ident) => {
+            vec![
+                mock_create(format!("3{}", $d), 103),
+                mock_modify(format!("4{}", $d), 104),
+                mock_delete(format!("5{}", $d)),
+                mock_modify(format!("7{}", $d), 107),
+                mock_delete(format!("8{}", $d)),
+                mock_modify(format!("10{}", $d), 110),
+                mock_delete(format!("11{}", $d)),
+                mock_create(format!("12{}", $d), 112),
+            ]
+        };
+    }
+    macro_rules! expected_resource_write_set {
+        ($d:ident) => {
+            BTreeMap::from([
+                mock_create_with_layout(format!("0{}", $d), 0, None),
+                mock_modify_with_layout(format!("1{}", $d), 1, None),
+                mock_delete_with_layout(format!("2{}", $d)),
+                mock_create_with_layout(format!("3{}", $d), 103, None),
+                mock_modify_with_layout(format!("4{}", $d), 104, None),
+                mock_delete_with_layout(format!("5{}", $d)),
+                mock_create_with_layout(format!("7{}", $d), 107, None),
+                mock_modify_with_layout(format!("10{}", $d), 110, None),
+                mock_delete_with_layout(format!("11{}", $d)),
+                mock_modify_with_layout(format!("12{}", $d), 112, None),
+            ])
+        };
+    }
+
+    macro_rules! expected_module_write_set {
+        ($d:ident) => {
+            BTreeMap::from([
+                mock_create(format!("0{}", $d), 0),
+                mock_modify(format!("1{}", $d), 1),
+                mock_delete(format!("2{}", $d)),
+                mock_create(format!("3{}", $d), 103),
+                mock_modify(format!("4{}", $d), 104),
+                mock_delete(format!("5{}", $d)),
+                mock_create(format!("7{}", $d), 107),
+                mock_modify(format!("10{}", $d), 110),
+                mock_delete(format!("11{}", $d)),
+                mock_modify(format!("12{}", $d), 112),
+            ])
+        };
+    }
+
+    // Populate sets according to the spec. Skip keys which lead to
+    // errors because we test them separately.
+    fn build_change_sets_for_test() -> (VMChangeSet, VMChangeSet) {
+        let mut descriptor = "r";
+        let resource_write_set_1 = resource_write_set_1!(descriptor);
+        descriptor = "m";
+        let module_write_set_1 = module_write_set_1!(descriptor);
+        let aggregator_write_set_1 = vec![mock_create("18a", 18), mock_modify("19a", 19)];
+        let aggregator_delta_set_1 = vec![
+            mock_add("15a", 15),
+            mock_add("17a", 17),
+            mock_add("22a", 22),
+            mock_add("23a", 23),
+        ];
+        let change_set_1 = VMChangeSetBuilder::new()
+            .with_resource_write_set(resource_write_set_1)
+            .with_module_write_set(module_write_set_1)
+            .with_aggregator_v1_write_set(aggregator_write_set_1)
+            .with_aggregator_v1_delta_set(aggregator_delta_set_1)
             .build();
-        let cs2 = VMChangeSetBuilder::new()
-            .with_resource_write_set($w2.clone())
+
+        descriptor = "r";
+        let resource_write_set_2 = resource_write_set_2!(descriptor);
+        descriptor = "m";
+        let module_write_set_2 = module_write_set_2!(descriptor);
+        let aggregator_write_set_2 = vec![mock_modify("22a", 122), mock_delete("23a")];
+        let aggregator_delta_set_2 = vec![
+            mock_add("16a", 116),
+            mock_add("17a", 117),
+            mock_add("18a", 118),
+            mock_add("19a", 119),
+        ];
+        let change_set_2 = VMChangeSetBuilder::new()
+            .with_resource_write_set(resource_write_set_2)
+            .with_module_write_set(module_write_set_2)
+            .with_aggregator_v1_write_set(aggregator_write_set_2)
+            .with_aggregator_v1_delta_set(aggregator_delta_set_2)
             .build();
-        let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
-        check(res);
-        let mut cs1 = VMChangeSetBuilder::new()
-            .with_module_write_set($w3.clone())
+
+        (change_set_1, change_set_2)
+    }
+
+    #[test]
+    fn test_successful_squash() {
+        let (mut change_set, additional_change_set) = build_change_sets_for_test();
+        assert_ok!(
+            change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker)
+        );
+
+        let mut descriptor = "r";
+        assert_eq!(
+            change_set.resource_write_set(),
+            &expected_resource_write_set!(descriptor)
+        );
+        descriptor = "m";
+        assert_eq!(
+            change_set.module_write_set(),
+            &expected_module_write_set!(descriptor)
+        );
+
+        let expected_aggregator_write_set = BTreeMap::from([
+            mock_create("18a", 136),
+            mock_modify("19a", 138),
+            mock_modify("22a", 122),
+            mock_delete("23a"),
+        ]);
+        let expected_aggregator_delta_set = BTreeMap::from([
+            mock_add("15a", 15),
+            mock_add("16a", 116),
+            mock_add("17a", 134),
+        ]);
+        assert_eq!(
+            change_set.aggregator_v1_write_set(),
+            &expected_aggregator_write_set
+        );
+        assert_eq!(
+            change_set.aggregator_v1_delta_set(),
+            &expected_aggregator_delta_set
+        );
+    }
+
+    macro_rules! assert_invariant_violation {
+        ($w1:ident, $w2:ident, $w3:ident, $w4:ident) => {
+            let check = |res: PartialVMResult<()>| {
+                let err = assert_err!(res);
+
+                // TODO[agg_v2](test): Uniformize errors for write op squashing.
+                assert!(
+                    err.major_status() == StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+                        || err.major_status()
+                            == StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR
+                );
+            };
+
+            let mut cs1 = VMChangeSetBuilder::new()
+                .with_resource_write_set($w1.clone())
+                .build();
+            let cs2 = VMChangeSetBuilder::new()
+                .with_resource_write_set($w2.clone())
+                .build();
+            let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
+            check(res);
+            let mut cs1 = VMChangeSetBuilder::new()
+                .with_module_write_set($w3.clone())
+                .build();
+            let cs2 = VMChangeSetBuilder::new()
+                .with_module_write_set($w4.clone())
+                .build();
+            let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
+            check(res);
+            let mut cs1 = VMChangeSetBuilder::new()
+                .with_aggregator_v1_write_set($w3.clone())
+                .build();
+            let cs2 = VMChangeSetBuilder::new()
+                .with_aggregator_v1_write_set($w4.clone())
+                .build();
+            let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
+            check(res);
+        };
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_create_create() {
+        // create 6 + create 106 throws an error
+        let write_set_1 = vec![mock_create_with_layout("6", 6, None)];
+        let write_set_2 = vec![mock_create_with_layout("6", 106, None)];
+        let write_set_3 = vec![mock_create("6", 6)];
+        let write_set_4 = vec![mock_create("6", 106)];
+        assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_modify_create() {
+        // modify 9 + create 109 throws an error
+        let write_set_1 = vec![mock_modify_with_layout("9", 9, None)];
+        let write_set_2 = vec![mock_create_with_layout("9", 109, None)];
+        let write_set_3 = vec![mock_modify("9", 9)];
+        let write_set_4 = vec![mock_create("9", 109)];
+        assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_delete_modify() {
+        // delete + modify 113 throws an error
+        let write_set_1 = vec![mock_delete_with_layout("13")];
+        let write_set_2 = vec![mock_modify_with_layout("13", 113, None)];
+        let write_set_3 = vec![mock_delete("13")];
+        let write_set_4 = vec![mock_modify("13", 113)];
+        assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_delete_delete() {
+        // delete + delete throws an error
+        let write_set_1 = vec![mock_delete_with_layout("14")];
+        let write_set_2 = vec![mock_delete_with_layout("14")];
+        let write_set_3 = vec![mock_delete("14")];
+        let write_set_4 = vec![mock_delete("14")];
+        assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_delete_delta() {
+        // delete + +120 throws an error
+        let aggregator_write_set_1 = vec![mock_delete("20")];
+        let aggregator_delta_set_2 = vec![mock_add("20", 120)];
+
+        let mut change_set = VMChangeSetBuilder::new()
+            .with_aggregator_v1_write_set(aggregator_write_set_1)
             .build();
-        let cs2 = VMChangeSetBuilder::new()
-            .with_module_write_set($w4.clone())
+        let additional_change_set = VMChangeSetBuilder::new()
+            .with_aggregator_v1_delta_set(aggregator_delta_set_2)
             .build();
-        let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
-        check(res);
-        let mut cs1 = VMChangeSetBuilder::new()
-            .with_aggregator_v1_write_set($w3.clone())
+        let res =
+            change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker);
+        let err = assert_err!(res);
+        assert_eq!(
+            err.major_status(),
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        );
+    }
+
+    #[test]
+    fn test_unsuccessful_squash_delta_create() {
+        // +21 + create 122 throws an error
+        let aggregator_delta_set_1 = vec![mock_add("21", 21)];
+        let aggregator_write_set_2 = vec![mock_create("21", 121)];
+
+        let mut change_set = VMChangeSetBuilder::new()
+            .with_aggregator_v1_delta_set(aggregator_delta_set_1)
             .build();
-        let cs2 = VMChangeSetBuilder::new()
-            .with_aggregator_v1_write_set($w4.clone())
+        let additional_change_set = VMChangeSetBuilder::new()
+            .with_aggregator_v1_write_set(aggregator_write_set_2)
             .build();
-        let res = cs1.squash_additional_change_set(cs2, &MockChangeSetChecker);
-        check(res);
-    };
-}
+        let res =
+            change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker);
+        let err = assert_err!(res);
+        assert_eq!(
+            err.major_status(),
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        );
+    }
 
-#[test]
-fn test_unsuccessful_squash_create_create() {
-    // create 6 + create 106 throws an error
-    let write_set_1 = vec![mock_create_with_layout("6", 6, None)];
-    let write_set_2 = vec![mock_create_with_layout("6", 106, None)];
-    let write_set_3 = vec![mock_create("6", 6)];
-    let write_set_4 = vec![mock_create("6", 106)];
-    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
-}
+    #[test]
+    fn test_roundtrip_to_storage_change_set() {
+        let test_struct_tag = StructTag {
+            address: AccountAddress::ONE,
+            module: ident_str!("foo").into(),
+            name: ident_str!("Foo").into(),
+            type_params: vec![],
+        };
+        let test_module_id = ModuleId::new(AccountAddress::ONE, ident_str!("bar").into());
 
-#[test]
-fn test_unsuccessful_squash_modify_create() {
-    // modify 9 + create 109 throws an error
-    let write_set_1 = vec![mock_modify_with_layout("9", 9, None)];
-    let write_set_2 = vec![mock_create_with_layout("9", 109, None)];
-    let write_set_3 = vec![mock_modify("9", 9)];
-    let write_set_4 = vec![mock_create("9", 109)];
-    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
-}
+        let resource_key = StateKey::access_path(
+            AccessPath::resource_access_path(AccountAddress::ONE, test_struct_tag).unwrap(),
+        );
+        let module_key = StateKey::access_path(AccessPath::code_access_path(test_module_id));
+        let write_set = WriteSetMut::new(vec![
+            (resource_key, WriteOp::legacy_deletion()),
+            (module_key, WriteOp::legacy_deletion()),
+        ])
+        .freeze()
+        .unwrap();
 
-#[test]
-fn test_unsuccessful_squash_delete_modify() {
-    // delete + modify 113 throws an error
-    let write_set_1 = vec![mock_delete_with_layout("13")];
-    let write_set_2 = vec![mock_modify_with_layout("13", 113, None)];
-    let write_set_3 = vec![mock_delete("13")];
-    let write_set_4 = vec![mock_modify("13", 113)];
-    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
-}
+        let storage_change_set_before = StorageChangeSet::new(write_set, vec![]);
+        let change_set = assert_ok!(
+            VMChangeSet::try_from_storage_change_set_with_delayed_field_optimization_disabled(
+                storage_change_set_before.clone(),
+                &MockChangeSetChecker,
+            )
+        );
+        let storage_change_set_after = assert_ok!(change_set.try_into_storage_change_set());
+        assert_eq!(storage_change_set_before, storage_change_set_after)
+    }
 
-#[test]
-fn test_unsuccessful_squash_delete_delete() {
-    // delete + delete throws an error
-    let write_set_1 = vec![mock_delete_with_layout("14")];
-    let write_set_2 = vec![mock_delete_with_layout("14")];
-    let write_set_3 = vec![mock_delete("14")];
-    let write_set_4 = vec![mock_delete("14")];
-    assert_invariant_violation!(write_set_1, write_set_2, write_set_3, write_set_4);
-}
+    #[test]
+    fn test_failed_conversion_to_change_set() {
+        let resource_write_set = vec![mock_delete_with_layout("a")];
+        let aggregator_delta_set = vec![mock_add("b", 100)];
+        let change_set = VMChangeSetBuilder::new()
+            .with_resource_write_set(resource_write_set)
+            .with_aggregator_v1_delta_set(aggregator_delta_set)
+            .build();
 
-#[test]
-fn test_unsuccessful_squash_delete_delta() {
-    // delete + +120 throws an error
-    let aggregator_write_set_1 = vec![mock_delete("20")];
-    let aggregator_delta_set_2 = vec![mock_add("20", 120)];
+        // Unchecked conversion ignores deltas.
+        let vm_status = change_set.try_into_storage_change_set();
+        assert_matches!(vm_status, Err(PanicError::CodeInvariantError(_)));
+    }
 
-    let mut change_set = VMChangeSetBuilder::new()
-        .with_aggregator_v1_write_set(aggregator_write_set_1)
-        .build();
-    let additional_change_set = VMChangeSetBuilder::new()
-        .with_aggregator_v1_delta_set(aggregator_delta_set_2)
-        .build();
-    let res = change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker);
-    let err = assert_err!(res);
-    assert_eq!(
-        err.major_status(),
-        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    );
-}
+    #[test]
+    fn test_conversion_to_change_set_fails() {
+        let resource_write_set = vec![mock_delete_with_layout("a")];
+        let aggregator_delta_set = vec![mock_add("b", 100)];
+        let change_set = VMChangeSetBuilder::new()
+            .with_resource_write_set(resource_write_set)
+            .with_aggregator_v1_delta_set(aggregator_delta_set)
+            .build();
 
-#[test]
-fn test_unsuccessful_squash_delta_create() {
-    // +21 + create 122 throws an error
-    let aggregator_delta_set_1 = vec![mock_add("21", 21)];
-    let aggregator_write_set_2 = vec![mock_create("21", 121)];
+        assert_err!(change_set.clone().try_into_storage_change_set());
+    }
 
-    let mut change_set = VMChangeSetBuilder::new()
-        .with_aggregator_v1_delta_set(aggregator_delta_set_1)
-        .build();
-    let additional_change_set = VMChangeSetBuilder::new()
-        .with_aggregator_v1_write_set(aggregator_write_set_2)
-        .build();
-    let res = change_set.squash_additional_change_set(additional_change_set, &MockChangeSetChecker);
-    let err = assert_err!(res);
-    assert_eq!(
-        err.major_status(),
-        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    );
-}
+    #[test]
+    fn test_aggregator_v2_snapshots_and_derived() {
+        use DelayedApplyChange::*;
+        use DelayedChange::*;
 
-#[test]
-fn test_roundtrip_to_storage_change_set() {
-    let test_struct_tag = StructTag {
-        address: AccountAddress::ONE,
-        module: ident_str!("foo").into(),
-        name: ident_str!("Foo").into(),
-        type_params: vec![],
-    };
-    let test_module_id = ModuleId::new(AccountAddress::ONE, ident_str!("bar").into());
-
-    let resource_key = StateKey::access_path(
-        AccessPath::resource_access_path(AccountAddress::ONE, test_struct_tag).unwrap(),
-    );
-    let module_key = StateKey::access_path(AccessPath::code_access_path(test_module_id));
-    let write_set = WriteSetMut::new(vec![
-        (resource_key, WriteOp::legacy_deletion()),
-        (module_key, WriteOp::legacy_deletion()),
-    ])
-    .freeze()
-    .unwrap();
-
-    let storage_change_set_before = StorageChangeSet::new(write_set, vec![]);
-    let change_set = assert_ok!(
-        VMChangeSet::try_from_storage_change_set_with_delayed_field_optimization_disabled(
-            storage_change_set_before.clone(),
-            &MockChangeSetChecker,
-        )
-    );
-    let storage_change_set_after = assert_ok!(change_set.try_into_storage_change_set());
-    assert_eq!(storage_change_set_before, storage_change_set_after)
-}
-
-#[test]
-fn test_failed_conversion_to_change_set() {
-    let resource_write_set = vec![mock_delete_with_layout("a")];
-    let aggregator_delta_set = vec![mock_add("b", 100)];
-    let change_set = VMChangeSetBuilder::new()
-        .with_resource_write_set(resource_write_set)
-        .with_aggregator_v1_delta_set(aggregator_delta_set)
-        .build();
-
-    // Unchecked conversion ignores deltas.
-    let vm_status = change_set.try_into_storage_change_set();
-    assert_matches!(vm_status, Err(PanicError::CodeInvariantError(_)));
-}
-
-#[test]
-fn test_conversion_to_change_set_fails() {
-    let resource_write_set = vec![mock_delete_with_layout("a")];
-    let aggregator_delta_set = vec![mock_add("b", 100)];
-    let change_set = VMChangeSetBuilder::new()
-        .with_resource_write_set(resource_write_set)
-        .with_aggregator_v1_delta_set(aggregator_delta_set)
-        .build();
-
-    assert_err!(change_set.clone().try_into_storage_change_set());
-}
-
-#[test]
-fn test_aggregator_v2_snapshots_and_derived() {
-    use DelayedApplyChange::*;
-    use DelayedChange::*;
-
-    let agg_changes_1 = vec![(
-        DelayedFieldID::new_for_test_for_u64(1),
-        Apply(AggregatorDelta {
-            delta: DeltaWithMax::new(SignedU128::Positive(3), 100),
-        }),
-    )];
-    let mut change_set_1 = VMChangeSetBuilder::new()
-        .with_delayed_field_change_set(agg_changes_1)
-        .build();
-
-    let agg_changes_2 = vec![
-        (
+        let agg_changes_1 = vec![(
             DelayedFieldID::new_for_test_for_u64(1),
             Apply(AggregatorDelta {
-                delta: DeltaWithMax::new(SignedU128::Positive(5), 100),
+                delta: DeltaWithMax::new(SignedU128::Positive(3), 100),
             }),
-        ),
-        (
-            DelayedFieldID::new_for_test_for_u64(2),
-            Apply(SnapshotDelta {
+        )];
+        let mut change_set_1 = VMChangeSetBuilder::new()
+            .with_delayed_field_change_set(agg_changes_1)
+            .build();
+
+        let agg_changes_2 = vec![
+            (
+                DelayedFieldID::new_for_test_for_u64(1),
+                Apply(AggregatorDelta {
+                    delta: DeltaWithMax::new(SignedU128::Positive(5), 100),
+                }),
+            ),
+            (
+                DelayedFieldID::new_for_test_for_u64(2),
+                Apply(SnapshotDelta {
+                    base_aggregator: DelayedFieldID::new_for_test_for_u64(1),
+                    delta: DeltaWithMax::new(SignedU128::Positive(2), 100),
+                }),
+            ),
+            (
+                DelayedFieldID::new_for_test_for_u64(3),
+                Apply(SnapshotDerived {
+                    base_snapshot: DelayedFieldID::new_for_test_for_u64(2),
+                    formula: SnapshotToStringFormula::Concat {
+                        prefix: "p".as_bytes().to_vec(),
+                        suffix: "s".as_bytes().to_vec(),
+                    },
+                }),
+            ),
+        ];
+        let change_set_2 = VMChangeSetBuilder::new()
+            .with_delayed_field_change_set(agg_changes_2)
+            .build();
+
+        assert_ok!(change_set_1.squash_additional_change_set(change_set_2, &MockChangeSetChecker));
+
+        let output_map = change_set_1.delayed_field_change_set();
+        assert_eq!(output_map.len(), 3);
+        assert_some_eq!(
+            output_map.get(&DelayedFieldID::new_for_test_for_u64(1)),
+            &Apply(AggregatorDelta {
+                delta: DeltaWithMax::new(SignedU128::Positive(8), 100)
+            })
+        );
+        assert_some_eq!(
+            output_map.get(&DelayedFieldID::new_for_test_for_u64(2)),
+            &Apply(SnapshotDelta {
                 base_aggregator: DelayedFieldID::new_for_test_for_u64(1),
-                delta: DeltaWithMax::new(SignedU128::Positive(2), 100),
-            }),
-        ),
-        (
-            DelayedFieldID::new_for_test_for_u64(3),
-            Apply(SnapshotDerived {
+                delta: DeltaWithMax::new(SignedU128::Positive(5), 100)
+            })
+        );
+        assert_some_eq!(
+            output_map.get(&DelayedFieldID::new_for_test_for_u64(3)),
+            &Apply(SnapshotDerived {
                 base_snapshot: DelayedFieldID::new_for_test_for_u64(2),
                 formula: SnapshotToStringFormula::Concat {
                     prefix: "p".as_bytes().to_vec(),
-                    suffix: "s".as_bytes().to_vec(),
+                    suffix: "s".as_bytes().to_vec()
                 },
-            }),
-        ),
-    ];
-    let change_set_2 = VMChangeSetBuilder::new()
-        .with_delayed_field_change_set(agg_changes_2)
-        .build();
+            })
+        );
+    }
 
-    assert_ok!(change_set_1.squash_additional_change_set(change_set_2, &MockChangeSetChecker));
-
-    let output_map = change_set_1.delayed_field_change_set();
-    assert_eq!(output_map.len(), 3);
-    assert_some_eq!(
-        output_map.get(&DelayedFieldID::new_for_test_for_u64(1)),
-        &Apply(AggregatorDelta {
-            delta: DeltaWithMax::new(SignedU128::Positive(8), 100)
-        })
-    );
-    assert_some_eq!(
-        output_map.get(&DelayedFieldID::new_for_test_for_u64(2)),
-        &Apply(SnapshotDelta {
-            base_aggregator: DelayedFieldID::new_for_test_for_u64(1),
-            delta: DeltaWithMax::new(SignedU128::Positive(5), 100)
-        })
-    );
-    assert_some_eq!(
-        output_map.get(&DelayedFieldID::new_for_test_for_u64(3)),
-        &Apply(SnapshotDerived {
-            base_snapshot: DelayedFieldID::new_for_test_for_u64(2),
-            formula: SnapshotToStringFormula::Concat {
-                prefix: "p".as_bytes().to_vec(),
-                suffix: "s".as_bytes().to_vec()
-            },
-        })
-    );
-}
-
-#[test]
-fn test_resource_groups_squashing() {
-    let modification_metadata = WriteOp::Modification {
-        data: Bytes::new(),
-        metadata: raw_metadata(2000),
-    };
-
-    macro_rules! as_create_op {
-        ($val:expr) => {
-            (WriteOp::legacy_creation(as_bytes!($val).into()), None)
+    #[test]
+    fn test_resource_groups_squashing() {
+        let modification_metadata = WriteOp::Modification {
+            data: Bytes::new(),
+            metadata: raw_metadata(2000),
         };
+
+        macro_rules! as_create_op {
+            ($val:expr) => {
+                (WriteOp::legacy_creation(as_bytes!($val).into()), None)
+            };
+        }
+        macro_rules! as_modify_op {
+            ($val:expr) => {
+                (WriteOp::legacy_modification(as_bytes!($val).into()), None)
+            };
+        }
+
+        let create_tag_0_op = (mock_tag_0(), as_create_op!(5));
+        let create_group_write_0 = GroupWrite::new(
+            modification_metadata.clone(),
+            BTreeMap::from([create_tag_0_op.clone()]),
+            100,
+        );
+        let create_tag_0 = ExpandedVMChangeSetBuilder::new()
+            .with_resource_group_write_set(vec![(as_state_key!("1"), create_group_write_0.clone())])
+            .build();
+
+        let modify_group_write_0 = GroupWrite::new(
+            modification_metadata.clone(),
+            BTreeMap::from([(mock_tag_0(), as_modify_op!(7))]),
+            100,
+        );
+        let modify_tag_0 = ExpandedVMChangeSetBuilder::new()
+            .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_0.clone())])
+            .build();
+
+        let create_tag_1_op = (mock_tag_1(), as_create_op!(15));
+        let create_group_write_1 = GroupWrite::new(
+            modification_metadata.clone(),
+            BTreeMap::from([create_tag_1_op.clone()]),
+            200,
+        );
+        let create_tag_1 = ExpandedVMChangeSetBuilder::new()
+            .with_resource_group_write_set(vec![(as_state_key!("1"), create_group_write_1.clone())])
+            .build();
+
+        let modify_tag_1_op = (mock_tag_1(), as_modify_op!(17));
+        let modify_group_write_1 = GroupWrite::new(
+            modification_metadata.clone(),
+            BTreeMap::from([modify_tag_1_op.clone()]),
+            200,
+        );
+        let modify_tag_1 = ExpandedVMChangeSetBuilder::new()
+            .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_1.clone())])
+            .build();
+
+        {
+            let mut change_set = create_tag_0.clone();
+            assert_ok!(change_set
+                .squash_additional_change_set(modify_tag_0.clone(), &MockChangeSetChecker));
+            assert_eq!(change_set.resource_write_set().len(), 1);
+            // create(x)+modify(y) becomes create(y)
+            assert_some_eq!(
+                change_set.resource_write_set().get(&as_state_key!("1")),
+                &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
+                    modification_metadata.clone(),
+                    BTreeMap::from([(mock_tag_0(), as_create_op!(7))]),
+                    100
+                ))
+            );
+        }
+
+        {
+            let mut change_set = create_tag_0.clone();
+            assert_ok!(change_set
+                .squash_additional_change_set(create_tag_1.clone(), &MockChangeSetChecker));
+            assert_eq!(change_set.resource_write_set().len(), 1);
+            assert_some_eq!(
+                change_set.resource_write_set().get(&as_state_key!("1")),
+                &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
+                    modification_metadata.clone(),
+                    BTreeMap::from([create_tag_0_op.clone(), create_tag_1_op.clone()]),
+                    200
+                ))
+            );
+
+            assert_ok!(change_set
+                .squash_additional_change_set(modify_tag_1.clone(), &MockChangeSetChecker));
+            assert_eq!(change_set.resource_write_set().len(), 1);
+            // create(x)+modify(y) becomes create(y)
+            assert_some_eq!(
+                change_set.resource_write_set().get(&as_state_key!("1")),
+                &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
+                    modification_metadata.clone(),
+                    BTreeMap::from([create_tag_0_op.clone(), (mock_tag_1(), as_create_op!(17))]),
+                    200
+                ))
+            );
+        }
+
+        {
+            let mut change_set = create_tag_0.clone();
+            assert_ok!(change_set
+                .squash_additional_change_set(modify_tag_1.clone(), &MockChangeSetChecker));
+            assert_eq!(change_set.resource_write_set().len(), 1);
+            assert_some_eq!(
+                change_set.resource_write_set().get(&as_state_key!("1")),
+                &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
+                    modification_metadata.clone(),
+                    BTreeMap::from([create_tag_0_op.clone(), modify_tag_1_op.clone()]),
+                    200
+                ))
+            );
+        }
+
+        {
+            let mut change_set = create_tag_0.clone();
+            assert_ok!(change_set.squash_additional_change_set(
+                ExpandedVMChangeSetBuilder::new()
+                    .with_group_reads_needing_delayed_field_exchange(vec![(
+                        as_state_key!("1"),
+                        (modification_metadata.clone(), 400)
+                    )])
+                    .build(),
+                &MockChangeSetChecker
+            ));
+            assert_eq!(change_set.resource_write_set().len(), 1);
+            // only read size should be updated
+            assert_some_eq!(
+                change_set.resource_write_set().get(&as_state_key!("1")),
+                &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
+                    modification_metadata.clone(),
+                    BTreeMap::from([create_tag_0_op.clone()]),
+                    400
+                ))
+            );
+        }
     }
-    macro_rules! as_modify_op {
-        ($val:expr) => {
-            (WriteOp::legacy_modification(as_bytes!($val).into()), None)
+
+    #[test]
+    fn test_write_and_read_discrepancy_caught() {
+        assert_err!(ExpandedVMChangeSetBuilder::new()
+            .with_resource_write_set(vec![(
+                as_state_key!("1"),
+                (WriteOp::legacy_modification(as_bytes!(1).into()), None),
+            )])
+            .with_reads_needing_delayed_field_exchange(vec![(
+                as_state_key!("1"),
+                (
+                    WriteOp::legacy_modification(as_bytes!(1).into()),
+                    Arc::new(MoveTypeLayout::U64)
+                )
+            )])
+            .try_build());
+
+        let metadata_op = WriteOp::Modification {
+            data: Bytes::new(),
+            metadata: raw_metadata(1000),
         };
+        let group_size = 15;
+
+        assert_err!(ExpandedVMChangeSetBuilder::new()
+            .with_resource_group_write_set(vec![(
+                as_state_key!("1"),
+                GroupWrite::new(metadata_op.clone(), BTreeMap::new(), group_size,)
+            )])
+            .with_group_reads_needing_delayed_field_exchange(vec![(
+                as_state_key!("1"),
+                (metadata_op, group_size)
+            )])
+            .try_build());
     }
-
-    let create_tag_0_op = (mock_tag_0(), as_create_op!(5));
-    let create_group_write_0 = GroupWrite::new(
-        modification_metadata.clone(),
-        BTreeMap::from([create_tag_0_op.clone()]),
-        100,
-    );
-    let create_tag_0 = ExpandedVMChangeSetBuilder::new()
-        .with_resource_group_write_set(vec![(as_state_key!("1"), create_group_write_0.clone())])
-        .build();
-
-    let modify_group_write_0 = GroupWrite::new(
-        modification_metadata.clone(),
-        BTreeMap::from([(mock_tag_0(), as_modify_op!(7))]),
-        100,
-    );
-    let modify_tag_0 = ExpandedVMChangeSetBuilder::new()
-        .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_0.clone())])
-        .build();
-
-    let create_tag_1_op = (mock_tag_1(), as_create_op!(15));
-    let create_group_write_1 = GroupWrite::new(
-        modification_metadata.clone(),
-        BTreeMap::from([create_tag_1_op.clone()]),
-        200,
-    );
-    let create_tag_1 = ExpandedVMChangeSetBuilder::new()
-        .with_resource_group_write_set(vec![(as_state_key!("1"), create_group_write_1.clone())])
-        .build();
-
-    let modify_tag_1_op = (mock_tag_1(), as_modify_op!(17));
-    let modify_group_write_1 = GroupWrite::new(
-        modification_metadata.clone(),
-        BTreeMap::from([modify_tag_1_op.clone()]),
-        200,
-    );
-    let modify_tag_1 = ExpandedVMChangeSetBuilder::new()
-        .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_1.clone())])
-        .build();
-
-    {
-        let mut change_set = create_tag_0.clone();
-        assert_ok!(
-            change_set.squash_additional_change_set(modify_tag_0.clone(), &MockChangeSetChecker)
-        );
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        // create(x)+modify(y) becomes create(y)
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([(mock_tag_0(), as_create_op!(7))]),
-                100
-            ))
-        );
-    }
-
-    {
-        let mut change_set = create_tag_0.clone();
-        assert_ok!(
-            change_set.squash_additional_change_set(create_tag_1.clone(), &MockChangeSetChecker)
-        );
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([create_tag_0_op.clone(), create_tag_1_op.clone()]),
-                200
-            ))
-        );
-
-        assert_ok!(
-            change_set.squash_additional_change_set(modify_tag_1.clone(), &MockChangeSetChecker)
-        );
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        // create(x)+modify(y) becomes create(y)
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([create_tag_0_op.clone(), (mock_tag_1(), as_create_op!(17))]),
-                200
-            ))
-        );
-    }
-
-    {
-        let mut change_set = create_tag_0.clone();
-        assert_ok!(
-            change_set.squash_additional_change_set(modify_tag_1.clone(), &MockChangeSetChecker)
-        );
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([create_tag_0_op.clone(), modify_tag_1_op.clone()]),
-                200
-            ))
-        );
-    }
-
-    {
-        let mut change_set = create_tag_0.clone();
-        assert_ok!(change_set.squash_additional_change_set(
-            ExpandedVMChangeSetBuilder::new()
-                .with_group_reads_needing_delayed_field_exchange(vec![(
-                    as_state_key!("1"),
-                    (modification_metadata.clone(), 400)
-                )])
-                .build(),
-            &MockChangeSetChecker
-        ));
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        // only read size should be updated
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([create_tag_0_op.clone()]),
-                400
-            ))
-        );
-    }
-}
-
-#[test]
-fn test_write_and_read_discrepancy_caught() {
-    assert_err!(ExpandedVMChangeSetBuilder::new()
-        .with_resource_write_set(vec![(
-            as_state_key!("1"),
-            (WriteOp::legacy_modification(as_bytes!(1).into()), None),
-        )])
-        .with_reads_needing_delayed_field_exchange(vec![(
-            as_state_key!("1"),
-            (
-                WriteOp::legacy_modification(as_bytes!(1).into()),
-                Arc::new(MoveTypeLayout::U64)
-            )
-        )])
-        .try_build());
-
-    let metadata_op = WriteOp::Modification {
-        data: Bytes::new(),
-        metadata: raw_metadata(1000),
-    };
-    let group_size = 15;
-
-    assert_err!(ExpandedVMChangeSetBuilder::new()
-        .with_resource_group_write_set(vec![(
-            as_state_key!("1"),
-            GroupWrite::new(metadata_op.clone(), BTreeMap::new(), group_size,)
-        )])
-        .with_group_reads_needing_delayed_field_exchange(vec![(
-            as_state_key!("1"),
-            (metadata_op, group_size)
-        )])
-        .try_build());
-}
-
-// TODO[agg_v2](cleanup) combine utilities with above utilities, and see if tests need cleanup.
-// below are moved from change_set.rs, to consolidate.
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tests::utils::{mock_tag_0, mock_tag_1, mock_tag_2, raw_metadata};
-    use bytes::Bytes;
-    use claims::{assert_err, assert_ok, assert_some_eq};
-    use move_core_types::language_storage::StructTag;
-    use test_case::test_case;
 
     const CREATION: u8 = 0;
     const MODIFICATION: u8 = 1;

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -10,11 +10,11 @@ use crate::{
 use aptos_aggregator::{
     delayed_change::DelayedChange,
     delta_change_set::{delta_add, DeltaOp},
-    types::DelayedFieldID,
 };
 use aptos_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
+    delayed_fields::DelayedFieldID,
     fee_statement::FeeStatement,
     on_chain_config::CurrentTimeMicroseconds,
     state_store::{state_key::StateKey, state_value::StateValueMetadata},

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use aptos_aggregator::{
     delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TAggregatorV1View,
-    types::DelayedFieldID,
 };
 use aptos_block_executor::{
     errors::BlockExecutionError, executor::BlockExecutor,
@@ -21,7 +20,7 @@ use aptos_infallible::Mutex;
 use aptos_types::{
     block_executor::config::BlockExecutorConfig,
     contract_event::ContractEvent,
-    delayed_fields::PanicError,
+    delayed_fields::{DelayedFieldID, PanicError},
     executable::ExecutableTestType,
     fee_statement::FeeStatement,
     state_store::{state_key::StateKey, StateView, StateViewId},

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -13,12 +13,12 @@ use crate::{
 use aptos_aggregator::{
     bounded_math::SignedU128,
     resolver::{TAggregatorV1View, TDelayedFieldView},
-    types::{DelayedFieldID, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
+    types::{DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
 use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     access_path::AccessPath,
-    delayed_fields::PanicError,
+    delayed_fields::{DelayedFieldID, PanicError},
     on_chain_config::{ConfigStorage, Features, OnChainConfig},
     state_store::{
         errors::StateviewError, state_key::StateKey, state_storage_usage::StateStorageUsage,

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -38,7 +38,7 @@ use aptos_vm_types::{
     storage::change_set_configs::ChangeSetConfigs,
 };
 use bytes::Bytes;
-use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
     language_storage::StructTag,
     value::MoveTypeLayout,
@@ -387,13 +387,7 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
             .transpose()?
             .and_then(|g| g.inner_ops().get(resource_tag))
         {
-            randomly_check_layout_matches(maybe_layout, layout.as_deref()).map_err(|e| {
-                // TODO[agg_v2](cleanup): Push into `randomly_check_layout_matches` once Satya's
-                //                        change lands. Consider the error code as well.
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("get_resource_from_group layout check: {:?}", e))
-            })?;
-
+            randomly_check_layout_matches(maybe_layout, layout.as_deref())?;
             Ok(write_op.extract_raw_bytes())
         } else {
             self.base_resource_group_view.get_resource_from_group(

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -11,14 +11,11 @@ use aptos_aggregator::{
     delayed_change::{ApplyBase, DelayedApplyChange, DelayedChange},
     delta_change_set::DeltaWithMax,
     resolver::{TAggregatorV1View, TDelayedFieldView},
-    types::{
-        code_invariant_error, expect_ok, DelayedFieldID, DelayedFieldValue,
-        DelayedFieldsSpeculativeError, PanicOr,
-    },
+    types::{expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr},
 };
 use aptos_gas_algebra::Fee;
 use aptos_types::{
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, DelayedFieldID, PanicError},
     state_store::{
         errors::StateviewError,
         state_key::StateKey,

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -10,10 +10,7 @@ use aptos_aggregator::{
     types::{DelayedFieldsSpeculativeError, PanicOr},
 };
 #[cfg(feature = "testing")]
-use aptos_aggregator::{
-    resolver::TDelayedFieldView,
-    types::{DelayedFieldID, DelayedFieldValue},
-};
+use aptos_aggregator::{resolver::TDelayedFieldView, types::DelayedFieldValue};
 #[cfg(feature = "testing")]
 use aptos_framework::natives::{cryptography::algebra::AlgebraContext, event::NativeEventContext};
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
@@ -27,7 +24,7 @@ use aptos_types::{
 #[cfg(feature = "testing")]
 use aptos_types::{
     chain_id::ChainId,
-    delayed_fields::PanicError,
+    delayed_fields::{DelayedFieldID, PanicError},
     state_store::{state_key::StateKey, state_value::StateValue},
     write_set::WriteOp,
 };

--- a/aptos-move/aptos-vm/src/tests/mock_view.rs
+++ b/aptos-move/aptos-vm/src/tests/mock_view.rs
@@ -1,11 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::types::{
-    DelayedFieldID, DelayedFieldValue, TryFromMoveValue, TryIntoMoveValue,
-};
+use aptos_aggregator::types::DelayedFieldValue;
 use aptos_table_natives::{TableHandle, TableResolver};
-use aptos_types::{access_path::AccessPath, state_store::state_key::StateKey};
+use aptos_types::{
+    access_path::AccessPath,
+    delayed_fields::{DelayedFieldID, TryFromMoveValue, TryIntoMoveValue},
+    state_store::state_key::StateKey,
+};
 use bytes::Bytes;
 use claims::assert_some;
 use move_binary_format::errors::PartialVMError;

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -5,10 +5,7 @@ use crate::types::InputOutputKey;
 use anyhow::bail;
 use aptos_aggregator::{
     delta_math::DeltaHistory,
-    types::{
-        code_invariant_error, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr,
-        ReadPosition,
-    },
+    types::{DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr, ReadPosition},
 };
 use aptos_mvhashmap::{
     types::{
@@ -20,8 +17,10 @@ use aptos_mvhashmap::{
     versioned_group_data::VersionedGroupData,
 };
 use aptos_types::{
-    delayed_fields::PanicError, state_store::state_value::StateValueMetadata,
-    transaction::BlockExecutableTransaction as Transaction, write_set::TransactionWrite,
+    delayed_fields::{code_invariant_error, PanicError},
+    state_store::state_value::StateValueMetadata,
+    transaction::BlockExecutableTransaction as Transaction,
+    write_set::TransactionWrite,
 };
 use aptos_vm_types::resolver::ResourceGroupSize;
 use derivative::Derivative;
@@ -743,8 +742,8 @@ impl<T: Transaction> UnsyncReadSet<T> {
 mod test {
     use super::*;
     use crate::proptest_types::types::{raw_metadata, KeyType, MockEvent, ValueType};
-    use aptos_aggregator::types::DelayedFieldID;
     use aptos_mvhashmap::types::StorageVersion;
+    use aptos_types::delayed_fields::DelayedFieldID;
     use claims::{assert_err, assert_gt, assert_matches, assert_none, assert_ok, assert_some_eq};
     use test_case::test_case;
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -785,7 +785,6 @@ where
             .map(|(group_key, mut metadata_op, finalized_group)| {
                 let btree: BTreeMap<T::Tag, Bytes> = finalized_group
                     .into_iter()
-                    // TODO[agg_v2](fix): Should anything be done using the layout here?
                     .map(|(resource_tag, arc_v)| {
                         let bytes = arc_v
                             .extract_raw_bytes()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -21,7 +21,7 @@ use crate::{
 use aptos_aggregator::{
     delayed_change::{ApplyBase, DelayedChange},
     delta_change_set::serialize,
-    types::{code_invariant_error, expect_ok, PanicOr},
+    types::{expect_ok, PanicOr},
 };
 use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_logger::{debug, error};
@@ -34,7 +34,7 @@ use aptos_mvhashmap::{
 use aptos_types::{
     block_executor::config::BlockExecutorConfig,
     contract_event::TransactionEvent,
-    delayed_fields::PanicError,
+    delayed_fields::{code_invariant_error, PanicError},
     executable::Executable,
     on_chain_config::BlockGasLimitType,
     state_store::TStateView,

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -10,14 +10,13 @@ use aptos_aggregator::{
     delayed_change::DelayedChange,
     delta_change_set::{delta_add, delta_sub, serialize, DeltaOp},
     resolver::TAggregatorV1View,
-    types::DelayedFieldID,
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     contract_event::TransactionEvent,
-    delayed_fields::PanicError,
+    delayed_fields::{DelayedFieldID, PanicError},
     executable::ModulePath,
     fee_statement::FeeStatement,
     on_chain_config::CurrentTimeMicroseconds,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -8,12 +8,14 @@ use crate::{
     task::{ExecutionStatus, TransactionOutput},
     types::{InputOutputKey, ReadWriteSummary},
 };
-use aptos_aggregator::types::{code_invariant_error, PanicOr};
+use aptos_aggregator::types::PanicOr;
 use aptos_logger::warn;
 use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
 use aptos_types::{
-    delayed_fields::PanicError, fee_statement::FeeStatement,
-    transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
+    delayed_fields::{code_invariant_error, PanicError},
+    fee_statement::FeeStatement,
+    transaction::BlockExecutableTransaction as Transaction,
+    write_set::WriteOp,
 };
 use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -16,10 +16,7 @@ use aptos_aggregator::{
     delta_change_set::serialize,
     delta_math::DeltaHistory,
     resolver::{TAggregatorV1View, TDelayedFieldView},
-    types::{
-        code_invariant_error, expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr,
-        ReadPosition, TryFromMoveValue, TryIntoMoveValue,
-    },
+    types::{expect_ok, DelayedFieldValue, DelayedFieldsSpeculativeError, PanicOr, ReadPosition},
 };
 use aptos_logger::error;
 use aptos_mvhashmap::{
@@ -33,7 +30,9 @@ use aptos_mvhashmap::{
     MVHashMap,
 };
 use aptos_types::{
-    delayed_fields::{ExtractUniqueIndex, PanicError},
+    delayed_fields::{
+        code_invariant_error, ExtractUniqueIndex, PanicError, TryFromMoveValue, TryIntoMoveValue,
+    },
     executable::{Executable, ModulePath},
     state_store::{
         errors::StateviewError,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -3234,14 +3234,14 @@ mod test {
         assert!(captured_reads.validate_data_reads(holder.versioned_map.data(), 1));
         let read_set_with_delayed_fields = captured_reads.get_read_values_with_delayed_fields();
 
-        // TODO[agg_v2](fix): This prints
+        // TODO[agg_v2](test): This prints
         // read: (KeyType(4, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         // read: (KeyType(2, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         for read in read_set_with_delayed_fields {
             println!("read: {:?}", read);
         }
 
-        // TODO[agg_v2](fix): This assertion fails.
+        // TODO[agg_v2](test): This assertion fails.
         // let data_read = DataRead::Versioned(Ok((1,0)), Arc::new(TransactionWrite::from_state_value(Some(state_value_4))), Some(Arc::new(layout)));
         // assert!(read_set_with_delayed_fields.any(|x| x == (&KeyType::<u32>(4, false), &data_read)));
     }

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -8,10 +8,11 @@ use aptos_aggregator::{
     delayed_field_extension::DelayedFieldData,
     delta_change_set::DeltaOp,
     resolver::{AggregatorV1Resolver, DelayedFieldResolver},
-    types::DelayedFieldID,
 };
 use aptos_types::{
-    delayed_fields::PanicError, state_store::state_key::StateKey, write_set::WriteOp,
+    delayed_fields::{DelayedFieldID, PanicError},
+    state_store::state_key::StateKey,
+    write_set::WriteOp,
 };
 use better_any::{Tid, TidAble};
 use move_core_types::value::MoveTypeLayout;

--- a/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::helpers_v1::set_aggregator_field;
-use aptos_aggregator::{resolver::DelayedFieldResolver, types::DelayedFieldID};
-use aptos_types::delayed_fields::{from_utf8_bytes, u128_to_u64};
+use aptos_aggregator::resolver::DelayedFieldResolver;
+use aptos_types::delayed_fields::{from_utf8_bytes, u128_to_u64, DelayedFieldID};
 use move_binary_format::errors::PartialVMResult;
 use move_vm_types::values::{StructRef, Value};
 

--- a/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
+++ b/aptos-move/mvhashmap/src/versioned_delayed_fields.rs
@@ -4,8 +4,9 @@
 use crate::types::{AtomicTxnIndex, MVDelayedFieldsError, TxnIndex};
 use aptos_aggregator::{
     delayed_change::{ApplyBase, DelayedApplyEntry, DelayedEntry},
-    types::{code_invariant_error, DelayedFieldValue, PanicError, PanicOr, ReadPosition},
+    types::{DelayedFieldValue, PanicOr, ReadPosition},
 };
+use aptos_types::delayed_fields::{code_invariant_error, PanicError};
 use claims::assert_matches;
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
@@ -711,9 +712,8 @@ mod test {
     use super::*;
     use aptos_aggregator::{
         bounded_math::SignedU128, delta_change_set::DeltaOp, delta_math::DeltaHistory,
-        types::DelayedFieldID,
     };
-    use aptos_types::delayed_fields::SnapshotToStringFormula;
+    use aptos_types::delayed_fields::{DelayedFieldID, SnapshotToStringFormula};
     use claims::{assert_err_eq, assert_ok_eq, assert_some};
     use test_case::test_case;
 

--- a/types/src/delayed_fields.rs
+++ b/types/src/delayed_fields.rs
@@ -216,7 +216,7 @@ impl TryFromMoveValue for DelayedFieldID {
     }
 }
 
-fn code_invariant_error<M: std::fmt::Debug>(message: M) -> PanicError {
+pub fn code_invariant_error<M: std::fmt::Debug>(message: M) -> PanicError {
     let msg = format!(
         "Delayed materialization code invariant broken (there is a bug in the code), {:?}",
         message


### PR DESCRIPTION
### Description

Removing outdated aggregator TODOs and addressing a minor cleanup aggregator TODO. 
There was one TODO in `test_change_set.rs` that asked to consolidate tests from 2 files. While addressing this change I had to indent a few test cases inside `mod tests` resulting in high line count for the PR. Otherwise, it's a very small PR.
