### PR TITLE
Try better Rust caching

### DIFF
--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -10,7 +10,7 @@ runs:
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
 
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+    - uses: ./.github/actions/rust-setup
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
 

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -12,23 +12,36 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
+    - name: Install Ubuntu dependencies
+      run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
       shell: bash
 
-    - uses: dsherret/rust-toolchain-file@v1
+    - name: Install rust toolchain
+      uses: dsherret/rust-toolchain-file@v1
 
     # rust-cache action will cache ~/.cargo and ./target
     # https://github.com/Swatinem/rust-cache#cache-details
-    - name: Run cargo cache
-      uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
+    - name: Setup cargo dependency cache
+      uses: swatinem/rust-cache@v2
       with:
         key: ${{ inputs.ADDITIONAL_KEY }}
 
-    - name: install protoc and related tools
+    - name: Run sccache-cache only on non-release runs
+      if: contains(github.event.pull_request.labels.*.name, 'CICD:sccache')
+      uses: mozilla-actions/sccache-action@v0.0.3
+    - name: Set Rust caching env vars only on non-release runs
+      if: contains(github.event.pull_request.labels.*.name, 'CICD:sccache')
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+    - name: Install protoc and related tools
       shell: bash
       run: scripts/dev_setup.sh -b -r -y -P -J -t
 
-    - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
+    - name: "Add ~/.cargo/bin to PATH"
+      run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
       shell: bash
 
     - name: Setup git credentials
@@ -39,6 +52,6 @@ runs:
         echo "${{ inputs.GIT_CREDENTIALS }}" > ~/.git-credentials
 
     # Display the rust toolchain version being installed
-    - name: Setup rust toolchain
+    - name: Show rust toolchain
       shell: bash
       run: rustup show

--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -10,7 +10,7 @@ runs:
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
 
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+    - uses: ./.github/actions/rust-setup
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
 


### PR DESCRIPTION
### Description

Use a shared key for `rust-cache`, to avoid including the job name in the cache key.
Use Mozilla SCCache for in-repository crates.