### PR TITLE
ObjectCodeDeployment API cleanup update

### DIFF
--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -412,7 +412,7 @@ impl MoveHarness {
         account: &Account,
         package: &BuiltPackage,
         mut patch_metadata: impl FnMut(&mut PackageMetadata),
-        publisher_ref: AccountAddress,
+        code_object: AccountAddress,
     ) -> SignedTransaction {
         let code = package.extract_code();
         let mut metadata = package
@@ -424,7 +424,7 @@ impl MoveHarness {
             aptos_stdlib::object_code_deployment_upgrade(
                 bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
                 code,
-                publisher_ref,
+                code_object,
             ),
         )
     }
@@ -451,7 +451,7 @@ impl MoveHarness {
         path: &Path,
         options: BuildOptions,
         patch_metadata: impl FnMut(&mut PackageMetadata),
-        publisher_ref: AccountAddress,
+        code_object: AccountAddress,
     ) -> SignedTransaction {
         let package =
             build_package(path.to_owned(), options).expect("building package must succeed");
@@ -459,7 +459,7 @@ impl MoveHarness {
             account,
             &package,
             patch_metadata,
-            publisher_ref,
+            code_object,
         )
     }
 
@@ -531,10 +531,10 @@ impl MoveHarness {
         account: &Account,
         path: &Path,
         options: BuildOptions,
-        publisher_ref: AccountAddress,
+        code_object: AccountAddress,
     ) -> TransactionStatus {
         let txn =
-            self.create_object_code_upgrade_package(account, path, options, |_| {}, publisher_ref);
+            self.create_object_code_upgrade_package(account, path, options, |_| {}, code_object);
         self.run(txn)
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/object_code_deployment.rs
+++ b/aptos-move/e2e-move-tests/src/tests/object_code_deployment.rs
@@ -5,7 +5,7 @@ use crate::{assert_abort, assert_success, assert_vm_status, tests::common, MoveH
 use aptos_framework::{
     natives::{
         code::{PackageRegistry, UpgradePolicy},
-        object_code_deployment::PublisherRef,
+        object_code_deployment::ManagingRefs,
     },
     BuildOptions,
 };
@@ -150,16 +150,16 @@ fn object_code_deployment_publish_package(enabled: Vec<FeatureFlag>, disabled: V
         assert_eq!(registry.packages[0].modules.len(), 1);
         assert_eq!(registry.packages[0].modules[0].name, "test");
 
-        let publisher_ref: PublisherRef = context
+        let code_object: ManagingRefs = context
             .harness
             .read_resource_from_resource_group(
                 &context.object_address,
                 parse_struct_tag("0x1::object::ObjectGroup").unwrap(),
-                parse_struct_tag("0x1::object_code_deployment::PublisherRef").unwrap(),
+                parse_struct_tag("0x1::object_code_deployment::ManagingRefs").unwrap(),
             )
             .unwrap();
-        // Verify the object created owns the `PublisherRef`
-        assert_eq!(publisher_ref, PublisherRef::new(context.object_address));
+        // Verify the object created owns the `ManagingRefs`
+        assert_eq!(code_object, ManagingRefs::new(context.object_address));
 
         let module_address = context.object_address.to_string();
         assert_success!(context.harness.run_entry_function(
@@ -244,8 +244,8 @@ fn object_code_deployment_upgrade_fail_when_publisher_ref_does_not_exist() {
     let mut context = TestContext::new(None, None);
     let acc = context.account.clone();
 
-    // We should not be able to `upgrade` as `PublisherRef` does not exist.
-    // `PublisherRef` is only created when calling `publish` first, i.e. deploying a package.
+    // We should not be able to `upgrade` as `ManagingRefs` does not exist.
+    // `ManagingRefs` is only created when calling `publish` first, i.e. deploying a package.
     let status = context.execute_object_code_action(
         &acc,
         "object_code_deployment.data/pack_initial",

--- a/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
+++ b/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
@@ -15,7 +15,7 @@ Publishing modules flow:
 1. Create a new object with the address derived from the publisher address and the object seed.
 2. Publish the module passed in the function via <code>metadata_serialized</code> and <code><a href="code.md#0x1_code">code</a></code> to the newly created object.
 3. Emits 'Publish' event with the address of the newly created object.
-4. Create a <code><a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a></code> which stores the extend ref of the newly created object.
+4. Create a <code><a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a></code> which stores the extend ref of the newly created object.
 Note: This is needed to upgrade the code as the signer must be generated to upgrade the existing code in an object.
 
 Upgrading modules flow:
@@ -35,7 +35,7 @@ Note: There is no unfreeze function as this gives no benefit if the user can fre
 Once modules are marked as immutable, they cannot be made mutable again.
 
 
--  [Resource `PublisherRef`](#0x1_object_code_deployment_PublisherRef)
+-  [Resource `ManagingRefs`](#0x1_object_code_deployment_ManagingRefs)
 -  [Struct `Publish`](#0x1_object_code_deployment_Publish)
 -  [Struct `Upgrade`](#0x1_object_code_deployment_Upgrade)
 -  [Struct `Freeze`](#0x1_object_code_deployment_Freeze)
@@ -59,15 +59,15 @@ Once modules are marked as immutable, they cannot be made mutable again.
 
 
 
-<a id="0x1_object_code_deployment_PublisherRef"></a>
+<a id="0x1_object_code_deployment_ManagingRefs"></a>
 
-## Resource `PublisherRef`
+## Resource `ManagingRefs`
 
-Object which contains the code deployed, along with the extend ref to upgrade the code.
+Internal struct, attached to the object, that holds Refs we need to manage the code deployment (i.e. upgrades).
 
 
 <pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a> <b>has</b> key
+<b>struct</b> <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> <b>has</b> key
 </code></pre>
 
 
@@ -256,7 +256,7 @@ the code to be published via <code><a href="code.md#0x1_code">code</a></code>. T
 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Publish">Publish</a> { object_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(code_signer), });
 
-    <b>move_to</b>(code_signer, <a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a> {
+    <b>move_to</b>(code_signer, <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> {
         extend_ref: <a href="object.md#0x1_object_generate_extend_ref">object::generate_extend_ref</a>(constructor_ref),
     });
 }
@@ -304,7 +304,7 @@ Note: If the modules were deployed as immutable when calling <code>publish</code
 Requires the publisher to be the owner of the <code>code_object</code>.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="object_code_deployment.md#0x1_object_code_deployment_upgrade">upgrade</a>(publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata_serialized: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, code_object: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">object_code_deployment::PublisherRef</a>&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="object_code_deployment.md#0x1_object_code_deployment_upgrade">upgrade</a>(publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata_serialized: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, code_object: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="code.md#0x1_code_PackageRegistry">code::PackageRegistry</a>&gt;)
 </code></pre>
 
 
@@ -317,8 +317,8 @@ Requires the publisher to be the owner of the <code>code_object</code>.
     publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     metadata_serialized: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
-    code_object: Object&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a>&gt;,
-) <b>acquires</b> <a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a> {
+    code_object: Object&lt;PackageRegistry&gt;,
+) <b>acquires</b> <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> {
     <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
     <b>assert</b>!(
         <a href="object.md#0x1_object_is_owner">object::is_owner</a>(code_object, publisher_address),
@@ -326,9 +326,9 @@ Requires the publisher to be the owner of the <code>code_object</code>.
     );
 
     <b>let</b> code_object_address = <a href="object.md#0x1_object_object_address">object::object_address</a>(&code_object);
-    <b>assert</b>!(<b>exists</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a>&gt;(code_object_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_ECODE_OBJECT_DOES_NOT_EXIST">ECODE_OBJECT_DOES_NOT_EXIST</a>));
+    <b>assert</b>!(<b>exists</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a>&gt;(code_object_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_ECODE_OBJECT_DOES_NOT_EXIST">ECODE_OBJECT_DOES_NOT_EXIST</a>));
 
-    <b>let</b> extend_ref = &<b>borrow_global</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_PublisherRef">PublisherRef</a>&gt;(code_object_address).extend_ref;
+    <b>let</b> extend_ref = &<b>borrow_global</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a>&gt;(code_object_address).extend_ref;
     <b>let</b> code_signer = &<a href="object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(extend_ref);
     <a href="code.md#0x1_code_publish_package_txn">code::publish_package_txn</a>(code_signer, metadata_serialized, <a href="code.md#0x1_code">code</a>);
 

--- a/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
@@ -44,7 +44,7 @@ pub fn publish_module_source(module_name: &str, module_src: &str) -> Transaction
 pub fn object_code_deployment_upgrade(
     metadata_serialized: Vec<u8>,
     code: Vec<Vec<u8>>,
-    publisher_ref: AccountAddress,
+    code_object: AccountAddress,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -59,7 +59,7 @@ pub fn object_code_deployment_upgrade(
         vec![
             bcs::to_bytes(&metadata_serialized).unwrap(),
             bcs::to_bytes(&code).unwrap(),
-            bcs::to_bytes(&publisher_ref).unwrap(),
+            bcs::to_bytes(&code_object).unwrap(),
         ],
     ))
 }

--- a/aptos-move/framework/src/natives/object_code_deployment.rs
+++ b/aptos-move/framework/src/natives/object_code_deployment.rs
@@ -11,13 +11,13 @@ pub struct ExtendRef {
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PublisherRef {
+pub struct ManagingRefs {
     pub extend_ref: ExtendRef,
 }
 
-impl PublisherRef {
+impl ManagingRefs {
     pub fn new(address: AccountAddress) -> Self {
-        PublisherRef {
+        ManagingRefs {
             extend_ref: ExtendRef { address },
         }
     }


### PR DESCRIPTION
backward incompatible change, to be included before current code is deployed  to testnet

main change is in the API in the object_code_deployment.move:

- since holding ExtendRef is internal implementation, renaming to ManagingRefs (similarly to naming in managed_fungible_asset.move)
- changing argument of upgrade to be Object<PackageRegistry> to align with freeze, and to not expose internal ManagingRefs object.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
