### PR TITLE
[preview] [aptos channel] always reset counters on new channel

### DIFF
--- a/crates/channel/src/aptos_channel.rs
+++ b/crates/channel/src/aptos_channel.rs
@@ -240,6 +240,9 @@ pub fn new<K: Eq + Hash + Clone, M>(
 ) -> (Sender<K, M>, Receiver<K, M>) {
     let max_queue_size_per_key =
         NonZeroUsize!(max_queue_size_per_key, "aptos_channel cannot be of size 0");
+    if let Some(counters) = counters {
+        counters.reset();
+    }
     let shared_state = Arc::new(Mutex::new(SharedState {
         internal_queue: PerKeyQueue::new(queue_style, max_queue_size_per_key, counters),
         waker: None,

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -18,6 +18,7 @@ use aptos_forge::{
     },
     ForgeConfig, Options, *,
 };
+use aptos_global_constants::PREVIEWNET_EXECUTION_MULTIPLIER;
 use aptos_logger::{info, Level};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
@@ -602,7 +603,7 @@ fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" => land_blocking_test_suite(duration), // TODO: remove land_blocking, superseded by below
-        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
+        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 100, 10),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test
@@ -1770,10 +1771,18 @@ fn realistic_env_max_load_test(
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_fullnodes)
+        .with_validator_resource_override(NodeResourceOverride {
+            cpu_cores: Some(58),
+            memory_gib: Some(200),
+        })
+        .with_fullnode_resource_override(NodeResourceOverride {
+            cpu_cores: Some(58),
+            memory_gib: Some(200),
+        })
         .add_network_test(wrap_with_realistic_env(TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
                 .mode(EmitJobMode::MaxLoad {
-                    mempool_backlog: 40000,
+                    mempool_backlog: 14_000 * PREVIEWNET_EXECUTION_MULTIPLIER * 6,
                 })
                 .init_gas_price_multiplier(20),
             inner_success_criteria: SuccessCriteria::new(

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -18,7 +18,6 @@ use aptos_forge::{
     },
     ForgeConfig, Options, *,
 };
-use aptos_global_constants::PREVIEWNET_EXECUTION_MULTIPLIER;
 use aptos_logger::{info, Level};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
@@ -603,7 +602,7 @@ fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" => land_blocking_test_suite(duration), // TODO: remove land_blocking, superseded by below
-        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 100, 10),
+        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test
@@ -1771,18 +1770,10 @@ fn realistic_env_max_load_test(
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_fullnodes)
-        .with_validator_resource_override(NodeResourceOverride {
-            cpu_cores: Some(58),
-            memory_gib: Some(200),
-        })
-        .with_fullnode_resource_override(NodeResourceOverride {
-            cpu_cores: Some(58),
-            memory_gib: Some(200),
-        })
         .add_network_test(wrap_with_realistic_env(TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
                 .mode(EmitJobMode::MaxLoad {
-                    mempool_backlog: 14_000 * PREVIEWNET_EXECUTION_MULTIPLIER * 6,
+                    mempool_backlog: 40000,
                 })
                 .init_gas_price_multiplier(20),
             inner_success_criteria: SuccessCriteria::new(


### PR DESCRIPTION
### Description

The consensus queues are recreated per epoch. Without resetting the counters, the metrics show as increasing number of "stuck" messages, which are simply messages that were in the queue during the epoch change (and hence were not dequeued or dropped).