### PR TITLE
[Compiler-v2] Fix issue 12077

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/main_return_type_not_unit.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/main_return_type_not_unit.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: The function entry point to a `script` must have the return type `()`
+  ┌─ tests/checking/typing/main_return_type_not_unit.move:4:9
+  │
+4 │     fun main(): u64 {
+  │         ^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/main_return_type_not_unit.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/main_return_type_not_unit.move
@@ -1,0 +1,7 @@
+script {
+    // despite script functions no longer have any built in checks,
+    // scripts still do not support return values
+    fun main(): u64 {
+        0
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/v1.matched
+++ b/third_party/move/move-compiler-v2/tests/v1.matched
@@ -301,6 +301,7 @@ move-compiler/tests/move_check/typing/main_arguments.exp   move-compiler-v2/test
 move-compiler/tests/move_check/typing/main_arguments_various_caes.exp   move-compiler-v2/tests/checking/typing/main_arguments_various_caes.exp
 move-compiler/tests/move_check/typing/main_call_entry.exp   move-compiler-v2/tests/checking/typing/main_call_entry.exp
 move-compiler/tests/move_check/typing/main_call_visibility_friend.exp   move-compiler-v2/tests/visibility-checker/v1-typing/main_call_visibility_friend.exp
+move-compiler/tests/move_check/typing/main_return_type_not_unit.exp   move-compiler-v2/tests/checking/typing/main_return_type_not_unit.exp
 move-compiler/tests/move_check/typing/main_with_type_parameters.exp   move-compiler-v2/tests/checking/typing/main_with_type_parameters.exp
 move-compiler/tests/move_check/typing/module_call.exp   move-compiler-v2/tests/checking/typing/module_call.exp
 move-compiler/tests/move_check/typing/module_call_complicated_rhs.exp   move-compiler-v2/tests/checking/typing/module_call_complicated_rhs.exp

--- a/third_party/move/move-compiler-v2/tests/v1.unmatched
+++ b/third_party/move/move-compiler-v2/tests/v1.unmatched
@@ -219,7 +219,6 @@ move-compiler/tests/move_check/typing/{
   infinite_instantiations_invalid.move,
   infinite_instantiations_valid.move,
   invalid_type_acquire.move,
-  main_return_type_not_unit.move,
   missing_acquire.move,
   module_call_constraints_not_satisfied.move,
   module_call_internal.move,

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -3751,6 +3751,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             if entry.module_id != self.module_id {
                 continue;
             }
+            // If the function is from a script, its return value must be unit.
+            if self.module_name.is_script() && !entry.result_type.is_unit() {
+                self.parent.error(
+                    &entry.name_loc,
+                    "The function entry point to a `script` must have the return type `()`",
+                );
+            }
             // New function
             let spec = self.fun_specs.remove(&name.symbol).unwrap_or_default();
             let def = self.fun_defs.remove(&name.symbol);


### PR DESCRIPTION
### Description

This PR closes #12077 by adding a check on the return type of functions defined in a script.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

1) existing tests pass;
2) port the test `main_return_type_not_unit.move` from V1 to V2.