### PR TITLE
[compiler-v2] Variable coalescing optimization

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
 task 1 'run'. lines 4-21:
-Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 12 }
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 18 }

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
 task 1 'run'. lines 4-21:
-Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 18 }
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 12 }

--- a/aptos-move/framework/aptos-token-objects/sources/property_map.move
+++ b/aptos-move/framework/aptos-token-objects/sources/property_map.move
@@ -343,41 +343,7 @@ module aptos_token_objects::property_map {
         let constructor_ref = object::create_named_object(creator, b"");
         let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
 
-        let input = prepare_input(
-            vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
-            vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
-            vector[
-                bcs::to_bytes<bool>(&true),
-                bcs::to_bytes<u8>(&0x12),
-                bcs::to_bytes<u16>(&0x1234),
-                bcs::to_bytes<u32>(&0x12345678),
-                bcs::to_bytes<u64>(&0x1234567812345678),
-                bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
-                bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678),
-                bcs::to_bytes<vector<u8>>(&vector[0x01]),
-                bcs::to_bytes<String>(&string::utf8(b"a")),
-            ],
-        );
+        let input = end_to_end_input();
         init(&constructor_ref, input);
         let mutator = generate_mutator_ref(&constructor_ref);
 
@@ -399,25 +365,7 @@ module aptos_token_objects::property_map {
 
         assert!(length(&object) == 9, 9);
 
-        update_typed<bool>(&mutator, &string::utf8(b"bool"), false);
-        update_typed<u8>(&mutator, &string::utf8(b"u8"), 0x21);
-        update_typed<u16>(&mutator, &string::utf8(b"u16"), 0x22);
-        update_typed<u32>(&mutator, &string::utf8(b"u32"), 0x23);
-        update_typed<u64>(&mutator, &string::utf8(b"u64"), 0x24);
-        update_typed<u128>(&mutator, &string::utf8(b"u128"), 0x25);
-        update_typed<u256>(&mutator, &string::utf8(b"u256"), 0x26);
-        update_typed<vector<u8>>(&mutator, &string::utf8(b"vector<u8>"), vector[0x02]);
-        update_typed<String>(&mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
-
-        assert!(!read_bool(&object, &string::utf8(b"bool")), 10);
-        assert!(read_u8(&object, &string::utf8(b"u8")) == 0x21, 11);
-        assert!(read_u16(&object, &string::utf8(b"u16")) == 0x22, 12);
-        assert!(read_u32(&object, &string::utf8(b"u32")) == 0x23, 13);
-        assert!(read_u64(&object, &string::utf8(b"u64")) == 0x24, 14);
-        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x25, 15);
-        assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 16);
-        assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
-        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
+        test_end_to_end_update_typed(&mutator, &object);
 
         assert!(length(&object) == 9, 19);
 
@@ -433,25 +381,7 @@ module aptos_token_objects::property_map {
 
         assert!(length(&object) == 0, 20);
 
-        add_typed<bool>(&mutator, string::utf8(b"bool"), false);
-        add_typed<u8>(&mutator, string::utf8(b"u8"), 0x21);
-        add_typed<u16>(&mutator, string::utf8(b"u16"), 0x22);
-        add_typed<u32>(&mutator, string::utf8(b"u32"), 0x23);
-        add_typed<u64>(&mutator, string::utf8(b"u64"), 0x24);
-        add_typed<u128>(&mutator, string::utf8(b"u128"), 0x25);
-        add_typed<u256>(&mutator, string::utf8(b"u256"), 0x26);
-        add_typed<vector<u8>>(&mutator, string::utf8(b"vector<u8>"), vector[0x02]);
-        add_typed<String>(&mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
-
-        assert!(!read_bool(&object, &string::utf8(b"bool")), 21);
-        assert!(read_u8(&object, &string::utf8(b"u8")) == 0x21, 22);
-        assert!(read_u16(&object, &string::utf8(b"u16")) == 0x22, 23);
-        assert!(read_u32(&object, &string::utf8(b"u32")) == 0x23, 24);
-        assert!(read_u64(&object, &string::utf8(b"u64")) == 0x24, 25);
-        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x25, 26);
-        assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 27);
-        assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 28);
-        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 29);
+        test_end_to_end_add_typed(&mutator, &object);
 
         assert!(length(&object) == 9, 30);
 
@@ -544,6 +474,91 @@ module aptos_token_objects::property_map {
         assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 16);
         assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
         assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
+    }
+
+    #[test_only]
+    fun test_end_to_end_update_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
+        update_typed<bool>(mutator, &string::utf8(b"bool"), false);
+        update_typed<u8>(mutator, &string::utf8(b"u8"), 0x21);
+        update_typed<u16>(mutator, &string::utf8(b"u16"), 0x22);
+        update_typed<u32>(mutator, &string::utf8(b"u32"), 0x23);
+        update_typed<u64>(mutator, &string::utf8(b"u64"), 0x24);
+        update_typed<u128>(mutator, &string::utf8(b"u128"), 0x25);
+        update_typed<u256>(mutator, &string::utf8(b"u256"), 0x26);
+        update_typed<vector<u8>>(mutator, &string::utf8(b"vector<u8>"), vector[0x02]);
+        update_typed<String>(mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+
+        assert!(!read_bool(object, &string::utf8(b"bool")), 10);
+        assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 11);
+        assert!(read_u16(object, &string::utf8(b"u16")) == 0x22, 12);
+        assert!(read_u32(object, &string::utf8(b"u32")) == 0x23, 13);
+        assert!(read_u64(object, &string::utf8(b"u64")) == 0x24, 14);
+        assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 15);
+        assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 16);
+        assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
+        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
+    }
+
+    #[test_only]
+    fun test_end_to_end_add_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
+        add_typed<bool>(mutator, string::utf8(b"bool"), false);
+        add_typed<u8>(mutator, string::utf8(b"u8"), 0x21);
+        add_typed<u16>(mutator, string::utf8(b"u16"), 0x22);
+        add_typed<u32>(mutator, string::utf8(b"u32"), 0x23);
+        add_typed<u64>(mutator, string::utf8(b"u64"), 0x24);
+        add_typed<u128>(mutator, string::utf8(b"u128"), 0x25);
+        add_typed<u256>(mutator, string::utf8(b"u256"), 0x26);
+        add_typed<vector<u8>>(mutator, string::utf8(b"vector<u8>"), vector[0x02]);
+        add_typed<String>(mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+
+        assert!(!read_bool(object, &string::utf8(b"bool")), 21);
+        assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 22);
+        assert!(read_u16(object, &string::utf8(b"u16")) == 0x22, 23);
+        assert!(read_u32(object, &string::utf8(b"u32")) == 0x23, 24);
+        assert!(read_u64(object, &string::utf8(b"u64")) == 0x24, 25);
+        assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 26);
+        assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 27);
+        assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 28);
+        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 29);
+    }
+
+    #[test_only]
+    fun end_to_end_input(): PropertyMap {
+        prepare_input(
+            vector[
+                string::utf8(b"bool"),
+                string::utf8(b"u8"),
+                string::utf8(b"u16"),
+                string::utf8(b"u32"),
+                string::utf8(b"u64"),
+                string::utf8(b"u128"),
+                string::utf8(b"u256"),
+                string::utf8(b"vector<u8>"),
+                string::utf8(b"0x1::string::String"),
+            ],
+            vector[
+                string::utf8(b"bool"),
+                string::utf8(b"u8"),
+                string::utf8(b"u16"),
+                string::utf8(b"u32"),
+                string::utf8(b"u64"),
+                string::utf8(b"u128"),
+                string::utf8(b"u256"),
+                string::utf8(b"vector<u8>"),
+                string::utf8(b"0x1::string::String"),
+            ],
+            vector[
+                bcs::to_bytes<bool>(&true),
+                bcs::to_bytes<u8>(&0x12),
+                bcs::to_bytes<u16>(&0x1234),
+                bcs::to_bytes<u32>(&0x12345678),
+                bcs::to_bytes<u64>(&0x1234567812345678),
+                bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
+                bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678),
+                bcs::to_bytes<vector<u8>>(&vector[0x01]),
+                bcs::to_bytes<String>(&string::utf8(b"a")),
+            ],
+        )
     }
 
     #[test(creator = @0x123)]

