### PR TITLE
[move-examples] Update shared account example to use objects

### DIFF
--- a/aptos-move/move-examples/common_account/Move.toml
+++ b/aptos-move/move-examples/common_account/Move.toml
@@ -7,3 +7,6 @@ AptosFramework = { local = "../../framework/aptos-framework" }
 
 [addresses]
 common_account = "_"
+
+[dev-addresses]
+common_account = "0xbeef"


### PR DESCRIPTION
### Description
Resource accounts cause a bunch more confusion around shared accounts; however, this object can simply replace those use cases.

### Test Plan
See unit tests
