### PR TITLE
[State Sync] Use fast sync by default.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -128,7 +128,7 @@ pub struct StateSyncDriverConfig {
 impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
-            bootstrapping_mode: BootstrappingMode::ExecuteOrApplyFromGenesis,
+            bootstrapping_mode: BootstrappingMode::DownloadLatestStates,
             commit_notification_timeout_ms: 5000,
             continuous_syncing_mode: ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs,
             enable_auto_bootstrapping: false,


### PR DESCRIPTION
### Description
This PR updates the configs for state sync so that node's will use fast syncing by default in previewnet.

### Test Plan
Manual verification.