--- a/aptos-move/framework/aptos-token-objects/sources/property_map.move
+++ b/aptos-move/framework/aptos-token-objects/sources/property_map.move
@@ -343,7 +343,41 @@ module aptos_token_objects::property_map {
         let constructor_ref = object::create_named_object(creator, b"");
         let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
 
-        let input = end_to_end_input();
+        let input = prepare_input(
+            vector[
+                string::utf8(b"bool"),
+                string::utf8(b"u8"),
+                string::utf8(b"u16"),
+                string::utf8(b"u32"),
+                string::utf8(b"u64"),
+                string::utf8(b"u128"),
+                string::utf8(b"u256"),
+                string::utf8(b"vector<u8>"),
+                string::utf8(b"0x1::string::String"),
+            ],
+            vector[
+                string::utf8(b"bool"),
+                string::utf8(b"u8"),
+                string::utf8(b"u16"),
+                string::utf8(b"u32"),
+                string::utf8(b"u64"),
+                string::utf8(b"u128"),
+                string::utf8(b"u256"),
+                string::utf8(b"vector<u8>"),
+                string::utf8(b"0x1::string::String"),
+            ],
+            vector[
+                bcs::to_bytes<bool>(&true),
+                bcs::to_bytes<u8>(&0x12),
+                bcs::to_bytes<u16>(&0x1234),
+                bcs::to_bytes<u32>(&0x12345678),
+                bcs::to_bytes<u64>(&0x1234567812345678),
+                bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
+                bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678),
+                bcs::to_bytes<vector<u8>>(&vector[0x01]),
+                bcs::to_bytes<String>(&string::utf8(b"a")),
+            ],
+        );
         init(&constructor_ref, input);
         let mutator = generate_mutator_ref(&constructor_ref);
 
@@ -365,7 +399,25 @@ module aptos_token_objects::property_map {
 
         assert!(length(&object) == 9, 9);
 
-        test_end_to_end_update_typed(&mutator, &object);
+        update_typed<bool>(&mutator, &string::utf8(b"bool"), false);
+        update_typed<u8>(&mutator, &string::utf8(b"u8"), 0x21);
+        update_typed<u16>(&mutator, &string::utf8(b"u16"), 0x22);
+        update_typed<u32>(&mutator, &string::utf8(b"u32"), 0x23);
+        update_typed<u64>(&mutator, &string::utf8(b"u64"), 0x24);
+        update_typed<u128>(&mutator, &string::utf8(b"u128"), 0x25);
+        update_typed<u256>(&mutator, &string::utf8(b"u256"), 0x26);
+        update_typed<vector<u8>>(&mutator, &string::utf8(b"vector<u8>"), vector[0x02]);
+        update_typed<String>(&mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+
+        assert!(!read_bool(&object, &string::utf8(b"bool")), 10);
+        assert!(read_u8(&object, &string::utf8(b"u8")) == 0x21, 11);
+        assert!(read_u16(&object, &string::utf8(b"u16")) == 0x22, 12);
+        assert!(read_u32(&object, &string::utf8(b"u32")) == 0x23, 13);
+        assert!(read_u64(&object, &string::utf8(b"u64")) == 0x24, 14);
+        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x25, 15);
+        assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 16);
+        assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
+        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
 
         assert!(length(&object) == 9, 19);
 
@@ -381,7 +433,25 @@ module aptos_token_objects::property_map {
 
         assert!(length(&object) == 0, 20);
 
-        test_end_to_end_add_typed(&mutator, &object);
+        add_typed<bool>(&mutator, string::utf8(b"bool"), false);
+        add_typed<u8>(&mutator, string::utf8(b"u8"), 0x21);
+        add_typed<u16>(&mutator, string::utf8(b"u16"), 0x22);
+        add_typed<u32>(&mutator, string::utf8(b"u32"), 0x23);
+        add_typed<u64>(&mutator, string::utf8(b"u64"), 0x24);
+        add_typed<u128>(&mutator, string::utf8(b"u128"), 0x25);
+        add_typed<u256>(&mutator, string::utf8(b"u256"), 0x26);
+        add_typed<vector<u8>>(&mutator, string::utf8(b"vector<u8>"), vector[0x02]);
+        add_typed<String>(&mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+
+        assert!(!read_bool(&object, &string::utf8(b"bool")), 21);
+        assert!(read_u8(&object, &string::utf8(b"u8")) == 0x21, 22);
+        assert!(read_u16(&object, &string::utf8(b"u16")) == 0x22, 23);
+        assert!(read_u32(&object, &string::utf8(b"u32")) == 0x23, 24);
+        assert!(read_u64(&object, &string::utf8(b"u64")) == 0x24, 25);
+        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x25, 26);
+        assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 27);
+        assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 28);
+        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 29);
 
         assert!(length(&object) == 9, 30);
 
@@ -474,91 +544,6 @@ module aptos_token_objects::property_map {
         assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 16);
         assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
         assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
