### PR TITLE
[NFT Metadata Crawler] Fix not committing duplicate images and animations

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
@@ -9,7 +9,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(asset_uri))]
 #[diesel(table_name = parsed_asset_uris)]
 pub struct NFTMetadataCrawlerURIs {

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris.rs
@@ -9,7 +9,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(asset_uri))]
 #[diesel(table_name = parsed_asset_uris)]
 pub struct NFTMetadataCrawlerURIs {

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tracing::error;
 
-#[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[derive(Clone, Debug, Deserialize, Identifiable, Queryable, Serialize)]
 #[diesel(primary_key(asset_uri))]
 #[diesel(table_name = parsed_asset_uris)]
 pub struct NFTMetadataCrawlerURIsQuery {
@@ -32,8 +32,8 @@ pub struct NFTMetadataCrawlerURIsQuery {
 
 impl NFTMetadataCrawlerURIsQuery {
     pub fn get_by_asset_uri(
-        asset_uri: &str,
         conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
+        asset_uri: &str,
     ) -> Option<Self> {
         let mut op = || {
             parsed_asset_uris::table
@@ -55,9 +55,9 @@ impl NFTMetadataCrawlerURIsQuery {
     }
 
     pub fn get_by_raw_image_uri(
+        conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
         asset_uri: &str,
         raw_image_uri: &str,
-        conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
     ) -> Option<Self> {
         let mut op = || {
             parsed_asset_uris::table
@@ -81,9 +81,9 @@ impl NFTMetadataCrawlerURIsQuery {
     }
 
     pub fn get_by_raw_animation_uri(
+        conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
         asset_uri: &str,
         raw_animation_uri: &str,
-        conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
     ) -> Option<Self> {
         let mut op = || {
             parsed_asset_uris::table

--- a/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/models/nft_metadata_crawler_uris_query.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tracing::error;
 
-#[derive(Clone, Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
 #[diesel(primary_key(asset_uri))]
 #[diesel(table_name = parsed_asset_uris)]
 pub struct NFTMetadataCrawlerURIsQuery {

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/database.rs
@@ -35,6 +35,7 @@ pub fn run_migrations(pool: &Pool<ConnectionManager<PgConnection>>) {
 pub fn upsert_uris(
     conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
     entry: &NFTMetadataCrawlerURIs,
+    ltv: i64,
 ) -> anyhow::Result<usize> {
     use schema::nft_metadata_crawler::parsed_asset_uris::dsl::*;
 
@@ -51,8 +52,9 @@ pub fn upsert_uris(
             image_optimizer_retry_count.eq(excluded(image_optimizer_retry_count)),
             json_parser_retry_count.eq(excluded(json_parser_retry_count)),
             animation_optimizer_retry_count.eq(excluded(animation_optimizer_retry_count)),
+            inserted_at.eq(excluded(inserted_at)),
             do_not_parse.eq(excluded(do_not_parse)),
-            last_transaction_version.eq(excluded(last_transaction_version)),
+            last_transaction_version.eq(ltv),
         ));
 
     let debug_query = diesel::debug_query::<diesel::pg::Pg, _>(&query).to_string();

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -283,7 +283,7 @@ impl Worker {
         } else if self.model.get_cdn_animation_uri().is_some() {
             None
         } else {
-            self.model.get_raw_animation_uri().map_or(None, |uri| {
+            self.model.get_raw_animation_uri().and_then(|uri| {
                 match NFTMetadataCrawlerURIsQuery::get_by_raw_animation_uri(
                     &mut self.conn,
                     &self.asset_uri,

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -295,7 +295,7 @@ impl Worker {
                         self.upsert();
                         None
                     },
-                    None => self.model.get_raw_animation_uri(),
+                    None => Some(uri),
                 }
             })
         };

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -96,6 +96,7 @@ impl Worker {
             self.model.set_do_not_parse(true);
             self.upsert();
             SKIP_URI_COUNT.with_label_values(&["blacklist"]).inc();
+            return Ok(());
         }
 
         // Skip if asset_uri is not a valid URI, do not write invalid URI to Postgres

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -95,7 +95,7 @@ impl Worker {
             return Ok(());
         }
 
-        // Skip if asset_uri is not a valid URI
+        // Skip if asset_uri is not a valid URI, do not write invalid URI to Postgres
         if Url::parse(&self.asset_uri).is_err() {
             self.log_info("URI is invalid, skipping parse, marking as do_not_parse");
             self.model.set_do_not_parse(true);
@@ -258,7 +258,7 @@ impl Worker {
         // Deduplicate raw_animation_uri
         // Proceed with animation optimization if force or if raw_animation_uri has not been parsed
         let mut raw_animation_uri_option = self.model.get_raw_animation_uri();
-        let dupe_animation_found = self.model.get_raw_animation_uri().map_or(false, |uri| {
+        let dupe_animation_found = raw_animation_uri_option.clone().map_or(false, |uri| {
             match NFTMetadataCrawlerURIsQuery::get_by_raw_animation_uri(
                 &mut self.conn,
                 &self.asset_uri,


### PR DESCRIPTION
### Description
Previously set the duplicate CDN URIs in the model but didn't write the models to DB

Also cleaned up some code

### Test Plan
Works locally (different asset_uri, same raw_image_uri, copy over cdn_image_uri)
![image](https://github.com/aptos-labs/aptos-core/assets/37165464/f211b75f-7e50-4a1e-8337-0126a8b2cdfd)
