### PR TITLE
[Framework] Add unchecked mul_div funcs, docs, tests, example

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -12,6 +12,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `average`](#0x1_math128_average)
 -  [Function `gcd`](#0x1_math128_gcd)
 -  [Function `mul_div`](#0x1_math128_mul_div)
+-  [Function `mul_div_unchecked`](#0x1_math128_mul_div_unchecked)
 -  [Function `clamp`](#0x1_math128_clamp)
 -  [Function `pow`](#0x1_math128_pow)
 -  [Function `floor_log2`](#0x1_math128_floor_log2)
@@ -180,6 +181,32 @@ Returns a * b / c going through u256 to prevent intermediate overflow
 <pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_mul_div">mul_div</a>(a: u128, b: u128, c: u128): u128 {
     // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
     <b>assert</b>!(c != 0, std::error::invalid_argument(4));
+    (((a <b>as</b> u256) * (b <b>as</b> u256) / (c <b>as</b> u256)) <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math128_mul_div_unchecked"></a>
+
+## Function `mul_div_unchecked`
+
+Returns a * b / c going through u256 to prevent intermediate overflow, omitting assert to
+enable 100% code coverage in safe scenarios where divisor is known to be nonzero.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_mul_div_unchecked">mul_div_unchecked</a>(a: u128, b: u128, c: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_mul_div_unchecked">mul_div_unchecked</a>(a: u128, b: u128, c: u128): u128 {
     (((a <b>as</b> u256) * (b <b>as</b> u256) / (c <b>as</b> u256)) <b>as</b> u128)
 }
 </code></pre>

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -12,6 +12,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `average`](#0x1_math64_average)
 -  [Function `gcd`](#0x1_math64_gcd)
 -  [Function `mul_div`](#0x1_math64_mul_div)
+-  [Function `mul_div_unchecked`](#0x1_math64_mul_div_unchecked)
 -  [Function `clamp`](#0x1_math64_clamp)
 -  [Function `pow`](#0x1_math64_pow)
 -  [Function `floor_log2`](#0x1_math64_floor_log2)
@@ -178,6 +179,32 @@ Returns a * b / c going through u128 to prevent intermediate overflow
 <pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_mul_div">mul_div</a>(a: u64, b: u64, c: u64): u64 {
     // Inline functions cannot take constants, <b>as</b> then every <b>module</b> using it needs the constant
     <b>assert</b>!(c != 0, std::error::invalid_argument(4));
+    (((a <b>as</b> u128) * (b <b>as</b> u128) / (c <b>as</b> u128)) <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math64_mul_div_unchecked"></a>
+
+## Function `mul_div_unchecked`
+
+Returns a * b / c going through u128 to prevent intermediate overflow, omitting assert to
+enable 100% code coverage in safe scenarios where divisor is known to be nonzero.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_mul_div_unchecked">mul_div_unchecked</a>(a: u64, b: u64, c: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_mul_div_unchecked">mul_div_unchecked</a>(a: u64, b: u64, c: u64): u64 {
     (((a <b>as</b> u128) * (b <b>as</b> u128) / (c <b>as</b> u128)) <b>as</b> u64)
 }
 </code></pre>

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -46,6 +46,12 @@ module aptos_std::math128 {
         (((a as u256) * (b as u256) / (c as u256)) as u128)
     }
 
+    /// Returns a * b / c going through u256 to prevent intermediate overflow, omitting assert to
+    /// enable 100% code coverage in safe scenarios where divisor is known to be nonzero.
+    public inline fun mul_div_unchecked(a: u128, b: u128, c: u128): u128 {
+        (((a as u256) * (b as u256) / (c as u256)) as u128)
+    }
+
     /// Return x clamped to the interval [lower, upper].
     public fun clamp(x: u128, lower: u128, upper: u128): u128 {
         min(upper, max(lower, x))
@@ -236,8 +242,10 @@ module aptos_std::math128 {
     public entry fun test_mul_div() {
         let tmp: u128 = 1<<127;
         assert!(mul_div(tmp,tmp,tmp) == tmp, 0);
+        assert!(mul_div_unchecked(tmp,tmp,tmp) == tmp, 0);
 
         assert!(mul_div(tmp,5,5) == tmp, 0);
+        assert!(mul_div_unchecked(tmp,5,5) == tmp, 0);
         // Note that ordering other way is imprecise.
         assert!((tmp / 5) * 5 != tmp, 0);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -44,6 +44,12 @@ module aptos_std::math64 {
         (((a as u128) * (b as u128) / (c as u128)) as u64)
     }
 
+    /// Returns a * b / c going through u128 to prevent intermediate overflow, omitting assert to
+    /// enable 100% code coverage in safe scenarios where divisor is known to be nonzero.
+    public inline fun mul_div_unchecked(a: u64, b: u64, c: u64): u64 {
+        (((a as u128) * (b as u128) / (c as u128)) as u64)
+    }
+
     /// Return x clamped to the interval [lower, upper].
     public fun clamp(x: u64, lower: u64, upper: u64): u64 {
         min(upper, max(lower, x))
@@ -216,8 +222,10 @@ module aptos_std::math64 {
     public entry fun test_mul_div() {
         let tmp: u64 = 1<<63;
         assert!(mul_div(tmp,tmp,tmp) == tmp, 0);
+        assert!(mul_div_unchecked(tmp,tmp,tmp) == tmp, 0);
 
         assert!(mul_div(tmp,5,5) == tmp, 0);
+        assert!(mul_div_unchecked(tmp,5,5) == tmp, 0);
         // Note that ordering other way is imprecise.
         assert!((tmp / 5) * 5 != tmp, 0);
     }

--- a/aptos-move/move-examples/inline-coverage/Move.toml
+++ b/aptos-move/move-examples/inline-coverage/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = 'InlineCoverage'
+version = '0.1.0'
+
+[addresses]
+publisher = '_'
+
+[dev-addresses]
+publisher = '0xace'
+
+[dependencies.AptosFramework]
+local = '../../framework/aptos-framework'

--- a/aptos-move/move-examples/inline-coverage/README.md
+++ b/aptos-move/move-examples/inline-coverage/README.md
@@ -1,0 +1,102 @@
+# Inline coverage example
+
+## Background
+
+Fungible assets can theoretically be seized at any moment by the issuer (unless
+said issuer destroys such capabilities at asset creation time), so in the case
+of a seizure from a public pool it may be useful to socialize losses across
+all depositors to prevent a bank run. For example:
+
+1. Ace deposits 200 of a centralized stablecoin into pool X
+1. Bee deposits 300 of a centralized stablecoin into pool X
+1. The centralized stablecoin issuer seizes 250 of the 500 in pool X
+1. Ace attempts to withdraw 200, but since the pool is only 50% collateralized,
+   he only ends up receiving 100. (If the pool returned all 200, then Ace would
+   have initiated a bank run and Bee would be in trouble).
+1. Bee decides to wait, judging that the stablecoin issuer will top off the pool
+   back to full collateralization, because if the issuer does not, then their
+   reputation will be destroyed and market participants will favor the
+   stablecoin of a competitor who does not arbitrarily seize from public pools.
+
+## Algorithms
+
+This example contains two Move modules, `full_coverage`, and `partial_coverage`.
+Both modules contain the same simple function definition for a socialized
+withdrawal from a pool, with one minor difference.
+
+In each module, the socialized withdrawal function first performs several
+well-formedness checks and simply returns the requested amount in the case of a
+fully-collateralized pool. However, in the case that the pool is not fully
+collateralized, the requested withdrawal amount is scaled by the
+collateralization ratio of the pool itself, as in the background example above.
+
+In `partial_coverage`, the scaling operation relies on `math64::mul_div`, while
+in `full_coverage`, the scaling operation relies on `math64::mul_div_unchecked`.
+Notably, only the latter module is able to achieve 100% coverage because the
+`mul_div` function in the former asserts a nonzero divisor.
+
+Note that if `mul_div` were a standard (non-inline) function, it wouldn't
+prohibit a calling module from being tested to 100% coverage. However, since it
+is an inline function, the code is effectively copy-pasted into the calling
+function `partial_coverage::socialize_withdrawal_amount` during compile time,
+including the assert statement to check for a nonzero divisor. Hence, since the
+well-formedness checks in the beginning of the socialized withdrawal function
+rule out the possibility of passing a divisor of zero to the `mul_div` function,
+it is impossible to construct a corresponding `expected_failure` test and thus
+impossible to achieve 100% coverage in the `partial_coverage` module.
+
+Conversely, `full_coverage` relies on the `mul_div_unchecked` function, which
+has no such assert statement, hence the module can be fully coverage tested.
+
+## Coverage walkthrough
+
+To coverage test both modules, run:
+
+```sh
+aptos move test --coverage --dev
+```
+
+This should return something like:
+
+```sh
+...
++-------------------------+
+| Move Coverage Summary   |
++-------------------------+
+Module ace::full_coverage
+>>> % Module coverage: 100.00
+Module ace::partial_coverage
+>>> % Module coverage: 93.88
+...
+```
+
+Noting that your tests have not achieved 100% coverage in one of your modules,
+you would typically then run the following to view module source code colored
+with coverage information:
+
+```sh
+aptos move coverage source --dev --module partial_coverage
+```
+
+However, as in this example, the `move coverage source` command does not always
+produce intelligible results for inline functions that have not hit coverage, so
+you'll actually have to compare against bytecode to identify the culprit:
+
+```sh
+aptos move coverage bytecode --dev --module partial_coverage
+```
+
+This reveals the coverage gap at:
+
+```sh
+        32: LdU64(4)
+        33: Call error::invalid_argument(u64): u64
+        34: Abort
+```
+
+Note that this branch corresponds to the assert statement from `mul_div`, which
+is not present in the `full_coverage` module bytecode:
+
+```sh
+aptos move coverage bytecode --dev --module full_coverage
+```

--- a/aptos-move/move-examples/inline-coverage/sources/full_coverage.move
+++ b/aptos-move/move-examples/inline-coverage/sources/full_coverage.move
@@ -1,0 +1,40 @@
+module publisher::full_coverage {
+    use aptos_std::math64;
+
+    /// Requested withdrawal amount exceeds expected value of pool.
+    const E_WITHDRAWAL_TOO_BIG: u64 = 0;
+
+    public fun socialize_withdrawal_amount(
+        requested_withdrawal_amount: u64,
+        expected_value_in_pool: u64,
+        actual_value_in_pool: u64,
+    ): u64 {
+        assert!(requested_withdrawal_amount <= expected_value_in_pool, E_WITHDRAWAL_TOO_BIG);
+        if (actual_value_in_pool > expected_value_in_pool) {
+            requested_withdrawal_amount
+        } else if (requested_withdrawal_amount == 0) {
+            0
+        } else {
+            math64::mul_div_unchecked( // <---------- Can be tested to 100% coverage
+                requested_withdrawal_amount,
+                actual_value_in_pool,
+                expected_value_in_pool,
+            )
+        }
+    }
+
+    #[test]
+    fun test_socialize_withdrawal_amount() {
+        assert!(socialize_withdrawal_amount(100, 200, 200) == 100, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 201) == 100, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 0) == 0, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 100) == 50, 0);
+        assert!(socialize_withdrawal_amount(0, 0, 25) == 0, 0);
+        assert!(socialize_withdrawal_amount(0, 0, 0) == 0, 0);
+    }
+
+    #[test, expected_failure(abort_code = E_WITHDRAWAL_TOO_BIG)]
+    fun test_socialize_withdrawal_amount_withdrawal_too_big() {
+        socialize_withdrawal_amount(1, 0, 0);
+    }
+}

--- a/aptos-move/move-examples/inline-coverage/sources/partial_coverage.move
+++ b/aptos-move/move-examples/inline-coverage/sources/partial_coverage.move
@@ -1,0 +1,40 @@
+module publisher::partial_coverage {
+    use aptos_std::math64;
+
+    /// Requested withdrawal amount exceeds expected value of pool.
+    const E_WITHDRAWAL_TOO_BIG: u64 = 0;
+
+    public fun socialize_withdrawal_amount(
+        requested_withdrawal_amount: u64,
+        expected_value_in_pool: u64,
+        actual_value_in_pool: u64,
+    ): u64 {
+        assert!(requested_withdrawal_amount <= expected_value_in_pool, E_WITHDRAWAL_TOO_BIG);
+        if (actual_value_in_pool > expected_value_in_pool) {
+            requested_withdrawal_amount
+        } else if (requested_withdrawal_amount == 0) {
+            0
+        } else {
+            math64::mul_div( // <---------- Impossible to test to 100% coverage
+                requested_withdrawal_amount,
+                actual_value_in_pool,
+                expected_value_in_pool,
+            )
+        }
+    }
+
+    #[test]
+    fun test_socialize_withdrawal_amount() {
+        assert!(socialize_withdrawal_amount(100, 200, 200) == 100, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 201) == 100, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 0) == 0, 0);
+        assert!(socialize_withdrawal_amount(100, 200, 100) == 50, 0);
+        assert!(socialize_withdrawal_amount(0, 0, 25) == 0, 0);
+        assert!(socialize_withdrawal_amount(0, 0, 0) == 0, 0);
+    }
+
+    #[test, expected_failure(abort_code = E_WITHDRAWAL_TOO_BIG)]
+    fun test_socialize_withdrawal_amount_withdrawal_too_big() {
+        socialize_withdrawal_amount(1, 0, 0);
+    }
+}


### PR DESCRIPTION
Tagging @junkil-park and @gregnazario for their involvement with Move math libraries and coverage testing

# Motivation

Currently, the math `mul_div` function is an inline implementation with an abort. Calling functions that can not possibly trigger the abort thus cannot be tested to 100% coverage, which is an important check for CI/CD pipelines

# What this PR adds

- `mul_div_unchecked` functions to math libraries, which make it possible to ensure 100% code coverage
- A comprehensive Move example demonstrating the rationale and results of the functions involved