### PR TITLE
improved txn emitter fund accounting

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -177,6 +177,12 @@ pub struct EmitArgs {
     #[clap(long)]
     pub expected_gas_per_txn: Option<u64>,
 
+    #[clap(long)]
+    pub expected_gas_per_transfer: Option<u64>,
+
+    #[clap(long)]
+    pub expected_gas_per_account_create: Option<u64>,
+
     #[clap(long, conflicts_with = "num_accounts")]
     pub max_transactions_per_account: Option<usize>,
 

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -15,7 +15,9 @@ use aptos_sdk::{
         AccountKey, LocalAccount,
     },
 };
-use aptos_transaction_generator_lib::{CounterState, ReliableTransactionSubmitter, SEND_AMOUNT};
+use aptos_transaction_generator_lib::{
+    CounterState, ReliableTransactionSubmitter, RootAccountHandle, SEND_AMOUNT,
+};
 use core::{
     cmp::min,
     result::Result::{Err, Ok},
@@ -28,16 +30,134 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[derive(Debug)]
+pub struct SourceAccountManager<'t> {
+    pub source_account: &'t LocalAccount,
+    pub txn_executor: &'t dyn ReliableTransactionSubmitter,
+    pub req: &'t EmitJobRequest,
+    pub txn_factory: TransactionFactory,
+}
+
+#[async_trait::async_trait]
+impl<'t> RootAccountHandle for SourceAccountManager<'t> {
+    async fn approve_funds(&self, amount: u64, reason: &str) {
+        self.check_approve_funds(amount, reason).await.unwrap();
+    }
+
+    fn get_root_account(&self) -> &LocalAccount {
+        self.source_account
+    }
+}
+
+impl<'t> SourceAccountManager<'t> {
+    // returns true if we might want to recheck the volume, as it was auto-approved.
+    async fn check_approve_funds(&self, amount: u64, reason: &str) -> Result<bool> {
+        let balance = self
+            .txn_executor
+            .get_account_balance(self.source_account.address())
+            .await?;
+        Ok(if self.req.mint_to_root {
+            // We have a root account, so amount of funds minted is not a problem
+            // We can have multiple txn emitter running simultaneously, each coming to this check at the same time.
+            // So they might all pass the check, but not be able to consume funds they need. So we check more conservatively
+            // here (and root acccount should have huge balance anyways)
+            if balance < amount.checked_mul(100).unwrap_or(u64::MAX / 2) {
+                info!(
+                    "Mint account {} current balance is {}, needing {} for {}, minting to refil it fully",
+                    self.source_account.address(),
+                    balance,
+                    amount,
+                    reason,
+                );
+                // Mint to refil the balance, to reduce number of mints
+                self.mint_to_root(self.txn_executor, u64::MAX - balance - 1)
+                    .await?;
+            } else {
+                info!(
+                    "Mint account {} current balance is {}, needing {} for {}. Proceeding without minting, as balance would overflow otherwise",
+                    self.source_account.address(),
+                    balance,
+                    amount,
+                    reason,
+                );
+                assert!(balance > amount);
+            }
+            false
+        } else {
+            info!(
+                "Source account {} current balance is {}, needed {} coins for {}, or {:.3}% of its balance",
+                self.source_account.address(),
+                balance,
+                amount,
+                reason,
+                amount as f64 / balance as f64 * 100.0,
+            );
+
+            if balance < amount {
+                return Err(anyhow!(
+                    "Source ({}) doesn't have enough coins, balance {} < needed {} for {}",
+                    self.source_account.address(),
+                    balance,
+                    amount,
+                    reason
+                ));
+            }
+
+            if self.req.prompt_before_spending {
+                if !prompt_yes(&format!(
+                    "plan will consume in total {} balance for {}, are you sure you want to proceed",
+                    amount,
+                    reason,
+                )) {
+                    panic!("Aborting");
+                }
+                false
+            } else {
+                // no checks performed, caller might want to recheck the amount makes sense
+                true
+            }
+        })
+    }
+
+    pub async fn mint_to_root(
+        &self,
+        txn_executor: &dyn ReliableTransactionSubmitter,
+        amount: u64,
+    ) -> Result<()> {
+        info!("Minting new coins to root");
+
+        let txn = self
+            .source_account
+            .sign_with_transaction_builder(self.txn_factory.payload(
+                aptos_stdlib::aptos_coin_mint(self.source_account.address(), amount),
+            ));
+
+        if let Err(e) = txn_executor.execute_transactions(&[txn]).await {
+            // This cannot work simultaneously across different txn emitters,
+            // so check on failure if another emitter has refilled it instead
+
+            let balance = txn_executor
+                .get_account_balance(self.source_account.address())
+                .await?;
+            if balance > u64::MAX / 2 {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
 pub struct AccountMinter<'t> {
     txn_factory: TransactionFactory,
     rng: StdRng,
-    source_account: &'t mut LocalAccount,
+    source_account: &'t SourceAccountManager<'t>,
 }
 
 impl<'t> AccountMinter<'t> {
     pub fn new(
-        source_account: &'t mut LocalAccount,
+        source_account: &'t SourceAccountManager<'t>,
         txn_factory: TransactionFactory,
         rng: StdRng,
     ) -> Self {
@@ -50,14 +170,70 @@ impl<'t> AccountMinter<'t> {
 
     pub fn get_needed_balance_per_account(&self, req: &EmitJobRequest, num_accounts: usize) -> u64 {
         if let Some(val) = req.coins_per_account_override {
+            info!("    with {} balance each because of override", val);
             val
         } else {
-            (req.expected_max_txns / num_accounts as u64)
-                .checked_mul(SEND_AMOUNT + req.expected_gas_per_txn * req.gas_price)
+            // round up:
+            let txnx_per_account =
+                (req.expected_max_txns + num_accounts as u64 - 1) / num_accounts as u64;
+            let min_balance = req.max_gas_per_txn * req.gas_price;
+            let coins_per_account = txnx_per_account
+                .checked_mul(SEND_AMOUNT + req.get_expected_gas_per_txn() * req.gas_price)
                 .unwrap()
-                .checked_add(req.max_gas_per_txn * req.gas_price)
-                .unwrap() // extra coins for secure to pay none zero gas price
+                .checked_add(min_balance)
+                .unwrap(); // extra coins for secure to pay none zero gas price
+
+            info!(
+                "    with {} balance each because of expecting {} txns per account, with {} gas at {} gas price per txn, and min balance {}",
+                coins_per_account,
+                txnx_per_account,
+                req.get_expected_gas_per_txn(),
+                req.gas_price,
+                min_balance,
+            );
+            coins_per_account
         }
+    }
+
+    pub fn funds_needed_for_multi_transfer(
+        name: &str,
+        num_destinations: u64,
+        send_amount: u64,
+        max_gas_per_txn: u64,
+        gas_price: u64,
+    ) -> u64 {
+        let min_balance = max_gas_per_txn * gas_price;
+
+        let funds_needed = num_destinations
+            .checked_mul(
+                // we transfer coins_per_account and rest is overhead (burnt gas)
+                send_amount + max_gas_per_txn * gas_price,
+            )
+            .unwrap_or_else(|| {
+                panic!(
+                    "money_needed_for_multi_transfer checked_mul exceeds u64: {} * ({} + {} * {})",
+                    num_destinations, send_amount, max_gas_per_txn, gas_price,
+                )
+            })
+            // we need to have the minimum balance for max gas we set
+            .checked_add(min_balance)
+            .unwrap_or_else(|| {
+                panic!(
+                "money_needed_for_multi_transfer checked_add exceeds u64: {} * ({} + {} * {}) + {}",
+                num_destinations,
+                send_amount,
+                max_gas_per_txn,
+                gas_price,
+                min_balance,
+            )
+            });
+
+        info!(
+            "    through {} accounts with {} each due to funding {} accounts with ({} balance + {} * {} gas), and min balance {}",
+            name, funds_needed, num_destinations, send_amount, max_gas_per_txn, gas_price, min_balance,
+        );
+
+        funds_needed
     }
 
     /// workflow of create accounts:
@@ -78,114 +254,47 @@ impl<'t> AccountMinter<'t> {
         local_accounts: Vec<Arc<LocalAccount>>,
     ) -> Result<()> {
         let num_accounts = local_accounts.len();
+
+        info!(
+            "Account creation plan created for {} accounts and {} txns:",
+            num_accounts, req.expected_max_txns,
+        );
+
         let expected_num_seed_accounts =
             (num_accounts / 50).clamp(1, (num_accounts as f32).sqrt() as usize + 1);
         let coins_per_account = self.get_needed_balance_per_account(req, num_accounts);
-        let txn_factory = self.txn_factory.clone();
         let expected_children_per_seed_account =
             (num_accounts + expected_num_seed_accounts - 1) / expected_num_seed_accounts;
-        info!(
-            "Account creation plan created for {} accounts with {} balance each.",
-            num_accounts, coins_per_account
-        );
-        info!(
-            "    because of expecting {} txns and {} gas at {} gas price for each ",
-            req.expected_max_txns, req.expected_gas_per_txn, req.gas_price,
-        );
-        let coins_per_seed_account = (expected_children_per_seed_account as u64)
-            .checked_mul(
-                coins_per_account
-                    + req.init_max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier,
-            )
-            .unwrap_or_else(|| {
-                panic!(
-                    "coins_per_seed_account exceeds u64: {} * ({} + {} * {} * {})",
-                    expected_children_per_seed_account,
-                    coins_per_account,
-                    req.init_max_gas_per_txn,
-                    req.gas_price,
-                    req.init_gas_price_multiplier
-                )
-            });
-        info!(
-            "    through {} seed accounts with {} each, each to fund {} accounts",
-            expected_num_seed_accounts, coins_per_seed_account, expected_children_per_seed_account,
-        );
-        let coins_for_source = coins_per_seed_account
-            .checked_add(req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier)
-            .unwrap_or_else(|| {
-                panic!(
-                    "coins_for_source exceeds u64: {} * {}",
-                    coins_per_seed_account, expected_num_seed_accounts
-                )
-            })
-            .checked_mul(expected_num_seed_accounts as u64)
-            .unwrap_or_else(|| {
-                panic!(
-                    "coins_for_source exceeds u64: {} * {}",
-                    coins_per_seed_account, expected_num_seed_accounts
-                )
-            });
 
-        let balance = txn_executor
-            .get_account_balance(self.source_account.address())
-            .await?;
-        if req.mint_to_root {
-            // Check against more than coins_for_source, because we can have multiple txn emitter running simultaneously
-            if balance < coins_for_source.checked_mul(100).unwrap_or(u64::MAX / 2) {
-                info!(
-                    "Mint account {} current balance is {}, needing {}, minting to refil it fully",
-                    self.source_account.address(),
-                    balance,
-                    coins_for_source,
-                );
-                // Mint to refil the balance, to reduce number of mints
-                self.mint_to_root(txn_executor, u64::MAX - balance - 1)
-                    .await?;
-            } else {
-                info!(
-                    "Mint account {} current balance is {}, needing {}. Proceeding without minting, as balance would overflow otherwise",
-                    self.source_account.address(),
-                    balance,
-                    coins_for_source,
-                );
-                assert!(balance > coins_for_source);
-            }
-        } else {
-            info!(
-                "Source account {} current balance is {}, needed {} coins, or {:.3}% of its balance",
-                self.source_account.address(),
-                balance,
+        let coins_per_seed_account = Self::funds_needed_for_multi_transfer(
+            "seed",
+            expected_children_per_seed_account as u64,
+            coins_per_account,
+            self.txn_factory.get_max_gas_amount(),
+            self.txn_factory.get_gas_unit_price(),
+        );
+        let coins_for_source = Self::funds_needed_for_multi_transfer(
+            if req.mint_to_root { "root" } else { "source" },
+            expected_num_seed_accounts as u64,
+            coins_per_seed_account,
+            self.txn_factory.get_max_gas_amount(),
+            self.txn_factory.get_gas_unit_price(),
+        );
+
+        if self
+            .source_account
+            .check_approve_funds(coins_for_source, "initial account minter")
+            .await?
+        {
+            // recheck value makes sense for auto-approval.
+            let max_allowed = (3 * req.expected_max_txns as u128)
+                .checked_mul((req.get_expected_gas_per_txn() * req.gas_price).into())
+                .unwrap();
+            assert!(coins_for_source as u128 <= max_allowed,
+                "Overhead too large to consume funds without approval - estimated total coins needed for load test ({}) are larger than expected_max_txns * expected_gas_per_txn, multiplied by 3 to account for rounding up and overheads ({})",
                 coins_for_source,
-                coins_for_source as f64 / balance as f64 * 100.0,
+                max_allowed,
             );
-
-            if balance < coins_for_source {
-                return Err(anyhow!(
-                    "Source ({}) doesn't have enough coins, balance {} < needed {}",
-                    self.source_account.address(),
-                    balance,
-                    coins_for_source
-                ));
-            }
-
-            if req.prompt_before_spending {
-                if !prompt_yes(&format!(
-                    "plan will consume in total {} balance, are you sure you want to proceed",
-                    coins_for_source
-                )) {
-                    panic!("Aborting");
-                }
-            } else {
-                let max_allowed = (2 * req.expected_max_txns as u128)
-                    .checked_mul((req.expected_gas_per_txn * req.gas_price).into())
-                    .unwrap();
-                assert!(coins_for_source as u128 <= max_allowed,
-                    "Estimated total coins needed for load test ({}) are larger than expected_max_txns * expected_gas_per_txn, multiplied by 2 to account for rounding up ({})",
-                    coins_for_source,
-                    max_allowed,
-                );
-            }
         }
 
         let new_source_account = if !req.coordination_delay_between_instances.is_zero() {
@@ -226,7 +335,7 @@ impl<'t> AccountMinter<'t> {
             "Creating additional {} accounts with {} coins each (txn {} gas price)",
             num_accounts,
             coins_per_account,
-            txn_factory.get_gas_unit_price(),
+            self.txn_factory.get_gas_unit_price(),
         );
 
         let start = Instant::now();
@@ -239,6 +348,8 @@ impl<'t> AccountMinter<'t> {
             .chunks(approx_accounts_per_seed)
             .map(|chunk| chunk.to_vec())
             .collect();
+
+        let txn_factory = self.txn_factory.clone();
 
         // For each seed account, create a future and transfer coins from that seed account to new accounts
         let account_futures = seed_accounts
@@ -278,36 +389,6 @@ impl<'t> AccountMinter<'t> {
         Ok(())
     }
 
-    pub async fn mint_to_root(
-        &mut self,
-        txn_executor: &dyn ReliableTransactionSubmitter,
-        amount: u64,
-    ) -> Result<()> {
-        info!("Minting new coins to root");
-
-        let txn = self
-            .source_account
-            .sign_with_transaction_builder(self.txn_factory.payload(
-                aptos_stdlib::aptos_coin_mint(self.source_account.address(), amount),
-            ));
-
-        if let Err(e) = txn_executor.execute_transactions(&[txn]).await {
-            // This cannot work simultaneously across different txn emitters,
-            // so check on failure if another emitter has refilled it instead
-
-            let balance = txn_executor
-                .get_account_balance(self.source_account.address())
-                .await?;
-            if balance > u64::MAX / 2 {
-                Ok(())
-            } else {
-                Err(e)
-            }
-        } else {
-            Ok(())
-        }
-    }
-
     pub async fn create_and_fund_seed_accounts(
         &mut self,
         mut new_source_account: Option<LocalAccount>,
@@ -335,7 +416,7 @@ impl<'t> AccountMinter<'t> {
                         if let Some(account) = &mut new_source_account {
                             account
                         } else {
-                            self.source_account
+                            self.source_account.get_root_account()
                         },
                         coins_per_seed_account,
                         account.public_key(),
@@ -385,15 +466,15 @@ impl<'t> AccountMinter<'t> {
     ) -> Result<LocalAccount> {
         const NUM_TRIES: usize = 3;
         for i in 0..NUM_TRIES {
-            self.source_account.set_sequence_number(
+            self.source_account.get_root_account().set_sequence_number(
                 txn_executor
-                    .query_sequence_number(self.source_account.address())
+                    .query_sequence_number(self.source_account.get_root_account().address())
                     .await?,
             );
 
             let new_source_account = LocalAccount::generate(self.rng());
             let txn = create_and_fund_account_request(
-                self.source_account,
+                self.source_account.get_root_account(),
                 coins_for_source,
                 new_source_account.public_key(),
                 &self.txn_factory,
@@ -432,7 +513,7 @@ impl<'t> AccountMinter<'t> {
 /// Create `num_new_accounts` by transferring coins from `source_account`. Return Vec of created
 /// accounts
 async fn create_and_fund_new_accounts(
-    mut source_account: LocalAccount,
+    source_account: LocalAccount,
     accounts: Vec<Arc<LocalAccount>>,
     coins_per_new_account: u64,
     max_num_accounts_per_batch: usize,
@@ -449,7 +530,7 @@ async fn create_and_fund_new_accounts(
             .iter()
             .map(|account| {
                 create_and_fund_account_request(
-                    &mut source_account,
+                    &source_account,
                     coins_per_new_account,
                     account.public_key(),
                     txn_factory,
@@ -503,7 +584,7 @@ where
 }
 
 pub fn create_and_fund_account_request(
-    creation_account: &mut LocalAccount,
+    creation_account: &LocalAccount,
     amount: u64,
     pubkey: &Ed25519PublicKey,
     txn_factory: &TransactionFactory,

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -7,7 +7,7 @@ pub mod submission_worker;
 pub mod transaction_executor;
 
 use crate::emitter::{
-    account_minter::{gen_reusable_accounts, AccountMinter},
+    account_minter::{gen_reusable_accounts, AccountMinter, SourceAccountManager},
     stats::{DynamicStatsTracking, TxnStats},
     submission_worker::SubmissionWorker,
     transaction_executor::RestApiReliableTransactionSubmitter,
@@ -143,8 +143,17 @@ pub struct EmitJobRequest {
     transaction_mix_per_phase: Vec<Vec<(TransactionType, usize)>>,
 
     max_gas_per_txn: u64,
+    init_max_gas_per_txn: Option<u64>,
+
+    expected_max_txns: u64,
+
+    expected_gas_per_txn: Option<u64>,
+    expected_gas_per_transfer: u64,
+    expected_gas_per_account_create: u64,
+
+    coins_per_account_override: Option<u64>,
+
     gas_price: u64,
-    init_max_gas_per_txn: u64,
     init_gas_price_multiplier: u64,
 
     mint_to_root: bool,
@@ -155,8 +164,6 @@ pub struct EmitJobRequest {
 
     init_retry_interval: Duration,
     num_accounts_mode: NumAccountsMode,
-    expected_max_txns: u64,
-    expected_gas_per_txn: u64,
     prompt_before_spending: bool,
 
     coordination_delay_between_instances: Duration,
@@ -164,7 +171,6 @@ pub struct EmitJobRequest {
     latency_polling_interval: Duration,
 
     account_minter_seed: Option<[u8; 32]>,
-    coins_per_account_override: Option<u64>,
 }
 
 impl Default for EmitJobRequest {
@@ -177,8 +183,8 @@ impl Default for EmitJobRequest {
             transaction_mix_per_phase: vec![vec![(TransactionType::default(), 1)]],
             max_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
             gas_price: aptos_global_constants::GAS_UNIT_PRICE,
-            init_max_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
-            init_gas_price_multiplier: 10,
+            init_max_gas_per_txn: None,
+            init_gas_price_multiplier: 2,
             mint_to_root: false,
             skip_minting_accounts: false,
             txn_expiration_time_secs: 60,
@@ -186,7 +192,9 @@ impl Default for EmitJobRequest {
             init_retry_interval: Duration::from_secs(10),
             num_accounts_mode: NumAccountsMode::TransactionsPerAccount(20),
             expected_max_txns: MAX_TXNS,
-            expected_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
+            expected_gas_per_txn: None,
+            expected_gas_per_transfer: 7,
+            expected_gas_per_account_create: 2000 + 5,
             prompt_before_spending: false,
             coordination_delay_between_instances: Duration::from_secs(0),
             latency_polling_interval: Duration::from_millis(300),
@@ -217,7 +225,7 @@ impl EmitJobRequest {
     }
 
     pub fn init_max_gas_per_txn(mut self, init_max_gas_per_txn: u64) -> Self {
-        self.init_max_gas_per_txn = init_max_gas_per_txn;
+        self.init_max_gas_per_txn = Some(init_max_gas_per_txn);
         self
     }
 
@@ -232,7 +240,17 @@ impl EmitJobRequest {
     }
 
     pub fn expected_gas_per_txn(mut self, expected_gas_per_txn: u64) -> Self {
-        self.expected_gas_per_txn = expected_gas_per_txn;
+        self.expected_gas_per_txn = Some(expected_gas_per_txn);
+        self
+    }
+
+    pub fn expected_gas_per_transfer(mut self, expected_gas_per_transfer: u64) -> Self {
+        self.expected_gas_per_transfer = expected_gas_per_transfer;
+        self
+    }
+
+    pub fn expected_gas_per_account_create(mut self, expected_gas_per_account_create: u64) -> Self {
+        self.expected_gas_per_account_create = expected_gas_per_account_create;
         self
     }
 
@@ -311,8 +329,29 @@ impl EmitJobRequest {
         self
     }
 
+    pub fn get_init_max_gas_per_txn(&self) -> u64 {
+        self.init_max_gas_per_txn.unwrap_or(self.max_gas_per_txn)
+    }
+
+    pub fn get_expected_gas_per_txn(&self) -> u64 {
+        self.expected_gas_per_txn.unwrap_or(self.max_gas_per_txn)
+    }
+
+    pub fn get_expected_gas_per_transfer(&self) -> u64 {
+        self.expected_gas_per_transfer
+    }
+
+    pub fn get_expected_gas_per_account_create(&self) -> u64 {
+        self.expected_gas_per_account_create
+    }
+
+    pub fn get_init_gas_price(&self) -> u64 {
+        self.gas_price * self.init_gas_price_multiplier
+    }
+
     pub fn calculate_mode_params(&self) -> EmitModeParams {
         let clients_count = self.rest_clients.len();
+        assert!(clients_count > 0, "No rest clients provided");
 
         match self.mode {
             EmitJobMode::MaxLoad { mempool_backlog } => {
@@ -333,6 +372,15 @@ impl EmitJobRequest {
                         mempool_backlog / transactions_per_account,
                     ),
                 };
+
+                assert!(
+                    transactions_per_account > 0,
+                    "mempool_backlog smaller than num_accounts"
+                );
+                assert!(
+                    num_accounts > 0,
+                    "mempool_backlog smaller than transactions_per_account"
+                );
 
                 info!(
                     " Transaction emitter target mempool backlog is {}",
@@ -613,7 +661,7 @@ impl TxnEmitter {
 
     pub async fn start_job(
         &mut self,
-        root_account: &mut LocalAccount,
+        root_account: &LocalAccount,
         req: EmitJobRequest,
         stats_tracking_phases: usize,
     ) -> Result<EmitJob> {
@@ -638,12 +686,13 @@ impl TxnEmitter {
             (mode_params.txn_expiration_time_secs as f64 * req.init_expiration_multiplier) as u64;
         let init_txn_factory = txn_factory
             .clone()
-            .with_max_gas_amount(req.init_max_gas_per_txn)
-            .with_gas_unit_price(req.gas_price * req.init_gas_price_multiplier)
+            .with_max_gas_amount(req.get_init_max_gas_per_txn())
+            .with_gas_unit_price(req.get_init_gas_price())
             .with_transaction_expiration_time(init_expiration_time);
         let init_retries: usize =
             usize::try_from(init_expiration_time / req.init_retry_interval.as_secs()).unwrap();
         let seed = req.account_minter_seed.unwrap_or_else(|| self.rng.gen());
+
         let mut all_accounts = create_accounts(
             root_account,
             &init_txn_factory,
@@ -655,6 +704,7 @@ impl TxnEmitter {
             init_retries,
         )
         .await?;
+
         let stop = Arc::new(AtomicBool::new(false));
         let stats = Arc::new(DynamicStatsTracking::new(stats_tracking_phases));
         let tokio_handle = Handle::current();
@@ -664,9 +714,15 @@ impl TxnEmitter {
             max_retries: init_retries,
             retry_after: req.init_retry_interval,
         };
+        let source_account_manager = SourceAccountManager {
+            source_account: root_account,
+            txn_executor: &txn_executor,
+            req: &req,
+            txn_factory: init_txn_factory.clone(),
+        };
         let (txn_generator_creator, _, _) = create_txn_generator_creator(
             &req.transaction_mix_per_phase,
-            root_account,
+            source_account_manager,
             &mut all_accounts,
             vec![],
             &txn_executor,
@@ -748,7 +804,7 @@ impl TxnEmitter {
 
     async fn emit_txn_for_impl(
         mut self,
-        source_account: &mut LocalAccount,
+        source_account: &LocalAccount,
         emit_job_request: EmitJobRequest,
         duration: Duration,
         print_stats_interval: Option<u64>,
@@ -794,7 +850,7 @@ impl TxnEmitter {
 
     pub async fn emit_txn_for_with_stats(
         self,
-        source_account: &mut LocalAccount,
+        source_account: &LocalAccount,
         emit_job_request: EmitJobRequest,
         duration: Duration,
         interval_secs: u64,
@@ -1062,7 +1118,7 @@ pub fn parse_seed(seed_string: &str) -> [u8; 32] {
 }
 
 pub async fn create_accounts(
-    root_account: &mut LocalAccount,
+    root_account: &LocalAccount,
     txn_factory: &TransactionFactory,
     req: &EmitJobRequest,
     max_submit_batch_size: usize,
@@ -1081,17 +1137,35 @@ pub async fn create_accounts(
         "AccountMinter Seed (reuse accounts by passing into --account-minter-seed): {:?}",
         seed
     );
-    let mut account_minter =
-        AccountMinter::new(root_account, txn_factory.clone(), StdRng::from_seed(seed));
     let txn_executor = RestApiReliableTransactionSubmitter {
         rest_clients: req.rest_clients.clone(),
         max_retries: retries,
         retry_after: req.init_retry_interval,
     };
+    let source_account_manager = SourceAccountManager {
+        source_account: root_account,
+        txn_executor: &txn_executor,
+        req,
+        txn_factory: txn_factory.clone(),
+    };
+
     let mut rng = StdRng::from_seed(seed);
 
     let accounts = gen_reusable_accounts(&txn_executor, num_accounts, &mut rng).await?;
     info!("Generated re-usable accounts for seed {:?}", seed);
+
+    let all_accounts_already_exist = accounts.iter().all(|account| account.sequence_number() > 0);
+    let send_money_gas = if all_accounts_already_exist {
+        req.get_expected_gas_per_transfer()
+    } else {
+        req.get_expected_gas_per_account_create()
+    };
+
+    let mut account_minter = AccountMinter::new(
+        &source_account_manager,
+        txn_factory.clone().with_max_gas_amount(send_money_gas),
+        StdRng::from_seed(seed),
+    );
 
     if !skip_minting_accounts {
         let accounts: Vec<_> = accounts.into_iter().map(Arc::new).collect();
@@ -1105,6 +1179,12 @@ pub async fn create_accounts(
         info!("Accounts created and funded");
         Ok(accounts)
     } else {
+        info!(
+            "Account reuse plan created for {} accounts and {} txns:",
+            accounts.len(),
+            req.expected_max_txns,
+        );
+
         let needed_min_balance = account_minter.get_needed_balance_per_account(req, accounts.len());
         let balance_futures = accounts
             .iter()

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -177,7 +177,7 @@ async fn warn_detailed_error(
     let balance = rest_client
         .get_account_balance(sender)
         .await
-        .map_or(-1, |v| v.into_inner().get() as i64);
+        .map_or(-1, |v| v.into_inner().get() as i128);
 
     warn!(
         "[{:?}] Failed {} transaction: {:?}, seq num: {}, gas: unit {} and max {}, for account {}, last seq_num {:?}, balance of {} and last transaction for account: {:?}",

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -3,8 +3,8 @@
 
 use super::{publishing::publish_util::Package, ReliableTransactionSubmitter};
 use crate::{
-    create_account_transaction, publishing::publish_util::PackageHandler, TransactionGenerator,
-    TransactionGeneratorCreator,
+    create_account_transaction, publishing::publish_util::PackageHandler, RootAccountHandle,
+    TransactionGenerator, TransactionGeneratorCreator,
 };
 use aptos_logger::info;
 use aptos_sdk::{
@@ -49,7 +49,7 @@ pub trait UserModuleTransactionGenerator: Sync + Send {
     /// (like creating and funding additional accounts), you can do so by using provided txn_executor
     async fn create_generator_fn(
         &self,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_factory: &TransactionFactory,
         txn_executor: &dyn ReliableTransactionSubmitter,
         rng: &mut StdRng,
@@ -127,7 +127,7 @@ impl CustomModulesDelegationGeneratorCreator {
     pub async fn new(
         txn_factory: TransactionFactory,
         init_txn_factory: TransactionFactory,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_executor: &dyn ReliableTransactionSubmitter,
         num_modules: usize,
         package_name: &str,
@@ -159,7 +159,7 @@ impl CustomModulesDelegationGeneratorCreator {
 
     pub async fn create_worker(
         init_txn_factory: TransactionFactory,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_executor: &dyn ReliableTransactionSubmitter,
         packages: &mut Vec<(Package, LocalAccount)>,
         workload: &mut dyn UserModuleTransactionGenerator,
@@ -196,7 +196,7 @@ impl CustomModulesDelegationGeneratorCreator {
 
     pub async fn publish_package(
         init_txn_factory: TransactionFactory,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_executor: &dyn ReliableTransactionSubmitter,
         num_modules: usize,
         package_name: &str,
@@ -207,17 +207,23 @@ impl CustomModulesDelegationGeneratorCreator {
         let mut requests_publish = Vec::with_capacity(num_modules);
         let mut package_handler = PackageHandler::new(package_name);
         let mut packages = Vec::new();
+
+        let publisher_balance = publisher_balance.unwrap_or(
+            2 * init_txn_factory.get_gas_unit_price() * init_txn_factory.get_max_gas_amount(),
+        );
+        let total_funds = (num_modules as u64) * publisher_balance;
+        root_account
+            .approve_funds(total_funds, "funding publishers")
+            .await;
+
         for _i in 0..num_modules {
             let publisher = LocalAccount::generate(&mut rng);
             let publisher_address = publisher.address();
             requests_create.push(create_account_transaction(
-                root_account,
+                root_account.get_root_account(),
                 publisher_address,
                 &init_txn_factory,
-                publisher_balance.unwrap_or(
-                    2 * init_txn_factory.get_gas_unit_price()
-                        * init_txn_factory.get_max_gas_amount(),
-                ),
+                publisher_balance,
             ));
 
             let package = package_handler.pick_package(&mut rng, publisher.address());

--- a/crates/transaction-generator-lib/src/entry_points.rs
+++ b/crates/transaction-generator-lib/src/entry_points.rs
@@ -9,6 +9,7 @@ use crate::{
     call_custom_modules::{TransactionGeneratorWorker, UserModuleTransactionGenerator},
     create_account_transaction,
     publishing::module_simple::MultiSigConfig,
+    RootAccountHandle,
 };
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
@@ -45,7 +46,7 @@ impl UserModuleTransactionGenerator for EntryPointTransactionGenerator {
 
     async fn create_generator_fn(
         &self,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_factory: &TransactionFactory,
         txn_executor: &dyn ReliableTransactionSubmitter,
         rng: &mut StdRng,
@@ -54,6 +55,15 @@ impl UserModuleTransactionGenerator for EntryPointTransactionGenerator {
 
         let additional_signers = match entry_point.multi_sig_additional_num() {
             MultiSigConfig::Random(num) => {
+                root_account
+                    .approve_funds(
+                        (num as u64)
+                            * txn_factory.get_max_gas_amount()
+                            * txn_factory.get_gas_unit_price(),
+                        "creating random multi-sig accounts",
+                    )
+                    .await;
+
                 let new_accounts = Arc::new(
                     (0..num)
                         .map(|_| LocalAccount::generate(rng))
@@ -65,7 +75,7 @@ impl UserModuleTransactionGenerator for EntryPointTransactionGenerator {
                             .iter()
                             .map(|to| {
                                 create_account_transaction(
-                                    root_account,
+                                    root_account.get_root_account(),
                                     to.address(),
                                     txn_factory,
                                     0,

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -200,9 +200,34 @@ impl CounterState {
     }
 }
 
+#[async_trait::async_trait]
+pub trait RootAccountHandle: Send + Sync {
+    async fn approve_funds(&self, amount: u64, reason: &str);
+
+    fn get_root_account(&self) -> &LocalAccount;
+}
+
+pub struct AlwaysApproveRootAccountHandle<'t> {
+    pub root_account: &'t LocalAccount,
+}
+
+#[async_trait::async_trait]
+impl<'t> RootAccountHandle for AlwaysApproveRootAccountHandle<'t> {
+    async fn approve_funds(&self, amount: u64, reason: &str) {
+        println!(
+            "Consuming funds from root/source account: up to {} for {}",
+            amount, reason
+        );
+    }
+
+    fn get_root_account(&self) -> &LocalAccount {
+        self.root_account
+    }
+}
+
 pub async fn create_txn_generator_creator(
     transaction_mix_per_phase: &[Vec<(TransactionType, usize)>],
-    root_account: &mut LocalAccount,
+    root_account: impl RootAccountHandle,
     source_accounts: &mut [LocalAccount],
     initial_burner_accounts: Vec<LocalAccount>,
     txn_executor: &dyn ReliableTransactionSubmitter,
@@ -308,7 +333,7 @@ pub async fn create_txn_generator_creator(
                         CustomModulesDelegationGeneratorCreator::new(
                             txn_factory.clone(),
                             init_txn_factory.clone(),
-                            root_account,
+                            &root_account,
                             txn_executor,
                             *num_modules,
                             entry_point.package_name(),
@@ -339,7 +364,7 @@ pub async fn create_txn_generator_creator(
                         *workflow_kind,
                         txn_factory.clone(),
                         init_txn_factory.clone(),
-                        root_account,
+                        &root_account,
                         txn_executor,
                         *num_modules,
                         use_account_pool.then(|| accounts_pool.clone()),

--- a/crates/transaction-generator-lib/src/workflow_delegator.rs
+++ b/crates/transaction-generator-lib/src/workflow_delegator.rs
@@ -5,8 +5,8 @@ use crate::{
     account_generator::AccountGeneratorCreator, accounts_pool_wrapper::AccountsPoolWrapperCreator,
     call_custom_modules::CustomModulesDelegationGeneratorCreator,
     entry_points::EntryPointTransactionGenerator, EntryPoints, ObjectPool,
-    ReliableTransactionSubmitter, TransactionGenerator, TransactionGeneratorCreator, WorkflowKind,
-    WorkflowProgress,
+    ReliableTransactionSubmitter, RootAccountHandle, TransactionGenerator,
+    TransactionGeneratorCreator, WorkflowKind, WorkflowProgress,
 };
 use aptos_logger::{info, sample, sample::SampleRate};
 use aptos_sdk::{
@@ -229,7 +229,7 @@ impl WorkflowTxnGeneratorCreator {
         workflow_kind: WorkflowKind,
         txn_factory: TransactionFactory,
         init_txn_factory: TransactionFactory,
-        root_account: &mut LocalAccount,
+        root_account: &dyn RootAccountHandle,
         txn_executor: &dyn ReliableTransactionSubmitter,
         num_modules: usize,
         _initial_account_pool: Option<Arc<ObjectPool<LocalAccount>>>,

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -39,8 +39,8 @@ use aptos_metrics_core::Histogram;
 use aptos_sdk::types::LocalAccount;
 use aptos_storage_interface::{state_view::LatestDbStateCheckpointView, DbReader, DbReaderWriter};
 use aptos_transaction_generator_lib::{
-    create_txn_generator_creator, TransactionGeneratorCreator, TransactionType,
-    TransactionType::NonConflictingCoinTransfer,
+    create_txn_generator_creator, AlwaysApproveRootAccountHandle, TransactionGeneratorCreator,
+    TransactionType::{self, NonConflictingCoinTransfer},
 };
 use db_reliable_submitter::DbReliableTransactionSubmitter;
 use pipeline::PipelineConfig;
@@ -270,7 +270,7 @@ where
 
         create_txn_generator_creator(
             &[transaction_mix],
-            root_account,
+            AlwaysApproveRootAccountHandle { root_account },
             &mut main_signer_accounts,
             burner_accounts,
             &db_gen_init_transaction_executor,

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -35,7 +35,7 @@ async fn generate_traffic_and_assert_committed(
         .await
         .unwrap();
 
-    let txn_stat = generate_traffic(swarm, nodes, duration, 1, vec![vec![
+    let txn_stat = generate_traffic(swarm, nodes, duration, 100, vec![vec![
         (
             TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 0,

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -1,11 +1,14 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder};
+use crate::{
+    smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
+    test_utils::create_and_fund_account,
+};
 use anyhow::ensure;
 use aptos_forge::{
-    args::TransactionTypeArg, EmitJobMode, EmitJobRequest, EntryPoints, NodeExt, Result, Swarm,
-    TransactionType, TxnEmitter, TxnStats, WorkflowProgress,
+    args::TransactionTypeArg, emitter::NumAccountsMode, EmitJobMode, EmitJobRequest, EntryPoints,
+    NodeExt, Result, Swarm, TransactionType, TxnEmitter, TxnStats, WorkflowProgress,
 };
 use aptos_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use rand::{rngs::OsRng, SeedableRng};
@@ -19,6 +22,7 @@ pub async fn generate_traffic(
     transaction_mix_per_phase: Vec<Vec<(TransactionType, usize)>>,
 ) -> Result<TxnStats> {
     ensure!(gas_price > 0, "gas_price is required to be non zero");
+
     let rng = SeedableRng::from_rng(OsRng)?;
     let validator_clients = swarm
         .validators()
@@ -165,5 +169,47 @@ async fn test_txn_emmitter_with_high_pending_latency() {
     )
     .await
     .unwrap();
+    assert!(txn_stat.submitted > 30);
+}
+
+#[tokio::test]
+async fn test_txn_emmitter_low_funds() {
+    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let account_1 = create_and_fund_account(&mut swarm, 5705100).await;
+
+    let transaction_type = TransactionType::CallCustomModules {
+        entry_point: EntryPoints::Nop,
+        num_modules: 1,
+        use_account_pool: false,
+    };
+
+    let rng = SeedableRng::from_rng(OsRng).unwrap();
+    let validator_clients = swarm
+        .validators()
+        .map(|n| n.rest_client())
+        .collect::<Vec<_>>();
+    let chain_info = swarm.chain_info();
+    let transaction_factory = TransactionFactory::new(chain_info.chain_id).with_gas_unit_price(100);
+    let emitter = TxnEmitter::new(transaction_factory, rng);
+
+    let emit_job_request = EmitJobRequest::default()
+        .rest_clients(validator_clients)
+        .gas_price(100)
+        .expected_max_txns(2000)
+        .expected_gas_per_txn(3)
+        .init_gas_price_multiplier(1)
+        .init_max_gas_per_txn(20000)
+        .max_gas_per_txn(3)
+        .num_accounts_mode(NumAccountsMode::TransactionsPerAccount(5))
+        .transaction_type(transaction_type)
+        .mode(EmitJobMode::MaxLoad {
+            mempool_backlog: 10,
+        });
+
+    let txn_stat = emitter
+        .emit_txn_for_with_stats(&account_1, emit_job_request, Duration::from_secs(10), 3)
+        .await
+        .unwrap();
+
     assert!(txn_stat.submitted > 30);
 }


### PR DESCRIPTION
Make computation of needed funds more precise:
- accounting for min balance needed
- accounting for difference between actual loadtest traffic and minting
  - check if accounts exist, and then use transfer gas costs, otherwise account creation gas costs for minting
  - init_max_gas_per_txn now refers to non-account creation initialization - i.e. module publishing. I.e. if we need to publish one module, we don't need to require larger balances and gas consumption for the whole acount minting stage
- make all consumption from root (i.e. module publishing) require approval - so that we don't consume unexpected amounts
- make more things optional and have sane defaults. init multiplier is 2x (enough to get to second bucket), transfer/creating gas needed is provided, expected-gas-per-txn defaults to max-gas-per-txn if not set.

So this is the full set of flags required for very low consumption load test:

--expected-max-txns 12000 --init-max-gas-per-txn=200000 --max-gas-per-txn=3 --max-transactions-per-account 5 --transaction-type no-op --account-minter-seed=...

you can also add --init-gas-price-multiplier=1 for slightly lower initialization costs.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
