### PR TITLE
[dag] Smoke tests and related fixes

### DIFF
--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -165,9 +165,8 @@ impl OrderedNotifier for OrderedNotifierAdapter {
 
         NUM_NODES_PER_BLOCK.observe(ordered_nodes.len() as f64);
         let rounds_between = {
-            let anchor_node = ordered_nodes.first().map_or(0, |node| node.round());
-            let lowest_round_node = ordered_nodes.last().map_or(0, |node| node.round());
-            anchor_node.saturating_sub(lowest_round_node)
+            let lowest_round_node = ordered_nodes.first().map_or(0, |node| node.round());
+            round.saturating_sub(lowest_round_node)
         };
         NUM_ROUNDS_PER_BLOCK.observe((rounds_between + 1) as f64);
 

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -336,6 +336,10 @@ impl DagDriver {
             observe_round(prev_round_timestamp, RoundStage::Finished);
         }
     }
+
+    pub fn try_order_all(&self) {
+        self.order_rule.lock().process_all();
+    }
 }
 
 #[async_trait]

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -191,7 +191,7 @@ impl DagFetcherService {
         let remote_request = {
             let dag_reader = self.dag.read();
             ensure!(
-                node.round() > dag_reader.lowest_incomplete_round(),
+                node.round() >= dag_reader.lowest_incomplete_round(),
                 "Already synced beyond requested round {}, lowest incomplete round {}",
                 node.round(),
                 dag_reader.lowest_incomplete_round()

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -160,6 +160,8 @@ impl NetworkHandler {
                             Ok(certified_node) => {
                                 if let Err(e) = dag_driver_clone.process(certified_node).await {
                                     warn!(error = ?e, "error processing certified node fetch notification");
+                                } else {
+                                    dag_driver_clone.try_order_all();
                                 }
                             },
                             Err(e) => {

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -375,20 +375,21 @@ impl InMemDag {
     }
 
     pub fn bitmask(&self, target_round: Round) -> DagSnapshotBitmask {
-        let lowest_round = self.lowest_incomplete_round();
-
+        let from_round = target_round
+            .saturating_sub(self.window_size)
+            .max(self.start_round);
         let mut bitmask: Vec<_> = self
             .nodes_by_round
-            .range(lowest_round..=target_round)
+            .range(from_round..=target_round)
             .map(|(_, round_nodes)| round_nodes.iter().map(|node| node.is_some()).collect())
             .collect();
 
         bitmask.resize(
-            (target_round - lowest_round + 1) as usize,
+            (target_round - from_round + 1) as usize,
             vec![false; self.author_to_index.len()],
         );
 
-        DagSnapshotBitmask::new(lowest_round, bitmask)
+        DagSnapshotBitmask::new(from_round, bitmask)
     }
 
     pub(super) fn prune(&mut self) -> BTreeMap<u64, Vec<Option<NodeStatus>>> {

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -375,9 +375,14 @@ impl InMemDag {
     }
 
     pub fn bitmask(&self, target_round: Round) -> DagSnapshotBitmask {
-        let from_round = target_round
-            .saturating_sub(self.window_size)
-            .max(self.start_round);
+        let from_round = if self.is_empty() {
+            self.lowest_round()
+        } else {
+            target_round
+                .saturating_sub(self.window_size)
+                .max(self.lowest_incomplete_round())
+                .max(self.lowest_round())
+        };
         let mut bitmask: Vec<_> = self
             .nodes_by_round
             .range(from_round..=target_round)

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -115,6 +115,11 @@ impl OrderRule {
                 {
                     return Some(anchor_node.clone());
                 }
+            } else {
+                debug!(
+                    anchor = anchor_author,
+                    "Anchor not found for round {}", start_round
+                );
             }
             start_round += 2;
         }
@@ -218,8 +223,13 @@ impl OrderRule {
     /// Check if this node can trigger anchors to be ordered
     pub fn process_new_node(&self, node_metadata: &NodeMetadata) {
         let lowest_unordered_anchor_round = *self.lowest_unordered_anchor_round.read();
-
         let round = node_metadata.round();
+
+        debug!(
+            lowest_unordered_round = lowest_unordered_anchor_round,
+            node_round = round,
+            "Trigger Ordering"
+        );
         // If the node comes from the proposal round in the current instance, it can't trigger any ordering
         if round <= lowest_unordered_anchor_round
             || Self::check_parity(round, lowest_unordered_anchor_round)

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -253,36 +253,42 @@ fn test_dag_bitmask() {
     let (signers, epoch_state, dag, _) = setup();
 
     assert_eq!(
-        dag.read().bitmask(15),
-        DagSnapshotBitmask::new(1, vec![vec![false; 4]; 15])
+        dag.read().bitmask(TEST_DAG_WINDOW),
+        DagSnapshotBitmask::new(1, vec![vec![false; 4]; TEST_DAG_WINDOW as usize])
     );
 
     for round in 1..5 {
         let parents = dag
             .read()
-            .get_strong_links_for_round(round, &epoch_state.verifier)
+            .get_strong_links_for_round(round - 1, &epoch_state.verifier)
             .unwrap_or_default();
+        if round > 1 {
+            assert!(!parents.is_empty());
+        }
         for signer in &signers[0..3] {
             let node = new_certified_node(round, signer.author(), parents.clone());
             assert!(dag.write().add_node_for_test(node).is_ok());
         }
     }
-    let mut bitmask = vec![vec![true, true, true, false]; 4];
-    bitmask.resize(15, vec![false; 4]);
-    assert_eq!(dag.read().bitmask(15), DagSnapshotBitmask::new(1, bitmask));
+    let mut bitmask = vec![vec![true, true, true, false]; 2];
+    bitmask.resize(TEST_DAG_WINDOW as usize + 1, vec![false; 4]);
+    assert_eq!(dag.read().bitmask(8), DagSnapshotBitmask::new(3, bitmask));
 
     // Populate the fourth author for all rounds
     for round in 1..5 {
         let parents = dag
             .read()
-            .get_strong_links_for_round(round, &epoch_state.verifier)
+            .get_strong_links_for_round(round - 1, &epoch_state.verifier)
             .unwrap_or_default();
+        if round > 1 {
+            assert!(!parents.is_empty());
+        }
         let node = new_certified_node(round, signers[3].author(), parents.clone());
         assert!(dag.write().add_node_for_test(node).is_ok());
     }
     assert_eq!(
-        dag.read().bitmask(15),
-        DagSnapshotBitmask::new(5, vec![vec![false; 4]; 11])
+        dag.read().bitmask(10),
+        DagSnapshotBitmask::new(5, vec![vec![false; 4]; 6])
     );
     assert_eq!(
         dag.read().bitmask(6),

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -267,6 +267,9 @@ impl NetworkSender {
         msg: ConsensusMsg,
         timeout_duration: Duration,
     ) -> anyhow::Result<ConsensusMsg> {
+        fail_point!("consensus::send::any", |_| {
+            Err(anyhow::anyhow!("Injected error in send_rpc"))
+        });
         counters::CONSENSUS_SENT_MSGS
             .with_label_values(&[msg.name()])
             .inc();

--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -70,7 +70,11 @@ impl Drop for ActiveTrafficGuard {
     }
 }
 
-pub async fn start_traffic(num_accounts: usize, tps: f32, swarm: &mut dyn Swarm) -> ActiveTrafficGuard {
+pub async fn start_traffic(
+    num_accounts: usize,
+    tps: f32,
+    swarm: &mut dyn Swarm,
+) -> ActiveTrafficGuard {
     let validator_clients = swarm.get_all_nodes_clients_with_names();
 
     let finish = Arc::new(AtomicBool::new(false));

--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -60,8 +60,8 @@ pub async fn create_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
     swarm
 }
 
-struct ActiveTrafficGuard {
-    finish_traffic: Arc<AtomicBool>,
+pub struct ActiveTrafficGuard {
+    pub finish_traffic: Arc<AtomicBool>,
 }
 
 impl Drop for ActiveTrafficGuard {
@@ -70,7 +70,7 @@ impl Drop for ActiveTrafficGuard {
     }
 }
 
-async fn start_traffic(num_accounts: usize, tps: f32, swarm: &mut dyn Swarm) -> ActiveTrafficGuard {
+pub async fn start_traffic(num_accounts: usize, tps: f32, swarm: &mut dyn Swarm) -> ActiveTrafficGuard {
     let validator_clients = swarm.get_all_nodes_clients_with_names();
 
     let finish = Arc::new(AtomicBool::new(false));

--- a/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
@@ -1,0 +1,249 @@
+// Copyright © Aptos Foundation
+
+use crate::{consensus::consensus_fault_tolerance::{start_traffic, ActiveTrafficGuard}, smoke_test_environment::SwarmBuilder};
+use aptos_config::config::DagFetcherConfig;
+use aptos_forge::{
+    test_utils::consensus_utils::{no_failure_injection, test_consensus_fault_tolerance, FailPointFailureInjection, NodeState},
+    LocalSwarm,
+};
+use aptos_types::on_chain_config::{
+    ConsensusAlgorithmConfig, DagConsensusConfigV1, OnChainConsensusConfig, ValidatorTxnConfig,
+};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::sync::{atomic::AtomicBool, Arc};
+
+pub async fn create_dag_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
+    let swarm = SwarmBuilder::new_local(num_nodes)
+        .with_init_config(Arc::new(move |_, config, _| {
+            config.api.failpoints_enabled = true;
+            config
+                .state_sync
+                .state_sync_driver
+                .enable_auto_bootstrapping = true;
+            config
+                .state_sync
+                .state_sync_driver
+                .max_connection_deadline_secs = 3;
+            config.dag_consensus.fetcher_config = DagFetcherConfig {
+                retry_interval_ms: 30,
+                rpc_timeout_ms: 500,
+                min_concurrent_responders: 2,
+                max_concurrent_responders: 7,
+            }
+        }))
+        .with_init_genesis_config(Arc::new(move |genesis_config| {
+            let onchain_consensus_config = OnChainConsensusConfig::V3 {
+                alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
+                vtxn: ValidatorTxnConfig::default_for_genesis(),
+            };
+
+            genesis_config.consensus_config = onchain_consensus_config;
+        }))
+        .build()
+        .await;
+
+    println!(
+        "Validators {:?}",
+        swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>()
+    );
+    swarm
+}
+
+#[tokio::test]
+async fn test_no_failures() {
+    let num_validators = 3;
+
+    let mut swarm = create_dag_swarm(num_validators, 1 * num_validators as u64).await;
+
+    test_consensus_fault_tolerance(
+        &mut swarm,
+        3,
+        5.0,
+        1,
+        no_failure_injection(),
+        Box::new(move |_, _, executed_rounds, executed_transactions, _, _| {
+            assert!(
+                executed_transactions >= 4,
+                "no progress with active consensus, only {} transactions",
+                executed_transactions
+            );
+            assert!(
+                executed_rounds >= 2,
+                "no progress with active consensus, only {} rounds",
+                executed_rounds
+            );
+            Ok(())
+        }),
+        true,
+        false,
+    )
+    .await
+    .unwrap();
+}
+
+async fn run_dag_fail_point_test(
+    num_validators: usize,
+    cycles: usize,
+    cycle_duration_s: f32,
+    parts_in_cycle: usize,
+    traffic_tps: f32,
+    max_block_size: u64,
+    // (cycle, part) -> (Vec(validator_index, name, action), reset_old_enpoints)
+    get_fail_points_to_set: Box<
+        dyn FnMut(usize, usize) -> (Vec<(usize, String, String)>, bool) + Send,
+    >,
+    // (cycle, executed_epochs, executed_rounds, executed_transactions, current_state, previous_state)
+    check_cycle: Box<
+        dyn FnMut(usize, u64, u64, u64, Vec<NodeState>, Vec<NodeState>) -> anyhow::Result<()>,
+    >,
+) {
+    let mut swarm = create_dag_swarm(num_validators, max_block_size).await;
+    let _active_traffic = if traffic_tps > 0.0 {
+        start_traffic(5, traffic_tps, &mut swarm).await
+    } else {
+        ActiveTrafficGuard {
+            finish_traffic: Arc::new(AtomicBool::new(false)),
+        }
+    };
+    test_consensus_fault_tolerance(
+        &mut swarm,
+        cycles,
+        cycle_duration_s,
+        parts_in_cycle,
+        Box::new(FailPointFailureInjection::new(get_fail_points_to_set)),
+        check_cycle,
+        false,
+        false,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_fault_tolerance_of_network_send() {
+    // Randomly increase network failure rate, until network halts, and check that it comes back afterwards.
+    let mut small_rng = SmallRng::from_entropy();
+    let num_validators = 3;
+    let num_cycles = 4;
+    run_dag_fail_point_test(
+        num_validators,
+        num_cycles,
+        2.5,
+        5,
+        1.0,
+        1,
+        Box::new(move |cycle, _part| {
+            let max = 10 * (10 - num_cycles + cycle + 1);
+            let rand: usize = small_rng.gen_range(0, 1000);
+            let rand_reliability = ((rand as f32 / 1000.0).powf(0.5) * max as f32) as i32;
+            let wanted_client = small_rng.gen_range(0usize, num_validators);
+
+            (
+                vec![(
+                    wanted_client,
+                    "consensus::send::any".to_string(),
+                    format!("{}%return", rand_reliability),
+                )],
+                false,
+            )
+        }),
+        Box::new(|_, _, _, _, _, _| Ok(())),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_fault_tolerance_of_network_receive() {
+    // Randomly increase network failure rate, until network halts, and check that it comes back afterwards.
+    let mut small_rng = SmallRng::from_entropy();
+    let num_validators = 3;
+    let num_cycles = 4;
+    run_dag_fail_point_test(
+        num_validators,
+        num_cycles,
+        2.5,
+        5,
+        1.0,
+        1,
+        Box::new(move |cycle, _part| {
+            let max = 10 * (10 - num_cycles + cycle + 1);
+            let rand: usize = small_rng.gen_range(0, 1000);
+            let rand_reliability = ((rand as f32 / 1000.0).powf(0.5) * max as f32) as i32;
+            let wanted_client = small_rng.gen_range(0usize, num_validators);
+
+            (
+                vec![(
+                    wanted_client,
+                    "consensus::process::any".to_string(),
+                    format!("{}%return", rand_reliability),
+                )],
+                false,
+            )
+        }),
+        Box::new(|_, _, _, _, _, _| Ok(())),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_changing_working_consensus() {
+    // with 7 nodes, consensus needs 5 to operate.
+    // we rotate in each cycle, which 2 nodes are down.
+    // we should consisnently be seeing progress.
+    let num_validators = 7;
+    run_dag_fail_point_test(
+        num_validators,
+        6,
+        10.0,
+        2,
+        1.0,
+        num_validators as u64,
+        Box::new(move |cycle, part| {
+            if part == 0 {
+                let client_1 = (cycle * 2) % num_validators;
+                let client_2 = (cycle * 2 + 1) % num_validators;
+                (
+                    vec![
+                        (
+                            client_1,
+                            "consensus::send::any".to_string(),
+                            "return".to_string(),
+                        ),
+                        (
+                            client_1,
+                            "consensus::process::any".to_string(),
+                            "return".to_string(),
+                        ),
+                        (
+                            client_2,
+                            "consensus::send::any".to_string(),
+                            "return".to_string(),
+                        ),
+                        (
+                            client_2,
+                            "consensus::process::any".to_string(),
+                            "return".to_string(),
+                        ),
+                    ],
+                    true,
+                )
+            } else {
+                (vec![], false)
+            }
+        }),
+        Box::new(|_, _, executed_rounds, executed_transactions, _, _| {
+            assert!(
+                executed_transactions >= 1,
+                "no progress with active consensus, only {} transactions",
+                executed_transactions
+            );
+            assert!(
+                executed_rounds >= 2,
+                "no progress with active consensus, only {} rounds",
+                executed_rounds
+            );
+            Ok(())
+        }),
+    )
+    .await;
+}

--- a/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
@@ -1,9 +1,14 @@
 // Copyright © Aptos Foundation
 
-use crate::{consensus::consensus_fault_tolerance::{start_traffic, ActiveTrafficGuard}, smoke_test_environment::SwarmBuilder};
+use crate::{
+    consensus::consensus_fault_tolerance::{start_traffic, ActiveTrafficGuard},
+    smoke_test_environment::SwarmBuilder,
+};
 use aptos_config::config::DagFetcherConfig;
 use aptos_forge::{
-    test_utils::consensus_utils::{no_failure_injection, test_consensus_fault_tolerance, FailPointFailureInjection, NodeState},
+    test_utils::consensus_utils::{
+        no_failure_injection, test_consensus_fault_tolerance, FailPointFailureInjection, NodeState,
+    },
     LocalSwarm,
 };
 use aptos_types::on_chain_config::{
@@ -12,7 +17,7 @@ use aptos_types::on_chain_config::{
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::sync::{atomic::AtomicBool, Arc};
 
-pub async fn create_dag_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
+pub async fn create_dag_swarm(num_nodes: usize) -> LocalSwarm {
     let swarm = SwarmBuilder::new_local(num_nodes)
         .with_init_config(Arc::new(move |_, config, _| {
             config.api.failpoints_enabled = true;
@@ -53,7 +58,7 @@ pub async fn create_dag_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwa
 async fn test_no_failures() {
     let num_validators = 3;
 
-    let mut swarm = create_dag_swarm(num_validators, 1 * num_validators as u64).await;
+    let mut swarm = create_dag_swarm(num_validators).await;
 
     test_consensus_fault_tolerance(
         &mut swarm,
@@ -87,7 +92,7 @@ async fn run_dag_fail_point_test(
     cycle_duration_s: f32,
     parts_in_cycle: usize,
     traffic_tps: f32,
-    max_block_size: u64,
+    _max_block_size: u64,
     // (cycle, part) -> (Vec(validator_index, name, action), reset_old_enpoints)
     get_fail_points_to_set: Box<
         dyn FnMut(usize, usize) -> (Vec<(usize, String, String)>, bool) + Send,
@@ -97,7 +102,7 @@ async fn run_dag_fail_point_test(
         dyn FnMut(usize, u64, u64, u64, Vec<NodeState>, Vec<NodeState>) -> anyhow::Result<()>,
     >,
 ) {
-    let mut swarm = create_dag_swarm(num_validators, max_block_size).await;
+    let mut swarm = create_dag_swarm(num_validators).await;
     let _active_traffic = if traffic_tps > 0.0 {
         start_traffic(5, traffic_tps, &mut swarm).await
     } else {

--- a/testsuite/smoke-test/src/consensus/dag/mod.rs
+++ b/testsuite/smoke-test/src/consensus/dag/mod.rs
@@ -1,0 +1,3 @@
+// Copyright © Aptos Foundation
+
+mod dag_fault_tolerance;

--- a/testsuite/smoke-test/src/consensus/mod.rs
+++ b/testsuite/smoke-test/src/consensus/mod.rs
@@ -4,4 +4,5 @@
 mod consensus_fault_tolerance;
 mod consensus_only;
 mod consensusdb_recovery;
+mod dag;
 mod quorum_store_fault_tolerance;


### PR DESCRIPTION
### Description

This PR copies the existing consensus smoke tests and adapts it to DAG consensus. It also includes two fixes identified from running the tests.
- Any fetch was fetching from the lowest incomplete round, but that is not realistic as validators fail to propose and rounds can be incomplete. Using the lowest incomplete round as the start round for fetch resulted in fetching >30 (3*window) rounds and failing because thats the GC limit. However, we only need to fetch the last 10 (window) rounds as that's the window we order.
- When a validator processes a certified node after its missing parents have been fetched, all the nodes in the fetched rounds should be processed to ensure prompt ordering. Otherwise the ordering can be arbitrarily delayed until a round that mis-matches the parity of last ordered round is processed for ordering.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Smoke tests pass