### PR TITLE
Resolved the `framework_upgrade` CI test failure

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -329,7 +329,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: aptos-node-v1.8.3 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      IMAGE_TAG: testnet # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -302,7 +302,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: testnet # test against a previous testnet release
+      IMAGE_TAG: aptos-node-v1.9.5 # test against a previous testnet release
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
@@ -329,7 +329,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: testnet # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      IMAGE_TAG: aptos-node-v1.9.5 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -33,9 +33,9 @@ proposals:
             - refundable_bytes
   - name: step_4_enable_fairness_shuffler
     metadata:
-      title: "Enable Fairness Shuffler"
-      description: "FairnessShuffler that tries to spread out (delay) transactions from dominant modules in a block, so that if block limit is hit, transactions from non-dominant modules have a fair share of the block space."
-      discussion_url: "TBA"
+      title: "AIP-68: Enable Fairness Shuffler"
+      description: "AIP-68: FairnessShuffler that tries to spread out (delay) transactions from dominant modules in a block, so that if block limit is hit, transactions from non-dominant modules have a fair share of the block space."
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/333"
     execution_mode: MultiStep
     update_sequence:
       - Execution:
@@ -106,7 +106,7 @@ proposals:
     update_sequence:
       - FeatureFlag:
           enabled:
-            - aggregator_v2_delayed_fields          
+            - aggregator_v2_delayed_fields
             - resource_groups_split_in_vm_change_set
   - name: step_10_enable_validator_txn
     metadata:

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -33,8 +33,8 @@ proposals:
             - refundable_bytes
   - name: step_4_enable_fairness_shuffler
     metadata:
-      title: "AIP-68: Enable Fairness Shuffler"
-      description: "AIP-68: FairnessShuffler that tries to spread out (delay) transactions from dominant modules in a block, so that if block limit is hit, transactions from non-dominant modules have a fair share of the block space."
+      title: "AIP-68: Reordering transactions in a block for fairness"
+      description: "AIP-68: This AIP proposes to update the Transaction Shuffler logic to add other aspects of fairness to how transactions are ordered in the block."
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/333"
     execution_mode: MultiStep
     update_sequence:


### PR DESCRIPTION
### Description

- Provide a valid URL for discussion, which resolves the framework_upgrade CI test failure
- Bump up the base commit to 1.9.5 for the compat test and framework_upgrade test

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
