### PR TITLE
[Block Executor] Halt executing, utilize PanicError, clean-up

### DIFF
--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::explicit_sync_wrapper::ExplicitSyncWrapper;
+use aptos_aggregator::types::code_invariant_error;
 use aptos_infallible::Mutex;
 use aptos_mvhashmap::types::{Incarnation, TxnIndex};
+use aptos_types::delayed_fields::PanicError;
 use concurrent_queue::{ConcurrentQueue, PopError};
 use crossbeam::utils::CachePadded;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
@@ -61,6 +63,7 @@ pub enum DependencyStatus {
 type DependencyCondvar = Arc<(Mutex<DependencyStatus>, Condvar)>;
 
 // Return value of the function wait_for_dependency
+#[derive(Debug)]
 pub enum DependencyResult {
     Dependency(DependencyCondvar),
     Resolved,
@@ -135,7 +138,7 @@ pub enum SchedulerTask {
 #[derive(Debug)]
 enum ExecutionStatus {
     Ready(Incarnation, ExecutionTaskType),
-    Executing(Incarnation),
+    Executing(Incarnation, ExecutionTaskType),
     Suspended(Incarnation, DependencyCondvar),
     Executed(Incarnation),
     // TODO[agg_v2](cleanup): rename to Finalized or ReadyToCommit / CommitReady?
@@ -149,8 +152,22 @@ impl PartialEq for ExecutionStatus {
     fn eq(&self, other: &Self) -> bool {
         use ExecutionStatus::*;
         match (self, other) {
-            (&Ready(ref a, _), &Ready(ref b, _))
-            | (&Executing(ref a), &Executing(ref b))
+            (
+                &Ready(ref a, ExecutionTaskType::Execution),
+                &Ready(ref b, ExecutionTaskType::Execution),
+            )
+            | (
+                &Executing(ref a, ExecutionTaskType::Execution),
+                &Executing(ref b, ExecutionTaskType::Execution),
+            )
+            | (
+                &Ready(ref a, ExecutionTaskType::Wakeup(_)),
+                &Ready(ref b, ExecutionTaskType::Wakeup(_)),
+            )
+            | (
+                &Executing(ref a, ExecutionTaskType::Wakeup(_)),
+                &Executing(ref b, ExecutionTaskType::Wakeup(_)),
+            )
             | (&Suspended(ref a, _), &Suspended(ref b, _))
             | (&Executed(ref a), &Executed(ref b))
             | (&Committed(ref a), &Committed(ref b))
@@ -228,7 +245,11 @@ impl ValidationStatus {
 }
 
 pub trait TWaitForDependency {
-    fn wait_for_dependency(&self, txn_idx: TxnIndex, dep_txn_idx: TxnIndex) -> DependencyResult;
+    fn wait_for_dependency(
+        &self,
+        txn_idx: TxnIndex,
+        dep_txn_idx: TxnIndex,
+    ) -> Result<DependencyResult, PanicError>;
 }
 
 pub struct Scheduler {
@@ -382,6 +403,7 @@ impl Scheduler {
             return None;
         }
 
+        // Re-arm to try commit again.
         self.queueing_commits_arm();
 
         None
@@ -461,7 +483,7 @@ impl Scheduler {
         );
     }
 
-    fn wake_dependencies_after_execution(&self, txn_idx: TxnIndex) {
+    fn wake_dependencies_after_execution(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
         let txn_deps: Vec<TxnIndex> = {
             let mut stored_deps = self.txn_dependency[txn_idx as usize].lock();
             // Holding the lock, take dependency vector.
@@ -469,22 +491,21 @@ impl Scheduler {
         };
 
         // Mark dependencies as resolved and find the minimum index among them.
-        let min_dep = txn_deps
-            .into_iter()
-            .map(|dep| {
-                // Mark the status of dependencies as 'Ready' since dependency on
-                // transaction txn_idx is now resolved.
-                self.resume(dep);
+        let mut min_dep = None;
+        for dep in txn_deps {
+            self.resume(dep)?;
 
-                dep
-            })
-            .min();
+            if min_dep.is_none() || min_dep.is_some_and(|min_dep| min_dep > dep) {
+                min_dep = Some(dep);
+            }
+        }
         if let Some(execution_target_idx) = min_dep {
             // Decrease the execution index as necessary to ensure resolved dependencies
             // get a chance to be re-executed.
             self.execution_idx
                 .fetch_min(execution_target_idx, Ordering::SeqCst);
         }
+        Ok(())
     }
 
     /// After txn is executed, schedule its dependencies for re-execution.
@@ -496,7 +517,7 @@ impl Scheduler {
         txn_idx: TxnIndex,
         incarnation: Incarnation,
         revalidate_suffix: bool,
-    ) -> SchedulerTask {
+    ) -> Result<SchedulerTask, PanicError> {
         // Note: It is preferable to hold the validation lock throughout the finish_execution,
         // in particular before updating execution status. The point was that we don't want
         // any validation to come before the validation status is correspondingly updated.
@@ -505,9 +526,9 @@ impl Scheduler {
         // the reason why we grab write lock directly, and never release it during the whole function.
         // So even validation status readers have to wait if they somehow end up at the same index.
         let mut validation_status = self.txn_status[txn_idx as usize].1.write();
-        self.set_executed_status(txn_idx, incarnation);
+        self.set_executed_status(txn_idx, incarnation)?;
 
-        self.wake_dependencies_after_execution(txn_idx);
+        self.wake_dependencies_after_execution(txn_idx)?;
 
         let (cur_val_idx, mut cur_wave) =
             Self::unpack_validation_idx(self.validation_idx.load(Ordering::Acquire));
@@ -524,25 +545,34 @@ impl Scheduler {
             }
             // Update the minimum wave this txn needs to pass.
             validation_status.required_wave = cur_wave;
-            return SchedulerTask::ValidationTask(txn_idx, incarnation, cur_wave);
+            return Ok(SchedulerTask::ValidationTask(
+                txn_idx,
+                incarnation,
+                cur_wave,
+            ));
         }
 
-        SchedulerTask::NoTask
+        Ok(SchedulerTask::NoTask)
     }
 
-    pub fn finish_execution_during_commit(&self, txn_idx: TxnIndex) {
+    pub fn finish_execution_during_commit(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
         // We have exclusivity on this transaction.
-
-        self.wake_dependencies_after_execution(txn_idx);
+        self.wake_dependencies_after_execution(txn_idx)?;
 
         // We skipped decreasing validation index when invalidating, as we were
         // executing it immediately, and are doing so now (unconditionally).
         self.decrease_validation_idx(txn_idx + 1);
+
+        Ok(())
     }
 
     /// Finalize a validation task of version (txn_idx, incarnation). In some cases,
     /// may return a re-execution task back to the caller (otherwise, NoTask).
-    pub fn finish_abort(&self, txn_idx: TxnIndex, incarnation: Incarnation) -> SchedulerTask {
+    pub fn finish_abort(
+        &self,
+        txn_idx: TxnIndex,
+        incarnation: Incarnation,
+    ) -> Result<SchedulerTask, PanicError> {
         {
             // acquire exclusive lock on the validation status of txn_idx, and hold the lock
             // while calling decrease_validation_idx below. Otherwise, this thread might get
@@ -555,7 +585,7 @@ impl Scheduler {
             // provide correctness between finish_execution & try_commit.
             let _validation_status = self.txn_status[txn_idx as usize].1.write();
 
-            self.set_aborted_status(txn_idx, incarnation);
+            self.set_aborted_status(txn_idx, incarnation)?;
 
             // Schedule higher txns for validation, skipping txn_idx itself (needs to be
             // re-executed first).
@@ -573,11 +603,15 @@ impl Scheduler {
             // nothing to do, as another thread must have succeeded to incarnate and
             // obtain the task for re-execution.
             if let Some((new_incarnation, execution_task_type)) = self.try_incarnate(txn_idx) {
-                return SchedulerTask::ExecutionTask(txn_idx, new_incarnation, execution_task_type);
+                return Ok(SchedulerTask::ExecutionTask(
+                    txn_idx,
+                    new_incarnation,
+                    execution_task_type,
+                ));
             }
         }
 
-        SchedulerTask::NoTask
+        Ok(SchedulerTask::NoTask)
     }
 
     /// This function can halt the BlockSTM early, even if there are unfinished tasks.
@@ -616,7 +650,17 @@ impl TWaitForDependency for Scheduler {
     /// transaction txn_idx will be resumed, and corresponding execution task created.
     /// If false is returned, it is caller's responsibility to repeat the read that caused the
     /// dependency and continue the ongoing execution of txn_idx.
-    fn wait_for_dependency(&self, txn_idx: TxnIndex, dep_txn_idx: TxnIndex) -> DependencyResult {
+    fn wait_for_dependency(
+        &self,
+        txn_idx: TxnIndex,
+        dep_txn_idx: TxnIndex,
+    ) -> Result<DependencyResult, PanicError> {
+        if txn_idx <= dep_txn_idx || dep_txn_idx >= self.num_txns {
+            return Err(code_invariant_error(
+                "In wait_for_dependency: {txn_idx} > {dep_txn_idx}, num txns = {self.num_txns}",
+            ));
+        }
+
         // Note: Could pre-check that txn dep_txn_idx isn't in an executed state, but the caller
         // usually has just observed the read dependency.
 
@@ -637,7 +681,7 @@ impl TWaitForDependency for Scheduler {
             // Note: acquires (a different, status) mutex, while holding (dependency) mutex.
             // Only place in scheduler where a thread may hold >1 mutexes, hence, such
             // acquisitions always happens in the same order (this function), may not deadlock.
-            return DependencyResult::Resolved;
+            return Ok(DependencyResult::Resolved);
         }
 
         // If the execution is already halted, suspend will return false.
@@ -646,8 +690,8 @@ impl TWaitForDependency for Scheduler {
         // to be ExecutionHalted, then notify the conditional variable. So if a thread sees ExecutionHalted,
         // it knows the execution is halted and it can return; otherwise, the finishing thread will notify
         // the conditional variable later and awake the pending thread.
-        if !self.suspend(txn_idx, dep_condvar.clone()) {
-            return DependencyResult::ExecutionHalted;
+        if !self.suspend(txn_idx, dep_condvar.clone())? {
+            return Ok(DependencyResult::ExecutionHalted);
         }
 
         // Safe to add dependency here (still holding the lock) - finish_execution of txn
@@ -656,33 +700,29 @@ impl TWaitForDependency for Scheduler {
 
         // Stored deps gets unlocked here.
 
-        DependencyResult::Dependency(dep_condvar)
+        Ok(DependencyResult::Dependency(dep_condvar))
     }
 }
 
 /// Private functions of the Scheduler
 impl Scheduler {
-    /// Helper function to be called from Scheduler::halt(); Sets the
-    /// transaction status to Halted. If the transaction is suspended,
-    /// it will wake it up.
+    /// Helper function to be called from Scheduler::halt(); Sets the transaction status to Halted.
+    /// If the transaction is suspended, it will wake it up.
     fn halt_transaction_execution(&self, txn_idx: TxnIndex) {
         let mut status = self.txn_status[txn_idx as usize].0.write();
-        {
-            // Only transactions with status Suspended or Ready may have the condition variable of pending threads.
-            match &*status {
-                ExecutionStatus::Suspended(_, condvar)
-                | ExecutionStatus::Ready(_, ExecutionTaskType::Wakeup(condvar)) => {
-                    let (lock, cvar) = &*(condvar.clone());
 
-                    let mut lock = lock.lock();
-                    *lock = DependencyStatus::ExecutionHalted;
-                    cvar.notify_one();
-                },
-                _ => (),
-            }
+        // Replace status to sure that the txn never gets suspended.
+        match std::mem::replace(&mut *status, ExecutionStatus::ExecutionHalted) {
+            ExecutionStatus::Suspended(_, condvar)
+            | ExecutionStatus::Ready(_, ExecutionTaskType::Wakeup(condvar))
+            | ExecutionStatus::Executing(_, ExecutionTaskType::Wakeup(condvar)) => {
+                let (lock, cvar) = &*(condvar.clone());
 
-            // Makes sure that the txn never gets suspended
-            *status = ExecutionStatus::ExecutionHalted;
+                let mut lock = lock.lock();
+                *lock = DependencyStatus::ExecutionHalted;
+                cvar.notify_one();
+            },
+            _ => (),
         }
     }
 
@@ -704,8 +744,7 @@ impl Scheduler {
     /// Decreases the validation index, adjusting the wave and validation status as needed.
     fn decrease_validation_idx(&self, target_idx: TxnIndex) -> Option<Wave> {
         // We only call with txn_idx + 1, so it can equal num_txns, but not be strictly larger.
-        debug_assert!(target_idx <= self.num_txns);
-
+        assert!(target_idx <= self.num_txns);
         if target_idx == self.num_txns {
             return None;
         }
@@ -754,7 +793,7 @@ impl Scheduler {
         let mut status = self.txn_status[txn_idx as usize].0.write();
         if let ExecutionStatus::Ready(incarnation, execution_task_type) = &*status {
             let ret: (u32, ExecutionTaskType) = (*incarnation, (*execution_task_type).clone());
-            *status = ExecutionStatus::Executing(*incarnation);
+            *status = ExecutionStatus::Executing(*incarnation, (*execution_task_type).clone());
             Some(ret)
         } else {
             None
@@ -771,8 +810,6 @@ impl Scheduler {
     /// and a committed (in between) txn does not need to be scheduled for validation -
     /// so can return None.
     fn is_executed(&self, txn_idx: TxnIndex, include_committed: bool) -> Option<Incarnation> {
-        debug_assert!(txn_idx < self.num_txns);
-
         let status = self.txn_status[txn_idx as usize].0.read();
         match *status {
             ExecutionStatus::Executed(incarnation) => Some(incarnation),
@@ -796,7 +833,7 @@ impl Scheduler {
         matches!(
             *status,
             ExecutionStatus::Ready(0, _)
-                | ExecutionStatus::Executing(0)
+                | ExecutionStatus::Executing(0, _)
                 | ExecutionStatus::Suspended(0, _)
         )
     }
@@ -867,62 +904,92 @@ impl Scheduler {
     /// used to wake it up after the dependency is resolved.
     /// Return true when the txn is successfully suspended.
     /// Return false when the execution is halted.
-    fn suspend(&self, txn_idx: TxnIndex, dep_condvar: DependencyCondvar) -> bool {
+    fn suspend(
+        &self,
+        txn_idx: TxnIndex,
+        dep_condvar: DependencyCondvar,
+    ) -> Result<bool, PanicError> {
         let mut status = self.txn_status[txn_idx as usize].0.write();
         match *status {
-            ExecutionStatus::Executing(incarnation) => {
+            ExecutionStatus::Executing(incarnation, _) => {
                 *status = ExecutionStatus::Suspended(incarnation, dep_condvar);
-                true
+                Ok(true)
             },
-            ExecutionStatus::ExecutionHalted => false,
-            _ => unreachable!(),
+            ExecutionStatus::ExecutionHalted => Ok(false),
+            _ => Err(code_invariant_error(format!(
+                "Unexpected status {:?} in suspend",
+                &*status,
+            ))),
         }
     }
 
     /// When a dependency is resolved, mark the transaction as Ready.
     /// The caller must ensure that the transaction is in the Suspended state.
-    fn resume(&self, txn_idx: TxnIndex) {
+    fn resume(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
         let mut status = self.txn_status[txn_idx as usize].0.write();
-
-        if matches!(*status, ExecutionStatus::ExecutionHalted) {
-            return;
-        }
-
-        if let ExecutionStatus::Suspended(incarnation, dep_condvar) = &*status {
-            *status = ExecutionStatus::Ready(
-                *incarnation,
-                ExecutionTaskType::Wakeup(dep_condvar.clone()),
-            );
-        } else {
-            unreachable!();
+        match &*status {
+            ExecutionStatus::Suspended(incarnation, dep_condvar) => {
+                *status = ExecutionStatus::Ready(
+                    *incarnation,
+                    ExecutionTaskType::Wakeup(dep_condvar.clone()),
+                );
+                Ok(())
+            },
+            ExecutionStatus::ExecutionHalted => Ok(()),
+            _ => Err(code_invariant_error(format!(
+                "Unexpected status {:?} in resume",
+                &*status,
+            ))),
         }
     }
 
     /// Set status of the transaction to Executed(incarnation).
-    fn set_executed_status(&self, txn_idx: TxnIndex, incarnation: Incarnation) {
+    fn set_executed_status(
+        &self,
+        txn_idx: TxnIndex,
+        incarnation: Incarnation,
+    ) -> Result<(), PanicError> {
         let mut status = self.txn_status[txn_idx as usize].0.write();
-        // The execution is already halted.
-        if matches!(*status, ExecutionStatus::ExecutionHalted) {
-            return;
+        match *status {
+            ExecutionStatus::Executing(stored_incarnation, _)
+                if stored_incarnation == incarnation =>
+            {
+                *status = ExecutionStatus::Executed(incarnation);
+                Ok(())
+            },
+            ExecutionStatus::ExecutionHalted => {
+                // The execution is already halted.
+                Ok(())
+            },
+            _ => Err(code_invariant_error(format!(
+                "Expected Executing incarnation {incarnation}, got {:?}",
+                &*status,
+            ))),
         }
-
-        // Only makes sense when the current status is 'Executing'.
-        debug_assert!(*status == ExecutionStatus::Executing(incarnation));
-        *status = ExecutionStatus::Executed(incarnation);
     }
 
     /// After a successful abort, mark the transaction as ready for re-execution with
     /// an incremented incarnation number.
-    fn set_aborted_status(&self, txn_idx: TxnIndex, incarnation: Incarnation) {
+    fn set_aborted_status(
+        &self,
+        txn_idx: TxnIndex,
+        incarnation: Incarnation,
+    ) -> Result<(), PanicError> {
         let mut status = self.txn_status[txn_idx as usize].0.write();
-        // The execution is already halted.
-        if matches!(*status, ExecutionStatus::ExecutionHalted) {
-            return;
+        match *status {
+            ExecutionStatus::Aborting(stored_incarnation) if stored_incarnation == incarnation => {
+                *status = ExecutionStatus::Ready(incarnation + 1, ExecutionTaskType::Execution);
+                Ok(())
+            },
+            ExecutionStatus::ExecutionHalted => {
+                // The execution is already halted.
+                Ok(())
+            },
+            _ => Err(code_invariant_error(format!(
+                "Expected Aborting incarnation {incarnation}, got {:?}",
+                &*status,
+            ))),
         }
-
-        // Only makes sense when the current status is 'Aborting'.
-        debug_assert!(*status == ExecutionStatus::Aborting(incarnation));
-        *status = ExecutionStatus::Ready(incarnation + 1, ExecutionTaskType::Execution);
     }
 
     /// Checks whether the done marker is set. The marker can only be set by 'try_commit'.
@@ -934,6 +1001,7 @@ impl Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::{assert_err, assert_matches, assert_ok, assert_ok_eq, assert_some};
 
     #[test]
     fn scheduler_halt() {
@@ -942,5 +1010,58 @@ mod tests {
         assert!(s.halt());
         assert!(s.done());
         assert!(!s.halt());
+    }
+
+    #[test]
+    fn scheduler_halt_status() {
+        let s = Scheduler::new(5);
+        for i in 0..5 {
+            s.try_incarnate(i);
+        }
+        let dep_arc = |wait_result| -> DependencyCondvar {
+            match wait_result {
+                Ok(DependencyResult::Dependency(dep_arc)) => dep_arc,
+                _ => unreachable!("Must return a dependency {:?}", wait_result),
+            }
+        };
+
+        let dep_1 = dep_arc(s.wait_for_dependency(1, 0));
+        let dep_2 = dep_arc(s.wait_for_dependency(2, 0));
+        // Check wait for dependency error conditions w. indices (correct statuses).
+        assert_err!(s.wait_for_dependency(3, 3));
+        assert_err!(s.wait_for_dependency(6, 5));
+        let dep_3 = dep_arc(s.wait_for_dependency(3, 0));
+        assert_ok!(s.resume(2));
+        assert_ok!(s.resume(3));
+        assert_some!(s.try_incarnate(3));
+
+        assert_matches!(&*dep_1.0.lock(), DependencyStatus::Unresolved);
+        assert_matches!(&*dep_2.0.lock(), DependencyStatus::Unresolved);
+        assert_matches!(&*dep_3.0.lock(), DependencyStatus::Unresolved);
+        s.halt();
+        assert_matches!(&*dep_1.0.lock(), DependencyStatus::ExecutionHalted);
+        assert_matches!(&*dep_2.0.lock(), DependencyStatus::ExecutionHalted);
+        assert_matches!(&*dep_3.0.lock(), DependencyStatus::ExecutionHalted);
+
+        assert_ok_eq!(
+            s.suspend(
+                1,
+                Arc::new((Mutex::new(DependencyStatus::Unresolved), Condvar::new()))
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn scheduler_panic_error() {
+        let s = Scheduler::new(2);
+        assert_err!(s.suspend(
+            0,
+            Arc::new((Mutex::new(DependencyStatus::Unresolved), Condvar::new()))
+        ));
+        assert_err!(s.resume(0));
+        assert_err!(s.set_executed_status(0, 0));
+        assert_err!(s.set_aborted_status(0, 0));
+        assert_err!(s.wait_for_dependency(1, 0));
     }
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -172,7 +172,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     pub(crate) fn fee_statement(&self, txn_idx: TxnIndex) -> Option<FeeStatement> {
         match self.outputs[txn_idx as usize]
             .load_full()
-            .expect("[BlockSTM]: Execution output must be recorded after execution")
+	    .unwrap_or_else(|| panic!("[BlockSTM]: Execution output for txn {txn_idx} must be recorded after execution"))
             .as_ref()
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
@@ -185,7 +185,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     pub(crate) fn output_approx_size(&self, txn_idx: TxnIndex) -> Option<u64> {
         match self.outputs[txn_idx as usize]
             .load_full()
-            .expect("[BlockSTM]: Execution output must be recorded after execution")
+            .unwrap_or_else(|| panic!("[BlockSTM]: Execution output for txn {txn_idx} must be recorded after execution"))
             .as_ref()
         {
             ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
@@ -200,7 +200,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         matches!(
             self.outputs[txn_idx as usize]
                 .load_full()
-                .expect("[BlockSTM]: Execution output must be recorded after execution")
+                .unwrap_or_else(|| panic!("[BlockSTM]: Execution output for txn {txn_idx} must be recorded after execution"))
                 .as_ref(),
             ExecutionStatus::SkipRest(_)
         )

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -529,26 +529,23 @@ fn scheduler_tasks() {
 
     for i in 0..5 {
         // No validation tasks.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if i == j
-        ));
+        );
     }
 
     for i in 0..5 {
         // Validation index is at 0, so transactions will be validated and no
         // need to return a validation task to the caller.
-        assert!(matches!(
-            s.finish_execution(i, 0, false),
-            SchedulerTask::NoTask
-        ));
+        assert_matches!(s.finish_execution(i, 0, false), Ok(SchedulerTask::NoTask));
     }
 
     for i in 0..5 {
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ValidationTask(j, 0, 0) if i == j
-        ));
+        );
     }
 
     // successful aborts.
@@ -561,44 +558,47 @@ fn scheduler_tasks() {
     assert!(!s.try_abort(1, 0));
     assert!(!s.try_abort(3, 0));
 
-    assert!(matches!(
+    assert_matches!(
         s.finish_abort(4, 0),
-        SchedulerTask::ExecutionTask(4, 1, ExecutionTaskType::Execution)
-    ));
-    assert!(matches!(
+        Ok(SchedulerTask::ExecutionTask(
+            4,
+            1,
+            ExecutionTaskType::Execution
+        ))
+    );
+    assert_matches!(
         s.finish_abort(1, 0),
-        SchedulerTask::ExecutionTask(1, 1, ExecutionTaskType::Execution)
-    ));
+        Ok(SchedulerTask::ExecutionTask(
+            1,
+            1,
+            ExecutionTaskType::Execution
+        ))
+    );
     // Validation index = 2, wave = 1.
-    assert!(matches!(
+    assert_matches!(
         s.finish_abort(3, 0),
-        SchedulerTask::ExecutionTask(3, 1, ExecutionTaskType::Execution)
-    ));
+        Ok(SchedulerTask::ExecutionTask(
+            3,
+            1,
+            ExecutionTaskType::Execution
+        ))
+    );
 
-    assert!(matches!(
-        s.finish_execution(4, 1, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
+    assert_matches!(s.finish_execution(4, 1, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(
         s.finish_execution(1, 1, false),
-        SchedulerTask::ValidationTask(1, 1, 1)
-    ));
+        Ok(SchedulerTask::ValidationTask(1, 1, 1))
+    );
 
     // Another validation task for (2, 0).
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(2, 0, 1)
-    ));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(2, 0, 1));
     // Now skip over txn 3 (status is Executing), and validate 4.
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(4, 1, 1)
-    ));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(4, 1, 1));
 
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(3, 1, false),
-        SchedulerTask::ValidationTask(3, 1, 1),
-    ));
+        Ok(SchedulerTask::ValidationTask(3, 1, 1))
+    );
 
     s.finish_validation(0, 0);
     s.finish_validation(1, 2);
@@ -611,7 +611,7 @@ fn scheduler_tasks() {
         assert_matches!(s.try_commit(), Some((v, _)) if v == i);
     }
 
-    assert!(matches!(s.next_task(), SchedulerTask::Done));
+    assert_matches!(s.next_task(), SchedulerTask::Done);
 }
 
 #[test]
@@ -620,53 +620,35 @@ fn scheduler_first_wave() {
 
     for i in 0..5 {
         // Nothing to validate.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if j == i
-        ));
+        );
     }
 
     // validation index will not increase for the first execution wave
     // until the status becomes executed.
-    assert!(matches!(
-        s.finish_execution(0, 0, false),
-        SchedulerTask::NoTask
-    ));
+    assert_matches!(s.finish_execution(0, 0, false), Ok(SchedulerTask::NoTask));
 
     // Now we can validate version (0, 0).
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(0, 0, 0)
-    ));
-    assert!(matches!(
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(0, 0, 0));
+    assert_matches!(
         s.next_task(),
         SchedulerTask::ExecutionTask(5, 0, ExecutionTaskType::Execution)
-    ));
+    );
     // Since (1, 0) is not EXECUTED, no validation tasks, and execution index
     // is already at the limit, so no tasks immediately available.
-    assert!(matches!(s.next_task(), SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::NoTask);
 
-    assert!(matches!(
-        s.finish_execution(2, 0, false),
-        SchedulerTask::NoTask
-    ));
+    assert_matches!(s.finish_execution(2, 0, false), Ok(SchedulerTask::NoTask));
     // There should be no tasks, but finishing (1,0) should enable validating
     // (1, 0) then (2,0).
-    assert!(matches!(s.next_task(), SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::NoTask);
 
-    assert!(matches!(
-        s.finish_execution(1, 0, false),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(1, 0, 0)
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(2, 0, 0)
-    ));
-    assert!(matches!(s.next_task(), SchedulerTask::NoTask));
+    assert_matches!(s.finish_execution(1, 0, false), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(1, 0, 0));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(2, 0, 0));
+    assert_matches!(s.next_task(), SchedulerTask::NoTask);
 }
 
 #[test]
@@ -675,44 +657,32 @@ fn scheduler_dependency() {
 
     for i in 0..5 {
         // Nothing to validate.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if j == i
-        ));
+        );
     }
 
     // validation index will not increase for the first execution wave
     // until the status becomes executed.
-    assert!(matches!(
-        s.finish_execution(0, 0, false),
-        SchedulerTask::NoTask
-    ));
+    assert_matches!(s.finish_execution(0, 0, false), Ok(SchedulerTask::NoTask));
     // Now we can validate version (0, 0).
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(0, 0, 0)
-    ));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(0, 0, 0));
     // Current status of 0 is executed - hence, no dependency added.
-    assert!(matches!(
-        s.wait_for_dependency(3, 0),
-        DependencyResult::Resolved
-    ));
+    assert_matches!(s.wait_for_dependency(3, 0), Ok(DependencyResult::Resolved));
     // Dependency added for transaction 4 on transaction 2.
-    assert!(matches!(
+    assert_matches!(
         s.wait_for_dependency(4, 2),
-        DependencyResult::Dependency(_)
-    ));
+        Ok(DependencyResult::Dependency(_))
+    );
 
-    assert!(matches!(
-        s.finish_execution(2, 0, false),
-        SchedulerTask::NoTask
-    ));
+    assert_matches!(s.finish_execution(2, 0, false), Ok(SchedulerTask::NoTask));
 
     // resumed task doesn't bump incarnation
-    assert!(matches!(
+    assert_matches!(
         s.next_task(),
         SchedulerTask::ExecutionTask(4, 0, ExecutionTaskType::Wakeup(_))
-    ));
+    );
 }
 
 // Will return a scheduler in a state where all transactions are scheduled for
@@ -722,23 +692,20 @@ fn incarnation_one_scheduler(num_txns: TxnIndex) -> Scheduler {
 
     for i in 0..num_txns {
         // Get the first executions out of the way.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if j == i
-        ));
-        assert!(matches!(
-            s.finish_execution(i, 0, false),
-            SchedulerTask::NoTask
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(s.finish_execution(i, 0, false), Ok(SchedulerTask::NoTask));
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ValidationTask(j, 0, 0) if i == j
-        ));
+        );
         assert!(s.try_abort(i, 0));
-        assert!(matches!(
+        assert_matches!(
             s.finish_abort(i, 0),
-            SchedulerTask::ExecutionTask(j, 1, ExecutionTaskType::Execution) if i == j
-        ));
+            Ok(SchedulerTask::ExecutionTask(j, 1, ExecutionTaskType::Execution)) if i == j
+        );
     }
     s
 }
@@ -748,86 +715,78 @@ fn scheduler_incarnation() {
     let s = incarnation_one_scheduler(5);
 
     // execution/validation index = 5, wave = 0.
-    assert!(matches!(
+    assert_matches!(
         s.wait_for_dependency(1, 0),
-        DependencyResult::Dependency(_)
-    ));
-    assert!(matches!(
+        Ok(DependencyResult::Dependency(_))
+    );
+    assert_matches!(
         s.wait_for_dependency(3, 0),
-        DependencyResult::Dependency(_)
-    ));
+        Ok(DependencyResult::Dependency(_))
+    );
 
     // Because validation index is higher, return validation task to caller (even with
     // revalidate_suffix = true) - because now we always decrease validation idx to txn_idx + 1
     // here validation wave increases to 1, and index is reduced to 3.
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(2, 1, true),
-        SchedulerTask::ValidationTask(2, 1, 1)
-    ));
+        Ok(SchedulerTask::ValidationTask(2, 1, 1))
+    );
     // Here since validation index is lower, wave doesn't increase and no task returned.
-    assert!(matches!(
-        s.finish_execution(4, 1, true),
-        SchedulerTask::NoTask
-    ));
+    assert_matches!(s.finish_execution(4, 1, true), Ok(SchedulerTask::NoTask));
 
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(4, 1, 1),
-    ));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(4, 1, 1));
 
     assert!(s.try_abort(2, 1));
     assert!(s.try_abort(4, 1));
     assert!(!s.try_abort(2, 1));
 
-    assert!(matches!(
+    assert_matches!(
         s.finish_abort(2, 1),
-        SchedulerTask::ExecutionTask(2, 2, ExecutionTaskType::Execution)
-    ));
+        Ok(SchedulerTask::ExecutionTask(
+            2,
+            2,
+            ExecutionTaskType::Execution
+        ))
+    );
     // wave = 2, validation index = 2.
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(0, 1, false),
-        SchedulerTask::ValidationTask(0, 1, 2)
-    ));
+        Ok(SchedulerTask::ValidationTask(0, 1, 2))
+    );
     // execution index =  1
 
-    assert!(matches!(s.finish_abort(4, 1), SchedulerTask::NoTask));
+    assert_matches!(s.finish_abort(4, 1), Ok(SchedulerTask::NoTask));
 
-    assert!(matches!(
+    assert_matches!(
         s.next_task(),
         SchedulerTask::ExecutionTask(1, 1, ExecutionTaskType::Wakeup(_))
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         s.next_task(),
         SchedulerTask::ExecutionTask(3, 1, ExecutionTaskType::Wakeup(_))
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         s.next_task(),
         SchedulerTask::ExecutionTask(4, 2, ExecutionTaskType::Execution)
-    ));
+    );
     // execution index = 5
 
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(1, 1, false),
-        SchedulerTask::ValidationTask(1, 1, 2)
-    ));
-    assert!(matches!(
+        Ok(SchedulerTask::ValidationTask(1, 1, 2))
+    );
+    assert_matches!(
         s.finish_execution(2, 2, false),
-        SchedulerTask::ValidationTask(2, 2, 2)
-    ));
-    assert!(matches!(
+        Ok(SchedulerTask::ValidationTask(2, 2, 2))
+    );
+    assert_matches!(
         s.finish_execution(3, 1, false),
-        SchedulerTask::ValidationTask(3, 1, 2)
-    ));
+        Ok(SchedulerTask::ValidationTask(3, 1, 2))
+    );
 
     // validation index is 4, so finish execution doesn't return validation task, next task does.
-    assert!(matches!(
-        s.finish_execution(4, 2, false),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(4, 2, 2)
-    ));
+    assert_matches!(s.finish_execution(4, 2, false), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(4, 2, 2));
 }
 
 #[test]
@@ -836,37 +795,19 @@ fn scheduler_basic() {
 
     for i in 0..3 {
         // Nothing to validate.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if j == i
-        ));
+        );
     }
 
     // Finish executions & dispatch validation tasks.
-    assert!(matches!(
-        s.finish_execution(0, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.finish_execution(1, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(0, 0, 0)
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(1, 0, 0)
-    ));
-    assert!(matches!(
-        s.finish_execution(2, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(2, 0, 0)
-    ));
+    assert_matches!(s.finish_execution(0, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.finish_execution(1, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(0, 0, 0));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(1, 0, 0));
+    assert_matches!(s.finish_execution(2, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(2, 0, 0));
 
     for i in 0..3 {
         s.finish_validation(i, 1)
@@ -877,7 +818,7 @@ fn scheduler_basic() {
         assert_matches!(s.try_commit(), Some((v, _)) if v == i);
     }
 
-    assert!(matches!(s.next_task(), SchedulerTask::Done));
+    assert_matches!(s.next_task(), SchedulerTask::Done);
 }
 
 #[test]
@@ -886,37 +827,19 @@ fn scheduler_drain_idx() {
 
     for i in 0..3 {
         // Nothing to validate.
-        assert!(matches!(
+        assert_matches!(
             s.next_task(),
             SchedulerTask::ExecutionTask(j, 0, ExecutionTaskType::Execution) if j == i
-        ));
+        );
     }
 
     // Finish executions & dispatch validation tasks.
-    assert!(matches!(
-        s.finish_execution(0, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.finish_execution(1, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(0, 0, 0)
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(1, 0, 0)
-    ));
-    assert!(matches!(
-        s.finish_execution(2, 0, true),
-        SchedulerTask::NoTask
-    ));
-    assert!(matches!(
-        s.next_task(),
-        SchedulerTask::ValidationTask(2, 0, 0)
-    ));
+    assert_matches!(s.finish_execution(0, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.finish_execution(1, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(0, 0, 0));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(1, 0, 0));
+    assert_matches!(s.finish_execution(2, 0, true), Ok(SchedulerTask::NoTask));
+    assert_matches!(s.next_task(), SchedulerTask::ValidationTask(2, 0, 0));
 
     for i in 0..3 {
         s.finish_validation(i, 1)
@@ -927,7 +850,7 @@ fn scheduler_drain_idx() {
         assert_matches!(s.try_commit(), Some((v, _)) if v == i);
     }
 
-    assert!(matches!(s.next_task(), SchedulerTask::Done));
+    assert_matches!(s.next_task(), SchedulerTask::Done);
 }
 
 #[test]
@@ -935,24 +858,24 @@ fn finish_execution_wave() {
     // Wave won't be increased, because validation index is already 2, and finish_execution
     // tries to reduce it to 2.
     let s = incarnation_one_scheduler(2);
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(1, 1, true),
-        SchedulerTask::ValidationTask(1, 1, 0),
-    ));
+        Ok(SchedulerTask::ValidationTask(1, 1, 0))
+    );
 
     // Here wave will increase, because validation index is reduced from 3 to 2.
     let s = incarnation_one_scheduler(3);
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(1, 1, true),
-        SchedulerTask::ValidationTask(1, 1, 1),
-    ));
+        Ok(SchedulerTask::ValidationTask(1, 1, 1))
+    );
 
     // Here wave won't be increased, because we pass revalidate_suffix = false.
     let s = incarnation_one_scheduler(3);
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(1, 1, false),
-        SchedulerTask::ValidationTask(1, 1, 0),
-    ));
+        Ok(SchedulerTask::ValidationTask(1, 1, 0))
+    );
 }
 
 #[test]
@@ -961,10 +884,10 @@ fn rolling_commit_wave() {
 
     // Finish execution for txn 0 without validate_suffix and because
     // validation index is higher will return validation task to the caller.
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(0, 1, false),
-        SchedulerTask::ValidationTask(0, 1, 0)
-    ));
+        Ok(SchedulerTask::ValidationTask(0, 1, 0))
+    );
     // finish validating txn 0 with proper wave
     s.finish_validation(0, 1);
     // txn 0 can be committed
@@ -973,10 +896,10 @@ fn rolling_commit_wave() {
 
     // This increases the wave, but only sets max_triggered_wave for transaction 2.
     // sets validation_index to 2.
-    assert!(matches!(
+    assert_matches!(
         s.finish_execution(1, 1, true),
-        SchedulerTask::ValidationTask(1, 1, 1),
-    ));
+        Ok(SchedulerTask::ValidationTask(1, 1, 1))
+    );
 
     // finish validating txn 1 with lower wave
     s.finish_validation(1, 0);
@@ -991,10 +914,7 @@ fn rolling_commit_wave() {
     assert_eq!(s.commit_state(), (2, 0));
 
     // No validation task because index is already 2.
-    assert!(matches!(
-        s.finish_execution(2, 1, false),
-        SchedulerTask::NoTask,
-    ));
+    assert_matches!(s.finish_execution(2, 1, false), Ok(SchedulerTask::NoTask,));
     // finish validating with a lower wave.
     s.finish_validation(2, 0);
     assert!(s.try_commit().is_none());
@@ -1005,7 +925,7 @@ fn rolling_commit_wave() {
     assert_eq!(s.commit_state(), (3, 1));
 
     // All txns have been committed.
-    assert!(matches!(s.next_task(), SchedulerTask::Done));
+    assert_matches!(s.next_task(), SchedulerTask::Done);
 }
 
 #[test]
@@ -1066,13 +986,14 @@ fn no_conflict_task_count() {
                         num_exec_tasks += 1;
 
                         // Process a task that may have been returned.
-                        if let SchedulerTask::ValidationTask(idx, incarnation, wave) = task_res {
+                        if let Ok(SchedulerTask::ValidationTask(idx, incarnation, wave)) = task_res
+                        {
                             assert_eq!(idx, txn_idx);
                             assert_eq!(incarnation, 0);
                             assert_eq!(wave, 0);
                             tasks.insert(rng.gen::<u32>(), (false, txn_idx));
                         } else {
-                            assert_matches!(task_res, SchedulerTask::NoTask);
+                            assert_matches!(task_res, Ok(SchedulerTask::NoTask));
                         }
                     },
                     (_, (false, txn_idx)) => {
@@ -1090,6 +1011,6 @@ fn no_conflict_task_count() {
             assert_matches!(s.try_commit(), Some((v, _)) if v == i);
             assert_eq!(s.commit_state(), (i + 1, 0));
         }
-        assert!(matches!(s.next_task(), SchedulerTask::Done));
+        assert_matches!(s.next_task(), SchedulerTask::Done);
     }
 }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -204,7 +204,7 @@ fn get_delayed_field_value_impl<T: Transaction>(
                 return Ok(value);
             },
             Err(PanicOr::Or(MVDelayedFieldsError::Dependency(dep_idx))) => {
-                if !wait_for_dependency(wait_for, txn_idx, dep_idx) {
+                if !wait_for_dependency(wait_for, txn_idx, dep_idx)? {
                     // TODO[agg_v2](cleanup): think of correct return type
                     return Err(PanicOr::Or(DelayedFieldsSpeculativeError::InconsistentRead));
                 }
@@ -370,7 +370,7 @@ fn delayed_field_try_add_delta_outcome_impl<T: Transaction>(
                 ) {
                     Ok(v) => break v,
                     Err(MVDelayedFieldsError::Dependency(dep_idx)) => {
-                        if !wait_for_dependency(wait_for, txn_idx, dep_idx) {
+                        if !wait_for_dependency(wait_for, txn_idx, dep_idx)? {
                             // TODO[agg_v2](cleanup): think of correct return type
                             return Err(PanicOr::Or(
                                 DelayedFieldsSpeculativeError::InconsistentRead,
@@ -406,8 +406,8 @@ fn wait_for_dependency(
     wait_for: &dyn TWaitForDependency,
     txn_idx: TxnIndex,
     dep_idx: TxnIndex,
-) -> bool {
-    match wait_for.wait_for_dependency(txn_idx, dep_idx) {
+) -> Result<bool, PanicError> {
+    match wait_for.wait_for_dependency(txn_idx, dep_idx)? {
         DependencyResult::Dependency(dep_condition) => {
             let _timer = counters::DEPENDENCY_WAIT_SECONDS.start_timer();
             // Wait on a condition variable corresponding to the encountered
@@ -430,10 +430,10 @@ fn wait_for_dependency(
                 dep_resolved = cvar.wait(dep_resolved).unwrap();
             }
             // dep resolved status is either resolved or execution halted.
-            matches!(*dep_resolved, DependencyStatus::Resolved)
+            Ok(matches!(*dep_resolved, DependencyStatus::Resolved))
         },
-        DependencyResult::ExecutionHalted => false,
-        DependencyResult::Resolved => true,
+        DependencyResult::ExecutionHalted => Ok(false),
+        DependencyResult::Resolved => Ok(true),
     }
 }
 
@@ -508,7 +508,7 @@ impl<'a, T: Transaction, X: Executable> ParallelState<'a, T, X> {
                     unreachable!("Reading group size does not require a specific tag look-up");
                 },
                 Err(Dependency(dep_idx)) => {
-                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
+                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx)? {
                         return Err(PartialVMError::new(
                             StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR,
                         )
@@ -633,10 +633,22 @@ impl<'a, T: Transaction, X: Executable> ResourceState<T> for ParallelState<'a, T
                     return ReadResult::Uninitialized;
                 },
                 Err(Dependency(dep_idx)) => {
-                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
-                        return ReadResult::HaltSpeculativeExecution(
-                            "Interrupted as block execution was halted".to_string(),
-                        );
+                    match wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
+                        Err(e) => {
+                            error!("Error {:?} in wait for dependency", e);
+                            return ReadResult::HaltSpeculativeExecution(format!(
+                                "Error {:?} in wait for dependency",
+                                e
+                            ));
+                        },
+                        Ok(false) => {
+                            return ReadResult::HaltSpeculativeExecution(
+                                "Interrupted as block execution was halted".to_string(),
+                            );
+                        },
+                        Ok(true) => {
+                            //dependency resolved
+                        },
                     }
                 },
                 Err(DeltaApplicationFailure) => {
@@ -737,7 +749,7 @@ impl<'a, T: Transaction, X: Executable> ResourceGroupState<T> for ParallelState<
                     return Ok(GroupReadResult::Value(None, None));
                 },
                 Err(Dependency(dep_idx)) => {
-                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
+                    if !wait_for_dependency(self.scheduler, txn_idx, dep_idx)? {
                         // TODO[agg_v2](cleanup): consider changing from PartialVMResult<GroupReadResult> to GroupReadResult
                         // like in ReadResult for resources.
                         return Err(PartialVMError::new(
@@ -1841,7 +1853,7 @@ mod test {
             &self,
             _txn_idx: TxnIndex,
             _dep_txn_idx: TxnIndex,
-        ) -> DependencyResult {
+        ) -> Result<DependencyResult, PanicError> {
             unreachable!();
         }
     }


### PR DESCRIPTION
- allow halting Executing status when waking up a dependency
- add panic/fallback error handling to scheduler invariants
- new unit tests for halting, errors