### PR TITLE
[agg_v2] executor exceptions propagation

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -99,6 +99,7 @@ static EXECUTION_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
 static NUM_EXECUTION_SHARD: OnceCell<usize> = OnceCell::new();
 static NUM_PROOF_READING_THREADS: OnceCell<usize> = OnceCell::new();
 static PARANOID_TYPE_CHECKS: OnceCell<bool> = OnceCell::new();
+static DISCARD_FAILED_BLOCKS: OnceCell<bool> = OnceCell::new();
 static PROCESSED_TRANSACTIONS_DETAILED_COUNTERS: OnceCell<bool> = OnceCell::new();
 static TIMED_FEATURE_OVERRIDE: OnceCell<TimedFeatureOverride> = OnceCell::new();
 
@@ -265,6 +266,20 @@ impl AptosVM {
     /// Get the paranoid type check flag if already set, otherwise return default true
     pub fn get_paranoid_checks() -> bool {
         match PARANOID_TYPE_CHECKS.get() {
+            Some(enable) => *enable,
+            None => true,
+        }
+    }
+
+    /// Sets runtime config when invoked the first time.
+    pub fn set_discard_failed_blocks(enable: bool) {
+        // Only the first call succeeds, due to OnceCell semantics.
+        DISCARD_FAILED_BLOCKS.set(enable).ok();
+    }
+
+    /// Get the paranoid type check flag if already set, otherwise return default true
+    pub fn get_discard_failed_blocks() -> bool {
+        match DISCARD_FAILED_BLOCKS.get() {
             Some(enable) => *enable,
             None => true,
         }
@@ -2084,6 +2099,7 @@ impl VMExecutor for AptosVM {
                 local: BlockExecutorLocalConfig {
                     concurrency_level: Self::get_concurrency_level(),
                     allow_fallback: true,
+                    discard_failed_blocks: Self::get_discard_failed_blocks(),
                 },
                 onchain: onchain_config,
             },

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -277,11 +277,11 @@ impl AptosVM {
         DISCARD_FAILED_BLOCKS.set(enable).ok();
     }
 
-    /// Get the paranoid type check flag if already set, otherwise return default true
+    /// Get the discard failed blocks flag if already set, otherwise return default (false)
     pub fn get_discard_failed_blocks() -> bool {
         match DISCARD_FAILED_BLOCKS.get() {
             Some(enable) => *enable,
-            None => true,
+            None => false,
         }
     }
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -33,7 +33,7 @@ use aptos_types::{
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{abstract_write_op::AbstractResourceWriteOp, output::VMOutput};
-use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::VMStatus};
+use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::{StatusCode, VMStatus}};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
 use std::{
@@ -86,6 +86,10 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     /// problem creating the output (e.g. group serialization issue).
     fn skip_output() -> Self {
         Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
+    }
+
+    fn discard_output(discard_code: StatusCode) -> Self {
+        Self::new(VMOutput::empty_with_status(TransactionStatus::Discard(discard_code)))
     }
 
     // TODO: get rid of the cloning data-structures in the following APIs.
@@ -431,11 +435,8 @@ impl BlockAptosVM {
 
                 Ok(BlockOutput::new(output_vec))
             },
-            Err(BlockExecutionError::FallbackToSequential(e)) => {
-                unreachable!(
-                    "[Execution]: Must be handled by sequential fallback: {:?}",
-                    e
-                )
+            Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(err_msg))) => {
+                Err(VMStatus::Error { status_code: StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR, sub_status: None, message: Some(err_msg) })
             },
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -33,7 +33,11 @@ use aptos_types::{
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{abstract_write_op::AbstractResourceWriteOp, output::VMOutput};
-use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::{StatusCode, VMStatus}};
+use move_core_types::{
+    language_storage::StructTag,
+    value::MoveTypeLayout,
+    vm_status::{StatusCode, VMStatus},
+};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
 use std::{
@@ -89,7 +93,9 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
     }
 
     fn discard_output(discard_code: StatusCode) -> Self {
-        Self::new(VMOutput::empty_with_status(TransactionStatus::Discard(discard_code)))
+        Self::new(VMOutput::empty_with_status(TransactionStatus::Discard(
+            discard_code,
+        )))
     }
 
     // TODO: get rid of the cloning data-structures in the following APIs.
@@ -435,9 +441,13 @@ impl BlockAptosVM {
 
                 Ok(BlockOutput::new(output_vec))
             },
-            Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(err_msg))) => {
-                Err(VMStatus::Error { status_code: StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR, sub_status: None, message: Some(err_msg) })
-            },
+            Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(
+                err_msg,
+            ))) => Err(VMStatus::Error {
+                status_code: StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR,
+                sub_status: None,
+                message: Some(err_msg),
+            }),
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }
     }

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -16,6 +16,7 @@ use aptos_types::{
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use aptos_vm_types::resolver::{ExecutorView, ResourceGroupView};
+use fail::fail_point;
 use move_core_types::vm_status::{StatusCode, VMStatus};
 
 pub(crate) struct AptosExecutorTask<'a, S> {
@@ -48,6 +49,12 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         txn: &SignatureVerifiedTransaction,
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
+        fail_point!("aptos_vm::vm_wrapper::execute_transaction", |_| {
+            ExecutionStatus::DelayedFieldsCodeInvariantError(
+                "fail points error".into(),
+            )
+        });
+
         let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx as usize);
         let resolver = self
             .vm

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -50,9 +50,7 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
         fail_point!("aptos_vm::vm_wrapper::execute_transaction", |_| {
-            ExecutionStatus::DelayedFieldsCodeInvariantError(
-                "fail points error".into(),
-            )
+            ExecutionStatus::DelayedFieldsCodeInvariantError("fail points error".into())
         });
 
         let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx as usize);

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -7,7 +7,7 @@ use crate::sharded_block_executor::{
 use aptos_logger::trace;
 use aptos_types::{
     block_executor::{
-        config::BlockExecutorConfigFromOnchain,
+        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
         partitioner::{TransactionWithDependencies, GLOBAL_ROUND_ID},
     },
     state_store::StateView,
@@ -59,8 +59,14 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
             None,
             GLOBAL_ROUND_ID,
             state_view,
-            self.concurrency_level,
-            onchain_config,
+            BlockExecutorConfig {
+                local: BlockExecutorLocalConfig {
+                    concurrency_level: self.concurrency_level,
+                    allow_fallback: true,
+                    discard_failed_blocks: false,
+                },
+                onchain: onchain_config,
+            },
         )
     }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -18,7 +18,7 @@ use crate::{
 use aptos_logger::{info, trace};
 use aptos_types::{
     block_executor::{
-        config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig},
+        config::{BlockExecutorConfig, BlockExecutorLocalConfig},
         partitioner::{ShardId, SubBlock, SubBlocksForShard, TransactionWithDependencies},
     },
     state_store::StateView,
@@ -72,8 +72,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         sub_block: SubBlock<AnalyzedTransaction>,
         round: usize,
         state_view: &S,
-        concurrency_level: usize,
-        onchain_config: BlockExecutorConfigFromOnchain,
+        config: BlockExecutorConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         disable_speculative_logging();
         trace!(
@@ -91,8 +90,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             Some(cross_shard_commit_sender),
             round,
             state_view,
-            concurrency_level,
-            onchain_config,
+            config,
         )
     }
 
@@ -104,8 +102,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         cross_shard_commit_sender: Option<CrossShardCommitSender>,
         round: usize,
         state_view: &S,
-        concurrency_level: usize,
-        onchain_config: BlockExecutorConfigFromOnchain,
+        config: BlockExecutorConfig,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let (callback, callback_receiver) = oneshot::channel();
 
@@ -141,13 +138,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     executor_thread_pool,
                     &signature_verified_transactions,
                     aggr_overridden_state_view.as_ref(),
-                    BlockExecutorConfig {
-                        local: BlockExecutorLocalConfig {
-                            concurrency_level,
-                            allow_fallback: true,
-                        },
-                        onchain: onchain_config,
-                    },
+                    config,
                     cross_shard_commit_sender,
                 )
                 .map(BlockOutput::into_transaction_outputs_forced);
@@ -183,8 +174,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         &self,
         transactions: SubBlocksForShard<AnalyzedTransaction>,
         state_view: &S,
