### PR TITLE
[Indexer-grpc] Add profiling support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ name = "aptos-indexer-grpc-server-framework"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "aptos-admin-service",
  "aptos-metrics-core",
  "aptos-runtimes",
  "async-trait",

--- a/crates/aptos-admin-service/src/server/mod.rs
+++ b/crates/aptos-admin-service/src/server/mod.rs
@@ -23,7 +23,7 @@ use tokio::runtime::Runtime;
 
 mod consensus;
 #[cfg(target_os = "linux")]
-mod profiling;
+pub mod profiling;
 #[cfg(target_os = "linux")]
 mod thread_dump;
 mod utils;

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
@@ -60,6 +60,7 @@ pub struct IndexerGrpcDataServiceConfig {
     #[serde(default = "IndexerGrpcDataServiceConfig::default_data_service_response_channel_size")]
     pub data_service_response_channel_size: usize,
     /// A list of auth tokens that are allowed to access the service.
+    #[serde(default)]
     pub whitelisted_auth_tokens: Vec<String>,
     /// If set, don't check for auth tokens.
     #[serde(default)]

--- a/ecosystem/indexer-grpc/indexer-grpc-server-framework/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-server-framework/Cargo.toml
@@ -29,3 +29,6 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 warp = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+aptos-admin-service = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
@@ -1,10 +1,14 @@
 // Copyright © Aptos Foundation
 
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Result};
+#[cfg(target_os = "linux")]
+use aptos_admin_service::profiling::start_cpu_profiling;
 use backtrace::Backtrace;
 use clap::Parser;
 use prometheus::{Encoder, TextEncoder};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+#[cfg(target_os = "linux")]
+use std::convert::Infallible;
 use std::{fs::File, io::Read, panic::PanicInfo, path::PathBuf, process};
 use tracing::error;
 use tracing_subscriber::EnvFilter;
@@ -42,7 +46,7 @@ where
     // Start liveness and readiness probes.
     let task_handler = tokio::spawn(async move {
         register_probes_and_metrics_handler(health_port).await;
-        Ok(())
+        anyhow::Ok(())
     });
     let main_task_handler =
         tokio::spawn(async move { config.run().await.expect("task should exit with Ok.") });
@@ -178,6 +182,7 @@ pub fn setup_logging(make_writer: Option<Box<dyn Fn() -> Box<dyn std::io::Write>
 async fn register_probes_and_metrics_handler(port: u16) {
     let readiness = warp::path("readiness")
         .map(move || warp::reply::with_status("ready", warp::http::StatusCode::OK));
+
     let metrics_endpoint = warp::path("metrics").map(|| {
         // Metrics encoding.
         let metrics = aptos_metrics_core::gather();
@@ -193,9 +198,42 @@ async fn register_probes_and_metrics_handler(port: u16) {
             .header("Content-Type", "text/plain")
             .body(encode_buffer)
     });
-    warp::serve(readiness.or(metrics_endpoint))
-        .run(([0, 0, 0, 0], port))
-        .await;
+
+    if cfg!(target_os = "linux") {
+        #[cfg(target_os = "linux")]
+        let profilez = warp::path("profilez").and_then(|| async move {
+            // TODO(grao): Consider make the parameters configurable.
+            Ok::<_, Infallible>(match start_cpu_profiling(10, 99, false).await {
+                Ok(body) => {
+                    let response = Response::builder()
+                        .header("Content-Length", body.len())
+                        .header("Content-Disposition", "inline")
+                        .header("Content-Type", "image/svg+xml")
+                        .body(body);
+
+                    match response {
+                        Ok(res) => warp::reply::with_status(res, warp::http::StatusCode::OK),
+                        Err(e) => warp::reply::with_status(
+                            Response::new(format!("Profiling failed: {e:?}.").as_bytes().to_vec()),
+                            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        ),
+                    }
+                },
+                Err(e) => warp::reply::with_status(
+                    Response::new(format!("Profiling failed: {e:?}.").as_bytes().to_vec()),
+                    warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                ),
+            })
+        });
+        #[cfg(target_os = "linux")]
+        warp::serve(readiness.or(metrics_endpoint).or(profilez))
+            .run(([0, 0, 0, 0], port))
+            .await;
+    } else {
+        warp::serve(readiness.or(metrics_endpoint))
+            .run(([0, 0, 0, 0], port))
+            .await;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description
host:port/profilez will start returning cpu profiling result.

Current use duration = 10s, frequency = 99Hz, format = flamegraph, will try to make it configurable in the future.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
