### PR TITLE
[GHA] Upgrade lint-test.yaml and the dependent actions to checkout@v4

### DIFF
--- a/.github/actions/general-lints/action.yaml
+++ b/.github/actions/general-lints/action.yaml
@@ -8,10 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    # Checkout the repository
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    # The source code must be checkout out by the workflow that invokes this action.
 
     # Install shellcheck and run it on the dev_setup.sh script
     - name: Run shell lints

--- a/.github/actions/python-lint-tests/action.yaml
+++ b/.github/actions/python-lint-tests/action.yaml
@@ -12,7 +12,7 @@ runs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
+      uses: tj-actions/changed-files@v42
 
     - uses: ./.github/actions/python-setup
       with:

--- a/.github/actions/python-lint-tests/action.yaml
+++ b/.github/actions/python-lint-tests/action.yaml
@@ -4,16 +4,11 @@ inputs:
   GIT_SHA:
     description: "Optional git sha to checkout"
     required: false
-    type: string
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.GIT_SHA }}
-        # Get enough commits to compare to
-        fetch-depth: 100
+    # The source code must be checkout out by the workflow that invokes this action.
 
     - name: Get changed files
       id: changed-files

--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -8,10 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Checkout the repository and setup the rust toolchain
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    # The source code must be checkout out by the workflow that invokes this action.
+
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -1,3 +1,5 @@
+name: "Rust Setup"
+description: "Setup the rust toolchain and cache"
 inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git"

--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -8,10 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Checkout the repository and setup the rust toolchain
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    # The source code must be checkout out by the workflow that invokes this action.
+
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}

--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -8,10 +8,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # Checkout the repository and setup the rust toolchain
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    # The source code must be checkout out by the workflow that invokes this action.
+
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
@@ -42,8 +40,8 @@ runs:
       shell: bash
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-        RUST_MIN_STACK: 4297152
-        MVP_TEST_ON_CI: true
+        RUST_MIN_STACK: "4297152"
+        MVP_TEST_ON_CI: "true"
         SOLC_EXE: /home/runner/bin/solc
         Z3_EXE: /home/runner/bin/z3
         CVC5_EXE: /home/runner/bin/cvc5

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -41,8 +41,10 @@ jobs:
     needs: file_change_determinator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          fetch-depth: 0 # get all the history because python-lint-tests requires it.
       - name: Run general lints
         uses: ./.github/actions/general-lints
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -57,7 +59,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
@@ -69,8 +71,10 @@ jobs:
     needs: file_change_determinator
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - name: Run rust lints
         uses: ./.github/actions/rust-lints
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -92,7 +96,7 @@ jobs:
       )
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run rust smoke tests
         uses: ./.github/actions/rust-smoke-tests
@@ -107,7 +111,7 @@ jobs:
     needs: file_change_determinator
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run rust unit tests
         uses: ./.github/actions/rust-unit-tests
@@ -122,9 +126,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
@@ -140,9 +142,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
@@ -158,7 +158,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
@@ -186,7 +186,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}


### PR DESCRIPTION
### Description

* actions/checkout@v4 doesn't behave well if both a workflow and an invoked action checkout the source code on top of each other.
* update pin for tj-actions/changed-files

### Test Plan

Commit and see if it breaks anything.