### PR TITLE
[Execution] Increase the default concurrency to 32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "hex",
  "jemallocator",
  "maplit",
+ "num_cpus",
  "rand 0.7.3",
  "rayon",
  "rstack-self",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -77,6 +77,7 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 url = { workspace = true }
+num_cpus = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{NodeConfig, DEFAULT_CONCURRENCY_LEVEL};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_storage_interface::{state_view::LatestDbStateCheckpointView, DbReaderWriter};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS, account_view::AccountView, chain_id::ChainId,
 };
 use aptos_vm::AptosVM;
+use std::cmp::min;
 
 /// Error message to display when non-production features are enabled
 pub const ERROR_MSG_BAD_FEATURE_FLAGS: &str = r#"
@@ -49,7 +50,12 @@ pub fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
 /// Sets the Aptos VM configuration based on the node configurations
 pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     AptosVM::set_paranoid_type_checks(node_config.execution.paranoid_type_verification);
-    AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    let effective_concurrency_level = if node_config.execution.concurrency_level == 0 {
+        min(DEFAULT_CONCURRENCY_LEVEL, (num_cpus::get() / 2) as u16)
+    } else {
+        node_config.execution.concurrency_level
+    };
+    AptosVM::set_concurrency_level_once(effective_concurrency_level as usize);
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,
     );

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 const GENESIS_DEFAULT: &str = "genesis.blob";
+pub const DEFAULT_CONCURRENCY_LEVEL: u16 = 32;
 
 #[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -24,7 +25,8 @@ pub struct ExecutionConfig {
     pub genesis: Option<Transaction>,
     /// Location of the genesis file
     pub genesis_file_location: PathBuf,
-    /// Number of threads to run execution
+    /// Number of threads to run execution.
+    /// If 0, we use min of (num of cores/2, DEFAULT_CONCURRENCY_LEVEL) as default concurrency level
     pub concurrency_level: u16,
     /// Number of threads to read proofs
     pub num_proof_reading_threads: u16,
@@ -59,8 +61,8 @@ impl Default for ExecutionConfig {
         ExecutionConfig {
             genesis: None,
             genesis_file_location: PathBuf::new(),
-            // Parallel execution by default.
-            concurrency_level: 8,
+            // use min of (num of cores/2, DEFAULT_CONCURRENCY_LEVEL) as default concurrency level
+            concurrency_level: 0,
             num_proof_reading_threads: 32,
             paranoid_type_verification: false,
             paranoid_hot_potato_verification: false,


### PR DESCRIPTION
### Description

Since we have upgraded our default machine spec, we need to bump up the concurrency level to utilize the additional cores. 32 concurrency level worked the best from our previewnet load test.


### Test Plan

Forge