-    }
-
-    #[test_only]
-    fun test_end_to_end_update_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
-        update_typed<bool>(mutator, &string::utf8(b"bool"), false);
-        update_typed<u8>(mutator, &string::utf8(b"u8"), 0x21);
-        update_typed<u16>(mutator, &string::utf8(b"u16"), 0x22);
-        update_typed<u32>(mutator, &string::utf8(b"u32"), 0x23);
-        update_typed<u64>(mutator, &string::utf8(b"u64"), 0x24);
-        update_typed<u128>(mutator, &string::utf8(b"u128"), 0x25);
-        update_typed<u256>(mutator, &string::utf8(b"u256"), 0x26);
-        update_typed<vector<u8>>(mutator, &string::utf8(b"vector<u8>"), vector[0x02]);
-        update_typed<String>(mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
-
-        assert!(!read_bool(object, &string::utf8(b"bool")), 10);
-        assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 11);
-        assert!(read_u16(object, &string::utf8(b"u16")) == 0x22, 12);
-        assert!(read_u32(object, &string::utf8(b"u32")) == 0x23, 13);
-        assert!(read_u64(object, &string::utf8(b"u64")) == 0x24, 14);
-        assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 15);
-        assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 16);
-        assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
-        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
-    }
-
-    #[test_only]
-    fun test_end_to_end_add_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
-        add_typed<bool>(mutator, string::utf8(b"bool"), false);
-        add_typed<u8>(mutator, string::utf8(b"u8"), 0x21);
-        add_typed<u16>(mutator, string::utf8(b"u16"), 0x22);
-        add_typed<u32>(mutator, string::utf8(b"u32"), 0x23);
-        add_typed<u64>(mutator, string::utf8(b"u64"), 0x24);
-        add_typed<u128>(mutator, string::utf8(b"u128"), 0x25);
-        add_typed<u256>(mutator, string::utf8(b"u256"), 0x26);
-        add_typed<vector<u8>>(mutator, string::utf8(b"vector<u8>"), vector[0x02]);
-        add_typed<String>(mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
-
-        assert!(!read_bool(object, &string::utf8(b"bool")), 21);
-        assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 22);
-        assert!(read_u16(object, &string::utf8(b"u16")) == 0x22, 23);
-        assert!(read_u32(object, &string::utf8(b"u32")) == 0x23, 24);
-        assert!(read_u64(object, &string::utf8(b"u64")) == 0x24, 25);
-        assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 26);
-        assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 27);
-        assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 28);
-        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 29);
-    }
-
-    #[test_only]
-    fun end_to_end_input(): PropertyMap {
-        prepare_input(
-            vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
-            vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
-            vector[
-                bcs::to_bytes<bool>(&true),
-                bcs::to_bytes<u8>(&0x12),
-                bcs::to_bytes<u16>(&0x1234),
-                bcs::to_bytes<u32>(&0x12345678),
-                bcs::to_bytes<u64>(&0x1234567812345678),
-                bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
-                bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678),
-                bcs::to_bytes<vector<u8>>(&vector[0x01]),
-                bcs::to_bytes<String>(&string::utf8(b"a")),
-            ],
-        )
     }
 
     #[test(creator = @0x123)]

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -22,7 +22,6 @@ use crate::pipeline::{
     uninitialized_use_checker::UninitializedUseChecker,
     unreachable_code_analysis::UnreachableCodeProcessor,
     unreachable_code_remover::UnreachableCodeRemover, variable_coalescing::VariableCoalescing,
-   
 };
 use anyhow::bail;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
@@ -208,6 +207,7 @@ pub fn run_file_format_gen(env: &GlobalEnv, targets: &FunctionTargetsHolder) -> 
 pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     let options = env.get_extension::<Options>().expect("options");
     let safety_on = !options.experiment_on(Experiment::NO_SAFETY);
+    let optimize_on = options.experiment_on(Experiment::OPTIMIZE);
     let mut pipeline = FunctionTargetPipeline::default();
     if options.experiment_on(Experiment::SPLIT_CRITICAL_EDGES) {
         pipeline.add_processor(Box::new(SplitCriticalEdgesProcessor {}));
@@ -219,9 +219,9 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
     pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
     pipeline.add_processor(Box::new(AbilityProcessor {}));
-
-    // The default optimization pipeline is currently always run by the compiler.
-    add_default_optimization_pipeline(&options, &mut pipeline);
+    if optimize_on {
+        add_default_optimization_pipeline(&mut pipeline);
+    }
     // Run live var analysis again because it could be invalidated by previous pipeline steps,
     // but it is needed by file format generator.
     pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
@@ -234,20 +234,18 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 /// potentially delete or change code through these optimizations.
 /// While this section of the pipeline is optional, some code that used to previously compile
 /// may no longer compile without this section because of using too many local (temp) variables.
-fn add_default_optimization_pipeline(options: &Options, pipeline: &mut FunctionTargetPipeline) {
-    if options.experiment_on(Experiment::OPTIMIZE) {
-        // Available copies analysis is needed by copy propagation.
-        pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {}));
-        pipeline.add_processor(Box::new(CopyPropagation {}));
-        // Live var analysis is needed by dead store elimination.
-        pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-        pipeline.add_processor(Box::new(DeadStoreElimination {}));
-        pipeline.add_processor(Box::new(UnreachableCodeProcessor {}));
-        pipeline.add_processor(Box::new(UnreachableCodeRemover {}));
-        // Live var analysis is needed by variable coalescing.
-        pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-        pipeline.add_processor(Box::new(VariableCoalescing {}));
-    }
+fn add_default_optimization_pipeline(pipeline: &mut FunctionTargetPipeline) {
+    // Available copies analysis is needed by copy propagation.
+    pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(CopyPropagation {}));
+    // Live var analysis is needed by dead store elimination.
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(DeadStoreElimination {}));
+    pipeline.add_processor(Box::new(UnreachableCodeProcessor {}));
+    pipeline.add_processor(Box::new(UnreachableCodeRemover {}));
+    // Live var analysis is needed by variable coalescing.
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(VariableCoalescing {}));
 }
 
 /// Disassemble the given compiled units and return the disassembled code as a string.

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -21,7 +21,8 @@ use crate::pipeline::{
     split_critical_edges_processor::SplitCriticalEdgesProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
     unreachable_code_analysis::UnreachableCodeProcessor,
-    unreachable_code_remover::UnreachableCodeRemover,
+    unreachable_code_remover::UnreachableCodeRemover, variable_coalescing::VariableCoalescing,
+   
 };
 use anyhow::bail;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
