### PR TITLE
clean up randomness seed in block metadata when feature is disabled

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
@@ -71,6 +71,21 @@
         "address": "0x1",
         "state_key_hash": "",
         "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
+          }
+        },
+        "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
           "type": "0x1::state_storage::StateStorageUsage",
           "data": "state storage omitted"
         },

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
@@ -80,6 +80,21 @@
           }
         },
         "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
+          }
+        },
+        "type": "write_resource"
       }
     ],
     "id": "0x8c9a041f736278db6559cb7f1de04381d82258dc80fa9e128d9e44bc47487682",
@@ -370,6 +385,21 @@
           "type": "0x1::timestamp::CurrentTimeMicroseconds",
           "data": {
             "microseconds": "7000000"
+          }
+        },
+        "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
           }
         },
         "type": "write_resource"
@@ -666,6 +696,21 @@
           }
         },
         "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
+          }
+        },
+        "type": "write_resource"
       }
     ],
     "id": "0x3ddcb6c382270184cb1c0e7044b272ba0b2382d21b06966dd5ff00f5fa36dbef",
@@ -956,6 +1001,21 @@
           "type": "0x1::timestamp::CurrentTimeMicroseconds",
           "data": {
             "microseconds": "8000000"
+          }
+        },
+        "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
           }
         },
         "type": "write_resource"
@@ -1252,6 +1312,21 @@
           }
         },
         "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
+          }
+        },
+        "type": "write_resource"
       }
     ],
     "id": "0xd2d00107d2f0b1323b9e27213f8b003f78a5cdd081007bd11f09b7e6fa232b0a",
@@ -1542,6 +1617,21 @@
           "type": "0x1::timestamp::CurrentTimeMicroseconds",
           "data": {
             "microseconds": "9000000"
+          }
+        },
+        "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
           }
         },
         "type": "write_resource"
@@ -1838,6 +1928,21 @@
           }
         },
         "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
+          }
+        },
+        "type": "write_resource"
       }
     ],
     "id": "0x142c31e08bfca525c34fa8a59ebcb300e72586225d613eb0af32ce80b0e9529f",
