### PR TITLE
[compiler-v2] Improvements in type unification error messages

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -569,7 +569,7 @@ For maps that cannot be dropped this is a utility to destroy them
 using lambdas to destroy the individual keys and values.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy">destroy</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, dk: |Key|(), dv: |Value|())
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_destroy">destroy</a>&lt;Key: store, Value: store&gt;(map: <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, dk: |Key|, dv: |Value|)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -983,7 +983,7 @@ Update <code>target_bucket_size</code>.
 Apply the function to a reference of each key-value pair in the table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &V)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_ref">for_each_ref</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &V)|)
 </code></pre>
 
 
@@ -1018,7 +1018,7 @@ Apply the function to a reference of each key-value pair in the table.
 Apply the function to a mutable reference of each key-value pair in the table.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_for_each_mut">for_each_mut</a>&lt;K, V&gt;(<a href="table.md#0x1_table">table</a>: &<b>mut</b> <a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -937,7 +937,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no Ts and <code
 Apply the function to each T in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each">for_each</a>&lt;T: store&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
 </code></pre>
 
 
@@ -963,7 +963,7 @@ Apply the function to each T in the vector, consuming it.
 Apply the function to each T in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_reverse">for_each_reverse</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |T|)
 </code></pre>
 
 
@@ -993,7 +993,7 @@ Apply the function to each T in the vector, consuming it.
 Apply the function to a reference of each T in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&T|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_ref">for_each_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&T|)
 </code></pre>
 
 
@@ -1023,7 +1023,7 @@ Apply the function to a reference of each T in the vector.
 Apply the function to a mutable reference to each T in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_for_each_mut">for_each_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |&<b>mut</b> T|)
 </code></pre>
 
 
@@ -1053,7 +1053,7 @@ Apply the function to a mutable reference to each T in the vector.
 Apply the function to a reference of each T in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &T)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_ref">enumerate_ref</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &T)|)
 </code></pre>
 
 
@@ -1083,7 +1083,7 @@ Apply the function to a reference of each T in the vector with its index.
 Apply the function to a mutable reference of each T in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &<b>mut</b> T)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_enumerate_mut">enumerate_mut</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, f: |(u64, &<b>mut</b> T)|)
 </code></pre>
 
 
@@ -1269,7 +1269,7 @@ Filter the vector using the boolean function, removing all Ts for which <code>p(
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip">zip</a>&lt;T1: store, T2: store&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
 </code></pre>
 
 
@@ -1298,7 +1298,7 @@ Apply the function to each pair of elements in the two given vectors in the reve
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_reverse">zip_reverse</a>&lt;T1, T2&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_reverse">zip_reverse</a>&lt;T1, T2&gt;(v1: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(T1, T2)|)
 </code></pre>
 
 
@@ -1337,7 +1337,7 @@ Apply the function to the references of each pair of elements in the two given v
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_ref">zip_ref</a>&lt;T1, T2&gt;(v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_ref">zip_ref</a>&lt;T1, T2&gt;(v1: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&T1, &T2)|)
 </code></pre>
 
 
@@ -1375,7 +1375,7 @@ Apply the function to mutable references to each pair of elements in the two giv
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_mut">zip_mut</a>&lt;T1, T2&gt;(v1: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&<b>mut</b> T1, &<b>mut</b> T2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_zip_mut">zip_mut</a>&lt;T1, T2&gt;(v1: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T1&gt;, v2: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T2&gt;, f: |(&<b>mut</b> T1, &<b>mut</b> T2)|)
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/option.md
+++ b/aptos-move/framework/move-stdlib/doc/option.md
@@ -628,7 +628,7 @@ and an empty vector otherwise
 Apply the function to the optional element, consuming it. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -657,7 +657,7 @@ Apply the function to the optional element, consuming it. Does nothing if no val
 Apply the function to the optional element reference. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|)
 </code></pre>
 
 
@@ -684,7 +684,7 @@ Apply the function to the optional element reference. Does nothing if no value p
 Apply the function to the optional element reference. Does nothing if no value present.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
 </code></pre>
 
 
@@ -859,7 +859,7 @@ Returns true if the option contains an element which satisfies predicate.
 Utility function to destroy an option that is not droppable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, d: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy">destroy</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, d: |Element|)
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -809,7 +809,7 @@ Aborts if <code>i</code> is out of bounds.
 Apply the function to each element in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each">for_each</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each">for_each</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -835,7 +835,7 @@ Apply the function to each element in the vector, consuming it.
 Apply the function to each element in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_reverse">for_each_reverse</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_reverse">for_each_reverse</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -865,7 +865,7 @@ Apply the function to each element in the vector, consuming it.
 Apply the function to a reference of each element in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_ref">for_each_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_ref">for_each_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|)
 </code></pre>
 
 
@@ -895,7 +895,7 @@ Apply the function to a reference of each element in the vector.
 Apply the function to each pair of elements in the two given vectors, consuming them.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip">zip</a>&lt;Element1, Element2&gt;(v1: <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(Element1, Element2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip">zip</a>&lt;Element1, Element2&gt;(v1: <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(Element1, Element2)|)
 </code></pre>
 
 
@@ -924,7 +924,7 @@ Apply the function to each pair of elements in the two given vectors in the reve
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_reverse">zip_reverse</a>&lt;Element1, Element2&gt;(v1: <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(Element1, Element2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_reverse">zip_reverse</a>&lt;Element1, Element2&gt;(v1: <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(Element1, Element2)|)
 </code></pre>
 
 
@@ -963,7 +963,7 @@ Apply the function to the references of each pair of elements in the two given v
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_ref">zip_ref</a>&lt;Element1, Element2&gt;(v1: &<a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: &<a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(&Element1, &Element2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_ref">zip_ref</a>&lt;Element1, Element2&gt;(v1: &<a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: &<a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(&Element1, &Element2)|)
 </code></pre>
 
 
@@ -1000,7 +1000,7 @@ This errors out if the vectors are not of the same length.
 Apply the function to a reference of each element in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_enumerate_ref">enumerate_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |(u64, &Element)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_enumerate_ref">enumerate_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |(u64, &Element)|)
 </code></pre>
 
 
@@ -1030,7 +1030,7 @@ Apply the function to a reference of each element in the vector with its index.
 Apply the function to a mutable reference to each element in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_mut">for_each_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&<b>mut</b> Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_mut">for_each_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
 </code></pre>
 
 
@@ -1061,7 +1061,7 @@ Apply the function to mutable references to each pair of elements in the two giv
 This errors out if the vectors are not of the same length.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_mut">zip_mut</a>&lt;Element1, Element2&gt;(v1: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(&<b>mut</b> Element1, &<b>mut</b> Element2)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_zip_mut">zip_mut</a>&lt;Element1, Element2&gt;(v1: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element1&gt;, v2: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element2&gt;, f: |(&<b>mut</b> Element1, &<b>mut</b> Element2)|)
 </code></pre>
 
 
@@ -1098,7 +1098,7 @@ This errors out if the vectors are not of the same length.
 Apply the function to a mutable reference of each element in the vector with its index.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_enumerate_mut">enumerate_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |(u64, &<b>mut</b> Element)|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_enumerate_mut">enumerate_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |(u64, &<b>mut</b> Element)|)
 </code></pre>
 
 
