### PR TITLE
Reverting PR #12103

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -346,7 +346,7 @@ impl BlockStore {
     async fn sync_to_highest_commit_cert(
         &self,
         ledger_info: &LedgerInfoWithSignatures,
-        network: &Arc<NetworkSender>,
+        network: &NetworkSender,
     ) {
         // if the block exists between commit root and ordered root
         if self.commit_root().round() < ledger_info.commit_info().round()
@@ -404,7 +404,7 @@ impl BlockStore {
 
 /// BlockRetriever is used internally to retrieve blocks
 pub struct BlockRetriever {
-    network: Arc<NetworkSender>,
+    network: NetworkSender,
     preferred_peer: Author,
     validator_addresses: Vec<AccountAddress>,
     max_blocks_to_request: u64,
@@ -412,7 +412,7 @@ pub struct BlockRetriever {
 
 impl BlockRetriever {
     pub fn new(
-        network: Arc<NetworkSender>,
+        network: NetworkSender,
         preferred_peer: Author,
         validator_addresses: Vec<AccountAddress>,
         max_blocks_to_request: u64,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -596,7 +596,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         ledger_data: LedgerRecoveryData,
         onchain_consensus_config: OnChainConsensusConfig,
         epoch_state: Arc<EpochState>,
-        network_sender: Arc<NetworkSender>,
+        network_sender: NetworkSender,
     ) {
         let (recovery_manager_tx, recovery_manager_rx) = aptos_channel::new(
             QueueStyle::LIFO,
@@ -646,7 +646,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 self.quorum_store_to_mempool_sender.clone(),
                 self.config.mempool_txn_pull_timeout_ms,
                 self.storage.aptos_db().clone(),
-                network_sender,
+                network_sender.clone(),
                 epoch_state.verifier.clone(),
                 self.config.safety_rules.backend.clone(),
                 self.quorum_store_storage.clone(),
@@ -701,7 +701,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         epoch_state: Arc<EpochState>,
         onchain_consensus_config: OnChainConsensusConfig,
         onchain_execution_config: OnChainExecutionConfig,
-        network_sender: Arc<NetworkSender>,
+        network_sender: NetworkSender,
         payload_client: Arc<dyn PayloadClient>,
         payload_manager: Arc<PayloadManager>,
         features: Features,
@@ -954,7 +954,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                     epoch_state,
                     consensus_config,
                     execution_config,
-                    Arc::new(network_sender),
+                    network_sender,
                     payload_client,
                     payload_manager,
                     features,
@@ -967,7 +967,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                     ledger_data,
                     consensus_config,
                     epoch_state,
-                    Arc::new(network_sender),
+                    network_sender,
                 )
                 .await
             },

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -298,12 +298,11 @@ impl NetworkSender {
     /// The future is fulfilled as soon as the message is put into the mpsc channel to network
     /// internal (to provide back pressure), it does not indicate the message is delivered or sent
     /// out.
-    async fn broadcast(&self, msg: ConsensusMsg) {
+    async fn broadcast(&mut self, msg: ConsensusMsg) {
         fail_point!("consensus::send::any", |_| ());
         // Directly send the message to ourself without going through network.
         let self_msg = Event::Message(self.author, msg.clone());
-        let mut self_sender = self.self_sender.clone();
-        if let Err(err) = self_sender.send(self_msg).await {
+        if let Err(err) = self.self_sender.send(self_msg).await {
             error!("Error broadcasting to self: {:?}", err);
         }
 
@@ -373,25 +372,25 @@ impl NetworkSender {
         }
     }
 
-    pub async fn broadcast_proposal(&self, proposal_msg: ProposalMsg) {
+    pub async fn broadcast_proposal(&mut self, proposal_msg: ProposalMsg) {
         fail_point!("consensus::send::broadcast_proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));
         self.broadcast(msg).await
     }
 
-    pub async fn broadcast_sync_info(&self, sync_info_msg: SyncInfo) {
+    pub async fn broadcast_sync_info(&mut self, sync_info_msg: SyncInfo) {
         fail_point!("consensus::send::broadcast_sync_info", |_| ());
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info_msg));
         self.broadcast(msg).await
     }
 
-    pub async fn broadcast_timeout_vote(&self, timeout_vote_msg: VoteMsg) {
+    pub async fn broadcast_timeout_vote(&mut self, timeout_vote_msg: VoteMsg) {
         fail_point!("consensus::send::broadcast_timeout_vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(timeout_vote_msg));
         self.broadcast(msg).await
     }
 
-    pub async fn broadcast_epoch_change(&self, epoch_change_proof: EpochChangeProof) {
+    pub async fn broadcast_epoch_change(&mut self, epoch_change_proof: EpochChangeProof) {
         fail_point!("consensus::send::broadcast_epoch_change", |_| ());
         let msg = ConsensusMsg::EpochChangeProof(Box::new(epoch_change_proof));
         self.broadcast(msg).await

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -23,7 +23,7 @@ pub enum BatchCoordinatorCommand {
 
 pub struct BatchCoordinator {
     my_peer_id: PeerId,
-    network_sender: Arc<NetworkSender>,
+    network_sender: NetworkSender,
     batch_store: Arc<BatchStore>,
     max_batch_txns: u64,
     max_batch_bytes: u64,
@@ -43,7 +43,7 @@ impl BatchCoordinator {
     ) -> Self {
         Self {
             my_peer_id,
-            network_sender: Arc::new(network_sender),
+            network_sender,
             batch_store,
             max_batch_txns,
             max_batch_bytes,

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -27,7 +27,7 @@ use std::{mem::Discriminant, process, sync::Arc};
 /// for processing the events carrying sync info and use the info to retrieve blocks from peers
 pub struct RecoveryManager {
     epoch_state: Arc<EpochState>,
-    network: Arc<NetworkSender>,
+    network: NetworkSender,
     storage: Arc<dyn PersistentLivenessStorage>,
     execution_client: Arc<dyn TExecutionClient>,
     last_committed_round: Round,
@@ -38,7 +38,7 @@ pub struct RecoveryManager {
 impl RecoveryManager {
     pub fn new(
         epoch_state: Arc<EpochState>,
-        network: Arc<NetworkSender>,
+        network: NetworkSender,
         storage: Arc<dyn PersistentLivenessStorage>,
         execution_client: Arc<dyn TExecutionClient>,
         last_committed_round: Round,

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -156,12 +156,12 @@ fn create_node_for_fuzzing() -> RoundManager {
         epoch: 1,
         verifier: storage.get_validator_set().into(),
     });
-    let network = Arc::new(NetworkSender::new(
+    let network = NetworkSender::new(
         signer.author(),
         consensus_network_client,
         self_sender,
         epoch_state.verifier.clone(),
-    ));
+    );
 
     // TODO: mock
     let block_store = build_empty_store(storage.clone(), initial_data);

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -244,12 +244,7 @@ impl NodeSetup {
         playground.add_node(twin_id, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
 
         let (self_sender, self_receiver) = aptos_channels::new_test(1000);
-        let network = Arc::new(NetworkSender::new(
-            author,
-            consensus_network_client,
-            self_sender,
-            validators,
-        ));
+        let network = NetworkSender::new(author, consensus_network_client, self_sender, validators);
 
         let all_network_events = Box::new(select(network_events, self_receiver));
 


### PR DESCRIPTION
### Description
This PR reverts the changes implemented in https://github.com/aptos-labs/aptos-core/pull/12103.
The original intention of PR 12103 is to reduce the latency. Due to incorrect forge tests, we thought the PR 12103 reduces latency. As we fixed the way ran forge tests, we found out PR 12103 actually increased the latency by a few ms. So, this PR reverts the changes in PR 12103.

### Test Plan
100 node forge run on main branch before PR 12103: https://github.com/aptos-labs/aptos-core/actions/runs/8012724931
100 node forge run on main branch after PR 12103: https://github.com/aptos-labs/aptos-core/actions/runs/8021550692
