### PR TITLE
[CLI] Upgrade processor dep to d44b2d209f57872ac593299c34751a5531b51352

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
 dependencies = [
  "chrono",
 ]
@@ -13016,11 +13016,11 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
 dependencies = [
  "ahash 0.8.8",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352)",
  "aptos-protos 1.3.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c)",
  "async-trait",
  "base64 0.13.1",
@@ -14625,7 +14625,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d5dc7a003c655bdbd30233a8e9076796cceae72c#d5dc7a003c655bdbd30233a8e9076796cceae72c"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## [2.5.0] - 2024/02/27
 - Updated CLI source compilation to use rust toolchain version 1.75.0 (from 1.74.1).
-- Upgraded indexer processors for local testnet from 9936ec73cef251fb01fd2c47412e064cad3975c2 to d5dc7a003c655bdbd30233a8e9076796cceae72c. Upgraded Hasura metadata accordingly.
+- Upgraded indexer processors for local testnet from 9936ec73cef251fb01fd2c47412e064cad3975c2 to d44b2d209f57872ac593299c34751a5531b51352. Upgraded Hasura metadata accordingly.
 - Added support for objects processor in local testnet and enabled it by default.
 
 ## [2.4.0] - 2024/01/05

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -79,7 +79,7 @@ move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 once_cell = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d5dc7a003c655bdbd30233a8e9076796cceae72c" }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d44b2d209f57872ac593299c34751a5531b51352" }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -87,7 +87,7 @@ self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d5dc7a003c655bdbd30233a8e9076796cceae72c" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d44b2d209f57872ac593299c34751a5531b51352" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary
Integrating https://github.com/aptos-labs/aptos-indexer-processors/pull/290.

Internal context: https://aptos-org.slack.com/archives/C03N83P7QUC/p1709258737987549.

## Test Plan
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-indexer-api
```
```
pnpm test:indexer
```