### PR TITLE
[storage] counting root dropping in smt benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3554,6 +3554,7 @@ dependencies = [
 name = "aptos-scratchpad"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-experimental-runtimes",

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+anyhow = {workspace = true }
 aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }


### PR DESCRIPTION
### Description

### Test Plan
`Previous`
insert to empty/batch_update/10000
                        time:   [2.4067 ms 2.4426 ms 2.4797 ms]
                        thrpt:  [4.0327 Melem/s 4.0940 Melem/s 4.1551 Melem/s]
                 change:
                        time:   [+1.3998% +3.8304% +6.1273%] (p = 0.00 < 0.05)
                        thrpt:  [-5.7735% -3.6891% -1.3805%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

insert to committed base/batch_update/10000
                        time:   [7.3363 ms 7.4373 ms 7.5406 ms]
                        thrpt:  [1.3262 Melem/s 1.3446 Melem/s 1.3631 Melem/s]
                 change:
                        time:   [-4.3511% -2.4514% -0.3840%] (p = 0.02 < 0.05)
                        thrpt:  [+0.3854% +2.5130% +4.5491%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe

insert to uncommitted base/batch_update/10000
                        time:   [7.6242 ms 7.7164 ms 7.8122 ms]
                        thrpt:  [1.2800 Melem/s 1.2959 Melem/s 1.3116 Melem/s]
                 change:
                        time:   [-1.3695% +0.7408% +2.9545%] (p = 0.50 > 0.05)
                        thrpt:  [-2.8697% -0.7354% +1.3885%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe