### PR TITLE
[previewnet] [cherry pick] remove more cases of dependency on the event index (use the block indices instead) #12245

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -20,7 +20,7 @@ use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
 use aptos_db_indexer::table_info_reader::TableInfoReader;
 use aptos_gas_schedule::{AptosGasParameters, FromOnChainGasSchedule};
-use aptos_logger::{error, info, warn, Schema};
+use aptos_logger::{error, info, Schema};
 use aptos_mempool::{MempoolClientRequest, MempoolClientSender, SubmissionStatus};
 use aptos_storage_interface::{
     state_view::{DbStateView, DbStateViewAtVersion, LatestDbStateCheckpointView},
@@ -221,55 +221,33 @@ impl Context {
     }
 
     pub fn get_latest_ledger_info<E: ServiceUnavailableError>(&self) -> Result<LedgerInfo, E> {
-        let maybe_oldest_version = self
-            .db
-            .get_first_viable_txn_version()
-            .context("Failed to retrieve oldest version in DB")
-            .map_err(|e| {
-                E::service_unavailable_with_code_no_info(e, AptosErrorCode::InternalError)
-            })?;
         let ledger_info = self
             .get_latest_ledger_info_with_signatures()
             .context("Failed to retrieve latest ledger info")
             .map_err(|e| {
                 E::service_unavailable_with_code_no_info(e, AptosErrorCode::InternalError)
             })?;
-
-        let (oldest_version, oldest_block_height, block_height) = match self
+        let (oldest_version, oldest_block_height) = self
             .db
-            .get_next_block_event(maybe_oldest_version)
-        {
-            Ok((version, oldest_block_event)) => {
-                let (_, _, newest_block_event) = self
-                    .db
-                    .get_block_info_by_version(ledger_info.ledger_info().version())
-                    .context("Failed to retrieve latest block information")
-                    .map_err(|e| {
-                        E::service_unavailable_with_code_no_info(e, AptosErrorCode::InternalError)
-                    })?;
-                (
-                    version,
-                    oldest_block_event.height(),
-                    newest_block_event.height(),
-                )
-            },
-            Err(err) => {
-                // when event index is disabled, we won't be able to search the NewBlock event stream.
-                // TODO(grao): evaluate adding dedicated block_height_by_version index
-                warn!(
-                    error = ?err,
-                    "Failed to query event indices, might be turned off. Ignoring.",
-                );
-                (maybe_oldest_version, 0, 0)
-            },
-        };
+            .get_first_viable_block()
+            .context("Failed to retrieve oldest block information")
+            .map_err(|e| {
+                E::service_unavailable_with_code_no_info(e, AptosErrorCode::InternalError)
+            })?;
+        let (_, _, newest_block_event) = self
+            .db
+            .get_block_info_by_version(ledger_info.ledger_info().version())
+            .context("Failed to retrieve latest block information")
+            .map_err(|e| {
+                E::service_unavailable_with_code_no_info(e, AptosErrorCode::InternalError)
+            })?;
 
         Ok(LedgerInfo::new(
             &self.chain_id(),
             &ledger_info,
             oldest_version,
             oldest_block_height,
-            block_height,
+            newest_block_event.height(),
         ))
     }
 

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -231,30 +231,49 @@ fn error_if_too_many_requested(num_requested: u64, max_allowed: u64) -> Result<(
     }
 }
 
+thread_local! {
+    static ENTERED_GAUGED_API: Cell<bool> = Cell::new(false);
+}
+
 fn gauged_api<T, F>(api_name: &'static str, api_impl: F) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
-    let timer = Instant::now();
+    let nested =  ENTERED_GAUGED_API.with(|entered| {
+        if entered.get() {
+            true
+        } else {
+            entered.set(true);
+            false
+        }
+    });
 
-    let res = api_impl();
+    if nested {
+        api_impl()
+    } else {
+        let timer = Instant::now();
 
-    let res_type = match &res {
-        Ok(_) => "Ok",
-        Err(e) => {
-            warn!(
-                api_name = api_name,
-                error = ?e,
-                "AptosDB API returned error."
-            );
-            "Err"
-        },
-    };
-    API_LATENCY_SECONDS
-        .with_label_values(&[api_name, res_type])
-        .observe(timer.elapsed().as_secs_f64());
+        let res = api_impl();
 
-    res
+        let res_type = match &res {
+            Ok(_) => "Ok",
+            Err(e) => {
+                warn!(
+                    api_name = api_name,
+                    error = ?e,
+                    "AptosDB API returned error."
+                );
+                "Err"
+            },
+        };
+        API_LATENCY_SECONDS
+            .with_label_values(&[api_name, res_type])
+            .observe(timer.elapsed().as_secs_f64());
+        ENTERED_GAUGED_API.with(|entered| entered.set(false));
+
+        res
+    }
+
 }
 
 // Convert requested range and order to a range in ascending order.

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_types::block_info::BlockHeight;
+
 impl DbReader for AptosDB {
     fn get_epoch_ending_ledger_infos(
         &self,
@@ -184,10 +186,23 @@ impl DbReader for AptosDB {
         })
     }
 
-    /// Get the first version that will likely not be pruned soon
-    fn get_first_viable_txn_version(&self) -> Result<Version> {
-        gauged_api("get_first_viable_txn_version", || {
-            Ok(self.ledger_pruner.get_min_viable_version())
+    /// Get the first block version / height that will likely not be pruned soon.
+    fn get_first_viable_block(&self) -> Result<(Version, BlockHeight)> {
+        gauged_api("get_first_viable_block", || {
+            let min_version = self.ledger_pruner.get_min_viable_version();
+            if !self.skip_index_and_usage {
+                let (block_version, index, _seq_num) = self
+                    .event_store
+                    .lookup_event_at_or_after_version(&new_block_event_key(), min_version)?
+                    .ok_or_else(|| AptosDbError::NotFound(format!("NewBlockEvent at or after version {}", min_version)))?;
+                let event = self.event_store.get_event_by_version_and_index(block_version, index)?;
+                return Ok((block_version, event.expect_new_block_event()?.height()));
+            }
+
+            self
+                .ledger_db
+                .metadata_db()
+                .get_block_height_at_or_after_version(min_version)
         })
     }
 
@@ -500,41 +515,8 @@ impl DbReader for AptosDB {
                 "version older than latest version"
             );
 
-            match self.event_store.get_block_metadata(version) {
-                Ok((_first_version, new_block_event)) => Ok(new_block_event.proposed_time()),
-                Err(err) => {
-                    // when event index is disabled, we won't be able to search the NewBlock event stream.
-                    // TODO(grao): evaluate adding dedicated block_height_by_version index
-                    warn!(
-                        error = ?err,
-                        "Failed to fetch block timestamp, falling back to on-chain config.",
-                    );
-                    let ts = self
-                        .get_state_value_by_version(
-                            &StateKey::access_path(CurrentTimeMicroseconds::access_path()?),
-                            version,
-                        )?
-                        .ok_or_else(|| anyhow!("Timestamp not found at version {}", version))?;
-                    Ok(bcs::from_bytes::<CurrentTimeMicroseconds>(ts.bytes())?.microseconds)
-                },
-            }
-        })
-    }
-
-    fn get_next_block_event(&self, version: Version) -> Result<(Version, NewBlockEvent)> {
-        gauged_api("get_next_block_event", || {
-            self.error_if_ledger_pruned("NewBlockEvent", version)?;
-            if let Some((block_version, _, _)) = self
-                .event_store
-                .lookup_event_at_or_after_version(&new_block_event_key(), version)?
-            {
-                self.event_store.get_block_metadata(block_version)
-            } else {
-                bail!(
-                    "Failed to find a block event at or after version {}",
-                    version
-                )
-            }
+            let (_first_version, _last_version, new_block_event) = self.get_block_info_by_version(version)?;
+            Ok(new_block_event.proposed_time())
         })
     }
 
