### PR TITLE
Avoid processing duplicate commit messages

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -81,12 +81,15 @@ impl BlockStore {
         &self,
         sync_info: &SyncInfo,
         mut retriever: BlockRetriever,
+        sync_commit_certs: bool,
     ) -> anyhow::Result<()> {
-        self.sync_to_highest_commit_cert(
-            sync_info.highest_commit_cert().ledger_info(),
-            &retriever.network,
-        )
-        .await;
+        if sync_commit_certs {
+            self.sync_to_highest_commit_cert(
+                sync_info.highest_commit_cert().ledger_info(),
+                &retriever.network,
+            )
+            .await;
+        }
         self.sync_to_highest_ordered_cert(
             sync_info.highest_ordered_cert().clone(),
             sync_info.highest_commit_cert().clone(),


### PR DESCRIPTION
### Description

Making sure the buffer manager processes a commit message from only one validator during sync up. We add `pending_highest_commit_cert` field in round manager that stores highest commit cert that is being synced by the buffer manager during this round. If any sync up request has a lower commit cert than this, we do not send the syncing request to buffer manager again. 