### PR TITLE
[move] Unify & fix layout construction

### DIFF
--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -44,10 +44,9 @@ fn native_to_bytes(
     let ref_to_val = safely_pop_arg!(args, Reference);
     let arg_type = ty_args.pop().unwrap();
 
-    // TODO[agg_v2](cleanup): Fail early if there are any custom layouts.
-    let (layout, _) = match context.type_to_type_layout(&arg_type) {
-        Ok(layout) => layout,
-        Err(_) => {
+    let layout = match context.type_to_type_layout(&arg_type) {
+        Ok((layout, false)) => layout,
+        _ => {
             context.charge(BCS_TO_BYTES_FAILURE)?;
             return Err(SafeNativeError::Abort {
                 abort_code: NFE_BCS_SERIALIZATION_FAILURE,

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -41,12 +41,11 @@ fn native_to_bytes(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    // pop type and value
     let ref_to_val = safely_pop_arg!(args, Reference);
     let arg_type = ty_args.pop().unwrap();
 
-    // get type layout
-    let layout = match context.type_to_type_layout(&arg_type) {
+    // TODO[agg_v2](cleanup): Fail early if there are any custom layouts.
+    let (layout, _) = match context.type_to_type_layout(&arg_type) {
         Ok(layout) => layout,
         Err(_) => {
             context.charge(BCS_TO_BYTES_FAILURE)?;
@@ -56,7 +55,6 @@ fn native_to_bytes(
         },
     };
 
-    // serialize value
     let val = ref_to_val.read_ref()?;
     let serialized_value = match val.simple_serialize(&layout) {
         Some(serialized_value) => serialized_value,

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -146,7 +146,10 @@ fn native_emitted_events_by_handle(
         .value_as::<AccountAddress>()?;
     let key = EventKey::new(creation_num, addr);
     let ty_tag = context.type_to_type_tag(&ty)?;
-    let ty_layout = context.type_to_type_layout(&ty)?;
+
+    // TODO[agg_v2](cleanup): Fail conservatively here.
+    let (ty_layout, _) = context.type_to_type_layout(&ty)?;
+
     let ctx = context.extensions_mut().get_mut::<NativeEventContext>();
     let events = ctx
         .emitted_v1_events(&key, &ty_tag)
@@ -174,7 +177,10 @@ fn native_emitted_events(
     let ty = ty_args.pop().unwrap();
 
     let ty_tag = context.type_to_type_tag(&ty)?;
-    let ty_layout = context.type_to_type_layout(&ty)?;
+
+    // TODO[agg_v2](cleanup): We probably should fail here?
+    let (ty_layout, _) = context.type_to_type_layout(&ty)?;
+
     let ctx = context.extensions_mut().get_mut::<NativeEventContext>();
     let events = ctx
         .emitted_v2_events(&ty_tag)

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -90,8 +90,7 @@ fn native_write_to_event_store(
             + EVENT_WRITE_TO_EVENT_STORE_PER_ABSTRACT_VALUE_UNIT * context.abs_val_size(&msg),
     )?;
     let ty_tag = context.type_to_type_tag(&ty)?;
-    let (layout, has_aggregator_lifting) =
-        context.type_to_type_layout_with_identifier_mappings(&ty)?;
+    let (layout, has_aggregator_lifting) = context.type_to_type_layout(&ty)?;
     let blob = serialize_and_allow_delayed_values(&msg, &layout).ok_or_else(|| {
         SafeNativeError::InvariantViolation(PartialVMError::new(
             StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
@@ -238,8 +237,7 @@ fn native_write_module_event_to_store(
             )));
         }
     }
-    let (layout, has_identifier_mappings) =
-        context.type_to_type_layout_with_identifier_mappings(&ty)?;
+    let (layout, has_identifier_mappings) = context.type_to_type_layout(&ty)?;
     let blob = serialize_and_allow_delayed_values(&msg, &layout).ok_or_else(|| {
         SafeNativeError::InvariantViolation(
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)

--- a/aptos-move/framework/src/natives/util.rs
+++ b/aptos-move/framework/src/natives/util.rs
@@ -34,7 +34,8 @@ fn native_from_bytes(
     debug_assert_eq!(args.len(), 1);
 
     // TODO(Gas): charge for getting the layout
-    let layout = context.type_to_type_layout(&ty_args[0])?;
+    // TODO[agg_v2](cleanup): Fail conservatively here if there are mappings.
+    let (layout, _) = context.type_to_type_layout(&ty_args[0])?;
 
     let bytes = safely_pop_arg!(args, Vec<u8>);
     context.charge(

--- a/aptos-move/framework/src/natives/util.rs
+++ b/aptos-move/framework/src/natives/util.rs
@@ -34,8 +34,12 @@ fn native_from_bytes(
     debug_assert_eq!(args.len(), 1);
 
     // TODO(Gas): charge for getting the layout
-    // TODO[agg_v2](cleanup): Fail conservatively here if there are mappings.
-    let (layout, _) = context.type_to_type_layout(&ty_args[0])?;
+    let (layout, has_identifier_mappings) = context.type_to_type_layout(&ty_args[0])?;
+    if has_identifier_mappings {
+        return Err(SafeNativeError::Abort {
+            abort_code: EFROM_BYTES,
+        });
+    }
 
     let bytes = safely_pop_arg!(args, Vec<u8>);
     context.charge(

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -192,8 +192,7 @@ impl TableData {
 
 impl LayoutInfo {
     fn from_value_ty(context: &SafeNativeContext, value_ty: &Type) -> PartialVMResult<Self> {
-        let (layout, has_identifier_mappings) =
-            context.type_to_type_layout_with_identifier_mappings(value_ty)?;
+        let (layout, has_identifier_mappings) = context.type_to_type_layout(value_ty)?;
         Ok(Self {
             layout: Arc::new(layout),
             has_identifier_mappings,

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -174,7 +174,8 @@ impl TableData {
     ) -> PartialVMResult<&mut Table> {
         Ok(match self.tables.entry(handle) {
             Entry::Vacant(e) => {
-                let key_layout = context.type_to_type_layout(key_ty)?;
+                // TODO[agg_v2](test): Make sure we have no custom layouts here?
+                let (key_layout, _) = context.type_to_type_layout(key_ty)?;
                 let value_layout_info = LayoutInfo::from_value_ty(context, value_ty)?;
                 let table = Table {
                     handle,

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -174,8 +174,13 @@ impl TableData {
     ) -> PartialVMResult<&mut Table> {
         Ok(match self.tables.entry(handle) {
             Entry::Vacant(e) => {
-                // TODO[agg_v2](test): Make sure we have no custom layouts here?
-                let (key_layout, _) = context.type_to_type_layout(key_ty)?;
+                let (key_layout, has_identifier_mappings) = context.type_to_type_layout(key_ty)?;
+                if has_identifier_mappings {
+                    return Err(partial_extension_error(
+                        "cannot serialize table key with delayed fields",
+                    ));
+                }
+
                 let value_layout_info = LayoutInfo::from_value_ty(context, value_ty)?;
                 let table = Table {
                     handle,

--- a/third_party/move/extensions/async/move-async-vm/src/async_vm.rs
+++ b/third_party/move/extensions/async/move-async-vm/src/async_vm.rs
@@ -341,7 +341,7 @@ impl<'r, 'l> AsyncSession<'r, 'l> {
     }
 
     fn to_bcs(&self, value: Value, tag: &TypeTag) -> PartialVMResult<Vec<u8>> {
-        let type_layout = self
+        let (type_layout, _) = self
             .vm_session
             .get_type_layout(tag)
             .map_err(|e| e.to_partial())?;

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -213,8 +213,8 @@ impl TableData {
     ) -> PartialVMResult<&mut Table> {
         Ok(match self.tables.entry(handle) {
             Entry::Vacant(e) => {
-                let key_layout = context.type_to_type_layout(key_ty)?;
-                let value_layout = context.type_to_type_layout(value_ty)?;
+                let (key_layout, _) = context.type_to_type_layout(key_ty)?;
+                let (value_layout, _) = context.type_to_type_layout(value_ty)?;
                 let table = Table {
                     handle,
                     key_layout,

--- a/third_party/move/move-stdlib/src/natives/bcs.rs
+++ b/third_party/move/move-stdlib/src/natives/bcs.rs
@@ -53,7 +53,7 @@ fn native_to_bytes(
     let arg_type = ty_args.pop().unwrap();
 
     // get type layout
-    let layout = match context.type_to_type_layout(&arg_type) {
+    let (layout, _) = match context.type_to_type_layout(&arg_type) {
         Ok(layout) => layout,
         Err(_) => {
             cost += gas_params.failure;

--- a/third_party/move/move-stdlib/src/natives/debug.rs
+++ b/third_party/move/move-stdlib/src/natives/debug.rs
@@ -259,13 +259,13 @@ mod testing {
         include_int_types: bool,
     ) -> PartialVMResult<()> {
         // get type layout in VM format
-        let ty_layout = context.type_to_type_layout(&ty)?;
+        let (ty_layout, _) = context.type_to_type_layout(&ty)?;
 
         match &ty_layout {
             MoveTypeLayout::Vector(_) => {
                 // get the inner type T of a vector<T>
                 let inner_ty = get_vector_inner_type(&ty)?;
-                let inner_tyl = context.type_to_type_layout(inner_ty)?;
+                let (inner_tyl, _) = context.type_to_type_layout(inner_ty)?;
 
                 match inner_tyl {
                     // We cannot simply convert a `Value` (of type vector) to a `MoveValue` because

--- a/third_party/move/move-stdlib/src/natives/debug.rs
+++ b/third_party/move/move-stdlib/src/natives/debug.rs
@@ -178,7 +178,7 @@ mod testing {
         context: &NativeContext,
         ty: &Type,
     ) -> PartialVMResult<MoveStructLayout> {
-        let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?;
+        let (annotated_type_layout, _) = context.type_to_fully_annotated_layout(ty)?;
         match annotated_type_layout {
             MoveTypeLayout::Struct(annotated_struct_layout) => Ok(annotated_struct_layout),
             _ => Err(

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -181,7 +181,7 @@ impl<'r> TransactionDataCache<'r> {
             };
             // TODO(Gas): Shall we charge for this?
             let (ty_layout, has_aggregator_lifting) =
-                loader.type_to_type_layout_with_identifier_mappings(ty, module_store)?;
+                loader.type_to_type_layout(ty, module_store)?;
 
             let module = module_store.module_at(&ty_tag.module_id());
             let metadata: &[Metadata] = match &module {

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1511,16 +1511,8 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<(MoveTypeLayout, bool)> {
         self.loader.type_to_type_layout(ty, self.module_store)
-    }
-
-    pub(crate) fn type_to_type_layout_with_identifier_mappings(
-        &self,
-        ty: &Type,
-    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
-        self.loader
-            .type_to_type_layout_with_identifier_mappings(ty, self.module_store)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
@@ -2114,24 +2106,13 @@ impl Loader {
         self.type_to_type_tag_impl(ty, &mut gas_context)
     }
 
-    pub(crate) fn type_to_type_layout_with_identifier_mappings(
+    pub(crate) fn type_to_type_layout(
         &self,
         ty: &Type,
         module_store: &ModuleStorageAdapter,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
         let mut count = 0;
         self.type_to_type_layout_impl(ty, module_store, &mut count, 1)
-    }
-
-    pub(crate) fn type_to_type_layout(
-        &self,
-        ty: &Type,
-        module_store: &ModuleStorageAdapter,
-    ) -> PartialVMResult<MoveTypeLayout> {
-        let mut count = 0;
-        let (layout, _has_identifier_mappings) =
-            self.type_to_type_layout_impl(ty, module_store, &mut count, 1)?;
-        Ok(layout)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
@@ -2151,7 +2132,7 @@ impl Loader {
         type_tag: &TypeTag,
         move_storage: &TransactionDataCache,
         module_storage: &ModuleStorageAdapter,
-    ) -> VMResult<MoveTypeLayout> {
+    ) -> VMResult<(MoveTypeLayout, bool)> {
         let ty = self.load_type(type_tag, move_storage, module_storage)?;
         self.type_to_type_layout(&ty, module_storage)
             .map_err(|e| e.finish(Location::Undefined))

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -153,13 +153,6 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.resolver.type_to_type_layout(ty)
     }
 
-    pub fn type_to_type_layout_with_identifier_mappings(
-        &self,
-        ty: &Type,
-    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
-        self.resolver.type_to_type_layout(ty)
-    }
-
     pub fn type_to_fully_annotated_layout(
         &self,
         ty: &Type,

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -160,7 +160,10 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.resolver.type_to_type_layout(ty)
     }
 
-    pub fn type_to_fully_annotated_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    pub fn type_to_fully_annotated_layout(
+        &self,
+        ty: &Type,
+    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
         self.resolver.type_to_fully_annotated_layout(ty)
     }
 

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -149,7 +149,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.resolver.loader().type_to_type_tag(ty)
     }
 
-    pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<(MoveTypeLayout, bool)> {
         self.resolver.type_to_type_layout(ty)
     }
 
@@ -157,8 +157,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         &self,
         ty: &Type,
     ) -> PartialVMResult<(MoveTypeLayout, bool)> {
-        self.resolver
-            .type_to_type_layout_with_identifier_mappings(ty)
+        self.resolver.type_to_type_layout(ty)
     }
 
     pub fn type_to_fully_annotated_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -214,7 +214,7 @@ impl VMRuntime {
     ) -> PartialVMResult<Value> {
         let (layout, has_identifier_mappings) =
             match self.loader.type_to_type_layout(ty, module_store) {
-                Ok(layout) => layout,
+                Ok(data) => data,
                 Err(_err) => {
                     return Err(PartialVMError::new(
                         StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -212,18 +212,16 @@ impl VMRuntime {
         ty: &Type,
         arg: impl Borrow<[u8]>,
     ) -> PartialVMResult<Value> {
-        let (layout, has_identifier_mappings) = match self
-            .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store)
-        {
-            Ok(layout) => layout,
-            Err(_err) => {
-                return Err(PartialVMError::new(
-                    StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,
-                )
-                .with_message("[VM] failed to get layout from type".to_string()));
-            },
-        };
+        let (layout, has_identifier_mappings) =
+            match self.loader.type_to_type_layout(ty, module_store) {
+                Ok(layout) => layout,
+                Err(_err) => {
+                    return Err(PartialVMError::new(
+                        StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,
+                    )
+                    .with_message("[VM] failed to get layout from type".to_string()));
+                },
+            };
 
         let deserialization_error = || -> PartialVMError {
             PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT)
@@ -303,13 +301,13 @@ impl VMRuntime {
 
         let (layout, has_identifier_mappings) = self
             .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store)
+            .type_to_type_layout(ty, module_store)
             .map_err(|_err| {
-                // TODO: Should we use `err` instead of mapping?
-                PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(
-                    "entry point functions cannot have non-serializable return types".to_string(),
-                )
-            })?;
+            // TODO: Should we use `err` instead of mapping?
+            PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(
+                "entry point functions cannot have non-serializable return types".to_string(),
+            )
+        })?;
 
         let serialization_error = || -> PartialVMError {
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -402,7 +402,10 @@ impl<'r, 'l> Session<'r, 'l> {
         )
     }
 
-    pub fn get_fully_annotated_type_layout(&self, type_tag: &TypeTag) -> VMResult<MoveTypeLayout> {
+    pub fn get_fully_annotated_type_layout(
+        &self,
+        type_tag: &TypeTag,
+    ) -> VMResult<(MoveTypeLayout, bool)> {
         self.move_vm
             .runtime
             .loader()

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -394,7 +394,7 @@ impl<'r, 'l> Session<'r, 'l> {
             .load_type(type_tag, &self.data_cache, &self.module_store)
     }
 
-    pub fn get_type_layout(&self, type_tag: &TypeTag) -> VMResult<MoveTypeLayout> {
+    pub fn get_type_layout(&self, type_tag: &TypeTag) -> VMResult<(MoveTypeLayout, bool)> {
         self.move_vm.runtime.loader().get_type_layout(
             type_tag,
             &self.data_cache,


### PR DESCRIPTION
### Description

This PR unifies ways to construct a type layout (non-annotated vs fully annotated). Because of copy-paste, the previous implementation of fully annotated layout construction did not account for node count.

 - Return type of layout construction APIs carries information if it has delayed fields or not, to make sure clients handle these cases, reducing risk of errors.
 - Single function to construct type layout (but still two functions for struct layouts for now).
 - Unified flags/counters under a common context which checks for exceeding the limit. 

### Test Plan

It is a bit tricky to add tests because loader and struct indices needs to be mocked, working on it:
- [ ] test counts
- [ ] test depths
- [ ] test identifier mappings are correctly propagated
