### PR TITLE
Move unit tests should use default Feature flags

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -1175,6 +1175,15 @@ module aptos_framework::multisig_account {
         chain_id::initialize_for_test(framework_signer, 1);
     }
 
+    #[test_only]
+    fun setup_disabled() {
+        let framework_signer = &create_signer(@0x1);
+        features::change_feature_flags(
+            framework_signer, vector[], vector[features::get_multisig_accounts_feature()]);
+        timestamp::set_time_has_started_for_testing(framework_signer);
+        chain_id::initialize_for_test(framework_signer, 1);
+    }
+
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_end_to_end(
         owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
@@ -1289,6 +1298,7 @@ module aptos_framework::multisig_account {
     #[expected_failure(abort_code = 0xD000E, location = Self)]
     public entry fun test_create_with_without_feature_flag_enabled_should_fail(
         owner: &signer) acquires MultisigAccount {
+        setup_disabled();
         create_account(address_of(owner));
         create(owner, 2, vector[], vector[]);
     }

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -617,34 +617,40 @@ module aptos_token_objects::collection {
 
     // Tests
 
-    #[test(creator = @0x123)]
-    fun test_create_mint_burn_for_unlimited(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+    #[test(fx = @aptos_framework, creator = @0x123)]
+    fun test_create_mint_burn_for_unlimited(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+        let feature = features::get_concurrent_token_v2_feature();
+        features::change_feature_flags(fx, vector[], vector[feature]);
+
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
         create_unlimited_collection(creator, string::utf8(b""), name, option::none(), string::utf8(b""));
         let collection_address = create_collection_address(&creator_address, &name);
         let collection = object::address_to_object<Collection>(collection_address);
         assert!(count(collection) == option::some(0), 0);
-        let cid = increment_supply(&collection, creator_address);
+        let cid = aggregator_v2::read_snapshot(&option::destroy_some(increment_concurrent_supply(&collection, creator_address)));
         assert!(count(collection) == option::some(1), 0);
         assert!(event::counter(&borrow_global<UnlimitedSupply>(collection_address).mint_events) == 1, 0);
-        decrement_supply(&collection, creator_address, cid, creator_address);
+        decrement_supply(&collection, creator_address, option::some(cid), creator_address);
         assert!(count(collection) == option::some(0), 0);
         assert!(event::counter(&borrow_global<UnlimitedSupply>(collection_address).burn_events) == 1, 0);
     }
 
-    #[test(creator = @0x123)]
-    fun test_create_mint_burn_for_fixed(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+    #[test(fx = @aptos_framework, creator = @0x123)]
+    fun test_create_mint_burn_for_fixed(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+        let feature = features::get_concurrent_token_v2_feature();
+        features::change_feature_flags(fx, vector[], vector[feature]);
+
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
         create_fixed_collection(creator, string::utf8(b""), 1, name, option::none(), string::utf8(b""));
         let collection_address = create_collection_address(&creator_address, &name);
         let collection = object::address_to_object<Collection>(collection_address);
         assert!(count(collection) == option::some(0), 0);
-        let cid = increment_supply(&collection, creator_address);
+        let cid = aggregator_v2::read_snapshot(&option::destroy_some(increment_concurrent_supply(&collection, creator_address)));
         assert!(count(collection) == option::some(1), 0);
         assert!(event::counter(&borrow_global<FixedSupply>(collection_address).mint_events) == 1, 0);
-        decrement_supply(&collection, creator_address, cid, creator_address);
+        decrement_supply(&collection, creator_address, option::some(cid), creator_address);
         assert!(count(collection) == option::some(0), 0);
         assert!(event::counter(&borrow_global<FixedSupply>(collection_address).burn_events) == 1, 0);
     }
@@ -652,10 +658,7 @@ module aptos_token_objects::collection {
     #[test(fx = @aptos_framework, creator = @0x123)]
     fun test_create_mint_burn_for_concurrent(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let feature = features::get_concurrent_token_v2_feature();
-        let agg_feature = features::get_aggregator_v2_api_feature();
-        let auid_feature = features::get_auids();
-        let module_event_feature = features::get_module_event_feature();
-        features::change_feature_flags(fx, vector[feature, auid_feature, module_event_feature, agg_feature], vector[]);
+        features::change_feature_flags(fx, vector[feature], vector[]);
 
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -4,11 +4,12 @@
 
 use aptos_framework::{extended_checks, path_in_crate};
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
-use aptos_types::{account_config::CORE_CODE_ADDRESS, on_chain_config::{Features, OnChainConfig, TimedFeaturesBuilder}};
+use aptos_types::on_chain_config::{
+    aptos_test_feature_flags_genesis, Features, TimedFeaturesBuilder,
+};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
 use move_command_line_common::{env::read_bool_env_var, testing::MOVE_COMPILER_V2};
-use move_core_types::effects::{ChangeSet, Op};
 use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -34,7 +35,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         // TODO(Gas): double check if this is correct
         UnitTestingConfig::default_with_bound(Some(100_000)),
         aptos_test_natives(),
-        aptos_test_genesis(),
+        aptos_test_feature_flags_genesis(),
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
@@ -52,7 +53,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
             build_config,
             UnitTestingConfig::default_with_bound(Some(100_000)),
             aptos_test_natives(),
-            aptos_test_genesis(),
+            aptos_test_feature_flags_genesis(),
             /* cost_table */ None,
             /* compute_coverage */ false,
             &mut std::io::stdout(),
@@ -76,20 +77,6 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     )
-}
-
-pub fn aptos_test_genesis() -> ChangeSet {
-    let features_value = bcs::to_bytes(&Features::default()).unwrap();
-
-    let mut change_set = ChangeSet::new();
-    // we need to initialize features to their defaults.
-    change_set.add_resource_op(
-        CORE_CODE_ADDRESS,
-        Features::struct_tag(),
-        Op::New(features_value.into()),
-    ).expect("adding genesis Feature resource must succeed");
-
-    change_set
 }
 
 #[test]

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -4,10 +4,11 @@
 
 use aptos_framework::{extended_checks, path_in_crate};
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
-use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
+use aptos_types::{account_config::CORE_CODE_ADDRESS, on_chain_config::{Features, OnChainConfig, TimedFeaturesBuilder}};
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
 use move_command_line_common::{env::read_bool_env_var, testing::MOVE_COMPILER_V2};
+use move_core_types::effects::{ChangeSet, Op};
 use move_package::{CompilerConfig, CompilerVersion};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -26,12 +27,14 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         full_model_generation: true, // Run extended checks also on test code
         ..Default::default()
     };
+
     let mut ok = run_move_unit_tests(
         &pkg_path,
         build_config.clone(),
         // TODO(Gas): double check if this is correct
         UnitTestingConfig::default_with_bound(Some(100_000)),
         aptos_test_natives(),
+        aptos_test_genesis(),
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
@@ -49,6 +52,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
             build_config,
             UnitTestingConfig::default_with_bound(Some(100_000)),
             aptos_test_natives(),
+            aptos_test_genesis(),
             /* cost_table */ None,
             /* compute_coverage */ false,
             &mut std::io::stdout(),
@@ -72,6 +76,20 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         TimedFeaturesBuilder::enable_all().build(),
         Features::default(),
     )
+}
+
+pub fn aptos_test_genesis() -> ChangeSet {
+    let features_value = bcs::to_bytes(&Features::default()).unwrap();
+
+    let mut change_set = ChangeSet::new();
+    // we need to initialize features to their defaults.
+    change_set.add_resource_op(
+        CORE_CODE_ADDRESS,
+        Features::struct_tag(),
+        Op::New(features_value.into()),
+    ).expect("adding genesis Feature resource must succeed");
+
+    change_set
 }
 
 #[test]

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -5,7 +5,7 @@ use aptos_framework::extended_checks;
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
-    on_chain_config::{Features, TimedFeaturesBuilder},
+    on_chain_config::{aptos_test_feature_flags_genesis, Features, TimedFeaturesBuilder},
 };
 use aptos_vm::natives;
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
@@ -44,6 +44,7 @@ pub fn run_tests_for_pkg(
         UnitTestingConfig::default_with_bound(Some(100_000)),
         // TODO(Gas): we may want to switch to non-zero costs in the future
         aptos_test_natives(),
+        aptos_test_feature_flags_genesis(),
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -44,6 +44,7 @@ use aptos_rest_client::aptos_api_types::{
 use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
     object_address::create_object_code_deployment_address,
+    on_chain_config::aptos_test_feature_flags_genesis,
     transaction::{TransactionArgument, TransactionPayload},
 };
 use async_trait::async_trait;
@@ -489,6 +490,7 @@ impl CliCommand<&'static str> for TestPackage {
                 NativeGasParameters::zeros(),
                 MiscGasParameters::zeros(),
             ),
+            aptos_test_feature_flags_genesis(),
             None,
             self.compute_coverage,
             &mut std::io::stdout(),

--- a/third_party/move/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/third_party/move/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_core_types::account_address::AccountAddress;
+use move_core_types::{account_address::AccountAddress, effects::ChangeSet};
 use move_table_extension::{table_natives, GasParameters};
 use move_unit_test::UnitTestingConfig;
 use std::path::PathBuf;
@@ -28,6 +28,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         },
         UnitTestingConfig::default_with_bound(Some(100_000)),
         natives,
+        ChangeSet::new(),
         None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),

