### PR TITLE
[Compiler-v2] Fix issue 12309

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -35,7 +35,7 @@ use move_binary_format::file_format::{Ability, AbilitySet, CodeOffset};
 use move_model::{
     ast::TempIndex,
     exp_generator::ExpGenerator,
-    model::{FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, Parameter, StructId, TypeParameterKind},
+    model::{FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, StructId, TypeParameterKind},
     ty,
     ty::{gen_get_ty_param_kinds, Type},
 };
@@ -99,29 +99,6 @@ impl FunctionTargetProcessor for AbilityProcessor {
             lifetime,
             exit_state,
         };
-
-        // Check whether unused parameters may be dropped
-        let live_vars = live_var.get_info_at(0).before_set();
-        if exit_state.get_state_at(0).may_return() {
-            let type_params = fun_env.get_type_parameters();
-            for (i, Parameter(sym, atype, loc)) in fun_env.get_parameters().iter().enumerate() {
-                // If parameter at `i` is not alive and its type is either a type parameter, a struct or a vector of struct
-                // we need to check its drop ability
-                if !live_vars.contains(&i)
-                    && (atype.is_type_parameter() || atype.is_struct_or_vector_of_struct())
-                {
-                    let ability = fun_env.module_env.env.type_abilities(atype, &type_params);
-                    if !ability.has_ability(Ability::Drop) {
-                        let msg = format!(
-                            "Unused parameter `{}` does not have the `drop` ability",
-                            sym.display(fun_env.module_env.env.symbol_pool()),
-                        );
-                        fun_env.module_env.env.diag(Severity::Error, loc, &msg);
-                    }
-                }
-            }
-        }
-
         let state_map = analyzer.analyze_function(CopyDropState::default(), &code, &cfg);
         let copy_drop =
             analyzer.state_per_instruction_with_default(state_map, &code, &cfg, |_, after| {
@@ -269,6 +246,22 @@ struct Transformer<'a> {
 
 impl<'a> Transformer<'a> {
     fn run(&mut self, code: Vec<Bytecode>) {
+        // Check and insert drop for parameters before the first instruction if it is a return
+        if !code.is_empty() && code.first().unwrap().is_return() {
+            let instr = code.first().unwrap();
+            for temp in self
+                .live_var
+                .0
+                .get(&0)
+                .unwrap()
+                .released_and_unused_temps(instr)
+            {
+                if temp < self.builder.fun_env.get_parameters().len() {
+                    self.copy_drop.get_mut(&0).unwrap().needs_drop.insert(temp);
+                }
+            }
+            self.check_and_add_implicit_drops(0, instr, true);
+        }
         for (offset, bc) in code.into_iter().enumerate() {
             self.transform_bytecode(offset as CodeOffset, bc)
         }
@@ -313,7 +306,7 @@ impl<'a> Transformer<'a> {
             _ => self.check_and_emit_bytecode(code_offset, bc.clone()),
         }
         // Insert/check any drops needed after this program point
-        self.check_and_add_implicit_drops(code_offset, &bc)
+        self.check_and_add_implicit_drops(code_offset, &bc, false)
     }
 
     fn check_and_emit_bytecode(&mut self, _code_offset: CodeOffset, bc: Bytecode) {
@@ -445,9 +438,14 @@ impl<'a> Transformer<'a> {
 
 impl<'a> Transformer<'a> {
     /// Add implicit drops at the given code offset.
-    fn check_and_add_implicit_drops(&mut self, code_offset: CodeOffset, bytecode: &Bytecode) {
-        // No drop after terminators
-        if !bytecode.is_always_branching() {
+    fn check_and_add_implicit_drops(
+        &mut self,
+        code_offset: CodeOffset,
+        bytecode: &Bytecode,
+        before: bool,
+    ) {
+        // No drop after terminators unless it is dropped before a return
+        if !bytecode.is_always_branching() || before {
             let copy_drop_at = self.copy_drop.get(&code_offset).expect("copy_drop");
             let id = bytecode.get_attr_id();
             for temp in copy_drop_at.check_drop.iter() {

--- a/third_party/move/move-compiler-v2/tests/ability-check/explicit_move.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/explicit_move.move
@@ -1,6 +1,6 @@
 module 0x42::m {
 
-    struct R has key {
+    struct R has key, drop {
         v: u64
     }
 

--- a/third_party/move/move-compiler-v2/tests/ability-check/inferred_copy.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/inferred_copy.move
@@ -1,6 +1,6 @@
 module 0x42::m {
 
-    struct R has key, copy {
+    struct R has key, copy, drop {
         v: u64
     }
 

--- a/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.exp
@@ -1,0 +1,61 @@
+
+Diagnostics:
+error: Unused parameter `_x` does not have the `drop` ability
+  ┌─ tests/ability-check/unused_para_no_drop.move:9:22
+  │
+9 │     public fun f1<T>(_x: T) {
+  │                      ^^
+
+error: Unused parameter `_x` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:15:19
+   │
+15 │     public fun f3(_x: S) {
+   │                   ^^
+
+error: Unused parameter `_x` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:21:19
+   │
+21 │     public fun f5(_x: vector<S>) {
+   │                   ^^
+
+error: Unused parameter `_y` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:37:29
+   │
+37 │     public fun f10<T>(x: T, _y:T): T {
+   │                             ^^
+
+error: local `x` of type `m::S` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:42:9
+   │
+42 │         &x == &y
+   │         ^^ still borrowed but will be implicitly dropped later since it is no longer used
+
+error: local `y` of type `m::S` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:42:15
+   │
+42 │         &x == &y
+   │               ^^ still borrowed but will be implicitly dropped later since it is no longer used
+
+error: local `x` of type `T` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:46:9
+   │
+46 │         &x == &y
+   │         ^^ still borrowed but will be implicitly dropped later since it is no longer used
+
+error: local `y` of type `T` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:46:15
+   │
+46 │         &x == &y
+   │               ^^ still borrowed but will be implicitly dropped later since it is no longer used
+
+error: local `x` of type `m::S2` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:54:9
+   │
+54 │         x.foo == y.foo
+   │         ^ still borrowed but will be implicitly dropped later since it is no longer used
+
+error: local `y` of type `m::S2` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:54:18
+   │
+54 │         x.foo == y.foo
+   │                  ^ still borrowed but will be implicitly dropped later since it is no longer used

--- a/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.exp
@@ -1,28 +1,34 @@
 
 Diagnostics:
-error: Unused parameter `_x` does not have the `drop` ability
-  ┌─ tests/ability-check/unused_para_no_drop.move:9:22
-  │
-9 │     public fun f1<T>(_x: T) {
-  │                      ^^
-
-error: Unused parameter `_x` does not have the `drop` ability
-   ┌─ tests/ability-check/unused_para_no_drop.move:15:19
+error: local `_x` of type `T` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:9:29
    │
-15 │     public fun f3(_x: S) {
-   │                   ^^
+ 9 │       public fun f1<T>(_x: T) {
+   │ ╭─────────────────────────────^
+10 │ │     }
+   │ ╰─────^ implicitly dropped here since it is no longer used
 
-error: Unused parameter `_x` does not have the `drop` ability
-   ┌─ tests/ability-check/unused_para_no_drop.move:21:19
+error: local `_x` of type `m::S` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:15:26
    │
-21 │     public fun f5(_x: vector<S>) {
-   │                   ^^
+15 │       public fun f3(_x: S) {
+   │ ╭──────────────────────────^
+16 │ │     }
+   │ ╰─────^ implicitly dropped here since it is no longer used
 
-error: Unused parameter `_y` does not have the `drop` ability
-   ┌─ tests/ability-check/unused_para_no_drop.move:37:29
+error: local `_x` of type `vector<m::S>` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:21:34
    │
-37 │     public fun f10<T>(x: T, _y:T): T {
-   │                             ^^
+21 │       public fun f5(_x: vector<S>) {
+   │ ╭──────────────────────────────────^
+22 │ │     }
+   │ ╰─────^ implicitly dropped here since it is no longer used
+
+error: local `_y` of type `T` does not have the `drop` ability
+   ┌─ tests/ability-check/unused_para_no_drop.move:38:9
+   │
+38 │         x
+   │         ^ implicitly dropped here since it is no longer used
 
 error: local `x` of type `m::S` does not have the `drop` ability
    ┌─ tests/ability-check/unused_para_no_drop.move:42:9

--- a/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/unused_para_no_drop.move
@@ -1,0 +1,57 @@
+module 0xc0ffee::m {
+
+    struct S {
+    }
+
+    struct G has drop {
+    }
+
+    public fun f1<T>(_x: T) {
+    }
+
+    public fun f2<T>(_x: &T) {
+    }
+
+    public fun f3(_x: S) {
+    }
+
+    public fun f4(_x: &S) {
+    }
+
+    public fun f5(_x: vector<S>) {
+    }
+
+    public fun f6(_x: G) {
+    }
+
+    public fun f7(_x: &G) {
+    }
+
+    public fun f8(_x: u64) {
+    }
+
+    public fun f9<T>(_x: T) {
+        abort 0 // no error for this function
+    }
+
+    public fun f10<T>(x: T, _y:T): T {
+        x
+    }
+
+    public fun f11(x: S, y: S): bool {
+        &x == &y
+    }
+
+    public fun f12<T>(x: T, y: T): bool {
+        &x == &y
+    }
+
+    struct S2 {
+        foo: u64
+    }
+
+    public fun f13(x: S2, y: S2): bool {
+        x.foo == y.foo
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
@@ -24,7 +24,7 @@ public fun m::singleton<#0>($t0: #0): vector<#0> {
 
 [variant baseline]
 fun m::g<#0>($t0: &mut vector<#0>) {
-     # live vars:
+     # live vars: $t0
   0: return ()
 }
 
@@ -53,7 +53,7 @@ public fun m::singleton<#0>($t0: #0): vector<#0> {
 
 [variant baseline]
 fun m::g<#0>($t0: &mut vector<#0>) {
-     # live vars:
+     # live vars: $t0
      # graph: {@1000000=external[borrow(true) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
@@ -111,7 +111,7 @@ public fun m::singleton<#0>($t0: #0): vector<#0> {
 [variant baseline]
 fun m::g<#0>($t0: &mut vector<#0>) {
      # abort state: {returns}
-     # live vars:
+     # live vars: $t0
      # graph: {@1000000=external[borrow(true) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
@@ -174,7 +174,8 @@ public fun m::singleton<#0>($t0: #0): vector<#0> {
 
 [variant baseline]
 fun m::g<#0>($t0: &mut vector<#0>) {
-  0: return ()
+  0: drop($t0)
+  1: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
@@ -387,13 +387,13 @@ fun m::id($t0: &mut m::R): &mut m::R {
 
 [variant baseline]
 fun m::some($t0: &mut m::R) {
-     # live vars:
+     # live vars: $t0
   0: return ()
 }
 
 
 [variant baseline]
 fun m::some2($t0: &mut m::R, $t1: &mut m::R) {
-     # live vars:
+     # live vars: $t0, $t1
   0: return ()
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/access_control/dynamic.exp
@@ -24,6 +24,6 @@ Error: Function execution failed with VMError: {
     sub_status: None,
     location: 0x42::test,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(1), 1)],
+    offsets: [(FunctionDefinitionIndex(1), 3)],
     exec_state: Some(ExecutionState { stack_trace: [] }),
 }


### PR DESCRIPTION
### Description

This PR closes #12309 by adding a check to the ability processor that if 1) an unused parameter is of generic type or a struct or a vector of struct; 2) the struct/generic type has no drop ability and 3) the function does not always abort, an error will be generated.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added a new test `unused_para_no_drop` to validate the fix