### PR TITLE
[cli] Force global config file

### DIFF
--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -197,7 +197,10 @@ impl GlobalConfig {
             from_yaml(&String::from_utf8(read_from_file(path.as_path())?)?)
         } else {
             // If we don't have a config, let's load the default
-            Ok(GlobalConfig::default())
+            // Let's create the file if it doesn't exist
+            let config = GlobalConfig::default();
+            config.save()?;
+            Ok(config)
         }
     }
 


### PR DESCRIPTION
### Description
Right now, we can't change the default on the global config, because no one has a file to fall back on.  So, this forces the file to show up, and then we can change the default afterwards.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
