### PR TITLE
fix the e2e localnet.

### DIFF
--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -36,6 +36,7 @@ pub struct ProcessorArgs {
             ProcessorName::DefaultProcessor,
             ProcessorName::EventsProcessor,
             ProcessorName::FungibleAssetProcessor,
+            ProcessorName::ObjectsProcessor,
             ProcessorName::StakeProcessor,
             ProcessorName::TokenProcessor,
             ProcessorName::TokenV2Processor,
@@ -85,9 +86,7 @@ impl ProcessorManager {
             ProcessorName::MonitoringProcessor => {
                 bail!("Monitoring processor is not supported in the local testnet")
             },
-            ProcessorName::ObjectsProcessor => {
-                bail!("Objects processor is not supported in the local testnet")
-            },
+            ProcessorName::ObjectsProcessor => ProcessorConfig::ObjectsProcessor,
         };
         let config = IndexerGrpcProcessorConfig {
             processor_config,


### PR DESCRIPTION
### Description

* Currently CI is broken due to object ownership data is missing. This is due to we split the object-related indexing to object processor. Added it here to fix. 


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
