### PR TITLE
[Framework] Add smart table keys lookup with pagination, tests

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -23,6 +23,7 @@ it tolerates collisions.
 -  [Function `add_all`](#0x1_smart_table_add_all)
 -  [Function `unzip_entries`](#0x1_smart_table_unzip_entries)
 -  [Function `to_simple_map`](#0x1_smart_table_to_simple_map)
+-  [Function `keys`](#0x1_smart_table_keys)
 -  [Function `keys_paginated`](#0x1_smart_table_keys_paginated)
 -  [Function `split_one_bucket`](#0x1_smart_table_split_one_bucket)
 -  [Function `bucket_index`](#0x1_smart_table_bucket_index)
@@ -195,6 +196,15 @@ Key not found in the smart table
 
 
 <pre><code><b>const</b> <a href="smart_table.md#0x1_smart_table_ENOT_FOUND">ENOT_FOUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_smart_table_ALL_KEYS"></a>
+
+
+
+<pre><code><b>const</b> <a href="smart_table.md#0x1_smart_table_ALL_KEYS">ALL_KEYS</a>: u64 = 18446744073709551615;
 </code></pre>
 
 
@@ -580,13 +590,56 @@ Disclaimer: This function may be costly as the smart table may be huge in size. 
 
 </details>
 
+<a id="0x1_smart_table_keys"></a>
+
+## Function `keys`
+
+Get all keys in a smart table.
+
+For a large enough smart table this function will fail due to execution gas limits, and
+<code>keys_paginated</code> should be used instead.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(
+    table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;
+): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; {
+    <b>let</b> (keys, _, _) = <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>(table_ref, 0, 0, <a href="smart_table.md#0x1_smart_table_ALL_KEYS">ALL_KEYS</a>);
+    keys
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_smart_table_keys_paginated"></a>
 
 ## Function `keys_paginated`
 
+Get keys from a smart table, paginated.
+
+This function can be used to paginate all keys in a large smart table outside of runtime,
+e.g. through chained view function calls. The maximum <code>num_keys_to_get</code> before hitting gas
+limits depends on the data types in the smart table.
+
+When starting pagination, pass <code>starting_bucket_index</code> = <code>starting_vector_index</code> = 0.
+
+The function will then return a vector of keys, a bucket index, and a vector index. The
+return indices can then be used as inputs to another pagination call, which will return a
+vector of more keys. This process can be repeated until the returned bucket index and vector
+index values are both 0, which means that pagination is complete.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, u64, u64)
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, u64, u64)
 </code></pre>
 
 
@@ -596,7 +649,7 @@ Disclaimer: This function may be costly as the smart table may be huge in size. 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(
-    <a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
+    table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">SmartTable</a>&lt;K, V&gt;,
     starting_bucket_index: u64,
     starting_vector_index: u64,
     num_keys_to_get: u64,
@@ -607,37 +660,37 @@ Disclaimer: This function may be costly as the smart table may be huge in size. 
 ) {
     <b>let</b> keys = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     <b>if</b> (num_keys_to_get &gt; 0) {
-        <b>let</b> num_buckets = <a href="table.md#0x1_table">table</a>.num_buckets;
-        <b>if</b> (num_buckets &gt; 0) {
-            <b>let</b> num_keys_checked = 0;
-            <b>let</b> buckets_ref = &<a href="table.md#0x1_table">table</a>.buckets;
-            <b>let</b> bucket_index = starting_bucket_index;
+        <b>let</b> num_buckets = table_ref.num_buckets;
+        <b>let</b> num_keys_checked = 0;
+        <b>let</b> buckets_ref = &table_ref.buckets;
+        <b>let</b> bucket_index = starting_bucket_index;
+        <b>if</b> (starting_bucket_index != 0) {
             <b>assert</b>!(starting_bucket_index &lt; num_buckets, <a href="smart_table.md#0x1_smart_table_EINVALID_BUCKET_INDEX">EINVALID_BUCKET_INDEX</a>);
-            <b>let</b> bucket_ref = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(buckets_ref, bucket_index);
-            <b>let</b> bucket_length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket_ref);
-            <b>let</b> vector_index = starting_vector_index;
-            <b>if</b> (starting_vector_index != 0) {
-                <b>assert</b>!(starting_vector_index &lt; bucket_length, <a href="smart_table.md#0x1_smart_table_EINVALID_VECTOR_INDEX">EINVALID_VECTOR_INDEX</a>);
-            };
-            <b>while</b> (<a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a> &lt; num_buckets) {
-                bucket_ref = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(buckets_ref, bucket_index);
-                bucket_length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket_ref);
-                <b>while</b> (vector_index &lt; bucket_length) {
-                    <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> keys, <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(bucket_ref, vector_index).key);
-                    num_keys_checked = num_keys_checked + 1;
-                    vector_index = vector_index + 1;
-                    <b>if</b> (num_keys_checked == num_keys_to_get) {
-                        <b>if</b> (vector_index == bucket_length) {
-                            vector_index = 0;
-                            bucket_index = bucket_index + 1;
-                            bucket_index = <b>if</b> (<a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a> &lt; num_buckets) bucket_index <b>else</b> 0;
-                        };
-                        <b>return</b> (keys, bucket_index, vector_index)
+        };
+        <b>let</b> bucket_ref = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(buckets_ref, bucket_index);
+        <b>let</b> bucket_length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket_ref);
+        <b>let</b> vector_index = starting_vector_index;
+        <b>if</b> (starting_vector_index != 0) {
+            <b>assert</b>!(starting_vector_index &lt; bucket_length, <a href="smart_table.md#0x1_smart_table_EINVALID_VECTOR_INDEX">EINVALID_VECTOR_INDEX</a>);
+        };
+        <b>while</b> (<a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a> &lt; num_buckets) {
+            bucket_ref = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(buckets_ref, bucket_index);
+            bucket_length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket_ref);
+            <b>while</b> (vector_index &lt; bucket_length) {
+                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> keys, <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(bucket_ref, vector_index).key);
+                num_keys_checked = num_keys_checked + 1;
+                vector_index = vector_index + 1;
+                <b>if</b> (num_keys_checked == num_keys_to_get) {
+                    <b>if</b> (vector_index == bucket_length) {
+                        vector_index = 0;
+                        bucket_index = bucket_index + 1;
+                        bucket_index = <b>if</b> (<a href="smart_table.md#0x1_smart_table_bucket_index">bucket_index</a> &lt; num_buckets) bucket_index <b>else</b> 0;
                     };
+                    <b>return</b> (keys, bucket_index, vector_index)
                 };
-                bucket_index = bucket_index + 1;
-                vector_index = 0;
             };
+            bucket_index = bucket_index + 1;
+            vector_index = 0;
         };
     };
     (keys, 0, 0)

--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -695,7 +695,7 @@ pagination is complete. For an example, see <code>test_keys()</code>.
                     }
                 };
             };
-            starting_vector_index = 0;
+            starting_vector_index = 0; // Start parsing the next bucket at <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a> index 0.
         };
     };
     (keys, <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>())

