### PR TITLE
Fix max fetcher tasks

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -229,7 +229,7 @@ async fn get_data_with_tasks(
                 if num_tasks >= MAX_FETCH_TASKS_PER_REQUEST {
                     // Limit the max tasks to MAX_FETCH_TASKS_PER_REQUEST
                     MAX_FETCH_TASKS_PER_REQUEST
-                } else if num_tasks <= 0 {
+                } else if num_tasks < 1 {
                     // Limit the min tasks to 1
                     1
                 } else {

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -160,7 +160,7 @@ impl RawData for RawDataServerWrapper {
             SERVICE_TYPE,
             IndexerGrpcStep::DataServiceNewRequestReceived,
             Some(current_version as i64),
-            None,
+            transactions_count.map(|v| (v as i64 + current_version as i64 - 1)),
             None,
             None,
             None,

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -224,9 +224,18 @@ async fn get_data_with_tasks(
         Ok(CacheCoverageStatus::CacheHit(_)) => 1,
         Ok(CacheCoverageStatus::CacheEvicted) => match transactions_count {
             None => MAX_FETCH_TASKS_PER_REQUEST,
-            Some(transactions_count) => (transactions_count / TRANSACTIONS_PER_STORAGE_BLOCK)
-                .min(MAX_FETCH_TASKS_PER_REQUEST)
-                .max(1),
+            Some(transactions_count) => {
+                let num_tasks = transactions_count / TRANSACTIONS_PER_STORAGE_BLOCK;
+                if num_tasks >= MAX_FETCH_TASKS_PER_REQUEST {
+                    // Limit the max tasks to MAX_FETCH_TASKS_PER_REQUEST
+                    MAX_FETCH_TASKS_PER_REQUEST
+                } else if num_tasks <= 0 {
+                    // Limit the min tasks to 1
+                    1
+                } else {
+                    num_tasks
+                }
+            },
         },
         Err(_) => {
             error!("[Data Service] Failed to get cache coverage status.");

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -225,7 +225,8 @@ async fn get_data_with_tasks(
         Ok(CacheCoverageStatus::CacheEvicted) => match transactions_count {
             None => MAX_FETCH_TASKS_PER_REQUEST,
             Some(transactions_count) => (transactions_count / TRANSACTIONS_PER_STORAGE_BLOCK)
-                .min(MAX_FETCH_TASKS_PER_REQUEST),
+                .min(MAX_FETCH_TASKS_PER_REQUEST)
+                .max(1),
         },
         Err(_) => {
             error!("[Data Service] Failed to get cache coverage status.");

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -225,7 +225,7 @@ async fn get_data_with_tasks(
         Ok(CacheCoverageStatus::CacheEvicted) => match transactions_count {
             None => MAX_FETCH_TASKS_PER_REQUEST,
             Some(transactions_count) => (transactions_count / TRANSACTIONS_PER_STORAGE_BLOCK)
-                .max(MAX_FETCH_TASKS_PER_REQUEST),
+                .min(MAX_FETCH_TASKS_PER_REQUEST),
         },
         Err(_) => {
             error!("[Data Service] Failed to get cache coverage status.");


### PR DESCRIPTION
### Description
This fixes a bug which allowed for unbounded number of fetcher tasks to spawn, causing data service to OOM. The bug only happens when processor ending_version (transactions_count) is set. 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
1. Deploy to devnet
2. Run backfill processor with ending_version set
3. See that processor receives txn's and data service ingress isn't crazy high