### PR TITLE
[CLI] Update aptos-indexer-processors dep to d5dc7a00, enable objects processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=9936ec73cef251fb01fd2c47412e064cad3975c2#9936ec73cef251fb01fd2c47412e064cad3975c2"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
 dependencies = [
  "chrono",
 ]
@@ -3285,8 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.1.2"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=af0dcea7144225a709e4f595e58f8026b99e901c#af0dcea7144225a709e4f595e58f8026b99e901c"
+version = "1.3.0"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -3299,6 +3298,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c#5d1cefad0ea0d37fb08e9aec7847080745c83f9c"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -13001,12 +13001,12 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=9936ec73cef251fb01fd2c47412e064cad3975c2#9936ec73cef251fb01fd2c47412e064cad3975c2"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
 dependencies = [
  "ahash 0.8.8",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=9936ec73cef251fb01fd2c47412e064cad3975c2)",
- "aptos-protos 1.1.2",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c)",
+ "aptos-protos 1.3.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c)",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -14610,7 +14610,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=9936ec73cef251fb01fd2c47412e064cad3975c2#9936ec73cef251fb01fd2c47412e064cad3975c2"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 - Updated CLI source compilation to use rust toolchain version 1.75.0 (from 1.74.1).
+- Upgraded indexer processors for local testnet from 9936ec73cef251fb01fd2c47412e064cad3975c2 to d5dc7a003c655bdbd30233a8e9076796cceae72c. Upgraded Hasura metadata accordingly.
+- Added support for objects processor in local testnet and enabled it by default.
 
 ## [2.4.0] - 2023/01/05
 - Hide the V2 compiler from input options until the V2 compiler is ready for release

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "9936ec73cef251fb01fd2c47412e064cad3975c2" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d5dc7a003c655bdbd30233a8e9076796cceae72c" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "9936ec73cef251fb01fd2c47412e064cad3975c2" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d5dc7a003c655bdbd30233a8e9076796cceae72c" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aptos/src/node/local_testnet/hasura_metadata.json
+++ b/crates/aptos/src/node/local_testnet/hasura_metadata.json
@@ -1,5 +1,5 @@
 {
-  "resource_version": 296,
+  "resource_version": 385,
   "metadata": {
     "version": 3,
     "sources": [
@@ -1404,6 +1404,32 @@
           },
           {
             "table": {
+              "name": "delegated_staking_pool_balances",
+              "schema": "public"
+            },
+            "select_permissions": [
+              {
+                "role": "anonymous",
+                "permission": {
+                  "columns": [
+                    "active_table_handle",
+                    "inactive_table_handle",
+                    "operator_commission_percentage",
+                    "staking_pool_address",
+                    "total_coins",
+                    "total_shares",
+                    "transaction_version"
+                  ],
+                  "filter": {},
+                  "limit": 100,
+                  "allow_aggregations": true
+                },
+                "comment": ""
+              }
+            ]
+          },
+          {
+            "table": {
               "name": "delegated_staking_pools",
               "schema": "public"
             },
@@ -1698,6 +1724,7 @@
                 "permission": {
                   "columns": [
                     "last_success_version",
+                    "last_transaction_timestamp",
                     "last_updated",
                     "processor"
                   ],
@@ -2070,13 +2097,6 @@
               "from_env": "INDEXER_V2_POSTGRES_URL"
             },
             "isolation_level": "read-committed",
-            "pool_settings": {
-              "connection_lifetime": 600,
-              "idle_timeout": 180,
-              "max_connections": 100,
-              "total_max_connections": 1500,
-              "pool_timeout": 120
-            },
             "use_prepared_statements": false
           }
         }
@@ -2089,7 +2109,7 @@
           "queries": [
             {
               "name": "Latest Processor Status",
-              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n  }\n}"
+              "query": "query LatestProcessorStatus {\n  processor_status {\n    processor\n    last_updated\n    last_success_version\n    last_transaction_timestamp\n  }\n}"
             }
           ]
         }

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -36,6 +36,7 @@ pub struct ProcessorArgs {
             ProcessorName::DefaultProcessor,
             ProcessorName::EventsProcessor,
             ProcessorName::FungibleAssetProcessor,
+            ProcessorName::ObjectsProcessor,
             ProcessorName::StakeProcessor,
             ProcessorName::TokenProcessor,
             ProcessorName::TokenV2Processor,
@@ -85,9 +86,7 @@ impl ProcessorManager {
             ProcessorName::MonitoringProcessor => {
                 bail!("Monitoring processor is not supported in the local testnet")
             },
-            ProcessorName::ObjectsProcessor => {
-                bail!("Objects processor is not supported in the local testnet")
-            },
+            ProcessorName::ObjectsProcessor => ProcessorConfig::ObjectsProcessor,
         };
         let config = IndexerGrpcProcessorConfig {
             processor_config,


### PR DESCRIPTION
### Description
This PR updates the aptos-indexer-processors dep. I see a few weeks back the dep was updated and the object processor was made available but unusable in the local testnet. This PR fixes that and enables it.

### Test Plan
Ran local testnet, saw that objects table exists, processor is processing, etc. Let's see how the TS SDK tests go.