### PR TITLE
[aptos-framework account] enable rotate auth key for self mapped auth…

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -610,6 +610,10 @@ module aptos_framework::account {
 
         // Set `OriginatingAddress[new_auth_key] = originating_address`.
         let new_auth_key = from_bcs::to_address(new_auth_key_vector);
+        // If new_auth_key was mapped to address new_auth_key (self map), remove the entry from table to enable  rotate
+        if (table::contains(address_map, new_auth_key) && *table::borrow(address_map, new_auth_key) == new_auth_key) {
+            table::remove(address_map, new_auth_key);
+        };
         table::add(address_map, new_auth_key, originating_addr);
 
         event::emit<KeyRotation>(KeyRotation {


### PR DESCRIPTION
Assume there were two accounts, alice and bob.
1. alice roate auth key to bob;
2. the account bob with alice_addr rotate auth key back to alice, 
    the OriginatingAddress table will hold an entry: alice_auth_key-> alice_addr;
   
At this time, none account can rotate auth key to alice since alice hold a "self mapped auth-key". 

This PR will solve this issue by removing the "self mapped auth-key" from table when  rorate.
 
