### PR TITLE
FatalVMError shouldn't create "Delayed materialization code invariant"

### DIFF
--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -4,12 +4,16 @@
 
 use aptos_types::delayed_fields::PanicError;
 
-// The same module access path for module was both read & written during speculative executions.
-// This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
-// aborting the parallel execution pipeline and falling back to the sequential execution.
-// TODO: provide proper multi-versioning for code (like data) for the cache.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ModulePathReadWriteError;
+pub(crate) enum ParallelBlockExecutionError {
+    // The same module access path for module was both read & written during speculative executions.
+    // This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
+    // aborting the parallel execution pipeline and falling back to the sequential execution.
+    // TODO: provide proper multi-versioning for code (like data) for the cache.
+    ModulePathReadWriteError,
+    /// unrecoverable VM error
+    FatalVMError,
+}
 
 // This is separate error because we need to match the error variant to provide a specialized
 // fallback logic if a resource group serialization error occurs.


### PR DESCRIPTION
- when FatalVMError happens, we have those logs, it doesn't get wrapped into delayed materialization code invariant error
- do not alert on FatalVMError - if it is invariant - it is already alerted, if it is node issue (i.e. old binary so VM_STARTUP_FAILURE) alert is too aggressive

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
