### PR TITLE
[storage] [2/3] remove error detail from txn info

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -434,11 +434,11 @@ impl AptosVM {
                 );
             }
         }
-
-        let txn_status = TransactionStatus::from_vm_status(
+        let (txn_status, txn_aux_data) = TransactionStatus::from_vm_status(
             error_vm_status.clone(),
             self.features()
                 .is_enabled(FeatureFlag::CHARGE_INVARIANT_VIOLATION),
+            self.features(),
         );
 
         match txn_status {
@@ -461,7 +461,7 @@ impl AptosVM {
                         change_set,
                         fee_statement,
                         TransactionStatus::Keep(status),
-                        TransactionAuxiliaryData::from_vm_status(&error_vm_status),
+                        txn_aux_data,
                     ),
                     Err(err) => discarded_output(err.status_code()),
                 };
@@ -1665,7 +1665,7 @@ impl AptosVM {
         let output = VMOutput::new(
             change_set,
             FeeStatement::zero(),
-            VMStatus::Executed.into(),
+            TransactionStatus::from_executed_vm_status(VMStatus::Executed),
             TransactionAuxiliaryData::default(),
         );
         Ok((VMStatus::Executed, output))

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -19,7 +19,7 @@ use crate::{
     epoch_state::EpochState,
     event::{EventHandle, EventKey},
     ledger_info::{generate_ledger_info_with_sig, LedgerInfo, LedgerInfoWithSignatures},
-    on_chain_config::ValidatorSet,
+    on_chain_config::{Features, ValidatorSet},
     proof::TransactionInfoListWithProof,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -497,7 +497,8 @@ impl TransactionPayload {
 
 prop_compose! {
     fn arb_transaction_status()(vm_status in any::<VMStatus>()) -> TransactionStatus {
-        vm_status.into()
+        let (txn_status, _) = TransactionStatus::from_vm_status(vm_status, true, &Features::default());
+        txn_status
     }
 }
 


### PR DESCRIPTION
### Description
Remove the detail error info from transaction status which is the upstream from the execution status used in transaction info. 

To rollout the feature,
1. test turning on the feature in testnet once 1.11 upgrade finishes.
2. aim to turn the feature on in 1.12 branch once we see all the validators are on the version >= 1.11

TODO:
add transaction auxiliary data backup and restore. 
### Test Plan
replay verify https://github.com/aptos-labs/aptos-core/actions/runs/8103822653