@@ -243,6 +244,9 @@ fn add_default_optimization_pipeline(options: &Options, pipeline: &mut FunctionT
         pipeline.add_processor(Box::new(DeadStoreElimination {}));
         pipeline.add_processor(Box::new(UnreachableCodeProcessor {}));
         pipeline.add_processor(Box::new(UnreachableCodeRemover {}));
+        // Live var analysis is needed by variable coalescing.
+        pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+        pipeline.add_processor(Box::new(VariableCoalescing {}));
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -29,7 +29,7 @@ use std::{
 
 /// Annotation which is attached to function data.
 #[derive(Default, Clone)]
-pub struct LiveVarAnnotation(BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>);
+pub struct LiveVarAnnotation(pub BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>);
 
 impl LiveVarAnnotation {
     /// Get the live var info at the given code offset

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -23,6 +23,7 @@ pub mod split_critical_edges_processor;
 pub mod uninitialized_use_checker;
 pub mod unreachable_code_analysis;
 pub mod unreachable_code_remover;
+pub mod variable_coalescing;
 pub mod visibility_checker;
 
 /// Function to register all annotation formatters in the pipeline. Those are used

--- a/third_party/move/move-compiler-v2/src/pipeline/variable_coalescing.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/variable_coalescing.rs
@@ -1,0 +1,235 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a transformation that reuses locals of the same type when
+//! possible.
+//! prerequisite: livevar annotation is available by performing liveness analysis.
+//! side effect: this transformation removes all pre-existing annotations.
+//!
+//! This transformation is closely related to the register allocation problem in
+//! compilers. As such, an optimal solution to reusing locals is NP-complete, as we
+//! can show its equivalence to the graph coloring problem.
+//!
+//! Our solution here is inspired by the paper "Linear Scan Register Allocation"
+//! by Poletto and Sarkar, which proposes a fast and greedy register allocation
+//! algorithm. While potentially suboptimal, it is simple and fast, and is known to
+//! produce good results in practice. Our solution uses some key ideas from that
+//! paper, and performs a linear scan for deciding which locals to reuse.
+//!
+//! A key concept in this transformation is the "live interval" of a local, as opposed
+//! to the more precise "live range" (the set of code offsets where a local is live).
+//! The live interval of a local `t` is a consecutive range of code offsets `[i, j]`
+//! such that there is no code offset `j' > j` where `t` is live at `j'`, and there is
+//! no code offset `i' < i` where `t` is live at `i'`. A trivial live interval for any
+//! local is `[0, MAX_CODE_OFFSET]`, but we can often compute more precise live intervals.
+//!
+//! The transformation greedily reuses (same-typed) locals outside their live intervals.
+
+use crate::pipeline::livevar_analysis_processor::LiveVarAnnotation;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv, ty::Type};
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The live interval of a local.
+#[derive(Debug)]
+struct LiveInterval(
+    /* first seen */ CodeOffset,
+    /* last seen */ CodeOffset,
+);
+
+impl LiveInterval {
+    /// Create a new live interval that only has the given offset.
+    fn new(offset: CodeOffset) -> Self {
+        Self(offset, offset)
+    }
+
+    /// Include the given offset in the live interval, expanding the interval as necessary.
+    fn include(&mut self, offset: CodeOffset) {
+        self.0 = std::cmp::min(self.0, offset);
+        self.1 = std::cmp::max(self.1, offset);
+    }
+}
+
+/// Live interval event of a local, used for sorting.
+enum LiveIntervalEvent {
+    Begin(
+        /* which local? */ TempIndex,
+        /* live interval begins */ CodeOffset,
+        /* live interval length */ usize, // used for tie-breaking
+    ),
+    End(
+        /* which local? */ TempIndex,
+        /* live interval ends */ CodeOffset,
+    ),
+}
+
+impl LiveIntervalEvent {
+    /// Get the code offset at which the event occurs.
+    fn offset(&self) -> CodeOffset {
+        match self {
+            LiveIntervalEvent::Begin(_, offset, _) => *offset,
+            LiveIntervalEvent::End(_, offset) => *offset,
+        }
+    }
+}
+
+pub struct VariableCoalescing {}
+
+impl VariableCoalescing {
+    /// Compute the live intervals of locals in the given function target.
+    /// The result is a vector of live intervals, where the index of the vector is the local.
+    /// If a local has `None` as its live interval, we can ignore the local for the coalescing
+    /// transformation (eg., because it is borrowed or because it is never used): it implies
+    /// that it is the trivial live interval.
+    fn live_intervals(target: &FunctionTarget) -> Vec<Option<LiveInterval>> {
+        let live_var_annotation = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("live var annotation is a prerequisite");
+        // Note: we currently exclude all the variables that are borrowed from participating in this
+        // transformation, which is safe. However, we could be more precise in this regard.
+        let borrowed_locals = target.get_borrowed_locals();
+        // Initially, all locals have trivial live intervals.
+        let mut live_intervals = std::iter::repeat_with(|| None)
+            .take(target.get_local_count())
+            .collect::<Vec<_>>();
+        for (offset, live_var_info) in live_var_annotation.0.iter() {
+            live_var_info
+                .after
+                .keys()
+                .chain(live_var_info.before.keys())
+                .filter(|local| !borrowed_locals.contains(local))
+                .for_each(|local| {
+                    // non-borrowed local that is live before and/or after the code offset.
+                    let interval =
+                        live_intervals[*local].get_or_insert_with(|| LiveInterval::new(*offset));
+                    interval.include(*offset);
+                });
+        }
+        live_intervals
+    }
+
+    /// Compute the sorted live interval events of locals in the given function target.
+    /// See implementation comments for the sorting order.
+    fn sorted_live_interval_events(target: &FunctionTarget) -> Vec<LiveIntervalEvent> {
+        let live_intervals = Self::live_intervals(target);
+        let mut live_interval_events = vec![];
+        for (local, interval) in live_intervals.into_iter().enumerate() {
+            if let Some(interval) = interval {
+                live_interval_events.push(LiveIntervalEvent::Begin(
+                    local as TempIndex,
+                    interval.0,
+                    (interval.1 - interval.0) as usize,
+                ));
+                live_interval_events.push(LiveIntervalEvent::End(local as TempIndex, interval.1));
+            }
+        }
+        live_interval_events.sort_by(|a, b| {
+            use LiveIntervalEvent::*;
+            match (a, b) {
+                // Sort events based on their code offsets (lower offset comes first).
+                _ if a.offset() < b.offset() => std::cmp::Ordering::Less,
+                _ if a.offset() > b.offset() => std::cmp::Ordering::Greater,
+                // If two events occur at the same offset, `End` comes before `Before`.
+                // This allows locals in `End` to be possibly remapped to locals in `Begin`
+                // at the same code offset.
+                (End(..), Begin(..)) => std::cmp::Ordering::Less,
+                (Begin(..), End(..)) => std::cmp::Ordering::Greater,
+                // If two locals `End` at the same offset, then we arbitrarily (but deterministically)
+                // use the local index to break the tie.
+                (End(local_a, _), End(local_b, _)) => local_a.cmp(local_b),
+                // If two locals `Begin` at the same offset, then we use the length of their live
+                // intervals to break the tie. The idea behind this heuristic is that remapping a
+                // local with shorter interval might make it available for remapping to other locals
+                // sooner. If the intervals are of the same length, we arbitrarily (but deterministically)
+                // use the local index to break the tie.
+                (Begin(local_a, _, length_a), Begin(local_b, _, length_b)) => {
+                    length_a.cmp(length_b).then_with(|| local_a.cmp(local_b))
+                },
+            }
+        });
+        live_interval_events
+    }
+
+    /// Compute the coalesceable locals of the given function target.
+    /// The result is a map, where for each mapping from local `t` to its coalesceable local `u`,
+    /// we can safely replace all occurrences of `t` with `u`.
+    /// This safety property follows from:
+    ///   - `t` and `u` are of the same type
+    ///   - either the live intervals of `t` and `u` do not overlap, in which case, they do not interfere
+    ///     with each others computations,
+    ///   - or `t` becomes live for the first time at the same code offset as `u` is last seen alive
+    ///     (i.e., `u` is one of the sources and `t` is one of the destinations at the code offset), in
+    ///     which case, we can safely reuse `u` in place of `t`.
+    fn coalesceable_locals(target: &FunctionTarget) -> BTreeMap<TempIndex, TempIndex> {
+        let sorted_events = Self::sorted_live_interval_events(target);
+        // Map local `t` to its coalesceable local `u`, where the replacement `t` -> `u` is safe.
+        let mut coalesceable_locals = BTreeMap::new();
+        // For each type in the function, keep track of the available locals (not alive) of that type.
+        let mut avail_map: BTreeMap<&Type, BTreeSet<TempIndex>> = BTreeMap::new();
+        for event in sorted_events {
+            match event {
+                LiveIntervalEvent::Begin(local, _, _) => {
+                    let local_type = target.get_local_type(local);
+                    if let Some(avail_locals) = avail_map.get_mut(local_type) {
+                        if let Some(avail) = avail_locals.pop_first() {
+                            // We found a local `avail` that is not alive with matching types.
+                            // Let's use it to replace occurrences of `local`.
+                            coalesceable_locals.insert(local, avail);
+                        }
+                    }
+                },
+                LiveIntervalEvent::End(local, _) => {
+                    let local_type = target.get_local_type(local);
+                    let avail_local = *coalesceable_locals.get(&local).unwrap_or(&local);
+                    // `local` is no longer alive, so it can be reused.
+                    avail_map.entry(local_type).or_default().insert(avail_local);
+                },
+            }
+        }
+        coalesceable_locals
+    }
+
+    /// Obtain the transformed code of the given function target by reusing coalesceable locals.
+    /// The resulting code can potentially leave several locals unused.
+    fn transform(target: &FunctionTarget) -> Vec<Bytecode> {
+        let coalesceable_locals = Self::coalesceable_locals(target);
+        let mut new_code = vec![];
+        let mut remapping_locals =
+            |local: TempIndex| *coalesceable_locals.get(&local).unwrap_or(&local);
+        for instr in target.get_bytecode() {
+            let remapped_instr = instr.clone().remap_all_vars(target, &mut remapping_locals);
+            new_code.push(remapped_instr);
+        }
+        new_code
+    }
+}
+
+impl FunctionTargetProcessor for VariableCoalescing {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        data.code = Self::transform(&target);
+        // Annotations may no longer be valid after this transformation.
+        // So remove them.
+        data.annotations.clear();
+        data
+    }
+
+    fn name(&self) -> String {
+        "VariableCoalescing".to_string()
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/variable_coalescing.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/variable_coalescing.rs
@@ -38,7 +38,6 @@ use std::collections::{BTreeMap, BTreeSet};
 /// The live interval of a local (inclusive).
 /// Note that two live intervals i1: [b1, x] and i2: [x, e2] are *not* considered to overlap
 /// even though the code offset `x` is in both intervals.
-#[derive(Debug)]
 struct LiveInterval {
     begin: CodeOffset,
     end: CodeOffset,

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/args_with_side_effects.exp
@@ -99,7 +99,7 @@ fun m::add($t0: u64, $t1: u64): u64 {
 public fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64
   0: $t2 := copy($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_2.exp
@@ -62,7 +62,7 @@ fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64
   0: if ($t0) goto 1 else goto 4
   1: label L0

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/branch_3.exp
@@ -62,8 +62,8 @@ fun m::test($t0: bool, $t1: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: bool, $t1: u64): u64 {
-     var $t2: u64
-     var $t3: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
   0: if ($t0) goto 1 else goto 3
   1: label L0
   2: goto 4

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
@@ -100,7 +100,7 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::id($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
   0: return $t0
 }
 
@@ -108,9 +108,9 @@ fun m::id($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: u64
-     var $t3: u64
-     var $t4: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
      var $t5: u64
      var $t6: u64
   0: $t6 := m::id($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
@@ -102,10 +102,10 @@ fun m::update($t0: &mut u64) {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
      var $t5: &mut u64
   0: $t2 := copy($t0)
   1: $t5 := borrow_local($t2)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
@@ -51,7 +51,7 @@ fun m::cyclic($t0: u64): u64 {
 fun m::cyclic($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64  [unused]
+     var $t3: u64 [unused]
   0: $t2 := move($t0)
   1: return $t2
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/cyclic_assignments.exp
@@ -49,9 +49,9 @@ fun m::cyclic($t0: u64): u64 {
 
 [variant baseline]
 fun m::cyclic($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64
+     var $t3: u64  [unused]
   0: $t2 := move($t0)
   1: return $t2
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_1.exp
@@ -45,8 +45,8 @@ fun m::dead($t0: u64): u64 {
 
 [variant baseline]
 fun m::dead($t0: u64): u64 {
-     var $t1: u64
-     var $t2: u64
-     var $t3: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
   0: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
@@ -35,6 +35,6 @@ fun m::dead($t0: u64): u64 {
 
 [variant baseline]
 fun m::dead($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
   0: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
@@ -60,10 +60,10 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: &u64
+     var $t2: &u64 [unused]
      var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64
+     var $t4: &u64 [unused]
+     var $t5: &u64 [unused]
   0: $t3 := borrow_local($t0)
   1: $t1 := read_ref($t3)
   2: return $t1

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
@@ -77,12 +77,12 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
-     var $t2: &u64
+     var $t1: u64 [unused]
+     var $t2: &u64 [unused]
      var $t3: &u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
   0: $t3 := borrow_local($t0)
   1: drop($t3)
   2: $t4 := move($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
@@ -131,7 +131,7 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
      var $t2: u64
      var $t3: u64
      var $t4: u64

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
@@ -124,8 +124,8 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
-     var $t2: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
      var $t3: u64
      var $t4: u64
      var $t5: bool

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
@@ -63,9 +63,9 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
+     var $t1: u64 [unused]
      var $t2: u64
-     var $t3: &mut u64
+     var $t3: &mut u64 [unused]
      var $t4: &mut u64
      var $t5: u64
   0: $t2 := copy($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
@@ -116,7 +116,7 @@ fun m::test($t0: m::S): u64 {
      var $t1: u64
      var $t2: m::S
      var $t3: m::S
-     var $t4: &mut u64
+     var $t4: &mut u64 [unused]
      var $t5: &mut u64
      var $t6: &mut m::S
      var $t7: u64

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -71,10 +71,10 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: &mut u64
+     var $t2: &mut u64 [unused]
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &mut u64
+     var $t4: &mut u64 [unused]
+     var $t5: &mut u64 [unused]
      var $t6: u64
   0: $t3 := borrow_local($t0)
   1: $t6 := 0

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
@@ -90,12 +90,12 @@ fun m::test($t0: u64): u64 {
 
 [variant baseline]
 fun m::test($t0: u64): u64 {
-     var $t1: u64
-     var $t2: &mut u64
+     var $t1: u64 [unused]
+     var $t2: &mut u64 [unused]
      var $t3: &mut u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
      var $t7: u64
   0: $t3 := borrow_local($t0)
   1: $t4 := copy($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_1.exp
@@ -71,8 +71,8 @@ fun m::test($t0: u64): bool {
 [variant baseline]
 fun m::test($t0: u64): bool {
      var $t1: bool
-     var $t2: u64
-     var $t3: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64
      var $t6: u64

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_2.exp
@@ -71,9 +71,9 @@ fun m::test($t0: u64): bool {
 [variant baseline]
 fun m::test($t0: u64): bool {
      var $t1: bool
-     var $t2: u64
+     var $t2: u64 [unused]
      var $t3: u64
-     var $t4: u64
+     var $t4: u64 [unused]
      var $t5: u64
      var $t6: u64
   0: $t3 := move($t0)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/sequential_assign_struct.exp
@@ -66,11 +66,11 @@ fun m::sequential($t0: m::Foo): m::Foo {
 
 [variant baseline]
 fun m::sequential($t0: m::Foo): m::Foo {
-     var $t1: m::Foo
-     var $t2: m::Foo
-     var $t3: m::Foo
-     var $t4: m::Foo
-     var $t5: m::Foo
-     var $t6: m::Foo
+     var $t1: m::Foo [unused]
+     var $t2: m::Foo [unused]
+     var $t3: m::Foo [unused]
+     var $t4: m::Foo [unused]
+     var $t5: m::Foo [unused]
+     var $t6: m::Foo [unused]
   0: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/simple_sequential_assign.exp
@@ -66,11 +66,11 @@ fun m::sequential($t0: u64): u64 {
 
 [variant baseline]
 fun m::sequential($t0: u64): u64 {
-     var $t1: u64
-     var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
   0: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
@@ -65,7 +65,7 @@ fun m::copy_kill($t0: u64): u64 {
 fun m::copy_kill($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64
   0: $t2 := copy($t0)

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -16,7 +16,6 @@ use move_compiler_v2::{
         uninitialized_use_checker::UninitializedUseChecker,
         unreachable_code_analysis::UnreachableCodeProcessor,
         unreachable_code_remover::UnreachableCodeRemover, variable_coalescing::VariableCoalescing,
-       
     },
     run_bytecode_verifier, run_file_format_gen, Options,
 };
@@ -286,7 +285,7 @@ impl TestConfig {
             }));
             pipeline.add_processor(Box::new(VariableCoalescing {}));
             Self {
-                type_check_only: false,
+                stop_before_generating_bytecode: false,
                 dump_ast: false,
                 pipeline,
                 generate_file_format: false,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -15,7 +15,8 @@ use move_compiler_v2::{
         reference_safety_processor::ReferenceSafetyProcessor,
         uninitialized_use_checker::UninitializedUseChecker,
         unreachable_code_analysis::UnreachableCodeProcessor,
-        unreachable_code_remover::UnreachableCodeRemover,
+        unreachable_code_remover::UnreachableCodeRemover, variable_coalescing::VariableCoalescing,
+       
     },
     run_bytecode_verifier, run_file_format_gen, Options,
 };
@@ -277,6 +278,19 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: true,
                 dump_annotated_targets: false,
+                dump_for_only_some_stages: None,
+            }
+        } else if path.contains("/variable-coalescing/") {
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
+                with_copy_inference: false,
+            }));
+            pipeline.add_processor(Box::new(VariableCoalescing {}));
+            Self {
+                type_check_only: false,
+                dump_ast: false,
+                pipeline,
+                generate_file_format: false,
+                dump_annotated_targets: true,
                 dump_for_only_some_stages: None,
             }
         } else {

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -280,9 +280,7 @@ impl TestConfig {
                 dump_for_only_some_stages: None,
             }
         } else if path.contains("/variable-coalescing/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {
-                with_copy_inference: false,
-            }));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(VariableCoalescing {}));
             Self {
                 stop_before_generating_bytecode: false,

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
@@ -125,12 +125,12 @@ fun m::test() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-     var $t11: u64
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
   0: $t1 := 0
   1: $t0 := infer($t1)
   2: label L0

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -117,14 +117,14 @@ fun m::test($t0: bool, $t1: bool) {
 
 [variant baseline]
 fun m::test($t0: bool, $t1: bool) {
-     var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: u64
-     var $t9: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
   0: label L0
   1: if ($t0) goto 2 else goto 9
   2: label L2

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
@@ -31,7 +31,7 @@ fun m::test(): u64 {
 
 [variant baseline]
 fun m::test(): u64 {
-     var $t0: u64
+     var $t0: u64 [unused]
   0: label L0
   1: goto 0
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
@@ -30,7 +30,7 @@ fun m::test(): u32 {
 
 [variant baseline]
 fun m::test(): u32 {
-     var $t0: u32
+     var $t0: u32 [unused]
      var $t1: u64
   0: $t1 := 0
   1: abort($t1)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -67,12 +67,12 @@ fun m::test() {
 fun m::test() {
      var $t0: u64
      var $t1: u64
-     var $t2: &u64
+     var $t2: &u64 [unused]
      var $t3: &u64
      var $t4: &u64
      var $t5: &u64
      var $t6: bool
-     var $t7: u64
+     var $t7: u64 [unused]
      var $t8: u64
   0: $t1 := 5
   1: $t0 := infer($t1)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -1,0 +1,88 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+  0: $t1 := 5
+  1: $t0 := infer($t1)
+  2: $t3 := borrow_local($t0)
+  3: $t2 := infer($t3)
+  4: $t4 := infer($t2)
+  5: $t5 := borrow_local($t0)
+  6: $t2 := infer($t5)
+  7: $t7 := read_ref($t2)
+  8: $t8 := 5
+  9: $t6 := ==($t7, $t8)
+ 10: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     # live vars:
+  0: $t1 := 5
+     # live vars: $t1
+  1: $t0 := infer($t1)
+     # live vars: $t0
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t3
+  3: $t2 := infer($t3)
+     # live vars: $t0, $t2
+  4: $t4 := infer($t2)
+     # live vars: $t0
+  5: $t5 := borrow_local($t0)
+     # live vars: $t5
+  6: $t2 := infer($t5)
+     # live vars: $t2
+  7: $t7 := read_ref($t2)
+     # live vars: $t7
+  8: $t8 := 5
+     # live vars: $t7, $t8
+  9: $t6 := ==($t7, $t8)
+     # live vars:
+ 10: return ()
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+  0: $t1 := 5
+  1: $t0 := infer($t1)
+  2: $t3 := borrow_local($t0)
+  3: $t3 := infer($t3)
+  4: $t4 := infer($t3)
+  5: $t5 := borrow_local($t0)
+  6: $t3 := infer($t5)
+  7: $t1 := read_ref($t3)
+  8: $t8 := 5
+  9: $t6 := ==($t1, $t8)
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+fun test() {
+    let x = 5;
+    let x_ref = &x;
+    x_ref;
+    x_ref = &x;
+    *x_ref == 5;
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -75,13 +75,13 @@ fun m::test($t0: bool): u64 {
 
 [variant baseline]
 fun m::test($t0: bool): u64 {
-     var $t1: u64
-     var $t2: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
      var $t3: u64
-     var $t4: u64
+     var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
      var $t8: u64
   0: $t3 := 2
   1: $t3 := infer($t3)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -1,0 +1,101 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t3 := 2
+  1: $t2 := infer($t3)
+  2: if ($t0) goto 3 else goto 8
+  3: label L0
+  4: $t5 := 3
+  5: $t4 := infer($t5)
+  6: $t1 := infer($t4)
+  7: goto 13
+  8: label L1
+  9: $t8 := 1
+ 10: $t7 := +($t2, $t8)
+ 11: $t6 := infer($t7)
+ 12: $t1 := infer($t6)
+ 13: label L2
+ 14: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # live vars: $t0
+  0: $t3 := 2
+     # live vars: $t0, $t3
+  1: $t2 := infer($t3)
+     # live vars: $t0, $t2
+  2: if ($t0) goto 3 else goto 8
+     # live vars: $t2
+  3: label L0
+     # live vars:
+  4: $t5 := 3
+     # live vars: $t5
+  5: $t4 := infer($t5)
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 13
+     # live vars: $t2
+  8: label L1
+     # live vars: $t2
+  9: $t8 := 1
+     # live vars: $t2, $t8
+ 10: $t7 := +($t2, $t8)
+     # live vars: $t7
+ 11: $t6 := infer($t7)
+     # live vars: $t6
+ 12: $t1 := infer($t6)
+     # live vars: $t1
+ 13: label L2
+     # live vars: $t1
+ 14: return $t1
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t3 := 2
+  1: $t3 := infer($t3)
+  2: if ($t0) goto 3 else goto 8
+  3: label L0
+  4: $t5 := 3
+  5: $t5 := infer($t5)
+  6: $t5 := infer($t5)
+  7: goto 13
+  8: label L1
+  9: $t8 := 1
+ 10: $t3 := +($t3, $t8)
+ 11: $t3 := infer($t3)
+ 12: $t5 := infer($t3)
+ 13: label L2
+ 14: return $t5
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun test(p: bool): u64 {
+        let x = 2;
+        if (p) {
+            let y = 3;
+            y
+        } else {
+            let y = x + 1;
+            y
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -63,14 +63,14 @@ fun m::test() {
 
 [variant baseline]
 fun m::test() {
-     var $t0: u64
+     var $t0: u64 [unused]
      var $t1: u64
-     var $t2: u64
+     var $t2: u64 [unused]
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
   0: $t1 := 1
   1: $t1 := infer($t1)
   2: $t3 := 1

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -1,0 +1,85 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t1 := 1
+  1: $t0 := infer($t1)
+  2: $t3 := 1
+  3: $t2 := +($t0, $t3)
+  4: $t0 := infer($t2)
+  5: $t5 := 2
+  6: $t4 := infer($t5)
+  7: $t7 := 1
+  8: $t6 := +($t4, $t7)
+  9: $t4 := infer($t6)
+ 10: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := infer($t1)
+     # live vars: $t0
+  2: $t3 := 1
+     # live vars: $t0, $t3
+  3: $t2 := +($t0, $t3)
+     # live vars: $t2
+  4: $t0 := infer($t2)
+     # live vars:
+  5: $t5 := 2
+     # live vars: $t5
+  6: $t4 := infer($t5)
+     # live vars: $t4
+  7: $t7 := 1
+     # live vars: $t4, $t7
+  8: $t6 := +($t4, $t7)
+     # live vars: $t6
+  9: $t4 := infer($t6)
+     # live vars:
+ 10: return ()
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t1 := 1
+  1: $t1 := infer($t1)
+  2: $t3 := 1
+  3: $t1 := +($t1, $t3)
+  4: $t1 := infer($t1)
+  5: $t1 := 2
+  6: $t1 := infer($t1)
+  7: $t3 := 1
+  8: $t1 := +($t1, $t3)
+  9: $t1 := infer($t1)
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun test() {
+        let x = 1;
+        x = x + 1;
+        let y = 2;
+        y = y + 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -1,0 +1,85 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u32
+     var $t1: u32
+     var $t2: u32
+     var $t3: u32
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t1 := 1
+  1: $t0 := infer($t1)
+  2: $t3 := 1
+  3: $t2 := +($t0, $t3)
+  4: $t0 := infer($t2)
+  5: $t5 := 2
+  6: $t4 := infer($t5)
+  7: $t7 := 1
+  8: $t6 := +($t4, $t7)
+  9: $t4 := infer($t6)
+ 10: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u32
+     var $t1: u32
+     var $t2: u32
+     var $t3: u32
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := infer($t1)
+     # live vars: $t0
+  2: $t3 := 1
+     # live vars: $t0, $t3
+  3: $t2 := +($t0, $t3)
+     # live vars: $t2
+  4: $t0 := infer($t2)
+     # live vars:
+  5: $t5 := 2
+     # live vars: $t5
+  6: $t4 := infer($t5)
+     # live vars: $t4
+  7: $t7 := 1
+     # live vars: $t4, $t7
+  8: $t6 := +($t4, $t7)
+     # live vars: $t6
+  9: $t4 := infer($t6)
+     # live vars:
+ 10: return ()
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u32
+     var $t1: u32
+     var $t2: u32
+     var $t3: u32
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t1 := 1
+  1: $t1 := infer($t1)
+  2: $t3 := 1
+  3: $t1 := +($t1, $t3)
+  4: $t1 := infer($t1)
+  5: $t5 := 2
+  6: $t5 := infer($t5)
+  7: $t7 := 1
+  8: $t5 := +($t5, $t7)
+  9: $t5 := infer($t5)
+ 10: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -63,13 +63,13 @@ fun m::test() {
 
 [variant baseline]
 fun m::test() {
-     var $t0: u32
+     var $t0: u32 [unused]
      var $t1: u32
-     var $t2: u32
+     var $t2: u32 [unused]
      var $t3: u32
-     var $t4: u64
+     var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64
+     var $t6: u64 [unused]
      var $t7: u64
   0: $t1 := 1
   1: $t1 := infer($t1)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun test() {
+        let x: u32 = 1;
+        x = x + 1;
+        let y: u64 = 2;
+        y = y + 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -1,0 +1,77 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t4 := 2
+  3: $t3 := infer($t4)
+  4: $t6 := 3
+  5: $t5 := infer($t6)
+  6: $t7 := +($t1, $t3)
+  7: $t0 := +($t7, $t5)
+  8: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+  0: $t2 := 1
+     # live vars: $t2
+  1: $t1 := infer($t2)
+     # live vars: $t1
+  2: $t4 := 2
+     # live vars: $t1, $t4
+  3: $t3 := infer($t4)
+     # live vars: $t1, $t3
+  4: $t6 := 3
+     # live vars: $t1, $t3, $t6
+  5: $t5 := infer($t6)
+     # live vars: $t1, $t3, $t5
+  6: $t7 := +($t1, $t3)
+     # live vars: $t5, $t7
+  7: $t0 := +($t7, $t5)
+     # live vars: $t0
+  8: return $t0
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := 1
+  1: $t2 := infer($t2)
+  2: $t4 := 2
+  3: $t4 := infer($t4)
+  4: $t6 := 3
+  5: $t6 := infer($t6)
+  6: $t2 := +($t2, $t4)
+  7: $t2 := +($t2, $t6)
+  8: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -57,14 +57,14 @@ fun m::test(): u64 {
 
 [variant baseline]
 fun m::test(): u64 {
-     var $t0: u64
-     var $t1: u64
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64
-     var $t5: u64
+     var $t5: u64 [unused]
      var $t6: u64
-     var $t7: u64
+     var $t7: u64 [unused]
   0: $t2 := 1
   1: $t2 := infer($t2)
   2: $t4 := 2

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let x = 1;
+        let y = 2;
+        let z = 3;
+        x + y + z
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -1,0 +1,67 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t4 := 2
+  3: $t3 := infer($t4)
+  4: $t5 := 9
+  5: $t1 := infer($t5)
+  6: $t0 := +($t1, $t3)
+  7: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars:
+  0: $t2 := 1
+     # live vars: $t2
+  1: $t1 := infer($t2)
+     # live vars:
+  2: $t4 := 2
+     # live vars: $t4
+  3: $t3 := infer($t4)
+     # live vars: $t3
+  4: $t5 := 9
+     # live vars: $t3, $t5
+  5: $t1 := infer($t5)
+     # live vars: $t1, $t3
+  6: $t0 := +($t1, $t3)
+     # live vars: $t0
+  7: return $t0
+}
+
+============ after VariableCoalescing: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := 1
+  1: $t5 := infer($t2)
+  2: $t2 := 2
+  3: $t2 := infer($t2)
+  4: $t5 := 9
+  5: $t5 := infer($t5)
+  6: $t2 := +($t5, $t2)
+  7: return $t2
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let a = 1;
+        let b = 2;
+        a = 9; // reassigned
+        a + b
+    }
+
+}

--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -717,11 +717,13 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
             writeln!(f, ";")?;
         } else {
             writeln!(f, " {{")?;
+            let verification = self.data.variant.is_verified();
             let mentioned_locals = self.get_mentioned_locals();
             for i in self.get_parameter_count()..self.get_local_count() {
                 write!(f, "     var ")?;
                 write_decl(f, i)?;
-                if !mentioned_locals.contains(&i) {
+                if !verification && !mentioned_locals.contains(&i) {
+                    // We do not display unused annotation in verification mode.
                     write!(f, " [unused]")?;
                 }
                 writeln!(f)?;

--- a/third_party/move/move-model/bytecode/tests/borrow/basic_test.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/basic_test.exp
@@ -234,7 +234,7 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
 [variant baseline]
 fun TestBorrow::test1(): TestBorrow::R {
      var $t0|r: TestBorrow::R
-     var $t1|x_ref: &mut u64
+     var $t1|x_ref: &mut u64 [unused]
      var $t2: u64
      var $t3: &mut TestBorrow::R
      var $t4: &mut u64

--- a/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.exp
@@ -245,7 +245,7 @@ public fun Collection::make_collection<#0>(): Collection::Collection<#0> {
 [variant baseline]
 public fun Test::foo<#0>($t0|i: u64) {
      var $t1|c: Collection::Collection<Test::Token<#0>>
-     var $t2|t: &mut Test::Token<#0>
+     var $t2|t: &mut Test::Token<#0> [unused]
      var $t3: &mut Collection::Collection<Test::Token<#0>>
      var $t4: &mut Test::Token<#0>
      var $t5: u64

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.exp
@@ -338,7 +338,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
 [variant baseline]
 fun TestBorrow::test1(): TestBorrow::R {
      var $t0|r: TestBorrow::R
-     var $t1|x_ref: &mut u64
+     var $t1|x_ref: &mut u64 [unused]
      var $t2: u64
      var $t3: u64
      var $t4: &mut TestBorrow::R
@@ -375,7 +375,7 @@ fun TestBorrow::test1(): TestBorrow::R {
 fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      var $t1|r: TestBorrow::R
      var $t2|r_field: &mut u64
-     var $t3|r_ref: &mut TestBorrow::R
+     var $t3|r_ref: &mut TestBorrow::R [unused]
      var $t4: u64
      var $t5: u64
      var $t6: &mut TestBorrow::R

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.exp
@@ -535,7 +535,7 @@ public intrinsic fun vector::swap_remove<#0>($t0|v: &mut vector<#0>, $t1|i: u64)
 
 [variant baseline]
 fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
-     var $t1|r: &mut u64
+     var $t1|r: &mut u64 [unused]
      var $t2|x: TestMutRef::N
      var $t3: u64
      var $t4: u64
@@ -580,8 +580,8 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
 [variant baseline]
 fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
      var $t1|is: vector<u64>
-     var $t2|r: &mut u64
-     var $t3|ts: vector<TestMutRef::T>
+     var $t2|r: &mut u64 [unused]
+     var $t3|ts: vector<TestMutRef::T> [unused]
      var $t4|x: TestMutRef::V
      var $t5: vector<TestMutRef::T>
      var $t6: &mut vector<u64>
@@ -657,7 +657,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
 [variant baseline]
 fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V {
      var $t1|is: vector<u64>
-     var $t2|r: &mut u64
+     var $t2|r: &mut u64 [unused]
      var $t3|ts: vector<TestMutRef::T>
      var $t4|x: TestMutRef::V
      var $t5: &mut vector<u64>
@@ -776,7 +776,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
 [variant baseline]
 fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): TestMutRef::V {
      var $t1|is: vector<u64>
-     var $t2|r: &mut u64
+     var $t2|r: &mut u64 [unused]
      var $t3|ts: vector<TestMutRef::T>
      var $t4|x: TestMutRef::V
      var $t5: &mut vector<u64>
@@ -894,7 +894,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
 
 [variant baseline]
 fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, TestMutRef::R) {
-     var $t1|r: &mut u64
+     var $t1|r: &mut u64 [unused]
      var $t2|x: TestMutRef::T
      var $t3|y: TestMutRef::R
      var $t4: u64

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.exp
@@ -234,7 +234,7 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
 [variant baseline]
 fun TestPackref::test1(): TestPackref::R {
      var $t0|r: TestPackref::R
-     var $t1|x_ref: &mut u64
+     var $t1|x_ref: &mut u64 [unused]
      var $t2: u64
      var $t3: &mut TestPackref::R
      var $t4: &mut u64

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.exp
@@ -282,7 +282,7 @@ public fun TestMutRefs::data_invariant($t0|_x: &mut TestMutRefs::T) {
 
 [variant baseline]
 public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
-     var $t1|r: &mut TestMutRefs::TSum
+     var $t1|r: &mut TestMutRefs::TSum [unused]
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -316,8 +316,8 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
 
 [variant baseline]
 public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
-     var $t1|r: &mut TestMutRefs::TSum
-     var $t2|v: u64
+     var $t1|r: &mut TestMutRefs::TSum [unused]
+     var $t2|v: u64 [unused]
      var $t3: address
      var $t4: &mut TestMutRefs::TSum
      var $t5: u64
@@ -339,7 +339,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
 
 [variant baseline]
 public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
-     var $t1|r: &mut TestMutRefs::TSum
+     var $t1|r: &mut TestMutRefs::TSum [unused]
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -391,7 +391,7 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
 
 [variant baseline]
 public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
-     var $t1|r: &mut TestMutRefs::TSum
+     var $t1|r: &mut TestMutRefs::TSum [unused]
      var $t2: address
      var $t3: &mut TestMutRefs::TSum
      var $t4: u64
@@ -420,7 +420,7 @@ fun TestMutRefs::private_data_invariant_invalid($t0|_x: &mut TestMutRefs::T) {
 
 [variant baseline]
 fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
-     var $t1|r: &mut TestMutRefs::TSum
+     var $t1|r: &mut TestMutRefs::TSum [unused]
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -462,7 +462,7 @@ fun TestMutRefs::private_to_public_caller($t0|r: &mut TestMutRefs::T) {
 
 [variant baseline]
 fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
-     var $t0|r: &mut TestMutRefs::T
+     var $t0|r: &mut TestMutRefs::T [unused]
      var $t1|x: TestMutRefs::T
      var $t2: u64
      var $t3: &mut TestMutRefs::T


### PR DESCRIPTION
### Description

Closes https://github.com/aptos-labs/aptos-core/issues/11773 and https://github.com/aptos-labs/aptos-core/issues/11724.

Implements a new optimization called variable coalescing, which reuses locals of the same type when possible, thereby (potentially) reducing the number of locals needed in the final code generated by compiler v2. To do this safely, we implement an abstraction called "live intervals", taken from the paper [Linear Scan Register Allocation](https://web.cs.ucla.edu/~palsberg/course/cs132/linearscan.pdf). Quickly scanning that paper might be useful in understanding this implementation, as it is inspired (but different) from that paper. For more details on the analysis, see the module documentation for `variable_coalescing.rs`.

Note that this PR only adds the variable coalescing optimization, but it is likely not the most optimal placement/combination in the pipeline. We will address this in a followup PR.

### Test Plan
- Manually tested compilation of `aptos-token-objects` on reverting the workaround introduced in #11724.
- Added some variable coalescing specific tests.

TODO: adding more tests and improve the combination of optimizations (and figure out if copy propagation is mostly rendered redundant because of this optimization), which will be coming up in a followup PR.
