### PR TITLE
[txn emitter] one liner to fix create-accounts command

### DIFF
--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -176,6 +176,7 @@ pub async fn create_accounts_command(
             .init_gas_price_multiplier(1)
             .expected_gas_per_txn(create_accounts_args.max_gas_per_txn)
             .max_gas_per_txn(create_accounts_args.max_gas_per_txn)
+            .init_max_gas_per_txn(create_accounts_args.max_gas_per_txn)
             .coins_per_account_override(0)
             .expected_max_txns(0)
             .prompt_before_spending();


### PR DESCRIPTION
### Description

Create accounts doesn't take a separate init_max_gas_per_txn, so assign it to max_gas_per_txn.

### Test Plan

Run command locally. In future, we need an integration test that keeps this from breaking.
