### PR TITLE
set debug to line-tables-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -780,7 +780,7 @@ codegen-units = 1
 
 [profile.ci]
 inherits = "release"
-debug = true
+debug = "line-tables-only"
 overflow-checks = true
 debug-assertions = true
 


### PR DESCRIPTION
### Description
Change the debuginfo settings to `line-tables-only`. This should reduce the size of our build artifacts and binaries without breaking backtraces.

After building all packages to run unit tests, the size of the `target` directory went from 255GB -> 188GB.

I also tested builing a nextest archive for running unit tests
`cargo nextest archive --cargo-profile ci --locked --workspace --exclude aptos-testcases --exclude smoke-test --archive-file nextest-archive.tar.zst`. With this change the archive file went from 39GB -> 11GB

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
- CI
- Add a test that panics and check that backtraces still contain function names and line numbers
```
alanluong@ubuntu:/Users/alanluong/vm/aptos-core$ RUST_BACKTRACE=full cargo test -p aptos-node --profile ci
warning: unused imports: `DKGTranscriptMetadata`, `DKGTranscript`
  --> consensus/src/payload_client/mixed.rs:14:11
   |
14 |     dkg::{DKGTranscript, DKGTranscriptMetadata},
   |           ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `move_core_types::account_address::AccountAddress`
  --> consensus/src/payload_client/mixed.rs:21:5
   |
21 | use move_core_types::account_address::AccountAddress;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: associated constant `RAND_AGG_DECISION` is never used
  --> consensus/src/block_storage/tracing.rs:23:15
   |
11 | impl BlockStage {
   | --------------- associated constant in this implementation
...
23 |     pub const RAND_AGG_DECISION: &'static str = "rand_agg_decision";
   |               ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `aptos-consensus` (lib) generated 3 warnings (run `cargo fix --lib -p aptos-consensus` to apply 2 suggestions)
   Compiling aptos-node v1.7.0 (/Users/alanluong/vm/aptos-core/aptos-node)
    Finished ci [optimized + debuginfo] target(s) in 54.57s
     Running unittests src/lib.rs (target/ci/deps/aptos_node-512fb3e8bfeaa91a)

running 4 tests
test verify_tool ... ok
test tests::test_create_single_node_test_config ... ok
test tests::test_always_fails ... FAILED
test tests::test_mutual_authentication_validators - should panic ... ok

failures:

---- tests::test_always_fails stdout ----
thread 'tests::test_always_fails' panicked at aptos-node/src/tests.rs:20:5:
This is a test panic
stack backtrace:
   0:     0xaaaad760012c - std::backtrace_rs::backtrace::libunwind::trace::h02f9e4f4471336e3
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1:     0xaaaad760012c - std::backtrace_rs::backtrace::trace_unsynchronized::hbb08758edbde5130
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0xaaaad760012c - std::sys_common::backtrace::_print_fmt::h5f86860630063d58
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:67:5
   3:     0xaaaad760012c - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h28b1846dca2a17cc
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:44:22
   4:     0xaaaad762b458 - core::fmt::rt::Argument::fmt::h4597596d5e31f449
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/fmt/rt.rs:142:9
   5:     0xaaaad762b458 - core::fmt::write::h76788fb7851cda1c
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/fmt/mod.rs:1120:17
   6:     0xaaaad75fc138 - std::io::Write::write_fmt::he62a8d14038c679c
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/io/mod.rs:1762:15
   7:     0xaaaad75fff5c - std::sys_common::backtrace::_print::hbe1ff52860729255
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:47:5
   8:     0xaaaad75fff5c - std::sys_common::backtrace::print::h13ddc61648c1b5cf
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:34:9
   9:     0xaaaad7601c78 - std::panicking::default_hook::{{closure}}::h3fb06cc4fa27f844
  10:     0xaaaad76018e0 - std::panicking::default_hook::h585763c48ee63ab9
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:289:9
  11:     0xaaaad63bfc10 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h65f50149bb96cd5b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2021:9
  12:     0xaaaad63bfc10 - test::test_main::{{closure}}::hf498debb90c2fe3b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:138:21
  13:     0xaaaad7602260 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::hbb5b20202d3a28fc
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2021:9
  14:     0xaaaad7602260 - std::panicking::rust_panic_with_hook::h25ba8e750f603eed
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:783:13
  15:     0xaaaad7601fb0 - std::panicking::begin_panic_handler::{{closure}}::he88f9d300c5c2c0b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:649:13
  16:     0xaaaad76005d4 - std::sys_common::backtrace::__rust_end_short_backtrace::h9c4571cb251fdb49
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:170:18
  17:     0xaaaad7601d64 - rust_begin_unwind
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:645:5
  18:     0xaaaad600fa8c - core::panicking::panic_fmt::h83f4337bb6f332d3
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:72:14
  19:     0xaaaad6202930 - a_test
                               at /Users/alanluong/vm/aptos-core/aptos-node/src/tests.rs:20:5
  20:     0xaaaad6202930 - another_test
                               at /Users/alanluong/vm/aptos-core/aptos-node/src/tests.rs:24:5
  21:     0xaaaad6202930 - test_always_fails
                               at /Users/alanluong/vm/aptos-core/aptos-node/src/tests.rs:29:5
  22:     0xaaaad6202930 - {closure#0}
                               at /Users/alanluong/vm/aptos-core/aptos-node/src/tests.rs:28:23
  23:     0xaaaad6202930 - call_once<aptos_node::tests::test_always_fails::{closure_env#0}, ()>
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
  24:     0xaaaad63c3ec0 - core::ops::function::FnOnce::call_once::hc19b8dc468f7b1c4
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
  25:     0xaaaad63c3ec0 - test::__rust_begin_short_backtrace::h1c39a1798ddb33db
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:628:18
  26:     0xaaaad63c2ffc - test::run_test_in_process::{{closure}}::h9829cdd77fff6af1
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:651:60
  27:     0xaaaad63c2ffc - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h5c33574934606d70
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panic/unwind_safe.rs:272:9
  28:     0xaaaad63c2ffc - std::panicking::try::do_call::he5140a4a5b1cd58d
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:552:40
  29:     0xaaaad63c2ffc - std::panicking::try::h0c1f355b97c20d4d
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:516:19
  30:     0xaaaad63c2ffc - std::panic::catch_unwind::h3aca08ac2bd6ebc8
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs:142:14
  31:     0xaaaad63c2ffc - test::run_test_in_process::hc2107605e7b18e15
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:651:27
  32:     0xaaaad63c2ffc - test::run_test::{{closure}}::ha99aa3413ab4953b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:574:43
  33:     0xaaaad6395ccc - test::run_test::{{closure}}::h5577bd7c19d6992c
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/test/src/lib.rs:602:41
  34:     0xaaaad6395ccc - std::sys_common::backtrace::__rust_begin_short_backtrace::h6725253c6f63726b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:154:18
  35:     0xaaaad639a6a4 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::hbd2f19ceac13516b
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/mod.rs:529:17
  36:     0xaaaad639a6a4 - <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h1d82eeecb63e1f9e
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panic/unwind_safe.rs:272:9
  37:     0xaaaad639a6a4 - std::panicking::try::do_call::hfeca01b008442abf
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:552:40
  38:     0xaaaad639a6a4 - std::panicking::try::h259c69401b79d721
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:516:19
  39:     0xaaaad639a6a4 - std::panic::catch_unwind::ha170c5c832412d49
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs:142:14
  40:     0xaaaad639a6a4 - std::thread::Builder::spawn_unchecked_::{{closure}}::h904a2984e8281943
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/mod.rs:528:30
  41:     0xaaaad639a6a4 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h555088e12a0e2b32
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
  42:     0xaaaad7607240 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h01a0bc1d2a7d0e07
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  43:     0xaaaad7607240 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hd783b5f63620b23f
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  44:     0xaaaad7607240 - std::sys::unix::thread::Thread::new::thread_start::h5012e69916d4afff
                               at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys/unix/thread.rs:108:17
  45:     0xffff9e8737d0 - <unknown>
  46:     0xffff9e8df5cc - <unknown>
  47:                0x0 - <unknown>


failures:
    tests::test_always_fails

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.22s

error: test failed, to rerun pass `-p aptos-node --lib`
```
