### PR TITLE
[E2E] Improve platform handling, fix faucet tests

### DIFF
--- a/.github/actions/run-faucet-tests/action.yaml
+++ b/.github/actions/run-faucet-tests/action.yaml
@@ -50,7 +50,7 @@ runs:
     # we don't pass the image tag.
     - name: Run integration tests
       if: ${{ inputs.NETWORK != 'custom' }}
-      run: poetry run python main.py --base-network ${{ inputs.NETWORK }} ${{ endif }} --external-test-dir ${{ runner.temp }}/testnet --image-repo-with-project ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
+      run: poetry run python main.py --base-network ${{ inputs.NETWORK }} --external-test-dir ${{ runner.temp }}/testnet --image-repo-with-project ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
       working-directory: crates/aptos-faucet/integration-tests
       shell: bash
 

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -689,7 +689,7 @@ mod test {
         // Create it on chain using the prod devnet faucet. We fund it with
         // exactly the minimum funds set in the config.
         let account_address =
-            AuthenticationKey::ed25519(&private_key.public_key()).derived_address();
+            AuthenticationKey::ed25519(&private_key.public_key()).account_address();
         unwrap_reqwest_result(
             reqwest::Client::new()
                 .post("https://faucet.devnet.aptoslabs.com/fund")

--- a/crates/aptos-faucet/integration-tests/main.py
+++ b/crates/aptos-faucet/integration-tests/main.py
@@ -97,7 +97,9 @@ def main():
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    if platform.system() == "Darwin" and platform.processor().startswith("arm"):
+    # If we're on Mac and DOCKER_DEFAULT_PLATFORM is not already set, set it to
+    # linux/amd64 since we only publish images for that platform.
+    if platform.system().lower() == "darwin" and platform.processor().lower().startswith("arm"):
         if not os.environ.get("DOCKER_DEFAULT_PLATFORM"):
             os.environ["DOCKER_DEFAULT_PLATFORM"] = "linux/amd64"
             LOG.info(

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -25,7 +25,9 @@ When the test suite is complete, it will tell you which tests passed and which f
 
 import argparse
 import logging
+import os
 import pathlib
+import platform
 import shutil
 import sys
 
@@ -192,6 +194,16 @@ def main():
     # Create the dir the test CLI will run from.
     shutil.rmtree(args.working_directory, ignore_errors=True)
     pathlib.Path(args.working_directory).mkdir(parents=True, exist_ok=True)
+
+    # If we're on Mac and DOCKER_DEFAULT_PLATFORM is not already set, set it to
+    # linux/amd64 since we only publish images for that platform.
+    if platform.system().lower() == "darwin" and platform.processor().lower().startswith("arm"):
+        if not os.environ.get("DOCKER_DEFAULT_PLATFORM"):
+            os.environ["DOCKER_DEFAULT_PLATFORM"] = "linux/amd64"
+            LOG.info(
+                "Detected ARM Mac and DOCKER_DEFAULT_PLATFORM was not set, setting it "
+                "to linux/amd64"
+            )
 
     # Run a node + faucet and wait for them to start up.
     container_name = run_node(


### PR DESCRIPTION
### Description
Improve platform handling in the faucet and CLI e2e tests so you don't have to worry about the docker platform env vars.

Beyond that, I fixed the faucet CI in two ways:
- The tests for confirming that the faucet works with the existing devnet / testnet were broken due to code changing, but I suppose the tests were disabled so the bad change landed. [Broken run](https://github.com/aptos-labs/aptos-core/actions/runs/8000725904/job/21851191929?pr=12161).
  - The breakage came from 72f04e09def0f6ed796a00a83b1b52fa31a5e860 so the tests have been broken for a hot minute. Only the tests were broken.
- The tests for confirming that upstream changes don't break compatibility with the existing faucet were broken due to syntax error in the CI that I think I messed up ages ago.

### Test Plan
I changed pull_request_target to pull_request temporarily to confirm that this worked: https://github.com/aptos-labs/aptos-core/actions/runs/8001108730/job/21851689189?pr=12161.

The faucet tests are legit and are meant to be reliable signal that something breaks faucet compatibility, so I will make them land blocking after this change lands and looks good for a bit.

This compiles now:
```
cargo test -p aptos-faucet-core --features integration-tests
```