### PR TITLE
[Compiler-v2] Fix issue 12255

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -77,6 +77,11 @@ impl LiveVarInfoAtCodeOffset {
         result
     }
 
+    /// Check whether temp is used after bc
+    pub fn is_temp_used_after(&self, temp: &TempIndex, bc: &Bytecode) -> bool {
+        self.after.contains_key(temp) && !bc.dests().contains(temp)
+    }
+
     /// Creates a set of the temporaries alive before this program point.
     pub fn before_set(&self) -> BTreeSet<TempIndex> {
         self.before.keys().cloned().collect()

--- a/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
@@ -1,0 +1,276 @@
+============ initial bytecode ================
+
+[variant baseline]
+public fun M::f($t0: M::R): (M::R, u64) {
+     var $t1: M::R
+     var $t2: u64
+  0: $t1 := infer($t0)
+  1: $t2 := 0
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: M::R
+     var $t2: M::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := 1
+  1: $t2 := pack M::R($t3)
+  2: $t1 := infer($t2)
+  3: $t5 := 3
+  4: $t4 := infer($t5)
+  5: ($t1, $t4) := M::f($t1)
+  6: move_to<M::R>($t0, $t1)
+  7: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: M::R): (M::R, u64) {
+     var $t1: M::R
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t2 := 0
+     # live vars: $t1, $t2
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: M::R
+     var $t2: M::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t3 := 1
+     # live vars: $t0, $t3
+  1: $t2 := pack M::R($t3)
+     # live vars: $t0, $t2
+  2: $t1 := infer($t2)
+     # live vars: $t0, $t1
+  3: $t5 := 3
+     # live vars: $t0, $t1, $t5
+  4: $t4 := infer($t5)
+     # live vars: $t0, $t1
+  5: ($t1, $t4) := M::f($t1)
+     # live vars: $t0, $t1
+  6: move_to<M::R>($t0, $t1)
+     # live vars:
+  7: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: M::R): (M::R, u64) {
+     var $t1: M::R
+     var $t2: u64
+     # live vars: $t0
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  1: $t2 := 0
+     # live vars: $t1, $t2
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: M::R
+     var $t2: M::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  0: $t3 := 1
+     # live vars: $t0, $t3
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  1: $t2 := pack M::R($t3)
+     # live vars: $t0, $t2
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  2: $t1 := infer($t2)
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  3: $t5 := 3
+     # live vars: $t0, $t1, $t5
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  4: $t4 := infer($t5)
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  5: ($t1, $t4) := M::f($t1)
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  6: move_to<M::R>($t0, $t1)
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  7: return ()
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: M::R): (M::R, u64) {
+     var $t1: M::R
+     var $t2: u64
+     # abort state: {returns}
+     # live vars: $t0
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  0: $t1 := infer($t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  1: $t2 := 0
+     # abort state: {returns}
+     # live vars: $t1, $t2
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: M::R
+     var $t2: M::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  0: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  1: $t2 := pack M::R($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  2: $t1 := infer($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  3: $t5 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  4: $t4 := infer($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  5: ($t1, $t4) := M::f($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
+     # locals: {$t0=@2000000}
+     # globals: {}
+     #
+  6: move_to<M::R>($t0, $t1)
+     # abort state: {returns}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+  7: return ()
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: M::R): (M::R, u64) {
+     var $t1: M::R
+     var $t2: u64
+  0: $t1 := move($t0)
+  1: $t2 := 0
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: M::R
+     var $t2: M::R
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := 1
+  1: $t2 := pack M::R($t3)
+  2: $t1 := move($t2)
+  3: $t5 := 3
+  4: $t4 := move($t5)
+  5: ($t1, $t4) := M::f($t1)
+  6: move_to<M::R>($t0, $t1)
+  7: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.move
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.move
@@ -1,0 +1,15 @@
+module 0x42::M {
+
+    struct R has key { f: u64 }
+    public fun f(r: R): (R, u64) {
+        (r, 0)
+    }
+
+    public fun g(s: &signer) acquires R {
+        let r = R{f:1};
+        let _i =3;
+        (r,_i) = f(r);
+        move_to<R>(s, r);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/dead_assignment_2.exp
@@ -14,7 +14,7 @@ fun m::dead($t0: u64): u64 {
 fun m::dead($t0: u64): u64 {
      var $t1: u64
      # before: {}, after: {}
-  0: $t0 := copy($t0)
+  0: $t0 := move($t0)
      # before: {}, after: {$t1 := $t0}
   1: $t1 := move($t0)
      # before: {$t1 := $t0}, after: {$t1 := $t0}
@@ -26,7 +26,7 @@ fun m::dead($t0: u64): u64 {
 [variant baseline]
 fun m::dead($t0: u64): u64 {
      var $t1: u64
-  0: $t0 := copy($t0)
+  0: $t0 := move($t0)
   1: $t1 := move($t0)
   2: return $t0
 }


### PR DESCRIPTION
### Description

This PR closes #12255 by adding a check for whether a variable is alive after a given program point, consider that this variable may be just introduced at this point. So a variable is alive if (a) it is in the after set of livevar (b) it is not in the instrs.dests() of the current instructions.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

1) existing tests pass
2) add a test `copy_ability_tuple.move` 
