### PR TITLE
exclude .exp files from whitespace checks in scripts/git-checks.sh

### DIFF
--- a/scripts/git-checks.sh
+++ b/scripts/git-checks.sh
@@ -74,11 +74,11 @@ done
 for rev in $(git rev-list $oldrev..$newrev); do
 	comparison=$(git rev-parse --quiet --verify $rev^ || true)
 
-	whitespace=$(git diff --check $comparison $rev || true)
+	whitespace=$(git diff --check $comparison $rev  -- . ':!*.exp' || true)
 	if [[ $whitespace ]] ; then
 		echo "Found whitespace errors in commit $rev:"
 		echo
-		git diff --check $comparison $rev
+		git diff --check $comparison $rev -- . ':!*.exp'
 		exit 1
 	fi
 done


### PR DESCRIPTION
### Description

In git-checks.sh, exclude whitespace checks for .exp files, which are program-generated and can have any syntax.

### Test Plan
Tested locally with various previous commits involving extra whitespaces.  Verified that .exp files are excluded, but others are not.

### Fixes
#12356 