@@ -2128,6 +2233,21 @@
           "type": "0x1::timestamp::CurrentTimeMicroseconds",
           "data": {
             "microseconds": "10000000"
+          }
+        },
+        "type": "write_resource"
+      },
+      {
+        "address": "0x1",
+        "state_key_hash": "",
+        "data": {
+          "type": "0x1::randomness::PerBlockRandomness",
+          "data": {
+            "epoch": "1",
+            "round": "1",
+            "seed": {
+              "vec": []
+            }
           }
         },
         "type": "write_resource"

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -451,6 +451,7 @@ The runtime always runs this before executing the transactions in a block.
     <a href="timestamp.md#0x1_timestamp">timestamp</a>: u64
 ) <b>acquires</b> <a href="block.md#0x1_block_BlockResource">BlockResource</a> {
     <b>let</b> epoch_interval = <a href="block.md#0x1_block_block_prologue_common">block_prologue_common</a>(&vm, <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>, epoch, round, proposer, failed_proposer_indices, previous_block_votes_bitvec, <a href="timestamp.md#0x1_timestamp">timestamp</a>);
+    <a href="randomness.md#0x1_randomness_on_new_block">randomness::on_new_block</a>(&vm, epoch, round, <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>());
     <b>if</b> (<a href="timestamp.md#0x1_timestamp">timestamp</a> - <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>() &gt;= epoch_interval) {
         <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
     };

--- a/aptos-move/framework/aptos-framework/doc/randomness.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness.md
@@ -155,10 +155,12 @@ Invoked in block prologues to update the block-level randomness seed.
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness.md#0x1_randomness_on_new_block">on_new_block</a>(vm: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch: u64, round: u64, seed_for_new_block: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;) <b>acquires</b> <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(vm);
-    <b>let</b> <a href="randomness.md#0x1_randomness">randomness</a> = <b>borrow_global_mut</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework);
-    <a href="randomness.md#0x1_randomness">randomness</a>.epoch = epoch;
-    <a href="randomness.md#0x1_randomness">randomness</a>.round = round;
-    <a href="randomness.md#0x1_randomness">randomness</a>.seed = seed_for_new_block;
+    <b>if</b> (<b>exists</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework)) {
+        <b>let</b> <a href="randomness.md#0x1_randomness">randomness</a> = <b>borrow_global_mut</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework);
+        <a href="randomness.md#0x1_randomness">randomness</a>.epoch = epoch;
+        <a href="randomness.md#0x1_randomness">randomness</a>.round = round;
+        <a href="randomness.md#0x1_randomness">randomness</a>.seed = seed_for_new_block;
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -170,6 +170,7 @@ module aptos_framework::block {
         timestamp: u64
     ) acquires BlockResource {
         let epoch_interval = block_prologue_common(&vm, hash, epoch, round, proposer, failed_proposer_indices, previous_block_votes_bitvec, timestamp);
+        randomness::on_new_block(&vm, epoch, round, option::none());
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration::reconfigure();
         };

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -44,10 +44,12 @@ module aptos_framework::randomness {
     /// Invoked in block prologues to update the block-level randomness seed.
     public(friend) fun on_new_block(vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>) acquires PerBlockRandomness {
         system_addresses::assert_vm(vm);
-        let randomness = borrow_global_mut<PerBlockRandomness>(@aptos_framework);
-        randomness.epoch = epoch;
-        randomness.round = round;
-        randomness.seed = seed_for_new_block;
+        if (exists<PerBlockRandomness>(@aptos_framework)) {
+            let randomness = borrow_global_mut<PerBlockRandomness>(@aptos_framework);
+            randomness.epoch = epoch;
+            randomness.round = round;
+            randomness.seed = seed_for_new_block;
+        }
     }
 
     /// Generate 32 random bytes.

--- a/testsuite/smoke-test/src/randomness/disable_feature_0.rs
+++ b/testsuite/smoke-test/src/randomness/disable_feature_0.rs
@@ -3,12 +3,10 @@
 use crate::{
     randomness::{decrypt_key_map, get_on_chain_resource, verify_dkg_transcript},
     smoke_test_environment::SwarmBuilder,
-    utils::get_current_consensus_config,
 };
 use aptos_forge::{Node, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
-use aptos_types::{dkg::DKGState, on_chain_config::FeatureFlag};
-use aptos_vm_genesis::default_features_resource_for_genesis;
+use aptos_types::{dkg::DKGState};
 use std::{sync::Arc, time::Duration};
 use aptos_types::randomness::PerBlockRandomness;
 

--- a/testsuite/smoke-test/src/randomness/disable_feature_0.rs
+++ b/testsuite/smoke-test/src/randomness/disable_feature_0.rs
@@ -6,9 +6,8 @@ use crate::{
 };
 use aptos_forge::{Node, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
-use aptos_types::{dkg::DKGState};
+use aptos_types::{dkg::DKGState, randomness::PerBlockRandomness};
 use std::{sync::Arc, time::Duration};
-use aptos_types::randomness::PerBlockRandomness;
 
 /// Disable on-chain randomness by only disabling feature `RECONFIGURE_WITH_DKG`.
 #[tokio::test]

--- a/testsuite/smoke-test/src/randomness/disable_feature_0.rs
+++ b/testsuite/smoke-test/src/randomness/disable_feature_0.rs
@@ -1,0 +1,93 @@
+// Copyright © Aptos Foundation
+
+use crate::{
+    randomness::{decrypt_key_map, get_on_chain_resource, verify_dkg_transcript},
+    smoke_test_environment::SwarmBuilder,
+    utils::get_current_consensus_config,
+};
+use aptos_forge::{Node, Swarm, SwarmExt};
+use aptos_logger::{debug, info};
+use aptos_types::{dkg::DKGState, on_chain_config::FeatureFlag};
+use aptos_vm_genesis::default_features_resource_for_genesis;
+use std::{sync::Arc, time::Duration};
+use aptos_types::randomness::PerBlockRandomness;
+
+/// Disable on-chain randomness by disabling feature `RECONFIGURE_WITH_DKG`.
+#[tokio::test]
+async fn disable_feature_0() {
+    let epoch_duration_secs = 20;
+    let estimated_dkg_latency_secs = 40;
+
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
+        .with_num_fullnodes(1)
+        .with_aptos()
+        .with_init_genesis_config(Arc::new(move |conf| {
+            conf.epoch_duration_secs = epoch_duration_secs;
+            conf.allow_new_validators = true;
+        }))
+        .build_with_cli(0)
+        .await;
+
+    let root_addr = swarm.chain_info().root_account().address();
+    let root_idx = cli.add_account_with_address_to_cli(swarm.root_key(), root_addr);
+
+    let decrypt_key_map = decrypt_key_map(&swarm);
+
+    let client_endpoint = swarm.validators().nth(1).unwrap().rest_api_endpoint();
+    let client = aptos_rest_client::Client::new(client_endpoint.clone());
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(3, Duration::from_secs(epoch_duration_secs * 2))
+        .await
+        .expect("Waited too long for epoch 3.");
+
+    info!("Now in epoch 3. Disabling feature RECONFIGURE_WITH_DKG.");
+    let disable_dkg_script = r#"
+script {
+    use aptos_framework::aptos_governance;
+    fun main(core_resources: &signer) {
+        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
+        let dkg_feature_id: u64 = std::features::get_reconfigure_with_dkg_feature();
+        aptos_governance::toggle_features(&framework_signer, vector[], vector[dkg_feature_id]);
+    }
+}
+"#;
+
+    let txn_summary = cli
+        .run_script(root_idx, disable_dkg_script)
+        .await
+        .expect("Txn execution error.");
+    debug!("disabling_dkg_summary={:?}", txn_summary);
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(4, Duration::from_secs(epoch_duration_secs * 2))
+        .await
+        .expect("Waited too long for epoch 4.");
+
+    info!("Now in epoch 4. DKG transcript should still be available. Randomness seed should be unavailable.");
+    let dkg_session = get_on_chain_resource::<DKGState>(&client)
+        .await
+        .last_completed
+        .expect("dkg result for epoch 4 should be present");
+    assert_eq!(4, dkg_session.target_epoch());
+    assert!(verify_dkg_transcript(&dkg_session, &decrypt_key_map).is_ok());
+
+    let randomness_seed = get_on_chain_resource::<PerBlockRandomness>(&client).await;
+    assert!(randomness_seed.seed.is_none());
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(5, Duration::from_secs(epoch_duration_secs * 2))
+        .await
+        .expect("Waited too long for epoch 5.");
+
+    info!("Now in epoch 5. DKG transcript should be unavailable. Randomness seed should be unavailable.");
+    let maybe_last_complete = get_on_chain_resource::<DKGState>(&client)
+        .await
+        .last_completed;
+    assert!(
+        maybe_last_complete.is_none() || maybe_last_complete.as_ref().unwrap().target_epoch() != 5
+    );
+
+    let randomness_seed = get_on_chain_resource::<PerBlockRandomness>(&client).await;
+    assert!(randomness_seed.seed.is_none());
+}

--- a/testsuite/smoke-test/src/randomness/disable_feature_1.rs
+++ b/testsuite/smoke-test/src/randomness/disable_feature_1.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use aptos_forge::{Node, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
-use aptos_types::{dkg::DKGState, on_chain_config::FeatureFlag};
-use aptos_vm_genesis::default_features_resource_for_genesis;
+use aptos_types::dkg::DKGState;
 use std::{sync::Arc, time::Duration};
 use aptos_types::randomness::PerBlockRandomness;
 

--- a/testsuite/smoke-test/src/randomness/disable_feature_1.rs
+++ b/testsuite/smoke-test/src/randomness/disable_feature_1.rs
@@ -7,9 +7,8 @@ use crate::{
 };
 use aptos_forge::{Node, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
-use aptos_types::dkg::DKGState;
+use aptos_types::{dkg::DKGState, randomness::PerBlockRandomness};
 use std::{sync::Arc, time::Duration};
-use aptos_types::randomness::PerBlockRandomness;
 
 /// Disable on-chain randomness by only disabling validator transactions.
 #[tokio::test]

--- a/testsuite/smoke-test/src/randomness/mod.rs
+++ b/testsuite/smoke-test/src/randomness/mod.rs
@@ -18,6 +18,7 @@ use rand::{prelude::StdRng, SeedableRng};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::Instant;
 
+mod disable_feature_0;
 mod dkg_basic;
 mod dkg_with_validator_down;
 mod dkg_with_validator_join_leave;

--- a/testsuite/smoke-test/src/randomness/mod.rs
+++ b/testsuite/smoke-test/src/randomness/mod.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, time::Duration};
 use tokio::time::Instant;
 
 mod disable_feature_0;
+mod disable_feature_1;
 mod dkg_basic;
 mod dkg_with_validator_down;
 mod dkg_with_validator_join_leave;


### PR DESCRIPTION
... so applications have no seed to consume and then abort (instead of reusing the previous seed, which is worse).