### PR TITLE
[consensus] unify different locks in state_computer

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -21,7 +21,7 @@ use aptos_consensus_notifications::ConsensusNotificationSender;
 use aptos_consensus_types::{block::Block, common::Round, pipelined_block::PipelinedBlock};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResult};
-use aptos_infallible::Mutex;
+use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_types::{
     account_address::AccountAddress,
@@ -29,7 +29,6 @@ use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::OnChainExecutionConfig,
     randomness::Randomness,
     transaction::{SignedTransaction, Transaction},
 };
@@ -76,6 +75,15 @@ impl LogicalTime {
     }
 }
 
+#[derive(Clone)]
+struct ExecutionProxyInner {
+    validators: Arc<[AccountAddress]>,
+    payload_manager: Arc<PayloadManager>,
+    transaction_shuffler: Arc<dyn TransactionShuffler>,
+    block_executor_onchain_config: BlockExecutorConfigFromOnchain,
+    transaction_deduper: Arc<dyn TransactionDeduper>,
+}
+
 /// Basic communication with the Execution module;
 /// implements StateComputer traits.
 pub struct ExecutionProxy {
@@ -83,14 +91,10 @@ pub struct ExecutionProxy {
     txn_notifier: Arc<dyn TxnNotifier>,
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
-    validators: Mutex<Vec<AccountAddress>>,
     write_mutex: AsyncMutex<LogicalTime>,
-    payload_manager: Mutex<Option<Arc<PayloadManager>>>,
-    transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
-    block_executor_onchain_config: Mutex<BlockExecutorConfigFromOnchain>,
-    transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
     transaction_filter: Arc<TransactionFilter>,
     execution_pipeline: ExecutionPipeline,
+    inner: RwLock<Option<ExecutionProxyInner>>,
     randomness_enabled: AtomicBool,
 }
 
@@ -123,21 +127,19 @@ impl ExecutionProxy {
             txn_notifier,
             state_sync_notifier,
             async_state_sync_notifier: tx,
-            validators: Mutex::new(vec![]),
             write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
-            payload_manager: Mutex::new(None),
-            transaction_shuffler: Mutex::new(None),
-            block_executor_onchain_config: Mutex::new(
-                OnChainExecutionConfig::default_if_missing().block_executor_onchain_config(),
-            ),
-            transaction_deduper: Mutex::new(None),
             transaction_filter: Arc::new(txn_filter),
             execution_pipeline,
             randomness_enabled: AtomicBool::new(false),
+            inner: RwLock::new(None),
         }
     }
 