-        concurrency_level: usize,
-        onchain_config: BlockExecutorConfigFromOnchain,
+        config: BlockExecutorConfig,
     ) -> Result<Vec<Vec<TransactionOutput>>, VMStatus> {
         let mut result = vec![];
         for (round, sub_block) in transactions.into_sub_blocks().into_iter().enumerate() {
@@ -200,13 +190,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 round,
                 sub_block.transactions.len()
             );
-            result.push(self.execute_sub_block(
-                sub_block,
-                round,
-                state_view,
-                concurrency_level,
-                onchain_config.clone(),
-            )?);
+            result.push(self.execute_sub_block(sub_block, round, state_view, config.clone())?);
             trace!(
                 "Finished executing sub block for shard {} and round {}",
                 self.shard_id,
@@ -244,8 +228,14 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     let ret = self.execute_block(
                         transactions,
                         state_view.as_ref(),
-                        concurrency_level_per_shard,
-                        onchain_config,
+                        BlockExecutorConfig {
+                            local: BlockExecutorLocalConfig {
+                                concurrency_level: concurrency_level_per_shard,
+                                allow_fallback: true,
+                                discard_failed_blocks: false,
+                            },
+                            onchain: onchain_config,
+                        },
                     );
                     drop(state_view);
                     drop(exe_timer);

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -9,20 +9,20 @@ use aptos_types::delayed_fields::PanicError;
 // aborting the parallel execution pipeline and falling back to the sequential execution.
 // TODO: provide proper multi-versioning for code (like data) for the cache.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ModulePathReadWriteError;
+pub(crate) struct ModulePathReadWriteError;
 
 // This is not PanicError because we need to match the error variant to provide a specialized
 // fallback logic if a resource group serialization error occurs.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ResourceGroupSerializationError;
+pub(crate) struct ResourceGroupSerializationError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Logging is bottlenecked in constructors.
-pub enum SequentialBlockExecutionError<E> {
+pub(crate) enum SequentialBlockExecutionError<E> {
     // This is not PanicError because we need to match the error variant to provide a specialized
     // fallback logic if a resource group serialization error occurs.
     ResourceGroupSerializationError,
-    ErrorToReturn(BlockExecutionError<E>)
+    ErrorToReturn(BlockExecutionError<E>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -43,6 +43,8 @@ impl<E> From<PanicError> for BlockExecutionError<E> {
 
 impl<E> From<PanicError> for SequentialBlockExecutionError<E> {
     fn from(err: PanicError) -> Self {
-        SequentialBlockExecutionError::ErrorToReturn(BlockExecutionError::FatalBlockExecutorError(err))
+        SequentialBlockExecutionError::ErrorToReturn(BlockExecutionError::FatalBlockExecutorError(
+            err,
+        ))
     }
 }

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -11,7 +11,7 @@ use aptos_types::delayed_fields::PanicError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ModulePathReadWriteError;
 
-// This is not PanicError because we need to match the error variant to provide a specialized
+// This is separate error because we need to match the error variant to provide a specialized
 // fallback logic if a resource group serialization error occurs.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ResourceGroupSerializationError;
@@ -19,17 +19,19 @@ pub(crate) struct ResourceGroupSerializationError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Logging is bottlenecked in constructors.
 pub(crate) enum SequentialBlockExecutionError<E> {
-    // This is not PanicError because we need to match the error variant to provide a specialized
+    // This is separate error because we need to match the error variant to provide a specialized
     // fallback logic if a resource group serialization error occurs.
     ResourceGroupSerializationError,
     ErrorToReturn(BlockExecutionError<E>),
 }
 
+/// If the unrecoverable error occurs during sequential execution (e.g. fallback),
+/// the error is propagated back to the caller (block execution is aborted).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlockExecutionError<E> {
+    /// unrecoverable BlockSTM error
     FatalBlockExecutorError(PanicError),
-    /// If the unrecoverable VM error occurs during sequential execution (e.g. fallback),
-    /// the error is propagated back to the caller (block execution is aborted).
+    /// unrecoverable VM error
     FatalVMError(E),
 }
 

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -2,47 +2,32 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::types::PanicOr;
-use aptos_logger::{debug, error};
-use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::delayed_fields::PanicError;
-use aptos_vm_logging::{alert, prelude::*};
+
+// The same module access path for module was both read & written during speculative executions.
+// This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
+// aborting the parallel execution pipeline and falling back to the sequential execution.
+// TODO: provide proper multi-versioning for code (like data) for the cache.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModulePathReadWriteError;
+
+// This is not PanicError because we need to match the error variant to provide a specialized
+// fallback logic if a resource group serialization error occurs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResourceGroupSerializationError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Logging is bottlenecked in constructors.
-pub enum IntentionalFallbackToSequential {
-    // The same module access path for module was both read & written during speculative executions.
-    // This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
-    // aborting the parallel execution pipeline and falling back to the sequential execution.
-    // TODO: provide proper multi-versioning for code (like data) for the cache.
-    ModulePathReadWrite,
+pub enum SequentialBlockExecutionError<E> {
     // This is not PanicError because we need to match the error variant to provide a specialized
     // fallback logic if a resource group serialization error occurs.
     ResourceGroupSerializationError,
-    // If multiple workers encounter conditions that qualify for a sequential fallback during parallel
-    // execution, it is not clear what is the "right" one to fallback with. Instead, we use the
-    // variant below. TODO: pass a vector of all encountered conditions (mainly for tests).
-    FallbackFromParallel,
-}
-
-impl IntentionalFallbackToSequential {
-    pub(crate) fn module_path_read_write(error_msg: String, txn_idx: TxnIndex) -> Self {
-        // Module R/W is an expected fallback behavior, no alert is required.
-        debug!("[Execution] At txn {}, {:?}", txn_idx, error_msg);
-
-        IntentionalFallbackToSequential::ModulePathReadWrite
-    }
-
-    pub(crate) fn resource_group_serialization_error(error_msg: String, txn_idx: TxnIndex) -> Self {
-        alert!("[Execution] At txn {}, {:?}", txn_idx, error_msg);
-
-        IntentionalFallbackToSequential::ResourceGroupSerializationError
-    }
+    ErrorToReturn(BlockExecutionError<E>)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlockExecutionError<E> {
-    FallbackToSequential(PanicOr<IntentionalFallbackToSequential>),
+    FatalBlockExecutorError(PanicError),
     /// If the unrecoverable VM error occurs during sequential execution (e.g. fallback),
     /// the error is propagated back to the caller (block execution is aborted).
     FatalVMError(E),
@@ -50,14 +35,14 @@ pub enum BlockExecutionError<E> {
 
 pub type BlockExecutionResult<T, E> = Result<T, BlockExecutionError<E>>;
 
-impl<E> From<PanicOr<IntentionalFallbackToSequential>> for BlockExecutionError<E> {
-    fn from(err: PanicOr<IntentionalFallbackToSequential>) -> Self {
-        BlockExecutionError::FallbackToSequential(err)
+impl<E> From<PanicError> for BlockExecutionError<E> {
+    fn from(err: PanicError) -> Self {
+        BlockExecutionError::FatalBlockExecutorError(err)
     }
 }
 
-impl<E> From<PanicError> for BlockExecutionError<E> {
+impl<E> From<PanicError> for SequentialBlockExecutionError<E> {
     fn from(err: PanicError) -> Self {
-        BlockExecutionError::FallbackToSequential(err.into())
+        SequentialBlockExecutionError::ErrorToReturn(BlockExecutionError::FatalBlockExecutorError(err))
     }
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -47,7 +47,7 @@ use bytes::Bytes;
 use claims::assert_none;
 use core::panic;
 use fail::fail_point;
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::{value::MoveTypeLayout, vm_status::StatusCode};
 use num_cpus;
 use rayon::ThreadPool;
 use std::{
@@ -106,7 +106,7 @@ where
         executor: &E,
         base_view: &S,
         latest_view: ParallelState<T, X>,
-    ) -> Result<bool, PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<bool, PanicOr<ModulePathReadWriteError>> {
         let _timer = TASK_EXECUTE_SECONDS.start_timer();
         let txn = &signature_verified_block[idx_to_execute as usize];
 
@@ -293,12 +293,10 @@ where
         }
 
         if !last_input_output.record(idx_to_execute, read_set, result, resource_write_set) {
-            return Err(PanicOr::Or(
-                IntentionalFallbackToSequential::module_path_read_write(
-                    "Module read & write".into(),
-                    idx_to_execute,
-                ),
-            ));
+            // Module R/W is an expected fallback behavior, no alert is required.
+            debug!("[Execution] At txn {}, Module read & write", idx_to_execute);
+
+            return Err(PanicOr::Or(ModulePathReadWriteError));
         }
         Ok(updates_outside)
     }
@@ -443,7 +441,7 @@ where
         shared_counter: &AtomicU32,
         executor: &E,
         block: &[T],
-    ) -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<(), PanicOr<ModulePathReadWriteError>> {
         let mut block_limit_processor = shared_commit_state.acquire();
 
         while let Some((txn_idx, incarnation)) = scheduler.try_commit() {
@@ -570,9 +568,6 @@ where
                         txn_idx + 1,
                         scheduler.num_txns(),
                     );
-                    fail_point!("commit-all-halt-err", |_| Err(PanicOr::Or(
-                        IntentionalFallbackToSequential::ResourceGroupSerializationError
-                    )));
                 }
                 return Ok(());
             }
@@ -642,7 +637,7 @@ where
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         base_view: &S,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
-    ) -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<(), PanicError> {
         let parallel_state = ParallelState::<T, X>::new(
             versioned_cache,
             scheduler,
@@ -653,7 +648,10 @@ where
         let finalized_groups = last_input_output.take_finalized_group(txn_idx);
         let materialized_finalized_groups =
             map_id_to_values_in_group_writes(finalized_groups, &latest_view)?;
-        let serialized_groups = serialize_groups::<T>(materialized_finalized_groups, txn_idx)?;
+
+        fail_point!("commit-all-halt-err", |_| Err(code_invariant_error("ResourceGroupSerializationError")));
+
+        let serialized_groups = serialize_groups::<T>(materialized_finalized_groups).map_err(|e| code_invariant_error(format!("Panic error in serializing groups {e:?}")))?;
 
         let resource_write_set = last_input_output.take_resource_write_set(txn_idx);
         let resource_writes_to_materialize = resource_writes_to_materialize!(
@@ -728,7 +726,7 @@ where
         shared_counter: &AtomicU32,
         shared_commit_state: &ExplicitSyncWrapper<BlockGasLimitProcessor<T>>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
-    ) -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<(), PanicOr<ModulePathReadWriteError>> {
         // Make executor for each task. TODO: fast concurrent executor.
         let init_timer = VM_INIT_SECONDS.start_timer();
         let executor = E::init(*executor_arguments);
@@ -737,7 +735,7 @@ where
         let _timer = WORK_WITH_TASK_SECONDS.start_timer();
         let mut scheduler_task = SchedulerTask::NoTask;
 
-        let drain_commit_queue = || -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
+        let drain_commit_queue = || -> Result<(), PanicError> {
             while let Ok(txn_idx) = scheduler.pop_from_commit_queue() {
                 self.materialize_txn_commit(
                     txn_idx,
@@ -833,7 +831,7 @@ where
         executor_initial_arguments: E::Argument,
         signature_verified_block: &[T],
         base_view: &S,
-    ) -> Result<BlockOutput<E::Output>, PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<BlockOutput<E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // Using parallel execution with 1 thread currently will not work as it
         // will only have a coordinator role but no workers for rolling commit.
@@ -877,7 +875,7 @@ where
         self.executor_thread_pool.scope(|s| {
             for _ in 0..self.config.local.concurrency_level {
                 s.spawn(|_| {
-                    if let Err(e) = self.worker_loop(
+                    if let Err(err) = self.worker_loop(
                         &executor_initial_arguments,
                         signature_verified_block,
                         &last_input_output,
@@ -890,11 +888,11 @@ where
                         &final_results,
                     ) {
                         // If there are multiple errors, they all get logged:
-                        // IntentionalFallbackToSequential variant is logged at construction,
+                        // ModulePathReadWriteError variant is logged at construction,
                         // and below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = &e {
+                        if let PanicOr::CodeInvariantError(err_msg) = err {
                             alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
-                        };
+                        }
                         shared_maybe_error.store(true, Ordering::SeqCst);
 
                         // Make sure to halt the scheduler if it hasn't already been halted.
@@ -912,27 +910,21 @@ where
 
         (!shared_maybe_error.load(Ordering::SeqCst))
             .then(|| BlockOutput::new(final_results.into_inner()))
-            .ok_or(PanicOr::Or(
-                IntentionalFallbackToSequential::FallbackFromParallel,
-            ))
+            .ok_or(())
     }
 
     fn apply_output_sequential(
         unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, X, T::Identifier>,
         output: &E::Output,
         resource_write_set: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
-    ) -> Result<(), PanicOr<IntentionalFallbackToSequential>> {
+    ) -> Result<(), SequentialBlockExecutionError<E::Error>> {
         for (key, write_op, layout) in resource_write_set.into_iter() {
             unsync_map.write(key, write_op, layout);
         }
 
         for (group_key, metadata_op, group_ops) in output.resource_group_write_set().into_iter() {
             for (value_tag, (group_op, maybe_layout)) in group_ops.into_iter() {
-                unsync_map
-                    .insert_group_op(&group_key, value_tag, group_op, maybe_layout)
-                    .map_err(|e| {
-                        code_invariant_error(format!("Unexpected resource group error {:?}", e))
-                    })?;
+                unsync_map.insert_group_op(&group_key, value_tag, group_op, maybe_layout)?;
             }
             unsync_map.write(group_key, Arc::new(metadata_op), None);
         }
@@ -995,14 +987,13 @@ where
         Ok(())
     }
 
-    // TODO[agg_v2][fix] Propagate code_invariant_error, to use second fallback.
     pub(crate) fn execute_transactions_sequential(
         &self,
         executor_arguments: E::Argument,
         signature_verified_block: &[T],
         base_view: &S,
         resource_group_bcs_fallback: bool,
-    ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
+    ) -> Result<BlockOutput<E::Output>, SequentialBlockExecutionError<E::Error>> {
         let num_txns = signature_verified_block.len();
         let init_timer = VM_INIT_SECONDS.start_timer();
         let executor = E::init(executor_arguments);
@@ -1029,6 +1020,24 @@ where
             let res = executor.execute_transaction(&latest_view, txn, idx as TxnIndex);
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
+                ExecutionStatus::Abort(err) => {
+                    if let Some(commit_hook) = &self.transaction_commit_hook {
+                        commit_hook.on_execution_aborted(idx as TxnIndex);
+                    }
+                    alert!("Fatal VM error by transaction {}", idx as TxnIndex);
+                    // Record the status indicating the unrecoverable VM failure.
+                    return Err(SequentialBlockExecutionError::ErrorToReturn(BlockExecutionError::FatalVMError(err)));
+                },
+                ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
+                    alert!("Discarding transaction because we got DelayedFieldsCodeInvariantError in the sequential fallback: {msg}");
+                    ret.push(E::Output::discard_output(StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR));
+                    continue;
+                },
+                ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
+                    alert!("Discarding transaction because we got SpeculativeExecutionAbortError in the sequential fallback {msg}");
+                    ret.push(E::Output::discard_output(StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR));
+                    continue;
+                },
                 ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                     // Calculating the accumulated gas costs of the committed txns.
                     let fee_statement = output.fee_statement();
@@ -1146,13 +1155,13 @@ where
                         if serialization_error {
                             // The corresponding error / alert must already be triggered, the goal in sequential
                             // fallback is to just skip any transactions that would cause such serialization errors.
-                            ret.push(E::Output::skip_output());
+                            alert!("Discarding transaction because serialization failed in bcs fallback");
+                            ret.push(E::Output::discard_output(StatusCode::DELAYED_MATERIALIZATION_CODE_INVARIANT_ERROR));
                             continue;
                         }
                     };
 
                     // Apply the writes.
-                    // TODO[agg_v2](fix): return code invariant error if dynamic change set optimizations disabled.
                     let resource_write_set = output.resource_write_set();
                     Self::apply_output_sequential(
                         &unsync_map,
@@ -1177,8 +1186,8 @@ where
                         let materialized_finalized_groups =
                             map_id_to_values_in_group_writes(finalized_groups, &latest_view)?;
                         let serialized_groups =
-                            serialize_groups::<T>(materialized_finalized_groups, idx as TxnIndex)
-                                .map_err(BlockExecutionError::FallbackToSequential)?;
+                            serialize_groups::<T>(materialized_finalized_groups)
+                                .map_err(|_| SequentialBlockExecutionError::ResourceGroupSerializationError)?;
 
                         let resource_writes_to_materialize = resource_writes_to_materialize!(
                             resource_write_set,
@@ -1208,40 +1217,19 @@ where
                                     .chain(serialized_groups.into_iter())
                                     .collect(),
                                 materialized_events,
-                            )
-                            .map_err(PanicOr::from)
-                            .map_err(BlockExecutionError::FallbackToSequential)?;
+                            )?;
                     }
                     // If dynamic change set is disabled, this can be used to assert nothing needs patching instead:
                     //   output.set_txn_output_for_non_dynamic_change_set();
 
                     if latest_view.is_incorrect_use() {
-                        panic!("Incorrect use in sequential execution")
+                        return Err(code_invariant_error("Incorrect use in sequential execution").into());
                     }
 
                     if let Some(commit_hook) = &self.transaction_commit_hook {
                         commit_hook.on_transaction_committed(idx as TxnIndex, &output);
                     }
                     ret.push(output);
-                },
-                ExecutionStatus::Abort(err) => {
-                    if let Some(commit_hook) = &self.transaction_commit_hook {
-                        commit_hook.on_execution_aborted(idx as TxnIndex);
-                    }
-                    alert!("Fatal VM error by transaction {}", idx as TxnIndex);
-                    // Record the status indicating the unrecoverable VM failure.
-                    return Err(BlockExecutionError::FatalVMError(err));
-                },
-                ExecutionStatus::DelayedFieldsCodeInvariantError(msg) => {
-                    return Err(BlockExecutionError::FallbackToSequential(
-                        code_invariant_error(msg).into(),
-                    ));
-                },
-                ExecutionStatus::SpeculativeExecutionAbortError(msg) => {
-                    panic!(
-                        "Sequential execution must not have SpeculativeExecutionAbortError: {:?}",
-                        msg
-                    );
                 },
             };
             // When the txn is a SkipRest txn, halt sequential execution.
@@ -1271,81 +1259,81 @@ where
         signature_verified_block: &[T],
         base_view: &S,
     ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
-        let mut ret = if self.config.local.concurrency_level > 1 {
-            self.execute_transactions_parallel(
+        if self.config.local.concurrency_level > 1 {
+            let parallel_result = self.execute_transactions_parallel(
                 executor_arguments,
                 signature_verified_block,
                 base_view,
-            )
-            .map_err(BlockExecutionError::FallbackToSequential)
-        } else {
-            self.execute_transactions_sequential(
-                executor_arguments,
-                signature_verified_block,
-                base_view,
-                false,
-            )
-        };
-
-        if self.config.local.allow_fallback {
-            let mut resource_group_bcs_fallback = matches!(
-                ret,
-                Err(BlockExecutionError::FallbackToSequential(PanicOr::Or(
-                    IntentionalFallbackToSequential::ResourceGroupSerializationError
-                )))
             );
 
-            if self.config.local.concurrency_level > 1 && !resource_group_bcs_fallback {
-                // Sequential execution fallback, only worth doing if we did a different pass before,
-                // i.e. parallel. This fallback does not handle resource group serialization issues.
-
-                if let Err(BlockExecutionError::FallbackToSequential(_)) = &ret {
-                    // Any error logs are already written at appropriate levels.
-                    debug!("Sequential_fallback occurred");
-
-                    // All logs from the parallel execution should be cleared and not reported.
-                    // Clear by re-initializing the speculative logs.
-                    init_speculative_logs(signature_verified_block.len());
-
-                    ret = self.execute_transactions_sequential(
-                        executor_arguments,
-                        signature_verified_block,
-                        base_view,
-                        false,
-                    );
-                    resource_group_bcs_fallback = matches!(
-                        ret,
-                        Err(BlockExecutionError::FallbackToSequential(PanicOr::Or(
-                            IntentionalFallbackToSequential::ResourceGroupSerializationError
-                        )))
-                    );
-                }
+            // If parallel gave us result, return it
+            if let Ok(output) = parallel_result {
+                return Ok(output);
             }
 
-            if resource_group_bcs_fallback {
-                alert!("Resource group serialization fallback");
+            if !self.config.local.allow_fallback {
+                panic!("Parallel execution failed and fallback is not allowed");
+            }
+
+            // All logs from the parallel execution should be cleared and not reported.
+            // Clear by re-initializing the speculative logs.
+            init_speculative_logs(signature_verified_block.len());
+
+            debug!("parallel execution requiring fallback");
+        }
+
+        // If we didn't run parallel or it didn't finish successfully - run sequential
+        let sequential_result = self.execute_transactions_sequential(
+            executor_arguments,
+            signature_verified_block,
+            base_view,
+            false,
+        );
+
+        // If sequential gave us result, return it
+        let sequential_error = match sequential_result {
+            Ok(output) => {
+                return Ok(output);
+            },
+            Err(SequentialBlockExecutionError::ResourceGroupSerializationError) => {
+                if !self.config.local.allow_fallback {
+                    panic!("Parallel execution failed and fallback is not allowed");
+                }
+
+                // All logs from the first pass of sequential execution should be cleared and not reported.
+                // Clear by re-initializing the speculative logs.
                 init_speculative_logs(signature_verified_block.len());
-                ret = self.execute_transactions_sequential(
+
+                let sequential_result = self.execute_transactions_sequential(
                     executor_arguments,
                     signature_verified_block,
                     base_view,
-                    true,
+                    false,
                 );
-            }
 
-            // If after trying available fallbacks, we still are askign to do a fallback,
-            // something unrecoverable went wrong.
-            if let Err(BlockExecutionError::FallbackToSequential(e)) = &ret {
-                // TODO[agg_v2][fix] make sure this can never happen - we have sequential raising
-                // this error often when something that should never happen goes wrong
-                panic!("Sequential execution failed with {:?}", e);
+                // If sequential gave us result, return it
+                match sequential_result {
+                    Ok(output) => {
+                        return Ok(output);
+                    },
+                    Err(SequentialBlockExecutionError::ResourceGroupSerializationError) => {
+                        BlockExecutionError::FatalBlockExecutorError(code_invariant_error("resource group serialization during bcs fallback should not happen"))
+                    },
+                    Err(SequentialBlockExecutionError::ErrorToReturn(err)) => {
+                        err
+                    }
+                }
+            },
+            Err(SequentialBlockExecutionError::ErrorToReturn(err)) => {
+                err
             }
-        } else if let Err(BlockExecutionError::FallbackToSequential(e)) = &ret {
-            // TODO[agg_v2][fix] make sure this can never happen - we have sequential raising
-            // this error often when something that should never happen goes wrong
-            panic!("Fallback disabled, execution failed due to {:?}", e);
+        };
+
+        // if not skip failed blocks enabled
+        if let BlockExecutionError::FatalBlockExecutorError(err) = sequential_error {
+            panic!("Fatal block executor error during sequential execution: {:?}", err);
         }
 
-        ret
+        Err(sequential_error)
     }
 }

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{errors::*, view::LatestView};
-use aptos_aggregator::types::{code_invariant_error, PanicOr};
+use aptos_aggregator::types::code_invariant_error;
 use aptos_logger::error;
-use aptos_mvhashmap::types::{TxnIndex, ValueWithLayout};
+use aptos_mvhashmap::types::ValueWithLayout;
 use aptos_types::{
     contract_event::TransactionEvent, delayed_fields::PanicError, executable::Executable,
     state_store::TStateView, transaction::BlockExecutableTransaction as Transaction,
@@ -118,14 +118,11 @@ pub(crate) fn map_finalized_group<T: Transaction>(
 
 pub(crate) fn serialize_groups<T: Transaction>(
     finalized_groups: Vec<(T::Key, T::Value, Vec<(T::Tag, Arc<T::Value>)>)>,
-    txn_idx: TxnIndex,
-) -> Result<Vec<(T::Key, T::Value)>, PanicOr<IntentionalFallbackToSequential>> {
+) -> Result<Vec<(T::Key, T::Value)>, ResourceGroupSerializationError> {
     fail_point!(
         "fail-point-resource-group-serialization",
         !finalized_groups.is_empty(),
-        |_| Err(PanicOr::Or(
-            IntentionalFallbackToSequential::ResourceGroupSerializationError
-        ))
+        |_| Err(ResourceGroupSerializationError)
     );
 
     finalized_groups
@@ -142,25 +139,15 @@ pub(crate) fn serialize_groups<T: Transaction>(
                 })
                 .collect();
 
-            let res = bcs::to_bytes(&btree)
+            bcs::to_bytes(&btree)
                 .map_err(|e| {
-                    PanicOr::Or(
-                        IntentionalFallbackToSequential::resource_group_serialization_error(
-                            format!("Unexpected resource group error {:?}", e),
-                            txn_idx,
-                        ),
-                    )
+                    alert!("Unexpected resource group error {:?}", e);
+                    ResourceGroupSerializationError
                 })
                 .map(|group_bytes| {
                     metadata_op.set_bytes(group_bytes.into());
                     (group_key, metadata_op)
-                });
-
-            if res.is_err() {
-                alert!("Failed to serialize resource group");
-            }
-
-            res
+                })
         })
         .collect()
 }

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -130,7 +130,6 @@ pub(crate) fn serialize_groups<T: Transaction>(
         .map(|(group_key, mut metadata_op, finalized_group)| {
             let btree: BTreeMap<T::Tag, Bytes> = finalized_group
                 .into_iter()
-                // TODO[agg_v2](fix): Should anything be done using the layout here?
                 .map(|(resource_tag, arc_v)| {
                     let bytes = arc_v
                         .extract_raw_bytes()

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -375,7 +375,6 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                 assert_eq!(*idx, self.resolved_deltas.len());
             },
             Err(BlockExecutionError::FatalBlockExecutorError(_)) => {
-                // Parallel execution currently returns an arbitrary error to fallback.
                 // TODO: adjust the logic to be able to test better.
             },
         }

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -377,7 +377,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                 assert_eq!(*idx, self.read_values.len());
                 assert_eq!(*idx, self.resolved_deltas.len());
             },
-            Err(BlockExecutionError::FallbackToSequential(_)) => {
+            Err(BlockExecutionError::FatalBlockExecutorError(_)) => {
                 // Parallel execution currently returns an arbitrary error to fallback.
                 // TODO: adjust the logic to be able to test better.
             },

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -230,147 +230,144 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         }
     }
 
+    fn assert_success<E: Debug>(&self, block_output: &BlockOutput<MockOutput<K, E>>) {
+        let base_map: HashMap<u32, Bytes> = HashMap::from([(RESERVED_TAG, vec![0].into())]);
+        let mut group_world = HashMap::new();
+
+        let results = block_output.get_transaction_outputs_forced();
+        let committed = self.read_values.len();
+        assert_eq!(self.resolved_deltas.len(), committed);
+
+        // Check read values & delta writes.
+        izip!(
+            results.iter().take(committed),
+            self.read_values.iter(),
+            self.resolved_deltas.iter(),
+            self.group_reads.iter(),
+        )
+        .for_each(|(output, reads, resolved_deltas, group_reads)| {
+            // Compute group read results.
+            let group_read_results: Vec<Option<Bytes>> = group_reads
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|(group_key, resource_tag)| {
+                    let group_map = group_world.entry(group_key).or_insert(base_map.clone());
+
+                    group_map.get(resource_tag).cloned()
+                })
+                .collect();
+            // Test group read results.
+            let read_len = reads.as_ref().unwrap().len();
+
+            assert_eq!(
+                group_read_results.len(),
+                output.read_results.len() - read_len
+            );
+            izip!(
+                output.read_results.iter().skip(read_len),
+                group_read_results.into_iter()
+            )
+            .for_each(|(result_group_read, baseline_group_read)| {
+                assert!(result_group_read.clone().map(Into::<Bytes>::into) == baseline_group_read);
+            });
+
+            for (group_key, size) in output.read_group_sizes.iter() {
+                let group_map = group_world.entry(group_key).or_insert(base_map.clone());
+
+                assert_eq!(
+                    group_size_as_sum(group_map.iter().map(|(t, v)| (t, v.len())))
+                        .unwrap()
+                        .get(),
+                    *size
+                );
+            }
+
+            // Test normal reads.
+            izip!(
+                reads
+                    .as_ref()
+                    .expect("Aggregator failures not yet tested")
+                    .iter(),
+                output.read_results.iter().take(read_len)
+            )
+            .for_each(|(baseline_read, result_read)| baseline_read.assert_read_result(result_read));
+
+            // Update group world.
+            for (group_key, _, updates) in output.group_writes.iter() {
+                for (tag, v) in updates {
+                    let group_map = group_world.entry(group_key).or_insert(base_map.clone());
+                    if v.is_deletion() {
+                        assert_some!(group_map.remove(tag));
+                    } else {
+                        let existed = group_map
+                            .insert(*tag, v.extract_raw_bytes().unwrap())
+                            .is_some();
+                        assert_eq!(existed, v.is_modification());
+                    }
+                }
+            }
+
+            // Test recorded finalized group writes: it should contain the whole group, and
+            // as such, correspond to the contents of the group_world.
+            // TODO: figure out what can still be tested here, e.g. RESERVED_TAG
+            // let groups_tested =
+            //     (output.group_writes.len() + group_reads.as_ref().unwrap().len()) > 0;
+            // for (group_key, _, finalized_updates) in output.recorded_groups.get().unwrap() {
+            //     let baseline_group_map =
+            //         group_world.entry(group_key).or_insert(base_map.clone());
+            //     assert_eq!(finalized_updates.len(), baseline_group_map.len());
+            //     if groups_tested {
+            //         // RESERVED_TAG should always be contained.
+            //         assert_ge!(finalized_updates.len(), 1);
+
+            //         for (tag, v) in finalized_updates.iter() {
+            //             assert_eq!(
+            //                 v.bytes().unwrap(),
+            //                 baseline_group_map.get(tag).unwrap(),
+            //             );
+            //         }
+            //     }
+            // }
+
+            let baseline_deltas = resolved_deltas
+                .as_ref()
+                .expect("Aggregator failures not yet tested");
+            output
+                .materialized_delta_writes
+                .get()
+                .expect("Delta writes must be set")
+                .iter()
+                .for_each(|(k, result_delta_write)| {
+                    assert_eq!(
+                        *baseline_deltas.get(k).expect("Baseline must contain delta"),
+                        result_delta_write
+                            .as_u128()
+                            .expect("Baseline must contain delta")
+                            .expect("Must deserialize aggregator write value")
+                    );
+                });
+        });
+
+        results.iter().skip(committed).for_each(|output| {
+            // Ensure the transaction is skipped based on the output.
+            assert!(output.skipped);
+
+            // Implies that materialize_delta_writes was never called, as should
+            // be for skipped transactions.
+            assert_none!(output.materialized_delta_writes.get());
+        });
+    }
+
     // Used for testing, hence the function asserts the correctness conditions within
     // itself to be easily traceable in case of an error.
     pub(crate) fn assert_output<E: Debug>(
         &self,
         results: &BlockExecutionResult<BlockOutput<MockOutput<K, E>>, usize>,
     ) {
-        let base_map: HashMap<u32, Bytes> = HashMap::from([(RESERVED_TAG, vec![0].into())]);
-        let mut group_world = HashMap::new();
-
         match results {
             Ok(block_output) => {
-                let results = block_output.get_transaction_outputs_forced();
-                let committed = self.read_values.len();
-                assert_eq!(self.resolved_deltas.len(), committed);
-
-                // Check read values & delta writes.
-                izip!(
-                    results.iter().take(committed),
-                    self.read_values.iter(),
-                    self.resolved_deltas.iter(),
-                    self.group_reads.iter(),
-                )
-                .for_each(|(output, reads, resolved_deltas, group_reads)| {
-                    // Compute group read results.
-                    let group_read_results: Vec<Option<Bytes>> = group_reads
-                        .as_ref()
-                        .unwrap()
-                        .iter()
-                        .map(|(group_key, resource_tag)| {
-                            let group_map =
-                                group_world.entry(group_key).or_insert(base_map.clone());
-
-                            group_map.get(resource_tag).cloned()
-                        })
-                        .collect();
-                    // Test group read results.
-                    let read_len = reads.as_ref().unwrap().len();
-
-                    assert_eq!(
-                        group_read_results.len(),
-                        output.read_results.len() - read_len
-                    );
-                    izip!(
-                        output.read_results.iter().skip(read_len),
-                        group_read_results.into_iter()
-                    )
-                    .for_each(|(result_group_read, baseline_group_read)| {
-                        assert!(
-                            result_group_read.clone().map(Into::<Bytes>::into)
-                                == baseline_group_read
-                        );
-                    });
-
-                    for (group_key, size) in output.read_group_sizes.iter() {
-                        let group_map = group_world.entry(group_key).or_insert(base_map.clone());
-
-                        assert_eq!(
-                            group_size_as_sum(group_map.iter().map(|(t, v)| (t, v.len())))
-                                .unwrap()
-                                .get(),
-                            *size
-                        );
-                    }
-
-                    // Test normal reads.
-                    izip!(
-                        reads
-                            .as_ref()
-                            .expect("Aggregator failures not yet tested")
-                            .iter(),
-                        output.read_results.iter().take(read_len)
-                    )
-                    .for_each(|(baseline_read, result_read)| {
-                        baseline_read.assert_read_result(result_read)
-                    });
-
-                    // Update group world.
-                    for (group_key, _, updates) in output.group_writes.iter() {
-                        for (tag, v) in updates {
-                            let group_map =
-                                group_world.entry(group_key).or_insert(base_map.clone());
-                            if v.is_deletion() {
-                                assert_some!(group_map.remove(tag));
-                            } else {
-                                let existed = group_map
-                                    .insert(*tag, v.extract_raw_bytes().unwrap())
-                                    .is_some();
-                                assert_eq!(existed, v.is_modification());
-                            }
-                        }
-                    }
-
-                    // Test recorded finalized group writes: it should contain the whole group, and
-                    // as such, correspond to the contents of the group_world.
-                    // TODO: figure out what can still be tested here, e.g. RESERVED_TAG
-                    // let groups_tested =
-                    //     (output.group_writes.len() + group_reads.as_ref().unwrap().len()) > 0;
-                    // for (group_key, _, finalized_updates) in output.recorded_groups.get().unwrap() {
-                    //     let baseline_group_map =
-                    //         group_world.entry(group_key).or_insert(base_map.clone());
-                    //     assert_eq!(finalized_updates.len(), baseline_group_map.len());
-                    //     if groups_tested {
-                    //         // RESERVED_TAG should always be contained.
-                    //         assert_ge!(finalized_updates.len(), 1);
-
-                    //         for (tag, v) in finalized_updates.iter() {
-                    //             assert_eq!(
-                    //                 v.bytes().unwrap(),
-                    //                 baseline_group_map.get(tag).unwrap(),
-                    //             );
-                    //         }
-                    //     }
-                    // }
-
-                    let baseline_deltas = resolved_deltas
-                        .as_ref()
-                        .expect("Aggregator failures not yet tested");
-                    output
-                        .materialized_delta_writes
-                        .get()
-                        .expect("Delta writes must be set")
-                        .iter()
-                        .for_each(|(k, result_delta_write)| {
-                            assert_eq!(
-                                *baseline_deltas.get(k).expect("Baseline must contain delta"),
-                                result_delta_write
-                                    .as_u128()
-                                    .expect("Baseline must contain delta")
-                                    .expect("Must deserialize aggregator write value")
-                            );
-                        });
-                });
-
-                results.iter().skip(committed).for_each(|output| {
-                    // Ensure the transaction is skipped based on the output.
-                    assert!(output.skipped);
-
-                    // Implies that materialize_delta_writes was never called, as should
-                    // be for skipped transactions.
-                    assert_none!(output.materialized_delta_writes.get());
-                });
+                self.assert_success(block_output);
             },
             Err(BlockExecutionError::FatalVMError(idx)) => {
                 assert_matches!(&self.status, BaselineStatus::Aborted);
@@ -378,6 +375,21 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                 assert_eq!(*idx, self.resolved_deltas.len());
             },
             Err(BlockExecutionError::FatalBlockExecutorError(_)) => {
+                // Parallel execution currently returns an arbitrary error to fallback.
+                // TODO: adjust the logic to be able to test better.
+            },
+        }
+    }
+
+    pub(crate) fn assert_parallel_output<E: Debug>(
+        &self,
+        results: &Result<BlockOutput<MockOutput<K, E>>, ()>,
+    ) {
+        match results {
+            Ok(block_output) => {
+                self.assert_success(block_output);
+            },
+            Err(()) => {
                 // Parallel execution currently returns an arbitrary error to fallback.
                 // TODO: adjust the logic to be able to test better.
             },

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::BlockExecutionError,
     executor::BlockExecutor,
     proptest_types::{
         baseline::BaselineOutput,
@@ -14,7 +13,6 @@ use crate::{
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
-use aptos_aggregator::types::code_invariant_error;
 use aptos_types::{
     block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
     executable::ExecutableTestType,
@@ -140,7 +138,6 @@ where
         >::new(config, executor_thread_pool, None)
         .execute_transactions_parallel((), &self.transactions, &data_view);
 
-        self.baseline_output
-            .assert_output(&output.map_err(|err| BlockExecutionError::FatalBlockExecutorError(code_invariant_error(""))));
+        self.baseline_output.assert_parallel_output(&output);
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
+use aptos_aggregator::types::code_invariant_error;
 use aptos_types::{
     block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
     executable::ExecutableTestType,
@@ -140,6 +141,6 @@ where
         .execute_transactions_parallel((), &self.transactions, &data_view);
 
         self.baseline_output
-            .assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+            .assert_output(&output.map_err(|err| BlockExecutionError::FatalBlockExecutorError(code_invariant_error(""))));
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::BlockExecutionError,
+    errors::SequentialBlockExecutionError,
     executor::BlockExecutor,
     proptest_types::{
         baseline::BaselineOutput,
@@ -15,7 +15,6 @@ use crate::{
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
-use aptos_aggregator::types::PanicOr;
 use aptos_types::{
     block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
     executable::ExecutableTestType,
@@ -91,7 +90,7 @@ fn run_transactions<K, V, E>(
         }
 
         BaselineOutput::generate(&transactions, maybe_block_gas_limit)
-            .assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+            .assert_parallel_output(&output);
     }
 }
 
@@ -221,7 +220,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         .execute_transactions_parallel((), &transactions, &data_view);
 
         BaselineOutput::generate(&transactions, maybe_block_gas_limit)
-            .assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+            .assert_parallel_output(&output);
     }
 }
 
@@ -272,7 +271,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .execute_transactions_parallel((), &transactions, &data_view);
 
         BaselineOutput::generate(&transactions, maybe_block_gas_limit)
-            .assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+            .assert_parallel_output(&output);
     }
 }
 
@@ -472,7 +471,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         ) // Ensure enough gas limit to commit the module txns (4 is maximum gas per txn)
         .execute_transactions_parallel((), &transactions, &data_view);
 
-        assert_matches!(output, Err(PanicOr::Or(_)));
+        assert_matches!(output, Err(()));
     }
 }
 
@@ -551,8 +550,7 @@ fn non_empty_group(
         )
         .execute_transactions_parallel((), &transactions, &data_view);
 
-        BaselineOutput::generate(&transactions, None)
-            .assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+        BaselineOutput::generate(&transactions, None).assert_parallel_output(&output);
     }
 
     for _ in 0..num_repeat_sequential {
@@ -570,7 +568,12 @@ fn non_empty_group(
         .execute_transactions_sequential((), &transactions, &data_view, false);
         // TODO: test dynamic disabled as well.
 
-        BaselineOutput::generate(&transactions, None).assert_output(&output);
+        BaselineOutput::generate(&transactions, None).assert_output(&output.map_err(|e| match e {
+            SequentialBlockExecutionError::ResourceGroupSerializationError => {
+                panic!("Unexpected error")
+            },
+            SequentialBlockExecutionError::ErrorToReturn(err) => err,
+        }));
     }
 }
 

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -86,7 +86,7 @@ fn run_transactions<K, V, E>(
         .execute_transactions_parallel((), &transactions, &data_view);
 
         if module_access.0 && module_access.1 {
-            assert_matches!(output, Err(PanicOr::Or(_)));
+            assert_matches!(output, Err(()));
             continue;
         }
 

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1100,6 +1100,20 @@ where
         }
     }
 
+    fn discard_output(discard_code: move_core_types::vm_status::StatusCode) -> Self {
+        Self {
+            writes: vec![],
+            group_writes: vec![],
+            deltas: vec![],
+            events: vec![],
+            read_results: vec![],
+            read_group_sizes: vec![],
+            materialized_delta_writes: OnceCell::new(),
+            total_gas: 0,
+            skipped: true,
+        }
+    }
+
     fn materialize_agg_v1(
         &self,
         _view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -1100,7 +1100,7 @@ where
         }
     }
 
-    fn discard_output(discard_code: move_core_types::vm_status::StatusCode) -> Self {
+    fn discard_output(_discard_code: move_core_types::vm_status::StatusCode) -> Self {
         Self {
             writes: vec![],
             group_writes: vec![],

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -13,7 +13,7 @@ use aptos_types::{
     transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::{value::MoveTypeLayout, vm_status::StatusCode};
 use std::{
     collections::{BTreeMap, HashSet},
     fmt::Debug,
@@ -162,6 +162,9 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;
+
+    /// Execution output for transactions that should be discarded.
+    fn discard_output(discard_code: StatusCode) -> Self;
 
     fn materialize_agg_v1(
         &self,

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -210,8 +210,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 return Err(code_invariant_error(format!(
                     "FatalVMError from parallel execution {:?} at txn {}",
                     err, txn_idx
-                ))
-                .into());
+                )));
             }
         }
         Ok(())

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -236,15 +236,17 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 ExecutionStatus::Abort(_) => {
                     Err(code_invariant_error("Abort status cannot be committed"))
                 },
-                ExecutionStatus::SpeculativeExecutionAbortError(_) => {
-                    Err(code_invariant_error("Speculative error status cannot be committed"))
-                },
+                ExecutionStatus::SpeculativeExecutionAbortError(_) => Err(code_invariant_error(
+                    "Speculative error status cannot be committed",
+                )),
                 ExecutionStatus::DelayedFieldsCodeInvariantError(_) => Err(code_invariant_error(
                     "Delayed field invariant error cannot be committed",
                 )),
             }
         } else {
-            Err(code_invariant_error("Recorded output not found during commit"))
+            Err(code_invariant_error(
+                "Recorded output not found during commit",
+            ))
         }
     }
 

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     captured_reads::CapturedReads,
-    errors::BlockExecutionError,
     explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
     types::{InputOutputKey, ReadWriteSummary},
@@ -33,7 +32,7 @@ macro_rules! forward_on_success_or_skip_rest {
         $self.outputs[$txn_idx as usize]
             .load()
             .as_ref()
-            .map_or(vec![], |txn_output| match &txn_output.output_status {
+            .map_or(vec![], |txn_output| match txn_output.as_ref() {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.$f(),
                 ExecutionStatus::Abort(_)
                 | ExecutionStatus::SpeculativeExecutionAbortError(_)
@@ -42,27 +41,10 @@ macro_rules! forward_on_success_or_skip_rest {
     }};
 }
 
-// When a transaction is committed, the output delta writes must be populated by
-// the WriteOps corresponding to the deltas in the corresponding outputs.
-#[derive(Debug)]
-pub(crate) struct TxnOutput<O: TransactionOutput, E: Debug> {
-    output_status: ExecutionStatus<O, BlockExecutionError<E>>,
-}
-
 pub(crate) enum KeyKind {
     Resource,
     Module,
     Group,
-}
-
-impl<O: TransactionOutput, E: Debug> TxnOutput<O, E> {
-    pub fn from_output_status(output_status: ExecutionStatus<O, BlockExecutionError<E>>) -> Self {
-        Self { output_status }
-    }
-
-    pub fn output_status(&self) -> &ExecutionStatus<O, BlockExecutionError<E>> {
-        &self.output_status
-    }
 }
 
 pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug> {
@@ -76,7 +58,7 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: 
     >,
 
     // TODO: Consider breaking down the outputs when storing (avoid traversals, cache below).
-    outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<O, E>>>>, // txn_idx -> output.
+    outputs: Vec<CachePadded<ArcSwapOption<ExecutionStatus<O, E>>>>, // txn_idx -> output.
     // Cache to avoid expensive clones of data.
     // TODO(clean-up): be consistent with naming resource writes: here it means specifically
     // individual writes, but in some contexts it refers to all writes (e.g. including group writes)
@@ -145,7 +127,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         &self,
         txn_idx: TxnIndex,
         input: CapturedReads<T>,
-        output: ExecutionStatus<O, BlockExecutionError<E>>,
+        output: ExecutionStatus<O, E>,
         arced_resource_writes: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
     ) -> bool {
         let written_modules = match &output {
@@ -165,7 +147,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
 
         *self.arced_resource_writes[txn_idx as usize].acquire() = arced_resource_writes;
         self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
-        self.outputs[txn_idx as usize].store(Some(Arc::new(TxnOutput::from_output_status(output))));
+        self.outputs[txn_idx as usize].store(Some(Arc::new(output)));
 
         true
     }
@@ -186,10 +168,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
 
     /// Returns the total gas, execution gas, io gas and storage gas of the transaction.
     pub(crate) fn fee_statement(&self, txn_idx: TxnIndex) -> Option<FeeStatement> {
-        match &self.outputs[txn_idx as usize]
+        match self.outputs[txn_idx as usize]
             .load_full()
             .expect("[BlockSTM]: Execution output must be recorded after execution")
-            .output_status
+            .as_ref()
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 Some(output.fee_statement())
@@ -199,10 +181,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     }
 
     pub(crate) fn output_approx_size(&self, txn_idx: TxnIndex) -> Option<u64> {
-        match &self.outputs[txn_idx as usize]
+        match self.outputs[txn_idx as usize]
             .load_full()
             .expect("[BlockSTM]: Execution output must be recorded after execution")
-            .output_status
+            .as_ref()
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
                 Some(output.output_approx_size())
@@ -214,12 +196,25 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     /// Does a transaction at txn_idx have SkipRest or Abort status.
     pub(crate) fn block_skips_rest_at_idx(&self, txn_idx: TxnIndex) -> bool {
         matches!(
-            &self.outputs[txn_idx as usize]
+            self.outputs[txn_idx as usize]
                 .load_full()
                 .expect("[BlockSTM]: Execution output must be recorded after execution")
-                .output_status,
+                .as_ref(),
             ExecutionStatus::SkipRest(_)
         )
+    }
+
+    pub(crate) fn check_fatal_vm_error(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
+        if let Some(status) = self.outputs[txn_idx as usize].load_full() {
+            if let ExecutionStatus::Abort(err) = status.as_ref() {
+                return Err(code_invariant_error(format!(
+                    "FatalVMError from parallel execution {:?} at txn {}",
+                    err, txn_idx
+                ))
+                .into());
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn check_execution_status_during_commit(
@@ -227,7 +222,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         txn_idx: TxnIndex,
     ) -> Result<(), PanicError> {
         if let Some(status) = self.outputs[txn_idx as usize].load_full() {
-            match &status.output_status {
+            match status.as_ref() {
                 ExecutionStatus::Success(_) | ExecutionStatus::SkipRest(_) => Ok(()),
                 // Transaction cannot be committed with below statuses, as:
                 // - Speculative error must have failed validation.
@@ -259,15 +254,13 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         // check_execution_status_during_commit must be used for checks re:status.
         // Hence, since the status is not SkipRest, it must be Success.
         if let ExecutionStatus::Success(output) = self.take_output(txn_idx) {
-            self.outputs[txn_idx as usize].store(Some(Arc::new(TxnOutput {
-                output_status: ExecutionStatus::SkipRest(output),
-            })));
+            self.outputs[txn_idx as usize].store(Some(Arc::new(ExecutionStatus::SkipRest(output))));
         } else {
             unreachable!("Unexpected status, must be Success");
         }
     }
 
-    pub(crate) fn txn_output(&self, txn_idx: TxnIndex) -> Option<Arc<TxnOutput<O, E>>> {
+    pub(crate) fn txn_output(&self, txn_idx: TxnIndex) -> Option<Arc<ExecutionStatus<O, E>>> {
         self.outputs[txn_idx as usize].load_full()
     }
 
@@ -279,7 +272,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     ) -> Option<impl Iterator<Item = (T::Key, KeyKind)>> {
         self.outputs[txn_idx as usize]
             .load_full()
-            .and_then(|txn_output| match &txn_output.output_status {
+            .and_then(|txn_output| match txn_output.as_ref() {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => Some(
                     t.resource_write_set()
                         .into_iter()
@@ -316,7 +309,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         self.outputs[txn_idx as usize]
             .load()
             .as_ref()
-            .and_then(|txn_output| match &txn_output.output_status {
+            .and_then(|txn_output| match txn_output.as_ref() {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
                     Some(t.delayed_field_change_set().into_keys())
                 },
@@ -357,7 +350,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     ) -> Box<dyn Iterator<Item = (T::Event, Option<MoveTypeLayout>)>> {
         self.outputs[txn_idx as usize].load().as_ref().map_or(
             Box::new(empty::<(T::Event, Option<MoveTypeLayout>)>()),
-            |txn_output| match &txn_output.output_status {
+            |txn_output| match txn_output.as_ref() {
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
                     let events = t.get_events();
                     Box::new(events.into_iter())
@@ -403,10 +396,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         patched_resource_write_set: Vec<(T::Key, T::Value)>,
         patched_events: Vec<T::Event>,
     ) -> Result<(), PanicError> {
-        match &self.outputs[txn_idx as usize]
+        match self.outputs[txn_idx as usize]
             .load_full()
             .expect("Output must exist")
-            .output_status
+            .as_ref()
         {
             ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => {
                 t.incorporate_materialized_txn_output(
@@ -434,10 +427,10 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         &self,
         txn_idx: TxnIndex,
     ) -> HashSet<InputOutputKey<T::Key, T::Tag, T::Identifier>> {
-        match &self.outputs[txn_idx as usize]
+        match self.outputs[txn_idx as usize]
             .load_full()
             .expect("Output must exist")
-            .output_status
+            .as_ref()
         {
             ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => t.get_write_summary(),
             ExecutionStatus::Abort(_)
@@ -448,16 +441,12 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
 
     // Must be executed after parallel execution is done, grabs outputs. Will panic if
     // other outstanding references to the recorded outputs exist.
-    pub(crate) fn take_output(
-        &self,
-        txn_idx: TxnIndex,
-    ) -> ExecutionStatus<O, BlockExecutionError<E>> {
+    pub(crate) fn take_output(&self, txn_idx: TxnIndex) -> ExecutionStatus<O, E> {
         let owning_ptr = self.outputs[txn_idx as usize]
             .swap(None)
             .expect("[BlockSTM]: Output must be recorded after execution");
 
         Arc::try_unwrap(owning_ptr)
-            .map(|output| output.output_status)
             .expect("[BlockSTM]: Output should be uniquely owned after execution")
     }
 }

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::BlockExecutionError,
+    errors::SequentialBlockExecutionError,
     executor::BlockExecutor,
     proptest_types::{
         baseline::BaselineOutput,
@@ -21,7 +21,6 @@ use aptos_aggregator::{
     bounded_math::SignedU128,
     delta_change_set::{delta_add, delta_sub, DeltaOp},
     delta_math::DeltaHistory,
-    types::PanicOr,
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
@@ -116,25 +115,24 @@ fn resource_group_bcs_fallback() {
     assert!(!fail::list().is_empty());
 
     let par_output = block_executor.execute_transactions_parallel((), &transactions, &data_view);
-    assert_matches!(
-        par_output,
-        Err(PanicOr::Or(
-            IntentionalFallbackToSequential::FallbackFromParallel
-        ))
-    );
+    assert_matches!(par_output, Err(()));
 
     let seq_output =
         block_executor.execute_transactions_sequential((), &transactions, &data_view, false);
     assert_matches!(
         seq_output,
-        Err(BlockExecutionError::FallbackToSequential(PanicOr::Or(
-            IntentionalFallbackToSequential::ResourceGroupSerializationError
-        )))
+        Err(SequentialBlockExecutionError::ResourceGroupSerializationError)
     );
 
     // Now execute with fallback handling for resource group serialization error:
-    let fallback_output =
-        block_executor.execute_transactions_sequential((), &transactions, &data_view, true);
+    let fallback_output = block_executor
+        .execute_transactions_sequential((), &transactions, &data_view, true)
+        .map_err(|e| match e {
+            SequentialBlockExecutionError::ResourceGroupSerializationError => {
+                panic!("Unexpected error")
+            },
+            SequentialBlockExecutionError::ErrorToReturn(err) => err,
+        });
     let fallback_output_block = block_executor.execute_block((), &transactions, &data_view);
     for output in [fallback_output, fallback_output_block] {
         match output {
@@ -197,12 +195,7 @@ fn block_output_err_precedence() {
     // Pause the thread that processes the aborting txn1, so txn2 can halt the scheduler first.
     // Confirm that the fatal VM error is still detected and sequential fallback triggered.
     let output = block_executor.execute_transactions_parallel((), &transactions, &data_view);
-    assert_matches!(
-        output,
-        Err(PanicOr::Or(
-            IntentionalFallbackToSequential::FallbackFromParallel
-        ))
-    );
+    assert_matches!(output, Err(()));
     scenario.teardown();
 }
 
@@ -268,7 +261,7 @@ where
     .execute_transactions_parallel((), &transactions, &data_view);
 
     let baseline = BaselineOutput::generate(&transactions, None);
-    baseline.assert_output(&output.map_err(BlockExecutionError::FallbackToSequential));
+    baseline.assert_parallel_output(&output);
 }
 
 fn random_value(delete_value: bool) -> ValueType {

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::{BlockExecutionError, IntentionalFallbackToSequential},
+    errors::BlockExecutionError,
     executor::BlockExecutor,
     proptest_types::{
         baseline::BaselineOutput,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1261,7 +1261,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                         {
                             return Some(Ok((key.clone(), (metadata, group_size.get()))));
                         } else {
-                            // TODO[agg_v2](fix): `get_group_size` can fail on group tag serialization. Do
+                            // TODO[agg_v2](cleanup): `get_group_size` can fail on group tag serialization. Do
                             //       we want to propagate this error? This is somewhat an invariant
                             //       violation so PanicError is also ok?
                             return Some(Err(code_invariant_error(format!(
@@ -3067,7 +3067,7 @@ mod test {
             Some(state_value_3.clone())
         );
 
-        // TODO[agg_v2](fix): This is printing Ok(Versioned(Err(StorageVersion), ValueType { bytes: Some(b"!0\0\0\0\0\0\0"), metadata: None }, None))
+        // TODO[agg_v2](test): This is printing Ok(Versioned(Err(StorageVersion), ValueType { bytes: Some(b"!0\0\0\0\0\0\0"), metadata: None }, None))
         // Is Err(StorageVersion) expected here?
         println!(
             "data: {:?}",
@@ -3108,14 +3108,14 @@ mod test {
         let _read_set_with_delayed_fields =
             captured_reads.get_read_values_with_delayed_fields(&HashSet::new(), &HashSet::new());
 
-        // TODO[agg_v2](fix): This prints
+        // TODO[agg_v2](test): This prints
         // read: (KeyType(4, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         // read: (KeyType(2, false), Versioned(Err(StorageVersion), Some(Struct(Runtime([Struct(Runtime([Tagged(IdentifierMapping(Aggregator), U64), U64]))])))))
         // for read in read_set_with_delayed_fields {
         //     println!("read: {:?}", read);
         // }
 
-        // TODO[agg_v2](fix): This assertion fails.
+        // TODO[agg_v2](test): This assertion fails.
         // let data_read = DataRead::Versioned(Ok((1,0)), Arc::new(TransactionWrite::from_state_value(Some(state_value_4))), Some(Arc::new(layout)));
         // assert!(read_set_with_delayed_fields.any(|x| x == (&KeyType::<u32>(4, false), &data_read)));
     }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -489,6 +489,7 @@ impl FakeExecutor {
                     usize::min(4, num_cpus::get())
                 },
                 allow_fallback: self.allow_block_executor_fallback,
+                discard_failed_blocks: false,
             },
             onchain: onchain_config,
         };

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -5,11 +5,10 @@ use crate::{
     types::{GroupReadResult, MVModulesOutput, UnsyncGroupError, ValueWithLayout},
     utils::module_hash,
 };
-use aptos_aggregator::types::DelayedFieldValue;
+use aptos_aggregator::types::{code_invariant_error, DelayedFieldValue};
 use aptos_crypto::hash::HashValue;
 use aptos_types::{
-    executable::{Executable, ExecutableDescriptor, ModulePath},
-    write_set::TransactionWrite,
+    delayed_fields::PanicError, executable::{Executable, ExecutableDescriptor, ModulePath}, write_set::TransactionWrite
 };
 use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use move_binary_format::errors::PartialVMResult;
@@ -150,8 +149,7 @@ impl<
         value_tag: T,
         v: V,
         maybe_layout: Option<Arc<MoveTypeLayout>>,
-    ) -> anyhow::Result<()> {
-        use anyhow::bail;
+    ) -> Result<(), PanicError> {
         use aptos_types::write_set::WriteOpKind::*;
         use std::collections::hash_map::Entry::*;
         match (
@@ -174,11 +172,11 @@ impl<
             },
             (l, r) => {
                 println!("WriteOp kind {:?} not consistent with previous value at tag {:?}. l: {:?}, r: {:?}", v.write_op_kind(), value_tag, l, r);
-                bail!(
+                return Err(code_invariant_error(format!(
                     "WriteOp kind {:?} not consistent with previous value at tag {:?}",
                     v.write_op_kind(),
                     value_tag
-                );
+                )));
             },
         }
 

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -8,7 +8,9 @@ use crate::{
 use aptos_aggregator::types::{code_invariant_error, DelayedFieldValue};
 use aptos_crypto::hash::HashValue;
 use aptos_types::{
-    delayed_fields::PanicError, executable::{Executable, ExecutableDescriptor, ModulePath}, write_set::TransactionWrite
+    delayed_fields::PanicError,
+    executable::{Executable, ExecutableDescriptor, ModulePath},
+    write_set::TransactionWrite,
 };
 use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use move_binary_format::errors::PartialVMResult;

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -50,6 +50,7 @@ pub fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
 pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     AptosVM::set_paranoid_type_checks(node_config.execution.paranoid_type_verification);
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    AptosVM::set_discard_failed_blocks(node_config.execution.discard_failed_blocks);
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,
     );

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -31,6 +31,8 @@ pub struct ExecutionConfig {
     pub num_proof_reading_threads: u16,
     /// Enables paranoid mode for types, which adds extra runtime VM checks
     pub paranoid_type_verification: bool,
+    /// Enabled discarding blocks that fail execution due to BlockSTM/VM issue.
+    pub discard_failed_blocks: bool,
     /// Enables paranoid mode for hot potatoes, which adds extra runtime VM checks
     pub paranoid_hot_potato_verification: bool,
     /// Enables enhanced metrics around processed transactions
@@ -67,6 +69,7 @@ impl Default for ExecutionConfig {
             num_proof_reading_threads: 32,
             paranoid_type_verification: true,
             paranoid_hot_potato_verification: true,
+            discard_failed_blocks: false,
             processed_transactions_detailed_counters: false,
             transaction_filter: Filter::empty(),
             genesis_waypoint: None,

--- a/testsuite/smoke-test/src/execution.rs
+++ b/testsuite/smoke-test/src/execution.rs
@@ -2,10 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    smoke_test_environment::SwarmBuilder,
-    utils::get_current_version,
-};
+use crate::{smoke_test_environment::SwarmBuilder, utils::get_current_version};
 use aptos_forge::{NodeExt, SwarmExt};
 use std::{sync::Arc, time::Duration};
 
@@ -25,12 +22,15 @@ async fn fallback_test() {
         .await
         .expect("Epoch 2 taking too long to come!");
 
-    let client = swarm.validators().nth(0).unwrap().rest_client();
+    let client = swarm.validators().next().unwrap().rest_client();
 
-    client.set_failpoint(
-        "aptos_vm::vm_wrapper::execute_transaction".to_string(),
-        "100%return".to_string(),
-    ).await.unwrap();
+    client
+        .set_failpoint(
+            "aptos_vm::vm_wrapper::execute_transaction".to_string(),
+            "100%return".to_string(),
+        )
+        .await
+        .unwrap();
 
     for _i in 0..1 {
         let version_milestone_0 = get_current_version(&client).await;

--- a/testsuite/smoke-test/src/execution.rs
+++ b/testsuite/smoke-test/src/execution.rs
@@ -1,0 +1,44 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    smoke_test_environment::SwarmBuilder,
+    utils::get_current_version,
+};
+use aptos_forge::{NodeExt, SwarmExt};
+use std::{sync::Arc, time::Duration};
+
+#[tokio::test]
+async fn fallback_test() {
+    let swarm = SwarmBuilder::new_local(1)
+        .with_init_config(Arc::new(|_, config, _| {
+            config.api.failpoints_enabled = true;
+            config.execution.discard_failed_blocks = true;
+        }))
+        .with_aptos()
+        .build()
+        .await;
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(2, Duration::from_secs(60))
+        .await
+        .expect("Epoch 2 taking too long to come!");
+
+    let client = swarm.validators().nth(0).unwrap().rest_client();
+
+    client.set_failpoint(
+        "aptos_vm::vm_wrapper::execute_transaction".to_string(),
+        "100%return".to_string(),
+    ).await.unwrap();
+
+    for _i in 0..1 {
+        let version_milestone_0 = get_current_version(&client).await;
+        let version_milestone_1 = version_milestone_0 + 5;
+        println!("Current version: {}, the chain should tolerate discarding failed blocks, waiting for {}.", version_milestone_0, version_milestone_1);
+        swarm
+            .wait_for_all_nodes_to_catchup_to_version(version_milestone_1, Duration::from_secs(30))
+            .await
+            .expect("milestone 1 taking too long");
+    }
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -11,9 +11,9 @@ mod aptos_cli;
 #[cfg(test)]
 mod client;
 #[cfg(test)]
-mod execution;
-#[cfg(test)]
 mod consensus;
+#[cfg(test)]
+mod execution;
 #[cfg(test)]
 mod full_nodes;
 #[cfg(test)]

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -11,6 +11,8 @@ mod aptos_cli;
 #[cfg(test)]
 mod client;
 #[cfg(test)]
+mod execution;
+#[cfg(test)]
 mod consensus;
 #[cfg(test)]
 mod full_nodes;

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -7,7 +7,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug)]
 pub struct BlockExecutorLocalConfig {
     pub concurrency_level: usize,
+    // If specified, parallel execution fallbacks to sequential, if issue occurs.
+    // Otherwise, if there is an error in either of the execution, we will panic.
     pub allow_fallback: bool,
+    // If true, we will discard the failed blocks and continue with the next block.
+    // (allow_fallback needs to be set)
+    pub discard_failed_blocks: bool,
 }
 
 /// Configuration from on-chain configuration, that is
@@ -66,6 +71,7 @@ impl BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 concurrency_level,
                 allow_fallback: true,
+                discard_failed_blocks: false,
             },
             onchain: BlockExecutorConfigFromOnchain::new_no_block_limit(),
         }
@@ -79,6 +85,7 @@ impl BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 concurrency_level,
                 allow_fallback: true,
+                discard_failed_blocks: false,
             },
             onchain: BlockExecutorConfigFromOnchain::new_maybe_block_limit(maybe_block_gas_limit),
         }


### PR DESCRIPTION
### Description

- make executor resilient to aggregator exceptions. where possible, skip transactions that are failing
- cleanup errors across parallel and sequential execution
- and discard_failed_blocks

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
