### PR TITLE
Fix zkid smoke tests

### DIFF
--- a/aptos-move/aptos-vm/src/zkid_validation.rs
+++ b/aptos-move/aptos-vm/src/zkid_validation.rs
@@ -105,10 +105,6 @@ pub fn validate_zkid_authenticators(
 ) -> Result<(), VMStatus> {
     if authenticators.is_empty() {
         return Ok(());
-    }
-
-    println!("hihi");
-    println!("1");
 
     let config = &get_configs_onchain(resolver)?;
 

--- a/aptos-move/aptos-vm/src/zkid_validation.rs
+++ b/aptos-move/aptos-vm/src/zkid_validation.rs
@@ -120,14 +120,12 @@ pub fn validate_zkid_authenticators(
             .verify_expiry(&onchain_timestamp_obj)
             .map_err(|_| invalid_signature!("The ephemeral keypair has expired"))?;
     }
-    println!("2");
 
     let patched_jwks = get_jwks_onchain(resolver)?;
     let pvk = &get_groth16_vk_onchain(resolver)?
         .try_into()
         .map_err(|_| invalid_signature!("Could not deserialize on-chain Groth16 VK"))?;
 
-    println!("3");
     let training_wheels_pk = match &config.training_wheels_pubkey {
         None => None,
         Some(bytes) => Some(EphemeralPublicKey::ed25519(

--- a/aptos-move/aptos-vm/src/zkid_validation.rs
+++ b/aptos-move/aptos-vm/src/zkid_validation.rs
@@ -107,6 +107,9 @@ pub fn validate_zkid_authenticators(
         return Ok(());
     }
 
+    println!("hihi");
+    println!("1");
+
     let config = &get_configs_onchain(resolver)?;
 
     if authenticators.len() > config.max_zkid_signatures_per_txn as usize {
@@ -120,12 +123,14 @@ pub fn validate_zkid_authenticators(
             .verify_expiry(&onchain_timestamp_obj)
             .map_err(|_| invalid_signature!("The ephemeral keypair has expired"))?;
     }
+    println!("2");
 
     let patched_jwks = get_jwks_onchain(resolver)?;
     let pvk = &get_groth16_vk_onchain(resolver)?
         .try_into()
         .map_err(|_| invalid_signature!("Could not deserialize on-chain Groth16 VK"))?;
 
+    println!("3");
     let training_wheels_pk = match &config.training_wheels_pubkey {
         None => None,
         Some(bytes) => Some(EphemeralPublicKey::ed25519(

--- a/aptos-move/aptos-vm/src/zkid_validation.rs
+++ b/aptos-move/aptos-vm/src/zkid_validation.rs
@@ -105,6 +105,7 @@ pub fn validate_zkid_authenticators(
 ) -> Result<(), VMStatus> {
     if authenticators.is_empty() {
         return Ok(());
+    }
 
     let config = &get_configs_onchain(resolver)?;
 

--- a/testsuite/smoke-test/src/zkid.rs
+++ b/testsuite/smoke-test/src/zkid.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn test_zkid_oidc_signature_transaction_submission() {
-    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
         .with_aptos()
         .build_with_cli(0)
         .await;

--- a/testsuite/smoke-test/src/zkid.rs
+++ b/testsuite/smoke-test/src/zkid.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn test_zkid_oidc_signature_transaction_submission() {
-    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()
         .build_with_cli(0)
         .await;
@@ -91,8 +91,8 @@ async fn test_zkid_oidc_signature_transaction_submission() {
 
     let epk_blinder = vec![0u8; 31];
     let jwt_header = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RfandrIiwidHlwIjoiSldUIn0".to_string();
-    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiIxYlFsNF9YYzUtSXBDcFViS19BZVhwZ2Q2R1o0MGxVVjN1YjN5b19FTHhrIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcwNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
-    let jwt_sig = "oBdOiIUc-ioG2-sHV1hWDLjgk4NrVf3z6V-HmgbOrVAz3PV1CwdfyTXsmVaCqLzOHzcbFB6ZRDxShs3aR7PsqdlhI0Dh8WrfU8kBkyk1FAmx2nST4SoSJROXsnusaOpNFpgSl96Rq3SXgr-yPBE9dEwTfD00vq2gH_fH1JAIeJJhc6WicMcsEZ7iONT1RZOid_9FlDrg1GxlGtNmpn4nEAmIxqnT0JrCESiRvzmuuXUibwx9xvHgIxhyVuAA9amlzaD1DL6jEc5B_0YnGKN7DO_l2Hkj9MbQZvU0beR-Lfcz8jxCjojODTYmWgbtu5E7YWIyC6dsjiBnTxc-svCsmQ".to_string();
+    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiJHRTJSNWtpSjN1QUZORGNVLTdFZWlRUVE2ZzhITXlTX3VFSERuV0V4NndJIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcyNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
+    let jwt_sig = "VjBhIlbIP7SmF-ra7GMgcWNghU1Ew8U7ZeGBukJ7NHUfjQkPsG2cMfZD_WwZoLJBk3HjjZJyItVq67XIUqdbIM30pVem-QPDX-bjaGEyRlHUkHonKT8JjOMUtKN9NQA9ikqd-DJCxT5UfpotJ_9n7D4kf2cO9wpITyVFHT_BP8yJoJEWT61bvqIzVuNNE3umMwL29lICnvnUa20KjDIyk2BOlUOvNJfjPdJHPuzFDuqjv8cRSTJqjd2N-E31-R7VvCtQ75WNfWu1mPY3IDfu7uiS5zqXNJzWq1GLe8K3o2_BP9_xP7loDyCYAcmX-gFSNCEc4gbpYEq_5vBYfwG7Vg".to_string();
 
     let openid_signature = OpenIdSig {
         jwt_sig,
@@ -106,7 +106,7 @@ async fn test_zkid_oidc_signature_transaction_submission() {
     let zk_sig = ZkIdSignature {
         sig: ZkpOrOpenIdSig::OpenIdSig(openid_signature),
         jwt_header,
-        exp_timestamp_secs: 1707812836,
+        exp_timestamp_secs: 1727812836,
         ephemeral_pubkey: ephemeral_public_key,
         ephemeral_signature,
     };
@@ -175,7 +175,7 @@ async fn test_zkid_oidc_signature_transaction_submission_fails_jwt_verification(
 
     let epk_blinder = vec![0u8; 31];
     let jwt_header = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RfandrIiwidHlwIjoiSldUIn0".to_string();
-    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiIxYlFsNF9YYzUtSXBDcFViS19BZVhwZ2Q2R1o0MGxVVjN1YjN5b19FTHhrIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcwNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
+    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiJHRTJSNWtpSjN1QUZORGNVLTdFZWlRUVE2ZzhITXlTX3VFSERuV0V4NndJIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcyNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
     let jwt_sig = "bad_signature".to_string();
 
     let openid_signature = OpenIdSig {
@@ -190,7 +190,7 @@ async fn test_zkid_oidc_signature_transaction_submission_fails_jwt_verification(
     let zk_sig = ZkIdSignature {
         sig: ZkpOrOpenIdSig::OpenIdSig(openid_signature),
         jwt_header,
-        exp_timestamp_secs: 1707812836,
+        exp_timestamp_secs: 1727812836,
         ephemeral_pubkey: ephemeral_public_key,
         ephemeral_signature,
     };
@@ -260,8 +260,8 @@ async fn test_zkid_oidc_signature_transaction_submission_epk_expired() {
 
     let epk_blinder = vec![0u8; 31];
     let jwt_header = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RfandrIiwidHlwIjoiSldUIn0".to_string();
-    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiIxYlFsNF9YYzUtSXBDcFViS19BZVhwZ2Q2R1o0MGxVVjN1YjN5b19FTHhrIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcwNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
-    let jwt_sig = "oBdOiIUc-ioG2-sHV1hWDLjgk4NrVf3z6V-HmgbOrVAz3PV1CwdfyTXsmVaCqLzOHzcbFB6ZRDxShs3aR7PsqdlhI0Dh8WrfU8kBkyk1FAmx2nST4SoSJROXsnusaOpNFpgSl96Rq3SXgr-yPBE9dEwTfD00vq2gH_fH1JAIeJJhc6WicMcsEZ7iONT1RZOid_9FlDrg1GxlGtNmpn4nEAmIxqnT0JrCESiRvzmuuXUibwx9xvHgIxhyVuAA9amlzaD1DL6jEc5B_0YnGKN7DO_l2Hkj9MbQZvU0beR-Lfcz8jxCjojODTYmWgbtu5E7YWIyC6dsjiBnTxc-svCsmQ".to_string();
+    let jwt_payload = "eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJ0ZXN0X2NsaWVudF9pZCIsInN1YiI6InRlc3RfYWNjb3VudCIsImVtYWlsIjoidGVzdEBnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiJHRTJSNWtpSjN1QUZORGNVLTdFZWlRUVE2ZzhITXlTX3VFSERuV0V4NndJIiwibmJmIjoxNzAyODA4OTM2LCJpYXQiOjE3MDQ5MDkyMzYsImV4cCI6MTcyNzgxMjgzNiwianRpIjoiZjEwYWZiZjBlN2JiOTcyZWI4ZmE2M2YwMjQ5YjBhMzRhMjMxZmM0MCJ9".to_string();
+    let jwt_sig = "VjBhIlbIP7SmF-ra7GMgcWNghU1Ew8U7ZeGBukJ7NHUfjQkPsG2cMfZD_WwZoLJBk3HjjZJyItVq67XIUqdbIM30pVem-QPDX-bjaGEyRlHUkHonKT8JjOMUtKN9NQA9ikqd-DJCxT5UfpotJ_9n7D4kf2cO9wpITyVFHT_BP8yJoJEWT61bvqIzVuNNE3umMwL29lICnvnUa20KjDIyk2BOlUOvNJfjPdJHPuzFDuqjv8cRSTJqjd2N-E31-R7VvCtQ75WNfWu1mPY3IDfu7uiS5zqXNJzWq1GLe8K3o2_BP9_xP7loDyCYAcmX-gFSNCEc4gbpYEq_5vBYfwG7Vg".to_string();
 
     let openid_signature = OpenIdSig {
         jwt_sig,
@@ -275,7 +275,7 @@ async fn test_zkid_oidc_signature_transaction_submission_epk_expired() {
     let zk_sig = ZkIdSignature {
         sig: ZkpOrOpenIdSig::OpenIdSig(openid_signature),
         jwt_header,
-        exp_timestamp_secs: 1704909236,
+        exp_timestamp_secs: 1, // Expired timestamp
         ephemeral_pubkey: ephemeral_public_key,
         ephemeral_signature,
     };


### PR DESCRIPTION
### Description
This fixes the JWT that was being used in the smoke test with a new one.  The old one expired causes the test to fail without a code change.  This new one will expire in 8 months.  There is a TODO to be able to generate the JWT for the test so that the expiry doesn't have to be hardcoded in.

JWT generated via https://token.dev/
