### PR TITLE
[simple] rename RG split in VmChangeSet flag

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -91,7 +91,7 @@ pub enum FeatureFlag {
     LimitMaxIdentifierLength,
     OperatorBeneficiaryChange,
     VMBinaryFormatV7,
-    ResourceGroupsChargeAsSizeSum,
+    ResourceGroupSplitInVmChangeSet,
     CommissionChangeDelegationPool,
     BN254Structures,
     WebAuthnSignature,
@@ -248,8 +248,8 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::ConcurrentTokenV2 => AptosFeatureFlag::CONCURRENT_TOKEN_V2,
             FeatureFlag::LimitMaxIdentifierLength => AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
             FeatureFlag::OperatorBeneficiaryChange => AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
-            FeatureFlag::ResourceGroupsChargeAsSizeSum => {
-                AptosFeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM
+            FeatureFlag::ResourceGroupSplitInVmChangeSet => {
+                AptosFeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET
             },
             FeatureFlag::CommissionChangeDelegationPool => {
                 AptosFeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL
@@ -332,8 +332,8 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::CONCURRENT_TOKEN_V2 => FeatureFlag::ConcurrentTokenV2,
             AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH => FeatureFlag::LimitMaxIdentifierLength,
             AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE => FeatureFlag::OperatorBeneficiaryChange,
-            AptosFeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM => {
-                FeatureFlag::ResourceGroupsChargeAsSizeSum
+            AptosFeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET => {
+                FeatureFlag::ResourceGroupSplitInVmChangeSet
             },
             AptosFeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL => {
                 FeatureFlag::CommissionChangeDelegationPool

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -91,7 +91,7 @@ pub enum FeatureFlag {
     LimitMaxIdentifierLength,
     OperatorBeneficiaryChange,
     VMBinaryFormatV7,
-    ResourceGroupSplitInVmChangeSet,
+    ResourceGroupsSplitInVmChangeSet,
     CommissionChangeDelegationPool,
     BN254Structures,
     WebAuthnSignature,
@@ -248,8 +248,8 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::ConcurrentTokenV2 => AptosFeatureFlag::CONCURRENT_TOKEN_V2,
             FeatureFlag::LimitMaxIdentifierLength => AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
             FeatureFlag::OperatorBeneficiaryChange => AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
-            FeatureFlag::ResourceGroupSplitInVmChangeSet => {
-                AptosFeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET
+            FeatureFlag::ResourceGroupsSplitInVmChangeSet => {
+                AptosFeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET
             },
             FeatureFlag::CommissionChangeDelegationPool => {
                 AptosFeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL
@@ -332,8 +332,8 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::CONCURRENT_TOKEN_V2 => FeatureFlag::ConcurrentTokenV2,
             AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH => FeatureFlag::LimitMaxIdentifierLength,
             AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE => FeatureFlag::OperatorBeneficiaryChange,
-            AptosFeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET => {
-                FeatureFlag::ResourceGroupSplitInVmChangeSet
+            AptosFeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET => {
+                FeatureFlag::ResourceGroupsSplitInVmChangeSet
             },
             AptosFeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL => {
                 FeatureFlag::CommissionChangeDelegationPool

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -76,7 +76,7 @@ pub trait TResourceGroupView {
 
     /// Some resolvers might not be capable of the optimization, and should return false.
     /// Others might return based on the config or the run parameters.
-    fn is_resource_group_split_in_change_set_capable(&self) -> bool {
+    fn is_resource_groups_split_in_change_set_capable(&self) -> bool {
         false
     }
 

--- a/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
@@ -30,9 +30,9 @@ pub enum GroupSizeKind {
 impl GroupSizeKind {
     pub fn from_gas_feature_version(
         gas_feature_version: u64,
-        resource_group_charge_as_size_sum_enabled: bool,
+        resource_group_split_in_vm_change_set_enabled: bool,
     ) -> Self {
-        if resource_group_charge_as_size_sum_enabled {
+        if resource_group_split_in_vm_change_set_enabled {
             GroupSizeKind::AsSum
         } else if gas_feature_version >= 9 {
             // Keep old caching behavior for replay.
@@ -122,10 +122,10 @@ impl<'r> ResourceGroupAdapter<'r> {
         maybe_resource_group_view: Option<&'r dyn ResourceGroupView>,
         resource_view: &'r dyn TResourceView<Key = StateKey, Layout = MoveTypeLayout>,
         gas_feature_version: u64,
-        resource_group_charge_as_size_sum_enabled: bool,
+        resource_group_split_in_vm_change_set_enabled: bool,
     ) -> Self {
         // when is_resource_group_split_in_change_set_capable is false,
-        // but resource_group_charge_as_size_sum_enabled is true, we still don't set
+        // but resource_group_split_in_vm_change_set_enabled is true, we still don't set
         // group_size_kind to GroupSizeKind::AsSum, meaning that
         // is_resource_group_split_in_change_set_capable affects gas charging.
         // Onchain execution always needs to go through capable resolvers.
@@ -140,7 +140,7 @@ impl<'r> ResourceGroupAdapter<'r> {
             //     (outside of BlockExecutor) i.e. unit tests, view functions, etc.
             //     In this case, disabled will lead to a different gas behavior,
             //     but gas is not relevant for those contexts.
-            resource_group_charge_as_size_sum_enabled
+            resource_group_split_in_vm_change_set_enabled
                 && maybe_resource_group_view
                     .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
         );
@@ -508,13 +508,16 @@ mod tests {
 
     #[test_case(9, false)]
     #[test_case(12, true)] // Without view, this falls back to as_blob
-    fn size_as_blob_len(gas_feature_version: u64, resource_group_charge_as_size_sum_enabled: bool) {
+    fn size_as_blob_len(
+        gas_feature_version: u64,
+        resource_group_split_in_vm_change_set_enabled: bool,
+    ) {
         let state_view = MockStateView::new();
         let adapter = ResourceGroupAdapter::new(
             None,
             &state_view,
             gas_feature_version,
-            resource_group_charge_as_size_sum_enabled,
+            resource_group_split_in_vm_change_set_enabled,
         );
         assert_eq!(adapter.group_size_kind, GroupSizeKind::AsBlob);
 

--- a/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/resource_group_adapter.rs
@@ -30,9 +30,9 @@ pub enum GroupSizeKind {
 impl GroupSizeKind {
     pub fn from_gas_feature_version(
         gas_feature_version: u64,
-        resource_group_split_in_vm_change_set_enabled: bool,
+        resource_groups_split_in_vm_change_set_enabled: bool,
     ) -> Self {
-        if resource_group_split_in_vm_change_set_enabled {
+        if resource_groups_split_in_vm_change_set_enabled {
             GroupSizeKind::AsSum
         } else if gas_feature_version >= 9 {
             // Keep old caching behavior for replay.
@@ -122,12 +122,12 @@ impl<'r> ResourceGroupAdapter<'r> {
         maybe_resource_group_view: Option<&'r dyn ResourceGroupView>,
         resource_view: &'r dyn TResourceView<Key = StateKey, Layout = MoveTypeLayout>,
         gas_feature_version: u64,
-        resource_group_split_in_vm_change_set_enabled: bool,
+        resource_groups_split_in_vm_change_set_enabled: bool,
     ) -> Self {
-        // when is_resource_group_split_in_change_set_capable is false,
-        // but resource_group_split_in_vm_change_set_enabled is true, we still don't set
+        // when is_resource_groups_split_in_change_set_capable is false,
+        // but resource_groups_split_in_vm_change_set_enabled is true, we still don't set
         // group_size_kind to GroupSizeKind::AsSum, meaning that
-        // is_resource_group_split_in_change_set_capable affects gas charging.
+        // is_resource_groups_split_in_change_set_capable affects gas charging.
         // Onchain execution always needs to go through capable resolvers.
 
         let group_size_kind = GroupSizeKind::from_gas_feature_version(
@@ -140,9 +140,10 @@ impl<'r> ResourceGroupAdapter<'r> {
             //     (outside of BlockExecutor) i.e. unit tests, view functions, etc.
             //     In this case, disabled will lead to a different gas behavior,
             //     but gas is not relevant for those contexts.
-            resource_group_split_in_vm_change_set_enabled
-                && maybe_resource_group_view
-                    .map_or(false, |v| v.is_resource_group_split_in_change_set_capable()),
+            resource_groups_split_in_vm_change_set_enabled
+                && maybe_resource_group_view.map_or(false, |v| {
+                    v.is_resource_groups_split_in_change_set_capable()
+                }),
         );
 
         Self {
@@ -204,7 +205,7 @@ impl TResourceGroupView for ResourceGroupAdapter<'_> {
     type Layout = MoveTypeLayout;
     type ResourceTag = StructTag;
 
-    fn is_resource_group_split_in_change_set_capable(&self) -> bool {
+    fn is_resource_groups_split_in_change_set_capable(&self) -> bool {
         self.group_size_kind == GroupSizeKind::AsSum
     }
 
@@ -360,7 +361,7 @@ mod tests {
         type Layout = MoveTypeLayout;
         type ResourceTag = StructTag;
 
-        fn is_resource_group_split_in_change_set_capable(&self) -> bool {
+        fn is_resource_groups_split_in_change_set_capable(&self) -> bool {
             true
         }
 
@@ -510,14 +511,14 @@ mod tests {
     #[test_case(12, true)] // Without view, this falls back to as_blob
     fn size_as_blob_len(
         gas_feature_version: u64,
-        resource_group_split_in_vm_change_set_enabled: bool,
+        resource_groups_split_in_vm_change_set_enabled: bool,
     ) {
         let state_view = MockStateView::new();
         let adapter = ResourceGroupAdapter::new(
             None,
             &state_view,
             gas_feature_version,
-            resource_group_split_in_vm_change_set_enabled,
+            resource_groups_split_in_vm_change_set_enabled,
         );
         assert_eq!(adapter.group_size_kind, GroupSizeKind::AsBlob);
 

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -128,7 +128,7 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
             if let Transaction::GenesisTransaction(WriteSetPayload::Direct(_)) = txn.expect_valid()
             {
                 // WriteSetPayload::Direct cannot be handled in mode where delayed_field_optimization or
-                // resource_group_split_in_write_set is enabled.
+                // resource_groups_split_in_change_set is enabled.
                 return false;
             }
         }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -86,7 +86,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
             maybe_resource_group_view,
             executor_view,
             gas_feature_version,
-            features.is_resource_group_charge_as_size_sum_enabled(),
+            features.is_resource_group_split_in_vm_change_set_enabled(),
         );
 
         Self::new(
@@ -325,7 +325,7 @@ impl<S: StateView> AsMoveResolver<S> for S {
             None,
             self,
             gas_feature_version,
-            features.is_resource_group_charge_as_size_sum_enabled(),
+            features.is_resource_group_split_in_vm_change_set_enabled(),
         );
         let max_identifier_size = get_max_identifier_size(&features);
         StorageAdapter::new(
@@ -373,19 +373,19 @@ pub(crate) mod tests {
     ) -> StorageAdapter<S> {
         assert!(group_size_kind != GroupSizeKind::AsSum, "not yet supported");
 
-        let (gas_feature_version, resource_group_charge_as_size_sum_enabled) = match group_size_kind
-        {
-            GroupSizeKind::AsSum => (12, true),
-            GroupSizeKind::AsBlob => (10, false),
-            GroupSizeKind::None => (1, false),
-        };
+        let (gas_feature_version, resource_group_split_in_vm_change_set_enabled) =
+            match group_size_kind {
+                GroupSizeKind::AsSum => (12, true),
+                GroupSizeKind::AsBlob => (10, false),
+                GroupSizeKind::None => (1, false),
+            };
 
         let group_adapter = ResourceGroupAdapter::new(
             // TODO[agg_v2](test) add a converter for StateView for tests that implements ResourceGroupView
             None,
             state_view,
             gas_feature_version,
-            resource_group_charge_as_size_sum_enabled,
+            resource_group_split_in_vm_change_set_enabled,
         );
         StorageAdapter::new(state_view, 0, 0, group_adapter)
     }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -86,7 +86,7 @@ impl<'e, E: ExecutorView> StorageAdapter<'e, E> {
             maybe_resource_group_view,
             executor_view,
             gas_feature_version,
-            features.is_resource_group_split_in_vm_change_set_enabled(),
+            features.is_resource_groups_split_in_vm_change_set_enabled(),
         );
 
         Self::new(
@@ -325,7 +325,7 @@ impl<S: StateView> AsMoveResolver<S> for S {
             None,
             self,
             gas_feature_version,
-            features.is_resource_group_split_in_vm_change_set_enabled(),
+            features.is_resource_groups_split_in_vm_change_set_enabled(),
         );
         let max_identifier_size = get_max_identifier_size(&features);
         StorageAdapter::new(
@@ -373,7 +373,7 @@ pub(crate) mod tests {
     ) -> StorageAdapter<S> {
         assert!(group_size_kind != GroupSizeKind::AsSum, "not yet supported");
 
-        let (gas_feature_version, resource_group_split_in_vm_change_set_enabled) =
+        let (gas_feature_version, resource_groups_split_in_vm_change_set_enabled) =
             match group_size_kind {
                 GroupSizeKind::AsSum => (12, true),
                 GroupSizeKind::AsBlob => (10, false),
@@ -385,7 +385,7 @@ pub(crate) mod tests {
             None,
             state_view,
             gas_feature_version,
-            resource_group_split_in_vm_change_set_enabled,
+            resource_groups_split_in_vm_change_set_enabled,
         );
         StorageAdapter::new(state_view, 0, 0, group_adapter)
     }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1515,7 +1515,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TResourceGr
         unimplemented!("Currently resolved by ResourceGroupAdapter");
     }
 
-    fn is_resource_group_split_in_change_set_capable(&self) -> bool {
+    fn is_resource_groups_split_in_change_set_capable(&self) -> bool {
         match &self.latest_view {
             ViewState::Sync(_) => true,
             ViewState::Unsync(_) => true,

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -80,14 +80,14 @@ fn initialize_harness(
             vec![
                 FeatureFlag::AGGREGATOR_V2_API,
                 FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-                FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+                FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
             ],
             vec![],
         );
     } else {
         harness.enable_features(vec![FeatureFlag::AGGREGATOR_V2_API], vec![
             FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-            FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
     let account = harness.new_account_at(AccountAddress::ONE);

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -80,14 +80,14 @@ fn initialize_harness(
             vec![
                 FeatureFlag::AGGREGATOR_V2_API,
                 FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-                FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
+                FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
             ],
             vec![],
         );
     } else {
         harness.enable_features(vec![FeatureFlag::AGGREGATOR_V2_API], vec![
             FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
+            FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
     let account = harness.new_account_at(AccountAddress::ONE);

--- a/aptos-move/e2e-move-tests/src/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/resource_groups.rs
@@ -64,12 +64,12 @@ fn initialize_harness(
     harness.modify_gas_scaling(1000);
     if resource_group_charge_as_sum_enabled {
         harness.enable_features(
-            vec![FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM],
+            vec![FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET],
             vec![],
         );
     } else {
         harness.enable_features(vec![], vec![
-            FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
     let account = harness.new_account_at(AccountAddress::ONE);

--- a/aptos-move/e2e-move-tests/src/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/resource_groups.rs
@@ -64,12 +64,12 @@ fn initialize_harness(
     harness.modify_gas_scaling(1000);
     if resource_group_charge_as_sum_enabled {
         harness.enable_features(
-            vec![FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET],
+            vec![FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET],
             vec![],
         );
     } else {
         harness.enable_features(vec![], vec![
-            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
+            FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
     let account = harness.new_account_at(AccountAddress::ONE);

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_events.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_events.rs
@@ -70,7 +70,7 @@ fn run_entry_functions<F: Fn(ExecutionStatus)>(
         vec![
             FeatureFlag::AGGREGATOR_V2_API,
             FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-            FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+            FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ],
         vec![],
     );

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_runtime_checks.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_runtime_checks.rs
@@ -43,7 +43,7 @@ fn run_entry_functions<F: Fn(ExecutionStatus)>(func_names: Vec<&str>, check_stat
         vec![
             FeatureFlag::AGGREGATOR_V2_API,
             FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
-            FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+            FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ],
         vec![],
     );

--- a/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
@@ -17,7 +17,7 @@ use proptest::prelude::*;
 use serde::Deserialize;
 use test_case::test_case;
 
-// This mode describes whether to enable or disable RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM flag
+// This mode describes whether to enable or disable RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET flag
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ResourceGroupMode {
     EnabledOnly,
@@ -34,7 +34,7 @@ const ERESOURCE_DOESNT_EXIST: u64 = 19;
 // Could cleanup later on.
 fn setup(
     executor_mode: ExecutorMode,
-    // This mode describes whether to enable or disable RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM flag
+    // This mode describes whether to enable or disable RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET flag
     resource_group_mode: ResourceGroupMode,
     txns: usize,
 ) -> ResourceGroupsTestHarness {
@@ -165,12 +165,12 @@ fn test_resource_groups(resource_group_charge_as_sum_enabled: bool) {
     let mut h = MoveHarness::new();
     if resource_group_charge_as_sum_enabled {
         h.enable_features(
-            vec![FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM],
+            vec![FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET],
             vec![],
         );
     } else {
         h.enable_features(vec![], vec![
-            FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
@@ -17,7 +17,7 @@ use proptest::prelude::*;
 use serde::Deserialize;
 use test_case::test_case;
 
-// This mode describes whether to enable or disable RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET flag
+// This mode describes whether to enable or disable RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET flag
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ResourceGroupMode {
     EnabledOnly,
@@ -34,7 +34,7 @@ const ERESOURCE_DOESNT_EXIST: u64 = 19;
 // Could cleanup later on.
 fn setup(
     executor_mode: ExecutorMode,
-    // This mode describes whether to enable or disable RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET flag
+    // This mode describes whether to enable or disable RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET flag
     resource_group_mode: ResourceGroupMode,
     txns: usize,
 ) -> ResourceGroupsTestHarness {
@@ -165,12 +165,12 @@ fn test_resource_groups(resource_group_charge_as_sum_enabled: bool) {
     let mut h = MoveHarness::new();
     if resource_group_charge_as_sum_enabled {
         h.enable_features(
-            vec![FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET],
+            vec![FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET],
             vec![],
         );
     } else {
         h.enable_features(vec![], vec![
-            FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
+            FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ]);
     }
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -506,11 +506,11 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 
-<a id="0x1_features_RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET"></a>
+<a id="0x1_features_RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET"></a>
 
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET">RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET</a>: u64 = 41;
+<pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET">RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET</a>: u64 = 41;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -506,11 +506,11 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 
-<a id="0x1_features_RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM"></a>
+<a id="0x1_features_RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET"></a>
 
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM">RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM</a>: u64 = 41;
+<pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET">RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET</a>: u64 = 41;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -324,7 +324,7 @@ module std::features {
 
     const VM_BINARY_FORMAT_V7: u64 = 40;
 
-    const RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET: u64 = 41;
+    const RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET: u64 = 41;
 
     /// Whether the operator commission rate change in delegation pool is enabled.
     /// Lifetime: transient

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -324,7 +324,7 @@ module std::features {
 
     const VM_BINARY_FORMAT_V7: u64 = 40;
 
-    const RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM: u64 = 41;
+    const RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET: u64 = 41;
 
     /// Whether the operator commission rate change in delegation pool is enabled.
     /// Lifetime: transient

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -450,7 +450,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
         FeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
         FeatureFlag::BN254_STRUCTURES,
-        FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM,
+        FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
         FeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL,
         FeatureFlag::WEBAUTHN_SIGNATURE,
         // FeatureFlag::RECONFIGURE_WITH_DKG, //TODO: re-enable once randomness is ready.

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -450,7 +450,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
         FeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
         FeatureFlag::BN254_STRUCTURES,
-        FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET,
+        FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         FeatureFlag::COMMISSION_CHANGE_DELEGATION_POOL,
         FeatureFlag::WEBAUTHN_SIGNATURE,
         // FeatureFlag::RECONFIGURE_WITH_DKG, //TODO: re-enable once randomness is ready.

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -48,7 +48,7 @@ pub enum FeatureFlag {
     LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
     VM_BINARY_FORMAT_V7 = 40,
-    RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET = 41,
+    RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET = 41,
     COMMISSION_CHANGE_DELEGATION_POOL = 42,
     BN254_STRUCTURES = 43,
     WEBAUTHN_SIGNATURE = 44,
@@ -155,14 +155,14 @@ impl Features {
     /// Once enabled, Aggregator V2 functions become parallel.
     pub fn is_aggregator_v2_delayed_fields_enabled(&self) -> bool {
         // This feature depends on resource groups being split inside VMChange set,
-        // which is gated by RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET feature, so
+        // which is gated by RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET feature, so
         // require that feature to be enabled as well.
         self.is_enabled(FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS)
-            && self.is_resource_group_split_in_vm_change_set_enabled()
+            && self.is_resource_groups_split_in_vm_change_set_enabled()
     }
 
-    pub fn is_resource_group_split_in_vm_change_set_enabled(&self) -> bool {
-        self.is_enabled(FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET)
+    pub fn is_resource_groups_split_in_vm_change_set_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET)
     }
 
     /// Whether the zkID feature is enabled, specifically the ZK path with ZKP-based signatures.

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -48,7 +48,7 @@ pub enum FeatureFlag {
     LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
     VM_BINARY_FORMAT_V7 = 40,
-    RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM = 41,
+    RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET = 41,
     COMMISSION_CHANGE_DELEGATION_POOL = 42,
     BN254_STRUCTURES = 43,
     WEBAUTHN_SIGNATURE = 44,
@@ -155,14 +155,14 @@ impl Features {
     /// Once enabled, Aggregator V2 functions become parallel.
     pub fn is_aggregator_v2_delayed_fields_enabled(&self) -> bool {
         // This feature depends on resource groups being split inside VMChange set,
-        // which is gated by RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM feature, so
+        // which is gated by RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET feature, so
         // require that feature to be enabled as well.
         self.is_enabled(FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS)
-            && self.is_resource_group_charge_as_size_sum_enabled()
+            && self.is_resource_group_split_in_vm_change_set_enabled()
     }
 
-    pub fn is_resource_group_charge_as_size_sum_enabled(&self) -> bool {
-        self.is_enabled(FeatureFlag::RESOURCE_GROUPS_CHARGE_AS_SIZE_SUM)
+    pub fn is_resource_group_split_in_vm_change_set_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::RESOURCE_GROUP_SPLIT_IN_VM_CHANGE_SET)
     }
 
     /// Whether the zkID feature is enabled, specifically the ZK path with ZKP-based signatures.


### PR DESCRIPTION
old name was stale, when charging was what was different, but we changed the logic to keep backward compatible charging, and only affect VmChangeSet split

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
