### PR TITLE
[gha] update broken create-pull-request action

### DIFF
--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -32,7 +32,7 @@ jobs:
           aptos_node_cargo_toml: aptos-node/Cargo.toml
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f # pin@v4
+        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # pin@v6.0.1
         with:
           add-paths: aptos-node
           title: "[aptos-node] update release version"

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ steps.check_update.outputs.NEED_UPDATE == 'True' }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # pin@v6.0.1
         with:
           token: ${{ secrets.REPO_TOKEN }}
           commit-message: "Update Docker images"


### PR DESCRIPTION
### Description

Update `create-pull-request` action due to a breaking change in the Github API: https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1

### Test Plan

See the patch notes

<!-- Please provide us with clear details for verifying that your changes work. -->
