### PR TITLE
[compiler-v2] Improved variable coalescing optimization

### DIFF
--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -13,8 +13,7 @@ pub mod options;
 pub mod pipeline;
 
 use crate::pipeline::{
-    ability_processor::AbilityProcessor, avail_copies_analysis::AvailCopiesAnalysisProcessor,
-    copy_propagation::CopyPropagation, dead_store_elimination::DeadStoreElimination,
+    ability_processor::AbilityProcessor, dead_store_elimination::DeadStoreElimination,
     exit_state_analysis::ExitStateAnalysisProcessor,
     livevar_analysis_processor::LiveVarAnalysisProcessor,
     reference_safety_processor::ReferenceSafetyProcessor,
@@ -215,7 +214,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     if safety_on {
         pipeline.add_processor(Box::new(UninitializedUseChecker {}));
     }
-    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
     pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
     pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
     pipeline.add_processor(Box::new(AbilityProcessor {}));
@@ -224,7 +223,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     }
     // Run live var analysis again because it could be invalidated by previous pipeline steps,
     // but it is needed by file format generator.
-    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
     pipeline
 }
 
@@ -235,17 +234,12 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 /// While this section of the pipeline is optional, some code that used to previously compile
 /// may no longer compile without this section because of using too many local (temp) variables.
 fn add_default_optimization_pipeline(pipeline: &mut FunctionTargetPipeline) {
-    // Available copies analysis is needed by copy propagation.
-    pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {}));
-    pipeline.add_processor(Box::new(CopyPropagation {}));
-    // Live var analysis is needed by dead store elimination.
-    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-    pipeline.add_processor(Box::new(DeadStoreElimination {}));
     pipeline.add_processor(Box::new(UnreachableCodeProcessor {}));
     pipeline.add_processor(Box::new(UnreachableCodeRemover {}));
-    // Live var analysis is needed by variable coalescing.
-    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-    pipeline.add_processor(Box::new(VariableCoalescing {}));
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
+    pipeline.add_processor(Box::new(VariableCoalescing::transform_only()));
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::track_all_usages()));
+    pipeline.add_processor(Box::new(DeadStoreElimination {}));
 }
 
 /// Disassemble the given compiled units and return the disassembled code as a string.

