### PR TITLE
[Consensus] Use unbounded channel for self messages

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -62,7 +62,8 @@ pub fn start_consensus(
 
     let (timeout_sender, timeout_receiver) =
         aptos_channels::new(1_024, &counters::PENDING_ROUND_TIMEOUTS);
-    let (self_sender, self_receiver) = aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
+    let (self_sender, self_receiver) =
+        aptos_channels::new_unbounded(&counters::PENDING_SELF_MESSAGES);
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
     let bounded_executor = BoundedExecutor::new(8, runtime.handle().clone());
 

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -46,7 +46,7 @@ struct DagBootstrapUnit {
     df_task_handle: JoinHandle<()>,
     dag_rpc_tx: aptos_channel::Sender<Author, IncomingDAGRequest>,
     network_events:
-        Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::Receiver<Event<ConsensusMsg>>>>,
+        Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>>,
 }
 
 impl DagBootstrapUnit {
@@ -58,7 +58,7 @@ impl DagBootstrapUnit {
         network: NetworkSender,
         time_service: TimeService,
         network_events: Box<
-            Select<NetworkEvents<ConsensusMsg>, aptos_channels::Receiver<Event<ConsensusMsg>>>,
+            Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>,
         >,
         all_signers: Vec<ValidatorSigner>,
     ) -> (Self, UnboundedReceiver<OrderedBlocks>) {
@@ -133,7 +133,7 @@ fn create_network(
     validators: ValidatorVerifier,
 ) -> (
     NetworkSender,
-    Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::Receiver<Event<ConsensusMsg>>>>,
+    Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>>,
 ) {
     let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
     let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
@@ -153,7 +153,7 @@ fn create_network(
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
     let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
 
-    let (self_sender, self_receiver) = aptos_channels::new_test(1000);
+    let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
     let network = NetworkSender::new(author, consensus_network_client, self_sender, validators);
 
     let twin_id = TwinId { id, author };

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -45,8 +45,9 @@ struct DagBootstrapUnit {
     nh_task_handle: JoinHandle<SyncOutcome>,
     df_task_handle: JoinHandle<()>,
     dag_rpc_tx: aptos_channel::Sender<Author, IncomingDAGRequest>,
-    network_events:
-        Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>>,
+    network_events: Box<
+        Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>,
+    >,
 }
 
 impl DagBootstrapUnit {
@@ -58,7 +59,10 @@ impl DagBootstrapUnit {
         network: NetworkSender,
         time_service: TimeService,
         network_events: Box<
-            Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>,
+            Select<
+                NetworkEvents<ConsensusMsg>,
+                aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>,
+            >,
         >,
         all_signers: Vec<ValidatorSigner>,
     ) -> (Self, UnboundedReceiver<OrderedBlocks>) {
@@ -133,7 +137,9 @@ fn create_network(
     validators: ValidatorVerifier,
 ) -> (
     NetworkSender,
-    Box<Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>>,
+    Box<
+        Select<NetworkEvents<ConsensusMsg>, aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>>,
+    >,
 ) {
     let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
     let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -118,7 +118,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     #[allow(unused)]
     execution_config: ExecutionConfig,
     time_service: Arc<dyn TimeService>,
-    self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+    self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     timeout_sender: aptos_channels::Sender<Round>,
     quorum_store_enabled: bool,
@@ -157,7 +157,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     pub(crate) fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
-        self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+        self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
         network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
         timeout_sender: aptos_channels::Sender<Round>,
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -196,7 +196,7 @@ pub struct NetworkSender {
     consensus_network_client: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     // Self sender and self receivers provide a shortcut for sending the messages to itself.
     // (self sending is not supported by the networking API).
-    self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+    self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
     validators: ValidatorVerifier,
     time_service: aptos_time_service::TimeService,
 }
@@ -205,7 +205,7 @@ impl NetworkSender {
     pub fn new(
         author: Author,
         consensus_network_client: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
-        self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+        self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
         validators: ValidatorVerifier,
     ) -> Self {
         NetworkSender {
@@ -608,7 +608,7 @@ impl NetworkTask {
     /// Establishes the initial connections with the peers and returns the receivers.
     pub fn new(
         network_service_events: NetworkServiceEvents<ConsensusMsg>,
-        self_receiver: aptos_channels::Receiver<Event<ConsensusMsg>>,
+        self_receiver: aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>,
     ) -> (NetworkTask, NetworkReceivers) {
         let (consensus_messages_tx, consensus_messages) = aptos_channel::new(
             QueueStyle::FIFO,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -584,7 +584,7 @@ mod tests {
             let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
-            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(8);
+            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(1024);
             let (_, conn_status_rx) = conn_notifs_channel::new();
 
             add_peer_to_storage(&peers_and_metadata, peer, &[
@@ -611,7 +611,7 @@ mod tests {
             };
             playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
-            let (self_sender, self_receiver) = aptos_channels::new_test(8);
+            let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
             let node = NetworkSender::new(
                 *peer,
                 consensus_network_client,
@@ -697,7 +697,7 @@ mod tests {
             let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
-            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(8);
+            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(1024);
             let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
@@ -724,7 +724,7 @@ mod tests {
             };
             playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
-            let (self_sender, self_receiver) = aptos_channels::new_test(8);
+            let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
             let node = NetworkSender::new(
                 *peer,
                 consensus_network_client.clone(),
@@ -807,7 +807,7 @@ mod tests {
         let network_events = NetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);
         let network_service_events =
             NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
-        let (self_sender, self_receiver) = aptos_channels::new_test(8);
+        let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
 
         let (network_task, mut network_receivers) =
             NetworkTask::new(network_service_events, self_receiver);

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -115,7 +115,7 @@ impl BufferManagerHandle {
 pub struct ExecutionProxyClient {
     execution_proxy: Arc<ExecutionProxy>,
     author: Author,
-    self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+    self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     bounded_executor: BoundedExecutor,
     // channels to buffer manager
@@ -126,7 +126,7 @@ impl ExecutionProxyClient {
     pub fn new(
         execution_proxy: Arc<ExecutionProxy>,
         author: Author,
-        self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
+        self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
         network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
         bounded_executor: BoundedExecutor,
     ) -> Self {

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -64,7 +64,7 @@ pub fn prepare_buffer_manager(
     Sender<OrderedBlocks>,
     Sender<ResetRequest>,
     aptos_channel::Sender<AccountAddress, IncomingCommitRequest>,
-    aptos_channels::Receiver<Event<ConsensusMsg>>,
+    aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>,
     PipelinePhase<ExecutionSchedulePhase>,
     PipelinePhase<ExecutionWaitPhase>,
     PipelinePhase<SigningPhase>,
@@ -113,7 +113,7 @@ pub fn prepare_buffer_manager(
     );
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
 
-    let (self_loop_tx, self_loop_rx) = aptos_channels::new_test(1000);
+    let (self_loop_tx, self_loop_rx) = aptos_channels::new_unbounded_test();
     let network = NetworkSender::new(
         author,
         consensus_network_client,
@@ -179,7 +179,7 @@ pub fn launch_buffer_manager() -> (
     Sender<OrderedBlocks>,
     Sender<ResetRequest>,
     aptos_channel::Sender<AccountAddress, IncomingCommitRequest>,
-    aptos_channels::Receiver<Event<ConsensusMsg>>,
+    aptos_channels::UnboundedReceiver<Event<ConsensusMsg>>,
     HashValue,
     Runtime,
     Vec<ValidatorSigner>,

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -150,7 +150,7 @@ fn create_node_for_fuzzing() -> RoundManager {
     );
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
 
-    let (self_sender, _self_receiver) = aptos_channels::new_test(8);
+    let (self_sender, _self_receiver) = aptos_channels::new_unbounded_test();
 
     let epoch_state = Arc::new(EpochState {
         epoch: 1,

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -243,7 +243,7 @@ impl NodeSetup {
 
         playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
-        let (self_sender, self_receiver) = aptos_channels::new_test(1000);
+        let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
         let network = Arc::new(NetworkSender::new(
             author,
             consensus_network_client,

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -143,7 +143,7 @@ impl SMRNode {
         let (timeout_sender, timeout_receiver) =
             aptos_channels::new(1_024, &counters::PENDING_ROUND_TIMEOUTS);
         let (self_sender, self_receiver) =
-            aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
+            aptos_channels::new_unbounded(&counters::PENDING_SELF_MESSAGES);
 
         let quorum_store_storage = Arc::new(MockQuorumStoreDB::new());
         let bounded_executor = BoundedExecutor::new(2, playground.handle());

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -111,6 +111,11 @@ impl<T> Stream for Receiver<T> {
     }
 }
 
+pub fn new_test<T>(size: usize) -> (Sender<T>, Receiver<T>) {
+    let gauge = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    new(size, &gauge)
+}
+
 /// Similar to `mpsc::channel`, `new` creates a pair of `Sender` and `Receiver`
 pub fn new<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
     gauge.set(0);
@@ -127,7 +132,88 @@ pub fn new<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
     )
 }
 
-pub fn new_test<T>(size: usize) -> (Sender<T>, Receiver<T>) {
+pub fn new_unbounded_test<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
     let gauge = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    new(size, &gauge)
+    new_unbounded(&gauge)
+}
+
+pub fn new_unbounded<T>(gauge: &IntGauge) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+    gauge.set(0);
+    let (sender, receiver) = mpsc::unbounded();
+    (
+        UnboundedSender {
+            inner: sender,
+            gauge: gauge.clone(),
+        },
+        UnboundedReceiver {
+            inner: receiver,
+            gauge: gauge.clone(),
+        },
+    )
+}
+
+pub struct UnboundedSender<T> {
+    inner: mpsc::UnboundedSender<T>,
+    gauge: IntGauge,
+}
+
+/// An [`mpsc::UnboundedReceiver`](futures::channel::mpsc::UnboundedReceiver) with an [`IntGauge`]
+/// counting the number of currently queued items.
+pub struct UnboundedReceiver<T> {
+    inner: mpsc::UnboundedReceiver<T>,
+    gauge: IntGauge,
+}
+
+impl<T> Clone for UnboundedSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            gauge: self.gauge.clone(),
+        }
+    }
+}
+
+/// `UnboundedSender` implements `Sink` in the same way as `mpsc::Sender`, but it increments the
+/// associated `IntGauge` when it sends a message successfully.
+impl<T> Sink<T> for UnboundedSender<T> {
+    type Error = mpsc::SendError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        (self).inner.poll_ready(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
+        (self).inner.start_send(msg).map(|_| self.gauge.inc())
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
+impl<T> FusedStream for UnboundedReceiver<T>
+where
+    T: std::fmt::Debug,
+{
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}
+
+/// `UnboundedReceiver` implements `Stream` in the same way as `mpsc::Stream`, but it decrements the
+/// associated `IntGauge` when it gets polled successfully.
+impl<T> Stream for UnboundedReceiver<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let next = Pin::new(&mut self.inner).poll_next(cx);
+        if let Poll::Ready(Some(_)) = next {
+            self.gauge.dec();
+        }
+        next
+    }
 }

--- a/network/framework/src/protocols/wire/messaging/v1/test.rs
+++ b/network/framework/src/protocols/wire/messaging/v1/test.rs
@@ -239,7 +239,6 @@ proptest! {
         let (mut msg_tx, msg_rx) = aptos_channels::new_test(1024);
         let mut outbound_stream = OutboundStream::new(128, 64 * 255, stream_tx);
         let mut inbound_stream = InboundStreamBuffer::new(255);
-
         let messages_clone = messages.clone();
         let f_stream_all = async move {
             for message in messages_clone {


### PR DESCRIPTION
### Description

Since the messages are from self, no need for this to be bounded. Having a bounded channel runs into the risk of blocking the round manager thread when the channel is full. 

### Test Plan

UTs