@@ -558,22 +540,9 @@ impl DbReader for AptosDB {
 
             let mut events = Vec::with_capacity(num_events);
             for item in iter.take(num_events) {
-                let (block_height, block_info) = item?;
+                let (_block_height, block_info) = item?;
                 let first_version = block_info.first_version();
-                let event = self
-                    .ledger_db
-                    .event_db()
-                    .get_events_by_version(first_version)?
-                    .into_iter()
-                    .find(|event| {
-                        if let Some(key) = event.event_key() {
-                            if *key == new_block_event_key() {
-                                return true;
-                            }
-                        }
-                        false
-                    })
-                    .ok_or_else(|| anyhow!("Event for block_height {block_height} at version {first_version} is not found."))?;
+                let event = self.ledger_db.event_db().expect_new_block_event(first_version)?;
                 events.push(EventWithVersion::new(first_version, event));
             }
 

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -49,7 +49,6 @@ use aptos_types::{
     epoch_state::EpochState,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::{CurrentTimeMicroseconds, OnChainConfig},
     proof::{
         accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProofExt,
         TransactionAccumulatorRangeProof, TransactionAccumulatorSummary,
@@ -75,6 +74,7 @@ use aptos_vm::data_cache::AsMoveResolver;
 use move_resource_viewer::MoveValueAnnotator;
 use rayon::prelude::*;
 use std::{
+    cell::Cell,
     fmt::{Debug, Formatter},
     iter::Iterator,
     path::Path,

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -21,6 +21,7 @@ use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::{AccountResource, NewBlockEvent},
+    block_info::BlockHeight,
     contract_event::EventWithVersion,
     epoch_state::EpochState,
     event::{EventHandle, EventKey},
@@ -511,8 +512,8 @@ impl DbReader for FakeAptosDB {
         self.inner.get_first_txn_version()
     }
 
-    fn get_first_viable_txn_version(&self) -> Result<Version> {
-        self.inner.get_first_viable_txn_version()
+    fn get_first_viable_block(&self) -> Result<(Version, BlockHeight)> {
+        self.inner.get_first_viable_block()
     }
 
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
@@ -595,10 +596,6 @@ impl DbReader for FakeAptosDB {
                 Err(AptosDbError::NotFound("NewBlockEvent".to_string()).into())
             }
         })
-    }
-
-    fn get_next_block_event(&self, version: Version) -> Result<(Version, NewBlockEvent)> {
-        self.inner.get_next_block_event(version)
     }
 
     fn get_block_info_by_version(

--- a/storage/aptosdb/src/schema/block_by_version/mod.rs
+++ b/storage/aptosdb/src/schema/block_by_version/mod.rs
@@ -15,11 +15,10 @@ use aptos_schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
 };
-use aptos_types::transaction::Version;
+use aptos_types::{block_info::BlockHeight, transaction::Version};
 use byteorder::{BigEndian, ReadBytesExt};
 use std::mem::size_of;
 
-type BlockHeight = u64;
 type Key = Version;
 type Value = BlockHeight;
 

--- a/storage/aptosdb/src/schema/block_info/mod.rs
+++ b/storage/aptosdb/src/schema/block_info/mod.rs
@@ -15,10 +15,10 @@ use aptos_schemadb::{
     schema::{KeyCodec, ValueCodec},
 };
 use aptos_storage_interface::block_info::BlockInfo;
+use aptos_types::block_info::BlockHeight;
 use byteorder::{BigEndian, ReadBytesExt};
 use std::mem::size_of;
 
-type BlockHeight = u64;
 type Key = BlockHeight;
 type Value = BlockInfo;
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -52,6 +52,7 @@ pub mod state_view;
 
 use crate::state_delta::StateDelta;
 use aptos_scratchpad::SparseMerkleTree;
+pub use aptos_types::block_info::BlockHeight;
 pub use errors::AptosDbError;
 pub use executed_trees::ExecutedTrees;
 
@@ -174,10 +175,10 @@ pub trait DbReader: Send + Sync {
         /// [AptosDB::get_first_txn_version]: ../aptosdb/struct.AptosDB.html#method.get_first_txn_version
         fn get_first_txn_version(&self) -> Result<Option<Version>>;
 
-        /// See [AptosDB::get_first_viable_txn_version].
+        /// See [AptosDB::get_first_viable_block].
         ///
-        /// [AptosDB::get_first_viable_txn_version]: ../aptosdb/struct.AptosDB.html#method.get_first_viable_txn_version
-        fn get_first_viable_txn_version(&self) -> Result<Version>;
+        /// [AptosDB::get_first_viable_block]: ../aptosdb/struct.AptosDB.html#method.get_first_viable_block
+        fn get_first_viable_block(&self) -> Result<(Version, BlockHeight)>;
 
         /// See [AptosDB::get_first_write_set_version].
         ///
@@ -240,8 +241,6 @@ pub trait DbReader: Send + Sync {
         /// [AptosDB::get_block_timestamp]:
         /// ../aptosdb/struct.AptosDB.html#method.get_block_timestamp
         fn get_block_timestamp(&self, version: Version) -> Result<u64>;
-
-        fn get_next_block_event(&self, version: Version) -> Result<(Version, NewBlockEvent)>;
 
         /// See [AptosDB::get_latest_block_events].
         fn get_latest_block_events(&self, num_events: usize) -> Result<Vec<EventWithVersion>>;

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -227,3 +227,6 @@ impl Display for BlockInfo {
         )
     }
 }
+
+/// A continuously increasing sequence number for committed blocks.
+pub type BlockHeight = u64;

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -161,6 +161,10 @@ impl ContractEvent {
             ContractEvent::V2(_event) => false,
         }
     }
+
+    pub fn expect_new_block_event(&self) -> Result<NewBlockEvent> {
+        NewBlockEvent::try_from_bytes(self.event_data())
+    }
 }
 
 /// Entry produced via a call to the `emit_event` builtin.


### PR DESCRIPTION
utilize the block indices for block timestamp fetching

avoid double logging api calls

instead, emit metrics only on the outmost call