--- a/third_party/move/move-stdlib/tests/move_unit_test.rs
+++ b/third_party/move/move-stdlib/tests/move_unit_test.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
-use move_core_types::account_address::AccountAddress;
+use move_core_types::{account_address::AccountAddress, effects::ChangeSet};
 use move_stdlib::{
     natives::{all_natives, nursery_natives, GasParameters, NurseryGasParameters},
     path_in_crate,
@@ -34,6 +34,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
         },
         UnitTestingConfig::default_with_bound(Some(100_000)),
         natives,
+        ChangeSet::new(),
         None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -13,6 +13,7 @@ use move_compiler::{
     unit_test::{plan_builder::construct_test_plan, TestPlan},
     Compiler, Flags, PASS_CFGIR,
 };
+use move_core_types::effects::ChangeSet;
 use move_coverage::coverage_map::{output_map_to_file, CoverageMap};
 use move_model::PackageInfo;
 use move_package::{
@@ -96,6 +97,7 @@ impl Test {
         path: Option<PathBuf>,
         config: BuildConfig,
         natives: Vec<NativeFunctionRecord>,
+        genesis: ChangeSet,
         cost_table: Option<CostTable>,
     ) -> anyhow::Result<()> {
         let rerooted_path = reroot_path(path)?;
@@ -133,6 +135,7 @@ impl Test {
             config,
             unit_test_config,
             natives,
+            genesis,
             cost_table,
             compute_coverage,
             &mut std::io::stdout(),
@@ -158,6 +161,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
     mut build_config: move_package::BuildConfig,
     mut unit_test_config: UnitTestingConfig,
     natives: Vec<NativeFunctionRecord>,
+    genesis: ChangeSet,
     cost_table: Option<CostTable>,
     compute_coverage: bool,
     writer: &mut W,
@@ -332,7 +336,7 @@ pub fn run_move_unit_tests<W: Write + Send>(
     // Run the tests. If any of the tests fail, then we don't produce a coverage report, so cleanup
     // the trace files.
     if !unit_test_config
-        .run_and_report_unit_tests(test_plan, Some(natives), cost_table, writer)
+        .run_and_report_unit_tests(test_plan, Some(natives), Some(genesis), cost_table, writer)
         .unwrap()
         .1
     {

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -24,7 +24,8 @@ const BCS_EXTENSION: &str = "bcs";
 use anyhow::Result;
 use clap::Parser;
 use move_core_types::{
-    account_address::AccountAddress, effects::ChangeSet, errmap::ErrorMapping, identifier::Identifier
+    account_address::AccountAddress, effects::ChangeSet, errmap::ErrorMapping,
+    identifier::Identifier,
 };
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_test_utils::gas_schedule::CostTable;

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -24,7 +24,7 @@ const BCS_EXTENSION: &str = "bcs";
 use anyhow::Result;
 use clap::Parser;
 use move_core_types::{
-    account_address::AccountAddress, errmap::ErrorMapping, identifier::Identifier,
+    account_address::AccountAddress, effects::ChangeSet, errmap::ErrorMapping, identifier::Identifier
 };
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_test_utils::gas_schedule::CostTable;
@@ -87,6 +87,7 @@ pub enum Command {
 
 pub fn run_cli(
     natives: Vec<NativeFunctionRecord>,
+    genesis: ChangeSet,
     cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
     move_args: Move,
@@ -108,6 +109,7 @@ pub fn run_cli(
             move_args.package_path,
             move_args.build_config,
             natives,
+            genesis,
             Some(cost_table.clone()),
         ),
         Command::Sandbox { storage_dir, cmd } => cmd.handle_command(
@@ -123,12 +125,14 @@ pub fn run_cli(
 
 pub fn move_cli(
     natives: Vec<NativeFunctionRecord>,
+    genesis: ChangeSet,
     cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
 ) -> Result<()> {
     let args = MoveCLI::parse();
     run_cli(
         natives,
+        genesis,
         cost_table,
         error_descriptions,
         args.move_args,

--- a/third_party/move/tools/move-cli/src/main.rs
+++ b/third_party/move/tools/move-cli/src/main.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use move_core_types::{account_address::AccountAddress, errmap::ErrorMapping};
+use move_core_types::{account_address::AccountAddress, effects::ChangeSet, errmap::ErrorMapping};
 use move_stdlib::natives::{all_natives, nursery_natives, GasParameters, NurseryGasParameters};
 
 fn main() -> Result<()> {
@@ -15,5 +15,5 @@ fn main() -> Result<()> {
         .chain(nursery_natives(addr, NurseryGasParameters::zeros()))
         .collect();
 
-    move_cli::move_cli(natives, cost_table, &error_descriptions)
+    move_cli::move_cli(natives, ChangeSet::new(), cost_table, &error_descriptions)
 }

--- a/third_party/move/tools/move-unit-test/src/cargo_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/cargo_runner.rs
@@ -4,6 +4,7 @@
 
 use crate::UnitTestingConfig;
 use move_command_line_common::files::find_filenames;
+use move_core_types::effects::ChangeSet;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use move_vm_test_utils::gas_schedule::CostTable;
 
@@ -13,6 +14,7 @@ pub fn run_tests_with_config_and_filter(
     source_pattern: &str,
     dep_root: Option<&str>,
     native_function_table: Option<NativeFunctionTable>,
+    genesis_state: Option<ChangeSet>,
     cost_table: Option<CostTable>,
 ) {
     let get_files = |root_path, pat| {
@@ -37,6 +39,7 @@ pub fn run_tests_with_config_and_filter(
         .run_and_report_unit_tests(
             test_plan,
             native_function_table,
+            genesis_state,
             cost_table,
             std::io::stdout(),
         )
@@ -56,7 +59,7 @@ macro_rules! register_move_unit_tests {
         #[test]
         fn move_unit_tests() {
             $crate::cargo_runner::run_tests_with_config_and_filter(
-                $config, $root, $pattern, None, None,
+                $config, $root, $pattern, None, None, None, None,
             )
         }
     };
@@ -71,6 +74,8 @@ macro_rules! register_move_unit_tests {
                 $source_pattern,
                 Some($dep_root),
                 $native_function_table,
+                None,
+                None,
             )
         }
     };

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -17,7 +17,7 @@ use move_compiler::{
     unit_test::{self, TestPlan},
     Compiler, Flags, PASS_CFGIR,
 };
-use move_core_types::language_storage::ModuleId;
+use move_core_types::{effects::ChangeSet, language_storage::ModuleId};
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use move_vm_test_utils::gas_schedule::CostTable;
 use std::{
@@ -215,6 +215,7 @@ impl UnitTestingConfig {
         &self,
         test_plan: TestPlan,
         native_function_table: Option<NativeFunctionTable>,
+        genesis_state: Option<ChangeSet>,
         cost_table: Option<CostTable>,
         writer: W,
     ) -> Result<(W, bool)> {
@@ -242,6 +243,7 @@ impl UnitTestingConfig {
             self.report_stacktrace_on_abort,
             test_plan,
             native_function_table,
+            genesis_state,
             cost_table,
             self.verbose,
             #[cfg(feature = "evm-backend")]

--- a/third_party/move/tools/move-unit-test/src/main.rs
+++ b/third_party/move/tools/move-unit-test/src/main.rs
@@ -10,7 +10,7 @@ pub fn main() {
 
     let test_plan = args.build_test_plan();
     if let Some(test_plan) = test_plan {
-        args.run_and_report_unit_tests(test_plan, None, None, std::io::stdout())
+        args.run_and_report_unit_tests(test_plan, None, None, None, std::io::stdout())
             .unwrap();
     }
 }

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -130,6 +130,7 @@ impl TestRunner {
         // TODO: maybe we should require the clients to always pass in a list of native functions so
         // we don't have to make assumptions about their gas parameters.
         native_function_table: Option<NativeFunctionTable>,
+        genesis_state: Option<ChangeSet>,
         cost_table: Option<CostTable>,
         record_writeset: bool,
         #[cfg(feature = "evm-backend")] evm: bool,
@@ -140,7 +141,10 @@ impl TestRunner {
             .map(|(filepath, _)| filepath.to_string())
             .collect();
         let modules = tests.module_info.values().map(|info| &info.module);
-        let starting_storage_state = setup_test_storage(modules)?;
+        let mut starting_storage_state = setup_test_storage(modules)?;
+        if let Some(genesis_state) = genesis_state {
+            starting_storage_state.apply(genesis_state)?;
+        }
         let native_function_table = native_function_table.unwrap_or_else(|| {
             move_stdlib::natives::all_natives(
                 AccountAddress::from_hex_literal("0x1").unwrap(),

--- a/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -54,7 +54,13 @@ fn run_test_with_modifiers(
             }
 
             results.push((
-                test_config.run_and_report_unit_tests(test_plan.unwrap(), None, None, None, buffer)?,
+                test_config.run_and_report_unit_tests(
+                    test_plan.unwrap(),
+                    None,
+                    None,
+                    None,
+                    buffer,
+                )?,
                 modified_exp_path,
             ))
         }

--- a/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/third_party/move/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -54,7 +54,7 @@ fn run_test_with_modifiers(
             }
 
             results.push((
-                test_config.run_and_report_unit_tests(test_plan.unwrap(), None, None, buffer)?,
+                test_config.run_and_report_unit_tests(test_plan.unwrap(), None, None, None, buffer)?,
                 modified_exp_path,
             ))
         }
@@ -68,7 +68,7 @@ fn run_test_with_modifiers(
     }
 
     results.push((
-        unit_test_config.run_and_report_unit_tests(test_plan.unwrap(), None, None, buffer)?,
+        unit_test_config.run_and_report_unit_tests(test_plan.unwrap(), None, None, None, buffer)?,
         path.with_extension(EXP_EXT),
     ));
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::on_chain_config::OnChainConfig;
+use move_core_types::{
+    effects::{ChangeSet, Op},
+    language_storage::CORE_CODE_ADDRESS,
+};
 use serde::{Deserialize, Serialize};
 use strum_macros::FromRepr;
 /// The feature flags define in the Move source. This must stay aligned with the constants there.
@@ -249,6 +253,22 @@ impl Features {
     pub fn is_refundable_bytes_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::REFUNDABLE_BYTES)
     }
+}
+
+pub fn aptos_test_feature_flags_genesis() -> ChangeSet {
+    let features_value = bcs::to_bytes(&Features::default()).unwrap();
+
+    let mut change_set = ChangeSet::new();
+    // we need to initialize features to their defaults.
+    change_set
+        .add_resource_op(
+            CORE_CODE_ADDRESS,
+            Features::struct_tag(),
+            Op::New(features_value.into()),
+        )
+        .expect("adding genesis Feature resource must succeed");
+
+    change_set
 }
 
 #[test]


### PR DESCRIPTION
Make move unit tests have ability to initialize with genesis state. 

Use that state to pass Feature flags

Let me know if any changes in third-party are problematic, and we can either try to minimize, or copy some of the testing code to our repo directly. All changes there are fully generic, and don't make any Aptos-specific assumptions.

### Test Plan
all move unit tests. 