--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -54,6 +54,8 @@ it tolerates collisions.
     -  [Function `clear`](#@Specification_1_clear)
     -  [Function `add_all`](#@Specification_1_add_all)
     -  [Function `to_simple_map`](#@Specification_1_to_simple_map)
+    -  [Function `keys`](#@Specification_1_keys)
+    -  [Function `keys_paginated`](#@Specification_1_keys_paginated)
     -  [Function `split_one_bucket`](#@Specification_1_split_one_bucket)
     -  [Function `bucket_index`](#@Specification_1_bucket_index)
     -  [Function `borrow_with_default`](#@Specification_1_borrow_with_default)
@@ -1519,6 +1521,38 @@ map_spec_has_key = spec_contains;
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_to_simple_map">to_simple_map</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(<a href="table.md#0x1_table">table</a>: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;K, V&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_keys"></a>
+
+### Function `keys`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys">keys</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_keys_paginated"></a>
+
+### Function `keys_paginated`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_table.md#0x1_smart_table_keys_paginated">keys_paginated</a>&lt;K: <b>copy</b>, drop, store, V: <b>copy</b>, store&gt;(table_ref: &<a href="smart_table.md#0x1_smart_table_SmartTable">smart_table::SmartTable</a>&lt;K, V&gt;, starting_bucket_index: u64, starting_vector_index: u64, num_keys_to_get: u64): (<a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -221,14 +221,16 @@ module aptos_std::smart_table {
     ) {
         let num_buckets = table_ref.num_buckets;
         let buckets_ref = &table_ref.buckets;
-        assert!(
-            starting_bucket_index == 0 || starting_bucket_index < num_buckets,
-            EINVALID_BUCKET_INDEX
-        );
+        assert!(starting_bucket_index < num_buckets, EINVALID_BUCKET_INDEX);
         let bucket_ref = table_with_length::borrow(buckets_ref, starting_bucket_index);
         let bucket_length = vector::length(bucket_ref);
         assert!(
-            starting_vector_index == 0 || starting_vector_index < bucket_length,
+            // In the general case, starting vector index should never be equal to bucket length
+            // because then iteration will attempt to borrow a vector element that is out of bounds.
+            // However starting vector index can be equal to bucket length in the special case of
+            // starting iteration at the beginning of an empty bucket since buckets are never
+            // destroyed, only emptied.
+            starting_vector_index < bucket_length || starting_vector_index == 0,
             EINVALID_VECTOR_INDEX
         );
         let keys = vector[];

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -256,7 +256,7 @@ module aptos_std::smart_table {
                         }
                     };
                 };
-                starting_vector_index = 0;
+                starting_vector_index = 0; // Start parsing the next bucket at vector index 0.
             };
         };
         (keys, option::none(), option::none())

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -225,15 +225,17 @@ module aptos_std::smart_table {
             let num_keys_checked = 0;
             let buckets_ref = &table_ref.buckets;
             let bucket_index = starting_bucket_index;
-            if (starting_bucket_index != 0) {
-                assert!(starting_bucket_index < num_buckets, EINVALID_BUCKET_INDEX);
-            };
+            assert!(
+                starting_bucket_index == 0 || starting_bucket_index < num_buckets,
+                EINVALID_BUCKET_INDEX
+            );
             let bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
             let bucket_length = vector::length(bucket_ref);
             let vector_index = starting_vector_index;
-            if (starting_vector_index != 0) {
-                assert!(starting_vector_index < bucket_length, EINVALID_VECTOR_INDEX);
-            };
+            assert!(
+                starting_vector_index == 0 || starting_vector_index < bucket_length,
+                EINVALID_VECTOR_INDEX
+            );
             while (bucket_index < num_buckets) {
                 bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
                 bucket_length = vector::length(bucket_ref);

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -232,7 +232,6 @@ module aptos_std::smart_table {
             );
             let bucket_ref = table_with_length::borrow(buckets_ref, starting_bucket_index);
             let bucket_length = vector::length(bucket_ref);
-            let vector_index = starting_vector_index;
             assert!(
                 starting_vector_index == 0 || starting_vector_index < bucket_length,
                 EINVALID_VECTOR_INDEX
@@ -240,11 +239,11 @@ module aptos_std::smart_table {
             for (bucket_index in starting_bucket_index..num_buckets) {
                 bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
                 bucket_length = vector::length(bucket_ref);
-                while (vector_index < bucket_length) {
+                for (vector_index in starting_vector_index..bucket_length) {
                     vector::push_back(&mut keys, vector::borrow(bucket_ref, vector_index).key);
                     num_keys_checked = num_keys_checked + 1;
-                    vector_index = vector_index + 1;
                     if (num_keys_checked == num_keys_to_get) {
+                        vector_index = vector_index + 1;
                         return if (vector_index == bucket_length) {
                             bucket_index = bucket_index + 1;
                             if (bucket_index < num_buckets) {
@@ -257,7 +256,7 @@ module aptos_std::smart_table {
                         }
                     };
                 };
-                vector_index = 0;
+                starting_vector_index = 0;
             };
         };
         (keys, option::none(), option::none())

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -34,8 +34,6 @@ module aptos_std::smart_table {
     /// Invalid vector index within a bucket.
     const EINVALID_VECTOR_INDEX: u64 = 9;
 
-    const ALL_KEYS: u64 = 0xffffffffffffffff;
-
     /// SmartTable entry contains both the key and value.
     struct Entry<K, V> has copy, drop, store {
         hash: u64,
@@ -194,7 +192,7 @@ module aptos_std::smart_table {
     public fun keys<K: store + copy + drop, V: store + copy>(
         table_ref: &SmartTable<K, V>
     ): vector<K> {
-        let (keys, _, _) = keys_paginated(table_ref, 0, 0, ALL_KEYS);
+        let (keys, _, _) = keys_paginated(table_ref, 0, 0, length(table_ref));
         keys
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -224,12 +224,11 @@ module aptos_std::smart_table {
             let num_buckets = table_ref.num_buckets;
             let num_keys_checked = 0;
             let buckets_ref = &table_ref.buckets;
-            let bucket_index = starting_bucket_index;
             assert!(
                 starting_bucket_index == 0 || starting_bucket_index < num_buckets,
                 EINVALID_BUCKET_INDEX
             );
-            let bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
+            let bucket_ref = table_with_length::borrow(buckets_ref, starting_bucket_index);
             let bucket_length = vector::length(bucket_ref);
             let vector_index = starting_vector_index;
             assert!(

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -186,11 +186,13 @@ module aptos_std::smart_table {
         res
     }
 
+    #[view]
     public fun keys<K: store + copy + drop, V: store + copy>(table: &SmartTable<K, V>): vector<K> {
         let (keys, _, _) = keys_paginated(table, 0, 0, ALL_KEYS);
         keys
     }
 
+    #[view]
     public fun keys_paginated<K: store + copy + drop, V: store + copy>(
         table: &SmartTable<K, V>,
         starting_bucket_index: u64,

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -236,14 +236,13 @@ module aptos_std::smart_table {
         let keys = vector[];
         if (num_keys_to_get == 0) return
             (keys, option::some(starting_bucket_index), option::some(starting_vector_index));
-        let num_keys_checked = 0;
         for (bucket_index in starting_bucket_index..num_buckets) {
             bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
             bucket_length = vector::length(bucket_ref);
             for (vector_index in starting_vector_index..bucket_length) {
                 vector::push_back(&mut keys, vector::borrow(bucket_ref, vector_index).key);
-                num_keys_checked = num_keys_checked + 1;
-                if (num_keys_checked == num_keys_to_get) {
+                num_keys_to_get = num_keys_to_get - 1;
+                if (num_keys_to_get == 0) {
                     vector_index = vector_index + 1;
                     return if (vector_index == bucket_length) {
                         bucket_index = bucket_index + 1;

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -236,7 +236,7 @@ module aptos_std::smart_table {
                 starting_vector_index == 0 || starting_vector_index < bucket_length,
                 EINVALID_VECTOR_INDEX
             );
-            while (bucket_index < num_buckets) {
+            for (bucket_index in starting_bucket_index..num_buckets) {
                 bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
                 bucket_length = vector::length(bucket_ref);
                 while (vector_index < bucket_length) {
@@ -252,7 +252,6 @@ module aptos_std::smart_table {
                         return (keys, bucket_index, vector_index)
                     };
                 };
-                bucket_index = bucket_index + 1;
                 vector_index = 0;
             };
         };

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
@@ -52,6 +52,23 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
+    spec keys<K: store + copy + drop, V: store + copy>(table_ref: &SmartTable<K, V>): vector<K> {
+        pragma verify = false;
+    }
+
+    spec keys_paginated<K: store + copy + drop, V: store + copy>(
+        table_ref: &SmartTable<K, V>,
+        starting_bucket_index: u64,
+        starting_vector_index: u64,
+        num_keys_to_get: u64,
+    ): (
+        vector<K>,
+        Option<u64>,
+        Option<u64>,
+    ) {
+        pragma verify = false;
+    }
+
     spec add_all<K, V>(table: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>) {
         pragma verify = false;
     }


### PR DESCRIPTION
@gregnazario @lightmark @vgao1996 

Presently, trying to get all keys for a sufficiently large simple table will error out due to execution gas errors.

Add a pagination function to get keys in a smart table, for indexing smart tables either across successive transactions or through chained view function calls. Also add a wrapper to the pagination function that gets all keys.

Affected functions tested to 100% coverage, but Move source coverage feature in the CLI might erroneously print red: so use `aptos move coverage bytecode --module smart_table` to verify bytecode coverage.


