### PR TITLE
[gha] Add additional optional cache key

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -2,6 +2,10 @@ inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git"
     required: false
+  ADDITIONAL_KEY:
+    description: "An optional additional key to pass to rust-cache"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -15,6 +19,8 @@ runs:
     # https://github.com/Swatinem/rust-cache#cache-details
     - name: Run cargo cache
       uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+      with:
+        key: ${{ inputs.ADDITIONAL_KEY }}
 
     - name: install protoc and related tools
       shell: bash


### PR DESCRIPTION
Add an optional cache key for rust cache

In some cases (like where we build the binary on a different base os in the same job) this automatic job based cache key is not specific enough so we need to further differentiate it.

Test Plan: PR checks dont die
