### PR TITLE
[quorum store] reduce QS backpressure txn limit to 12K

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -11,6 +11,7 @@ use cfg_if::cfg_if;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+// NOTE: when changing, make sure to update QuorumStoreBackPressureConfig::backlog_txn_limit_count as well.
 pub(crate) const MAX_SENDING_BLOCK_TXNS: u64 = 1900;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -29,7 +29,7 @@ impl Default for QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
             // Roughly, target TPS * commit latency seconds
-            backlog_txn_limit_count: 8000 * 2,
+            backlog_txn_limit_count: 12_000,
             // QS will create batches at the max rate until this number is reached
             backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,


### PR DESCRIPTION
### Description

As the recent block size change means txns are removed at max at a slower rate (previously, a portion of these txns were block cut).

### Test Plan
e2e perf test for QsPosToProposal reduction: ~0.4s -> ~0.2s