### PR TITLE
Properly handle `exp_horizon` + zkid.move VK & Configuration initialization in Rust

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -63,7 +63,6 @@
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 <b>use</b> <a href="version.md#0x1_version">0x1::version</a>;
 <b>use</b> <a href="vesting.md#0x1_vesting">0x1::vesting</a>;
-<b>use</b> <a href="zkid.md#0x1_zkid">0x1::zkid</a>;
 </code></pre>
 
 
@@ -367,7 +366,6 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="state_storage.md#0x1_state_storage_initialize">state_storage::initialize</a>(&aptos_framework_account);
     <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
     <a href="jwks.md#0x1_jwks_initialize">jwks::initialize</a>(&aptos_framework_account);
-    <a href="zkid.md#0x1_zkid_initialize">zkid::initialize</a>(&aptos_framework_account, <a href="zkid.md#0x1_zkid_devnet_groth16_vk">zkid::devnet_groth16_vk</a>(), <a href="zkid.md#0x1_zkid_default_devnet_configuration">zkid::default_devnet_configuration</a>());
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/zkid.md
+++ b/aptos-move/framework/aptos-framework/doc/zkid.md
@@ -9,14 +9,13 @@
 -  [Resource `Groth16VerificationKey`](#0x1_zkid_Groth16VerificationKey)
 -  [Resource `Configuration`](#0x1_zkid_Configuration)
 -  [Constants](#@Constants_0)
--  [Function `initialize`](#0x1_zkid_initialize)
 -  [Function `new_groth16_verification_key`](#0x1_zkid_new_groth16_verification_key)
 -  [Function `new_configuration`](#0x1_zkid_new_configuration)
--  [Function `devnet_groth16_vk`](#0x1_zkid_devnet_groth16_vk)
--  [Function `default_devnet_configuration`](#0x1_zkid_default_devnet_configuration)
 -  [Function `update_groth16_verification_key`](#0x1_zkid_update_groth16_verification_key)
 -  [Function `update_configuration`](#0x1_zkid_update_configuration)
 -  [Function `update_training_wheels`](#0x1_zkid_update_training_wheels)
+-  [Function `remove_all_override_auds`](#0x1_zkid_remove_all_override_auds)
+-  [Function `add_override_aud`](#0x1_zkid_add_override_aud)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
@@ -203,33 +202,6 @@ The training wheels PK needs to be 32 bytes long.
 
 
 
-<a id="0x1_zkid_initialize"></a>
-
-## Function `initialize`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="zkid.md#0x1_zkid_initialize">initialize</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, vk: <a href="zkid.md#0x1_zkid_Groth16VerificationKey">zkid::Groth16VerificationKey</a>, constants: <a href="zkid.md#0x1_zkid_Configuration">zkid::Configuration</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="zkid.md#0x1_zkid_initialize">initialize</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, vk: <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a>, constants: <a href="zkid.md#0x1_zkid_Configuration">Configuration</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
-
-    <b>move_to</b>(fx, vk);
-    <b>move_to</b>(fx, constants);
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_zkid_new_groth16_verification_key"></a>
 
 ## Function `new_groth16_verification_key`
@@ -245,7 +217,12 @@ The training wheels PK needs to be 32 bytes long.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_new_groth16_verification_key">new_groth16_verification_key</a>(alpha_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, beta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, gamma_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, delta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, gamma_abc_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;): <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_new_groth16_verification_key">new_groth16_verification_key</a>(alpha_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+                                        beta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+                                        gamma_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+                                        delta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+                                        gamma_abc_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+): <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
     <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
         alpha_g1,
         beta_g2,
@@ -304,84 +281,13 @@ The training wheels PK needs to be 32 bytes long.
 
 </details>
 
-<a id="0x1_zkid_devnet_groth16_vk"></a>
-
-## Function `devnet_groth16_vk`
-
-Returns the Groth16 VK for our devnet deployment.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_devnet_groth16_vk">devnet_groth16_vk</a>(): <a href="zkid.md#0x1_zkid_Groth16VerificationKey">zkid::Groth16VerificationKey</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_devnet_groth16_vk">devnet_groth16_vk</a>(): <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
-    <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
-        alpha_g1: x"6d1c152d2705e35fe7a07a66eb8a10a7f42f1e38c412fbbc3ac7f9affc25dc24",
-        beta_g2: x"e20a834c55ae6e2fcbd66636e09322727f317aff8957dd342afa11f936ef7c02cfdc8c9862849a0442bcaa4e03f45343e8bf261ef4ab58cead2efc17100a3b16",
-        gamma_g2: x"edf692d95cbdde46ddda5ef7d422436779445c5e66006a42761e1f12efde0018c212f3aeb785e49712e7a9353349aaf1255dfb31b7bf60723a480d9293938e19",
-        delta_g2: x"edf692d95cbdde46ddda5ef7d422436779445c5e66006a42761e1f12efde0018c212f3aeb785e49712e7a9353349aaf1255dfb31b7bf60723a480d9293938e19",
-        gamma_abc_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[
-            x"9aae6580d6040e77969d70e748e861664228e3567e77aa99822f8a4a19c29101",
-            x"e38ad8b845e3ef599232b43af2a64a73ada04d5f0e73f1848e6631e17a247415",
-        ],
-    }
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_zkid_default_devnet_configuration"></a>
-
-## Function `default_devnet_configuration`
-
-Returns the configuration for our devnet deployment.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_default_devnet_configuration">default_devnet_configuration</a>(): <a href="zkid.md#0x1_zkid_Configuration">zkid::Configuration</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_default_devnet_configuration">default_devnet_configuration</a>(): <a href="zkid.md#0x1_zkid_Configuration">Configuration</a> {
-    // TODO(<a href="zkid.md#0x1_zkid">zkid</a>): Put reasonable defaults & circuit-specific constants here.
-    <a href="zkid.md#0x1_zkid_Configuration">Configuration</a> {
-        override_aud_vals: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        max_zkid_signatures_per_txn: 3,
-        max_exp_horizon_secs: 100_255_944, // ~1160 days
-        training_wheels_pubkey: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(x"aa"),
-        // The commitment is using the Poseidon-BN254 <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a> function, hence the 254-bit (32 byte) size.
-        nonce_commitment_num_bytes: 32,
-        max_commited_epk_bytes: 3 * 31,
-        max_iss_field_bytes: 126,
-        max_extra_field_bytes:  350,
-        max_jwt_header_b64_bytes: 300,
-    }
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_zkid_update_groth16_verification_key"></a>
 
 ## Function `update_groth16_verification_key`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_update_groth16_verification_key">update_groth16_verification_key</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, alpha_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, beta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, gamma_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, delta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, gamma_abc_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_update_groth16_verification_key">update_groth16_verification_key</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, vk: <a href="zkid.md#0x1_zkid_Groth16VerificationKey">zkid::Groth16VerificationKey</a>)
 </code></pre>
 
 
@@ -390,13 +296,7 @@ Returns the configuration for our devnet deployment.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_update_groth16_verification_key">update_groth16_verification_key</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-                                           alpha_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-                                           beta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-                                           gamma_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-                                           delta_g2: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-                                           gamma_abc_g1: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
-) <b>acquires</b> <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_update_groth16_verification_key">update_groth16_verification_key</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, vk: <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a>) <b>acquires</b> <a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>if</b> (<b>exists</b>&lt;<a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))) {
@@ -409,7 +309,6 @@ Returns the configuration for our devnet deployment.
         } = <b>move_from</b>&lt;<a href="zkid.md#0x1_zkid_Groth16VerificationKey">Groth16VerificationKey</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
     };
 
-    <b>let</b> vk = <a href="zkid.md#0x1_zkid_new_groth16_verification_key">new_groth16_verification_key</a>(alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc_g1);
     <b>move_to</b>(fx, vk);
 }
 </code></pre>
@@ -481,6 +380,60 @@ Returns the configuration for our devnet deployment.
 
     <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="zkid.md#0x1_zkid_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
     config.training_wheels_pubkey = pk;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_zkid_remove_all_override_auds"></a>
+
+## Function `remove_all_override_auds`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_remove_all_override_auds">remove_all_override_auds</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_remove_all_override_auds">remove_all_override_auds</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="zkid.md#0x1_zkid_Configuration">Configuration</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="zkid.md#0x1_zkid_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    config.override_aud_vals = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_zkid_add_override_aud"></a>
+
+## Function `add_override_aud`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_add_override_aud">add_override_aud</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aud: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="zkid.md#0x1_zkid_add_override_aud">add_override_aud</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aud: String) <b>acquires</b> <a href="zkid.md#0x1_zkid_Configuration">Configuration</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="zkid.md#0x1_zkid_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> config.override_aud_vals, aud);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -29,7 +29,6 @@ module aptos_framework::genesis {
     use aptos_framework::transaction_validation;
     use aptos_framework::version;
     use aptos_framework::vesting;
-    use aptos_framework::zkid;
 
     const EDUPLICATE_ACCOUNT: u64 = 1;
     const EACCOUNT_DOES_NOT_EXIST: u64 = 2;
@@ -133,7 +132,6 @@ module aptos_framework::genesis {
         state_storage::initialize(&aptos_framework_account);
         timestamp::set_time_has_started(&aptos_framework_account);
         jwks::initialize(&aptos_framework_account);
-        zkid::initialize(&aptos_framework_account, zkid::devnet_groth16_vk(), zkid::default_devnet_configuration());
     }
 
     /// Genesis step 2: Initialize Aptos coin.

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -532,9 +532,7 @@ fn initialize_on_chain_governance(session: &mut SessionExt, genesis_config: &Gen
 }
 
 fn initialize_zkid(session: &mut SessionExt) {
-    println!("GENESIS Initializing zkID in genesis");
     let config = zkid::Configuration::new_for_devnet_and_testing();
-    println!("GENESIS zkid::update_configuration... begin");
     exec_function(
         session,
         ZKID_MODULE_NAME,
@@ -545,9 +543,6 @@ fn initialize_zkid(session: &mut SessionExt) {
             config.as_move_value(),
         ]),
     );
-    println!("GENESIS zkid::update_configuration... end");
-
-    println!("GENESIS zkid::update_groth16_verification_key... begin");
     let vk = Groth16VerificationKey::from(bn254_circom::DEVNET_VERIFYING_KEY.clone());
     exec_function(
         session,
@@ -559,7 +554,6 @@ fn initialize_zkid(session: &mut SessionExt) {
             vk.as_move_value(),
         ]),
     );
-    println!("GENESIS zkid::update_groth16_verification_key... end");
 }
 
 fn create_accounts(session: &mut SessionExt, accounts: &[AccountBalance]) {

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -19,14 +19,18 @@ use aptos_gas_schedule::{
 };
 use aptos_types::{
     account_config::{self, aptos_test_root_address, events::NewEpochEvent, CORE_CODE_ADDRESS},
+    bn254_circom,
+    bn254_circom::Groth16VerificationKey,
     chain_id::ChainId,
     contract_event::{ContractEvent, ContractEventV1},
+    move_utils::as_move_value::AsMoveValue,
     on_chain_config::{
         FeatureFlag, Features, GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig,
         TimedFeaturesBuilder, APTOS_MAX_KNOWN_VERSION,
     },
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
     write_set::TransactionWrite,
+    zkid,
 };
 use aptos_vm::{
     data_cache::AsMoveResolver,
@@ -51,6 +55,7 @@ const GENESIS_MODULE_NAME: &str = "genesis";
 const GOVERNANCE_MODULE_NAME: &str = "aptos_governance";
 const CODE_MODULE_NAME: &str = "code";
 const VERSION_MODULE_NAME: &str = "version";
+const ZKID_MODULE_NAME: &str = "zkid";
 
 const NUM_SECONDS_PER_YEAR: u64 = 365 * 24 * 60 * 60;
 const MICRO_SECONDS_PER_SECOND: u64 = 1_000_000;
@@ -249,6 +254,7 @@ pub fn encode_genesis_change_set(
     if genesis_config.is_test {
         allow_core_resources_to_set_version(&mut session);
     }
+    initialize_zkid(&mut session);
     set_genesis_end(&mut session);
 
     // Reconfiguration should happen after all on-chain invocations.
@@ -523,6 +529,37 @@ fn initialize_on_chain_governance(session: &mut SessionExt, genesis_config: &Gen
             MoveValue::U64(genesis_config.voting_duration_secs),
         ]),
     );
+}
+
+fn initialize_zkid(session: &mut SessionExt) {
+    println!("GENESIS Initializing zkID in genesis");
+    let config = zkid::Configuration::new_for_devnet_and_testing();
+    println!("GENESIS zkid::update_configuration... begin");
+    exec_function(
+        session,
+        ZKID_MODULE_NAME,
+        "update_configuration",
+        vec![],
+        serialize_values(&vec![
+            MoveValue::Signer(CORE_CODE_ADDRESS),
+            config.as_move_value(),
+        ]),
+    );
+    println!("GENESIS zkid::update_configuration... end");
+
+    println!("GENESIS zkid::update_groth16_verification_key... begin");
+    let vk = Groth16VerificationKey::from(bn254_circom::DEVNET_VERIFYING_KEY.clone());
+    exec_function(
+        session,
+        ZKID_MODULE_NAME,
+        "update_groth16_verification_key",
+        vec![],
+        serialize_values(&vec![
+            MoveValue::Signer(CORE_CODE_ADDRESS),
+            vk.as_move_value(),
+        ]),
+    );
+    println!("GENESIS zkid::update_groth16_verification_key... end");
 }
 
 fn create_accounts(session: &mut SessionExt, accounts: &[AccountBalance]) {

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -459,6 +459,7 @@ SignedGroth16Zkp:
     - extra_field: STR
     - override_aud_val:
         OPTION: STR
+    - exp_horizon_secs: U64
 SignedTransaction:
   STRUCT:
     - raw_txn:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -391,6 +391,7 @@ SignedGroth16Zkp:
     - extra_field: STR
     - override_aud_val:
         OPTION: STR
+    - exp_horizon_secs: U64
 SignedTransaction:
   STRUCT:
     - raw_txn:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -750,6 +750,7 @@ SignedGroth16Zkp:
     - extra_field: STR
     - override_aud_val:
         OPTION: STR
+    - exp_horizon_secs: U64
 SignedTransaction:
   STRUCT:
     - raw_txn:

--- a/testsuite/smoke-test/src/zkid.rs
+++ b/testsuite/smoke-test/src/zkid.rs
@@ -24,8 +24,8 @@ use aptos_types::{
         SignedTransaction,
     },
     zkid::{
-        Groth16Zkp, IdCommitment, OpenIdSig, Pepper, SignedGroth16Zkp, ZkIdPublicKey,
-        ZkIdSignature, ZkpOrOpenIdSig,
+        Configuration, Groth16Zkp, IdCommitment, OpenIdSig, Pepper, SignedGroth16Zkp,
+        ZkIdPublicKey, ZkIdSignature, ZkpOrOpenIdSig,
     },
 };
 use move_core_types::account_address::AccountAddress;
@@ -378,6 +378,7 @@ async fn test_zkid_groth16_verifies() {
 
     // TODO(zkid): Refactor tests to be modular and add test for bad training wheels signature (commented out below).
     //let bad_sk = Ed25519PrivateKey::generate(&mut thread_rng());
+    let config = Configuration::new_for_testing();
     let zk_sig = ZkIdSignature {
         sig: ZkpOrOpenIdSig::Groth16Zkp(SignedGroth16Zkp {
             proof: proof.clone(),
@@ -386,6 +387,7 @@ async fn test_zkid_groth16_verifies() {
             //training_wheels_signature: EphemeralSignature::ed25519(bad_sk.sign(&proof).unwrap()),
             extra_field: "\"family_name\":\"Straka\",".to_string(),
             override_aud_val: None,
+            exp_horizon_secs: config.max_exp_horizon_secs,
         }),
         jwt_header,
         exp_timestamp_secs: 1900255944,
@@ -485,6 +487,7 @@ async fn test_zkid_groth16_signature_transaction_submission_proof_signature_chec
 
     let jwt_header = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RfandrIiwidHlwIjoiSldUIn0".to_string();
 
+    let config = Configuration::new_for_testing();
     let zk_sig = ZkIdSignature {
         sig: ZkpOrOpenIdSig::Groth16Zkp(SignedGroth16Zkp {
             proof: proof.clone(),
@@ -492,6 +495,7 @@ async fn test_zkid_groth16_signature_transaction_submission_proof_signature_chec
             training_wheels_signature: EphemeralSignature::ed25519(tw_sk.sign(&proof).unwrap()),
             extra_field: "\"family_name\":\"Straka\",".to_string(),
             override_aud_val: None,
+            exp_horizon_secs: config.max_exp_horizon_secs,
         }),
         jwt_header,
         exp_timestamp_secs: 1900255944,

--- a/types/src/bn254_circom.rs
+++ b/types/src/bn254_circom.rs
@@ -3,7 +3,6 @@
 use crate::{
     jwks::rsa::RSA_JWK,
     move_utils::as_move_value::AsMoveValue,
-    on_chain_config::OnChainConfig,
     zkid::{Configuration, IdCommitment, ZkIdPublicKey, ZkIdSignature, ZkpOrOpenIdSig},
 };
 use anyhow::bail;
@@ -12,7 +11,12 @@ use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G1Projective, G2Affine, G2Projecti
 use ark_ff::PrimeField;
 use ark_groth16::{PreparedVerifyingKey, VerifyingKey};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use move_core_types::value::{MoveStruct, MoveValue};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::MoveStructType,
+    value::{MoveStruct, MoveValue},
+};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
@@ -54,9 +58,11 @@ impl AsMoveValue for Groth16VerificationKey {
     }
 }
 
-impl OnChainConfig for Groth16VerificationKey {
-    const MODULE_IDENTIFIER: &'static str = "zkid";
-    const TYPE_IDENTIFIER: &'static str = "Groth16VerificationKey";
+/// WARNING: This struct uses resource groups on the Move side. Do NOT implement OnChainConfig
+/// for it, since `OnChainConfig::fetch_config` does not work with resource groups (yet).
+impl MoveStructType for Groth16VerificationKey {
+    const MODULE_NAME: &'static IdentStr = ident_str!("zkid");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Groth16VerificationKey");
 }
 
 impl TryFrom<Groth16VerificationKey> for PreparedVerifyingKey<Bn254> {

--- a/types/src/bn254_circom.rs
+++ b/types/src/bn254_circom.rs
@@ -322,6 +322,7 @@ pub fn get_public_inputs_hash(
     sig: &ZkIdSignature,
     pk: &ZkIdPublicKey,
     jwk: &RSA_JWK,
+    exp_horizon_secs: u64,
     config: &Configuration,
 ) -> anyhow::Result<Fr> {
     let extra_field_hashed;
@@ -360,7 +361,7 @@ pub fn get_public_inputs_hash(
     frs.push(Fr::from(sig.exp_timestamp_secs));
 
     // Add the epk lifespan as a scalar
-    frs.push(Fr::from(config.max_exp_horizon_secs));
+    frs.push(Fr::from(exp_horizon_secs));
 
     // Add the hash of the iss (formatted key-value pair string).
     let formatted_iss = format!("\"iss\":\"{}\",", pk.iss);

--- a/types/src/jwks/mod.rs
+++ b/types/src/jwks/mod.rs
@@ -184,9 +184,9 @@ impl PatchedJWKs {
     }
 }
 
-impl MoveStructType for PatchedJWKs {
-    const MODULE_NAME: &'static IdentStr = ident_str!("jwks");
-    const STRUCT_NAME: &'static IdentStr = ident_str!("PatchedJWKs");
+impl OnChainConfig for PatchedJWKs {
+    const MODULE_IDENTIFIER: &'static str = "jwks";
+    const TYPE_IDENTIFIER: &'static str = "PatchedJWKs";
 }
 
 /// A JWK update in format of `ProviderJWKs` and a multi-signature of it as a quorum certificate.

--- a/types/src/move_utils/as_move_value.rs
+++ b/types/src/move_utils/as_move_value.rs
@@ -39,6 +39,18 @@ impl AsMoveValue for u8 {
     }
 }
 
+impl AsMoveValue for u16 {
+    fn as_move_value(&self) -> MoveValue {
+        MoveValue::U16(*self)
+    }
+}
+
+impl AsMoveValue for u32 {
+    fn as_move_value(&self) -> MoveValue {
+        MoveValue::U32(*self)
+    }
+}
+
 impl AsMoveValue for u64 {
     fn as_move_value(&self) -> MoveValue {
         MoveValue::U64(*self)

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -161,6 +161,7 @@ pub trait OnChainConfig: Send + Sync + DeserializeOwned {
         Self::deserialize_default_impl(bytes)
     }
 
+    /// TODO: This does not work if `T`'s reflection on the Move side is using resource groups.
     fn fetch_config<T>(storage: &T) -> Option<Self>
     where
         T: ConfigStorage + ?Sized,

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1126,7 +1126,7 @@ mod tests {
     use crate::{
         bn254_circom::{G1Bytes, G2Bytes},
         transaction::{webauthn::AssertionSignature, SignedTransaction},
-        zkid::{Groth16Zkp, IdCommitment, OpenIdSig, Pepper, SignedGroth16Zkp},
+        zkid::{Configuration, Groth16Zkp, IdCommitment, OpenIdSig, Pepper, SignedGroth16Zkp},
     };
     use aptos_crypto::{
         ed25519::Ed25519PrivateKey,
@@ -1797,6 +1797,7 @@ mod tests {
         let proof_sig = sender.sign(&proof).unwrap();
         let ephem_proof_sig = EphemeralSignature::ed25519(proof_sig);
         ephem_proof_sig.verify(&proof, &epk).unwrap();
+        let config = Configuration::new_for_testing();
         let zk_sig = ZkIdSignature {
             sig: ZkpOrOpenIdSig::Groth16Zkp(SignedGroth16Zkp {
                 proof: proof.clone(),
@@ -1806,6 +1807,7 @@ mod tests {
                 ),
                 extra_field: "\"family_name\":\"Straka\",".to_string(),
                 override_aud_val: None,
+                exp_horizon_secs: config.max_exp_horizon_secs,
             }),
             jwt_header: "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RfandrIiwidHlwIjoiSldUIn0".to_owned(),
             exp_timestamp_secs: 1900255944,

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1797,7 +1797,7 @@ mod tests {
         let proof_sig = sender.sign(&proof).unwrap();
         let ephem_proof_sig = EphemeralSignature::ed25519(proof_sig);
         ephem_proof_sig.verify(&proof, &epk).unwrap();
-        let config = Configuration::new_for_testing();
+        let config = Configuration::new_for_devnet_and_testing();
         let zk_sig = ZkIdSignature {
             sig: ZkpOrOpenIdSig::Groth16Zkp(SignedGroth16Zkp {
                 proof: proof.clone(),

--- a/types/src/zkid.rs
+++ b/types/src/zkid.rs
@@ -4,7 +4,7 @@ use crate::{
     bn254_circom::{G1Bytes, G2Bytes},
     jwks::rsa::RSA_JWK,
     move_utils::as_move_value::AsMoveValue,
-    on_chain_config::{CurrentTimeMicroseconds, OnChainConfig},
+    on_chain_config::CurrentTimeMicroseconds,
     transaction::{
         authenticator::{
             AnyPublicKey, AnySignature, EphemeralPublicKey, EphemeralSignature, MAX_NUM_OF_SIGS,
@@ -20,6 +20,9 @@ use ark_groth16::{Groth16, PreparedVerifyingKey, Proof};
 use ark_serialize::CanonicalSerialize;
 use base64::URL_SAFE_NO_PAD;
 use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::MoveStructType,
     value::{MoveStruct, MoveValue},
     vm_status::{StatusCode, VMStatus},
 };
@@ -74,9 +77,11 @@ impl AsMoveValue for Configuration {
     }
 }
 
-impl OnChainConfig for Configuration {
-    const MODULE_IDENTIFIER: &'static str = "zkid";
-    const TYPE_IDENTIFIER: &'static str = "Configuration";
+/// WARNING: This struct uses resource groups on the Move side. Do NOT implement OnChainConfig
+/// for it, since `OnChainConfig::fetch_config` does not work with resource groups (yet).
+impl MoveStructType for Configuration {
+    const MODULE_NAME: &'static IdentStr = ident_str!("zkid");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("Configuration");
 }
 
 impl Configuration {


### PR DESCRIPTION
### Description

Fixes some things in #11895.