### PR TITLE
[GHA] Update pin for tj-actions/changed-files

### DIFF
--- a/.github/actions/python-lint-tests/action.yaml
+++ b/.github/actions/python-lint-tests/action.yaml
@@ -17,7 +17,7 @@ runs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
+      uses: tj-actions/changed-files@v42
 
     - uses: ./.github/actions/python-setup
       with:


### PR DESCRIPTION
### Description

The current pinned version is two years old.
