### PR TITLE
[api] default to json accept type

### DIFF
--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_api_types::mime_types::BCS;
+use aptos_api_types::mime_types::{BCS, JSON};
 use poem::{web::Accept, FromRequest, Request, RequestBody, Result};
 
 /// Accept types from input headers
@@ -29,6 +29,9 @@ impl<'a> FromRequest<'a> for AcceptType {
 /// overriding explicit accept type, default to JSON.
 fn parse_accept(accept: &Accept) -> Result<AcceptType> {
     for mime in &accept.0 {
+        if matches!(mime.as_ref(), JSON) {
+            return Ok(AcceptType::Json);
+        }
         if matches!(mime.as_ref(), BCS) {
             return Ok(AcceptType::Bcs);
         }


### PR DESCRIPTION
Addresses the issue described in #7855 

By first matching on JSON, rather than BCS, the default accept type will be JSON which the UI can display. To test that this works, you can: 
1) Go to https://fullnode.testnet.aptoslabs.com/v1/spec#/operations/view
2) Send this payload:
```
 {
  "function": "0x1::timestamp::now_seconds",
  "type_arguments": [],
  "arguments": []
}
```
3) You will see `200 "No supported response body returned". `
4) Run local testnet on this branch (`cargo run -p aptos -- node run-local-testnet --faucet-port 8081 --force-restart --assume-yes`)
5) Go to http://127.0.0.1:8080/v1/spec#/operations/view
6) The same payload will now return `200 ["correct timestamp"]. `

This also works for the other endpoints i.e. `https://fullnode.testnet.aptoslabs.com/v1/spec#/operations/get_account` for 0x01.

This change should not require changing the spec or ts docs as functionality remains essentially the same. 