--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -684,7 +684,7 @@ impl<'a> Transformer<'a> {
         temp: TempIndex,
     ) -> Vec<(Loc, String)> {
         if let Some(info) = self.live_var.get_info_at(code_offset).after.get(&temp) {
-            info.usages
+            info.usage_locations()
                 .iter()
                 .map(|loc| (loc.clone(), "used here".to_owned()))
                 .collect()

--- a/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/dead_store_elimination.rs
@@ -1,57 +1,202 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implements the "dead store elimination" transformation. This transformation pairs well with
-//! copy propagation transformation, as it removes the dead stores that copy propagation may introduce.
+//! Implements the "dead store elimination" transformation.
 //!
-//! prerequisite: the `LiveVarAnnotation` should already be computed by running the `LiveVarAnalysisProcessor`.
+//! This transformation should be run after the variable coalescing transformation,
+//! as it removes the dead stores that variable coalescing may introduce.
+//!
+//! prerequisite: the `LiveVarAnnotation` should already be computed by running the
+//! `LiveVarAnalysisProcessor` in the `track_all_usages` mode.
 //! side effect: all annotations will be removed from the function target annotations.
 //!
-//! Given live variables at each program point, this transformation removes dead stores, i.e.,
-//! assignments and loads to locals which are not live afterwards.
+//! Given live variables and all their usages at each program point,
+//! this transformation removes dead stores, i.e., assignments and loads to locals which
+//! are not live afterwards (or are live only in dead code, making them effectively dead).
 //! In addition, it also removes self-assignments, i.e., assignments of the form `x = x`.
 
 use crate::pipeline::livevar_analysis_processor::LiveVarAnnotation;
 use move_binary_format::file_format::CodeOffset;
-use move_model::model::FunctionEnv;
+use move_model::{ast::TempIndex, model::FunctionEnv};
 use move_stackless_bytecode::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
     stackless_bytecode::Bytecode,
 };
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A definition-use graph, where:
+/// - each node is a code offset, representing a definition and/or a use of a local.
+/// - a forward edge (`children`) `a -> b` means that the definition at `a` is used at `b`.
+/// - each forward edge `a -> b` has a corresponding backward edge (`parents`) `a <- b`.
+/// - nodes that are known to be dead stores are marked as `dead`.
+///
+/// Note that this graph only contains side-effect-free *definitions* of the form:
+/// - `Assign(dst, src)`
+/// - `Load(dst, constant)`
+/// This is a conservative over-approximation of side-effect-free definitions.
+/// The nodes representing only *uses* have no restrictions like for definitions.
+/// A node can represent both a definition and a use: such a node can only be of the
+/// form `Assign(dst, src)`, which follows from the above restrictions.
+/// As such, many code offsets in a function that do not meet the above criteria
+/// may not be present in this graph.
+///
+/// A side-effect-free definition can be removed safely if it is not alive later.
+struct DefUseGraph {
+    children: BTreeMap<CodeOffset, BTreeSet<CodeOffset>>,
+    parents: BTreeMap<CodeOffset, BTreeSet<CodeOffset>>,
+    dead: BTreeSet<CodeOffset>,
+}
+
+impl DefUseGraph {
+    /// Create a new `DefUseGraph` from the function `target`.
+    pub fn new(target: &FunctionTarget) -> Self {
+        let mut this = Self {
+            children: BTreeMap::new(),
+            parents: BTreeMap::new(),
+            dead: BTreeSet::new(),
+        };
+        this.populate_from(target);
+        this
+    }
+
+    /// Obtain the set of dead stores, i.e., code offsets which can be removed safely.
+    pub fn dead_stores(mut self) -> BTreeSet<CodeOffset> {
+        let mut dead = BTreeSet::new();
+        while let Some(offset) = self.remove_a_dead_node() {
+            dead.insert(offset);
+        }
+        dead
+    }
+
+    /// Populate an empty graph from the (restricted) definitions and uses in `target`.
+    fn populate_from(&mut self, target: &FunctionTarget) {
+        let code = target.get_bytecode();
+        let live_vars = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("live variable annotation is a prerequisite");
+        for (offset, instr) in code.iter().enumerate() {
+            use Bytecode::*;
+            match instr {
+                Assign(_, dst, src, _) if dst == src => {
+                    // self-assignment is always a dead store
+                    self.incorporate_definition(*dst, offset as CodeOffset, live_vars, true);
+                },
+                Assign(_, dst, ..) | Load(_, dst, _) => {
+                    self.incorporate_definition(*dst, offset as CodeOffset, live_vars, false);
+                },
+                _ => {},
+            }
+        }
+    }
+
+    /// Remove one dead node (arbitrary but deterministic) from the graph, if present.
+    fn remove_a_dead_node(&mut self) -> Option<CodeOffset> {
+        if let Some(node) = self.dead.pop_last() {
+            let parents = self.disconnect_from_parents(node);
+            let children = self.disconnect_from_children(node);
+            // Reconnect all parents to all children.
+            for parent in parents.iter() {
+                for child in children.iter() {
+                    self.children.entry(*parent).or_default().insert(*child);
+                    self.parents.entry(*child).or_default().insert(*parent);
+                }
+            }
+            // Parents are the only ones who could become dead (if `node` was their last child).
+            parents
+                .iter()
+                .for_each(|parent| self.re_evaluate_death(*parent));
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a `parent` node is now dead, and mark it as such if it is.
+    /// A parent node is always a (restricted) definition, and is dead if all its children are dead.
+    fn re_evaluate_death(&mut self, parent: CodeOffset) {
+        if let Some(children) = self.children.get(&parent) {
+            if children.iter().all(|child| self.dead.contains(child)) {
+                self.dead.insert(parent);
+            }
+        } else {
+            self.dead.insert(parent);
+        }
+    }
+
+    /// Disconnect `node` from its parents and return the set of parents.
+    fn disconnect_from_parents(&mut self, node: CodeOffset) -> BTreeSet<CodeOffset> {
+        if let Some(parents) = self.parents.remove(&node) {
+            for parent in parents.iter() {
+                let children = self
+                    .children
+                    .get_mut(parent)
+                    .expect("parent of a child must have children");
+                children.remove(&node);
+            }
+            parents
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    /// Disconnect `node` from its children and return the set of children.
+    fn disconnect_from_children(&mut self, node: CodeOffset) -> BTreeSet<CodeOffset> {
+        if let Some(children) = self.children.remove(&node) {
+            for child in children.iter() {
+                let parents = self
+                    .parents
+                    .get_mut(child)
+                    .expect("child of a parent must have parents");
+                parents.remove(&node);
+            }
+            children
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    /// Incorporate a definition `def` at `offset` into the graph, using the `live_vars` annotation.
+    /// If `always_mark` is true, the definition is marked as dead regardless of its liveness.
+    fn incorporate_definition(
+        &mut self,
+        def: TempIndex,
+        offset: CodeOffset,
+        live_vars: &LiveVarAnnotation,
+        always_mark: bool,
+    ) {
+        let live_after = live_vars.get_info_at(offset).after.get(&def);
+        if let Some(live) = live_after {
+            if always_mark {
+                self.dead.insert(offset);
+            }
+            let children = self.children.entry(offset).or_default();
+            live.usage_offsets().iter().for_each(|child| {
+                children.insert(*child);
+                self.parents.entry(*child).or_default().insert(offset);
+            });
+        } else {
+            self.dead.insert(offset);
+        }
+    }
+}
 
 /// A processor which performs dead store elimination transformation.
 pub struct DeadStoreElimination {}
 
 impl DeadStoreElimination {
-    /// Transforms the `code` of a function using the `live_vars_annotation`,
-    /// by removing assignments and loads to locals which are not live afterwards.
-    /// Also removes self-assignments.
+    /// Transforms the `code` of a function by removing the instructions corresponding to
+    /// the code offsets contained in `dead_stores`.
     ///
     /// Returns the transformed code.
-    fn transform(code: Vec<Bytecode>, live_vars_annotation: &LiveVarAnnotation) -> Vec<Bytecode> {
+    fn transform(target: &FunctionTarget, dead_stores: BTreeSet<CodeOffset>) -> Vec<Bytecode> {
         let mut new_code = vec![];
-        for (offset, instr) in code.into_iter().enumerate() {
-            if let Bytecode::Assign(_, dst, ..) | Bytecode::Load(_, dst, _) = instr {
-                // Is the local that was just assigned to/loaded into, not live afterwards?
-                // Then this is a dead store, we don't need to emit it.
-                if !live_vars_annotation
-                    .get_live_var_info_at(offset as CodeOffset)
-                    .expect("live var info is a prerequisite")
-                    .after
-                    .contains_key(&dst)
-                {
-                    continue;
-                }
+        let code = target.get_bytecode();
+        for (offset, instr) in code.iter().enumerate() {
+            if !dead_stores.contains(&(offset as CodeOffset)) {
+                new_code.push(instr.clone());
             }
-            if let Bytecode::Assign(_, dst, src, _) = instr {
-                if dst == src {
-                    // This is a self-assignment, we don't need to emit it.
-                    continue;
-                }
-            }
-            // None of the above special cases, so we emit the instruction.
-            new_code.push(instr);
         }
         new_code
     }
@@ -68,13 +213,10 @@ impl FunctionTargetProcessor for DeadStoreElimination {
         if func_env.is_native() {
             return data;
         }
-        let code = std::mem::take(&mut data.code);
         let target = FunctionTarget::new(func_env, &data);
-        let live_var_annotation = target
-            .get_annotations()
-            .get::<LiveVarAnnotation>()
-            .expect("live variable annotation is a prerequisite");
-        let new_code = Self::transform(code, live_var_annotation);
+        let def_use_graph = DefUseGraph::new(&target);
+        let dead_stores = def_use_graph.dead_stores();
+        let new_code = Self::transform(&target, dead_stores);
         // Note that the file format generator will not include unused locals in the generated code,
         // so we don't need to prune unused locals here for various fields of `data` (like `local_types`).
         data.code = new_code;

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ use crate::pipeline::{
     livevar_analysis_processor::LiveVarAnalysisProcessor,
     reference_safety_processor::ReferenceSafetyProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
-    unreachable_code_analysis::UnreachableCodeProcessor,
+    unreachable_code_analysis::UnreachableCodeProcessor, variable_coalescing::VariableCoalescing,
 };
 use move_stackless_bytecode::function_target::FunctionTarget;
 
@@ -36,4 +36,5 @@ pub fn register_formatters(target: &FunctionTarget) {
     AvailCopiesAnalysisProcessor::register_formatters(target);
     UninitializedUseChecker::register_formatters(target);
     UnreachableCodeProcessor::register_formatters(target);
+    VariableCoalescing::register_formatters(target);
 }

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -3,6 +3,8 @@
 
 //! Implements memory safety analysis.
 //!
+//! prerequisite: livevar annotation is available by performing liveness analysis.
+//!
 //! This is an intra functional, forward-directed data flow analysis over the domain
 //! of what we call a *borrow graph*. The borrow graph tracks the creation of references from
 //! root memory locations and derivation of other references, by recording an edge for each
@@ -1318,7 +1320,7 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
         let mut infos = vec![];
         for (temp, _) in cands {
             if let Some(info) = self.alive.after.get(&temp) {
-                for loc in &info.usages {
+                for loc in info.usage_locations().iter() {
                     infos.push((
                         loc.clone(),
                         format!(

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -42,14 +42,10 @@ struct TestConfig {
     pipeline: FunctionTargetPipeline,
     /// Whether we should generate file format from resulting bytecode.
     generate_file_format: bool,
-    /// Whether we should dump annotated targets for each stage of the pipeline.
+    /// Whether we should dump annotated targets for various stages of the pipeline.
+    /// Note: even when this flag is `true`, stages added to the pipeline with
+    /// `add_processor_without_annotation_dump` are not dumped.
     dump_annotated_targets: bool,
-    /// Optionally, dump annotated targets for only certain stages of the pipeline.
-    /// If None, dump annotated targets for all stages.
-    /// If Some(list), dump annotated targets for pipeline stages whose index is in the list.
-    /// If `dump_annotated_targets` is false, this field is ignored.
-    /// Note: the pipeline stages are numbered starting from 0.
-    dump_for_only_some_stages: Option<Vec<usize>>,
 }
 
 fn path_from_crate_root(path: &str) -> String {
@@ -93,7 +89,7 @@ impl TestConfig {
         let verbose = cfg!(feature = "verbose-debug-print");
         let mut pipeline = FunctionTargetPipeline::default();
         if path.contains("/inlining/bug_11112") || path.contains("/inlining/bug_9717_looponly") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             Self {
                 stop_before_generating_bytecode: false,
@@ -101,10 +97,9 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/inlining/") || path.contains("/folding/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
             pipeline.add_processor(Box::new(AbilityProcessor {}));
@@ -114,10 +109,9 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: verbose,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/unit_test/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             options.testing = true;
             Self {
                 stop_before_generating_bytecode: false,
@@ -125,7 +119,6 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: verbose,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/checking/") || path.contains("/parser/") {
             Self {
@@ -134,7 +127,6 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: verbose,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/bytecode-generator/") {
             Self {
@@ -143,21 +135,19 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/file-format-generator/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
             pipeline.add_processor(Box::new(AbilityProcessor {}));
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             Self {
                 stop_before_generating_bytecode: false,
                 dump_ast: false,
                 pipeline,
                 generate_file_format: true,
                 dump_annotated_targets: false,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/visibility-checker/") {
             Self {
@@ -166,20 +156,18 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: verbose,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/live-var/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             Self {
                 stop_before_generating_bytecode: false,
                 dump_ast: false,
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/reference-safety/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             Self {
                 stop_before_generating_bytecode: false,
@@ -187,7 +175,6 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: verbose,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/abort-analysis/") {
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
@@ -197,10 +184,9 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/ability-check/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
             pipeline.add_processor(Box::new(AbilityProcessor {}));
@@ -210,11 +196,10 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: false,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/ability-transform/") {
             // Difference to above is that we dump targets
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
             pipeline.add_processor(Box::new(AbilityProcessor {}));
@@ -224,26 +209,27 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/copy-propagation/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
-            pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(AbilityProcessor {}));
-            pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {})); // 4
-            pipeline.add_processor(Box::new(CopyPropagation {})); // 5
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(DeadStoreElimination {})); // 7
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline
+                .add_processor_without_annotation_dump(Box::new(LiveVarAnalysisProcessor::basic()));
+            pipeline.add_processor_without_annotation_dump(Box::new(ReferenceSafetyProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(ExitStateAnalysisProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(AbilityProcessor {}));
+            pipeline.add_processor(Box::new(AvailCopiesAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(CopyPropagation {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(
+                LiveVarAnalysisProcessor::track_all_usages(),
+            ));
+            pipeline.add_processor(Box::new(DeadStoreElimination {}));
+            pipeline
+                .add_processor_without_annotation_dump(Box::new(LiveVarAnalysisProcessor::basic()));
             Self {
                 stop_before_generating_bytecode: false,
                 dump_ast: false,
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                // Only dump with annotations after these pipeline stages.
-                dump_for_only_some_stages: Some(vec![4, 5, 7]),
             }
         } else if path.contains("/uninit-use-checker/") {
             pipeline.add_processor(Box::new(UninitializedUseChecker {}));
@@ -253,7 +239,6 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/unreachable-code-remover/") {
             pipeline.add_processor(Box::new(UnreachableCodeProcessor {}));
@@ -264,10 +249,9 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: false,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/bytecode-verify-failure/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::basic()));
             // Note that we do not run ability checker here, as we want to induce
             // a bytecode verification failure. The test in /bytecode-verify-failure/
             // has erroneous ability annotations.
@@ -277,18 +261,31 @@ impl TestConfig {
                 pipeline,
                 generate_file_format: true,
                 dump_annotated_targets: false,
-                dump_for_only_some_stages: None,
             }
         } else if path.contains("/variable-coalescing/") {
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(VariableCoalescing {}));
+            pipeline
+                .add_processor_without_annotation_dump(Box::new(LiveVarAnalysisProcessor::basic()));
+            pipeline.add_processor_without_annotation_dump(Box::new(ReferenceSafetyProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(ExitStateAnalysisProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(AbilityProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(UnreachableCodeProcessor {}));
+            pipeline.add_processor_without_annotation_dump(Box::new(UnreachableCodeRemover {}));
+            pipeline
+                .add_processor_without_annotation_dump(Box::new(LiveVarAnalysisProcessor::basic()));
+            pipeline.add_processor(Box::new(VariableCoalescing::annotate_only()));
+            pipeline.add_processor(Box::new(VariableCoalescing::transform_only()));
+            pipeline.add_processor_without_annotation_dump(Box::new(
+                LiveVarAnalysisProcessor::track_all_usages(),
+            ));
+            pipeline.add_processor(Box::new(DeadStoreElimination {}));
+            pipeline
+                .add_processor_without_annotation_dump(Box::new(LiveVarAnalysisProcessor::basic()));
             Self {
                 stop_before_generating_bytecode: false,
                 dump_ast: false,
                 pipeline,
-                generate_file_format: false,
+                generate_file_format: true,
                 dump_annotated_targets: true,
-                dump_for_only_some_stages: None,
             }
         } else {
             panic!(
@@ -388,13 +385,9 @@ impl TestConfig {
                     |i, processor, targets_after| {
                         let out = &mut test_output.borrow_mut();
                         Self::check_diags(out, &env);
-                        // Note that `i` starts at 1.
                         let title = format!("after {}:", processor.name());
-                        let stage_dump_enabled = self.dump_for_only_some_stages.is_none()
-                            || self
-                                .dump_for_only_some_stages
-                                .as_ref()
-                                .is_some_and(|list| list.contains(&(i - 1)));
+                        // Note that `i` starts at 1.
+                        let stage_dump_enabled = self.pipeline.should_dump_target_annotations(i);
                         if self.dump_annotated_targets && stage_dump_enabled {
                             out.push_str(
                                 &move_stackless_bytecode::print_targets_with_annotations_for_test(

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
@@ -1,0 +1,151 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := +($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t5 := 1
+  2: $t4 := +($t0, $t5)
+  3: $t0 := infer($t4)
+  4: $t3 := infer($t0)
+  5: $t1 := m::add($t2, $t3)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, e:$t0, e:$t1, b:$t2
+  0: $t2 := +($t0, $t1)
+     # live vars: $t2
+     # events: e:$t2
+  1: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: b:$t5
+  1: $t5 := 1
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5, b:$t4
+  2: $t4 := +($t0, $t5)
+     # live vars: $t2, $t4
+     # events: e:$t4
+  3: $t0 := move($t4)
+     # live vars: $t0, $t2
+     # events: e:$t0, b:$t3
+  4: $t3 := move($t0)
+     # live vars: $t2, $t3
+     # events: e:$t2, e:$t3, b:$t1
+  5: $t1 := m::add($t2, $t3)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+  0: $t0 := +($t0, $t1)
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t5 := 1
+  2: $t5 := +($t0, $t5)
+  3: $t0 := move($t5)
+  4: $t0 := move($t0)
+  5: $t0 := m::add($t2, $t0)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+  0: $t0 := +($t0, $t1)
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t5 := 1
+  2: $t5 := +($t0, $t5)
+  3: $t0 := move($t5)
+  4: $t0 := m::add($t2, $t0)
+  5: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+add(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: u64)
+	2: Add
+	3: Ret
+}
+public test(Arg0: u64): u64 /* def_idx: 1 */ {
+L0:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(1)
+	3: StLoc[2](loc1: u64)
+	4: MoveLoc[0](Arg0: u64)
+	5: CopyLoc[2](loc1: u64)
+	6: Add
+	7: StLoc[0](Arg0: u64)
+	8: MoveLoc[1](loc0: u64)
+	9: CopyLoc[0](Arg0: u64)
+	10: Call add(u64, u64): u64
+	11: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun add(a: u64, b: u64): u64 {
+        a + b
+    }
+
+    public fun test(p: u64): u64 {
+        add(p, {p = p + 1; p})
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -24,7 +24,7 @@ fun m::test() {
  10: return ()
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test() {
@@ -38,30 +38,43 @@ fun m::test() {
      var $t7: u64
      var $t8: u64
      # live vars:
+     # events: b:$t1
   0: $t1 := 5
      # live vars: $t1
-  1: $t0 := infer($t1)
+     # events: e:$t1
+  1: $t0 := move($t1)
      # live vars: $t0
+     # events: b:$t3
   2: $t3 := borrow_local($t0)
      # live vars: $t0, $t3
-  3: $t2 := infer($t3)
+     # events: e:$t3, b:$t2
+  3: $t2 := move($t3)
      # live vars: $t0, $t2
-  4: $t4 := infer($t2)
+     # events: b:$t4
+  4: $t4 := move($t2)
+     # live vars: $t0, $t4
+     # events: e:$t4
+  5: drop($t4)
      # live vars: $t0
-  5: $t5 := borrow_local($t0)
+     # events: b:$t5
+  6: $t5 := borrow_local($t0)
      # live vars: $t5
-  6: $t2 := infer($t5)
+     # events: e:$t5
+  7: $t2 := move($t5)
      # live vars: $t2
-  7: $t7 := read_ref($t2)
+     # events: e:$t2, b:$t7
+  8: $t7 := read_ref($t2)
      # live vars: $t7
-  8: $t8 := 5
+     # events: b:$t8
+  9: $t8 := 5
      # live vars: $t7, $t8
-  9: $t6 := ==($t7, $t8)
+     # events: e:$t7, e:$t8
+ 10: $t6 := ==($t7, $t8)
      # live vars:
- 10: return ()
+ 11: return ()
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
@@ -70,19 +83,76 @@ fun m::test() {
      var $t2: &u64 [unused]
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
+     var $t5: &u64 [unused]
      var $t6: bool
      var $t7: u64 [unused]
      var $t8: u64
   0: $t1 := 5
-  1: $t0 := infer($t1)
+  1: $t0 := move($t1)
   2: $t3 := borrow_local($t0)
-  3: $t3 := infer($t3)
-  4: $t4 := infer($t3)
-  5: $t5 := borrow_local($t0)
-  6: $t3 := infer($t5)
+  3: $t3 := move($t3)
+  4: $t4 := move($t3)
+  5: drop($t4)
+  6: $t4 := borrow_local($t0)
+  7: $t3 := move($t4)
+  8: $t1 := read_ref($t3)
+  9: $t8 := 5
+ 10: $t6 := ==($t1, $t8)
+ 11: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64 [unused]
+     var $t6: bool
+     var $t7: u64 [unused]
+     var $t8: u64
+  0: $t1 := 5
+  1: $t0 := move($t1)
+  2: $t3 := borrow_local($t0)
+  3: $t4 := move($t3)
+  4: drop($t4)
+  5: $t4 := borrow_local($t0)
+  6: $t3 := move($t4)
   7: $t1 := read_ref($t3)
   8: $t8 := 5
   9: $t6 := ==($t1, $t8)
  10: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test() /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: &u64
+L2:	loc2: &u64
+B0:
+	0: LdU64(5)
+	1: StLoc[0](loc0: u64)
+	2: ImmBorrowLoc[0](loc0: u64)
+	3: StLoc[1](loc1: &u64)
+	4: MoveLoc[1](loc1: &u64)
+	5: Pop
+	6: ImmBorrowLoc[0](loc0: u64)
+	7: StLoc[1](loc1: &u64)
+	8: MoveLoc[1](loc1: &u64)
+	9: StLoc[2](loc2: &u64)
+	10: MoveLoc[2](loc2: &u64)
+	11: ReadRef
+	12: LdU64(5)
+	13: Eq
+	14: Pop
+	15: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
@@ -1,0 +1,124 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := infer($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := 0
+  4: $t3 := infer($t4)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t5 := 1
+  9: $t2 := +($t3, $t5)
+ 10: return $t2
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0, $t1
+     # events: b:$t1, b:$t0, e:$t1, b:$t3
+  0: $t3 := move($t1)
+     # live vars: $t0, $t3
+     # events: e:$t0
+  1: if ($t0) goto 2 else goto 6
+     # live vars: $t3
+  2: label L0
+     # live vars:
+     # events: b:$t4
+  3: $t4 := 0
+     # live vars: $t4
+     # events: e:$t4
+  4: $t3 := move($t4)
+     # live vars: $t3
+  5: goto 7
+     # live vars: $t3
+  6: label L1
+     # live vars: $t3
+  7: label L2
+     # live vars: $t3
+     # events: b:$t5
+  8: $t5 := 1
+     # live vars: $t3, $t5
+     # events: e:$t3, e:$t5, b:$t2
+  9: $t2 := +($t3, $t5)
+     # live vars: $t2
+     # events: e:$t2
+ 10: return $t2
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+  0: $t1 := move($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := 0
+  4: $t1 := move($t4)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t4 := 1
+  9: $t1 := +($t1, $t4)
+ 10: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::foo($t0: bool, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t4 := 0
+  3: $t1 := move($t4)
+  4: goto 6
+  5: label L1
+  6: label L2
+  7: $t4 := 1
+  8: $t1 := +($t1, $t4)
+  9: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: bool)
+	1: BrFalse(5)
+B1:
+	2: LdU64(0)
+	3: StLoc[1](Arg1: u64)
+	4: Branch(5)
+B2:
+	5: LdU64(1)
+	6: StLoc[2](loc0: u64)
+	7: CopyLoc[1](Arg1: u64)
+	8: MoveLoc[2](loc0: u64)
+	9: Add
+	10: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+
+    fun foo(b: bool, p: u64): u64 {
+        let a = p;
+        if (b) {
+            a = 0; // kills copy `a := p`
+        };
+        a + 1 // should not have any copies available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
@@ -1,0 +1,104 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := infer($t2)
+  6: label L2
+  7: $t3 := infer($t4)
+  8: return $t3
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0, $t1, $t2
+     # events: b:$t0, b:$t1, b:$t2, e:$t0
+  0: if ($t0) goto 1 else goto 4
+     # live vars: $t1, $t2
+  1: label L0
+     # live vars: $t1
+     # events: b:$t4
+  2: $t4 := move($t1)
+     # live vars: $t4
+  3: goto 6
+     # live vars: $t1, $t2
+     # events: e:$t1
+  4: label L1
+     # live vars: $t2
+     # events: e:$t2
+  5: $t4 := move($t2)
+     # live vars: $t4
+  6: label L2
+     # live vars: $t4
+     # events: e:$t4, b:$t3
+  7: $t3 := move($t4)
+     # live vars: $t3
+     # events: e:$t3
+  8: return $t3
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64 [unused]
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := move($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := move($t2)
+  6: label L2
+  7: $t4 := move($t4)
+  8: return $t4
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
+     var $t3: u64 [unused]
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t4 := move($t1)
+  3: goto 6
+  4: label L1
+  5: $t4 := move($t2)
+  6: label L2
+  7: return $t4
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: bool, Arg1: u64, Arg2: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: bool)
+	1: BrFalse(5)
+B1:
+	2: MoveLoc[1](Arg1: u64)
+	3: StLoc[3](loc0: u64)
+	4: Branch(7)
+B2:
+	5: MoveLoc[2](Arg2: u64)
+	6: StLoc[3](loc0: u64)
+B3:
+	7: MoveLoc[3](loc0: u64)
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(b: bool, p: u64, q: u64): u64 {
+        let a: u64;
+        if (b) {
+            a = p;
+        } else {
+            a = q;
+        };
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
@@ -1,0 +1,103 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t3 := infer($t1)
+  3: goto 6
+  4: label L1
+  5: $t3 := infer($t1)
+  6: label L2
+  7: $t2 := infer($t3)
+  8: return $t2
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, e:$t0
+  0: if ($t0) goto 1 else goto 4
+     # live vars: $t1
+  1: label L0
+     # live vars: $t1
+     # events: b:$t3
+  2: $t3 := move($t1)
+     # live vars: $t3
+  3: goto 6
+     # live vars: $t1
+  4: label L1
+     # live vars: $t1
+     # events: e:$t1
+  5: $t3 := move($t1)
+     # live vars: $t3
+  6: label L2
+     # live vars: $t3
+     # events: e:$t3, b:$t2
+  7: $t2 := move($t3)
+     # live vars: $t2
+     # events: e:$t2
+  8: return $t2
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t3 := move($t1)
+  3: goto 6
+  4: label L1
+  5: $t3 := move($t1)
+  6: label L2
+  7: $t3 := move($t3)
+  8: return $t3
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: bool, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: if ($t0) goto 1 else goto 4
+  1: label L0
+  2: $t3 := move($t1)
+  3: goto 6
+  4: label L1
+  5: $t3 := move($t1)
+  6: label L2
+  7: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: bool)
+	1: BrFalse(5)
+B1:
+	2: MoveLoc[1](Arg1: u64)
+	3: StLoc[2](loc0: u64)
+	4: Branch(7)
+B2:
+	5: MoveLoc[1](Arg1: u64)
+	6: StLoc[2](loc0: u64)
+B3:
+	7: MoveLoc[2](loc0: u64)
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(b: bool, p: u64): u64 {
+        let a: u64;
+        if (b) {
+            a = p;
+        } else {
+            a = p;
+        };
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
@@ -1,0 +1,248 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 11
+  2: label L0
+  3: $t3 := 1
+  4: $t0 := infer($t3)
+  5: $t4 := move($t0)
+  6: $t1 := infer($t4)
+  7: $t5 := 5
+  8: $t0 := infer($t5)
+  9: $t6 := infer($t1)
+ 10: goto 14
+ 11: label L1
+ 12: $t7 := 0
+ 13: $t0 := infer($t7)
+ 14: label L2
+ 15: $t9 := copy($t0)
+ 16: $t10 := 5
+ 17: $t8 := ==($t9, $t10)
+ 18: if ($t8) goto 19 else goto 21
+ 19: label L3
+ 20: goto 24
+ 21: label L4
+ 22: $t11 := 42
+ 23: abort($t11)
+ 24: label L5
+ 25: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := true
+     # live vars: $t2
+     # events: e:$t2
+  1: if ($t2) goto 2 else goto 11
+     # live vars:
+  2: label L0
+     # live vars:
+     # events: b:$t3
+  3: $t3 := 1
+     # live vars: $t3
+     # events: e:$t3, b:$t0
+  4: $t0 := move($t3)
+     # live vars: $t0
+     # events: b:$t4
+  5: $t4 := move($t0)
+     # live vars: $t4
+     # events: e:$t4, b:$t1
+  6: $t1 := move($t4)
+     # live vars: $t1
+     # events: b:$t5
+  7: $t5 := 5
+     # live vars: $t1, $t5
+     # events: e:$t5
+  8: $t0 := move($t5)
+     # live vars: $t0, $t1
+     # events: e:$t1
+  9: $t6 := move($t1)
+     # live vars: $t0
+ 10: goto 14
+     # live vars:
+ 11: label L1
+     # live vars:
+     # events: b:$t7
+ 12: $t7 := 0
+     # live vars: $t7
+     # events: e:$t7
+ 13: $t0 := move($t7)
+     # live vars: $t0
+ 14: label L2
+     # live vars: $t0
+     # events: e:$t0, b:$t9
+ 15: $t9 := copy($t0)
+     # live vars: $t9
+     # events: b:$t10
+ 16: $t10 := 5
+     # live vars: $t9, $t10
+     # events: e:$t9, e:$t10, b:$t8
+ 17: $t8 := ==($t9, $t10)
+     # live vars: $t8
+     # events: e:$t8
+ 18: if ($t8) goto 19 else goto 21
+     # live vars:
+ 19: label L3
+     # live vars:
+ 20: goto 24
+     # live vars:
+ 21: label L4
+     # live vars:
+     # events: b:$t11
+ 22: $t11 := 42
+     # live vars: $t11
+     # events: e:$t11
+ 23: abort($t11)
+     # live vars:
+ 24: label L5
+     # live vars:
+ 25: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 11
+  2: label L0
+  3: $t3 := 1
+  4: $t3 := move($t3)
+  5: $t4 := move($t3)
+  6: $t4 := move($t4)
+  7: $t5 := 5
+  8: $t3 := move($t5)
+  9: $t6 := move($t4)
+ 10: goto 14
+ 11: label L1
+ 12: $t4 := 0
+ 13: $t3 := move($t4)
+ 14: label L2
+ 15: $t3 := copy($t3)
+ 16: $t4 := 5
+ 17: $t2 := ==($t3, $t4)
+ 18: if ($t2) goto 19 else goto 21
+ 19: label L3
+ 20: goto 24
+ 21: label L4
+ 22: $t3 := 42
+ 23: abort($t3)
+ 24: label L5
+ 25: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun <SELF>_0::main() {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+  0: $t2 := true
+  1: if ($t2) goto 2 else goto 6
+  2: label L0
+  3: $t5 := 5
+  4: $t3 := move($t5)
+  5: goto 9
+  6: label L1
+  7: $t4 := 0
+  8: $t3 := move($t4)
+  9: label L2
+ 10: $t4 := 5
+ 11: $t2 := ==($t3, $t4)
+ 12: if ($t2) goto 13 else goto 15
+ 13: label L3
+ 14: goto 18
+ 15: label L4
+ 16: $t3 := 42
+ 17: abort($t3)
+ 18: label L5
+ 19: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+script {
+
+
+main() /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdTrue
+	1: BrFalse(5)
+B1:
+	2: LdU64(5)
+	3: StLoc[0](loc0: u64)
+	4: Branch(7)
+B2:
+	5: LdU64(0)
+	6: StLoc[0](loc0: u64)
+B3:
+	7: LdU64(5)
+	8: StLoc[1](loc1: u64)
+	9: MoveLoc[0](loc0: u64)
+	10: MoveLoc[1](loc1: u64)
+	11: Eq
+	12: BrFalse(14)
+B4:
+	13: Branch(16)
+B5:
+	14: LdU64(42)
+	15: Abort
+B6:
+	16: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.move
@@ -1,0 +1,15 @@
+script {
+fun main() {
+    let x;
+    let y;
+    if (true) {
+        x = 1;
+        y = move x;
+        x = 5;
+        y;
+    } else {
+        x = 0;
+    };
+    assert!(copy x == 5, 42);
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -1,0 +1,225 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+  0: $t1 := 0
+  1: $t0 := infer($t1)
+  2: label L0
+  3: $t2 := true
+  4: if ($t2) goto 5 else goto 11
+  5: label L2
+  6: $t4 := 1
+  7: $t3 := +($t0, $t4)
+  8: $t0 := infer($t3)
+  9: goto 15
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 2
+ 15: label L1
+ 16: $t6 := 1
+ 17: $t5 := ==($t0, $t6)
+ 18: if ($t5) goto 19 else goto 21
+ 19: label L5
+ 20: goto 24
+ 21: label L6
+ 22: $t7 := 42
+ 23: abort($t7)
+ 24: label L7
+ 25: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::main() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+     # events: b:$t1
+  0: $t1 := 0
+     # live vars: $t1
+     # events: e:$t1, b:$t0
+  1: $t0 := move($t1)
+     # live vars: $t0
+  2: label L0
+     # live vars: $t0
+     # events: b:$t2
+  3: $t2 := true
+     # live vars: $t0, $t2
+     # events: e:$t2
+  4: if ($t2) goto 5 else goto 10
+     # live vars: $t0
+  5: label L2
+     # live vars: $t0
+     # events: b:$t4
+  6: $t4 := 1
+     # live vars: $t0, $t4
+     # events: e:$t4, b:$t3
+  7: $t3 := +($t0, $t4)
+     # live vars: $t3
+     # events: e:$t3
+  8: $t0 := move($t3)
+     # live vars: $t0
+  9: goto 12
+     # live vars: $t0
+ 10: label L3
+     # live vars: $t0
+ 11: goto 12
+     # live vars: $t0
+ 12: label L1
+     # live vars: $t0
+     # events: b:$t6
+ 13: $t6 := 1
+     # live vars: $t0, $t6
+     # events: e:$t0, e:$t6, b:$t5
+ 14: $t5 := ==($t0, $t6)
+     # live vars: $t5
+     # events: e:$t5
+ 15: if ($t5) goto 16 else goto 18
+     # live vars:
+ 16: label L5
+     # live vars:
+ 17: goto 21
+     # live vars:
+ 18: label L6
+     # live vars:
+     # events: b:$t7
+ 19: $t7 := 42
+     # live vars: $t7
+     # events: e:$t7
+ 20: abort($t7)
+     # live vars:
+ 21: label L7
+     # live vars:
+ 22: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::main() {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: bool [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t1 := 0
+  1: $t1 := move($t1)
+  2: label L0
+  3: $t2 := true
+  4: if ($t2) goto 5 else goto 10
+  5: label L2
+  6: $t4 := 1
+  7: $t4 := +($t1, $t4)
+  8: $t1 := move($t4)
+  9: goto 12
+ 10: label L3
+ 11: goto 12
+ 12: label L1
+ 13: $t4 := 1
+ 14: $t2 := ==($t1, $t4)
+ 15: if ($t2) goto 16 else goto 18
+ 16: label L5
+ 17: goto 21
+ 18: label L6
+ 19: $t1 := 42
+ 20: abort($t1)
+ 21: label L7
+ 22: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::main() {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: bool [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t1 := 0
+  1: label L0
+  2: $t2 := true
+  3: if ($t2) goto 4 else goto 9
+  4: label L2
+  5: $t4 := 1
+  6: $t4 := +($t1, $t4)
+  7: $t1 := move($t4)
+  8: goto 11
+  9: label L3
+ 10: goto 11
+ 11: label L1
+ 12: $t4 := 1
+ 13: $t2 := ==($t1, $t4)
+ 14: if ($t2) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t1 := 42
+ 19: abort($t1)
+ 20: label L7
+ 21: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module 32.m {
+
+
+main() /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+	2: LdTrue
+	3: BrFalse(11)
+B1:
+	4: LdU64(1)
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: CopyLoc[1](loc1: u64)
+	8: Add
+	9: StLoc[0](loc0: u64)
+	10: Branch(12)
+B2:
+	11: Branch(12)
+B3:
+	12: LdU64(1)
+	13: StLoc[1](loc1: u64)
+	14: MoveLoc[0](loc0: u64)
+	15: MoveLoc[1](loc1: u64)
+	16: Eq
+	17: BrFalse(19)
+B4:
+	18: Branch(21)
+B5:
+	19: LdU64(42)
+	20: Abort
+B6:
+	21: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.move
@@ -1,0 +1,10 @@
+module 0x32::m {
+    fun main() {
+        let x = 0;
+        while (true) {
+            x = x + 1;
+            break
+        };
+        assert!(x == 1, 42);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
@@ -1,0 +1,154 @@
+
+Diagnostics:
+warning: Unused local variable `a`. Consider removing or prefixing with an underscore: `_a`
+  ┌─ tests/variable-coalescing/call_1.move:7:13
+  │
+7 │         let a = p;
+  │             ^
+
+============ initial bytecode ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
+  3: $t6 := m::id($t4)
+  4: $t5 := m::id($t6)
+  5: $t1 := m::id($t5)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t1
+  0: $t1 := move($t0)
+     # live vars: $t1
+     # events: e:$t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # events: b:$t0
+  0: $t2 := copy($t0)
+     # live vars: $t0
+     # events: e:$t0, b:$t3
+  1: $t3 := move($t0)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
+     # live vars: $t4
+     # events: e:$t4, b:$t6
+  3: $t6 := m::id($t4)
+     # live vars: $t6
+     # events: e:$t6, b:$t5
+  4: $t5 := m::id($t6)
+     # live vars: $t5
+     # events: e:$t5, b:$t1
+  5: $t1 := m::id($t5)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64 [unused]
+  0: $t0 := move($t0)
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t2 := copy($t0)
+  1: $t0 := move($t0)
+  2: $t0 := move($t0)
+  3: $t0 := m::id($t0)
+  4: $t0 := m::id($t0)
+  5: $t0 := m::id($t0)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64 [unused]
+  0: return $t0
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t0 := m::id($t0)
+  1: $t0 := m::id($t0)
+  2: $t0 := m::id($t0)
+  3: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+id(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+test(Arg0: u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: Call id(u64): u64
+	2: StLoc[0](Arg0: u64)
+	3: CopyLoc[0](Arg0: u64)
+	4: Call id(u64): u64
+	5: StLoc[0](Arg0: u64)
+	6: CopyLoc[0](Arg0: u64)
+	7: Call id(u64): u64
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun id(x: u64): u64 {
+        x
+    }
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = p;
+        let c = b;
+        id(id(id(c)))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
@@ -1,0 +1,147 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
+  3: $t5 := borrow_local($t2)
+  4: m::update($t5)
+  5: $t1 := infer($t4)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t1
+  0: $t1 := 0
+     # live vars: $t0, $t1
+     # events: e:$t0, e:$t1
+  1: write_ref($t0, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars: $t0
+     # events: b:$t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t0, b:$t3
+  1: $t3 := move($t0)
+     # live vars: $t2, $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
+     # live vars: $t2, $t4
+     # events: b:$t5
+  3: $t5 := borrow_local($t2)
+     # live vars: $t4, $t5
+     # events: e:$t5
+  4: m::update($t5)
+     # live vars: $t4
+     # events: e:$t4, b:$t1
+  5: $t1 := move($t4)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: &mut u64
+  0: $t2 := copy($t0)
+  1: $t0 := move($t0)
+  2: $t0 := move($t0)
+  3: $t5 := borrow_local($t2)
+  4: m::update($t5)
+  5: $t0 := move($t0)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 0
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: &mut u64
+  0: $t2 := copy($t0)
+  1: $t5 := borrow_local($t2)
+  2: m::update($t5)
+  3: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+update(Arg0: &mut u64) /* def_idx: 0 */ {
+B0:
+	0: LdU64(0)
+	1: MoveLoc[0](Arg0: &mut u64)
+	2: WriteRef
+	3: Ret
+}
+test(Arg0: u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MutBorrowLoc[1](loc0: u64)
+	3: Call update(&mut u64)
+	4: MoveLoc[0](Arg0: u64)
+	5: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun update(p: &mut u64) {
+        *p = 0;
+    }
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = p;
+        let c = b;
+        update(&mut a);
+        c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -1,0 +1,193 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64, $t1: bool) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t2 := infer($t3)
+  2: if ($t1) goto 3 else goto 6
+  3: label L0
+  4: m::consume($t2)
+  5: goto 13
+  6: label L1
+  7: $t4 := 99
+  8: $t0 := infer($t4)
+  9: $t5 := infer($t2)
+ 10: $t7 := 1
+ 11: $t6 := +($t5, $t7)
+ 12: $t5 := infer($t6)
+ 13: label L2
+ 14: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0
+  0: $t1 := move($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64, $t1: bool) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, e:$t0, b:$t3
+  0: $t3 := move($t0)
+     # live vars: $t1, $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t1, $t2
+     # events: e:$t1
+  2: if ($t1) goto 3 else goto 6
+     # live vars: $t2
+  3: label L0
+     # live vars: $t2
+  4: m::consume($t2)
+     # live vars:
+  5: goto 13
+     # live vars: $t2
+  6: label L1
+     # live vars: $t2
+     # events: b:$t4
+  7: $t4 := 99
+     # live vars: $t2, $t4
+     # events: e:$t4
+  8: $t0 := move($t4)
+     # live vars: $t2
+     # events: e:$t2, b:$t5
+  9: $t5 := move($t2)
+     # live vars: $t5
+     # events: b:$t7
+ 10: $t7 := 1
+     # live vars: $t5, $t7
+     # events: e:$t5, e:$t7, b:$t6
+ 11: $t6 := +($t5, $t7)
+     # live vars: $t6
+     # events: e:$t6
+ 12: $t5 := move($t6)
+     # live vars:
+ 13: label L2
+     # live vars:
+ 14: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     var $t1: u64
+  0: $t1 := move($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64, $t1: bool) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: if ($t1) goto 3 else goto 6
+  3: label L0
+  4: m::consume($t0)
+  5: goto 13
+  6: label L1
+  7: $t4 := 99
+  8: $t0 := move($t4)
+  9: $t0 := move($t0)
+ 10: $t4 := 1
+ 11: $t0 := +($t0, $t4)
+ 12: $t0 := move($t0)
+ 13: label L2
+ 14: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     var $t1: u64 [unused]
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::test($t0: u64, $t1: bool) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: if ($t1) goto 1 else goto 4
+  1: label L0
+  2: m::consume($t0)
+  3: goto 9
+  4: label L1
+  5: $t4 := 99
+  6: $t0 := move($t4)
+  7: $t4 := 1
+  8: $t0 := +($t0, $t4)
+  9: label L2
+ 10: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+test(Arg0: u64, Arg1: bool) /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[1](Arg1: bool)
+	1: BrFalse(5)
+B1:
+	2: MoveLoc[0](Arg0: u64)
+	3: Call consume(u64)
+	4: Branch(13)
+B2:
+	5: LdU64(99)
+	6: StLoc[0](Arg0: u64)
+	7: LdU64(1)
+	8: StLoc[2](loc0: u64)
+	9: MoveLoc[0](Arg0: u64)
+	10: MoveLoc[2](loc0: u64)
+	11: Add
+	12: Pop
+B3:
+	13: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.move
@@ -1,0 +1,17 @@
+module 0xc0ffee::m {
+    fun consume(a: u64) {
+        a;
+    }
+
+    fun test(a: u64, p: bool) {
+        let b = move a;
+        if (p) {
+            consume(b);
+        } else {
+            a = 99;
+            let c = b;
+            c = c + 1;
+        }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -27,7 +27,7 @@ fun m::test($t0: bool): u64 {
  14: return $t1
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test($t0: bool): u64 {
@@ -40,38 +40,49 @@ fun m::test($t0: bool): u64 {
      var $t7: u64
      var $t8: u64
      # live vars: $t0
+     # events: b:$t0, b:$t3
   0: $t3 := 2
      # live vars: $t0, $t3
-  1: $t2 := infer($t3)
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
      # live vars: $t0, $t2
+     # events: e:$t0
   2: if ($t0) goto 3 else goto 8
      # live vars: $t2
   3: label L0
      # live vars:
+     # events: b:$t5
   4: $t5 := 3
      # live vars: $t5
-  5: $t4 := infer($t5)
+     # events: e:$t5, b:$t4
+  5: $t4 := move($t5)
      # live vars: $t4
-  6: $t1 := infer($t4)
+     # events: e:$t4, b:$t1
+  6: $t1 := move($t4)
      # live vars: $t1
   7: goto 13
      # live vars: $t2
   8: label L1
      # live vars: $t2
+     # events: b:$t8
   9: $t8 := 1
      # live vars: $t2, $t8
+     # events: e:$t2, e:$t8, b:$t7
  10: $t7 := +($t2, $t8)
      # live vars: $t7
- 11: $t6 := infer($t7)
+     # events: e:$t7, b:$t6
+ 11: $t6 := move($t7)
      # live vars: $t6
- 12: $t1 := infer($t6)
+     # events: e:$t6
+ 12: $t1 := move($t6)
      # live vars: $t1
  13: label L2
      # live vars: $t1
+     # events: e:$t1
  14: return $t1
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test($t0: bool): u64 {
@@ -84,18 +95,76 @@ fun m::test($t0: bool): u64 {
      var $t7: u64 [unused]
      var $t8: u64
   0: $t3 := 2
-  1: $t3 := infer($t3)
+  1: $t3 := move($t3)
   2: if ($t0) goto 3 else goto 8
   3: label L0
   4: $t5 := 3
-  5: $t5 := infer($t5)
-  6: $t5 := infer($t5)
+  5: $t5 := move($t5)
+  6: $t5 := move($t5)
   7: goto 13
   8: label L1
   9: $t8 := 1
  10: $t3 := +($t3, $t8)
- 11: $t3 := infer($t3)
- 12: $t5 := infer($t3)
+ 11: $t3 := move($t3)
+ 12: $t5 := move($t3)
  13: label L2
  14: return $t5
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: bool): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     var $t8: u64
+  0: $t3 := 2
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: $t5 := 3
+  4: goto 9
+  5: label L1
+  6: $t8 := 1
+  7: $t3 := +($t3, $t8)
+  8: $t5 := move($t3)
+  9: label L2
+ 10: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: bool): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: LdU64(2)
+	1: MoveLoc[0](Arg0: bool)
+	2: StLoc[0](Arg0: bool)
+	3: StLoc[1](loc0: u64)
+	4: MoveLoc[0](Arg0: bool)
+	5: BrFalse(9)
+B1:
+	6: LdU64(3)
+	7: StLoc[2](loc1: u64)
+	8: Branch(15)
+B2:
+	9: LdU64(1)
+	10: StLoc[3](loc2: u64)
+	11: CopyLoc[1](loc0: u64)
+	12: MoveLoc[3](loc2: u64)
+	13: Add
+	14: StLoc[2](loc1: u64)
+B3:
+	15: MoveLoc[2](loc1: u64)
+	16: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
@@ -1,0 +1,301 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: m::consume($t0)
+  2: m::consume($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+  0: $t1 := infer($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := infer($t0)
+  1: m::consume_($t0)
+  2: m::consume_($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := infer($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+     # events: e:$t0
+  1: m::consume($t0)
+     # live vars: $t1
+     # events: e:$t1
+  2: m::consume($t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+     # events: e:$t1
+  1: m::consume($t1)
+     # live vars: $t0
+     # events: e:$t0
+  2: m::consume($t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: m::W) {
+     var $t1: m::W
+     # live vars: $t0
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+     # events: e:$t0
+  1: m::consume_($t0)
+     # live vars: $t1
+     # events: e:$t1
+  2: m::consume_($t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: m::W) {
+     var $t1: m::W
+     # live vars: $t0
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+     # events: e:$t1
+  1: m::consume_($t1)
+     # live vars: $t0
+     # events: e:$t0
+  2: m::consume_($t0)
+     # live vars:
+  3: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+  0: $t1 := copy($t0)
+  1: m::consume($t0)
+  2: m::consume($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t0)
+  2: m::consume_($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+  0: $t1 := copy($t0)
+  1: m::consume($t0)
+  2: m::consume($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t0)
+  2: m::consume_($t1)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: m::W) {
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct W has copy, drop {
+	x: u64
+}
+
+consume(Arg0: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+consume_(Arg0: W) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test1(Arg0: u64) /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: Call consume(u64)
+	4: MoveLoc[1](loc0: u64)
+	5: Call consume(u64)
+	6: Ret
+}
+public test2(Arg0: u64) /* def_idx: 3 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[1](loc0: u64)
+	3: Call consume(u64)
+	4: MoveLoc[0](Arg0: u64)
+	5: Call consume(u64)
+	6: Ret
+}
+public test3(Arg0: W) /* def_idx: 4 */ {
+B0:
+	0: CopyLoc[0](Arg0: W)
+	1: StLoc[1](loc0: W)
+	2: MoveLoc[0](Arg0: W)
+	3: Call consume_(W)
+	4: MoveLoc[1](loc0: W)
+	5: Call consume_(W)
+	6: Ret
+}
+public test4(Arg0: W) /* def_idx: 5 */ {
+B0:
+	0: CopyLoc[0](Arg0: W)
+	1: StLoc[1](loc0: W)
+	2: MoveLoc[1](loc0: W)
+	3: Call consume_(W)
+	4: MoveLoc[0](Arg0: W)
+	5: Call consume_(W)
+	6: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.move
@@ -1,0 +1,33 @@
+module 0xc0ffee::m {
+    fun consume(_x: u64) {}
+
+    public fun test1(x: u64) {
+        let y = x;
+        consume(x);
+        consume(y);
+    }
+
+    public fun test2(x: u64) {
+        let y = x;
+        consume(y);
+        consume(x);
+    }
+
+    struct W has copy, drop{
+        x: u64,
+    }
+
+    fun consume_(_x: W) {}
+
+    public fun test3(x: W) {
+        let y = x;
+        consume_(x);
+        consume_(y);
+    }
+
+    public fun test4(x: W) {
+        let y = x;
+        consume_(y);
+        consume_(x);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
@@ -1,0 +1,208 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+  0: $t2 := move($t0)
+  1: $t1 := infer($t2)
+  2: m::consume($t1)
+  3: m::consume($t1)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+  0: $t2 := move($t0)
+  1: $t1 := infer($t2)
+  2: m::consume_($t1)
+  3: m::consume_($t1)
+  4: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t1
+  2: m::consume($t1)
+     # live vars: $t1
+     # events: e:$t1
+  3: m::consume($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+     var $t3: m::W
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # events: b:$t3
+  2: $t3 := copy($t1)
+     # live vars: $t1, $t3
+     # events: e:$t3
+  3: m::consume_($t3)
+     # live vars: $t1
+     # events: e:$t1
+  4: m::consume_($t1)
+     # live vars:
+  5: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: m::consume($t0)
+  3: m::consume($t0)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W [unused]
+     var $t3: m::W
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: $t3 := copy($t0)
+  3: m::consume_($t3)
+  4: m::consume_($t0)
+  5: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+  0: m::consume($t0)
+  1: m::consume($t0)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W [unused]
+     var $t3: m::W
+  0: $t3 := copy($t0)
+  1: m::consume_($t3)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct W has copy, drop {
+	x: u64
+}
+
+consume(Arg0: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+consume_(Arg0: W) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test1(Arg0: u64) /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: Call consume(u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: Call consume(u64)
+	4: Ret
+}
+public test2(Arg0: W) /* def_idx: 3 */ {
+B0:
+	0: CopyLoc[0](Arg0: W)
+	1: StLoc[1](loc0: W)
+	2: MoveLoc[1](loc0: W)
+	3: Call consume_(W)
+	4: MoveLoc[0](Arg0: W)
+	5: Call consume_(W)
+	6: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun consume(_x: u64) {}
+
+    public fun test1(x: u64) {
+        let y = move x;
+        consume(y);
+        consume(y);
+    }
+
+    struct W has copy, drop{
+        x: u64,
+    }
+
+    fun consume_(_x: W) {}
+
+    public fun test2(x: W) {
+        let y = move x;
+        consume_(y);
+        consume_(y);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
@@ -1,0 +1,205 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32
+     var $t2: u32
+  0: $t2 := copy($t0)
+  1: $t1 := infer($t2)
+  2: m::consume($t1)
+  3: m::consume($t0)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test_($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+  0: $t2 := copy($t0)
+  1: $t1 := infer($t2)
+  2: m::consume_($t1)
+  3: m::consume_($t0)
+  4: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32
+     var $t2: u32
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # events: e:$t1
+  2: m::consume($t1)
+     # live vars: $t0
+     # events: e:$t0
+  3: m::consume($t0)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test_($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # events: e:$t1
+  2: m::consume_($t1)
+     # live vars: $t0
+     # events: e:$t0
+  3: m::consume_($t0)
+     # live vars:
+  4: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32 [unused]
+     var $t2: u32
+  0: $t2 := copy($t0)
+  1: $t2 := move($t2)
+  2: m::consume($t2)
+  3: m::consume($t0)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test_($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W
+  0: $t2 := copy($t0)
+  1: $t2 := move($t2)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32 [unused]
+     var $t2: u32
+  0: $t2 := copy($t0)
+  1: m::consume($t2)
+  2: m::consume($t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test_($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W
+  0: $t2 := copy($t0)
+  1: m::consume_($t2)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct W has copy, drop {
+	a: u32
+}
+
+consume(Arg0: u32) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+consume_(Arg0: W) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test(Arg0: u32) /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[0](Arg0: u32)
+	1: StLoc[1](loc0: u32)
+	2: MoveLoc[1](loc0: u32)
+	3: Call consume(u32)
+	4: MoveLoc[0](Arg0: u32)
+	5: Call consume(u32)
+	6: Ret
+}
+public test_(Arg0: W) /* def_idx: 3 */ {
+B0:
+	0: CopyLoc[0](Arg0: W)
+	1: StLoc[1](loc0: W)
+	2: MoveLoc[1](loc0: W)
+	3: Call consume_(W)
+	4: MoveLoc[0](Arg0: W)
+	5: Call consume_(W)
+	6: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun consume(_a: u32) {}
+
+    public fun test(a: u32) {
+        let b = copy a;
+        consume(b);
+        consume(a);
+    }
+
+    struct W has copy, drop {
+        a: u32,
+    }
+
+    fun consume_(_a: W) {}
+
+    public fun test_(a: W) {
+        let b = copy a;
+        consume_(b);
+        consume_(a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
@@ -1,0 +1,241 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32
+     var $t2: u32
+     var $t3: u32
+     var $t4: u32
+  0: $t2 := copy($t0)
+  1: $t1 := infer($t2)
+  2: $t4 := move($t1)
+  3: $t3 := infer($t4)
+  4: m::consume($t3)
+  5: m::consume($t0)
+  6: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+     var $t3: m::W
+     var $t4: m::W
+  0: $t2 := copy($t0)
+  1: $t1 := infer($t2)
+  2: $t4 := move($t1)
+  3: $t3 := infer($t4)
+  4: m::consume_($t3)
+  5: m::consume_($t0)
+  6: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32
+     var $t2: u32
+     var $t3: u32
+     var $t4: u32
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # events: e:$t1, b:$t4
+  2: $t4 := move($t1)
+     # live vars: $t0, $t4
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
+     # live vars: $t0, $t3
+     # events: e:$t3
+  4: m::consume($t3)
+     # live vars: $t0
+     # events: e:$t0
+  5: m::consume($t0)
+     # live vars:
+  6: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: m::W) {
+     var $t1: m::W
+     var $t2: m::W
+     var $t3: m::W
+     var $t4: m::W
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t0, $t1
+     # events: e:$t1, b:$t4
+  2: $t4 := move($t1)
+     # live vars: $t0, $t4
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
+     # live vars: $t0, $t3
+     # events: e:$t3
+  4: m::consume_($t3)
+     # live vars: $t0
+     # events: e:$t0
+  5: m::consume_($t0)
+     # live vars:
+  6: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32 [unused]
+     var $t2: u32
+     var $t3: u32 [unused]
+     var $t4: u32 [unused]
+  0: $t2 := copy($t0)
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: $t2 := move($t2)
+  4: m::consume($t2)
+  5: m::consume($t0)
+  6: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W
+     var $t3: m::W [unused]
+     var $t4: m::W [unused]
+  0: $t2 := copy($t0)
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: $t2 := move($t2)
+  4: m::consume_($t2)
+  5: m::consume_($t0)
+  6: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u32) {
+     var $t1: u32 [unused]
+     var $t2: u32
+     var $t3: u32 [unused]
+     var $t4: u32 [unused]
+  0: $t2 := copy($t0)
+  1: m::consume($t2)
+  2: m::consume($t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: m::W) {
+     var $t1: m::W [unused]
+     var $t2: m::W
+     var $t3: m::W [unused]
+     var $t4: m::W [unused]
+  0: $t2 := copy($t0)
+  1: m::consume_($t2)
+  2: m::consume_($t0)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct W has copy, drop {
+	m: u32
+}
+
+consume(Arg0: u32) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+consume_(Arg0: W) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test(Arg0: u32) /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[0](Arg0: u32)
+	1: StLoc[1](loc0: u32)
+	2: MoveLoc[1](loc0: u32)
+	3: Call consume(u32)
+	4: MoveLoc[0](Arg0: u32)
+	5: Call consume(u32)
+	6: Ret
+}
+public test_struct(Arg0: W) /* def_idx: 3 */ {
+B0:
+	0: CopyLoc[0](Arg0: W)
+	1: StLoc[1](loc0: W)
+	2: MoveLoc[1](loc0: W)
+	3: Call consume_(W)
+	4: MoveLoc[0](Arg0: W)
+	5: Call consume_(W)
+	6: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun consume(_x: u32) {}
+
+    public fun test(a: u32) {
+        let b = copy a;
+        let c = move b;
+        consume(c);
+        consume(a);
+    }
+
+    struct W has copy, drop {m: u32}
+
+    fun consume_(_x: W) {}
+
+    public fun test_struct(a: W) {
+        let b = copy a;
+        let c = move b;
+        consume_(c);
+        consume_(a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
@@ -1,0 +1,403 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: bool, $t1: u32) {
+     var $t2: u32
+     var $t3: u32
+     var $t4: bool
+  0: $t3 := copy($t1)
+  1: $t2 := infer($t3)
+  2: if ($t0) goto 3 else goto 6
+  3: label L0
+  4: m::consume($t2)
+  5: goto 8
+  6: label L1
+  7: m::consume($t1)
+  8: label L2
+  9: $t4 := !($t0)
+ 10: if ($t4) goto 11 else goto 14
+ 11: label L3
+ 12: m::consume($t1)
+ 13: goto 16
+ 14: label L4
+ 15: m::consume($t2)
+ 16: label L5
+ 17: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: bool, $t1: m::W) {
+     var $t2: m::W
+     var $t3: m::W
+     var $t4: bool
+  0: $t3 := copy($t1)
+  1: $t2 := infer($t3)
+  2: if ($t0) goto 3 else goto 6
+  3: label L0
+  4: m::consume_($t2)
+  5: goto 8
+  6: label L1
+  7: m::consume_($t1)
+  8: label L2
+  9: $t4 := !($t0)
+ 10: if ($t4) goto 11 else goto 14
+ 11: label L3
+ 12: m::consume_($t1)
+ 13: goto 16
+ 14: label L4
+ 15: m::consume_($t2)
+ 16: label L5
+ 17: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+     # live vars:
+     # events: e:$t0, b:$t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: bool, $t1: u32) {
+     var $t2: u32
+     var $t3: u32
+     var $t4: bool
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, b:$t3
+  0: $t3 := copy($t1)
+     # live vars: $t0, $t1, $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t0, $t1, $t2
+  2: if ($t0) goto 3 else goto 6
+     # live vars: $t0, $t1, $t2
+  3: label L0
+     # live vars: $t0, $t1, $t2
+  4: m::consume($t2)
+     # live vars: $t0, $t1, $t2
+  5: goto 8
+     # live vars: $t0, $t1, $t2
+  6: label L1
+     # live vars: $t0, $t1, $t2
+  7: m::consume($t1)
+     # live vars: $t0, $t1, $t2
+  8: label L2
+     # live vars: $t0, $t1, $t2
+     # events: e:$t0, b:$t4
+  9: $t4 := !($t0)
+     # live vars: $t1, $t2, $t4
+     # events: e:$t4
+ 10: if ($t4) goto 11 else goto 14
+     # live vars: $t1, $t2
+ 11: label L3
+     # live vars: $t1
+ 12: m::consume($t1)
+     # live vars:
+ 13: goto 16
+     # live vars: $t1, $t2
+     # events: e:$t1
+ 14: label L4
+     # live vars: $t2
+     # events: e:$t2
+ 15: m::consume($t2)
+     # live vars:
+ 16: label L5
+     # live vars:
+ 17: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: bool, $t1: m::W) {
+     var $t2: m::W
+     var $t3: m::W
+     var $t4: bool
+     var $t5: m::W
+     var $t6: m::W
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, b:$t3
+  0: $t3 := copy($t1)
+     # live vars: $t0, $t1, $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t0, $t1, $t2
+  2: if ($t0) goto 3 else goto 7
+     # live vars: $t0, $t1, $t2
+  3: label L0
+     # live vars: $t0, $t1, $t2
+     # events: b:$t5
+  4: $t5 := copy($t2)
+     # live vars: $t0, $t1, $t2, $t5
+     # events: e:$t5
+  5: m::consume_($t5)
+     # live vars: $t0, $t1, $t2
+  6: goto 10
+     # live vars: $t0, $t1, $t2
+  7: label L1
+     # live vars: $t0, $t1, $t2
+     # events: b:$t6
+  8: $t6 := copy($t1)
+     # live vars: $t0, $t1, $t2, $t6
+     # events: e:$t6
+  9: m::consume_($t6)
+     # live vars: $t0, $t1, $t2
+ 10: label L2
+     # live vars: $t0, $t1, $t2
+     # events: e:$t0, b:$t4
+ 11: $t4 := !($t0)
+     # live vars: $t1, $t2, $t4
+     # events: e:$t4
+ 12: if ($t4) goto 13 else goto 16
+     # live vars: $t1, $t2
+ 13: label L3
+     # live vars: $t1
+ 14: m::consume_($t1)
+     # live vars:
+ 15: goto 18
+     # live vars: $t1, $t2
+     # events: e:$t1
+ 16: label L4
+     # live vars: $t2
+     # events: e:$t2
+ 17: m::consume_($t2)
+     # live vars:
+ 18: label L5
+     # live vars:
+ 19: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: bool, $t1: u32) {
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: bool [unused]
+  0: $t3 := copy($t1)
+  1: $t3 := move($t3)
+  2: if ($t0) goto 3 else goto 6
+  3: label L0
+  4: m::consume($t3)
+  5: goto 8
+  6: label L1
+  7: m::consume($t1)
+  8: label L2
+  9: $t0 := !($t0)
+ 10: if ($t0) goto 11 else goto 14
+ 11: label L3
+ 12: m::consume($t1)
+ 13: goto 16
+ 14: label L4
+ 15: m::consume($t3)
+ 16: label L5
+ 17: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: bool, $t1: m::W) {
+     var $t2: m::W [unused]
+     var $t3: m::W
+     var $t4: bool [unused]
+     var $t5: m::W
+     var $t6: m::W [unused]
+  0: $t3 := copy($t1)
+  1: $t3 := move($t3)
+  2: if ($t0) goto 3 else goto 7
+  3: label L0
+  4: $t5 := copy($t3)
+  5: m::consume_($t5)
+  6: goto 10
+  7: label L1
+  8: $t5 := copy($t1)
+  9: m::consume_($t5)
+ 10: label L2
+ 11: $t0 := !($t0)
+ 12: if ($t0) goto 13 else goto 16
+ 13: label L3
+ 14: m::consume_($t1)
+ 15: goto 18
+ 16: label L4
+ 17: m::consume_($t3)
+ 18: label L5
+ 19: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::consume($t0: u32) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_($t0: m::W) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: bool, $t1: u32) {
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: bool [unused]
+  0: $t3 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t3)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t0 := !($t0)
+  9: if ($t0) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t3)
+ 15: label L5
+ 16: return ()
+}
+
+
+[variant baseline]
+public fun m::test_struct($t0: bool, $t1: m::W) {
+     var $t2: m::W [unused]
+     var $t3: m::W
+     var $t4: bool [unused]
+     var $t5: m::W
+     var $t6: m::W [unused]
+  0: $t3 := copy($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t5 := copy($t3)
+  4: m::consume_($t5)
+  5: goto 9
+  6: label L1
+  7: $t5 := copy($t1)
+  8: m::consume_($t5)
+  9: label L2
+ 10: $t0 := !($t0)
+ 11: if ($t0) goto 12 else goto 15
+ 12: label L3
+ 13: m::consume_($t1)
+ 14: goto 17
+ 15: label L4
+ 16: m::consume_($t3)
+ 17: label L5
+ 18: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct W has copy, drop {
+	x: u32
+}
+
+consume(Arg0: u32) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+consume_(Arg0: W) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test(Arg0: bool, Arg1: u32) /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[1](Arg1: u32)
+	1: StLoc[2](loc0: u32)
+	2: CopyLoc[0](Arg0: bool)
+	3: BrFalse(7)
+B1:
+	4: CopyLoc[2](loc0: u32)
+	5: Call consume(u32)
+	6: Branch(9)
+B2:
+	7: CopyLoc[1](Arg1: u32)
+	8: Call consume(u32)
+B3:
+	9: CopyLoc[0](Arg0: bool)
+	10: Not
+	11: BrFalse(15)
+B4:
+	12: MoveLoc[1](Arg1: u32)
+	13: Call consume(u32)
+	14: Branch(17)
+B5:
+	15: MoveLoc[2](loc0: u32)
+	16: Call consume(u32)
+B6:
+	17: Ret
+}
+public test_struct(Arg0: bool, Arg1: W) /* def_idx: 3 */ {
+B0:
+	0: CopyLoc[1](Arg1: W)
+	1: StLoc[2](loc0: W)
+	2: CopyLoc[0](Arg0: bool)
+	3: BrFalse(9)
+B1:
+	4: CopyLoc[2](loc0: W)
+	5: StLoc[3](loc1: W)
+	6: MoveLoc[3](loc1: W)
+	7: Call consume_(W)
+	8: Branch(13)
+B2:
+	9: CopyLoc[1](Arg1: W)
+	10: StLoc[3](loc1: W)
+	11: MoveLoc[3](loc1: W)
+	12: Call consume_(W)
+B3:
+	13: CopyLoc[0](Arg0: bool)
+	14: Not
+	15: BrFalse(19)
+B4:
+	16: MoveLoc[1](Arg1: W)
+	17: Call consume_(W)
+	18: Branch(21)
+B5:
+	19: MoveLoc[2](loc0: W)
+	20: Call consume_(W)
+B6:
+	21: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.move
@@ -1,0 +1,35 @@
+module 0xc0ffee::m {
+    fun consume(_x: u32) {}
+
+    public fun test(p: bool, a: u32) {
+        let b = copy a;
+        if (p) {
+            consume(b);
+        } else {
+            consume(a);
+        };
+        if (!p) {
+            consume(a);
+        } else {
+            consume(b);
+        }
+    }
+
+    struct W has copy, drop { x: u32 }
+
+    fun consume_(_x: W) {}
+
+    public fun test_struct(p: bool, a: W) {
+        let b = copy a;
+        if (p) {
+            consume_(b);
+        } else {
+            consume_(a);
+        };
+        if (!p) {
+            consume_(a);
+        } else {
+            consume_(b);
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
@@ -1,0 +1,80 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t0 := infer($t3)
+  3: $t1 := infer($t0)
+  4: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3
+  2: $t0 := move($t3)
+     # live vars: $t0
+     # events: e:$t0, b:$t1
+  3: $t1 := move($t0)
+     # live vars: $t1
+     # events: e:$t1
+  4: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+  0: $t2 := move($t0)
+  1: $t2 := move($t2)
+  2: $t0 := move($t2)
+  3: $t0 := move($t0)
+  4: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::cyclic($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+  0: $t2 := move($t0)
+  1: $t0 := move($t2)
+  2: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+cyclic(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[1](loc0: u64)
+	3: StLoc[0](Arg0: u64)
+	4: MoveLoc[0](Arg0: u64)
+	5: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun cyclic(p: u64): u64 {
+        let a = p;
+        let b = a;
+        p = b;
+        p
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
@@ -1,0 +1,69 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t1 := infer($t3)
+  3: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3, b:$t1
+  2: $t1 := move($t3)
+     # live vars: $t1
+     # events: e:$t1
+  3: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: $t0 := move($t0)
+  3: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+  0: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+dead(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    fun dead(p: u64): u64 {
+        let a = p;
+        let a = a;
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
@@ -1,0 +1,56 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+  0: $t0 := infer($t0)
+  1: $t1 := infer($t0)
+  2: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+     # events: b:$t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+     # events: e:$t0, b:$t1
+  1: $t1 := move($t0)
+     # live vars: $t1
+     # events: e:$t1
+  2: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64 [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::dead($t0: u64): u64 {
+     var $t1: u64 [unused]
+  0: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+dead(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+    fun dead(p: u64): u64 {
+        p = p;
+        p
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
@@ -1,0 +1,90 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t2)
+  3: $t5 := infer($t4)
+  4: $t1 := read_ref($t5)
+  5: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: &u64
+     # live vars: $t0
+     # events: e:$t0, b:$t0, b:$t3
+  0: $t3 := borrow_local($t0)
+     # live vars: $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t2
+     # events: e:$t2, b:$t4
+  2: $t4 := move($t2)
+     # live vars: $t4
+     # events: e:$t4, b:$t5
+  3: $t5 := move($t4)
+     # live vars: $t5
+     # events: e:$t5, b:$t1
+  4: $t1 := read_ref($t5)
+     # live vars: $t1
+     # events: e:$t1
+  5: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64 [unused]
+     var $t3: &u64
+     var $t4: &u64 [unused]
+     var $t5: &u64 [unused]
+  0: $t3 := borrow_local($t0)
+  1: $t3 := move($t3)
+  2: $t3 := move($t3)
+  3: $t3 := move($t3)
+  4: $t1 := read_ref($t3)
+  5: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64 [unused]
+     var $t3: &u64
+     var $t4: &u64 [unused]
+     var $t5: &u64 [unused]
+  0: $t3 := borrow_local($t0)
+  1: $t1 := read_ref($t3)
+  2: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ReadRef
+	2: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &p;
+        let b = a;
+        let c = b;
+        *c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
@@ -1,0 +1,118 @@
+
+Diagnostics:
+warning: Unused local variable `a`. Consider removing or prefixing with an underscore: `_a`
+  ┌─ tests/variable-coalescing/immut_refs_2.move:4:13
+  │
+4 │         let a = &p;
+  │             ^
+
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := infer($t3)
+  2: $t4 := infer($t0)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # events: e:$t0, b:$t0, b:$t3
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  2: drop($t2)
+     # live vars: $t0
+     # events: b:$t4
+  3: $t4 := move($t0)
+     # live vars: $t4
+     # events: e:$t4, b:$t5
+  4: $t5 := move($t4)
+     # live vars: $t5
+     # events: e:$t5, b:$t6
+  5: $t6 := move($t5)
+     # live vars: $t6
+     # events: e:$t6, b:$t1
+  6: $t1 := move($t6)
+     # live vars: $t1
+     # events: e:$t1
+  7: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t3 := borrow_local($t0)
+  1: $t3 := move($t3)
+  2: drop($t3)
+  3: $t4 := move($t0)
+  4: $t4 := move($t4)
+  5: $t4 := move($t4)
+  6: $t4 := move($t4)
+  7: return $t4
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t3 := borrow_local($t0)
+  1: drop($t3)
+  2: $t4 := move($t0)
+  3: return $t4
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &u64)
+	2: MoveLoc[1](loc0: &u64)
+	3: Pop
+	4: MoveLoc[0](Arg0: u64)
+	5: StLoc[2](loc1: u64)
+	6: MoveLoc[2](loc1: u64)
+	7: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = &p;
+        let b = p;
+        let c = b;
+        let d = c;
+        d
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.exp
@@ -1,0 +1,70 @@
+============ initial bytecode ================
+
+[variant baseline]
+public fun Test::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+  0: $t2 := 10
+  1: $t1 := infer($t2)
+  2: $t0 := 3
+  3: return $t0
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+public fun Test::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := 10
+     # live vars: $t2
+     # events: e:$t2
+  1: $t1 := move($t2)
+     # live vars:
+     # events: b:$t0
+  2: $t0 := 3
+     # live vars: $t0
+     # events: e:$t0
+  3: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+public fun Test::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+  0: $t2 := 10
+  1: $t1 := move($t2)
+  2: $t2 := 3
+  3: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+public fun Test::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: $t2 := 3
+  1: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module 42.Test {
+
+
+public test(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(3)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.move
@@ -1,0 +1,9 @@
+module 0x42::Test {
+    inline fun foo(f:|u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    public fun test(): u64 {
+        foo(|_| 3, 10)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -1,0 +1,127 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t4 := 2
+  3: $t3 := infer($t4)
+  4: $t5 := +($t1, $t3)
+  5: $t1 := infer($t5)
+  6: $t6 := infer($t3)
+  7: $t0 := +($t6, $t3)
+  8: return $t0
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := 1
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # events: b:$t4
+  2: $t4 := 2
+     # live vars: $t1, $t4
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+     # events: e:$t1, b:$t5
+  4: $t5 := +($t1, $t3)
+     # live vars: $t3, $t5
+     # events: e:$t5
+  5: $t1 := move($t5)
+     # live vars: $t3
+     # events: b:$t6
+  6: $t6 := copy($t3)
+     # live vars: $t3, $t6
+     # events: e:$t3, e:$t6, b:$t0
+  7: $t0 := +($t6, $t3)
+     # live vars: $t0
+     # events: e:$t0
+  8: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t2 := 1
+  1: $t2 := move($t2)
+  2: $t4 := 2
+  3: $t4 := move($t4)
+  4: $t2 := +($t2, $t4)
+  5: $t2 := move($t2)
+  6: $t2 := copy($t4)
+  7: $t2 := +($t2, $t4)
+  8: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t2 := 1
+  1: $t4 := 2
+  2: $t2 := +($t2, $t4)
+  3: $t2 := copy($t4)
+  4: $t2 := +($t2, $t4)
+  5: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: StLoc[0](loc0: u64)
+	3: CopyLoc[0](loc0: u64)
+	4: Add
+	5: CopyLoc[0](loc0: u64)
+	6: StLoc[1](loc1: u64)
+	7: StLoc[1](loc1: u64)
+	8: CopyLoc[1](loc1: u64)
+	9: MoveLoc[0](loc0: u64)
+	10: Add
+	11: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let t = 1;
+        let u = 2;
+        t = t + u;
+        let b = u;
+        b + u
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
@@ -1,0 +1,140 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t4 := 2
+  3: $t3 := infer($t4)
+  4: $t6 := 1
+  5: $t5 := +($t1, $t6)
+  6: $t1 := infer($t5)
+  7: $t7 := infer($t3)
+  8: $t0 := +($t7, $t1)
+  9: return $t0
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := 1
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # events: b:$t4
+  2: $t4 := 2
+     # live vars: $t1, $t4
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+     # events: b:$t6
+  4: $t6 := 1
+     # live vars: $t1, $t3, $t6
+     # events: e:$t6, b:$t5
+  5: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+     # events: e:$t5
+  6: $t1 := move($t5)
+     # live vars: $t1, $t3
+     # events: e:$t3, b:$t7
+  7: $t7 := move($t3)
+     # live vars: $t1, $t7
+     # events: e:$t1, e:$t7, b:$t0
+  8: $t0 := +($t7, $t1)
+     # live vars: $t0
+     # events: e:$t0
+  9: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+  0: $t2 := 1
+  1: $t2 := move($t2)
+  2: $t4 := 2
+  3: $t4 := move($t4)
+  4: $t6 := 1
+  5: $t6 := +($t2, $t6)
+  6: $t2 := move($t6)
+  7: $t4 := move($t4)
+  8: $t2 := +($t4, $t2)
+  9: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+  0: $t2 := 1
+  1: $t4 := 2
+  2: $t6 := 1
+  3: $t6 := +($t2, $t6)
+  4: $t2 := move($t6)
+  5: $t2 := +($t4, $t2)
+  6: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(1)
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: StLoc[2](loc2: u64)
+	6: MoveLoc[2](loc2: u64)
+	7: CopyLoc[0](loc0: u64)
+	8: Add
+	9: StLoc[2](loc2: u64)
+	10: MoveLoc[1](loc1: u64)
+	11: CopyLoc[2](loc2: u64)
+	12: Add
+	13: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let t = 1;
+        let u = 2;
+        t = t + 1;
+        let b = u;
+        b + t
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -1,0 +1,138 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t4 := 2
+  3: $t3 := infer($t4)
+  4: $t6 := 1
+  5: $t5 := +($t1, $t6)
+  6: $t1 := infer($t5)
+  7: $t7 := infer($t3)
+  8: $t0 := infer($t7)
+  9: return $t0
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := 1
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
+     # live vars: $t1
+     # events: b:$t4
+  2: $t4 := 2
+     # live vars: $t1, $t4
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
+     # live vars: $t1, $t3
+     # events: b:$t6
+  4: $t6 := 1
+     # live vars: $t1, $t3, $t6
+     # events: e:$t1, e:$t6, b:$t5
+  5: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+     # events: e:$t5
+  6: $t1 := move($t5)
+     # live vars: $t3
+     # events: e:$t3, b:$t7
+  7: $t7 := move($t3)
+     # live vars: $t7
+     # events: e:$t7, b:$t0
+  8: $t0 := move($t7)
+     # live vars: $t0
+     # events: e:$t0
+  9: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+  0: $t2 := 1
+  1: $t2 := move($t2)
+  2: $t4 := 2
+  3: $t4 := move($t4)
+  4: $t6 := 1
+  5: $t2 := +($t2, $t6)
+  6: $t2 := move($t2)
+  7: $t4 := move($t4)
+  8: $t4 := move($t4)
+  9: return $t4
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+  0: $t2 := 1
+  1: $t4 := 2
+  2: $t6 := 1
+  3: $t2 := +($t2, $t6)
+  4: return $t4
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(1)
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: StLoc[2](loc2: u64)
+	6: MoveLoc[2](loc2: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Add
+	9: MoveLoc[1](loc1: u64)
+	10: StLoc[1](loc1: u64)
+	11: Pop
+	12: MoveLoc[1](loc1: u64)
+	13: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let t = 1;
+        let u = 2;
+        t = t + 1;
+        let b = u;
+        b
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -1,0 +1,215 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t3 := 0
+  1: $t2 := infer($t3)
+  2: $t5 := 0
+  3: $t4 := infer($t5)
+  4: label L0
+  5: $t7 := 10
+  6: $t6 := <($t4, $t7)
+  7: if ($t6) goto 8 else goto 14
+  8: label L2
+  9: $t2 := infer($t0)
+ 10: $t9 := 1
+ 11: $t8 := +($t4, $t9)
+ 12: $t4 := infer($t8)
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 4
+ 18: label L1
+ 19: $t1 := infer($t2)
+ 20: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t3
+  0: $t3 := 0
+     # live vars: $t0, $t3
+     # events: e:$t3, b:$t2
+  1: $t2 := move($t3)
+     # live vars: $t0, $t2
+     # events: b:$t5
+  2: $t5 := 0
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5, b:$t4
+  3: $t4 := move($t5)
+     # live vars: $t0, $t2, $t4
+  4: label L0
+     # live vars: $t0, $t2, $t4
+     # events: b:$t7
+  5: $t7 := 10
+     # live vars: $t0, $t2, $t4, $t7
+     # events: e:$t7, b:$t6
+  6: $t6 := <($t4, $t7)
+     # live vars: $t0, $t2, $t4, $t6
+     # events: e:$t6
+  7: if ($t6) goto 8 else goto 14
+     # live vars: $t0, $t2, $t4
+  8: label L2
+     # live vars: $t0, $t4
+  9: $t2 := copy($t0)
+     # live vars: $t0, $t2, $t4
+     # events: b:$t9
+ 10: $t9 := 1
+     # live vars: $t0, $t2, $t4, $t9
+     # events: e:$t9, b:$t8
+ 11: $t8 := +($t4, $t9)
+     # live vars: $t0, $t2, $t8
+     # events: e:$t8
+ 12: $t4 := move($t8)
+     # live vars: $t0, $t2, $t4
+ 13: goto 16
+     # live vars: $t0, $t2, $t4
+ 14: label L3
+     # live vars: $t2
+ 15: goto 18
+     # live vars: $t0, $t2, $t4
+ 16: label L4
+     # live vars: $t0, $t2, $t4
+     # events: e:$t0, e:$t4
+ 17: goto 4
+     # live vars: $t2
+ 18: label L1
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+ 19: $t1 := move($t2)
+     # live vars: $t1
+     # events: e:$t1
+ 20: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+  0: $t3 := 0
+  1: $t3 := move($t3)
+  2: $t5 := 0
+  3: $t5 := move($t5)
+  4: label L0
+  5: $t7 := 10
+  6: $t6 := <($t5, $t7)
+  7: if ($t6) goto 8 else goto 14
+  8: label L2
+  9: $t3 := copy($t0)
+ 10: $t7 := 1
+ 11: $t7 := +($t5, $t7)
+ 12: $t5 := move($t7)
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 4
+ 18: label L1
+ 19: $t3 := move($t3)
+ 20: return $t3
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+  0: $t3 := 0
+  1: $t5 := 0
+  2: label L0
+  3: $t7 := 10
+  4: $t6 := <($t5, $t7)
+  5: if ($t6) goto 6 else goto 12
+  6: label L2
+  7: $t3 := copy($t0)
+  8: $t7 := 1
+  9: $t7 := +($t5, $t7)
+ 10: $t5 := move($t7)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: LdU64(0)
+	1: LdU64(0)
+	2: StLoc[1](loc0: u64)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: LdU64(10)
+	5: StLoc[3](loc2: u64)
+	6: CopyLoc[1](loc0: u64)
+	7: MoveLoc[3](loc2: u64)
+	8: Lt
+	9: BrFalse(19)
+B2:
+	10: CopyLoc[0](Arg0: u64)
+	11: StLoc[2](loc1: u64)
+	12: LdU64(1)
+	13: StLoc[3](loc2: u64)
+	14: MoveLoc[1](loc0: u64)
+	15: CopyLoc[3](loc2: u64)
+	16: Add
+	17: StLoc[1](loc0: u64)
+	18: Branch(20)
+B3:
+	19: Branch(21)
+B4:
+	20: Branch(4)
+B5:
+	21: MoveLoc[2](loc1: u64)
+	22: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = 0;
+        let count = 0;
+        while (count < 10) {
+            a = p;
+            count = count + 1;
+        };
+        a // copy `a := p` should not be available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
@@ -1,0 +1,206 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t2 := infer($t0)
+  1: $t4 := 0
+  2: $t3 := infer($t4)
+  3: label L0
+  4: $t6 := 10
+  5: $t5 := <($t3, $t6)
+  6: if ($t5) goto 7 else goto 13
+  7: label L2
+  8: $t2 := infer($t0)
+  9: $t8 := 1
+ 10: $t7 := +($t3, $t8)
+ 11: $t3 := infer($t7)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 3
+ 17: label L1
+ 18: $t1 := infer($t2)
+ 19: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: b:$t4
+  1: $t4 := 0
+     # live vars: $t0, $t2, $t4
+     # events: e:$t4, b:$t3
+  2: $t3 := move($t4)
+     # live vars: $t0, $t2, $t3
+  3: label L0
+     # live vars: $t0, $t2, $t3
+     # events: b:$t6
+  4: $t6 := 10
+     # live vars: $t0, $t2, $t3, $t6
+     # events: e:$t6, b:$t5
+  5: $t5 := <($t3, $t6)
+     # live vars: $t0, $t2, $t3, $t5
+     # events: e:$t5
+  6: if ($t5) goto 7 else goto 13
+     # live vars: $t0, $t2, $t3
+  7: label L2
+     # live vars: $t0, $t3
+  8: $t2 := copy($t0)
+     # live vars: $t0, $t2, $t3
+     # events: b:$t8
+  9: $t8 := 1
+     # live vars: $t0, $t2, $t3, $t8
+     # events: e:$t8, b:$t7
+ 10: $t7 := +($t3, $t8)
+     # live vars: $t0, $t2, $t7
+     # events: e:$t7
+ 11: $t3 := move($t7)
+     # live vars: $t0, $t2, $t3
+ 12: goto 15
+     # live vars: $t0, $t2, $t3
+ 13: label L3
+     # live vars: $t2
+ 14: goto 17
+     # live vars: $t0, $t2, $t3
+ 15: label L4
+     # live vars: $t0, $t2, $t3
+     # events: e:$t0, e:$t3
+ 16: goto 3
+     # live vars: $t2
+ 17: label L1
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+ 18: $t1 := move($t2)
+     # live vars: $t1
+     # events: e:$t1
+ 19: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+  0: $t2 := copy($t0)
+  1: $t4 := 0
+  2: $t4 := move($t4)
+  3: label L0
+  4: $t6 := 10
+  5: $t5 := <($t4, $t6)
+  6: if ($t5) goto 7 else goto 13
+  7: label L2
+  8: $t2 := copy($t0)
+  9: $t6 := 1
+ 10: $t6 := +($t4, $t6)
+ 11: $t4 := move($t6)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 3
+ 17: label L1
+ 18: $t2 := move($t2)
+ 19: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+  0: $t2 := copy($t0)
+  1: $t4 := 0
+  2: label L0
+  3: $t6 := 10
+  4: $t5 := <($t4, $t6)
+  5: if ($t5) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t6 := 1
+  9: $t6 := +($t4, $t6)
+ 10: $t4 := move($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(0)
+	3: StLoc[2](loc1: u64)
+B1:
+	4: LdU64(10)
+	5: StLoc[3](loc2: u64)
+	6: CopyLoc[2](loc1: u64)
+	7: MoveLoc[3](loc2: u64)
+	8: Lt
+	9: BrFalse(19)
+B2:
+	10: CopyLoc[0](Arg0: u64)
+	11: StLoc[1](loc0: u64)
+	12: LdU64(1)
+	13: StLoc[3](loc2: u64)
+	14: MoveLoc[2](loc1: u64)
+	15: CopyLoc[3](loc2: u64)
+	16: Add
+	17: StLoc[2](loc1: u64)
+	18: Branch(20)
+B3:
+	19: Branch(21)
+B4:
+	20: Branch(4)
+B5:
+	21: MoveLoc[1](loc0: u64)
+	22: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let count = 0;
+        while (count < 10) {
+            a = p;
+            count = count + 1;
+        };
+        a // copy `a := p` should be available
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
@@ -1,0 +1,84 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: $t3 := 2
+  3: $t1 := infer($t3)
+  4: $t0 := infer($t1)
+  5: return $t0
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+     # events: b:$t2
+  0: $t2 := 1
+     # live vars: $t2
+     # events: e:$t2
+  1: $t1 := move($t2)
+     # live vars:
+     # events: b:$t3
+  2: $t3 := 2
+     # live vars: $t3
+     # events: e:$t3, b:$t1
+  3: $t1 := move($t3)
+     # live vars: $t1
+     # events: e:$t1, b:$t0
+  4: $t0 := move($t1)
+     # live vars: $t0
+     # events: e:$t0
+  5: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+  0: $t2 := 1
+  1: $t2 := move($t2)
+  2: $t2 := 2
+  3: $t2 := move($t2)
+  4: $t2 := move($t2)
+  5: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+  0: $t2 := 2
+  1: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    fun test(): u64 {
+        let x = 1;
+        x = 2;
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -1,0 +1,107 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t3 := infer($t4)
+  3: $t5 := 1
+  4: write_ref($t3, $t5)
+  5: $t1 := infer($t2)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+     # live vars: $t0
+     # events: e:$t0, b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: b:$t4
+  1: $t4 := borrow_local($t0)
+     # live vars: $t2, $t4
+     # events: e:$t4, b:$t3
+  2: $t3 := move($t4)
+     # live vars: $t2, $t3
+     # events: b:$t5
+  3: $t5 := 1
+     # live vars: $t2, $t3, $t5
+     # events: e:$t3, e:$t5
+  4: write_ref($t3, $t5)
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  5: $t1 := move($t2)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: &mut u64 [unused]
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t4 := move($t4)
+  3: $t5 := 1
+  4: write_ref($t4, $t5)
+  5: $t2 := move($t2)
+  6: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: &mut u64 [unused]
+     var $t4: &mut u64
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t4 := borrow_local($t0)
+  2: $t5 := 1
+  3: write_ref($t4, $t5)
+  4: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: &mut u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MutBorrowLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: StLoc[2](loc1: u64)
+	5: StLoc[3](loc2: &mut u64)
+	6: MoveLoc[2](loc1: u64)
+	7: MoveLoc[3](loc2: &mut u64)
+	8: WriteRef
+	9: MoveLoc[1](loc0: u64)
+	10: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+
+    fun test(p: u64): u64 {
+        let a = p;
+        let b = &mut p;
+        *b = 1;
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -1,0 +1,156 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t4 := infer($t5)
+  5: $t7 := 0
+  6: write_ref($t4, $t7)
+  7: $t8 := borrow_local($t3)
+  8: $t9 := borrow_field<m::S>.a($t8)
+  9: $t1 := read_ref($t9)
+ 10: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t3 := copy($t2)
+     # live vars: $t2, $t3
+     # events: b:$t6
+  2: $t6 := borrow_local($t2)
+     # live vars: $t3, $t6
+     # events: e:$t6, b:$t5
+  3: $t5 := borrow_field<m::S>.a($t6)
+     # live vars: $t3, $t5
+     # events: e:$t5, b:$t4
+  4: $t4 := move($t5)
+     # live vars: $t3, $t4
+     # events: b:$t7
+  5: $t7 := 0
+     # live vars: $t3, $t4, $t7
+     # events: e:$t4, e:$t7
+  6: write_ref($t4, $t7)
+     # live vars: $t3
+     # events: b:$t8
+  7: $t8 := borrow_local($t3)
+     # live vars: $t8
+     # events: e:$t8, b:$t9
+  8: $t9 := borrow_field<m::S>.a($t8)
+     # live vars: $t9
+     # events: e:$t9, b:$t1
+  9: $t1 := read_ref($t9)
+     # live vars: $t1
+     # events: e:$t1
+ 10: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64 [unused]
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64 [unused]
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := move($t0)
+  1: $t3 := copy($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t5 := move($t5)
+  5: $t7 := 0
+  6: write_ref($t5, $t7)
+  7: $t8 := borrow_local($t3)
+  8: $t9 := borrow_field<m::S>.a($t8)
+  9: $t7 := read_ref($t9)
+ 10: return $t7
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: m::S): u64 {
+     var $t1: u64 [unused]
+     var $t2: m::S
+     var $t3: m::S
+     var $t4: &mut u64 [unused]
+     var $t5: &mut u64
+     var $t6: &mut m::S
+     var $t7: u64
+     var $t8: &m::S
+     var $t9: &u64
+  0: $t2 := move($t0)
+  1: $t3 := copy($t2)
+  2: $t6 := borrow_local($t2)
+  3: $t5 := borrow_field<m::S>.a($t6)
+  4: $t7 := 0
+  5: write_ref($t5, $t7)
+  6: $t8 := borrow_local($t3)
+  7: $t9 := borrow_field<m::S>.a($t8)
+  8: $t7 := read_ref($t9)
+  9: return $t7
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct S has copy, drop {
+	a: u64,
+	b: u64
+}
+
+test(Arg0: S): u64 /* def_idx: 0 */ {
+L0:	loc1: S
+L1:	loc2: u64
+L2:	loc3: &mut u64
+B0:
+	0: MoveLoc[0](Arg0: S)
+	1: StLoc[1](loc0: S)
+	2: CopyLoc[1](loc0: S)
+	3: StLoc[2](loc1: S)
+	4: MutBorrowLoc[1](loc0: S)
+	5: MutBorrowField[0](S.a: u64)
+	6: LdU64(0)
+	7: StLoc[3](loc2: u64)
+	8: StLoc[4](loc3: &mut u64)
+	9: MoveLoc[3](loc2: u64)
+	10: MoveLoc[4](loc3: &mut u64)
+	11: WriteRef
+	12: ImmBorrowLoc[2](loc1: S)
+	13: ImmBorrowField[0](S.a: u64)
+	14: ReadRef
+	15: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+
+    struct S has copy, drop {
+        a: u64,
+        b: u64,
+    }
+
+    fun test(s: S): u64 {
+        let p = s;
+        let q = p;
+        let ref = &mut p.a;
+        *ref = 0;
+        q.a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -23,7 +23,7 @@ fun m::test() {
  10: return ()
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test() {
@@ -36,30 +36,40 @@ fun m::test() {
      var $t6: u64
      var $t7: u64
      # live vars:
+     # events: b:$t1
   0: $t1 := 1
      # live vars: $t1
-  1: $t0 := infer($t1)
+     # events: e:$t1, b:$t0
+  1: $t0 := move($t1)
      # live vars: $t0
+     # events: b:$t3
   2: $t3 := 1
      # live vars: $t0, $t3
+     # events: e:$t0, e:$t3, b:$t2
   3: $t2 := +($t0, $t3)
      # live vars: $t2
-  4: $t0 := infer($t2)
+     # events: e:$t2
+  4: $t0 := move($t2)
      # live vars:
+     # events: b:$t5
   5: $t5 := 2
      # live vars: $t5
-  6: $t4 := infer($t5)
+     # events: e:$t5, b:$t4
+  6: $t4 := move($t5)
      # live vars: $t4
+     # events: b:$t7
   7: $t7 := 1
      # live vars: $t4, $t7
+     # events: e:$t4, e:$t7, b:$t6
   8: $t6 := +($t4, $t7)
      # live vars: $t6
-  9: $t4 := infer($t6)
+     # events: e:$t6
+  9: $t4 := move($t6)
      # live vars:
  10: return ()
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
@@ -72,14 +82,55 @@ fun m::test() {
      var $t6: u64 [unused]
      var $t7: u64 [unused]
   0: $t1 := 1
-  1: $t1 := infer($t1)
+  1: $t1 := move($t1)
   2: $t3 := 1
   3: $t1 := +($t1, $t3)
-  4: $t1 := infer($t1)
+  4: $t1 := move($t1)
   5: $t1 := 2
-  6: $t1 := infer($t1)
+  6: $t1 := move($t1)
   7: $t3 := 1
   8: $t1 := +($t1, $t3)
-  9: $t1 := infer($t1)
+  9: $t1 := move($t1)
  10: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t1 := +($t1, $t3)
+  3: $t1 := 2
+  4: $t3 := 1
+  5: $t1 := +($t1, $t3)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test() /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Add
+	3: LdU64(2)
+	4: LdU64(1)
+	5: Add
+	6: Pop
+	7: Pop
+	8: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -23,7 +23,7 @@ fun m::test() {
  10: return ()
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test() {
@@ -36,30 +36,40 @@ fun m::test() {
      var $t6: u64
      var $t7: u64
      # live vars:
+     # events: b:$t1
   0: $t1 := 1
      # live vars: $t1
-  1: $t0 := infer($t1)
+     # events: e:$t1, b:$t0
+  1: $t0 := move($t1)
      # live vars: $t0
+     # events: b:$t3
   2: $t3 := 1
      # live vars: $t0, $t3
+     # events: e:$t0, e:$t3, b:$t2
   3: $t2 := +($t0, $t3)
      # live vars: $t2
-  4: $t0 := infer($t2)
+     # events: e:$t2
+  4: $t0 := move($t2)
      # live vars:
+     # events: b:$t5
   5: $t5 := 2
      # live vars: $t5
-  6: $t4 := infer($t5)
+     # events: e:$t5, b:$t4
+  6: $t4 := move($t5)
      # live vars: $t4
+     # events: b:$t7
   7: $t7 := 1
      # live vars: $t4, $t7
+     # events: e:$t4, e:$t7, b:$t6
   8: $t6 := +($t4, $t7)
      # live vars: $t6
-  9: $t4 := infer($t6)
+     # events: e:$t6
+  9: $t4 := move($t6)
      # live vars:
  10: return ()
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
@@ -72,14 +82,55 @@ fun m::test() {
      var $t6: u64 [unused]
      var $t7: u64
   0: $t1 := 1
-  1: $t1 := infer($t1)
+  1: $t1 := move($t1)
   2: $t3 := 1
   3: $t1 := +($t1, $t3)
-  4: $t1 := infer($t1)
+  4: $t1 := move($t1)
   5: $t5 := 2
-  6: $t5 := infer($t5)
+  6: $t5 := move($t5)
   7: $t7 := 1
   8: $t5 := +($t5, $t7)
-  9: $t5 := infer($t5)
+  9: $t5 := move($t5)
  10: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test() {
+     var $t0: u32 [unused]
+     var $t1: u32
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t1 := +($t1, $t3)
+  3: $t5 := 2
+  4: $t7 := 1
+  5: $t5 := +($t5, $t7)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test() /* def_idx: 0 */ {
+B0:
+	0: LdU32(1)
+	1: LdU32(1)
+	2: Add
+	3: LdU64(2)
+	4: LdU64(1)
+	5: Add
+	6: Pop
+	7: Pop
+	8: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -21,7 +21,7 @@ fun m::test(): u64 {
   8: return $t0
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test(): u64 {
@@ -34,26 +34,35 @@ fun m::test(): u64 {
      var $t6: u64
      var $t7: u64
      # live vars:
+     # events: b:$t2
   0: $t2 := 1
      # live vars: $t2
-  1: $t1 := infer($t2)
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
      # live vars: $t1
+     # events: b:$t4
   2: $t4 := 2
      # live vars: $t1, $t4
-  3: $t3 := infer($t4)
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
      # live vars: $t1, $t3
+     # events: b:$t6
   4: $t6 := 3
      # live vars: $t1, $t3, $t6
-  5: $t5 := infer($t6)
+     # events: e:$t6, b:$t5
+  5: $t5 := move($t6)
      # live vars: $t1, $t3, $t5
+     # events: e:$t1, e:$t3, b:$t7
   6: $t7 := +($t1, $t3)
      # live vars: $t5, $t7
+     # events: e:$t5, e:$t7, b:$t0
   7: $t0 := +($t7, $t5)
      # live vars: $t0
+     # events: e:$t0
   8: return $t0
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test(): u64 {
@@ -66,12 +75,60 @@ fun m::test(): u64 {
      var $t6: u64
      var $t7: u64 [unused]
   0: $t2 := 1
-  1: $t2 := infer($t2)
+  1: $t2 := move($t2)
   2: $t4 := 2
-  3: $t4 := infer($t4)
+  3: $t4 := move($t4)
   4: $t6 := 3
-  5: $t6 := infer($t6)
+  5: $t6 := move($t6)
   6: $t2 := +($t2, $t4)
   7: $t2 := +($t2, $t6)
   8: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+  0: $t2 := 1
+  1: $t4 := 2
+  2: $t6 := 3
+  3: $t2 := +($t2, $t4)
+  4: $t2 := +($t2, $t6)
+  5: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: StLoc[2](loc2: u64)
+	6: CopyLoc[2](loc2: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: Add
+	9: StLoc[2](loc2: u64)
+	10: CopyLoc[2](loc2: u64)
+	11: MoveLoc[0](loc0: u64)
+	12: Add
+	13: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -18,7 +18,7 @@ fun m::test(): u64 {
   7: return $t0
 }
 
-============ after LiveVarAnalysisProcessor: ================
+============ after VariableCoalescingAnnotator: ================
 
 [variant baseline]
 fun m::test(): u64 {
@@ -29,24 +29,32 @@ fun m::test(): u64 {
      var $t4: u64
      var $t5: u64
      # live vars:
+     # events: b:$t2
   0: $t2 := 1
      # live vars: $t2
-  1: $t1 := infer($t2)
+     # events: e:$t2
+  1: $t1 := move($t2)
      # live vars:
+     # events: b:$t4
   2: $t4 := 2
      # live vars: $t4
-  3: $t3 := infer($t4)
+     # events: e:$t4, b:$t3
+  3: $t3 := move($t4)
      # live vars: $t3
+     # events: b:$t5
   4: $t5 := 9
      # live vars: $t3, $t5
-  5: $t1 := infer($t5)
+     # events: e:$t5, b:$t1
+  5: $t1 := move($t5)
      # live vars: $t1, $t3
+     # events: e:$t1, e:$t3, b:$t0
   6: $t0 := +($t1, $t3)
      # live vars: $t0
+     # events: e:$t0
   7: return $t0
 }
 
-============ after VariableCoalescing: ================
+============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test(): u64 {
@@ -57,11 +65,48 @@ fun m::test(): u64 {
      var $t4: u64 [unused]
      var $t5: u64
   0: $t2 := 1
-  1: $t5 := infer($t2)
+  1: $t5 := move($t2)
   2: $t2 := 2
-  3: $t2 := infer($t2)
+  3: $t2 := move($t2)
   4: $t5 := 9
-  5: $t5 := infer($t5)
+  5: $t5 := move($t5)
   6: $t2 := +($t5, $t2)
   7: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := 2
+  1: $t5 := 9
+  2: $t2 := +($t5, $t2)
+  3: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(): u64 /* def_idx: 0 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(2)
+	1: LdU64(9)
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: CopyLoc[1](loc1: u64)
+	6: Add
+	7: Ret
+}
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -1,0 +1,118 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t6 := 1
+  4: $t5 := +($t0, $t6)
+  5: $t3 := infer($t5)
+  6: $t1 := ==($t2, $t4)
+  7: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: b:$t3
+  1: $t3 := copy($t2)
+     # live vars: $t0, $t2, $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
+     # live vars: $t0, $t2, $t4
+     # events: b:$t6
+  3: $t6 := 1
+     # live vars: $t0, $t2, $t4, $t6
+     # events: e:$t0, e:$t6, b:$t5
+  4: $t5 := +($t0, $t6)
+     # live vars: $t2, $t4, $t5
+     # events: e:$t5
+  5: $t3 := move($t5)
+     # live vars: $t2, $t4
+     # events: e:$t2, e:$t4, b:$t1
+  6: $t1 := ==($t2, $t4)
+     # live vars: $t1
+     # events: e:$t1
+  7: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t2)
+  2: $t3 := move($t3)
+  3: $t6 := 1
+  4: $t0 := +($t0, $t6)
+  5: $t3 := move($t0)
+  6: $t1 := ==($t2, $t3)
+  7: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+  0: $t2 := copy($t0)
+  1: $t6 := 1
+  2: $t0 := +($t0, $t6)
+  3: $t3 := move($t0)
+  4: $t1 := ==($t2, $t3)
+  5: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): bool /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(1)
+	3: StLoc[2](loc1: u64)
+	4: CopyLoc[0](Arg0: u64)
+	5: MoveLoc[2](loc1: u64)
+	6: Add
+	7: StLoc[3](loc2: u64)
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[3](loc2: u64)
+	10: Eq
+	11: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun test(p: u64): bool {
+        let a = p;
+        let b = a;
+        let c = b;
+
+        b = p + 1; // kill b := a, which removes the whole copy chain
+        a == c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -1,0 +1,121 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t6 := 1
+  4: $t5 := +($t0, $t6)
+  5: $t2 := infer($t5)
+  6: $t1 := ==($t3, $t4)
+  7: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t0, $t3
+     # events: b:$t4
+  2: $t4 := copy($t3)
+     # live vars: $t0, $t3, $t4
+     # events: b:$t6
+  3: $t6 := 1
+     # live vars: $t0, $t3, $t4, $t6
+     # events: e:$t0, e:$t6, b:$t5
+  4: $t5 := +($t0, $t6)
+     # live vars: $t3, $t4, $t5
+     # events: e:$t5
+  5: $t2 := move($t5)
+     # live vars: $t3, $t4
+     # events: e:$t3, e:$t4, b:$t1
+  6: $t1 := ==($t3, $t4)
+     # live vars: $t1
+     # events: e:$t1
+  7: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+  0: $t2 := copy($t0)
+  1: $t2 := move($t2)
+  2: $t4 := copy($t2)
+  3: $t6 := 1
+  4: $t0 := +($t0, $t6)
+  5: $t2 := move($t0)
+  6: $t1 := ==($t2, $t4)
+  7: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64
+  0: $t2 := copy($t0)
+  1: $t4 := copy($t2)
+  2: $t6 := 1
+  3: $t0 := +($t0, $t6)
+  4: $t2 := move($t0)
+  5: $t1 := ==($t2, $t4)
+  6: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+test(Arg0: u64): bool /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[1](loc0: u64)
+	3: StLoc[2](loc1: u64)
+	4: LdU64(1)
+	5: StLoc[3](loc2: u64)
+	6: CopyLoc[0](Arg0: u64)
+	7: MoveLoc[3](loc2: u64)
+	8: Add
+	9: StLoc[1](loc0: u64)
+	10: MoveLoc[1](loc0: u64)
+	11: MoveLoc[2](loc1: u64)
+	12: Eq
+	13: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun test(p: u64): bool {
+        let a = p;
+        let b = a;
+        let c = b;
+
+        a = p + 1; // kill b := a
+        b == c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
@@ -1,0 +1,102 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo
+     var $t2: m::Foo
+     var $t3: m::Foo
+     var $t4: m::Foo
+     var $t5: m::Foo
+     var $t6: m::Foo
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
+     # live vars: $t4
+     # events: e:$t4, b:$t5
+  3: $t5 := move($t4)
+     # live vars: $t5
+     # events: e:$t5, b:$t6
+  4: $t6 := move($t5)
+     # live vars: $t6
+     # events: e:$t6, b:$t1
+  5: $t1 := move($t6)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo [unused]
+     var $t2: m::Foo [unused]
+     var $t3: m::Foo [unused]
+     var $t4: m::Foo [unused]
+     var $t5: m::Foo [unused]
+     var $t6: m::Foo [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: $t0 := move($t0)
+  3: $t0 := move($t0)
+  4: $t0 := move($t0)
+  5: $t0 := move($t0)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::sequential($t0: m::Foo): m::Foo {
+     var $t1: m::Foo [unused]
+     var $t2: m::Foo [unused]
+     var $t3: m::Foo [unused]
+     var $t4: m::Foo [unused]
+     var $t5: m::Foo [unused]
+     var $t6: m::Foo [unused]
+  0: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo has copy {
+	a: u64,
+	b: u64,
+	c: u64,
+	d: u64,
+	e: u64
+}
+
+sequential(Arg0: Foo): Foo /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: Foo)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    struct Foo has copy {
+        a: u64,
+        b: u64,
+        c: u64,
+        d: u64,
+        e: u64,
+    }
+
+    fun sequential(p: Foo): Foo {
+        let a = p;
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        e
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
@@ -1,0 +1,96 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t5)
+  5: $t1 := infer($t6)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
+     # live vars: $t4
+     # events: e:$t4, b:$t5
+  3: $t5 := move($t4)
+     # live vars: $t5
+     # events: e:$t5, b:$t6
+  4: $t6 := move($t5)
+     # live vars: $t6
+     # events: e:$t6, b:$t1
+  5: $t1 := move($t6)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t0 := move($t0)
+  1: $t0 := move($t0)
+  2: $t0 := move($t0)
+  3: $t0 := move($t0)
+  4: $t0 := move($t0)
+  5: $t0 := move($t0)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::sequential($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+sequential(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun sequential(p: u64): u64 {
+        let a = p;
+        let b = a;
+        let c = b;
+        let d = c;
+        let e = d;
+        e
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -1,0 +1,113 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t2)
+  2: $t5 := 1
+  3: $t4 := +($t0, $t5)
+  4: $t0 := infer($t4)
+  5: $t1 := +($t3, $t2)
+  6: return $t1
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # events: b:$t0, b:$t2
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+     # events: b:$t3
+  1: $t3 := copy($t2)
+     # live vars: $t0, $t2, $t3
+     # events: b:$t5
+  2: $t5 := 1
+     # live vars: $t0, $t2, $t3, $t5
+     # events: e:$t0, e:$t5, b:$t4
+  3: $t4 := +($t0, $t5)
+     # live vars: $t2, $t3, $t4
+     # events: e:$t4
+  4: $t0 := move($t4)
+     # live vars: $t2, $t3
+     # events: e:$t2, e:$t3, b:$t1
+  5: $t1 := +($t3, $t2)
+     # live vars: $t1
+     # events: e:$t1
+  6: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t2)
+  2: $t5 := 1
+  3: $t0 := +($t0, $t5)
+  4: $t0 := move($t0)
+  5: $t0 := +($t3, $t2)
+  6: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::copy_kill($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := copy($t0)
+  1: $t3 := copy($t2)
+  2: $t5 := 1
+  3: $t0 := +($t0, $t5)
+  4: $t0 := +($t3, $t2)
+  5: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+copy_kill(Arg0: u64): u64 /* def_idx: 0 */ {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[1](loc0: u64)
+	3: StLoc[2](loc1: u64)
+	4: LdU64(1)
+	5: StLoc[3](loc2: u64)
+	6: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[3](loc2: u64)
+	8: Add
+	9: MoveLoc[2](loc1: u64)
+	10: MoveLoc[1](loc0: u64)
+	11: Add
+	12: StLoc[0](Arg0: u64)
+	13: StLoc[0](Arg0: u64)
+	14: MoveLoc[0](Arg0: u64)
+	15: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    fun copy_kill(p: u64): u64 {
+        let a = p;
+        let b = a;
+        p = p + 1;
+        b + a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
@@ -1,0 +1,88 @@
+============ initial bytecode ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: $t0 := infer($t1)
+  2: $t1 := infer($t4)
+  3: $t2 := infer($t0)
+  4: $t3 := infer($t1)
+  5: return ($t2, $t3)
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, b:$t4
+  0: $t4 := move($t0)
+     # live vars: $t1, $t4
+  1: $t0 := move($t1)
+     # live vars: $t0, $t4
+     # events: e:$t4
+  2: $t1 := move($t4)
+     # live vars: $t0, $t1
+     # events: e:$t0, b:$t2
+  3: $t2 := move($t0)
+     # live vars: $t1, $t2
+     # events: e:$t1, b:$t3
+  4: $t3 := move($t1)
+     # live vars: $t2, $t3
+     # events: e:$t2, e:$t3
+  5: return ($t2, $t3)
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: $t0 := move($t1)
+  2: $t1 := move($t4)
+  3: $t0 := move($t0)
+  4: $t1 := move($t1)
+  5: return ($t0, $t1)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+  0: $t4 := move($t0)
+  1: $t0 := move($t1)
+  2: $t1 := move($t4)
+  3: return ($t0, $t1)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: StLoc[2](loc0: u64)
+	2: MoveLoc[1](Arg1: u64)
+	3: StLoc[0](Arg0: u64)
+	4: MoveLoc[2](loc0: u64)
+	5: StLoc[1](Arg1: u64)
+	6: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[1](Arg1: u64)
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    public fun test(x: u64, y: u64): (u64, u64) {
+        let t = x;
+        x = y;
+        y = t;
+        (x, y)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
@@ -1,0 +1,213 @@
+============ initial bytecode ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: $t4 := infer($t0)
+  1: label L0
+  2: $t7 := 0
+  3: $t6 := >($t4, $t7)
+  4: if ($t6) goto 5 else goto 13
+  5: label L2
+  6: $t5 := infer($t0)
+  7: $t0 := infer($t1)
+  8: $t1 := infer($t5)
+  9: $t9 := 1
+ 10: $t8 := -($t4, $t9)
+ 11: $t4 := infer($t8)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 1
+ 17: label L1
+ 18: $t2 := infer($t0)
+ 19: $t3 := infer($t1)
+ 20: return ($t2, $t3)
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # live vars: $t0, $t1
+     # events: b:$t0, b:$t1, b:$t4
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: label L0
+     # live vars: $t0, $t1, $t4
+     # events: b:$t7
+  2: $t7 := 0
+     # live vars: $t0, $t1, $t4, $t7
+     # events: e:$t7, b:$t6
+  3: $t6 := >($t4, $t7)
+     # live vars: $t0, $t1, $t4, $t6
+     # events: e:$t6
+  4: if ($t6) goto 5 else goto 13
+     # live vars: $t0, $t1, $t4
+  5: label L2
+     # live vars: $t0, $t1, $t4
+     # events: b:$t5
+  6: $t5 := move($t0)
+     # live vars: $t1, $t4, $t5
+  7: $t0 := move($t1)
+     # live vars: $t0, $t4, $t5
+     # events: e:$t5
+  8: $t1 := move($t5)
+     # live vars: $t0, $t1, $t4
+     # events: b:$t9
+  9: $t9 := 1
+     # live vars: $t0, $t1, $t4, $t9
+     # events: e:$t9, b:$t8
+ 10: $t8 := -($t4, $t9)
+     # live vars: $t0, $t1, $t8
+     # events: e:$t8
+ 11: $t4 := move($t8)
+     # live vars: $t0, $t1, $t4
+ 12: goto 15
+     # live vars: $t0, $t1, $t4
+ 13: label L3
+     # live vars: $t0, $t1
+ 14: goto 17
+     # live vars: $t0, $t1, $t4
+ 15: label L4
+     # live vars: $t0, $t1, $t4
+     # events: e:$t4
+ 16: goto 1
+     # live vars: $t0, $t1
+ 17: label L1
+     # live vars: $t0, $t1
+     # events: e:$t0, b:$t2
+ 18: $t2 := move($t0)
+     # live vars: $t1, $t2
+     # events: e:$t1, b:$t3
+ 19: $t3 := move($t1)
+     # live vars: $t2, $t3
+     # events: e:$t2, e:$t3
+ 20: return ($t2, $t3)
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+  0: $t4 := copy($t0)
+  1: label L0
+  2: $t7 := 0
+  3: $t6 := >($t4, $t7)
+  4: if ($t6) goto 5 else goto 13
+  5: label L2
+  6: $t7 := move($t0)
+  7: $t0 := move($t1)
+  8: $t1 := move($t7)
+  9: $t7 := 1
+ 10: $t7 := -($t4, $t7)
+ 11: $t4 := move($t7)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 1
+ 17: label L1
+ 18: $t0 := move($t0)
+ 19: $t1 := move($t1)
+ 20: return ($t0, $t1)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+  0: $t4 := copy($t0)
+  1: label L0
+  2: $t7 := 0
+  3: $t6 := >($t4, $t7)
+  4: if ($t6) goto 5 else goto 13
+  5: label L2
+  6: $t7 := move($t0)
+  7: $t0 := move($t1)
+  8: $t1 := move($t7)
+  9: $t7 := 1
+ 10: $t7 := -($t4, $t7)
+ 11: $t4 := move($t7)
+ 12: goto 15
+ 13: label L3
+ 14: goto 17
+ 15: label L4
+ 16: goto 1
+ 17: label L1
+ 18: return ($t0, $t1)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[2](loc0: u64)
+B1:
+	2: LdU64(0)
+	3: StLoc[3](loc1: u64)
+	4: CopyLoc[2](loc0: u64)
+	5: MoveLoc[3](loc1: u64)
+	6: Gt
+	7: BrFalse(21)
+B2:
+	8: MoveLoc[0](Arg0: u64)
+	9: StLoc[3](loc1: u64)
+	10: MoveLoc[1](Arg1: u64)
+	11: StLoc[0](Arg0: u64)
+	12: MoveLoc[3](loc1: u64)
+	13: StLoc[1](Arg1: u64)
+	14: LdU64(1)
+	15: StLoc[3](loc1: u64)
+	16: MoveLoc[2](loc0: u64)
+	17: CopyLoc[3](loc1: u64)
+	18: Sub
+	19: StLoc[2](loc0: u64)
+	20: Branch(22)
+B3:
+	21: Branch(23)
+B4:
+	22: Branch(2)
+B5:
+	23: MoveLoc[0](Arg0: u64)
+	24: MoveLoc[1](Arg1: u64)
+	25: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    public fun test(x: u64, y: u64): (u64, u64) {
+        let i = x;
+        let t;
+        while (i > 0) {
+            t = x;
+            x = y;
+            y = t;
+            i = i - 1;
+        };
+        (x, y)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
@@ -1,0 +1,109 @@
+
+Diagnostics:
+warning: Unused local variable `z`. Consider removing or prefixing with an underscore: `_z`
+  ┌─ tests/variable-coalescing/unused_add.move:5:13
+  │
+5 │         let z = x + y;
+  │             ^
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t1 := 1
+  1: $t0 := infer($t1)
+  2: $t3 := 2
+  3: $t2 := infer($t3)
+  4: $t5 := +($t0, $t2)
+  5: $t4 := infer($t5)
+  6: return ()
+}
+
+============ after VariableCoalescingAnnotator: ================
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars:
+     # events: b:$t1
+  0: $t1 := 1
+     # live vars: $t1
+     # events: e:$t1, b:$t0
+  1: $t0 := move($t1)
+     # live vars: $t0
+     # events: b:$t3
+  2: $t3 := 2
+     # live vars: $t0, $t3
+     # events: e:$t3, b:$t2
+  3: $t2 := move($t3)
+     # live vars: $t0, $t2
+     # events: e:$t0, e:$t2, b:$t5
+  4: $t5 := +($t0, $t2)
+     # live vars: $t5
+     # events: e:$t5
+  5: $t4 := move($t5)
+     # live vars:
+  6: return ()
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64 [unused]
+  0: $t1 := 1
+  1: $t1 := move($t1)
+  2: $t3 := 2
+  3: $t3 := move($t3)
+  4: $t1 := +($t1, $t3)
+  5: $t4 := move($t1)
+  6: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+  0: $t1 := 1
+  1: $t3 := 2
+  2: $t1 := +($t1, $t3)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test() /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: Add
+	3: Pop
+	4: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.move
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    public fun test() {
+        let x = 1;
+        let y = 2;
+        let z = x + y;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/loop_invariant_code_1.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/loop_invariant_code_1.exp
@@ -1,0 +1,9 @@
+processed 3 tasks
+
+task 1 'run'. lines 15-15:
+return values: 44
+
+task 2 'run'. lines 17-17:
+return values: 6
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/loop_invariant_code_1.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/loop_invariant_code_1.move
@@ -1,0 +1,17 @@
+//# publish
+module 0xc0ffee::m {
+
+    public fun test(p: u64): u64 {
+        let a = p;
+        let count = 0;
+        while (count < 10) {
+            a = p;
+            count = count + 1;
+        };
+        a // copy `a := p` should be available
+    }
+}
+
+//# run 0xc0ffee::m::test --args 44
+
+//# run 0xc0ffee::m::test --args 6

--- a/third_party/move/move-model/bytecode/src/dataflow_domains.rs
+++ b/third_party/move/move-model/bytecode/src/dataflow_domains.rs
@@ -126,6 +126,9 @@ impl<E: Ord + Clone> std::iter::IntoIterator for SetDomain<E> {
 impl<E: Ord + Clone> AbstractDomain for SetDomain<E> {
     fn join(&mut self, other: &Self) -> JoinResult {
         let mut change = JoinResult::Unchanged;
+        if self.ptr_eq(other) {
+            return change;
+        }
         for e in other.iter() {
             if self.insert(e.clone()).is_none() {
                 change = JoinResult::Changed;
@@ -237,6 +240,9 @@ impl<K: Ord + Clone, V: AbstractDomain + Clone> std::iter::IntoIterator for MapD
 impl<K: Ord + Clone, V: AbstractDomain + Clone> AbstractDomain for MapDomain<K, V> {
     fn join(&mut self, other: &Self) -> JoinResult {
         let mut change = JoinResult::Unchanged;
+        if self.ptr_eq(other) {
+            return change;
+        }
         for (k, v) in other.iter() {
             change = change.combine(self.insert_join(k.clone(), v.clone()));
         }

--- a/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
+++ b/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
@@ -13,7 +13,11 @@ use itertools::{Either, Itertools};
 use log::{debug, info};
 use move_model::model::{FunId, FunctionEnv, GlobalEnv, QualifiedId};
 use petgraph::graph::DiGraph;
-use std::{collections::BTreeMap, fmt::Formatter, fs};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Formatter,
+    fs,
+};
 
 /// A data structure which holds data for multiple function targets, and allows to
 /// manipulate them as part of a transformation pipeline.
@@ -148,6 +152,8 @@ impl<'a> fmt::Display for ProcessorResultDisplay<'a> {
 #[derive(Default)]
 pub struct FunctionTargetPipeline {
     processors: Vec<Box<dyn FunctionTargetProcessor>>,
+    /// Indices of processors which have been marked to not dump their target annotations.
+    no_annotation_dump_indices: BTreeSet<usize>,
 }
 
 impl FunctionTargetsHolder {
@@ -300,6 +306,23 @@ impl FunctionTargetPipeline {
     /// added.
     pub fn add_processor(&mut self, processor: Box<dyn FunctionTargetProcessor>) {
         self.processors.push(processor)
+    }
+
+    /// Similar to `add_processor`,
+    /// but additionally records that we should not dump its target annotations.
+    pub fn add_processor_without_annotation_dump(
+        &mut self,
+        processor: Box<dyn FunctionTargetProcessor>,
+    ) {
+        self.no_annotation_dump_indices
+            .insert(self.processors.len());
+        self.processors.push(processor)
+    }
+
+    /// Returns true if the processor at `index` should not have its target annotations dumped.
+    /// `index` is 1-based, similar to `hook_after_each_processor`.
+    pub fn should_dump_target_annotations(&self, index: usize) -> bool {
+        !self.no_annotation_dump_indices.contains(&(index - 1))
     }
 
     /// Gets the last processor in the pipeline, for testing.


### PR DESCRIPTION
### Description

This PR contains several different pieces that ended up being mostly related:
- Several improvements to variable coalescing (annotations of live interval events, better heuristics for coalescing, reuse of parameters).
- Dead store elimination is now transitive (if all the uses of a store are also dead, then the store is dead).
- Live variable analysis can now be run in two modes: tracking all usages or tracking only the unshadowed usages (which is what we did before).
- Use of immut sets in live variable analysis and other minor optimization in immut set and map joins.
- In compiler v2 testsuite, you can now use `add_processor_without_annotation_dump` to add a processor to the pipeline without dumping the annotated targets. This simplifies the code and reduces the chances of incorrectly specifying pipeline indexes to be dumped.
- Added lots of tests, including porting all copy propagation tests to variable coalescing tests. Manually verified that we are better in almost all cases (copy prop only vs. var coalescing only, fewer code is better). Thus, we can turn off the broken copy propagation for now, and fix it as medium priority issue later (I wanted to add the fix here, but is a fairly significant change and this PR is already quite large).

With these changes, all transaction tests pass with `MVC_EXP=optimize` (i.e., with default optimization pipeline turned on).

### Test Plan
- All previous tests pass, added lots of new tests.
- All transaction tests pass with `MVC_EXP=optimize`: many were failing before this PR.