-    pub fn transactions_to_commit(&self, executed_block: &PipelinedBlock) -> Vec<Transaction> {
+    fn transactions_to_commit(
+        &self,
+        executed_block: &PipelinedBlock,
+        validators: &[AccountAddress],
+    ) -> Vec<Transaction> {
         // reconfiguration suffix don't execute
         if executed_block.is_reconfiguration_suffix() {
             return vec![];
@@ -145,16 +147,12 @@ impl ExecutionProxy {
 
         let user_txns = executed_block.input_transactions().clone();
         let validator_txns = executed_block.validator_txns().cloned().unwrap_or_default();
-        let validators = self.validators.lock();
         let metadata = if self.randomness_enabled.load(Ordering::SeqCst) {
             executed_block
                 .block()
-                .new_metadata_with_randomness(&validators, executed_block.randomness().cloned())
+                .new_metadata_with_randomness(validators, executed_block.randomness().cloned())
         } else {
-            executed_block
-                .block()
-                .new_block_metadata(&validators)
-                .into()
+            executed_block.block().new_block_metadata(validators).into()
         };
 
         let input_txns = Block::combine_to_input_transactions(validator_txns, user_txns, metadata);
@@ -182,22 +180,34 @@ impl StateComputer for ExecutionProxy {
             parent_id = parent_block_id,
             "Executing block",
         );
+        let ExecutionProxyInner {
+            validators,
+            payload_manager,
+            transaction_shuffler,
+            block_executor_onchain_config,
+            transaction_deduper,
+        } = self
+            .inner
+            .read()
+            .as_ref()
+            .cloned()
+            .expect("must be set within an epoch");
 
         let txn_notifier = self.txn_notifier.clone();
         let transaction_generator = BlockPreparer::new(
-            self.payload_manager.lock().as_ref().unwrap().clone(),
+            payload_manager.clone(),
             self.transaction_filter.clone(),
-            self.transaction_deduper.lock().as_ref().unwrap().clone(),
-            self.transaction_shuffler.lock().as_ref().unwrap().clone(),
+            transaction_deduper.clone(),
+            transaction_shuffler.clone(),
         );
 
-        let block_executor_onchain_config = self.block_executor_onchain_config.lock().clone();
+        let block_executor_onchain_config = block_executor_onchain_config.clone();
 
         let timestamp = block.timestamp_usecs();
         let metadata = if self.randomness_enabled.load(Ordering::SeqCst) {
-            block.new_metadata_with_randomness(&self.validators.lock(), randomness)
+            block.new_metadata_with_randomness(&validators, randomness)
         } else {
-            block.new_block_metadata(&self.validators.lock()).into()
+            block.new_block_metadata(&validators).into()
         };
 
         let fut = self
@@ -249,8 +259,12 @@ impl StateComputer for ExecutionProxy {
             finality_proof.ledger_info().round(),
         );
         let block_timestamp = finality_proof.commit_info().timestamp_usecs();
-        let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
 
+        let ExecutionProxyInner {
+            payload_manager,
+            validators,
+            ..
+        } = self.inner.read().as_ref().cloned().expect("");
         for block in blocks {
             block_ids.push(block.id());
 
@@ -258,7 +272,7 @@ impl StateComputer for ExecutionProxy {
                 payloads.push(payload.clone());
             }
 
-            txns.extend(self.transactions_to_commit(block));
+            txns.extend(self.transactions_to_commit(block, &validators));
             subscribable_txn_events.extend(block.subscribable_events());
         }
 
@@ -313,9 +327,10 @@ impl StateComputer for ExecutionProxy {
         // This is to update QuorumStore with the latest known commit in the system,
         // so it can set batches expiration accordingly.
         // Might be none if called in the recovery path, or between epoch stop and start.
-        let maybe_payload_manager = self.payload_manager.lock().as_ref().cloned();
-        if let Some(payload_manager) = maybe_payload_manager {
-            payload_manager.notify_commit(block_timestamp, Vec::new());
+        if let Some(inner) = self.inner.read().as_ref() {
+            inner
+                .payload_manager
+                .notify_commit(block_timestamp, Vec::new());
         }
 
         fail_point!("consensus::sync_to", |_| {
@@ -351,16 +366,17 @@ impl StateComputer for ExecutionProxy {
         transaction_deduper: Arc<dyn TransactionDeduper>,
         randomness_enabled: bool,
     ) {
-        *self.validators.lock() = epoch_state
-            .verifier
-            .get_ordered_account_addresses_iter()
-            .collect();
-        self.payload_manager.lock().replace(payload_manager);
-        self.transaction_shuffler
-            .lock()
-            .replace(transaction_shuffler);
-        *self.block_executor_onchain_config.lock() = block_executor_onchain_config;
-        self.transaction_deduper.lock().replace(transaction_deduper);
+        *self.inner.write() = Some(ExecutionProxyInner {
+            validators: epoch_state
+                .verifier
+                .get_ordered_account_addresses_iter()
+                .collect::<Vec<_>>()
+                .into(),
+            payload_manager,
+            transaction_shuffler,
+            block_executor_onchain_config,
+            transaction_deduper,
+        });
         self.randomness_enabled
             .store(randomness_enabled, Ordering::SeqCst);
     }
@@ -368,8 +384,7 @@ impl StateComputer for ExecutionProxy {
     // Clears the epoch-specific state. Only a sync_to call is expected before calling new_epoch
     // on the next epoch.
     fn end_epoch(&self) {
-        *self.validators.lock() = vec![];
-        self.payload_manager.lock().take();
+        self.inner.write().take();
     }
 }
 
@@ -382,6 +397,7 @@ async fn test_commit_sync_race() {
     use aptos_config::config::transaction_filter_type::Filter;
     use aptos_consensus_notifications::Error;
     use aptos_executor_types::state_checkpoint_output::StateCheckpointOutput;
+    use aptos_infallible::Mutex;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
         block_executor::partitioner::ExecutableBlock,


### PR DESCRIPTION
### Description

This PR unifies the different Mutex fields in ExecutionProxy by moving them to a Inner struct wrapped with a RwLock. This should prevent any potential accidental lock reordering deadlocks in state computer.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