@@ -1584,7 +1584,7 @@ Destroy a vector, just a wrapper around for_each_reverse with a descriptive name
 when used in the context of destroying a vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_destroy">destroy</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, d: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_destroy">destroy</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, d: |Element|)
 </code></pre>
 
 

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_err.exp
@@ -30,7 +30,7 @@ error: undeclared `m::y`
 21 │     fun f6(x: address) acquires *(make_up_address(y)) {
    │                                                   ^
 
-error: expected `address` but found `u64`
+error: cannot pass `u64` to a function which expects argument of type `address`
    ┌─ tests/checking/access_specifiers/access_err.move:24:30
    │
 24 │     fun f7(x: u64) acquires *(make_up_address_wrong(x)) {

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/for_type_mismatch.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/for_type_mismatch.exp
@@ -1,14 +1,6 @@
 
 Diagnostics:
-error: invalid call of `+`: expected `integer` but found `bool` for argument 1
-  ┌─ tests/checking/control_flow/for_type_mismatch.move:5:9
-  │
-5 │ ╭         for (i in true..false) {
-6 │ │             x = x + 1;
-7 │ │         };
-  │ ╰─────────^
-
-error: invalid call of `<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/control_flow/for_type_mismatch.move:5:9
   │
 5 │ ╭         for (i in true..false) {

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/argument.exp
@@ -1,0 +1,43 @@
+
+Diagnostics:
+error: cannot pass `integer` to a function which expects argument of type `bool`
+   ┌─ tests/checking/error_context/argument.move:14:14
+   │
+14 │         f(1, 2);
+   │              ^
+
+error: cannot pass `&mut integer` to a function which expects argument of type `&mut bool`
+   ┌─ tests/checking/error_context/argument.move:20:15
+   │
+20 │         g(&1, &mut x);
+   │               ^^^^^^
+
+error: cannot pass `&bool` to a function which expects argument of type `&u64`
+   ┌─ tests/checking/error_context/argument.move:21:11
+   │
+21 │         g(&true, &mut y);
+   │           ^^^^^
+
+error: cannot pass `&bool` to a function which expects argument of type `&mut address`
+   ┌─ tests/checking/error_context/argument.move:26:19
+   │
+26 │         h(&mut x, &true);
+   │                   ^^^^^
+
+error: the function takes `&mut` but `&` was provided
+   ┌─ tests/checking/error_context/argument.move:30:15
+   │
+30 │         g(&1, x)
+   │               ^
+
+error: the function takes 2 arguments but 1 were provided
+   ┌─ tests/checking/error_context/argument.move:34:9
+   │
+34 │         f(1);
+   │         ^^^^
+
+error: the function takes 2 arguments but 3 were provided
+   ┌─ tests/checking/error_context/argument.move:35:9
+   │
+35 │         f(1, false, 2);
+   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/argument.move
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/argument.move
@@ -1,0 +1,38 @@
+module 0x42::m {
+
+    fun f(_x: u64, _y: bool) {
+    }
+
+    fun g(_x: &u64, _y: &mut bool) {
+    }
+
+    fun h(_x: &address, _y: &mut address) {
+    }
+
+    fun arg_1() {
+        let x = 22;
+        f(1, 2);
+    }
+
+    fun arg_2() {
+        let x = 1;
+        let y;
+        g(&1, &mut x);
+        g(&true, &mut y);
+    }
+
+    fun arg_3() {
+        let x = @0x1;
+        h(&mut x, &true);
+    }
+
+    fun arg_4(x: &bool) {
+        g(&1, x)
+    }
+
+    fun arg_5() {
+        f(1);
+        f(1, false, 2);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/assign.exp
@@ -1,0 +1,37 @@
+
+Diagnostics:
+error: cannot assign `R` to left-hand side of type `S`
+   ┌─ tests/checking/error_context/assign.move:15:10
+   │
+15 │         (S{x, y}, R{z, s}) = (r, s);
+   │          ^^^^^^^
+
+error: cannot assign `S` to left-hand side of type `R`
+   ┌─ tests/checking/error_context/assign.move:15:19
+   │
+15 │         (S{x, y}, R{z, s}) = (r, s);
+   │                   ^^^^^^^
+
+error: the left-hand side has 2 items but the right-hand side provided 3
+   ┌─ tests/checking/error_context/assign.move:20:9
+   │
+20 │         (x, y) = (1, 2, 3);
+   │         ^^^^^^
+
+error: expected `bool` but found a value of type `u64`
+   ┌─ tests/checking/error_context/assign.move:24:9
+   │
+24 │         s.x = true;
+   │         ^^^
+
+error: cannot assign `&mut u8` to left-hand side of type `&mut u64`
+   ┌─ tests/checking/error_context/assign.move:25:10
+   │
+25 │         *x = 1u8;
+   │          ^
+
+error: the left-hand side expected `&mut` but `&` was provided
+   ┌─ tests/checking/error_context/assign.move:30:9
+   │
+30 │         r = &s2;
+   │         ^

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/assign.move
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/assign.move
@@ -1,0 +1,33 @@
+module 0x42::m {
+
+    struct S {
+        x: u64,
+        y: u8
+    }
+
+    struct R {
+        z: u16,
+        s: S
+    }
+
+    fun assign_1(r: R, s: S) {
+        let x; let y; let z; let s;
+        (S{x, y}, R{z, s}) = (r, s);
+    }
+
+    fun assign_2() {
+        let x; let y;
+        (x, y) = (1, 2, 3);
+    }
+
+    fun assign_3(s: &mut S, x: &mut u64) {
+        s.x = true;
+        *x = 1u8;
+    }
+
+    fun assign_4(s1: S, s2: S) {
+        let r = &mut s1;
+        r = &s2;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/bind.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/bind.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: cannot bind `R` to left-hand side of type `S`
+   ┌─ tests/checking/error_context/bind.move:14:13
+   │
+14 │         let S{x, y} = r;
+   │             ^^^^^^^
+
+error: cannot bind `R` to left-hand side of type `S`
+   ┌─ tests/checking/error_context/bind.move:15:14
+   │
+15 │         let (S{x, y}, R{z, s}) = (r, s);
+   │              ^^^^^^^
+
+error: cannot bind `S` to left-hand side of type `R`
+   ┌─ tests/checking/error_context/bind.move:15:23
+   │
+15 │         let (S{x, y}, R{z, s}) = (r, s);
+   │                       ^^^^^^^
+
+error: the left-hand side has 2 items but the right-hand side provided 3
+   ┌─ tests/checking/error_context/bind.move:19:13
+   │
+19 │         let (x, y) = (1, 2, 3);
+   │             ^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/bind.move
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/bind.move
@@ -1,0 +1,21 @@
+module 0x42::m {
+
+    struct S {
+        x: u64,
+        y: u8
+    }
+
+    struct R {
+        z: u16,
+        s: S
+    }
+
+    fun bind_1(r: R, s: S) {
+        let S{x, y} = r;
+        let (S{x, y}, R{z, s}) = (r, s);
+    }
+
+    fun bind_2() {
+        let (x, y) = (1, 2, 3);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/return.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/return.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+error: cannot return `bool` from a function with result type `u64`
+  ┌─ tests/checking/error_context/return.move:4:9
+  │
+4 │         true
+  │         ^^^^
+
+error: cannot return `bool` from a function with result type `u64`
+  ┌─ tests/checking/error_context/return.move:8:23
+  │
+8 │         if (c) return false;
+  │                       ^^^^^
+
+error: cannot return `integer` from a function which returns nothing
+   ┌─ tests/checking/error_context/return.move:13:9
+   │
+13 │         1
+   │         ^
+
+error: cannot return `bool` from a function which returns nothing
+   ┌─ tests/checking/error_context/return.move:17:23
+   │
+17 │         if (c) return true;
+   │                       ^^^^
+
+error: cannot return nothing from a function with result type `bool`
+   ┌─ tests/checking/error_context/return.move:20:26
+   │
+20 │       fun return_5(): bool {
+   │ ╭──────────────────────────^
+21 │ │     }
+   │ ╰─────^
+
+error: the function returns `&mut` but `&` was provided
+   ┌─ tests/checking/error_context/return.move:24:9
+   │
+24 │         r
+   │         ^

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/return.move
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/return.move
@@ -1,0 +1,26 @@
+module 0x42::m {
+
+    fun return_1(): u64 {
+        true
+    }
+
+    fun return_2(c: bool): u64 {
+        if (c) return false;
+        1
+    }
+
+    fun return_3() {
+        1
+    }
+
+    fun return_4(c: bool) {
+        if (c) return true;
+    }
+
+    fun return_5(): bool {
+    }
+
+    fun return_6(r: &u64): &mut u64 {
+        r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/type_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/type_annotation.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: cannot adapt `bool` to annotated type `u64`
+  ┌─ tests/checking/error_context/type_annotation.move:4:10
+  │
+4 │         (true : u64);
+  │          ^^^^
+
+error: cannot adapt `(integer, bool)` to annotated type `u64`
+  ┌─ tests/checking/error_context/type_annotation.move:8:10
+  │
+8 │         ((1, true) : u64);
+  │          ^^^^^^^^^
+
+error: cannot adapt `(address, bool)` to annotated type `address`
+   ┌─ tests/checking/error_context/type_annotation.move:12:10
+   │
+12 │         ((@0x1, true) : address);
+   │          ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/type_annotation.move
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/type_annotation.move
@@ -1,0 +1,14 @@
+module 0x42::m {
+
+    fun an_1() {
+        (true : u64);
+    }
+
+    fun an_2() {
+        ((1, true) : u64);
+    }
+
+    fun an_3() {
+        ((@0x1, true) : address);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
@@ -43,7 +43,7 @@ module 0x42::LambdaTest2 {
           }
         }
     }
-    spec fun $foreach<T>(v: &vector<#0>,action: |&#0|());
+    spec fun $foreach<T>(v: &vector<#0>,action: |&#0|);
     spec fun $inline_apply2(g: |u64|u64,c: u64): u64 {
         Add(LambdaTest1::$inline_apply1(|z: u64| z, (g)(LambdaTest1::$inline_mul(c, LambdaTest1::$inline_apply(|x: u64| x, 3)))), 2)
     }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast_err.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: invalid call of `vector::fold`: expected `integer` but found `vector<u8>` for argument 3
+error: cannot pass `|(u64, integer)|u64` to a function which expects argument of type `|(u64, vector<u8>)|u64`
   ┌─ tests/checking/inlining/lambda_cast_err.move:7:53
   │
 7 │         vector::fold(gas_schedule_blob, (0 as u64), |sum, addend| sum + (addend as u64))

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused.exp
@@ -61,8 +61,8 @@ module 0x42::Test {
           }
         }
     }
-    spec fun $foo(f: |(u64, u64)|(),z: u64);
-    spec fun $quux(f: |(u64, u64)|(),_z: u64);
+    spec fun $foo(f: |(u64, u64)|,z: u64);
+    spec fun $quux(f: |(u64, u64)|,_z: u64);
     spec fun $test_shadowing();
     spec fun $test_shadowing2();
 } // end 0x42::Test

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused_nodecl.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused_nodecl.exp
@@ -69,8 +69,8 @@ module 0x42::Test {
           }
         }
     }
-    spec fun $foo(f: |(u64, u64)|(),z: u64);
-    spec fun $quux(f: |(u64, u64)|(),z: u64);
+    spec fun $foo(f: |(u64, u64)|,z: u64);
+    spec fun $quux(f: |(u64, u64)|,z: u64);
     spec fun $test_shadowing();
     spec fun $test_shadowing2();
 } // end 0x42::Test

--- a/third_party/move/move-compiler-v2/tests/checking/naming/generics_shadowing_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/generics_shadowing_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: expected `M::S` but found `S`
+error: cannot adapt `S` to annotated type `M::S`
   ┌─ tests/checking/naming/generics_shadowing_invalid.move:7:10
   │
 7 │         (s1: Self::S);
   │          ^^
 
-error: expected `S` but found `M::S`
+error: cannot adapt `M::S` to annotated type `S`
   ┌─ tests/checking/naming/generics_shadowing_invalid.move:8:20
   │
 8 │         let s: S = S {};
   │                    ^^^^
 
-error: invalid call of `M::bar`: expected `M::S` but found `S` for argument 1
+error: cannot pass `S` to a function which expects argument of type `M::S`
   ┌─ tests/checking/naming/generics_shadowing_invalid.move:9:13
   │
 9 │         bar(s1);
   │             ^^
 
-error: expected `S` but found `M::S`
+error: cannot return `M::S` from a function with result type `S`
    ┌─ tests/checking/naming/generics_shadowing_invalid.move:10:9
    │
 10 │         S {}

--- a/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_many_type_arguments.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_many_type_arguments.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: invalid call of `borrow_global`: generic count mismatch (expected 1 but found 2)
+error: the function expected 1 type argument but 2 were provided
   ┌─ tests/checking/naming/global_builtin_many_type_arguments.move:8:9
   │
 8 │         borrow_global<R1, R2>(@0x1);
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `exists`: generic count mismatch (expected 1 but found 3)
+error: the function expected 1 type argument but 3 were provided
   ┌─ tests/checking/naming/global_builtin_many_type_arguments.move:9:9
   │
 9 │         exists<R1, R2, R3>(@0x1);
   │         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_from`: generic count mismatch (expected 1 but found 4)
+error: the function expected 1 type argument but 4 were provided
    ┌─ tests/checking/naming/global_builtin_many_type_arguments.move:10:17
    │
 10 │         R1 {} = move_from<R1, R2, R3, R4>(@0x1);
    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: generic count mismatch (expected 1 but found 5)
+error: the function expected 1 type argument but 5 were provided
    ┌─ tests/checking/naming/global_builtin_many_type_arguments.move:11:9
    │
 11 │         move_to<R1, R2, R3, R4, R5>(account, R1{});

--- a/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_zero_type_arguments.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_zero_type_arguments.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: invalid call of `borrow_global`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
   ┌─ tests/checking/naming/global_builtin_zero_type_arguments.move:4:9
   │
 4 │         borrow_global<>(@0x1);
   │         ^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `exists`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
   ┌─ tests/checking/naming/global_builtin_zero_type_arguments.move:5:9
   │
 5 │         exists<>(@0x1);
   │         ^^^^^^^^^^^^^^
 
-error: invalid call of `move_from`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
   ┌─ tests/checking/naming/global_builtin_zero_type_arguments.move:6:17
   │
 6 │         R1 {} = move_from<>(@0x1);
   │                 ^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
   ┌─ tests/checking/naming/global_builtin_zero_type_arguments.move:7:9
   │
 7 │         move_to<>(account, R1{});

--- a/third_party/move/move-compiler-v2/tests/checking/naming/other_builtins_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/other_builtins_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `freeze`: generic count mismatch (expected 1 but found 2)
+error: the function expected 1 type argument but 2 were provided
   ┌─ tests/checking/naming/other_builtins_invalid.move:3:9
   │
 3 │         freeze<u64, bool>(x);
   │         ^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `freeze`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
   ┌─ tests/checking/naming/other_builtins_invalid.move:4:9
   │
 4 │         freeze<>(x);

--- a/third_party/move/move-compiler-v2/tests/checking/specs/conditions_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/conditions_err.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `&mut u64`
   ┌─ tests/checking/specs/conditions_err.move:6:15
   │
 6 │     aborts_if x; // Type of condition not bool.
   │               ^
 
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
   ┌─ tests/checking/specs/conditions_err.move:7:13
   │
 7 │     ensures old(x) + x; // Type of condition not bool.
@@ -18,7 +18,7 @@ error: undeclared `M::result_1`
 8 │     ensures result_1 == 0; // Using result which does not exist.
   │             ^^^^^^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/specs/conditions_err.move:14:28
    │
 14 │     emits _msg to _guid if x; // Type of condition for "if" is not bool.

--- a/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
@@ -12,37 +12,37 @@ error: no function named `not_declared` found
 15 │       not_declared() // Undeclared function.
    │       ^^^^^^^^^^^^^^
 
-error: expected `num` but found `bool`
+error: cannot return `bool` from a function with result type `num`
    ┌─ tests/checking/specs/expressions_err.move:19:7
    │
 19 │       false // Wrong result type.
    │       ^^^^^
 
-error: invalid call of `>`: expected `num` but found `vector<num>` for argument 1
+error: cannot use `vector<num>` with an operator which expects a value of type `num`
    ┌─ tests/checking/specs/expressions_err.move:23:7
    │
 23 │       x > y // No matching function.
    │       ^
 
-error: expected `(num, bool)` but found `bool`
+error: cannot return `bool` from a function with result type `(num, bool)`
    ┌─ tests/checking/specs/expressions_err.move:27:7
    │
 27 │       false // Wrong result type tuple.
    │       ^^^^^
 
-error: invalid call of `M::wrongly_typed_callee`: expected `bool` but found `u256` for argument 2
+error: cannot pass `u256` to a function which expects argument of type `bool`
    ┌─ tests/checking/specs/expressions_err.move:32:31
    │
 32 │       wrongly_typed_callee(1, 1) // Wrongly typed function application
    │                               ^
 
-error: invalid call of `M::wrongly_typed_fun_arg_callee`: expected `num` but found `bool` for argument 1
+error: cannot pass `|num|bool` to a function which expects argument of type `|num|num`
    ┌─ tests/checking/specs/expressions_err.move:37:36
    │
 37 │       wrongly_typed_fun_arg_callee(|x| false) // Wrongly typed function argument.
    │                                    ^^^^^^^^^
 
-error: invalid call of `M::wrong_instantiation`: generic count mismatch (expected 2 but found 1)
+error: the function expected 2 type arguments but 1 were provided
    ┌─ tests/checking/specs/expressions_err.move:42:7
    │
 42 │       wrong_instantiation<u64>(x) // Wrong instantiation

--- a/third_party/move/move-compiler-v2/tests/checking/specs/expressions_inference_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/expressions_inference_err.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `?2`
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/specs/expressions_inference_err.move:6:16
   │
 6 │       let f = |x|x; // Incomplete types.

--- a/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/invariants_err.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
   ┌─ tests/checking/specs/invariants_err.move:9:15
   │
 9 │     invariant x + 1;

--- a/third_party/move/move-compiler-v2/tests/checking/specs/schemas_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/schemas_err.exp
@@ -24,25 +24,25 @@ error: `wrong` not declared in schema
 19 │         include WrongTypeArgsIncluded<num>{wrong: 1};
    │                                            ^^^^^
 
-error: expected `num` but found `bool`
+error: expected `num` but found a value of type `bool`
    ┌─ tests/checking/specs/schemas_err.move:24:47
    │
 24 │         include WrongTypeArgsIncluded<num>{x: y};
    │                                               ^
 
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
    ┌─ tests/checking/specs/schemas_err.move:28:48
    │
 28 │         include WrongTypeArgsIncluded<bool>{x: 1 + 2};
    │                                                ^^^^^
 
-error: expected `bool` but found `num` (for `x` included from schema)
+error: variable `x` bound by schema inclusion expected to have type `bool` but provided was `num`
    ┌─ tests/checking/specs/schemas_err.move:33:17
    │
 33 │         include WronglyTypedVarIncluded;
    │                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `num` (for `x` included from schema)
+error: variable `x` bound by schema inclusion expected to have type `bool` but provided was `num`
    ┌─ tests/checking/specs/schemas_err.move:41:17
    │
 41 │         include WronglyTypedInstantiationIncluded<num>;
@@ -66,7 +66,7 @@ error: cyclic schema dependency: Cycle1 -> Cycle2 -> Cycle3 -> Cycle1
 80 │         include Cycle1;
    │                 ^^^^^^
 
-error: expected `bool` but found `u256`
+error: expected `bool` but found a value of type `u256`
    ┌─ tests/checking/specs/schemas_err.move:84:17
    │
 84 │         include 22 ==> Condition;

--- a/third_party/move/move-compiler-v2/tests/checking/specs/structs_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/structs_err.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: field `xx` not declared in struct `M::S`
+error: field `xx` not declared in struct `S`
    ┌─ tests/checking/specs/structs_err.move:26:7
    │
 26 │       s.xx
    │       ^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/specs/structs_err.move:31:7
    │
 31 │       s.x
    │       ^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/specs/structs_err.move:36:18
    │
 36 │       S{x: x, y: y, z: z}
@@ -24,13 +24,13 @@ error: missing fields `y`, `z`
 40 │       S{x: x}
    │       ^^^^^^^
 
-error: expected `bool` but found `u64`
+error: cannot return `G<u64>` from a function with result type `G<bool>`
    ┌─ tests/checking/specs/structs_err.move:45:7
    │
 45 │       G{x: x, y: y}
    │       ^^^^^^^^^^^^^
 
-error: generic count mismatch (expected 1 but found 2)
+error: the type expected 1 type argument but 2 were provided
    ┌─ tests/checking/specs/structs_err.move:50:7
    │
 50 │       G<u64, bool>{x: x, y: y}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_err.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: field `z` not declared in struct `update_field_ok::R` (update field)
+error: field `z` not declared in struct `R`
    ┌─ tests/checking/specs/update_field_err.move:16:9
    │
 16 │         update_field(r, z, 1)
    │         ^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `u64` but found `bool`
+error: expected `u64` but found a value of type `bool`
    ┌─ tests/checking/specs/update_field_err.move:20:28
    │
 20 │         update_field(r, x, true)

--- a/third_party/move/move-compiler-v2/tests/checking/specs/use_erroneous_schema.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/use_erroneous_schema.exp
@@ -6,7 +6,7 @@ error: undeclared `M::x`
 5 │         ensures x > 0;
   │                 ^
 
-error: invalid call of `<`: expected `num` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `num`
    ┌─ tests/checking/specs/use_erroneous_schema.move:13:21
    │
 13 │         ensures 2 < true;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_nested.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_nested.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
    ┌─ tests/checking/typing/assign_nested.move:14:9
    │
 14 │         (_, x, _) = four();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_unpack_references_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_unpack_references_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: expected `&u64` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `&u64`
   ┌─ tests/checking/typing/assign_unpack_references_invalid.move:9:9
   │
 9 │         f = 0;
   │         ^
 
-error: expected `&M::S` but found `M::S` (from assignment or declaration context)
+error: cannot assign `S` to left-hand side of type `&S`
    ┌─ tests/checking/typing/assign_unpack_references_invalid.move:10:9
    │
 10 │         s2 = S { f: 0 }
    │         ^^
 
-error: expected `&mut u64` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `&mut u64`
    ┌─ tests/checking/typing/assign_unpack_references_invalid.move:17:9
    │
 17 │         f = 0;
    │         ^
 
-error: expected `&mut M::S` but found `M::S` (from assignment or declaration context)
+error: cannot assign `S` to left-hand side of type `&mut S`
    ┌─ tests/checking/typing/assign_unpack_references_invalid.move:18:9
    │
 18 │         s2 = S { f: 0 }
    │         ^^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/assign_unpack_references_invalid.move:26:9
    │
 26 │         f = &0;
    │         ^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/assign_unpack_references_invalid.move:27:9
    │
 27 │         s2 = &S { f: 0 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_arity.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: tuples have different arity (0 != 3) (from assignment or declaration context)
+error: the left-hand side has 3 items but the right-hand side provided 0
   ┌─ tests/checking/typing/assign_wrong_arity.move:7:9
   │
 7 │         x = (0, 1, 2);
   │         ^
 
-error: expected `()` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `()`
   ┌─ tests/checking/typing/assign_wrong_arity.move:8:9
   │
 8 │         () = 0;
   │         ^^
 
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
    ┌─ tests/checking/typing/assign_wrong_arity.move:11:9
    │
 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
    │         ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 2
    ┌─ tests/checking/typing/assign_wrong_arity.move:12:9
    │
 12 │         (x, b, R{f}) = (0, false);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_type.exp
@@ -1,54 +1,54 @@
 
 Diagnostics:
-error: expected `M::S` but found `M::R`
+error: cannot assign `R` to left-hand side of type `S`
   ┌─ tests/checking/typing/assign_wrong_type.move:8:9
   │
 8 │         S { g } = R {f :0};
   │         ^^^^^^^
 
-error: expected `M::S` but found `M::R`
+error: cannot assign `R` to left-hand side of type `S`
   ┌─ tests/checking/typing/assign_wrong_type.move:9:10
   │
 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
   │          ^^^^^^^
 
-error: expected `()` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `()`
    ┌─ tests/checking/typing/assign_wrong_type.move:17:9
    │
 17 │         () = 0;
    │         ^^
 
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
    ┌─ tests/checking/typing/assign_wrong_type.move:18:9
    │
 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
    │         ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 2
    ┌─ tests/checking/typing/assign_wrong_type.move:19:9
    │
 19 │         (x, b, R{f}) = (0, false);
    │         ^^^^^^^^^^^^
 
-error: expected `bool` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `bool`
    ┌─ tests/checking/typing/assign_wrong_type.move:27:10
    │
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │          ^
 
-error: expected `integer` but found `bool` (from assignment or declaration context)
+error: cannot assign `bool` to left-hand side of type `integer`
    ┌─ tests/checking/typing/assign_wrong_type.move:27:13
    │
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │             ^
 
-error: expected `address` but found `u64` (from assignment or declaration context)
+error: cannot assign `u64` to left-hand side of type `address`
    ┌─ tests/checking/typing/assign_wrong_type.move:27:18
    │
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
    │                  ^
 
-error: expected `M::S` but found `M::R` (from assignment or declaration context)
+error: cannot assign `R` to left-hand side of type `S`
    ┌─ tests/checking/typing/assign_wrong_type.move:27:22
    │
 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_fun.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_fun.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: invalid call of `M::foo`: generic count mismatch (expected 1 but found 0)
+error: the function expected 1 type argument but 0 were provided
    ┌─ tests/checking/typing/bad_type_argument_arity_fun.move:11:17
    │
 11 │         let x = foo<>(0);
    │                 ^^^^^^^^
 
-error: invalid call of `M::foo`: generic count mismatch (expected 1 but found 2)
+error: the function expected 1 type argument but 2 were provided
    ┌─ tests/checking/typing/bad_type_argument_arity_fun.move:12:17
    │
 12 │         let b = foo<bool, u64>(false);
    │                 ^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: generic count mismatch (expected 1 but found 2)
+error: the function expected 1 type argument but 2 were provided
    ┌─ tests/checking/typing/bad_type_argument_arity_fun.move:14:17
    │
 14 │         let r = foo<&mut u64, bool>(&mut 0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_struct_pack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_struct_pack.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: generic count mismatch (expected 1 but found 0)
+error: the type expected 1 type argument but 0 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_struct_pack.move:7:9
   │
 7 │         S<> { f: 0 };
   │         ^^^^^^^^^^^^
 
-error: generic count mismatch (expected 1 but found 2)
+error: the type expected 1 type argument but 2 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_struct_pack.move:8:9
   │
 8 │         S<u64, u64> { f: 0 };

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_struct_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_struct_unpack.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: generic count mismatch (expected 1 but found 0)
+error: the type expected 1 type argument but 0 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_struct_unpack.move:7:13
   │
 7 │         let S<> { f } = copy s;
@@ -12,7 +12,7 @@ error: undeclared `M::f`
 8 │         f;
   │         ^
 
-error: generic count mismatch (expected 1 but found 2)
+error: the type expected 1 type argument but 2 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_struct_unpack.move:9:13
   │
 9 │         let S<u64, u64> { f } = copy s;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_add_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_add_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `+`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_add_invalid.move:8:9
   │
 8 │         false + true;
   │         ^^^^^
 
-error: invalid call of `+`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_add_invalid.move:9:13
   │
 9 │         1 + false;
   │             ^^^^^
 
-error: invalid call of `+`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:10:9
    │
 10 │         false + 1;
    │         ^^^^^
 
-error: invalid call of `+`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:11:9
    │
 11 │         @0x0 + @0x1;
    │         ^^^^
 
-error: invalid call of `+`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_add_invalid.move:12:20
    │
 12 │         (0: u8) + (1: u128);
    │                    ^
 
-error: invalid call of `+`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:13:9
    │
 13 │         r + r;
    │         ^
 
-error: invalid call of `+`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:14:9
    │
 14 │         s + s;
    │         ^
 
-error: invalid call of `+`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:15:13
    │
 15 │         1 + false + @0x0 + 0;
    │             ^^^^^
 
-error: invalid call of `+`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:15:21
    │
 15 │         1 + false + @0x0 + 0;
    │                     ^^^^
 
-error: invalid call of `+`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:16:9
    │
 16 │         () + ();
    │         ^^
 
-error: invalid call of `+`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:17:13
    │
 17 │         1 + ();
    │             ^^
 
-error: invalid call of `+`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:18:9
    │
 18 │         (0, 1) + (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `+`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_add_invalid.move:19:9
    │
 19 │         (1, 2) + (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_and_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_and_invalid.exp
@@ -1,66 +1,66 @@
 
 Diagnostics:
-error: invalid call of `&&`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/binary_and_invalid.move:8:9
   │
 8 │         0 && 1;
   │         ^
 
-error: invalid call of `&&`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/binary_and_invalid.move:9:9
   │
 9 │         1 && false;
   │         ^
 
-error: invalid call of `&&`: expected `bool` but found `integer` for argument 2
+error: cannot use `integer` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:10:18
    │
 10 │         false && 1;
    │                  ^
 
-error: invalid call of `&&`: expected `bool` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:11:9
    │
 11 │         @0x0 && @0x1;
    │         ^^^^
 
-error: invalid call of `&&`: expected `bool` but found `u8` for argument 1
+error: cannot use `u8` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:12:10
    │
 12 │         (0: u8) && (1: u128);
    │          ^
 
-error: invalid call of `&&`: expected `bool` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:13:9
    │
 13 │         r && r;
    │         ^
 
-error: invalid call of `&&`: expected `bool` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:14:9
    │
 14 │         s && s;
    │         ^
 
-error: invalid call of `&&`: expected `bool` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:15:9
    │
 15 │         () && ();
    │         ^^
 
-error: invalid call of `&&`: expected `bool` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:16:17
    │
 16 │         true && ();
    │                 ^^
 
-error: invalid call of `&&`: expected `bool` but found `(bool, bool)` for argument 1
+error: cannot use `(bool, bool)` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:17:9
    │
 17 │         (true, false) && (true, false, true);
    │         ^^^^^^^^^^^^^
 
-error: invalid call of `&&`: expected `bool` but found `(bool, bool)` for argument 1
+error: cannot use `(bool, bool)` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_and_invalid.move:18:9
    │
 18 │         (true, true) && (false, false);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `&`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_bit_and_invalid.move:8:9
   │
 8 │         false & true;
   │         ^^^^^
 
-error: invalid call of `&`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_bit_and_invalid.move:9:13
   │
 9 │         1 & false;
   │             ^^^^^
 
-error: invalid call of `&`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:10:9
    │
 10 │         false & 1;
    │         ^^^^^
 
-error: invalid call of `&`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:11:9
    │
 11 │         @0x0 & @0x1;
    │         ^^^^
 
-error: invalid call of `&`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:12:20
    │
 12 │         (0: u8) & (1: u128);
    │                    ^
 
-error: invalid call of `&`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:13:9
    │
 13 │         r & r;
    │         ^
 
-error: invalid call of `&`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:14:9
    │
 14 │         s & s;
    │         ^
 
-error: invalid call of `&`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:15:13
    │
 15 │         1 & false & @0x0 & 0;
    │             ^^^^^
 
-error: invalid call of `&`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:15:21
    │
 15 │         1 & false & @0x0 & 0;
    │                     ^^^^
 
-error: invalid call of `&`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:16:9
    │
 16 │         () & ();
    │         ^^
 
-error: invalid call of `&`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:17:13
    │
 17 │         1 & ();
    │             ^^
 
-error: invalid call of `&`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:18:9
    │
 18 │         (0, 1) & (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `&`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:19:9
    │
 19 │         (1, 2) & (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `|`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_bit_or_invalid.move:8:9
   │
 8 │         false | true;
   │         ^^^^^
 
-error: invalid call of `|`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_bit_or_invalid.move:9:13
   │
 9 │         1 | false;
   │             ^^^^^
 
-error: invalid call of `|`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:10:9
    │
 10 │         false | 1;
    │         ^^^^^
 
-error: invalid call of `|`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:11:9
    │
 11 │         @0x0 | @0x1;
    │         ^^^^
 
-error: invalid call of `|`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:12:20
    │
 12 │         (0: u8) | (1: u128);
    │                    ^
 
-error: invalid call of `|`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:13:9
    │
 13 │         r | r;
    │         ^
 
-error: invalid call of `|`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:14:9
    │
 14 │         s | s;
    │         ^
 
-error: invalid call of `|`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:15:13
    │
 15 │         1 | false | @0x0 | 0;
    │             ^^^^^
 
-error: invalid call of `|`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:15:21
    │
 15 │         1 | false | @0x0 | 0;
    │                     ^^^^
 
-error: invalid call of `|`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:16:9
    │
 16 │         () | ();
    │         ^^
 
-error: invalid call of `|`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:17:13
    │
 17 │         1 | ();
    │             ^^
 
-error: invalid call of `|`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:18:9
    │
 18 │         (0, 1) | (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `|`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:19:9
    │
 19 │         (1, 2) | (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_xor_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_xor_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `^`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_bit_xor_invalid.move:8:9
   │
 8 │         false ^ true;
   │         ^^^^^
 
-error: invalid call of `^`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_bit_xor_invalid.move:9:13
   │
 9 │         1 ^ false;
   │             ^^^^^
 
-error: invalid call of `^`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:10:9
    │
 10 │         false ^ 1;
    │         ^^^^^
 
-error: invalid call of `^`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:11:9
    │
 11 │         @0x0 ^ @0x1;
    │         ^^^^
 
-error: invalid call of `^`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:12:20
    │
 12 │         (0: u8) ^ (1: u128);
    │                    ^
 
-error: invalid call of `^`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:13:9
    │
 13 │         r ^ r;
    │         ^
 
-error: invalid call of `^`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:14:9
    │
 14 │         s ^ s;
    │         ^
 
-error: invalid call of `^`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:15:13
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
    │             ^^^^^
 
-error: invalid call of `^`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:15:21
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
    │                     ^^^^
 
-error: invalid call of `^`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:16:9
    │
 16 │         () ^ ();
    │         ^^
 
-error: invalid call of `^`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:17:13
    │
 17 │         1 ^ ();
    │             ^^
 
-error: invalid call of `^`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:18:9
    │
 18 │         (0, 1) ^ (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `^`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:19:9
    │
 19 │         (1, 2) ^ (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_div_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_div_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `/`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_div_invalid.move:8:9
   │
 8 │         false / true;
   │         ^^^^^
 
-error: invalid call of `/`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_div_invalid.move:9:13
   │
 9 │         1 / false;
   │             ^^^^^
 
-error: invalid call of `/`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:10:9
    │
 10 │         false / 1;
    │         ^^^^^
 
-error: invalid call of `/`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:11:9
    │
 11 │         @0x0 / @0x1;
    │         ^^^^
 
-error: invalid call of `/`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_div_invalid.move:12:20
    │
 12 │         (0: u8) / (1: u128);
    │                    ^
 
-error: invalid call of `/`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:13:9
    │
 13 │         r / r;
    │         ^
 
-error: invalid call of `/`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:14:9
    │
 14 │         s / s;
    │         ^
 
-error: invalid call of `/`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:15:13
    │
 15 │         1 / false / @0x0 / 0;
    │             ^^^^^
 
-error: invalid call of `/`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:15:21
    │
 15 │         1 / false / @0x0 / 0;
    │                     ^^^^
 
-error: invalid call of `/`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:16:9
    │
 16 │         () / ();
    │         ^^
 
-error: invalid call of `/`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:17:13
    │
 17 │         1 / ();
    │             ^^
 
-error: invalid call of `/`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:18:9
    │
 18 │         (0, 1) / (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `/`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_div_invalid.move:19:9
    │
 19 │         (1, 2) / (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq_invalid.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `>=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_geq_invalid.move:8:9
   │
 8 │         false >= true;
   │         ^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_geq_invalid.move:9:14
   │
 9 │         1 >= false;
   │              ^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:10:9
    │
 10 │         false >= 1;
    │         ^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:11:9
    │
 11 │         @0x0 >= @0x1;
    │         ^^^^
 
-error: invalid call of `>=`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_geq_invalid.move:12:21
    │
 12 │         (0: u8) >= (1: u128);
    │                     ^
 
-error: invalid call of `>=`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:13:9
    │
 13 │         r >= r;
    │         ^
 
-error: invalid call of `>=`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:14:9
    │
 14 │         s >= s;
    │         ^
 
-error: invalid call of `>=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:15:9
    │
 15 │         0 >= 1 >= 2;
    │         ^^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:16:15
    │
 16 │         (1 >= false) && (@0x0 >= 0);
    │               ^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:16:26
    │
 16 │         (1 >= false) && (@0x0 >= 0);
    │                          ^^^^
 
-error: invalid call of `>=`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:17:9
    │
 17 │         () >= ();
    │         ^^
 
-error: invalid call of `>=`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:18:14
    │
 18 │         1 >= ();
    │              ^^
 
-error: invalid call of `>=`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:19:9
    │
 19 │         (0, 1) >= (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `>=`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_geq_invalid.move:20:9
    │
 20 │         (1, 2) >= (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt_invalid.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `>`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_gt_invalid.move:8:9
   │
 8 │         false > true;
   │         ^^^^^
 
-error: invalid call of `>`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_gt_invalid.move:9:13
   │
 9 │         1 > false;
   │             ^^^^^
 
-error: invalid call of `>`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:10:9
    │
 10 │         false > 1;
    │         ^^^^^
 
-error: invalid call of `>`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:11:9
    │
 11 │         @0x0 > @0x1;
    │         ^^^^
 
-error: invalid call of `>`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_gt_invalid.move:12:20
    │
 12 │         (0: u8) > (1: u128);
    │                    ^
 
-error: invalid call of `>`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:13:9
    │
 13 │         r > r;
    │         ^
 
-error: invalid call of `>`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:14:9
    │
 14 │         s > s;
    │         ^
 
-error: invalid call of `>`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:15:9
    │
 15 │         0 > 1 > 2;
    │         ^^^^^
 
-error: invalid call of `>`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:16:14
    │
 16 │         (1 > false) && (@0x0 > 0);
    │              ^^^^^
 
-error: invalid call of `>`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:16:25
    │
 16 │         (1 > false) && (@0x0 > 0);
    │                         ^^^^
 
-error: invalid call of `>`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:17:9
    │
 17 │         () > ();
    │         ^^
 
-error: invalid call of `>`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:18:13
    │
 18 │         1 > ();
    │             ^^
 
-error: invalid call of `>`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:19:9
    │
 19 │         (0, 1) > (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `>`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_gt_invalid.move:20:9
    │
 20 │         (1, 2) > (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq_invalid.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `<=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_leq_invalid.move:8:9
   │
 8 │         false <= true;
   │         ^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_leq_invalid.move:9:14
   │
 9 │         1 <= false;
   │              ^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:10:9
    │
 10 │         false <= 1;
    │         ^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:11:9
    │
 11 │         @0x0 <= @0x1;
    │         ^^^^
 
-error: invalid call of `<=`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_leq_invalid.move:12:21
    │
 12 │         (0: u8) <= (1: u128);
    │                     ^
 
-error: invalid call of `<=`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:13:9
    │
 13 │         r <= r;
    │         ^
 
-error: invalid call of `<=`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:14:9
    │
 14 │         s <= s;
    │         ^
 
-error: invalid call of `<=`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:15:9
    │
 15 │         0 <= 1 <= 2;
    │         ^^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:16:15
    │
 16 │         (1 <= false) && (@0x0 <= 0);
    │               ^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:16:26
    │
 16 │         (1 <= false) && (@0x0 <= 0);
    │                          ^^^^
 
-error: invalid call of `<=`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:17:9
    │
 17 │         () <= ();
    │         ^^
 
-error: invalid call of `<=`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:18:14
    │
 18 │         1 <= ();
    │              ^^
 
-error: invalid call of `<=`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:19:9
    │
 19 │         (0, 1) <= (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `<=`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_leq_invalid.move:20:9
    │
 20 │         (1, 2) <= (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt_invalid.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_lt_invalid.move:8:9
   │
 8 │         false < true;
   │         ^^^^^
 
-error: invalid call of `<`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_lt_invalid.move:9:13
   │
 9 │         1 < false;
   │             ^^^^^
 
-error: invalid call of `<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:10:9
    │
 10 │         false < 1;
    │         ^^^^^
 
-error: invalid call of `<`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:11:9
    │
 11 │         @0x0 < @0x1;
    │         ^^^^
 
-error: invalid call of `<`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_lt_invalid.move:12:20
    │
 12 │         (0: u8) < (1: u128);
    │                    ^
 
-error: invalid call of `<`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:13:9
    │
 13 │         r < r;
    │         ^
 
-error: invalid call of `<`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:14:9
    │
 14 │         s < s;
    │         ^
 
-error: invalid call of `<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:15:9
    │
 15 │         0 < 1 < 2;
    │         ^^^^^
 
-error: invalid call of `<`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:16:14
    │
 16 │         (1 < false) && (@0x0 < 0);
    │              ^^^^^
 
-error: invalid call of `<`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:16:25
    │
 16 │         (1 < false) && (@0x0 < 0);
    │                         ^^^^
 
-error: invalid call of `<`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:17:9
    │
 17 │         () < ();
    │         ^^
 
-error: invalid call of `<`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:18:13
    │
 18 │         1 < ();
    │             ^^
 
-error: invalid call of `<`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:19:9
    │
 19 │         (0, 1) < (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `<`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_lt_invalid.move:20:9
    │
 20 │         (1, 2) < (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `%`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_mod_invalid.move:8:9
   │
 8 │         false % true;
   │         ^^^^^
 
-error: invalid call of `%`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_mod_invalid.move:9:13
   │
 9 │         1 % false;
   │             ^^^^^
 
-error: invalid call of `%`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:10:9
    │
 10 │         false % 1;
    │         ^^^^^
 
-error: invalid call of `%`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:11:9
    │
 11 │         @0x0 % @0x1;
    │         ^^^^
 
-error: invalid call of `%`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_mod_invalid.move:12:20
    │
 12 │         (0: u8) % (1: u128);
    │                    ^
 
-error: invalid call of `%`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:13:9
    │
 13 │         r % r;
    │         ^
 
-error: invalid call of `%`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:14:9
    │
 14 │         s % s;
    │         ^
 
-error: invalid call of `%`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:15:13
    │
 15 │         1 % false % @0x0 % 0;
    │             ^^^^^
 
-error: invalid call of `%`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:15:21
    │
 15 │         1 % false % @0x0 % 0;
    │                     ^^^^
 
-error: invalid call of `%`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:16:9
    │
 16 │         () % ();
    │         ^^
 
-error: invalid call of `%`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:17:13
    │
 17 │         1 % ();
    │             ^^
 
-error: invalid call of `%`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:18:9
    │
 18 │         (0, 1) % (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `%`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mod_invalid.move:19:9
    │
 19 │         (1, 2) % (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `*`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_mul_invalid.move:8:9
   │
 8 │         false * true;
   │         ^^^^^
 
-error: invalid call of `*`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_mul_invalid.move:9:13
   │
 9 │         1 * false;
   │             ^^^^^
 
-error: invalid call of `*`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:10:9
    │
 10 │         false * 1;
    │         ^^^^^
 
-error: invalid call of `*`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:11:9
    │
 11 │         @0x0 * @0x1;
    │         ^^^^
 
-error: invalid call of `*`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_mul_invalid.move:12:20
    │
 12 │         (0: u8) * (1: u128);
    │                    ^
 
-error: invalid call of `*`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:13:9
    │
 13 │         r * r;
    │         ^
 
-error: invalid call of `*`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:14:9
    │
 14 │         s * s;
    │         ^
 
-error: invalid call of `*`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:15:13
    │
 15 │         1 * false * @0x0 * 0;
    │             ^^^^^
 
-error: invalid call of `*`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:15:21
    │
 15 │         1 * false * @0x0 * 0;
    │                     ^^^^
 
-error: invalid call of `*`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:16:9
    │
 16 │         () * ();
    │         ^^
 
-error: invalid call of `*`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:17:13
    │
 17 │         1 * ();
    │             ^^
 
-error: invalid call of `*`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:18:9
    │
 18 │         (0, 1) * (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `*`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_mul_invalid.move:19:9
    │
 19 │         (1, 2) * (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_or_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_or_invalid.exp
@@ -1,66 +1,66 @@
 
 Diagnostics:
-error: invalid call of `||`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/binary_or_invalid.move:8:9
   │
 8 │         0 || 1;
   │         ^
 
-error: invalid call of `||`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/binary_or_invalid.move:9:9
   │
 9 │         1 || false;
   │         ^
 
-error: invalid call of `||`: expected `bool` but found `integer` for argument 2
+error: cannot use `integer` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:10:18
    │
 10 │         false || 1;
    │                  ^
 
-error: invalid call of `||`: expected `bool` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:11:9
    │
 11 │         @0x0 || @0x1;
    │         ^^^^
 
-error: invalid call of `||`: expected `bool` but found `u8` for argument 1
+error: cannot use `u8` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:12:10
    │
 12 │         (0: u8) || (1: u128);
    │          ^
 
-error: invalid call of `||`: expected `bool` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:13:9
    │
 13 │         r || r;
    │         ^
 
-error: invalid call of `||`: expected `bool` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:14:9
    │
 14 │         s || s;
    │         ^
 
-error: invalid call of `||`: expected `bool` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:15:9
    │
 15 │         () || ();
    │         ^^
 
-error: invalid call of `||`: expected `bool` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:16:17
    │
 16 │         true || ();
    │                 ^^
 
-error: invalid call of `||`: expected `bool` but found `(bool, bool)` for argument 1
+error: cannot use `(bool, bool)` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:17:9
    │
 17 │         (true, false) || (true, false, true);
    │         ^^^^^^^^^^^^^
 
-error: invalid call of `||`: expected `bool` but found `(bool, bool)` for argument 1
+error: cannot use `(bool, bool)` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/binary_or_invalid.move:18:9
    │
 18 │         (true, true) || (false, false);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `<<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_shl_invalid.move:8:9
   │
 8 │         false << true;
   │         ^^^^^
 
-error: invalid call of `<<`: expected `u8` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `u8`
   ┌─ tests/checking/typing/binary_shl_invalid.move:9:14
   │
 9 │         1 << false;
   │              ^^^^^
 
-error: invalid call of `<<`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:10:9
    │
 10 │         false << 1;
    │         ^^^^^
 
-error: invalid call of `<<`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:11:9
    │
 11 │         @0x0 << @0x1;
    │         ^^^^
 
-error: invalid call of `<<`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shl_invalid.move:12:21
    │
 12 │         (0: u8) << (1: u128);
    │                     ^
 
-error: invalid call of `<<`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:13:9
    │
 13 │         r << r;
    │         ^
 
-error: invalid call of `<<`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:14:9
    │
 14 │         s << s;
    │         ^
 
-error: invalid call of `<<`: expected `u8` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shl_invalid.move:15:14
    │
 15 │         1 << false << @0x0 << 0;
    │              ^^^^^
 
-error: invalid call of `<<`: expected `u8` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shl_invalid.move:15:23
    │
 15 │         1 << false << @0x0 << 0;
    │                       ^^^^
 
-error: invalid call of `<<`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:16:9
    │
 16 │         () << ();
    │         ^^
 
-error: invalid call of `<<`: expected `u8` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shl_invalid.move:17:14
    │
 17 │         1 << ();
    │              ^^
 
-error: invalid call of `<<`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:18:9
    │
 18 │         (0, 1) << (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `<<`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shl_invalid.move:19:9
    │
 19 │         (1, 2) << (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `>>`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_shr_invalid.move:8:9
   │
 8 │         false >> true;
   │         ^^^^^
 
-error: invalid call of `>>`: expected `u8` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `u8`
   ┌─ tests/checking/typing/binary_shr_invalid.move:9:14
   │
 9 │         1 >> false;
   │              ^^^^^
 
-error: invalid call of `>>`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:10:9
    │
 10 │         false >> 1;
    │         ^^^^^
 
-error: invalid call of `>>`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:11:9
    │
 11 │         @0x0 >> @0x1;
    │         ^^^^
 
-error: invalid call of `>>`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shr_invalid.move:12:21
    │
 12 │         (0: u8) >> (1: u128);
    │                     ^
 
-error: invalid call of `>>`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:13:9
    │
 13 │         r >> r;
    │         ^
 
-error: invalid call of `>>`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:14:9
    │
 14 │         s >> s;
    │         ^
 
-error: invalid call of `>>`: expected `u8` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shr_invalid.move:15:14
    │
 15 │         1 >> false >> @0x0 >> 0;
    │              ^^^^^
 
-error: invalid call of `>>`: expected `u8` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shr_invalid.move:15:23
    │
 15 │         1 >> false >> @0x0 >> 0;
    │                       ^^^^
 
-error: invalid call of `>>`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:16:9
    │
 16 │         () >> ();
    │         ^^
 
-error: invalid call of `>>`: expected `u8` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_shr_invalid.move:17:14
    │
 17 │         1 >> ();
    │              ^^
 
-error: invalid call of `>>`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:18:9
    │
 18 │         (0, 1) >> (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `>>`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_shr_invalid.move:19:9
    │
 19 │         (1, 2) >> (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
@@ -1,78 +1,78 @@
 
 Diagnostics:
-error: invalid call of `-`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_sub_invalid.move:8:9
   │
 8 │         false - true;
   │         ^^^^^
 
-error: invalid call of `-`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
   ┌─ tests/checking/typing/binary_sub_invalid.move:9:13
   │
 9 │         1 - false;
   │             ^^^^^
 
-error: invalid call of `-`: expected `integer` but found `bool` for argument 1
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:10:9
    │
 10 │         false - 1;
    │         ^^^^^
 
-error: invalid call of `-`: expected `integer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:11:9
    │
 11 │         @0x0 - @0x1;
    │         ^^^^
 
-error: invalid call of `-`: expected `u8` but found `u128` for argument 2
+error: cannot use `u128` with an operator which expects a value of type `u8`
    ┌─ tests/checking/typing/binary_sub_invalid.move:12:20
    │
 12 │         (0: u8) - (1: u128);
    │                    ^
 
-error: invalid call of `-`: expected `integer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:13:9
    │
 13 │         r - r;
    │         ^
 
-error: invalid call of `-`: expected `integer` but found `M::S` for argument 1
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:14:9
    │
 14 │         s - s;
    │         ^
 
-error: invalid call of `-`: expected `integer` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:15:13
    │
 15 │         1 - false - @0x0 - 0;
    │             ^^^^^
 
-error: invalid call of `-`: expected `integer` but found `address` for argument 2
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:15:21
    │
 15 │         1 - false - @0x0 - 0;
    │                     ^^^^
 
-error: invalid call of `-`: expected `integer` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:16:9
    │
 16 │         () - ();
    │         ^^
 
-error: invalid call of `-`: expected `integer` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `integer & integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:17:13
    │
 17 │         1 - ();
    │             ^^
 
-error: invalid call of `-`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:18:9
    │
 18 │         (0, 1) - (0, 1, 2);
    │         ^^^^^^
 
-error: invalid call of `-`: expected `integer` but found `(integer, integer)` for argument 1
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:19:9
    │
 19 │         (1, 2) - (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_unpack_references_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_unpack_references_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: expected `&u64` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `&u64`
   ┌─ tests/checking/typing/bind_unpack_references_invalid.move:7:9
   │
 7 │         f = 0;
   │         ^
 
-error: expected `&M::S` but found `M::S` (from assignment or declaration context)
+error: cannot assign `S` to left-hand side of type `&S`
   ┌─ tests/checking/typing/bind_unpack_references_invalid.move:8:9
   │
 8 │         s2 = S { f: 0 }
   │         ^^
 
-error: expected `&mut u64` but found `integer` (from assignment or declaration context)
+error: cannot assign `integer` to left-hand side of type `&mut u64`
    ┌─ tests/checking/typing/bind_unpack_references_invalid.move:13:9
    │
 13 │         f = 0;
    │         ^
 
-error: expected `&mut M::S` but found `M::S` (from assignment or declaration context)
+error: cannot assign `S` to left-hand side of type `&mut S`
    ┌─ tests/checking/typing/bind_unpack_references_invalid.move:14:9
    │
 14 │         s2 = S { f: 0 }
    │         ^^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/bind_unpack_references_invalid.move:20:9
    │
 20 │         f = &0;
    │         ^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/bind_unpack_references_invalid.move:21:9
    │
 21 │         s2 = &S { f: 0 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_arity.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: expected `()` but found `u64` (from assignment or declaration context)
+error: cannot bind `u64` to left-hand side of type `()`
   ┌─ tests/checking/typing/bind_wrong_arity.move:6:13
   │
 6 │         let (): u64 = 0;
   │             ^^
 
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
   ┌─ tests/checking/typing/bind_wrong_arity.move:7:13
   │
 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
   │             ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 2
   ┌─ tests/checking/typing/bind_wrong_arity.move:8:13
   │
 8 │         let (x, b, R{f}): (u64, bool) = (0, false);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_type.exp
@@ -1,72 +1,72 @@
 
 Diagnostics:
-error: expected `M::S` but found `M::R`
+error: cannot bind `R` to left-hand side of type `S`
   ┌─ tests/checking/typing/bind_wrong_type.move:6:13
   │
 6 │         let S { g } = R {f :0};
   │             ^^^^^^^
 
-error: expected `M::S` but found `M::R`
+error: cannot bind `R` to left-hand side of type `S`
   ┌─ tests/checking/typing/bind_wrong_type.move:7:14
   │
 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
   │              ^^^^^^^
 
-error: expected `()` but found `integer` (from assignment or declaration context)
+error: cannot bind `integer` to left-hand side of type `()`
    ┌─ tests/checking/typing/bind_wrong_type.move:12:13
    │
 12 │         let () = 0;
    │             ^^
 
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
    ┌─ tests/checking/typing/bind_wrong_type.move:13:13
    │
 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
    │             ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 2
    ┌─ tests/checking/typing/bind_wrong_type.move:14:13
    │
 14 │         let (x, b, R{f}) = (0, false);
    │             ^^^^^^^^^^^^
 
-error: expected `()` but found `integer`
+error: cannot adapt `integer` to annotated type `()`
    ┌─ tests/checking/typing/bind_wrong_type.move:18:21
    │
 18 │         let x: () = 0;
    │                     ^
 
-error: expected `()` but found `u64` (from assignment or declaration context)
+error: cannot bind `u64` to left-hand side of type `()`
    ┌─ tests/checking/typing/bind_wrong_type.move:19:13
    │
 19 │         let (): u64 = ();
    │             ^^
 
-error: expected `u64` but found `()`
+error: cannot adapt `()` to annotated type `u64`
    ┌─ tests/checking/typing/bind_wrong_type.move:19:23
    │
 19 │         let (): u64 = ();
    │                       ^^
 
-error: expected 4 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 4
    ┌─ tests/checking/typing/bind_wrong_type.move:20:13
    │
 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
    │             ^^^^^^^^^^^^
 
-error: expected 4 item(s), found 3
+error: expected 4 items but found 3
    ┌─ tests/checking/typing/bind_wrong_type.move:20:47
    │
 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
    │                                               ^^^^^^^^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: the left-hand side has 3 items but the right-hand side provided 2
    ┌─ tests/checking/typing/bind_wrong_type.move:21:13
    │
 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
    │             ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: expected 2 items but found 3
    ┌─ tests/checking/typing/bind_wrong_type.move:21:41
    │
 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});

--- a/third_party/move/move-compiler-v2/tests/checking/typing/block_empty_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/block_empty_invalid.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: expected `u64` but found `()`
+error: cannot adapt `()` to annotated type `u64`
   ┌─ tests/checking/typing/block_empty_invalid.move:3:10
   │
 3 │         ({}: u64);
   │          ^^
 
-error: expected `&u64` but found `()`
+error: cannot adapt `()` to annotated type `&u64`
   ┌─ tests/checking/typing/block_empty_invalid.move:4:10
   │
 4 │         ({}: &u64);
   │          ^^
 
-error: tuples have different arity (0 != 2)
+error: expected 2 items but found 0
   ┌─ tests/checking/typing/block_empty_invalid.move:5:10
   │
 5 │         ({}: (u64, bool));

--- a/third_party/move/move-compiler-v2/tests/checking/typing/block_single_expr_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/block_single_expr_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot adapt `integer` to annotated type `bool`
   ┌─ tests/checking/typing/block_single_expr_invalid.move:4:12
   │
 4 │         ({ 0 } : bool);
   │            ^
 
-error: expected `u64` but found `&?3`
+error: cannot adapt `&_` to annotated type `u64`
   ┌─ tests/checking/typing/block_single_expr_invalid.move:5:12
   │
 5 │         ({ &0 } : u64);
   │            ^^
 
-error: expected `()` but found `&mut ?6`
+error: cannot adapt `&mut _` to annotated type `()`
   ┌─ tests/checking/typing/block_single_expr_invalid.move:6:12
   │
 6 │         ({ &mut 0 } : ());
   │            ^^^^^^
 
-error: expected 2 item(s), found 3
+error: expected 2 items but found 3
   ┌─ tests/checking/typing/block_single_expr_invalid.move:8:12
   │
 8 │         ({ (0, false, false) } : (u64, bool));

--- a/third_party/move/move-compiler-v2/tests/checking/typing/block_with_statements_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/block_with_statements_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot adapt `integer` to annotated type `bool`
   ┌─ tests/checking/typing/block_with_statements_invalid.move:4:23
   │
 4 │         ({ let x = 0; x } : bool);
   │                       ^
 
-error: expected `u64` but found `&?6`
+error: cannot adapt `&_` to annotated type `u64`
   ┌─ tests/checking/typing/block_with_statements_invalid.move:5:23
   │
 5 │         ({ let x = 0; &x } : u64);
   │                       ^^
 
-error: expected `()` but found `&mut ?10`
+error: cannot adapt `&mut _` to annotated type `()`
   ┌─ tests/checking/typing/block_with_statements_invalid.move:6:23
   │
 6 │         ({ let y = 0; &mut (y + 1) } : ());
   │                       ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: expected 2 items but found 3
   ┌─ tests/checking/typing/block_with_statements_invalid.move:8:23
   │
 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_chain_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_chain_missing.exp
@@ -1,54 +1,54 @@
 
 Diagnostics:
-error: field `f` not declared in struct `M::X1`
+error: field `f` not declared in struct `X1`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:7:10
   │
 7 │         &x1.f;
   │          ^^
 
-error: field `f` not declared in struct `M::X2`
+error: field `f` not declared in struct `X2`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:8:10
   │
 8 │         &x1.x2.f;
   │          ^^^^^
 
-error: field `g` not declared in struct `M::X3`
+error: field `g` not declared in struct `X3`
   ┌─ tests/checking/typing/borrow_field_chain_missing.move:9:10
   │
 9 │         &x1.x2.x3.g;
   │          ^^^^^^^^
 
-error: field `f` not declared in struct `M::X1`
+error: field `f` not declared in struct `X1`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:11:10
    │
 11 │         &x1_mut.f;
    │          ^^^^^^
 
-error: field `f` not declared in struct `M::X2`
+error: field `f` not declared in struct `X2`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:12:10
    │
 12 │         &x1_mut.x2.f;
    │          ^^^^^^^^^
 
-error: field `g` not declared in struct `M::X3`
+error: field `g` not declared in struct `X3`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:13:10
    │
 13 │         &x1_mut.x2.x3.g;
    │          ^^^^^^^^^^^^
 
-error: field `f` not declared in struct `M::X1`
+error: field `f` not declared in struct `X1`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:15:14
    │
 15 │         &mut x1_mut.f;
    │              ^^^^^^
 
-error: field `f` not declared in struct `M::X2`
+error: field `f` not declared in struct `X2`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:16:14
    │
 16 │         &mut x1_mut.x2.f;
    │              ^^^^^^^^^
 
-error: field `g` not declared in struct `M::X3`
+error: field `g` not declared in struct `X3`
    ┌─ tests/checking/typing/borrow_field_chain_missing.move:17:14
    │
 17 │         &mut x1_mut.x2.x3.g;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_from_non_struct.exp
@@ -42,7 +42,7 @@ error: expected a struct with field `R` but found `()`
 12 │         &().R;
    │          ^^
 
-error: expected a struct with field `f` but found `(?26, ?27)`
+error: expected a struct with field `f` but found `(&S, &S)`
    ┌─ tests/checking/typing/borrow_field_from_non_struct.move:13:10
    │
 13 │         &(&S{f: 0}, &S{f:0}).f;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_missing.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: field `g` not declared in struct `M::S`
+error: field `g` not declared in struct `S`
   ┌─ tests/checking/typing/borrow_field_missing.move:5:10
   │
 5 │         &s.g;
   │          ^
 
-error: field `h` not declared in struct `M::S`
+error: field `h` not declared in struct `S`
   ┌─ tests/checking/typing/borrow_field_missing.move:6:10
   │
 6 │         &s_mut.h;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_inference.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_inference.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: invalid call of `+`: expected `u16|u32|u64|u128|u256` but found `u8` for argument 2
+error: cannot use `u8` with an operator which expects a value of type `u16|u32|u64|u128|u256 & u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/constant_inference.move:19:27
    │
 19 │         let error = 257 + r; // Should error

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_usage.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_usage.exp
@@ -1,42 +1,42 @@
 
 Diagnostics:
-error: expected `u8` but found `vector<u8>`
+error: cannot return `vector<u8>` from a function with result type `u8`
    ┌─ tests/checking/typing/constant_invalid_usage.move:11:20
    │
 11 │     fun t1(): u8 { C6 }
    │                    ^^
 
-error: expected `u64` but found `vector<u8>`
+error: cannot return `vector<u8>` from a function with result type `u64`
    ┌─ tests/checking/typing/constant_invalid_usage.move:12:21
    │
 12 │     fun t2(): u64 { C7 }
    │                     ^^
 
-error: expected `u128` but found `u8`
+error: cannot return `u8` from a function with result type `u128`
    ┌─ tests/checking/typing/constant_invalid_usage.move:13:22
    │
 13 │     fun t3(): u128 { C1 }
    │                      ^^
 
-error: expected `bool` but found `u64`
+error: cannot return `u64` from a function with result type `bool`
    ┌─ tests/checking/typing/constant_invalid_usage.move:14:22
    │
 14 │     fun t4(): bool { C2 }
    │                      ^^
 
-error: expected `address` but found `u128`
+error: cannot return `u128` from a function with result type `address`
    ┌─ tests/checking/typing/constant_invalid_usage.move:15:25
    │
 15 │     fun t5(): address { C3 }
    │                         ^^
 
-error: expected `vector<u8>` but found `bool`
+error: cannot return `bool` from a function with result type `vector<u8>`
    ┌─ tests/checking/typing/constant_invalid_usage.move:16:28
    │
 16 │     fun t6(): vector<u8> { C4 }
    │                            ^^
 
-error: expected `vector<u8>` but found `address`
+error: cannot return `address` from a function with result type `vector<u8>`
    ┌─ tests/checking/typing/constant_invalid_usage.move:17:28
    │
 17 │     fun t7(): vector<u8> { C5 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
@@ -32,7 +32,7 @@ error: Invalid type for constant
   │     │
   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
 
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/constant_non_base_type.move:4:26
   │
 4 │     const C2: &mut u64 = &0;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_unsupported_exps.exp
@@ -30,13 +30,13 @@ error: no function named `X::f_private` found
 27 │         0x42::X::f_private();
    │         ^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: expected `&signer` but found `signer` for argument 1
+error: cannot use `signer` with an operator which expects a value of type `&signer`
    ┌─ tests/checking/typing/constant_unsupported_exps.move:30:17
    │
 30 │         move_to(s, R{});
    │                 ^
 
-error: expected `()` but found `integer`
+error: cannot return `integer` from a function which returns nothing
    ┌─ tests/checking/typing/constant_unsupported_exps.move:39:16
    │
 39 │         return 0;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_arity.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: expected `u64` but found `()` (from assignment or declaration context)
+error: cannot adapt `()` to annotated type `u64`
   ┌─ tests/checking/typing/declare_wrong_arity.move:6:13
   │
 6 │         let (): u64;
   │             ^^
 
-error: expected 4 item(s), found 3
+error: expected 3 items but found 4
   ┌─ tests/checking/typing/declare_wrong_arity.move:7:13
   │
 7 │         let (x, b, R{f}): (u64, bool, R, R);
   │             ^^^^^^^^^^^^
 
-error: expected 2 item(s), found 3
+error: expected 3 items but found 2
   ┌─ tests/checking/typing/declare_wrong_arity.move:8:13
   │
 8 │         let (x, b, R{f}): (u64, bool);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_type.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `M::R` but found `M::S`
+error: cannot adapt `S` to annotated type `R`
   ┌─ tests/checking/typing/declare_wrong_type.move:6:13
   │
 6 │         let S { g } : R;
   │             ^^^^^^^
 
-error: expected `M::R` but found `M::S`
+error: cannot adapt `S` to annotated type `R`
   ┌─ tests/checking/typing/declare_wrong_type.move:7:14
   │
 7 │         let (S { g }, R { f }): (R, R);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
   ┌─ tests/checking/typing/derefrence_invalid.move:6:10
   │
 6 │         (*x : bool);
   │          ^^
 
-error: expected `&u64` but found `u64`
+error: expected `&u64` but found a value of type `u64`
   ┌─ tests/checking/typing/derefrence_invalid.move:7:10
   │
 7 │         (*x_mut: &u64);
   │          ^^^^^^
 
-error: expected `M::X` but found `M::S`
+error: expected `X` but found a value of type `S`
   ┌─ tests/checking/typing/derefrence_invalid.move:9:10
   │
 9 │         (*s: X);
   │          ^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:10:12
    │
 10 │         (*&s.f: bool);
    │            ^^^
 
-error: expected `&u64` but found `u64`
+error: expected `&u64` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:11:10
    │
 11 │         (s.f: &u64);
    │          ^^^
 
-error: expected `&M::X` but found `M::X`
+error: expected `&X` but found a value of type `X`
    ┌─ tests/checking/typing/derefrence_invalid.move:12:12
    │
 12 │         (*&s.x: &X);
@@ -42,37 +42,37 @@ error: cannot borrow from a reference
 12 │         (*&s.x: &X);
    │           ^^^^
 
-error: expected `M::X` but found `M::S`
+error: expected `X` but found a value of type `S`
    ┌─ tests/checking/typing/derefrence_invalid.move:14:10
    │
 14 │         (*s_mut: X);
    │          ^^^^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:15:12
    │
 15 │         (*&s_mut.f: bool);
    │            ^^^^^^^
 
-error: expected `(bool, u64)` but found `u64`
+error: expected `(bool, u64)` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:16:16
    │
 16 │         (*&mut s_mut.f: (bool, u64));
    │                ^^^^^^^
 
-error: expected `&u64` but found `u64`
+error: expected `&u64` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:17:10
    │
 17 │         (s_mut.f: &u64);
    │          ^^^^^^^
 
-error: expected `(M::X, M::S)` but found `M::X`
+error: expected `(X, S)` but found a value of type `X`
    ┌─ tests/checking/typing/derefrence_invalid.move:18:12
    │
 18 │         (*&s_mut.x: (X, S));
    │            ^^^^^^^
 
-error: expected `()` but found `M::X`
+error: expected expression with no value but found `X`
    ┌─ tests/checking/typing/derefrence_invalid.move:19:16
    │
 19 │         (*&mut s_mut.x: ());

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_inline.exp
@@ -15,7 +15,7 @@ module 0x42::m {
         };
         Tuple()
     }
-    spec fun $foo(f: |&u64|()) {
+    spec fun $foo(f: |&u64|) {
         Tuple()
     }
     spec fun $g();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
@@ -1,79 +1,55 @@
 
 Diagnostics:
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:13:9
+error: cannot use `u128` with an operator which expects a value of type `u8`
+   ┌─ tests/checking/typing/eq_invalid.move:13:21
    │
 13 │         (0: u8) == (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?3` but found `u8` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (expected `u8` but found `u128` for argument 2)
+   │                     ^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:14:9
+error: cannot use `bool` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/eq_invalid.move:14:14
    │
 14 │         0 == false;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?9` but found `integer` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (expected `integer` but found `bool` for argument 2)
+   │              ^^^^^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:15:9
+error: cannot use `integer` with an operator which expects a value of type `&integer`
+   ┌─ tests/checking/typing/eq_invalid.move:15:15
    │
 15 │         &0 == 1;
-   │         ^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?17` but found `integer` for argument 2)
-   = outruled candidate `==(#0, #0): bool` (expected `&integer` but found `integer` for argument 2)
+   │               ^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:16:9
+error: cannot use `&integer` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/eq_invalid.move:16:14
    │
 16 │         1 == &0;
-   │         ^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?25` but found `integer` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (expected `integer` but found `&integer` for argument 2)
+   │              ^^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:17:9
+error: cannot use `&S` with an operator which expects a value of type `S`
+   ┌─ tests/checking/typing/eq_invalid.move:17:14
    │
 17 │         s == s_ref;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?30` but found `M::S` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (expected `M::S` but found `&M::S` for argument 2)
+   │              ^^^^^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:18:9
+error: cannot use `S` with an operator which expects a value of type `&mut S`
+   ┌─ tests/checking/typing/eq_invalid.move:18:18
    │
 18 │         s_mut == s;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&M::S` but found `M::S` for argument 2)
-   = outruled candidate `==(#0, #0): bool` (expected `&mut M::S` but found `M::S` for argument 2)
+   │                  ^
 
-error: unable to infer type: `M::G2<?9>`
+error: unable to infer instantiation of type `G2<_>` (consider providing type arguments or annotating the type)
    ┌─ tests/checking/typing/eq_invalid.move:28:9
    │
 28 │         G2{} == G2{};
    │         ^^^^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:35:9
+error: the operator takes 2 arguments but 3 were provided
+   ┌─ tests/checking/typing/eq_invalid.move:35:22
    │
 35 │         (1, 2, 3) == (0, 1);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?31` but found `(integer, integer, integer)` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (tuples have different arity (3 != 2) for argument 2)
+   │                      ^^^^^^
 
-error: no matching declaration of `==`
-   ┌─ tests/checking/typing/eq_invalid.move:36:9
+error: the operator takes 3 arguments but 2 were provided
+   ┌─ tests/checking/typing/eq_invalid.move:36:19
    │
 36 │         (0, 1) == (1, 2, 3);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `==(&#0, &#0): bool` (expected `&?46` but found `(integer, integer)` for argument 1)
-   = outruled candidate `==(#0, #0): bool` (tuples have different arity (2 != 3) for argument 2)
+   │                   ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/exp_list_nested.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/exp_list_nested.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected 3 item(s), found 2
+error: the function returns 3 arguments but 2 were provided
   ┌─ tests/checking/typing/exp_list_nested.move:6:9
   │
 6 │         (0, (S{}, R{}))

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins_invalid.exp
@@ -1,96 +1,96 @@
 
 Diagnostics:
-error: invalid call of `exists`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
   ┌─ tests/checking/typing/global_builtins_invalid.move:5:24
   │
 5 │         let _ : bool = exists<R>();
   │                        ^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 0)
+error: the function takes 2 arguments but 0 were provided
   ┌─ tests/checking/typing/global_builtins_invalid.move:6:18
   │
 6 │         let () = move_to<R>();
   │                  ^^^^^^^^^^^^
 
-error: invalid call of `borrow_global`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
   ┌─ tests/checking/typing/global_builtins_invalid.move:7:22
   │
 7 │         let _ : &R = borrow_global<R>();
   │                      ^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `borrow_global_mut`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
   ┌─ tests/checking/typing/global_builtins_invalid.move:8:26
   │
 8 │         let _ : &mut R = borrow_global_mut<R>();
   │                          ^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_from`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
   ┌─ tests/checking/typing/global_builtins_invalid.move:9:20
   │
 9 │         let R {} = move_from<R>();
   │                    ^^^^^^^^^^^^^^
 
-error: invalid call of `exists`: expected `address` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `address`
    ┌─ tests/checking/typing/global_builtins_invalid.move:13:34
    │
 13 │         let _ : bool = exists<R>(0);
    │                                  ^
 
-error: invalid call of `move_to`: expected `M::R` but found `integer` for argument 2
+error: cannot use `integer` with an operator which expects a value of type `R`
    ┌─ tests/checking/typing/global_builtins_invalid.move:14:32
    │
 14 │         let () = move_to<R>(a, 0);
    │                                ^
 
-error: invalid call of `borrow_global`: expected `address` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `address`
    ┌─ tests/checking/typing/global_builtins_invalid.move:16:39
    │
 16 │         let _ : &R = borrow_global<R>(0);
    │                                       ^
 
-error: invalid call of `borrow_global_mut`: expected `address` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `address`
    ┌─ tests/checking/typing/global_builtins_invalid.move:17:47
    │
 17 │         let _ : &mut R = borrow_global_mut<R>(0);
    │                                               ^
 
-error: invalid call of `move_from`: expected `address` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `address`
    ┌─ tests/checking/typing/global_builtins_invalid.move:18:33
    │
 18 │         let R {} = move_from<R>(0);
    │                                 ^
 
-error: invalid call of `exists`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:22:24
    │
 22 │         let _ : bool = exists<R>(@0x0, 0);
    │                        ^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 3)
+error: the function takes 2 arguments but 3 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:23:18
    │
 23 │         let () = move_to<R>(a, R{}, 0);
    │                  ^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 3)
+error: the function takes 2 arguments but 3 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:24:18
    │
 24 │         let () = move_to(a, R{}, 0);
    │                  ^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `borrow_global`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:25:22
    │
 25 │         let _ : &R = borrow_global<R>(@0x0, false);
    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `borrow_global_mut`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:26:26
    │
 26 │         let _ : &mut R = borrow_global_mut<R>(@0x0, true);
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_from`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/global_builtins_invalid.move:27:20
    │
 27 │         let R {} = move_from<R>(@0x0, 0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/if_branches_subtype_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/if_branches_subtype_invalid.exp
@@ -1,109 +1,103 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:3:37
   │
 3 │         let _: &mut u64 = if (cond) u else u_mut;
   │                                     ^
 
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:4:48
   │
 4 │         let _: &mut u64 = if (cond) u_mut else u;
   │                                                ^
 
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:5:37
   │
 5 │         let _: &mut u64 = if (cond) u else u;
   │                                     ^
 
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:5:44
   │
 5 │         let _: &mut u64 = if (cond) u else u;
   │                                            ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&bool` to annotated type `&u64`
   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:9:40
   │
 9 │         let _: &u64 = if (cond) u else b;
   │                                        ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&bool` to annotated type `&u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:10:33
    │
 10 │         let _: &u64 = if (cond) b else u;
    │                                 ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&bool` to annotated type `&u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:12:44
    │
 12 │         let _: &u64 = if (cond) u_mut else b;
    │                                            ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&bool` to annotated type `&u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:13:33
    │
 13 │         let _: &u64 = if (cond) b else u_mut;
    │                                 ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&mut bool` to annotated type `&u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:15:40
    │
 15 │         let _: &u64 = if (cond) u else b_mut;
    │                                        ^^^^^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&mut bool` to annotated type `&u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:16:33
    │
 16 │         let _: &u64 = if (cond) b_mut else u;
    │                                 ^^^^^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&mut bool` to annotated type `&mut u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:19:48
    │
 19 │         let _: &mut u64 = if (cond) u_mut else b_mut;
    │                                                ^^^^^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `&mut bool` to annotated type `&mut u64`
    ┌─ tests/checking/typing/if_branches_subtype_invalid.move:20:37
    │
 20 │         let _: &mut u64 = if (cond) b_mut else u_mut;
    │                                     ^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:25:55
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:25:54
    │
 25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
-   │                                                       ^
+   │                                                      ^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:25:58
-   │
-25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
-   │                                                          ^
-
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:26:62
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:26:54
    │
 26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
-   │                                                              ^
+   │                                                      ^^^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:26:71
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:26:70
    │
 26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
-   │                                                                       ^
+   │                                                                      ^^^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:27:55
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:27:54
    │
 27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
-   │                                                       ^
+   │                                                      ^^^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:27:78
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/if_branches_subtype_invalid.move:27:70
    │
 27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
-   │                                                                              ^
+   │                                                                      ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/if_condition_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/if_condition_invalid.exp
@@ -1,48 +1,48 @@
 
 Diagnostics:
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/if_condition_invalid.move:3:13
   │
 3 │         if (()) () else ();
   │             ^^
 
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/if_condition_invalid.move:4:13
   │
 4 │         if ((())) () else ();
   │             ^^^^
 
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/if_condition_invalid.move:5:13
   │
 5 │         if ({}) () else ()
   │             ^^
 
-error: expected `bool` but found `T`
+error: expected `bool` but found a value of type `T`
   ┌─ tests/checking/typing/if_condition_invalid.move:9:13
   │
 9 │         if (x) () else ();
   │             ^
 
-error: expected `bool` but found `integer`
+error: expected `bool` but found a value of type `integer`
    ┌─ tests/checking/typing/if_condition_invalid.move:10:13
    │
 10 │         if (0) () else ();
    │             ^
 
-error: expected `bool` but found `address`
+error: expected `bool` but found a value of type `address`
    ┌─ tests/checking/typing/if_condition_invalid.move:11:13
    │
 11 │         if (@0x0) () else ()
    │             ^^^^
 
-error: expected `bool` but found `(?3, ?4)`
+error: expected `bool` but found a value of type `(bool, bool)`
    ┌─ tests/checking/typing/if_condition_invalid.move:15:13
    │
 15 │         if ((false, true)) () else ();
    │             ^^^^^^^^^^^^^
 
-error: expected `bool` but found `(?5, ?6)`
+error: expected `bool` but found a value of type `(integer, bool)`
    ┌─ tests/checking/typing/if_condition_invalid.move:16:13
    │
 16 │         if ((0, false)) () else ()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/if_mismatched_branches.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/if_mismatched_branches.exp
@@ -1,54 +1,54 @@
 
 Diagnostics:
-error: expected `()` but found `integer` (in if-else)
+error: expected `integer` but found a value of type `()`
   ┌─ tests/checking/typing/if_mismatched_branches.move:3:9
   │
 3 │         if (cond) () else 0;
   │         ^^^^^^^^^^^^^^^^^^^
 
-error: expected `()` but found `integer` (in if-else)
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/if_mismatched_branches.move:4:9
   │
 4 │         if (cond) 0 else ();
   │         ^^^^^^^^^^^^^^^^^^^
 
-error: expected `address` but found `integer` (in if-else)
+error: expected `integer` but found a value of type `address`
   ┌─ tests/checking/typing/if_mismatched_branches.move:8:9
   │
 8 │         if (cond) @0x0 else 0;
   │         ^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer` (in if-else)
+error: expected `bool` but found a value of type `integer`
   ┌─ tests/checking/typing/if_mismatched_branches.move:9:9
   │
 9 │         if (cond) 0 else false;
   │         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer` (in if-else)
+error: expected `(integer, integer)` but found a value of type `(integer, bool)`
    ┌─ tests/checking/typing/if_mismatched_branches.move:13:9
    │
 13 │         if (cond) (0, false) else (1, 1);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer` (in if-else)
+error: expected `(bool, bool)` but found a value of type `(integer, bool)`
    ┌─ tests/checking/typing/if_mismatched_branches.move:14:9
    │
 14 │         if (cond) (0, false) else (false, false);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer` (in if-else)
+error: expected `(bool, address)` but found a value of type `(integer, bool)`
    ┌─ tests/checking/typing/if_mismatched_branches.move:15:9
    │
 15 │         if (cond) (0, false) else (true, @0x0);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: tuples have different arity (3 != 2) (in if-else)
+error: expected 2 items but found 3
    ┌─ tests/checking/typing/if_mismatched_branches.move:19:9
    │
 19 │         if (cond) (0, false, 0) else (0, false);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: tuples have different arity (2 != 3) (in if-else)
+error: expected 3 items but found 2
    ┌─ tests/checking/typing/if_mismatched_branches.move:20:9
    │
 20 │         if (cond) (0, false) else (0, false, 0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_chain_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_chain_missing.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: field `f` not declared in struct `M::X1`
+error: field `f` not declared in struct `X1`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:7:9
   │
 7 │         x1.f;
   │         ^^
 
-error: field `f` not declared in struct `M::X2`
+error: field `f` not declared in struct `X2`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:8:9
   │
 8 │         x1.x2.f;
   │         ^^^^^
 
-error: field `g` not declared in struct `M::X3`
+error: field `g` not declared in struct `X3`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:9:9
   │
 9 │         x1.x2.x3.g;
@@ -24,19 +24,19 @@ error: expected a struct with field `g` but found `u64`
 10 │         x1.x2.x3.f.g;
    │         ^^^^^^^^^^
 
-error: field `f` not declared in struct `M::X1`
+error: field `f` not declared in struct `X1`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:11:9
    │
 11 │         x1_mut.f;
    │         ^^^^^^
 
-error: field `f` not declared in struct `M::X2`
+error: field `f` not declared in struct `X2`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:12:9
    │
 12 │         x1_mut.x2.f;
    │         ^^^^^^^^^
 
-error: field `g` not declared in struct `M::X3`
+error: field `g` not declared in struct `X3`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_chain_missing.move:13:9
    │
 13 │         x1_mut.x2.x3.g;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_from_non_struct.exp
@@ -42,7 +42,7 @@ error: expected a struct with field `R` but found `()`
 12 │         ().R;
    │         ^^
 
-error: expected a struct with field `f` but found `(?18, ?19)`
+error: expected a struct with field `f` but found `(S, S)`
    ┌─ tests/checking/typing/implicit_deref_borrow_field_from_non_struct.move:13:9
    │
 13 │         (S{f: 0}, S{f:0}).f;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_missing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_missing.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: field `g` not declared in struct `M::S`
+error: field `g` not declared in struct `S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:5:9
   │
 5 │         s.g;
   │         ^
 
-error: field `g` not declared in struct `M::S`
+error: field `g` not declared in struct `S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:6:9
   │
 6 │         sref.g;
   │         ^^^^
 
-error: field `h` not declared in struct `M::S`
+error: field `h` not declared in struct `S`
   ┌─ tests/checking/typing/implicit_deref_borrow_field_missing.move:7:9
   │
 7 │         s_mut.h;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -6,37 +6,37 @@ error: `M::reduce` is a function and not a macro
 34 │         foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
    │                                     ^^^^^^
 
-error: expected `&T` but found `(&T, u64)`
+error: expected `|(&T, u64)|_` but found a value of type `|&T|`
    ┌─ tests/checking/typing/lambda.move:40:13
    │
 40 │             action(XVector::borrow(v, i), i); // expected to have wrong argument count
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `&T` but found `u64`
+error: expected `|u64|_` but found a value of type `|&T|`
    ┌─ tests/checking/typing/lambda.move:48:13
    │
 48 │             action(i); // expected to have wrong argument type
    │             ^^^^^^^^^
 
-error: invalid call of `+`: expected `u64` but found `()` for argument 2
+error: cannot use `()` with an operator which expects a value of type `u64`
    ┌─ tests/checking/typing/lambda.move:56:21
    │
 56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `|integer|()` but found `u64`
+error: cannot return `u64` from a function with result type `|integer|`
    ┌─ tests/checking/typing/lambda.move:61:9
    │
 61 │         x(1) // expected to be not a function
    │         ^^^^
 
-error: invalid call of `M::foreach`: expected `integer` but found `&?19` for argument 2
+error: cannot pass `|integer|` to a function which expects argument of type `|&integer|`
    ┌─ tests/checking/typing/lambda.move:67:21
    │
 67 │         foreach(&v, |e| sum = sum + e) // expected to cannot infer type
    │                     ^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foreach`: expected `()` but found `integer` for argument 2
+error: cannot pass `|&integer|integer` to a function which expects argument of type `|&integer|`
    ┌─ tests/checking/typing/lambda.move:73:21
    │
 73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda

--- a/third_party/move/move-compiler-v2/tests/checking/typing/loop_body_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/loop_body_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/loop_body_invalid.move:3:14
   │
 3 │         loop 0
   │              ^
 
-error: expected `()` but found `bool`
+error: expected expression with no value but found `bool`
   ┌─ tests/checking/typing/loop_body_invalid.move:7:14
   │
 7 │         loop false
   │              ^^^^^
 
-error: expected `()` but found `address`
+error: expected expression with no value but found `address`
    ┌─ tests/checking/typing/loop_body_invalid.move:11:16
    │
 11 │         loop { @0x0 }
    │                ^^^^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
    ┌─ tests/checking/typing/loop_body_invalid.move:15:27
    │
 15 │         loop { let x = 0; x }
    │                           ^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
    ┌─ tests/checking/typing/loop_body_invalid.move:19:26
    │
 19 │         loop { if (true) 1 else 0 }
    │                          ^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
    ┌─ tests/checking/typing/loop_body_invalid.move:19:33
    │
 19 │         loop { if (true) 1 else 0 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/loop_result_type_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/loop_result_type_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: expected `X::R` but found `()`
+error: cannot return nothing from a function with result type `X::R`
    ┌─ tests/checking/typing/loop_result_type_invalid.move:11:9
    │
 11 │         loop { if (false) break }
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `u64` but found `()`
+error: cannot return nothing from a function with result type `u64`
    ┌─ tests/checking/typing/loop_result_type_invalid.move:15:9
    │
 15 │         loop { let x = 0; break }
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: expected `u64` but found `()` for argument 1
+error: cannot pass `()` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/loop_result_type_invalid.move:19:13
    │
 19 │         foo(loop { break })
    │             ^^^^^^^^^^^^^^
 
-error: expected 0 item(s), found 2
+error: the left-hand side has 2 items but the right-hand side provided 0
    ┌─ tests/checking/typing/loop_result_type_invalid.move:26:13
    │
 26 │         let (x, y) = loop { if (false) break };

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:43:26
    │
 43 │         let () = X::bing(X::baz(X::bar(X::foo()))); // invalid
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:43:18
    │
 43 │         let () = X::bing(X::baz(X::bar(X::foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:44:27
    │
 44 │         let () = X::bing (X::baz (X::bar (X::foo()))); // invalid
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:44:18
    │
 44 │         let () = X::bing (X::baz (X::bar (X::foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:45:27
    │
 45 │         let () = X::bing (X::baz (X::bar(1))); // invalid
    │                           ^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:45:18
    │
 45 │         let () = X::bing (X::baz (X::bar(1))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:46:18
    │
 46 │         let () = X::bing (X::baz (@0x0, 1)); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:51:23
    │
 51 │         let () = bing(baz(bar(foo()))); // invalid
    │                       ^^^^^^^^^^^^^^^
 
-error: invalid call of `M::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:51:18
    │
 51 │         let () = bing(baz(bar(foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:52:24
    │
 52 │         let () = bing (baz (bar (foo()))); // invalid
    │                        ^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:52:18
    │
 52 │         let () = bing (baz (bar (foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:53:24
    │
 53 │         let () = bing (baz (bar(1))); // invalid
    │                        ^^^^^^^^^^^^
 
-error: invalid call of `M::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:53:18
    │
 53 │         let () = bing (baz (bar(1))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::bing`: argument count mismatch (expected 3 but found 1)
+error: the function takes 3 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call.move:54:18
    │
 54 │         let () = bing (baz (@0x0, 1)); // invalid

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_complicated_rhs.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_complicated_rhs.exp
@@ -1,72 +1,72 @@
 
 Diagnostics:
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:11:9
    │
 11 │         foo (if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:13:9
    │
 13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:17:9
    │
 17 │         foo(if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:19:9
    │
 19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:23:9
    │
 23 │         foo({});
    │         ^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:24:9
    │
 24 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:31:9
    │
 31 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:32:9
    │
 32 │         baz({ let a = false; (a, x) });
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:36:9
    │
 36 │         foo({});
    │         ^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:37:9
    │
 37 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:44:9
    │
 44 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:45:9
    │
 45 │         baz({ let a = false; (a, x) });

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_explicit_type_arguments_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_explicit_type_arguments_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: invalid call of `M::foo`: expected `u64` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `u64`
   ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:6:23
   │
 6 │         foo<u64, u64>(false, false);
   │                       ^^^^^
 
-error: invalid call of `M::foo`: expected `bool` but found `integer` for argument 1
+error: cannot pass `integer` to a function which expects argument of type `bool`
   ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:7:25
   │
 7 │         foo<bool, bool>(0, false);
   │                         ^
 
-error: invalid call of `M::foo`: expected `bool` but found `integer` for argument 2
+error: cannot pass `integer` to a function which expects argument of type `bool`
   ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:8:32
   │
 8 │         foo<bool, bool>(false, 0);
   │                                ^
 
-error: invalid call of `M::foo`: expected `bool` but found `integer` for argument 1
+error: cannot pass `integer` to a function which expects argument of type `bool`
   ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:9:25
   │
 9 │         foo<bool, bool>(0, 0);
   │                         ^
 
-error: invalid call of `M::foo`: expected `U` but found `T` for argument 1
+error: cannot pass `T` to a function which expects argument of type `U`
    ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:13:21
    │
 13 │         foo<U, u64>(t, 0);
    │                     ^
 
-error: invalid call of `M::foo`: expected `V` but found `U` for argument 1
+error: cannot pass `U` to a function which expects argument of type `V`
    ┌─ tests/checking/typing/module_call_explicit_type_arguments_invalid.move:14:19
    │
 14 │         foo<V, T>(u, v);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_argument_in_list.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_argument_in_list.exp
@@ -1,72 +1,72 @@
 
 Diagnostics:
-error: invalid call of `M::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:20:13
    │
 20 │         foo(false, 0, S{});
    │             ^^^^^
 
-error: invalid call of `M::foo`: expected `u64` but found `bool` for argument 2
+error: cannot pass `bool` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:21:19
    │
 21 │         foo(@0x0, false, S{});
    │                   ^^^^^
 
-error: invalid call of `M::foo`: expected `M::S` but found `bool` for argument 3
+error: cannot pass `bool` to a function which expects argument of type `S`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:22:22
    │
 22 │         foo(@0x0, 0, false);
    │                      ^^^^^
 
-error: invalid call of `M::foo`: expected `u64` but found `bool` for argument 2
+error: cannot pass `bool` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:23:19
    │
 23 │         foo(@0x0, false, false);
    │                   ^^^^^
 
-error: invalid call of `M::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:24:13
    │
 24 │         foo(false, 0, false);
    │             ^^^^^
 
-error: invalid call of `M::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:25:13
    │
 25 │         foo(false, false, S{});
    │             ^^^^^
 
-error: invalid call of `X::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:29:16
    │
 29 │         X::foo(false, 0, X::s());
    │                ^^^^^
 
-error: invalid call of `X::foo`: expected `u64` but found `bool` for argument 2
+error: cannot pass `bool` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:30:22
    │
 30 │         X::foo(@0x0, false, X::s());
    │                      ^^^^^
 
-error: invalid call of `X::foo`: expected `X::S` but found `M::S` for argument 3
+error: cannot pass `S` to a function which expects argument of type `X::S`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:31:25
    │
 31 │         X::foo(@0x0, 0, S{});
    │                         ^^^
 
-error: invalid call of `X::foo`: expected `u64` but found `bool` for argument 2
+error: cannot pass `bool` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:32:22
    │
 32 │         X::foo(@0x0, false, S{});
    │                      ^^^^^
 
-error: invalid call of `X::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:33:16
    │
 33 │         X::foo(false, 0, S{});
    │                ^^^^^
 
-error: invalid call of `X::foo`: expected `address` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `address`
    ┌─ tests/checking/typing/module_call_wrong_argument_in_list.move:34:16
    │
 34 │         X::foo(false, false, X::s());

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_arity.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: invalid call of `X::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:27:9
    │
 27 │         X::foo(1);
    │         ^^^^^^^^^
 
-error: invalid call of `X::foo`: argument count mismatch (expected 0 but found 2)
+error: the function takes 0 arguments but 2 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:28:9
    │
 28 │         X::foo(1, 2);
    │         ^^^^^^^^^^^^
 
-error: invalid call of `X::bar`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:29:9
    │
 29 │         X::bar();
    │         ^^^^^^^^
 
-error: invalid call of `X::bar`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:30:9
    │
 30 │         X::bar(1, 2);
    │         ^^^^^^^^^^^^
 
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 0)
+error: the function takes 2 arguments but 0 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:31:9
    │
 31 │         X::baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:32:9
    │
 32 │         X::baz<u64, u64>(1);
    │         ^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `X::baz`: argument count mismatch (expected 2 but found 3)
+error: the function takes 2 arguments but 3 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:33:9
    │
 33 │         X::baz(1, 2, 3);
    │         ^^^^^^^^^^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 1)
+error: the function takes 0 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:37:9
    │
 37 │         foo(1);
    │         ^^^^^^
 
-error: invalid call of `M::foo`: argument count mismatch (expected 0 but found 2)
+error: the function takes 0 arguments but 2 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:38:9
    │
 38 │         foo(1, 2);
    │         ^^^^^^^^^
 
-error: invalid call of `M::bar`: argument count mismatch (expected 1 but found 0)
+error: the function takes 1 argument but 0 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:39:9
    │
 39 │         bar();
    │         ^^^^^
 
-error: invalid call of `M::bar`: argument count mismatch (expected 1 but found 2)
+error: the function takes 1 argument but 2 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:40:9
    │
 40 │         bar(1, 2);
    │         ^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 0)
+error: the function takes 2 arguments but 0 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:41:9
    │
 41 │         baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:42:9
    │
 42 │         baz<u64, u64>(1);
    │         ^^^^^^^^^^^^^^^^
 
-error: invalid call of `M::baz`: argument count mismatch (expected 2 but found 3)
+error: the function takes 2 arguments but 3 were provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:43:9
    │
 43 │         baz(1, 2, 3);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_single_argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_single_argument.exp
@@ -1,42 +1,42 @@
 
 Diagnostics:
-error: invalid call of `M::foo`: expected `M::S` but found `integer` for argument 1
+error: cannot pass `integer` to a function which expects argument of type `S`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:24:13
    │
 24 │         foo(0);
    │             ^
 
-error: invalid call of `M::bar`: expected `u64` but found `M::S` for argument 1
+error: cannot pass `S` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:25:13
    │
 25 │         bar(S{});
    │             ^^^
 
-error: invalid call of `M::bar`: expected `u64` but found `address` for argument 1
+error: cannot pass `address` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:26:13
    │
 26 │         bar(@0x0);
    │             ^^^^
 
-error: invalid call of `X::foo`: expected `X::S` but found `M::S` for argument 1
+error: cannot pass `S` to a function which expects argument of type `X::S`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:30:16
    │
 30 │         X::foo(S{});
    │                ^^^
 
-error: invalid call of `X::foo`: expected `X::S` but found `integer` for argument 1
+error: cannot pass `integer` to a function which expects argument of type `X::S`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:31:16
    │
 31 │         X::foo(0);
    │                ^
 
-error: invalid call of `X::bar`: expected `u64` but found `M::S` for argument 1
+error: cannot pass `S` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:32:16
    │
 32 │         X::bar(S{});
    │                ^^^
 
-error: invalid call of `X::bar`: expected `u64` but found `bool` for argument 1
+error: cannot pass `bool` to a function which expects argument of type `u64`
    ┌─ tests/checking/typing/module_call_wrong_single_argument.move:33:16
    │
 33 │         X::bar(false);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutate_immutable.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutate_immutable.exp
@@ -1,19 +1,22 @@
-
-Diagnostics:
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/mutate_immutable.move:5:10
-  │
-5 │         *(s: &S) = S { f: 0 };
-  │          ^^^^^^^
-
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/mutate_immutable.move:6:10
-  │
-6 │         *&0 = 1;
-  │          ^^
-
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/mutate_immutable.move:10:10
-   │
-10 │         *x_ref = 0;
-   │          ^^^^^
+// ---- Model Dump
+module 0x8675309::M {
+    struct S {
+        f: u64,
+    }
+    private fun t0(s: &mut M::S) {
+        s = pack M::S(0);
+        Borrow(Immutable)(0) = 1;
+        {
+          let x: u64 = 0;
+          {
+            let x_ref: &mut u64 = Borrow(Mutable)(x);
+            {
+              let x_ref: &u64 = x_ref;
+              x_ref = 0;
+              Tuple()
+            }
+          }
+        }
+    }
+    spec fun $t0(s: &mut M::S);
+} // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutate_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutate_invalid.exp
@@ -1,73 +1,61 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
-  ┌─ tests/checking/typing/mutate_invalid.move:6:15
+error: cannot assign `&mut bool` to left-hand side of type `&mut integer`
+  ┌─ tests/checking/typing/mutate_invalid.move:6:10
   │
 6 │         *&mut 0 = false;
-  │               ^
+  │          ^^^^^^
 
-error: expected `&integer` but found `u64`
-  ┌─ tests/checking/typing/mutate_invalid.move:7:15
-  │
-7 │         *&mut S{f:0}.f = &1;
-  │               ^^^^^^^^
-
-error: cannot borrow from a reference
+error: cannot assign `&mut &integer` to left-hand side of type `&mut u64`
   ┌─ tests/checking/typing/mutate_invalid.move:7:10
   │
 7 │         *&mut S{f:0}.f = &1;
   │          ^^^^^^^^^^^^^
 
-error: expected `(integer, integer)` but found `u64`
+error: cannot assign `&mut (integer, integer)` to left-hand side of type `&mut u64`
   ┌─ tests/checking/typing/mutate_invalid.move:8:10
   │
 8 │         *foo(&mut 0) = (1, 0);
   │          ^^^^^^^^^^^
 
-error: expected `()` but found `u64`
+error: expected expression with no value but found `u64`
   ┌─ tests/checking/typing/mutate_invalid.move:9:9
   │
 9 │         bar(&mut S{f:0}).f = ();
   │         ^^^^^^^^^^^^^^^^^^
 
-error: expected `&integer` but found `u64`
-   ┌─ tests/checking/typing/mutate_invalid.move:10:15
-   │
-10 │         *&mut bar(&mut S{f:0}).f = &0;
-   │               ^^^^^^^^^^^^^^^^^^
-
-error: cannot borrow from a reference
+error: cannot assign `&mut &integer` to left-hand side of type `&mut u64`
    ┌─ tests/checking/typing/mutate_invalid.move:10:10
    │
 10 │         *&mut bar(&mut S{f:0}).f = &0;
    │          ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/checking/typing/mutate_invalid.move:11:9
    │
 11 │         baz().f = false;
    │         ^^^^^^^
 
-error: expected `bool` but found `u64`
-   ┌─ tests/checking/typing/mutate_invalid.move:12:15
+error: cannot assign `&mut bool` to left-hand side of type `&mut u64`
+   ┌─ tests/checking/typing/mutate_invalid.move:12:10
    │
 12 │         *&mut baz().f = false;
-   │               ^^^^^^^
+   │          ^^^^^^^^^^^^
 
-error: expected `M::X` but found `M::S`
+error: cannot assign `&mut X` to left-hand side of type `&mut S`
    ┌─ tests/checking/typing/mutate_invalid.move:17:10
    │
 17 │         *r = X { f: 1 };
    │          ^
 
-error: expected `&integer` but found `u64`
+error: expected `&integer` but found a value of type `u64`
    ┌─ tests/checking/typing/mutate_invalid.move:19:9
    │
 19 │         r.f = &0;
    │         ^^^
 
-error: expected `()` but found `u64`
-   ┌─ tests/checking/typing/mutate_invalid.move:20:15
+error: cannot assign `&mut ()` to left-hand side of type `&mut u64`
+   ┌─ tests/checking/typing/mutate_invalid.move:20:10
    │
 20 │         *&mut r.f = ();
-   │               ^^^
+   │          ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutate_non_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutate_non_ref.exp
@@ -1,48 +1,48 @@
 
 Diagnostics:
-error: expected `&mut integer` but found `integer`
+error: cannot assign `&mut integer` to left-hand side of type `integer`
   ┌─ tests/checking/typing/mutate_non_ref.move:7:10
   │
 7 │         *u = 1;
   │          ^
 
-error: expected `&mut M::S` but found `M::S`
+error: cannot assign `&mut S` to left-hand side of type `S`
    ┌─ tests/checking/typing/mutate_non_ref.move:10:10
    │
 10 │         *s = S { f: 0 };
    │          ^
 
-error: expected `&mut integer` but found `u64`
+error: cannot assign `&mut integer` to left-hand side of type `u64`
    ┌─ tests/checking/typing/mutate_non_ref.move:11:10
    │
 11 │         *s.f = 0;
    │          ^^^
 
-error: expected `&mut integer` but found `u64`
+error: cannot assign `&mut integer` to left-hand side of type `u64`
    ┌─ tests/checking/typing/mutate_non_ref.move:14:10
    │
 14 │         *s_ref.f = 0;
    │          ^^^^^^^
 
-error: expected `&mut M::S` but found `M::S`
+error: cannot assign `&mut S` to left-hand side of type `S`
    ┌─ tests/checking/typing/mutate_non_ref.move:17:10
    │
 17 │         *x.s = S { f: 0 };
    │          ^^^
 
-error: expected `&mut integer` but found `u64`
+error: cannot assign `&mut integer` to left-hand side of type `u64`
    ┌─ tests/checking/typing/mutate_non_ref.move:18:10
    │
 18 │         *x.s.f = 0;
    │          ^^^^^
 
-error: expected `&mut M::S` but found `M::S`
+error: cannot assign `&mut S` to left-hand side of type `S`
    ┌─ tests/checking/typing/mutate_non_ref.move:21:10
    │
 21 │         *x_ref.s = S{ f: 0 };
    │          ^^^^^^^
 
-error: expected `&mut integer` but found `u64`
+error: cannot assign `&mut integer` to left-hand side of type `u64`
    ┌─ tests/checking/typing/mutate_non_ref.move:22:10
    │
 22 │         *x_ref.s.f = 0;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
@@ -1,91 +1,67 @@
 
 Diagnostics:
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:13:9
+error: cannot use `u128` with an operator which expects a value of type `u8`
+   ┌─ tests/checking/typing/neq_invalid.move:13:21
    │
 13 │         (0: u8) != (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?3` but found `u8` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (expected `u8` but found `u128` for argument 2)
+   │                     ^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:14:9
+error: cannot use `bool` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/neq_invalid.move:14:14
    │
 14 │         0 != false;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?9` but found `integer` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (expected `integer` but found `bool` for argument 2)
+   │              ^^^^^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:15:9
+error: cannot use `integer` with an operator which expects a value of type `&integer`
+   ┌─ tests/checking/typing/neq_invalid.move:15:15
    │
 15 │         &0 != 1;
-   │         ^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?17` but found `integer` for argument 2)
-   = outruled candidate `!=(#0, #0): bool` (expected `&integer` but found `integer` for argument 2)
+   │               ^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:16:9
+error: cannot use `&integer` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/neq_invalid.move:16:14
    │
 16 │         1 != &0;
-   │         ^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?25` but found `integer` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (expected `integer` but found `&integer` for argument 2)
+   │              ^^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:17:9
+error: cannot use `&S` with an operator which expects a value of type `S`
+   ┌─ tests/checking/typing/neq_invalid.move:17:14
    │
 17 │         s != s_ref;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?30` but found `M::S` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (expected `M::S` but found `&M::S` for argument 2)
+   │              ^^^^^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:18:9
+error: cannot use `S` with an operator which expects a value of type `&mut S`
+   ┌─ tests/checking/typing/neq_invalid.move:18:18
    │
 18 │         s_mut != s;
-   │         ^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&M::S` but found `M::S` for argument 2)
-   = outruled candidate `!=(#0, #0): bool` (expected `&mut M::S` but found `M::S` for argument 2)
+   │                  ^
 
-error: unable to infer type: `M::G0<?4>`
+error: unable to infer instantiation of type `G0<_>` (consider providing type arguments or annotating the type)
    ┌─ tests/checking/typing/neq_invalid.move:26:9
    │
 26 │         G0{} != G0{};
    │         ^^^^
 
-error: unable to infer type: `M::G1<?11>`
+error: unable to infer instantiation of type `G1<_>` (consider providing type arguments or annotating the type)
    ┌─ tests/checking/typing/neq_invalid.move:27:9
    │
 27 │         G1{} != G1{};
    │         ^^^^
 
-error: unable to infer type: `M::G2<?18>`
+error: unable to infer instantiation of type `G2<_>` (consider providing type arguments or annotating the type)
    ┌─ tests/checking/typing/neq_invalid.move:28:9
    │
 28 │         G2{} != G2{};
    │         ^^^^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:34:9
+error: the operator takes 2 arguments but 3 were provided
+   ┌─ tests/checking/typing/neq_invalid.move:34:22
    │
 34 │         (1, 2, 3) != (0, 1);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?31` but found `(integer, integer, integer)` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (tuples have different arity (3 != 2) for argument 2)
+   │                      ^^^^^^
 
-error: no matching declaration of `!=`
-   ┌─ tests/checking/typing/neq_invalid.move:35:9
+error: the operator takes 3 arguments but 2 were provided
+   ┌─ tests/checking/typing/neq_invalid.move:35:19
    │
 35 │         (0, 1) != (1, 2, 3);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `!=(&#0, &#0): bool` (expected `&?46` but found `(integer, integer)` for argument 1)
-   = outruled candidate `!=(#0, #0): bool` (tuples have different arity (2 != 3) for argument 2)
+   │                   ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/other_builtins_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/other_builtins_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: invalid call of `freeze`: mutability mismatch (&mut != &) for argument 1
+error: the operator takes `&mut` but `&` was provided
   ┌─ tests/checking/typing/other_builtins_invalid.move:4:22
   │
 4 │         (freeze<u64>(x): &mut u64);
   │                      ^
 
-error: invalid call of `freeze`: mutability mismatch (&mut != &) for argument 1
+error: the operator takes `&mut` but `&` was provided
   ┌─ tests/checking/typing/other_builtins_invalid.move:5:31
   │
 5 │         (freeze<vector<bool>>(&any()): &mut vector<bool>);
   │                               ^^^^^^
 
-error: expected `bool` but found `integer`
+error: expected `bool` but found a value of type `integer`
   ┌─ tests/checking/typing/other_builtins_invalid.move:7:18
   │
 7 │         (assert!(42, true): ());
   │                  ^^
 
-error: expected `u64` but found `bool`
+error: expected `u64` but found a value of type `bool`
   ┌─ tests/checking/typing/other_builtins_invalid.move:7:22
   │
 7 │         (assert!(42, true): ());
   │                      ^^^^
 
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/other_builtins_invalid.move:8:10
   │
 8 │         (assert!(true && false, *x): bool);
   │          ^^^^^^
 
-error: expected `u64` but found `u8`
+error: expected `u64` but found a value of type `u8`
   ┌─ tests/checking/typing/other_builtins_invalid.move:9:32
   │
 9 │         assert!(true || false, 0u8);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/pack_invalid_argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/pack_invalid_argument.exp
@@ -1,30 +1,30 @@
 
 Diagnostics:
-error: expected `u64` but found `bool`
+error: expected `u64` but found a value of type `bool`
   ┌─ tests/checking/typing/pack_invalid_argument.move:7:17
   │
 7 │         (S { f: false } : S);
   │                 ^^^^^
 
-error: expected `M::S` but found `M::R`
+error: expected `S` but found a value of type `R`
    ┌─ tests/checking/typing/pack_invalid_argument.move:17:16
    │
 17 │             s: r,
    │                ^
 
-error: expected `u64` but found `bool`
+error: expected `u64` but found a value of type `bool`
    ┌─ tests/checking/typing/pack_invalid_argument.move:18:16
    │
 18 │             f: false,
    │                ^^^^^
 
-error: expected `u64` but found `bool`
+error: expected `Nat<u64>` but found a value of type `Nat<bool>`
    ┌─ tests/checking/typing/pack_invalid_argument.move:19:17
    │
 19 │             n1: Nat { f: false },
    │                 ^^^^^^^^^^^^^^^^
 
-error: expected `M::S` but found `M::R`
+error: expected `Nat<S>` but found a value of type `Nat<R>`
    ┌─ tests/checking/typing/pack_invalid_argument.move:20:17
    │
 20 │             n2: Nat{ f: r }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/pack_multiple.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/pack_multiple.exp
@@ -12,7 +12,7 @@ error: invalid type instantiation `(u64, u64, u64)`: only structs, vectors, and 
 6 │         Box { f: (0, 1, 2) };
   │         ^^^^^^^^^^^^^^^^^^^^
 
-error: invalid type instantiation `(bool, M::Box<u64>)`: only structs, vectors, and primitive types allowed
+error: invalid type instantiation `(bool, Box<u64>)`: only structs, vectors, and primitive types allowed
   ┌─ tests/checking/typing/pack_multiple.move:7:9
   │
 7 │         Box { f: (true, Box { f: 0 }) };

--- a/third_party/move/move-compiler-v2/tests/checking/typing/pack_reference_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/pack_reference_2.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `u64` but found `bool` (from assignment or declaration context)
+error: cannot assign `bool` to left-hand side of type `u64`
   ┌─ tests/checking/typing/pack_reference_2.move:7:9
   │
 7 │         x = false

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: type unification cycle check failed (`?3 =?= (?3, integer)`, try to annotate type) (from assignment or declaration context)
+error: unable to infer type due to cyclic type constraints (try annotating the type)
   ┌─ tests/checking/typing/recursive_local.move:5:9
   │
 5 │         x = (x, 0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/return_type_explicit_exp_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/return_type_explicit_exp_invalid.exp
@@ -1,43 +1,37 @@
 
 Diagnostics:
-error: expected `u64` but found `()`
+error: cannot return nothing from a function with result type `u64`
   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:5:16
   │
 5 │         return ()
   │                ^^
 
-error: expected `()` but found `integer`
+error: cannot return `integer` from a function which returns nothing
   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:9:26
   │
 9 │         if (true) return 1 else return 0
   │                          ^
 
-error: expected `()` but found `integer`
+error: cannot return `integer` from a function which returns nothing
   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:9:40
   │
 9 │         if (true) return 1 else return 0
   │                                        ^
 
-error: expected 2 item(s), found 3
+error: the function returns 2 arguments but 3 were provided
    ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:13:21
    │
 13 │         loop return (0, false, R{});
    │                     ^^^^^^^^^^^^^^^
 
-error: expected 4 item(s), found 3
+error: the function returns 4 arguments but 3 were provided
    ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:18:29
    │
 18 │         while (true) return (0, false, R{});
    │                             ^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer`
-   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:23:31
+error: cannot return `(integer, bool, R)` from a function with result type `(bool, u64, R)`
+   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:23:30
    │
 23 │         while (false) return (0, false, R{});
-   │                               ^
-
-error: expected `u64` but found `bool`
-   ┌─ tests/checking/typing/return_type_explicit_exp_invalid.move:23:34
-   │
-23 │         while (false) return (0, false, R{});
-   │                                  ^^^^^
+   │                              ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/return_type_last_exp_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/return_type_last_exp_invalid.exp
@@ -1,37 +1,31 @@
 
 Diagnostics:
-error: expected `u64` but found `()`
+error: cannot return nothing from a function with result type `u64`
   ┌─ tests/checking/typing/return_type_last_exp_invalid.move:5:9
   │
 5 │         ()
   │         ^^
 
-error: expected `()` but found `integer`
+error: cannot return `integer` from a function which returns nothing
   ┌─ tests/checking/typing/return_type_last_exp_invalid.move:9:9
   │
 9 │         0
   │         ^
 
-error: expected 2 item(s), found 3
+error: the function returns 2 arguments but 3 were provided
    ┌─ tests/checking/typing/return_type_last_exp_invalid.move:13:9
    │
 13 │         (0, false, R{})
    │         ^^^^^^^^^^^^^^^
 
-error: expected 4 item(s), found 3
+error: the function returns 4 arguments but 3 were provided
    ┌─ tests/checking/typing/return_type_last_exp_invalid.move:17:9
    │
 17 │         (0, false, R{})
    │         ^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `integer`
-   ┌─ tests/checking/typing/return_type_last_exp_invalid.move:21:10
+error: cannot return `(integer, bool, R)` from a function with result type `(bool, u64, R)`
+   ┌─ tests/checking/typing/return_type_last_exp_invalid.move:21:9
    │
 21 │         (0, false, R{})
-   │          ^
-
-error: expected `u64` but found `bool`
-   ┌─ tests/checking/typing/return_type_last_exp_invalid.move:21:13
-   │
-21 │         (0, false, R{})
-   │             ^^^^^
+   │         ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/shadowing_invalid_types.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/shadowing_invalid_types.exp
@@ -1,54 +1,66 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot adapt `integer` to annotated type `bool`
   ┌─ tests/checking/typing/shadowing_invalid_types.move:8:10
   │
 8 │         (x: bool);
   │          ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `bool` to annotated type `u64`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:10:27
    │
 10 │         { let x = false; (x: u64); };
    │                           ^
 
-error: expected `u64` but found `address`
+error: cannot adapt `integer` to annotated type `bool`
+   ┌─ tests/checking/typing/shadowing_invalid_types.move:11:10
+   │
+11 │         (x: bool);
+   │          ^
+
+error: cannot adapt `address` to annotated type `u64`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:13:43
    │
 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
    │                                           ^
 
-error: expected `address` but found `bool`
+error: cannot adapt `bool` to annotated type `address`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:13:56
    │
 13 │         { let x = false; { let x = @0x0; (x: u64); }; (x: address); };
    │                                                        ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `integer` to annotated type `bool`
+   ┌─ tests/checking/typing/shadowing_invalid_types.move:14:10
+   │
+14 │         (x: bool);
+   │          ^
+
+error: cannot adapt `bool` to annotated type `u64`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:21:14
    │
 21 │             (x: u64);
    │              ^
 
-error: expected `u64` but found `address`
+error: cannot adapt `address` to annotated type `u64`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:25:14
    │
 25 │             (x: u64);
    │              ^
 
-error: expected `address` but found `integer`
+error: cannot adapt `integer` to annotated type `address`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:27:10
    │
 27 │         (x: address);
    │          ^
 
-error: expected `u64` but found `bool`
+error: cannot adapt `bool` to annotated type `u64`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:34:14
    │
 34 │             (x: u64);
    │              ^
 
-error: expected `bool` but found `integer`
+error: cannot adapt `integer` to annotated type `bool`
    ┌─ tests/checking/typing/shadowing_invalid_types.move:37:10
    │
 37 │         (x: bool);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/spec_block_fail.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/spec_block_fail.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: expected `u64` but found `()`
+error: cannot adapt `()` to annotated type `u64`
   ┌─ tests/checking/typing/spec_block_fail.move:3:10
   │
 3 │         (spec {}: u64);
   │          ^^^^^^^
 
-error: expected `&u64` but found `()`
+error: cannot adapt `()` to annotated type `&u64`
   ┌─ tests/checking/typing/spec_block_fail.move:4:10
   │
 4 │         (spec {}: &u64);
   │          ^^^^^^^
 
-error: tuples have different arity (0 != 2)
+error: expected 2 items but found 0
   ┌─ tests/checking/typing/spec_block_fail.move:5:10
   │
 5 │         (spec {}: (u64, u64));

--- a/third_party/move/move-compiler-v2/tests/checking/typing/specs.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/specs.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `bool` but found `u256`
+error: expected `bool` but found a value of type `u256`
   ┌─ tests/checking/typing/specs.move:5:20
   │
 5 │             assert 1;
   │                    ^
 
-error: invalid call of `+`: expected `num` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `num`
    ┌─ tests/checking/typing/specs.move:10:31
    │
 10 │         ensures result == x + true;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_annotation_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_annotation_invalid.exp
@@ -1,31 +1,25 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/subtype_annotation_invalid.move:5:10
   │
 5 │         (&0: &mut u64);
   │          ^^
 
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/subtype_annotation_invalid.move:9:11
+error: expected `&mut` but `&` was provided
+  ┌─ tests/checking/typing/subtype_annotation_invalid.move:9:10
   │
 9 │         ((&0, &0): (&mut u64, &mut u64));
-  │           ^^
+  │          ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/subtype_annotation_invalid.move:9:15
-  │
-9 │         ((&0, &0): (&mut u64, &mut u64));
-  │               ^^
-
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_annotation_invalid.move:10:11
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_annotation_invalid.move:10:10
    │
 10 │         ((&0, &0): (&mut u64, &u64));
-   │           ^^
+   │          ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_annotation_invalid.move:11:15
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_annotation_invalid.move:11:10
    │
 11 │         ((&0, &0): (&u64, &mut u64));
-   │               ^^
+   │          ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
@@ -42,5 +42,5 @@ module 0x8675309::M {
     }
     spec fun $t0();
     spec fun $t1();
-    spec fun $t2(f: |(&u64, &mut u64)|());
+    spec fun $t2(f: |(&u64, &mut u64)|);
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: invalid call of `M::mut`: mutability mismatch (&mut != &) for argument 1
+error: the function takes `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_args_invalid.move:10:18
    │
 10 │         mut<u64>(&0);
    │                  ^^
 
-error: invalid call of `M::mut`: expected `u64` but found `M::S` for argument 1
+error: cannot pass `&S` to a function which expects argument of type `&mut u64`
    ┌─ tests/checking/typing/subtype_args_invalid.move:11:18
    │
 11 │         mut<u64>(&S{});
    │                  ^^^^
 
-error: invalid call of `M::imm_mut`: mutability mismatch (&mut != &) for argument 2
+error: the function takes `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_args_invalid.move:15:26
    │
 15 │         imm_mut<u64>(&0, &0);
    │                          ^^
 
-error: invalid call of `M::mut_imm`: mutability mismatch (&mut != &) for argument 1
+error: the function takes `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_args_invalid.move:16:22
    │
 16 │         mut_imm<u64>(&0, &0);
    │                      ^^
 
-error: invalid call of `M::mut_mut`: mutability mismatch (&mut != &) for argument 1
+error: the function takes `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_args_invalid.move:17:22
    │
 17 │         mut_mut<u64>(&0, &0);
    │                      ^^
 
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_args_invalid.move:21:9
    │
 21 │         f(&0, &0); // not okay

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_assign_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_assign_invalid.exp
@@ -1,30 +1,30 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/subtype_assign_invalid.move:5:27
   │
 5 │         let x: &mut u64 = &0;
   │                           ^^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_assign_invalid.move:10:10
    │
 10 │         (x, y) = (&0, &0);
    │          ^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_assign_invalid.move:10:13
    │
 10 │         (x, y) = (&0, &0);
    │             ^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_assign_invalid.move:13:10
    │
 13 │         (x, y) = (&0, &0);
    │          ^
 
-error: mutability mismatch (&mut != &) (from assignment or declaration context)
+error: the left-hand side expected `&mut` but `&` was provided
    ┌─ tests/checking/typing/subtype_assign_invalid.move:16:13
    │
 16 │         (x, y)= (&0, &0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_bind_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_bind_invalid.exp
@@ -1,31 +1,25 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/subtype_bind_invalid.move:5:27
   │
 5 │         let x: &mut u64 = &0;
   │                           ^^
 
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/subtype_bind_invalid.move:9:45
+error: expected `&mut` but `&` was provided
+  ┌─ tests/checking/typing/subtype_bind_invalid.move:9:44
   │
 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-  │                                             ^^
+  │                                            ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-  ┌─ tests/checking/typing/subtype_bind_invalid.move:9:49
-  │
-9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-  │                                                 ^^
-
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_bind_invalid.move:10:41
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_bind_invalid.move:10:40
    │
 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
-   │                                         ^^
+   │                                        ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_bind_invalid.move:11:45
+error: expected `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_bind_invalid.move:11:40
    │
 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
-   │                                             ^^
+   │                                        ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_return_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_return_invalid.exp
@@ -1,37 +1,31 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: the function returns `&mut` but `&` was provided
   ┌─ tests/checking/typing/subtype_return_invalid.move:5:9
   │
 5 │         u
   │         ^
 
-error: mutability mismatch (&mut != &)
+error: the function returns `&mut` but `&` was provided
   ┌─ tests/checking/typing/subtype_return_invalid.move:9:9
   │
 9 │         s
   │         ^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_return_invalid.move:13:14
+error: the function returns `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_return_invalid.move:13:9
    │
 13 │         (u1, u2)
-   │              ^^
+   │         ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_return_invalid.move:17:10
+error: the function returns `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_return_invalid.move:17:9
    │
 17 │         (u1, u2)
-   │          ^^
+   │         ^^^^^^^^
 
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_return_invalid.move:21:10
+error: the function returns `&mut` but `&` was provided
+   ┌─ tests/checking/typing/subtype_return_invalid.move:21:9
    │
 21 │         (u1, u2)
-   │          ^^
-
-error: mutability mismatch (&mut != &)
-   ┌─ tests/checking/typing/subtype_return_invalid.move:21:14
-   │
-21 │         (u1, u2)
-   │              ^^
+   │         ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_pack_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_pack_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: expected `bool` but found a value of type `integer`
   ┌─ tests/checking/typing/type_variable_join_single_pack_invalid.move:5:38
   │
 5 │         let b = Box { f1: false, f2: 1 };
   │                                      ^
 
-error: expected `integer` but found `bool`
+error: expected `Box<integer>` but found a value of type `Box<bool>`
   ┌─ tests/checking/typing/type_variable_join_single_pack_invalid.move:6:55
   │
 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_assign_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_assign_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `bool` but found `u64`
+error: cannot adapt `u64` to annotated type `bool`
    ┌─ tests/checking/typing/type_variable_join_single_unpack_assign_invalid.move:13:10
    │
 13 │         (f2: bool);
    │          ^^
 
-error: expected `bool` but found `u64`
+error: cannot adapt `Box<u64>` to annotated type `Box<bool>`
    ┌─ tests/checking/typing/type_variable_join_single_unpack_assign_invalid.move:18:10
    │
 18 │         (f2: Box<bool>);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected `bool` but found `u64`
+error: cannot adapt `u64` to annotated type `bool`
    ┌─ tests/checking/typing/type_variable_join_single_unpack_invalid.move:11:10
    │
 11 │         (f2: bool);
    │          ^^
 
-error: expected `bool` but found `u64`
+error: cannot adapt `Box<u64>` to annotated type `Box<bool>`
    ┌─ tests/checking/typing/type_variable_join_single_unpack_invalid.move:14:10
    │
 14 │         (f2: Box<bool>);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_pack_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_pack_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot return `Box<integer>` from a function with result type `Box<bool>`
    ┌─ tests/checking/typing/type_variable_join_threaded_pack_invalid.move:42:9
    │
 42 │         b

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_unpack_assign_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_unpack_assign_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot return `integer` from a function with result type `bool`
    ┌─ tests/checking/typing/type_variable_join_threaded_unpack_assign_invalid.move:36:9
    │
 36 │         f1

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_unpack_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_unpack_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: cannot return `integer` from a function with result type `bool`
    ┌─ tests/checking/typing/type_variable_join_threaded_unpack_invalid.move:34:9
    │
 34 │         f1

--- a/third_party/move/move-compiler-v2/tests/checking/typing/unary_not_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/unary_not_invalid.exp
@@ -1,48 +1,48 @@
 
 Diagnostics:
-error: invalid call of `!`: expected `bool` but found `&bool` for argument 1
+error: cannot use `&bool` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/unary_not_invalid.move:7:10
   │
 7 │         !&true;
   │          ^^^^^
 
-error: invalid call of `!`: expected `bool` but found `&bool` for argument 1
+error: cannot use `&bool` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/unary_not_invalid.move:8:10
   │
 8 │         !&false;
   │          ^^^^^^
 
-error: invalid call of `!`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/unary_not_invalid.move:9:10
   │
 9 │         !0;
   │          ^
 
-error: invalid call of `!`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/unary_not_invalid.move:10:10
    │
 10 │         !1;
    │          ^
 
-error: invalid call of `!`: expected `bool` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/unary_not_invalid.move:11:10
    │
 11 │         !r;
    │          ^
 
-error: invalid call of `!`: expected `bool` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/unary_not_invalid.move:12:10
    │
 12 │         !r;
    │          ^
 
-error: invalid call of `!`: expected `bool` but found `(integer, bool)` for argument 1
+error: cannot use `(integer, bool)` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/unary_not_invalid.move:13:10
    │
 13 │         !(0, false);
    │          ^^^^^^^^^^
 
-error: invalid call of `!`: expected `bool` but found `()` for argument 1
+error: cannot use `()` with an operator which expects a value of type `bool`
    ┌─ tests/checking/typing/unary_not_invalid.move:14:10
    │
 14 │         !();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_call.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_call.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `?0`
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/uninferred_type_call.move:3:9
   │
 3 │         foo()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_pack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_pack.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `M::S<?1>`
+error: unable to infer instantiation of type `S<_>` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/uninferred_type_pack.move:5:9
   │
 5 │         S{};

--- a/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_assign.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `M::S<?2>`
+error: unable to infer instantiation of type `S<_>` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/uninferred_type_unpack_assign.move:5:15
   │
 5 │         S{} = S{};

--- a/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_bind.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_bind.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `M::S<?1>`
+error: unable to infer instantiation of type `S<_>` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/uninferred_type_unpack_bind.move:5:19
   │
 5 │         let S{} = S{};

--- a/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_decl.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/uninferred_type_unpack_decl.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `M::S<?1>`
+error: unable to infer instantiation of type `S<_>` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/uninferred_type_unpack_decl.move:5:13
   │
 5 │         let S{};

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/assign_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/assign_wrong_type.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `u64` but found `bool` (from assignment or declaration context)
+error: cannot assign `bool` to left-hand side of type `u64`
   ┌─ tests/checking/typing/v1-commands/assign_wrong_type.move:6:5
   │
 6 │     x = false

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_negative.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_negative.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected 3 item(s), found 4
+error: the left-hand side has 4 items but the right-hand side provided 3
   ┌─ tests/checking/typing/v1-commands/pop_negative.move:7:9
   │
 7 │         (_, _, _, _) = three();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_positive.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_positive.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected 3 item(s), found 2
+error: the left-hand side has 2 items but the right-hand side provided 3
   ┌─ tests/checking/typing/v1-commands/pop_positive.move:7:9
   │
 7 │         (_, _) = three();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_weird.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/pop_weird.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: expected 0 item(s), found 2
+error: the left-hand side has 2 items but the right-hand side provided 0
    ┌─ tests/checking/typing/v1-commands/pop_weird.move:13:9
    │
 13 │         (_, _) = ();
    │         ^^^^^^
 
-error: expected 0 item(s), found 1
+error: the left-hand side has 0 items but the right-hand side provided 1
    ┌─ tests/checking/typing/v1-commands/pop_weird.move:14:9
    │
 14 │         (_) = ();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/unpack_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-commands/unpack_wrong_type.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: expected `Test::X` but found `Test::T`
+error: cannot assign `T` to left-hand side of type `X`
   ┌─ tests/checking/typing/v1-commands/unpack_wrong_type.move:6:9
   │
 6 │         X { b: _ } = t;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-naming/vector_literal_type_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-naming/vector_literal_type_arity.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: wrong number of type arguments (expected 1, got 0)
+error: expected 1 items but found 0
   ┌─ tests/checking/typing/v1-naming/vector_literal_type_arity.move:4:18
   │
 4 │         let v0 = vector<>[];
   │                  ^^^^^^
 
-error: wrong number of type arguments (expected 1, got 2)
+error: expected 1 items but found 2
   ┌─ tests/checking/typing/v1-naming/vector_literal_type_arity.move:5:18
   │
 5 │         let v2 = vector<u64, bool>[0, false];

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-operators/boolean_not_non_boolean.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-operators/boolean_not_non_boolean.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: invalid call of `!`: expected `bool` but found `integer` for argument 1
+error: cannot use `integer` with an operator which expects a value of type `bool`
   ┌─ tests/checking/typing/v1-operators/boolean_not_non_boolean.move:3:6
   │
 3 │     !0;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_extra_arg.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_extra_arg.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 3)
+error: the function takes 2 arguments but 3 were provided
   ┌─ tests/checking/typing/v1-signer/move_to_extra_arg.move:5:9
   │
 5 │         move_to<R>(s, R { f: false }, a);
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 4)
+error: the function takes 2 arguments but 4 were provided
    ┌─ tests/checking/typing/v1-signer/move_to_extra_arg.move:15:9
    │
 15 │         move_to<R<bool>>(a, s, a, R<bool> { f: false });

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
   ┌─ tests/checking/typing/v1-signer/move_to_missing_resource.move:4:9
   │
 4 │         move_to<R>(s)
   │         ^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/v1-signer/move_to_missing_resource.move:14:14
    │
 14 │         () = move_to<R<bool>>(s);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_signer.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_signer.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
   ┌─ tests/checking/typing/v1-signer/move_to_missing_signer.move:4:9
   │
 4 │         move_to<R>(R { f: false })
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 1)
+error: the function takes 2 arguments but 1 were provided
    ┌─ tests/checking/typing/v1-signer/move_to_missing_signer.move:14:14
    │
 14 │         () = move_to<R<bool>>(R<bool> { f: false });

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_no_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_no_args.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 0)
+error: the function takes 2 arguments but 0 were provided
   ┌─ tests/checking/typing/v1-signer/move_to_no_args.move:4:9
   │
 4 │         move_to<R>();
   │         ^^^^^^^^^^^^
 
-error: invalid call of `move_to`: argument count mismatch (expected 2 but found 0)
+error: the function takes 2 arguments but 0 were provided
    ┌─ tests/checking/typing/v1-signer/move_to_no_args.move:12:14
    │
 12 │         () = move_to<R<bool>>();

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_non_signer.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_non_signer.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: expected `signer` but found `address` for argument 1
+error: cannot use `&address` with an operator which expects a value of type `&signer`
   ┌─ tests/checking/typing/v1-signer/move_to_non_signer.move:4:17
   │
 4 │         move_to(s, R { f: false })
   │                 ^
 
-error: invalid call of `move_to`: expected `&signer` but found `address` for argument 1
+error: cannot use `address` with an operator which expects a value of type `&signer`
    ┌─ tests/checking/typing/v1-signer/move_to_non_signer.move:12:17
    │
 12 │         move_to(s, R { f: false })

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_args_flipped.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_args_flipped.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: expected `&signer` but found `M::R` for argument 1
+error: cannot use `R` with an operator which expects a value of type `&signer`
   ┌─ tests/checking/typing/v1-signer/move_to_reference_to_args_flipped.move:4:20
   │
 4 │         move_to<R>(R { f: false }, s)
   │                    ^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: expected `&signer` but found `N::R<bool>` for argument 1
+error: cannot use `R<bool>` with an operator which expects a value of type `&signer`
    ┌─ tests/checking/typing/v1-signer/move_to_reference_to_args_flipped.move:14:26
    │
 14 │         move_to<R<bool>>(R { f: false }, s);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: expected `M::R` but found `&M::R` for argument 2
+error: cannot use `&R` with an operator which expects a value of type `R`
   ┌─ tests/checking/typing/v1-signer/move_to_reference_to_resource.move:4:23
   │
 4 │         move_to<R>(s, move r)
   │                       ^^^^^^
 
-error: invalid call of `move_to`: expected `N::R<bool>` but found `&mut N::R<bool>` for argument 2
+error: cannot use `&mut R<bool>` with an operator which expects a value of type `R<bool>`
    ┌─ tests/checking/typing/v1-signer/move_to_reference_to_resource.move:14:29
    │
 14 │         move_to<R<bool>>(s, move r)

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_wrong_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_reference_to_wrong_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: invalid call of `move_to`: expected `M::R` but found `M::X` for argument 2
+error: cannot use `X` with an operator which expects a value of type `R`
   ┌─ tests/checking/typing/v1-signer/move_to_reference_to_wrong_resource.move:5:23
   │
 5 │         move_to<R>(s, X { f: false })
   │                       ^^^^^^^^^^^^^^
 
-error: invalid call of `move_to`: expected `N::X<bool>` but found `N::R<bool>` for argument 2
+error: cannot use `R<bool>` with an operator which expects a value of type `X<bool>`
    ┌─ tests/checking/typing/v1-signer/move_to_reference_to_wrong_resource.move:16:34
    │
 16 │         () = move_to<X<bool>>(s, R { f: false })

--- a/third_party/move/move-compiler-v2/tests/checking/typing/vector_mismatched_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/vector_mismatched_args.exp
@@ -1,30 +1,30 @@
 
 Diagnostics:
-error: expected `bool` but found `integer`
+error: expected `integer` but found a value of type `bool`
   ┌─ tests/checking/typing/vector_mismatched_args.move:7:19
   │
 7 │         vector[0, false];
   │                   ^^^^^
 
-error: expected `u8` but found `u64`
+error: expected `u8` but found a value of type `u64`
   ┌─ tests/checking/typing/vector_mismatched_args.move:8:21
   │
 8 │         vector[0u8, 0u64, 0u128];
   │                     ^^^^
 
-error: expected `address` but found `integer`
+error: expected `integer` but found a value of type `address`
   ┌─ tests/checking/typing/vector_mismatched_args.move:9:19
   │
 9 │         vector[0, @0];
   │                   ^^
 
-error: expected `Test::X` but found `Test::Y`
+error: expected `X` but found a value of type `Y`
    ┌─ tests/checking/typing/vector_mismatched_args.move:10:21
    │
 10 │         vector[X{}, Y{}];
    │                     ^^^
 
-error: expected `bool` but found `integer`
+error: expected `&integer` but found a value of type `&bool`
    ┌─ tests/checking/typing/vector_mismatched_args.move:11:20
    │
 11 │         vector[&0, &false];

--- a/third_party/move/move-compiler-v2/tests/checking/typing/vector_mismatched_args_non_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/vector_mismatched_args_non_base_type.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: mutability mismatch (&mut != &)
+error: expected `&mut` but `&` was provided
   ┌─ tests/checking/typing/vector_mismatched_args_non_base_type.move:7:26
   │
 7 │         vector<&mut u64>[&0];
   │                          ^^
 
-error: tuples have different arity (2 != 0)
+error: expected 0 items but found 2
   ┌─ tests/checking/typing/vector_mismatched_args_non_base_type.move:8:20
   │
 8 │         vector[(), (0, 1)];

--- a/third_party/move/move-compiler-v2/tests/checking/typing/vector_no_type_inferred.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/vector_no_type_inferred.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: unable to infer type: `vector<?1>`
+error: unable to infer instantiation of type `vector<_>` (consider providing type arguments or annotating the type)
   ┌─ tests/checking/typing/vector_no_type_inferred.move:4:9
   │
 4 │         vector[];

--- a/third_party/move/move-compiler-v2/tests/checking/typing/while_body_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/while_body_invalid.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/while_body_invalid.move:3:22
   │
 3 │         while (cond) 0;
   │                      ^
 
-error: expected `()` but found `bool`
+error: expected expression with no value but found `bool`
   ┌─ tests/checking/typing/while_body_invalid.move:4:22
   │
 4 │         while (cond) false;
   │                      ^^^^^
 
-error: expected `()` but found `address`
+error: expected expression with no value but found `address`
   ┌─ tests/checking/typing/while_body_invalid.move:5:24
   │
 5 │         while (cond) { @0x0 };
   │                        ^^^^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/while_body_invalid.move:6:35
   │
 6 │         while (cond) { let x = 0; x };
   │                                   ^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/while_body_invalid.move:7:34
   │
 7 │         while (cond) { if (cond) 1 else 0 };
   │                                  ^
 
-error: expected `()` but found `integer`
+error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/while_body_invalid.move:7:41
   │
 7 │         while (cond) { if (cond) 1 else 0 };

--- a/third_party/move/move-compiler-v2/tests/checking/typing/while_condition_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/while_condition_invalid.exp
@@ -1,48 +1,48 @@
 
 Diagnostics:
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/while_condition_invalid.move:3:16
   │
 3 │         while (()) ();
   │                ^^
 
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/while_condition_invalid.move:4:16
   │
 4 │         while ((())) ();
   │                ^^^^
 
-error: expected `bool` but found `()`
+error: expected `bool` but found a value of type `()`
   ┌─ tests/checking/typing/while_condition_invalid.move:5:16
   │
 5 │         while ({}) ()
   │                ^^
 
-error: expected `bool` but found `T`
+error: expected `bool` but found a value of type `T`
   ┌─ tests/checking/typing/while_condition_invalid.move:9:16
   │
 9 │         while (x) ();
   │                ^
 
-error: expected `bool` but found `integer`
+error: expected `bool` but found a value of type `integer`
    ┌─ tests/checking/typing/while_condition_invalid.move:10:16
    │
 10 │         while (0) ();
    │                ^
 
-error: expected `bool` but found `address`
+error: expected `bool` but found a value of type `address`
    ┌─ tests/checking/typing/while_condition_invalid.move:11:16
    │
 11 │         while (@0x0) ()
    │                ^^^^
 
-error: expected `bool` but found `(?1, ?2)`
+error: expected `bool` but found a value of type `(bool, bool)`
    ┌─ tests/checking/typing/while_condition_invalid.move:15:16
    │
 15 │         while ((false, true)) ();
    │                ^^^^^^^^^^^^^
 
-error: expected `bool` but found `(?3, ?4)`
+error: expected `bool` but found a value of type `(integer, bool)`
    ┌─ tests/checking/typing/while_condition_invalid.move:16:16
    │
 16 │         while ((0, false)) ()

--- a/third_party/move/move-model/src/builder/mod.rs
+++ b/third_party/move/move-model/src/builder/mod.rs
@@ -7,3 +7,12 @@ mod exp_builder;
 mod macros;
 pub(crate) mod model_builder;
 pub(crate) mod module_builder;
+
+pub(crate) fn pluralize(s: &str, n: usize) -> String {
+    // Should add special cases here as we come along them
+    if n != 1 {
+        s.to_owned() + "s"
+    } else {
+        s.to_owned()
+    }
+}

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -24,11 +24,7 @@ use crate::{
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
 use move_binary_format::file_format::{AbilitySet, Visibility};
-use move_compiler::{
-    expansion::ast::{self as EA},
-    parser::ast as PA,
-    shared::NumericalAddress,
-};
+use move_compiler::{expansion::ast as EA, parser::ast as PA, shared::NumericalAddress};
 use move_core_types::account_address::AccountAddress;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -166,6 +162,16 @@ impl AnyFunEntry {
             AnyFunEntry::SpecOrBuiltin(e) => e.oper.clone(),
             AnyFunEntry::UserFun(e) => Operation::MoveFunction(e.module_id, e.fun_id),
         }
+    }
+
+    pub fn is_equality_on_ref(&self) -> bool {
+        matches!(self.get_operation(), Operation::Eq | Operation::Neq)
+            && self.get_signature().1[0].1.is_reference()
+    }
+
+    pub fn is_equality_on_non_ref(&self) -> bool {
+        matches!(self.get_operation(), Operation::Eq | Operation::Neq)
+            && !self.get_signature().1[0].1.is_reference()
     }
 }
 

--- a/third_party/move/move-model/tests/sources/conditions_err.exp
+++ b/third_party/move/move-model/tests/sources/conditions_err.exp
@@ -1,10 +1,10 @@
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `&mut u64`
   ┌─ tests/sources/conditions_err.move:7:15
   │
 7 │     aborts_if x;
   │               ^
 
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
   ┌─ tests/sources/conditions_err.move:8:13
   │
 8 │     ensures old(x) + x;
@@ -16,7 +16,7 @@ error: undeclared `M::result_1`
 10 │     ensures result_1 == 0;
    │             ^^^^^^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/sources/conditions_err.move:17:28
    │
 17 │     emits _msg to _guid if x;

--- a/third_party/move/move-model/tests/sources/expressions_err.exp
+++ b/third_party/move/move-model/tests/sources/expressions_err.exp
@@ -10,37 +10,37 @@ error: no function named `not_declared` found
 17 │       not_declared()
    │       ^^^^^^^^^^^^^^
 
-error: expected `num` but found `bool`
+error: cannot return `bool` from a function with result type `num`
    ┌─ tests/sources/expressions_err.move:22:7
    │
 22 │       false
    │       ^^^^^
 
-error: invalid call of `>`: expected `num` but found `vector<num>` for argument 1
+error: cannot use `vector<num>` with an operator which expects a value of type `num`
    ┌─ tests/sources/expressions_err.move:27:7
    │
 27 │       x > y
    │       ^
 
-error: expected `(num, bool)` but found `bool`
+error: cannot return `bool` from a function with result type `(num, bool)`
    ┌─ tests/sources/expressions_err.move:32:7
    │
 32 │       false
    │       ^^^^^
 
-error: invalid call of `M::wrongly_typed_callee`: expected `bool` but found `u256` for argument 2
+error: cannot pass `u256` to a function which expects argument of type `bool`
    ┌─ tests/sources/expressions_err.move:37:63
    │
 37 │     fun wrongly_typed_caller(): num { wrongly_typed_callee(1, 1) }
    │                                                               ^
 
-error: invalid call of `M::wrongly_typed_fun_arg_callee`: expected `num` but found `bool` for argument 1
+error: cannot pass `|num|bool` to a function which expects argument of type `|num|num`
    ┌─ tests/sources/expressions_err.move:41:76
    │
 41 │     fun wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
    │                                                                            ^^^^^^^^^
 
-error: invalid call of `M::wrong_instantiation`: generic count mismatch (expected 2 but found 1)
+error: the function expected 2 type arguments but 1 were provided
    ┌─ tests/sources/expressions_err.move:46:7
    │
 46 │       wrong_instantiation<u64>(x)

--- a/third_party/move/move-model/tests/sources/expressions_inference_err.exp
+++ b/third_party/move/move-model/tests/sources/expressions_inference_err.exp
@@ -1,4 +1,4 @@
-error: unable to infer type: `?2`
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
   ┌─ tests/sources/expressions_inference_err.move:7:16
   │
 7 │       let f = |x|x;

--- a/third_party/move/move-model/tests/sources/invariants_err.exp
+++ b/third_party/move/move-model/tests/sources/invariants_err.exp
@@ -1,4 +1,4 @@
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
   ┌─ tests/sources/invariants_err.move:9:15
   │
 9 │     invariant x + 1;

--- a/third_party/move/move-model/tests/sources/schemas_err.exp
+++ b/third_party/move/move-model/tests/sources/schemas_err.exp
@@ -22,25 +22,25 @@ error: `wrong` not declared in schema
 19 │         include WrongTypeArgsIncluded<num>{wrong: 1};
    │                                            ^^^^^
 
-error: expected `num` but found `bool`
+error: expected `num` but found a value of type `bool`
    ┌─ tests/sources/schemas_err.move:24:47
    │
 24 │         include WrongTypeArgsIncluded<num>{x: y};
    │                                               ^
 
-error: expected `bool` but found `num`
+error: expected `bool` but found a value of type `num`
    ┌─ tests/sources/schemas_err.move:28:48
    │
 28 │         include WrongTypeArgsIncluded<bool>{x: 1 + 2};
    │                                                ^^^^^
 
-error: expected `bool` but found `num` (for `x` included from schema)
+error: variable `x` bound by schema inclusion expected to have type `bool` but provided was `num`
    ┌─ tests/sources/schemas_err.move:33:17
    │
 33 │         include WronglyTypedVarIncluded;
    │                 ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected `bool` but found `num` (for `x` included from schema)
+error: variable `x` bound by schema inclusion expected to have type `bool` but provided was `num`
    ┌─ tests/sources/schemas_err.move:41:17
    │
 41 │         include WronglyTypedInstantiationIncluded<num>;
@@ -64,7 +64,7 @@ error: cyclic schema dependency: Cycle1 -> Cycle2 -> Cycle3 -> Cycle1
 80 │         include Cycle1;
    │                 ^^^^^^
 
-error: expected `bool` but found `u256`
+error: expected `bool` but found a value of type `u256`
    ┌─ tests/sources/schemas_err.move:84:17
    │
 84 │         include 22 ==> Condition;

--- a/third_party/move/move-model/tests/sources/structs_err.exp
+++ b/third_party/move/move-model/tests/sources/structs_err.exp
@@ -1,16 +1,16 @@
-error: field `xx` not declared in struct `M::S`
+error: field `xx` not declared in struct `S`
    ┌─ tests/sources/structs_err.move:26:7
    │
 26 │       s.xx
    │       ^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/sources/structs_err.move:31:7
    │
 31 │       s.x
    │       ^^^
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found a value of type `u64`
    ┌─ tests/sources/structs_err.move:36:18
    │
 36 │       S{x: x, y: y, z: z}
@@ -22,13 +22,13 @@ error: missing fields `y`, `z`
 40 │       S{x: x}
    │       ^^^^^^^
 
-error: expected `bool` but found `u64`
+error: cannot return `G<u64>` from a function with result type `G<bool>`
    ┌─ tests/sources/structs_err.move:45:7
    │
 45 │       G{x: x, y: y}
    │       ^^^^^^^^^^^^^
 
-error: generic count mismatch (expected 1 but found 2)
+error: the type expected 1 type argument but 2 were provided
    ┌─ tests/sources/structs_err.move:50:7
    │
 50 │       G<u64, bool>{x: x, y: y}

--- a/third_party/move/move-model/tests/sources/use_erroneous_schema.exp
+++ b/third_party/move/move-model/tests/sources/use_erroneous_schema.exp
@@ -4,7 +4,7 @@ error: undeclared `M::x`
 5 │         ensures x > 0;
   │                 ^
 
-error: invalid call of `<`: expected `num` but found `bool` for argument 2
+error: cannot use `bool` with an operator which expects a value of type `num`
    ┌─ tests/sources/use_erroneous_schema.move:13:21
    │
 13 │         ensures 2 < true;

--- a/third_party/move/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
+++ b/third_party/move/move-prover/tests/sources/functional/pure_function_call_incorrect.exp
@@ -13,7 +13,7 @@ error: calling impure function `vector::pop_back` is not allowed
 56 │         ensures result == vector::pop_back(old(v));
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = impure function `vector::pop_back(&mut vector<#0>): #0`
+   = impure function `vector::pop_back<Element>(&mut vector<Element>): Element`
 
 error: calling impure function `TestPureFun::impure_f_2` is not allowed
    ┌─ tests/sources/functional/pure_function_call_incorrect.move:62:13

--- a/third_party/move/move-stdlib/docs/option.md
+++ b/third_party/move/move-stdlib/docs/option.md
@@ -860,7 +860,7 @@ and an empty vector otherwise
 Apply the function to the optional element, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each">for_each</a>&lt;Element&gt;(o: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -889,7 +889,7 @@ Apply the function to the optional element, consuming it.
 Apply the function to the optional element reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_ref">for_each_ref</a>&lt;Element&gt;(o: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&Element|)
 </code></pre>
 
 
@@ -916,7 +916,7 @@ Apply the function to the optional element reference.
 Apply the function to the optional element reference.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_for_each_mut">for_each_mut</a>&lt;Element&gt;(o: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
 </code></pre>
 
 

--- a/third_party/move/move-stdlib/docs/vector.md
+++ b/third_party/move/move-stdlib/docs/vector.md
@@ -602,7 +602,7 @@ Aborts if <code>i</code> is out of bounds.
 Apply the function to each element in the vector, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each">for_each</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each">for_each</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |Element|)
 </code></pre>
 
 
@@ -631,7 +631,7 @@ Apply the function to each element in the vector, consuming it.
 Apply the function to a reference of each element in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_ref">for_each_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_ref">for_each_ref</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|)
 </code></pre>
 
 
@@ -660,7 +660,7 @@ Apply the function to a reference of each element in the vector.
 Apply the function to a mutable reference to each element in the vector.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_mut">for_each_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&<b>mut</b> Element|())
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_for_each_mut">for_each_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&<b>mut</b> Element|)
 </code></pre>
 
 

--- a/third_party/move/move-stdlib/nursery/docs/acl.md
+++ b/third_party/move/move-stdlib/nursery/docs/acl.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_acl"></a>
+<a id="0x1_acl"></a>
 
 # Module `0x1::acl`
 
@@ -24,7 +24,7 @@ use a "set" instead when it's available in the language in the future.
 
 
 
-<a name="0x1_acl_ACL"></a>
+<a id="0x1_acl_ACL"></a>
 
 ## Struct `ACL`
 
@@ -51,12 +51,12 @@ use a "set" instead when it's available in the language in the future.
 
 </details>
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_acl_ECONTAIN"></a>
+<a id="0x1_acl_ECONTAIN"></a>
 
 The ACL already contains the address.
 
@@ -66,7 +66,7 @@ The ACL already contains the address.
 
 
 
-<a name="0x1_acl_ENOT_CONTAIN"></a>
+<a id="0x1_acl_ENOT_CONTAIN"></a>
 
 The ACL does not contain the address.
 
@@ -76,7 +76,7 @@ The ACL does not contain the address.
 
 
 
-<a name="0x1_acl_empty"></a>
+<a id="0x1_acl_empty"></a>
 
 ## Function `empty`
 
@@ -101,7 +101,7 @@ Return an empty ACL.
 
 </details>
 
-<a name="0x1_acl_add"></a>
+<a id="0x1_acl_add"></a>
 
 ## Function `add`
 
@@ -127,7 +127,7 @@ Add the address to the ACL.
 
 </details>
 
-<a name="0x1_acl_remove"></a>
+<a id="0x1_acl_remove"></a>
 
 ## Function `remove`
 
@@ -154,7 +154,7 @@ Remove the address from the ACL.
 
 </details>
 
-<a name="0x1_acl_contains"></a>
+<a id="0x1_acl_contains"></a>
 
 ## Function `contains`
 
@@ -179,7 +179,7 @@ Return true iff the ACL contains the address.
 
 </details>
 
-<a name="0x1_acl_assert_contains"></a>
+<a id="0x1_acl_assert_contains"></a>
 
 ## Function `assert_contains`
 

--- a/third_party/move/move-stdlib/nursery/docs/capability.md
+++ b/third_party/move/move-stdlib/nursery/docs/capability.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_capability"></a>
+<a id="0x1_capability"></a>
 
 # Module `0x1::capability`
 
@@ -9,7 +9,7 @@ A module which defines the basic concept of
 EXPERIMENTAL
 
 
-<a name="@Overview_0"></a>
+<a id="@Overview_0"></a>
 
 ## Overview
 
@@ -21,7 +21,7 @@ called within a transaction which has a capability as a parameter, it is guarant
 has been obtained via a proper signer-based authorization step previously in the transaction's execution.
 
 
-<a name="@Usage_1"></a>
+<a id="@Usage_1"></a>
 
 ### Usage
 
@@ -59,7 +59,7 @@ public fun do_something(_cap: Cap<Feature>) { ... }
 ```
 
 
-<a name="@Delegation_2"></a>
+<a id="@Delegation_2"></a>
 
 ### Delegation
 
@@ -117,7 +117,7 @@ is_valid_delegate_for_feature(d);
 
 
 
-<a name="0x1_capability_Cap"></a>
+<a id="0x1_capability_Cap"></a>
 
 ## Struct `Cap`
 
@@ -145,7 +145,7 @@ The token representing an acquired capability. Cannot be stored in memory, but c
 
 </details>
 
-<a name="0x1_capability_LinearCap"></a>
+<a id="0x1_capability_LinearCap"></a>
 
 ## Struct `LinearCap`
 
@@ -174,7 +174,7 @@ to be used only once for an authorization.
 
 </details>
 
-<a name="0x1_capability_CapState"></a>
+<a id="0x1_capability_CapState"></a>
 
 ## Resource `CapState`
 
@@ -202,7 +202,7 @@ An internal data structure for representing a configured capability.
 
 </details>
 
-<a name="0x1_capability_CapDelegateState"></a>
+<a id="0x1_capability_CapDelegateState"></a>
 
 ## Resource `CapDelegateState`
 
@@ -230,12 +230,12 @@ An internal data structure for representing a configured delegated capability.
 
 </details>
 
-<a name="@Constants_3"></a>
+<a id="@Constants_3"></a>
 
 ## Constants
 
 
-<a name="0x1_capability_ECAP"></a>
+<a id="0x1_capability_ECAP"></a>
 
 
 
@@ -244,7 +244,7 @@ An internal data structure for representing a configured delegated capability.
 
 
 
-<a name="0x1_capability_EDELEGATE"></a>
+<a id="0x1_capability_EDELEGATE"></a>
 
 
 
@@ -253,7 +253,7 @@ An internal data structure for representing a configured delegated capability.
 
 
 
-<a name="0x1_capability_create"></a>
+<a id="0x1_capability_create"></a>
 
 ## Function `create`
 
@@ -281,7 +281,7 @@ they own the <code>Feature</code> type parameter.
 
 </details>
 
-<a name="0x1_capability_acquire"></a>
+<a id="0x1_capability_acquire"></a>
 
 ## Function `acquire`
 
@@ -309,7 +309,7 @@ parameter.
 
 </details>
 
-<a name="0x1_capability_acquire_linear"></a>
+<a id="0x1_capability_acquire_linear"></a>
 
 ## Function `acquire_linear`
 
@@ -336,7 +336,7 @@ whether to expose a linear or non-linear capability.
 
 </details>
 
-<a name="0x1_capability_validate_acquire"></a>
+<a id="0x1_capability_validate_acquire"></a>
 
 ## Function `validate_acquire`
 
@@ -373,7 +373,7 @@ Helper to validate an acquire. Returns the root address of the capability.
 
 </details>
 
-<a name="0x1_capability_root_addr"></a>
+<a id="0x1_capability_root_addr"></a>
 
 ## Function `root_addr`
 
@@ -399,7 +399,7 @@ of the feature can do this.
 
 </details>
 
-<a name="0x1_capability_linear_root_addr"></a>
+<a id="0x1_capability_linear_root_addr"></a>
 
 ## Function `linear_root_addr`
 
@@ -424,7 +424,7 @@ Returns the root address associated with the given linear capability token.
 
 </details>
 
-<a name="0x1_capability_delegate"></a>
+<a id="0x1_capability_delegate"></a>
 
 ## Function `delegate`
 
@@ -454,7 +454,7 @@ nothing.
 
 </details>
 
-<a name="0x1_capability_revoke"></a>
+<a id="0x1_capability_revoke"></a>
 
 ## Function `revoke`
 
@@ -483,7 +483,7 @@ Revokes a delegation relation. If no relation exists, this function does nothing
 
 </details>
 
-<a name="0x1_capability_remove_element"></a>
+<a id="0x1_capability_remove_element"></a>
 
 ## Function `remove_element`
 
@@ -511,7 +511,7 @@ Helper to remove an element from a vector.
 
 </details>
 
-<a name="0x1_capability_add_element"></a>
+<a id="0x1_capability_add_element"></a>
 
 ## Function `add_element`
 
@@ -538,14 +538,14 @@ Helper to add an element to a vector.
 
 </details>
 
-<a name="@Module_Specification_4"></a>
+<a id="@Module_Specification_4"></a>
 
 ## Module Specification
 
 Helper specification function to check whether a capability exists at address.
 
 
-<a name="0x1_capability_spec_has_cap"></a>
+<a id="0x1_capability_spec_has_cap"></a>
 
 
 <pre><code><b>fun</b> <a href="capability.md#0x1_capability_spec_has_cap">spec_has_cap</a>&lt;Feature&gt;(addr: <b>address</b>): bool {
@@ -557,7 +557,7 @@ Helper specification function to check whether a capability exists at address.
 Helper specification function to obtain the delegates of a capability.
 
 
-<a name="0x1_capability_spec_delegates"></a>
+<a id="0x1_capability_spec_delegates"></a>
 
 
 <pre><code><b>fun</b> <a href="capability.md#0x1_capability_spec_delegates">spec_delegates</a>&lt;Feature&gt;(addr: <b>address</b>): <a href="">vector</a>&lt;<b>address</b>&gt; {

--- a/third_party/move/move-stdlib/nursery/docs/compare.md
+++ b/third_party/move/move-stdlib/nursery/docs/compare.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_compare"></a>
+<a id="0x1_compare"></a>
 
 # Module `0x1::compare`
 
@@ -16,12 +16,12 @@ Utilities for comparing Move values based on their representation in BCS.
 
 
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_compare_EQUAL"></a>
+<a id="0x1_compare_EQUAL"></a>
 
 
 
@@ -30,7 +30,7 @@ Utilities for comparing Move values based on their representation in BCS.
 
 
 
-<a name="0x1_compare_GREATER_THAN"></a>
+<a id="0x1_compare_GREATER_THAN"></a>
 
 
 
@@ -39,7 +39,7 @@ Utilities for comparing Move values based on their representation in BCS.
 
 
 
-<a name="0x1_compare_LESS_THAN"></a>
+<a id="0x1_compare_LESS_THAN"></a>
 
 
 
@@ -48,7 +48,7 @@ Utilities for comparing Move values based on their representation in BCS.
 
 
 
-<a name="0x1_compare_cmp_bcs_bytes"></a>
+<a id="0x1_compare_cmp_bcs_bytes"></a>
 
 ## Function `cmp_bcs_bytes`
 
@@ -116,7 +116,7 @@ Keep this in mind when using this function to compare addresses.
 
 </details>
 
-<a name="0x1_compare_cmp_u8"></a>
+<a id="0x1_compare_cmp_u8"></a>
 
 ## Function `cmp_u8`
 
@@ -143,7 +143,7 @@ Compare two <code>u8</code>'s
 
 </details>
 
-<a name="0x1_compare_cmp_u64"></a>
+<a id="0x1_compare_cmp_u64"></a>
 
 ## Function `cmp_u64`
 

--- a/third_party/move/move-stdlib/nursery/docs/debug.md
+++ b/third_party/move/move-stdlib/nursery/docs/debug.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_debug"></a>
+<a id="0x1_debug"></a>
 
 # Module `0x1::debug`
 
@@ -14,7 +14,7 @@ Module providing debug functionality.
 
 
 
-<a name="0x1_debug_print"></a>
+<a id="0x1_debug_print"></a>
 
 ## Function `print`
 
@@ -37,7 +37,7 @@ Pretty-prints any Move value. For a Move struct, includes its field names, their
 
 </details>
 
-<a name="0x1_debug_print_stack_trace"></a>
+<a id="0x1_debug_print_stack_trace"></a>
 
 ## Function `print_stack_trace`
 

--- a/third_party/move/move-stdlib/nursery/docs/errors.md
+++ b/third_party/move/move-stdlib/nursery/docs/errors.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_errors"></a>
+<a id="0x1_errors"></a>
 
 # Module `0x1::errors`
 
@@ -37,12 +37,12 @@ framework evolves.
 
 
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_errors_ALREADY_PUBLISHED"></a>
+<a id="0x1_errors_ALREADY_PUBLISHED"></a>
 
 Attempting to publish a resource that is already published. Example: calling an initialization function
 twice.
@@ -53,7 +53,7 @@ twice.
 
 
 
-<a name="0x1_errors_CUSTOM"></a>
+<a id="0x1_errors_CUSTOM"></a>
 
 A custom error category for extension points.
 
@@ -63,7 +63,7 @@ A custom error category for extension points.
 
 
 
-<a name="0x1_errors_INTERNAL"></a>
+<a id="0x1_errors_INTERNAL"></a>
 
 An internal error (bug) has occurred.
 
@@ -73,7 +73,7 @@ An internal error (bug) has occurred.
 
 
 
-<a name="0x1_errors_INVALID_ARGUMENT"></a>
+<a id="0x1_errors_INVALID_ARGUMENT"></a>
 
 An argument provided to an operation is invalid. Example: a signing key has the wrong format.
 
@@ -83,7 +83,7 @@ An argument provided to an operation is invalid. Example: a signing key has the 
 
 
 
-<a name="0x1_errors_INVALID_STATE"></a>
+<a id="0x1_errors_INVALID_STATE"></a>
 
 The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
 in genesis.
@@ -94,7 +94,7 @@ in genesis.
 
 
 
-<a name="0x1_errors_LIMIT_EXCEEDED"></a>
+<a id="0x1_errors_LIMIT_EXCEEDED"></a>
 
 A limit on an amount, e.g. a currency, is exceeded. Example: withdrawal of money after account limits window
 is exhausted.
@@ -105,7 +105,7 @@ is exhausted.
 
 
 
-<a name="0x1_errors_NOT_PUBLISHED"></a>
+<a id="0x1_errors_NOT_PUBLISHED"></a>
 
 A resource is required but not published. Example: access to non-existing AccountLimits resource.
 
@@ -115,7 +115,7 @@ A resource is required but not published. Example: access to non-existing Accoun
 
 
 
-<a name="0x1_errors_REQUIRES_ADDRESS"></a>
+<a id="0x1_errors_REQUIRES_ADDRESS"></a>
 
 The signer of a transaction does not have the expected address for this operation. Example: a call to a function
 which publishes a resource under a particular address.
@@ -126,7 +126,7 @@ which publishes a resource under a particular address.
 
 
 
-<a name="0x1_errors_REQUIRES_CAPABILITY"></a>
+<a id="0x1_errors_REQUIRES_CAPABILITY"></a>
 
 The signer of a transaction does not have a required capability.
 
@@ -136,7 +136,7 @@ The signer of a transaction does not have a required capability.
 
 
 
-<a name="0x1_errors_REQUIRES_ROLE"></a>
+<a id="0x1_errors_REQUIRES_ROLE"></a>
 
 The signer of a transaction does not have the expected  role for this operation. Example: a call to a function
 which requires the signer to have the role of treasury compliance.
@@ -147,7 +147,7 @@ which requires the signer to have the role of treasury compliance.
 
 
 
-<a name="0x1_errors_make"></a>
+<a id="0x1_errors_make"></a>
 
 ## Function `make`
 
@@ -187,7 +187,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_invalid_state"></a>
+<a id="0x1_errors_invalid_state"></a>
 
 ## Function `invalid_state`
 
@@ -223,7 +223,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_requires_address"></a>
+<a id="0x1_errors_requires_address"></a>
 
 ## Function `requires_address`
 
@@ -259,7 +259,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_requires_role"></a>
+<a id="0x1_errors_requires_role"></a>
 
 ## Function `requires_role`
 
@@ -295,7 +295,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_requires_capability"></a>
+<a id="0x1_errors_requires_capability"></a>
 
 ## Function `requires_capability`
 
@@ -331,7 +331,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_not_published"></a>
+<a id="0x1_errors_not_published"></a>
 
 ## Function `not_published`
 
@@ -367,7 +367,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_already_published"></a>
+<a id="0x1_errors_already_published"></a>
 
 ## Function `already_published`
 
@@ -403,7 +403,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_invalid_argument"></a>
+<a id="0x1_errors_invalid_argument"></a>
 
 ## Function `invalid_argument`
 
@@ -439,7 +439,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_limit_exceeded"></a>
+<a id="0x1_errors_limit_exceeded"></a>
 
 ## Function `limit_exceeded`
 
@@ -475,7 +475,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_internal"></a>
+<a id="0x1_errors_internal"></a>
 
 ## Function `internal`
 
@@ -511,7 +511,7 @@ A function to create an error from from a category and a reason.
 
 </details>
 
-<a name="0x1_errors_custom"></a>
+<a id="0x1_errors_custom"></a>
 
 ## Function `custom`
 

--- a/third_party/move/move-stdlib/nursery/docs/event.md
+++ b/third_party/move/move-stdlib/nursery/docs/event.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_event"></a>
+<a id="0x1_event"></a>
 
 # Module `0x1::event`
 
@@ -26,7 +26,7 @@ events emitted to a handle and emit events to the event store.
 
 
 
-<a name="0x1_event_GUIDWrapper"></a>
+<a id="0x1_event_GUIDWrapper"></a>
 
 ## Struct `GUIDWrapper`
 
@@ -60,7 +60,7 @@ Wrapper for a GUID for layout compatibility with legacy EventHandle id's
 
 </details>
 
-<a name="0x1_event_EventHandle"></a>
+<a id="0x1_event_EventHandle"></a>
 
 ## Struct `EventHandle`
 
@@ -96,7 +96,7 @@ A handle for an event such that:
 
 </details>
 
-<a name="0x1_event_EventHandleGenerator"></a>
+<a id="0x1_event_EventHandleGenerator"></a>
 
 ## Resource `EventHandleGenerator`
 
@@ -130,7 +130,7 @@ Deprecated. Only kept around so Diem clients know how to deserialize existing Ev
 
 </details>
 
-<a name="0x1_event_new_event_handle"></a>
+<a id="0x1_event_new_event_handle"></a>
 
 ## Function `new_event_handle`
 
@@ -160,7 +160,7 @@ Use EventHandleGenerator to generate a unique event handle for <code>sig</code>
 
 </details>
 
-<a name="0x1_event_emit_event"></a>
+<a id="0x1_event_emit_event"></a>
 
 ## Function `emit_event`
 
@@ -186,7 +186,7 @@ Emit an event with payload <code>msg</code> by using <code>handle_ref</code>'s k
 
 </details>
 
-<a name="0x1_event_guid"></a>
+<a id="0x1_event_guid"></a>
 
 ## Function `guid`
 
@@ -211,7 +211,7 @@ Return the GUIID associated with this EventHandle
 
 </details>
 
-<a name="0x1_event_write_to_event_store"></a>
+<a id="0x1_event_write_to_event_store"></a>
 
 ## Function `write_to_event_store`
 
@@ -234,7 +234,7 @@ Log <code>msg</code> as the <code>count</code>th event associated with the event
 
 </details>
 
-<a name="0x1_event_destroy_handle"></a>
+<a id="0x1_event_destroy_handle"></a>
 
 ## Function `destroy_handle`
 
@@ -259,7 +259,7 @@ Destroy a unique handle.
 
 </details>
 
-<a name="@Module_Specification_0"></a>
+<a id="@Module_Specification_0"></a>
 
 ## Module Specification
 
@@ -277,7 +277,7 @@ Determines equality between the guids of two event handles. Since fields of intr
 structs cannot be accessed, this function is provided.
 
 
-<a name="0x1_event_spec_guid_eq"></a>
+<a id="0x1_event_spec_guid_eq"></a>
 
 
 <pre><code><b>fun</b> <a href="event.md#0x1_event_spec_guid_eq">spec_guid_eq</a>&lt;T&gt;(h1: <a href="event.md#0x1_event_EventHandle">EventHandle</a>&lt;T&gt;, h2: <a href="event.md#0x1_event_EventHandle">EventHandle</a>&lt;T&gt;): bool {

--- a/third_party/move/move-stdlib/nursery/docs/guid.md
+++ b/third_party/move/move-stdlib/nursery/docs/guid.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_guid"></a>
+<a id="0x1_guid"></a>
 
 # Module `0x1::guid`
 
@@ -31,7 +31,7 @@ A module for generating globally unique identifiers
 
 
 
-<a name="0x1_guid_Generator"></a>
+<a id="0x1_guid_Generator"></a>
 
 ## Resource `Generator`
 
@@ -59,7 +59,7 @@ A generator for new GUIDs.
 
 </details>
 
-<a name="0x1_guid_GUID"></a>
+<a id="0x1_guid_GUID"></a>
 
 ## Struct `GUID`
 
@@ -87,7 +87,7 @@ A globally unique identifier derived from the sender's address and a counter
 
 </details>
 
-<a name="0x1_guid_ID"></a>
+<a id="0x1_guid_ID"></a>
 
 ## Struct `ID`
 
@@ -121,7 +121,7 @@ A non-privileged identifier that can be freely created by anyone. Useful for loo
 
 </details>
 
-<a name="0x1_guid_CreateCapability"></a>
+<a id="0x1_guid_CreateCapability"></a>
 
 ## Resource `CreateCapability`
 
@@ -149,12 +149,12 @@ A capability to create a privileged identifier on behalf of the given address
 
 </details>
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_guid_EGUID_GENERATOR_NOT_PUBLISHED"></a>
+<a id="0x1_guid_EGUID_GENERATOR_NOT_PUBLISHED"></a>
 
 GUID generator must be published ahead of first usage of <code>create_with_capability</code> function.
 
@@ -164,7 +164,7 @@ GUID generator must be published ahead of first usage of <code>create_with_capab
 
 
 
-<a name="0x1_guid_gen_create_capability"></a>
+<a id="0x1_guid_gen_create_capability"></a>
 
 ## Function `gen_create_capability`
 
@@ -193,7 +193,7 @@ Generates a capability to create the privileged GUID on behalf of the signer
 
 </details>
 
-<a name="0x1_guid_create_id"></a>
+<a id="0x1_guid_create_id"></a>
 
 ## Function `create_id`
 
@@ -218,7 +218,7 @@ Create a non-privileged id from <code>addr</code> and <code>creation_num</code>
 
 </details>
 
-<a name="0x1_guid_create_with_capability"></a>
+<a id="0x1_guid_create_with_capability"></a>
 
 ## Function `create_with_capability`
 
@@ -243,7 +243,7 @@ Create a non-privileged id from <code>addr</code> and <code>creation_num</code>
 
 </details>
 
-<a name="0x1_guid_create"></a>
+<a id="0x1_guid_create"></a>
 
 ## Function `create`
 
@@ -273,7 +273,7 @@ if it does not already have one
 
 </details>
 
-<a name="0x1_guid_create_impl"></a>
+<a id="0x1_guid_create_impl"></a>
 
 ## Function `create_impl`
 
@@ -300,7 +300,7 @@ if it does not already have one
 
 </details>
 
-<a name="0x1_guid_publish_generator"></a>
+<a id="0x1_guid_publish_generator"></a>
 
 ## Function `publish_generator`
 
@@ -325,7 +325,7 @@ Publish a Generator resource under <code>account</code>
 
 </details>
 
-<a name="0x1_guid_id"></a>
+<a id="0x1_guid_id"></a>
 
 ## Function `id`
 
@@ -350,7 +350,7 @@ Get the non-privileged ID associated with a GUID
 
 </details>
 
-<a name="0x1_guid_creator_address"></a>
+<a id="0x1_guid_creator_address"></a>
 
 ## Function `creator_address`
 
@@ -375,7 +375,7 @@ Return the account address that created the GUID
 
 </details>
 
-<a name="0x1_guid_id_creator_address"></a>
+<a id="0x1_guid_id_creator_address"></a>
 
 ## Function `id_creator_address`
 
@@ -400,7 +400,7 @@ Return the account address that created the guid::ID
 
 </details>
 
-<a name="0x1_guid_creation_num"></a>
+<a id="0x1_guid_creation_num"></a>
 
 ## Function `creation_num`
 
@@ -425,7 +425,7 @@ Return the creation number associated with the GUID
 
 </details>
 
-<a name="0x1_guid_id_creation_num"></a>
+<a id="0x1_guid_id_creation_num"></a>
 
 ## Function `id_creation_num`
 
@@ -450,7 +450,7 @@ Return the creation number associated with the guid::ID
 
 </details>
 
-<a name="0x1_guid_eq_id"></a>
+<a id="0x1_guid_eq_id"></a>
 
 ## Function `eq_id`
 
@@ -475,7 +475,7 @@ Return true if the GUID's ID is <code>id</code>
 
 </details>
 
-<a name="0x1_guid_get_next_creation_num"></a>
+<a id="0x1_guid_get_next_creation_num"></a>
 
 ## Function `get_next_creation_num`
 

--- a/third_party/move/move-stdlib/nursery/docs/offer.md
+++ b/third_party/move/move-stdlib/nursery/docs/offer.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_offer"></a>
+<a id="0x1_offer"></a>
 
 # Module `0x1::offer`
 
@@ -39,7 +39,7 @@ redeemed it.
 
 
 
-<a name="0x1_offer_Offer"></a>
+<a id="0x1_offer_Offer"></a>
 
 ## Resource `Offer`
 
@@ -73,12 +73,12 @@ A wrapper around value <code>offered</code> that can be claimed by the address s
 
 </details>
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_offer_EOFFER_ALREADY_CREATED"></a>
+<a id="0x1_offer_EOFFER_ALREADY_CREATED"></a>
 
 Address already has an offer of this type.
 
@@ -88,7 +88,7 @@ Address already has an offer of this type.
 
 
 
-<a name="0x1_offer_EOFFER_DNE_FOR_ACCOUNT"></a>
+<a id="0x1_offer_EOFFER_DNE_FOR_ACCOUNT"></a>
 
 An offer of the specified type for the account does not exist
 
@@ -98,7 +98,7 @@ An offer of the specified type for the account does not exist
 
 
 
-<a name="0x1_offer_EOFFER_DOES_NOT_EXIST"></a>
+<a id="0x1_offer_EOFFER_DOES_NOT_EXIST"></a>
 
 Address does not have an offer of this type to redeem.
 
@@ -108,7 +108,7 @@ Address does not have an offer of this type to redeem.
 
 
 
-<a name="0x1_offer_create"></a>
+<a id="0x1_offer_create"></a>
 
 ## Function `create`
 
@@ -152,7 +152,7 @@ placing the offer under the signer's address
 
 </details>
 
-<a name="0x1_offer_redeem"></a>
+<a id="0x1_offer_redeem"></a>
 
 ## Function `redeem`
 
@@ -203,7 +203,7 @@ Ensures that the offered struct under <code>offer_address</code> is removed.
 
 </details>
 
-<a name="0x1_offer_exists_at"></a>
+<a id="0x1_offer_exists_at"></a>
 
 ## Function `exists_at`
 
@@ -246,7 +246,7 @@ Returns whether or not an <code><a href="offer.md#0x1_offer_Offer">Offer</a></co
 
 </details>
 
-<a name="0x1_offer_address_of"></a>
+<a id="0x1_offer_address_of"></a>
 
 ## Function `address_of`
 
@@ -288,24 +288,24 @@ under the <code>offer_address</code>.
 
 </details>
 
-<a name="@Module_Specification_1"></a>
+<a id="@Module_Specification_1"></a>
 
 ## Module Specification
 
 
 
-<a name="@Access_Control_2"></a>
+<a id="@Access_Control_2"></a>
 
 ### Access Control
 
 
-<a name="@Creation_of_Offers_3"></a>
+<a id="@Creation_of_Offers_3"></a>
 
 #### Creation of Offers
 
 
 
-<a name="0x1_offer_NoOfferCreated"></a>
+<a id="0x1_offer_NoOfferCreated"></a>
 
 Says no offer is created for any address. Later, it is applied to all functions
 except <code>create</code>
@@ -326,13 +326,13 @@ Apply OnlyCreateCanCreateOffer to every function except <code>create</code>
 
 
 
-<a name="@Removal_of_Offers_4"></a>
+<a id="@Removal_of_Offers_4"></a>
 
 #### Removal of Offers
 
 
 
-<a name="0x1_offer_NoOfferRemoved"></a>
+<a id="0x1_offer_NoOfferRemoved"></a>
 
 Says no offer is removed for any address. Applied below to everything except <code>redeem</code>
 
@@ -353,7 +353,7 @@ Only <code>redeem</code> can remove an offer from the global store.
 
 
 
-<a name="@Helper_Functions_5"></a>
+<a id="@Helper_Functions_5"></a>
 
 ### Helper Functions
 
@@ -362,7 +362,7 @@ Returns true if the recipient is allowed to redeem <code><a href="offer.md#0x1_o
 and false otherwise.
 
 
-<a name="0x1_offer_is_allowed_recipient"></a>
+<a id="0x1_offer_is_allowed_recipient"></a>
 
 
 <pre><code><b>fun</b> <a href="offer.md#0x1_offer_is_allowed_recipient">is_allowed_recipient</a>&lt;Offered&gt;(offer_addr: <b>address</b>, recipient: <b>address</b>): bool {

--- a/third_party/move/move-stdlib/nursery/docs/role.md
+++ b/third_party/move/move-stdlib/nursery/docs/role.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_role"></a>
+<a id="0x1_role"></a>
 
 # Module `0x1::role`
 
@@ -20,7 +20,7 @@ A generic module for role-based access control (RBAC).
 
 
 
-<a name="0x1_role_Role"></a>
+<a id="0x1_role_Role"></a>
 
 ## Resource `Role`
 
@@ -47,12 +47,12 @@ A generic module for role-based access control (RBAC).
 
 </details>
 
-<a name="@Constants_0"></a>
+<a id="@Constants_0"></a>
 
 ## Constants
 
 
-<a name="0x1_role_EROLE"></a>
+<a id="0x1_role_EROLE"></a>
 
 
 
@@ -61,7 +61,7 @@ A generic module for role-based access control (RBAC).
 
 
 
-<a name="0x1_role_assign_role"></a>
+<a id="0x1_role_assign_role"></a>
 
 ## Function `assign_role`
 
@@ -88,7 +88,7 @@ expected to be a function of the module that defines <code>Type</code>.
 
 </details>
 
-<a name="0x1_role_revoke_role"></a>
+<a id="0x1_role_revoke_role"></a>
 
 ## Function `revoke_role`
 
@@ -115,7 +115,7 @@ expected to be a function of the module that defines <code>Type</code>.
 
 </details>
 
-<a name="0x1_role_has_role"></a>
+<a id="0x1_role_has_role"></a>
 
 ## Function `has_role`
 
@@ -140,7 +140,7 @@ Return true iff the address has the role.
 
 </details>
 
-<a name="0x1_role_assert_has_role"></a>
+<a id="0x1_role_assert_has_role"></a>
 
 ## Function `assert_has_role`
 

--- a/third_party/move/move-stdlib/nursery/docs/vault.md
+++ b/third_party/move/move-stdlib/nursery/docs/vault.md
@@ -1,5 +1,5 @@
 
-<a name="0x1_vault"></a>
+<a id="0x1_vault"></a>
 
 # Module `0x1::vault`
 
@@ -9,13 +9,13 @@ on if authorized by a signer. Authorization is managed by
 of capabilities to other signers (including revocation) as well as transfer of ownership.
 
 
-<a name="@Overview_0"></a>
+<a id="@Overview_0"></a>
 
 ## Overview
 
 
 
-<a name="@Capabilities_1"></a>
+<a id="@Capabilities_1"></a>
 
 ### Capabilities
 
@@ -52,7 +52,7 @@ vault::release_read_accessor(accessor);
 ```
 
 
-<a name="@Delegation_2"></a>
+<a id="@Delegation_2"></a>
 
 ### Delegation
 
@@ -88,7 +88,7 @@ vault::revoke_read_cap(&delegate_cap, signer::address_of(other_signer));
 ```
 
 
-<a name="@Abilities_3"></a>
+<a id="@Abilities_3"></a>
 
 ### Abilities
 
@@ -156,7 +156,7 @@ language to have 'phantom type parameters' or similar features added, which will
 
 
 
-<a name="0x1_vault_ReadCap"></a>
+<a id="0x1_vault_ReadCap"></a>
 
 ## Struct `ReadCap`
 
@@ -192,7 +192,7 @@ TODO: remove <code>drop</code> on <code>Content</code> here and elsewhere once w
 
 </details>
 
-<a name="0x1_vault_ModifyCap"></a>
+<a id="0x1_vault_ModifyCap"></a>
 
 ## Struct `ModifyCap`
 
@@ -226,7 +226,7 @@ A capability to modify the content of the vault.
 
 </details>
 
-<a name="0x1_vault_DelegateCap"></a>
+<a id="0x1_vault_DelegateCap"></a>
 
 ## Struct `DelegateCap`
 
@@ -260,7 +260,7 @@ A capability to delegate access to the vault.
 
 </details>
 
-<a name="0x1_vault_TransferCap"></a>
+<a id="0x1_vault_TransferCap"></a>
 
 ## Struct `TransferCap`
 
@@ -294,7 +294,7 @@ A capability to transfer ownership of the vault.
 
 </details>
 
-<a name="0x1_vault_CapType"></a>
+<a id="0x1_vault_CapType"></a>
 
 ## Struct `CapType`
 
@@ -323,7 +323,7 @@ specify capability types.
 
 </details>
 
-<a name="0x1_vault_VaultDelegateEvent"></a>
+<a id="0x1_vault_VaultDelegateEvent"></a>
 
 ## Struct `VaultDelegateEvent`
 
@@ -381,7 +381,7 @@ An event which we generate on vault access delegation or revocation if event gen
 
 </details>
 
-<a name="0x1_vault_VaultTransferEvent"></a>
+<a id="0x1_vault_VaultTransferEvent"></a>
 
 ## Struct `VaultTransferEvent`
 
@@ -427,7 +427,7 @@ An event which we generate on vault transfer if event generation is enabled.
 
 </details>
 
-<a name="0x1_vault_Vault"></a>
+<a id="0x1_vault_Vault"></a>
 
 ## Resource `Vault`
 
@@ -456,7 +456,7 @@ Private. The vault representation.
 
 </details>
 
-<a name="0x1_vault_VaultDelegates"></a>
+<a id="0x1_vault_VaultDelegates"></a>
 
 ## Resource `VaultDelegates`
 
@@ -484,7 +484,7 @@ Private. If the vault supports delegation, information about the delegates.
 
 </details>
 
-<a name="0x1_vault_VaultEvents"></a>
+<a id="0x1_vault_VaultEvents"></a>
 
 ## Resource `VaultEvents`
 
@@ -525,7 +525,7 @@ Private. If event generation is enabled, contains the event generators.
 
 </details>
 
-<a name="0x1_vault_VaultDelegate"></a>
+<a id="0x1_vault_VaultDelegate"></a>
 
 ## Resource `VaultDelegate`
 
@@ -560,7 +560,7 @@ describes the capabilities granted to this delegate.
 
 </details>
 
-<a name="0x1_vault_ReadAccessor"></a>
+<a id="0x1_vault_ReadAccessor"></a>
 
 ## Struct `ReadAccessor`
 
@@ -594,7 +594,7 @@ A read accessor for the content of the vault.
 
 </details>
 
-<a name="0x1_vault_ModifyAccessor"></a>
+<a id="0x1_vault_ModifyAccessor"></a>
 
 ## Struct `ModifyAccessor`
 
@@ -628,12 +628,12 @@ A modify accessor for the content of the vault.
 
 </details>
 
-<a name="@Constants_4"></a>
+<a id="@Constants_4"></a>
 
 ## Constants
 
 
-<a name="0x1_vault_EDELEGATE"></a>
+<a id="0x1_vault_EDELEGATE"></a>
 
 
 
@@ -642,7 +642,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EACCESSOR_INCONSISTENCY"></a>
+<a id="0x1_vault_EACCESSOR_INCONSISTENCY"></a>
 
 
 
@@ -651,7 +651,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EACCESSOR_IN_USE"></a>
+<a id="0x1_vault_EACCESSOR_IN_USE"></a>
 
 
 
@@ -660,7 +660,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EDELEGATE_TO_SELF"></a>
+<a id="0x1_vault_EDELEGATE_TO_SELF"></a>
 
 
 
@@ -669,7 +669,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EDELEGATION_NOT_ENABLED"></a>
+<a id="0x1_vault_EDELEGATION_NOT_ENABLED"></a>
 
 
 
@@ -678,7 +678,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EEVENT"></a>
+<a id="0x1_vault_EEVENT"></a>
 
 
 
@@ -687,7 +687,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_EVAULT"></a>
+<a id="0x1_vault_EVAULT"></a>
 
 
 
@@ -696,7 +696,7 @@ A modify accessor for the content of the vault.
 
 
 
-<a name="0x1_vault_read_cap_type"></a>
+<a id="0x1_vault_read_cap_type"></a>
 
 ## Function `read_cap_type`
 
@@ -719,7 +719,7 @@ Creates a read capability type.
 
 </details>
 
-<a name="0x1_vault_modify_cap_type"></a>
+<a id="0x1_vault_modify_cap_type"></a>
 
 ## Function `modify_cap_type`
 
@@ -742,7 +742,7 @@ Creates a modify  capability type.
 
 </details>
 
-<a name="0x1_vault_delegate_cap_type"></a>
+<a id="0x1_vault_delegate_cap_type"></a>
 
 ## Function `delegate_cap_type`
 
@@ -765,7 +765,7 @@ Creates a delegate  capability type.
 
 </details>
 
-<a name="0x1_vault_transfer_cap_type"></a>
+<a id="0x1_vault_transfer_cap_type"></a>
 
 ## Function `transfer_cap_type`
 
@@ -788,7 +788,7 @@ Creates a transfer  capability type.
 
 </details>
 
-<a name="0x1_vault_new"></a>
+<a id="0x1_vault_new"></a>
 
 ## Function `new`
 
@@ -820,7 +820,7 @@ Creates new vault for the given signer. The vault is populated with the <code>in
 
 </details>
 
-<a name="0x1_vault_is_delegation_enabled"></a>
+<a id="0x1_vault_is_delegation_enabled"></a>
 
 ## Function `is_delegation_enabled`
 
@@ -848,7 +848,7 @@ Returns <code><b>false</b></code> otherwise.
 
 </details>
 
-<a name="0x1_vault_enable_delegation"></a>
+<a id="0x1_vault_enable_delegation"></a>
 
 ## Function `enable_delegation`
 
@@ -874,7 +874,7 @@ Enables delegation functionality for this vault. By default, vaults to not suppo
 
 </details>
 
-<a name="0x1_vault_enable_events"></a>
+<a id="0x1_vault_enable_events"></a>
 
 ## Function `enable_events`
 
@@ -910,7 +910,7 @@ the vault in events.
 
 </details>
 
-<a name="0x1_vault_remove_vault"></a>
+<a id="0x1_vault_remove_vault"></a>
 
 ## Function `remove_vault`
 
@@ -953,7 +953,7 @@ this to succeed, there must be no active accessor for the vault.
 
 </details>
 
-<a name="0x1_vault_acquire_read_cap"></a>
+<a id="0x1_vault_acquire_read_cap"></a>
 
 ## Function `acquire_read_cap`
 
@@ -981,7 +981,7 @@ of the vault or a delegate with appropriate access.
 
 </details>
 
-<a name="0x1_vault_acquire_modify_cap"></a>
+<a id="0x1_vault_acquire_modify_cap"></a>
 
 ## Function `acquire_modify_cap`
 
@@ -1009,7 +1009,7 @@ of the vault or a delegate with appropriate access.
 
 </details>
 
-<a name="0x1_vault_acquire_delegate_cap"></a>
+<a id="0x1_vault_acquire_delegate_cap"></a>
 
 ## Function `acquire_delegate_cap`
 
@@ -1037,7 +1037,7 @@ of the vault or a delegate with appropriate access.
 
 </details>
 
-<a name="0x1_vault_acquire_transfer_cap"></a>
+<a id="0x1_vault_acquire_transfer_cap"></a>
 
 ## Function `acquire_transfer_cap`
 
@@ -1065,7 +1065,7 @@ of the vault or a delegate with appropriate access.
 
 </details>
 
-<a name="0x1_vault_validate_cap"></a>
+<a id="0x1_vault_validate_cap"></a>
 
 ## Function `validate_cap`
 
@@ -1102,7 +1102,7 @@ pair of the vault address and the used authority.
 
 </details>
 
-<a name="0x1_vault_read_accessor"></a>
+<a id="0x1_vault_read_accessor"></a>
 
 ## Function `read_accessor`
 
@@ -1134,7 +1134,7 @@ function will abort if one is in use. An accessor must be explicitly released us
 
 </details>
 
-<a name="0x1_vault_borrow"></a>
+<a id="0x1_vault_borrow"></a>
 
 ## Function `borrow`
 
@@ -1159,7 +1159,7 @@ Returns a reference to the content represented by a read accessor.
 
 </details>
 
-<a name="0x1_vault_release_read_accessor"></a>
+<a id="0x1_vault_release_read_accessor"></a>
 
 ## Function `release_read_accessor`
 
@@ -1190,7 +1190,7 @@ Releases read accessor.
 
 </details>
 
-<a name="0x1_vault_modify_accessor"></a>
+<a id="0x1_vault_modify_accessor"></a>
 
 ## Function `modify_accessor`
 
@@ -1220,7 +1220,7 @@ the content.
 
 </details>
 
-<a name="0x1_vault_borrow_mut"></a>
+<a id="0x1_vault_borrow_mut"></a>
 
 ## Function `borrow_mut`
 
@@ -1245,7 +1245,7 @@ Returns a mutable reference to the content represented by a modify accessor.
 
 </details>
 
-<a name="0x1_vault_release_modify_accessor"></a>
+<a id="0x1_vault_release_modify_accessor"></a>
 
 ## Function `release_modify_accessor`
 
@@ -1277,7 +1277,7 @@ to the vault.
 
 </details>
 
-<a name="0x1_vault_delegate"></a>
+<a id="0x1_vault_delegate"></a>
 
 ## Function `delegate`
 
@@ -1328,7 +1328,7 @@ during vault creation for this to succeed.
 
 </details>
 
-<a name="0x1_vault_revoke"></a>
+<a id="0x1_vault_revoke"></a>
 
 ## Function `revoke`
 
@@ -1372,7 +1372,7 @@ Revokes the delegated right to acquire a capability of given type.
 
 </details>
 
-<a name="0x1_vault_revoke_all"></a>
+<a id="0x1_vault_revoke_all"></a>
 
 ## Function `revoke_all`
 
@@ -1411,7 +1411,7 @@ Revokes all delegate rights for this vault.
 
 </details>
 
-<a name="0x1_vault_remove_element"></a>
+<a id="0x1_vault_remove_element"></a>
 
 ## Function `remove_element`
 
@@ -1439,7 +1439,7 @@ Helper to remove an element from a vector.
 
 </details>
 
-<a name="0x1_vault_add_element"></a>
+<a id="0x1_vault_add_element"></a>
 
 ## Function `add_element`
 
@@ -1466,7 +1466,7 @@ Helper to add an element to a vector.
 
 </details>
 
-<a name="0x1_vault_emit_delegate_event"></a>
+<a id="0x1_vault_emit_delegate_event"></a>
 
 ## Function `emit_delegate_event`
 
@@ -1506,7 +1506,7 @@ Emits a delegation or revocation event if event generation is enabled.
 
 </details>
 
-<a name="0x1_vault_transfer"></a>
+<a id="0x1_vault_transfer"></a>
 
 ## Function `transfer`
 


### PR DESCRIPTION
This overall improves error messages around type unification:

- A new `ErrorMessageContext` is passed into displaying unification errors. This gives more context on why the type error happens. For the resulting variations of error messages see the new test folder `checking/error_context`.
- When a critical pair is detected unification, we now lift it to the top level types. This leads to more consistent messages in each particular context. For instance, if the type of a lanbda is wrong, we now show the full function type and not some confusing sub-context. 
- No more printing of type variables unless actually needed. 
- Various other bug fixes.

This proposes to close the following bugs which have been individually verified, and instead open new more specific bugs as needed for remaining issues:

Closes #9861
Closes #11055
Closes #11867
Closes #11963
Closes #12118
Closes #12234
Closes #9863

