### PR TITLE
[consensus configs] reduce sending block size from 2500 to 1900 (#12091)

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -11,7 +11,7 @@ use cfg_if::cfg_if;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub(crate) const MAX_SENDING_BLOCK_TXNS: u64 = 2500;
+pub(crate) const MAX_SENDING_BLOCK_TXNS: u64 = 1900;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]


### PR DESCRIPTION
### Description

The block output limit is no longer hit with p2p txns.

### Test Plan

Forge `realistic_env_max_load` TPS improves.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
