### PR TITLE
[CLI] Add support for self-downloading Revela

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "2.5.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1023,10 +1023,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "curve25519-dalek-ng",
  "digest 0.9.0",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "hex",
  "hkdf 0.10.0",
  "libsecp256k1",
@@ -2516,7 +2516,7 @@ dependencies = [
  "base64 0.13.1",
  "bcs 0.1.4",
  "byteorder",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "ff 0.13.0",
  "group 0.13.0",
  "hex",
@@ -6758,6 +6758,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7348,17 +7376,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek 4.1.2",
+ "ed25519 2.2.3",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.2.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -7369,7 +7422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
 dependencies = [
  "derivation-path",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "hmac 0.12.1",
  "sha2 0.10.8",
 ]
@@ -7903,6 +7956,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "field_count"
@@ -12627,6 +12686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
+name = "platforms"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14462,9 +14527,8 @@ dependencies = [
 
 [[package]]
 name = "self_update"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3c585a1ced6b97ac13bd5e56f66559e5a75f477da5913f70df98e114518446"
+version = "0.39.0"
+source = "git+https://github.com/banool/self_update.git?rev=65916eade8b37e90ea5778c62592f20614b56627#65916eade8b37e90ea5778c62592f20614b56627"
 dependencies = [
  "hyper",
  "indicatif 0.17.7",
@@ -14478,6 +14542,7 @@ dependencies = [
  "tempfile",
  "urlencoding",
  "zip",
+ "zipsign-api",
 ]
 
 [[package]]
@@ -17365,7 +17430,7 @@ name = "x25519-dalek"
 version = "1.2.0"
 source = "git+https://github.com/aptos-labs/x25519-dalek?branch=zeroize_v1#762a9501668d213daa4a1864fa1f9db22716b661"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
  "zeroize",
 ]
@@ -17491,6 +17556,16 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "time",
+]
+
+[[package]]
+name = "zipsign-api"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba5aa1827d6b1a35a29b3413ec69ce5f796e4d897e3e5b38f461bef41d225ea"
+dependencies = [
+ "ed25519-dalek 2.1.1",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 
+## [3.0.0] - 2024/03/05
+- **Breaking Change**: `aptos update` is now `aptos update aptos`.
+- Added `aptos update revela`. This installs / updates the `revela` binary, which is needed for the new `aptos move decompile` subcommand.
 - Extended `aptos move download` with an option `--bytecode` to also download the bytecode of a module
-- Integrate the Revela decompiler which is now available via `aptos move decompile` 
+- Integrated the Revela decompiler which is now available via `aptos move decompile` 
 - Extended `aptos move disassemble` and the new `aptos move decompile` to also work on entire packages instead of only single files
 
 ## [2.5.0] - 2024/02/27

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "2.5.0"
+version = "3.0.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
@@ -84,7 +84,7 @@ processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git"
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-self_update = { version = "0.38.0", features = ["archive-zip", "compression-zip-deflate"] }
+self_update = { git = "https://github.com/banool/self_update.git", rev = "65916eade8b37e90ea5778c62592f20614b56627", features = ["archive-zip", "compression-zip-deflate"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -49,6 +49,7 @@ pub enum Tool {
     Node(node::NodeTool),
     #[clap(subcommand)]
     Stake(stake::StakeTool),
+    #[clap(subcommand)]
     Update(update::UpdateTool),
 }
 
@@ -68,7 +69,7 @@ impl Tool {
             Multisig(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
-            Update(tool) => tool.execute_serialized().await,
+            Update(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/aptos/src/update/aptos.rs
+++ b/crates/aptos/src/update/aptos.rs
@@ -1,0 +1,197 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Out of the box the self_update crate assumes that you have releases named a
+// specific way with the crate name, version, and target triple in a specific
+// format. We don't do this with our releases, we have other GitHub releases beyond
+// just the CLI, and we don't build for all major target triples, so we have to do
+// some of the work ourselves first to figure out what the latest version of the
+// CLI is and which binary to download based on the current OS. Then we can plug
+// that into the library which takes care of the rest.
+
+use super::{BinaryUpdater, UpdateRequiredInfo};
+use crate::common::{
+    types::{CliCommand, CliTypedResult},
+    utils::cli_build_information,
+};
+use anyhow::{anyhow, Context, Result};
+use aptos_build_info::BUILD_OS;
+use async_trait::async_trait;
+use clap::Parser;
+use self_update::{
+    backends::github::{ReleaseList, Update},
+    cargo_crate_version,
+    update::ReleaseUpdate,
+};
+use std::process::Command;
+
+/// Update the CLI itself
+///
+/// This can be used to update the CLI to the latest version. This is useful if you
+/// installed the CLI via the install script / by downloading the binary directly.
+#[derive(Debug, Parser)]
+pub struct AptosUpdateTool {
+    /// The owner of the repo to download the binary from.
+    #[clap(long, default_value = "aptos-labs")]
+    repo_owner: String,
+
+    /// The name of the repo to download the binary from.
+    #[clap(long, default_value = "aptos-core")]
+    repo_name: String,
+}
+
+impl BinaryUpdater for AptosUpdateTool {
+    fn pretty_name(&self) -> &'static str {
+        "Aptos CLI"
+    }
+
+    /// Return information about whether an update is required.
+    fn get_update_info(&self) -> Result<UpdateRequiredInfo> {
+        // Build a configuration for determining the latest release.
+        let config = ReleaseList::configure()
+            .repo_owner(&self.repo_owner)
+            .repo_name(&self.repo_name)
+            .build()
+            .map_err(|e| anyhow!("Failed to build configuration to fetch releases: {:#}", e))?;
+
+        // Get the most recent releases.
+        let releases = config
+            .fetch()
+            .map_err(|e| anyhow!("Failed to fetch releases: {:#}", e))?;
+
+        // Find the latest release of the CLI, in which we filter for the CLI tag.
+        // If the release isn't in the last 30 items (the default API page size)
+        // this will fail. See https://github.com/aptos-labs/aptos-core/issues/6411.
+        let mut releases = releases.into_iter();
+        let latest_release = loop {
+            let release = match releases.next() {
+                Some(release) => release,
+                None => return Err(anyhow!("Failed to find latest CLI release")),
+            };
+            if release.version.starts_with("aptos-cli-") {
+                break release;
+            }
+        };
+        let target_version = latest_release.version.split("-v").last().unwrap();
+
+        // Return early if we're up to date already.
+        let current_version = cargo_crate_version!();
+
+        Ok(UpdateRequiredInfo {
+            current_version: Some(current_version.to_string()),
+            target_version: target_version.to_string(),
+        })
+    }
+
+    fn build_updater(&self, info: &UpdateRequiredInfo) -> Result<Box<dyn ReleaseUpdate>> {
+        let installation_method =
+            InstallationMethod::from_env().context("Failed to determine installation method")?;
+        match installation_method {
+            InstallationMethod::Source => {
+                return Err(anyhow!(
+                    "Detected this CLI was built from source, refusing to update"
+                ));
+            },
+            InstallationMethod::Homebrew => {
+                return Err(anyhow!(
+                    "Detected this CLI comes from homebrew, use `brew upgrade aptos` instead"
+                ));
+            },
+            InstallationMethod::Other => {},
+        }
+
+        // Determine the target we should download. This is necessary because we don't
+        // name our binary releases using the target triples nor do we build specifically
+        // for all major triples, so we have to generalize to one of the binaries we do
+        // happen to build. We figure this out based on what system the CLI was built on.
+        let build_info = cli_build_information();
+        let target = match build_info.get(BUILD_OS).context("Failed to determine build info of current CLI")?.as_str() {
+            "linux-x86_64" => {
+                // In the case of Linux, which build to use depends on the OpenSSL
+                // library on the host machine. So we try to determine that here.
+                // This code below parses the output of the `openssl version` command,
+                // where the version string is the 1th (0-indexing) item in the string
+                // when split by whitespace.
+                let output = Command::new("openssl")
+                .args(["version"])
+                .output();
+                let version = match output {
+                    Ok(output) => {
+                        let stdout = String::from_utf8(output.stdout).unwrap();
+                        stdout.split_whitespace().collect::<Vec<&str>>()[1].to_string()
+                    },
+                    Err(e) => {
+                        println!("Failed to determine OpenSSL version, assuming an older version: {:#}", e);
+                        "1.0.0".to_string()
+                    }
+                };
+                // On Ubuntu < 22.04 the bundled OpenSSL is version 1.x.x, whereas on
+                // 22.04+ it is 3.x.x. Unfortunately if you build the CLI on a system
+                // with one major version of OpenSSL, you cannot use it on a system
+                // with a different version. Accordingly, if the current system uses
+                // OpenSSL 3.x.x, we use the version of the CLI built on a system with
+                // OpenSSL 3.x.x, meaning Ubuntu 22.04. Otherwise we use the one built
+                // on 20.04.
+                if version.starts_with('3') {
+                    "Ubuntu-22.04-x86_64"
+                } else {
+                    "Ubuntu-x86_64"
+                }
+            },
+            "macos-x86_64" => "MacOSX-x86_64",
+            "windows-x86_64" => "Windows-x86_64",
+            wildcard => return Err(anyhow!("Self-updating is not supported on your OS ({}) right now, please download the binary manually", wildcard)),
+        };
+
+        let current_version = match &info.current_version {
+            Some(version) => version,
+            None => unreachable!("current_version should always be Some at this point"),
+        };
+
+        // Build a new configuration that will direct the library to download the
+        // binary with the target version tag and target that we determined above.
+        Update::configure()
+            .repo_owner(&self.repo_owner)
+            .repo_name(&self.repo_name)
+            .bin_name("aptos")
+            .current_version(current_version)
+            .target_version_tag(&format!("aptos-cli-v{}", info.target_version))
+            .target(target)
+            .build()
+            .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))
+    }
+}
+
+pub enum InstallationMethod {
+    Source,
+    Homebrew,
+    Other,
+}
+
+impl InstallationMethod {
+    pub fn from_env() -> Result<Self> {
+        // Determine update instructions based on what we detect about the installation.
+        let exe_path = std::env::current_exe()?;
+        let installation_method = if exe_path.to_string_lossy().contains("brew") {
+            InstallationMethod::Homebrew
+        } else if exe_path.to_string_lossy().contains("target") {
+            InstallationMethod::Source
+        } else {
+            InstallationMethod::Other
+        };
+        Ok(installation_method)
+    }
+}
+
+#[async_trait]
+impl CliCommand<String> for AptosUpdateTool {
+    fn command_name(&self) -> &'static str {
+        "UpdateAptos"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        tokio::task::spawn_blocking(move || self.update())
+            .await
+            .context("Failed to self-update Aptos CLI")?
+    }
+}

--- a/crates/aptos/src/update/helpers.rs
+++ b/crates/aptos/src/update/helpers.rs
@@ -1,77 +1,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context, Result};
-use self_update::{backends::github::ReleaseList, cargo_crate_version, version::bump_is_greater};
+use std::path::PathBuf;
 
-#[derive(Debug)]
-pub struct UpdateRequiredInfo {
-    pub update_required: bool,
-    pub current_version: String,
-    pub latest_version: String,
-    pub latest_version_tag: String,
-}
+/// Some functionality of the Aptos CLI relies on some additional binaries. This is
+/// where we install them by default. These paths align with the installation script,
+/// which is generally how the Linux and Windows users install the CLI.
+pub fn get_additional_binaries_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        let home_dir = std::env::var("USERPROFILE").unwrap_or_else(|_| "".into());
+        PathBuf::from(home_dir).join(".aptoscli/bin")
+    }
 
-/// Return information about whether an update is required.
-pub fn check_if_update_required(repo_owner: &str, repo_name: &str) -> Result<UpdateRequiredInfo> {
-    // Build a configuration for determining the latest release.
-    let config = ReleaseList::configure()
-        .repo_owner(repo_owner)
-        .repo_name(repo_name)
-        .build()
-        .map_err(|e| anyhow!("Failed to build configuration to fetch releases: {:#}", e))?;
-
-    // Get the most recent releases.
-    let releases = config
-        .fetch()
-        .map_err(|e| anyhow!("Failed to fetch releases: {:#}", e))?;
-
-    // Find the latest release of the CLI, in which we filter for the CLI tag.
-    // If the release isn't in the last 30 items (the default API page size)
-    // this will fail. See https://github.com/aptos-labs/aptos-core/issues/6411.
-    let mut releases = releases.into_iter();
-    let latest_release = loop {
-        let release = match releases.next() {
-            Some(release) => release,
-            None => return Err(anyhow!("Failed to find latest CLI release")),
-        };
-        if release.version.starts_with("aptos-cli-") {
-            break release;
-        }
-    };
-    let latest_version_tag = latest_release.version;
-    let latest_version = latest_version_tag.split("-v").last().unwrap();
-
-    // Return early if we're up to date already.
-    let current_version = cargo_crate_version!();
-    let update_required = bump_is_greater(current_version, latest_version)
-        .context("Failed to compare current and latest CLI versions")?;
-
-    Ok(UpdateRequiredInfo {
-        update_required,
-        current_version: current_version.to_string(),
-        latest_version: latest_version.to_string(),
-        latest_version_tag,
-    })
-}
-
-pub enum InstallationMethod {
-    Source,
-    Homebrew,
-    Other,
-}
-
-impl InstallationMethod {
-    pub fn from_env() -> Result<Self> {
-        // Determine update instructions based on what we detect about the installation.
-        let exe_path = std::env::current_exe()?;
-        let installation_method = if exe_path.to_string_lossy().contains("brew") {
-            InstallationMethod::Homebrew
-        } else if exe_path.to_string_lossy().contains("target") {
-            InstallationMethod::Source
-        } else {
-            InstallationMethod::Other
-        };
-        Ok(installation_method)
+    #[cfg(not(windows))]
+    {
+        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "".into());
+        PathBuf::from(home_dir).join(".local/bin")
     }
 }

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -1,8 +1,91 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Note: We make use of the self_update crate, but as you can see in the case of
+// Revela, this can also be used to install / update other binaries.
+
+mod aptos;
 mod helpers;
+mod revela;
 mod tool;
 
-use helpers::check_if_update_required;
+use crate::common::types::CliTypedResult;
+use anyhow::{anyhow, Context, Result};
+pub use helpers::get_additional_binaries_dir;
+pub use revela::get_revela_path;
+use self_update::{update::ReleaseUpdate, version::bump_is_greater, Status};
 pub use tool::UpdateTool;
+
+/// Things that implement this trait are able to update a binary.
+trait BinaryUpdater {
+    /// Only used for messages we print to the user.
+    fn pretty_name(&self) -> &'static str;
+
+    /// Return information about whether an update is required.
+    fn get_update_info(&self) -> Result<UpdateRequiredInfo>;
+
+    /// Build the updater from the self_update crate.
+    fn build_updater(&self, info: &UpdateRequiredInfo) -> Result<Box<dyn ReleaseUpdate>>;
+
+    /// Update the binary. Install if not present, in the case of additional binaries
+    /// such as Revela.
+    fn update(&self) -> CliTypedResult<String> {
+        // Confirm that we need to update.
+        let info = self
+            .get_update_info()
+            .context("Failed to check if we need to update")?;
+        if !info.update_required()? {
+            return Ok(format!("Already up to date (v{})", info.target_version));
+        }
+
+        // Build the updater.
+        let updater = self.build_updater(&info)?;
+
+        // Update the binary.
+        let result = updater
+            .update()
+            .map_err(|e| anyhow!("Failed to update {}: {:#}", self.pretty_name(), e))?;
+
+        let message = match result {
+            Status::UpToDate(_) => unreachable!("We should have caught this already"),
+            Status::Updated(_) => match info.current_version {
+                Some(current_version) => format!(
+                    "Successfully updated {} from v{} to v{}",
+                    self.pretty_name(),
+                    current_version,
+                    info.target_version
+                ),
+                None => {
+                    format!(
+                        "Successfully installed {} v{}",
+                        self.pretty_name(),
+                        info.target_version
+                    )
+                },
+            },
+        };
+
+        Ok(message)
+    }
+}
+
+/// Information used to determine if an update is required. The versions given to this
+/// struct should not have any prefix, it should just be the version. e.g. 2.5.0 rather
+/// than aptos-cli-v2.5.0.
+#[derive(Debug)]
+pub struct UpdateRequiredInfo {
+    pub current_version: Option<String>,
+    pub target_version: String,
+}
+
+impl UpdateRequiredInfo {
+    pub fn update_required(&self) -> Result<bool> {
+        match self.current_version {
+            Some(ref current_version) => bump_is_greater(current_version, &self.target_version)
+                .context(
+                    "Failed to compare current and latest CLI versions, please update manually",
+                ),
+            None => Ok(true),
+        }
+    }
+}

--- a/crates/aptos/src/update/revela.rs
+++ b/crates/aptos/src/update/revela.rs
@@ -1,0 +1,173 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{get_additional_binaries_dir, BinaryUpdater, UpdateRequiredInfo};
+use crate::common::{
+    types::{CliCommand, CliTypedResult},
+    utils::cli_build_information,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use aptos_build_info::BUILD_OS;
+use async_trait::async_trait;
+use clap::Parser;
+use self_update::{backends::github::Update, update::ReleaseUpdate};
+use std::path::PathBuf;
+
+const REVELA_BINARY_NAME: &str = "revela";
+const TARGET_REVELA_VERSION: &str = "1.0.0-rc3";
+
+const REVELA_EXE_ENV: &str = "REVELA_EXE";
+#[cfg(target_os = "windows")]
+const REVELA_EXE: &str = "revela.exe";
+#[cfg(not(target_os = "windows"))]
+const REVELA_EXE: &str = "revela";
+
+/// Update Revela, the tool used for decompilation.
+#[derive(Debug, Parser)]
+pub struct RevelaUpdateTool {
+    /// The owner of the repo to download the binary from.
+    #[clap(long, default_value = "verichains")]
+    repo_owner: String,
+
+    /// The name of the repo to download the binary from.
+    #[clap(long, default_value = "revela")]
+    repo_name: String,
+
+    /// The version to install, e.g. 1.0.1. Use with caution, the default value is a
+    /// version that is tested for compatibility with the version of the CLI you are
+    /// using.
+    #[clap(long, default_value = TARGET_REVELA_VERSION)]
+    target_version: String,
+
+    /// Where to install the binary. Make sure this directory is on your PATH. If not
+    /// given we will put it in a standard location for your OS that the CLI will use
+    /// later when the tool is required.
+    #[clap(long)]
+    install_dir: Option<PathBuf>,
+}
+
+impl BinaryUpdater for RevelaUpdateTool {
+    fn pretty_name(&self) -> &'static str {
+        "Revela"
+    }
+
+    /// Return information about whether an update is required.
+    fn get_update_info(&self) -> Result<UpdateRequiredInfo> {
+        // Get the current version, if any.
+        let revela_path = get_revela_path();
+        let current_version = match revela_path {
+            Ok(path) => {
+                let output = std::process::Command::new(path)
+                    .arg("--version")
+                    .output()
+                    .context("Failed to get current version of Revela")?;
+                let stdout = String::from_utf8(output.stdout)
+                    .context("Failed to parse current version of Revela as UTF-8")?;
+                let current_version = stdout
+                    .split_whitespace()
+                    .nth(1)
+                    .map(|s| s.to_string())
+                    .context("Failed to extract version number from command output")?;
+                Some(current_version.trim_start_matches('v').to_string())
+            },
+            Err(_) => None,
+        };
+
+        // Strip v prefix from target version if present.
+        let target_version = self.target_version.trim_start_matches('v').to_string();
+
+        Ok(UpdateRequiredInfo {
+            current_version,
+            target_version,
+        })
+    }
+
+    fn build_updater(&self, info: &UpdateRequiredInfo) -> Result<Box<dyn ReleaseUpdate>> {
+        // Determine the target we should download based on how the CLI itself was built.
+        let arch_str = get_arch();
+        let build_info = cli_build_information();
+        let target = match build_info.get(BUILD_OS).context("Failed to determine build info of current CLI")?.as_str() {
+            "linux-aarch64" | "linux-x86_64" => "unknown-linux-gnu",
+            "macos-aarch64" | "macos-x86" => "apple-darwin",
+            "windows-x86_64" => "pc-windows-gnu",
+            wildcard => bail!("Self-updating is not supported on your OS ({}) right now, please download the binary manually", wildcard),
+        };
+
+        let target = format!("{}-{}", arch_str, target);
+
+        let install_dir = match self.install_dir.clone() {
+            Some(dir) => dir,
+            None => get_additional_binaries_dir(),
+        };
+
+        let current_version = match &info.current_version {
+            Some(version) => version,
+            None => "0.0.0",
+        };
+
+        Update::configure()
+            .bin_install_dir(install_dir)
+            .bin_name(REVELA_BINARY_NAME)
+            .repo_owner(&self.repo_owner)
+            .repo_name(&self.repo_name)
+            .current_version(current_version)
+            .target_version_tag(&format!("v{}", info.target_version))
+            .target(&target)
+            .build()
+            .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))
+    }
+}
+
+#[async_trait]
+impl CliCommand<String> for RevelaUpdateTool {
+    fn command_name(&self) -> &'static str {
+        "UpdateRevela"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        tokio::task::spawn_blocking(move || self.update())
+            .await
+            .context("Failed to install / update Revela")?
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn get_arch() -> &'static str {
+    "x86_64"
+}
+
+#[cfg(target_arch = "aarch64")]
+fn get_arch() -> &'static str {
+    "aarch64"
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+fn get_arch() -> &'static str {
+    unimplemented!("Self-updating is not supported on your CPU architecture right now, please download the binary manually")
+}
+
+pub fn get_revela_path() -> Result<PathBuf> {
+    // Look at the environment variable first.
+    if let Ok(path) = std::env::var(REVELA_EXE_ENV) {
+        return Ok(PathBuf::from(path));
+    }
+
+    // See if it is present in the path where we usually install additional binaries.
+    let path = get_additional_binaries_dir().join(REVELA_BINARY_NAME);
+    if path.exists() && path.is_file() {
+        return Ok(path);
+    }
+
+    // See if we can find the binary in the PATH.
+    if let Some(path) = pathsearch::find_executable_in_path(REVELA_EXE) {
+        return Ok(path);
+    }
+
+    Err(anyhow!(
+        "Cannot locate the decompiler executable. \
+            Environment variable `{}` is not set, and `{}` is not in the PATH. \
+            Try running `aptos update revela` to download it.",
+        REVELA_EXE_ENV,
+        REVELA_EXE
+    ))
+}

--- a/crates/aptos/src/update/tool.rs
+++ b/crates/aptos/src/update/tool.rs
@@ -1,145 +1,22 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{check_if_update_required, helpers::InstallationMethod};
-use crate::common::{
-    types::{CliCommand, CliTypedResult},
-    utils::cli_build_information,
-};
-use anyhow::{anyhow, Context};
-use aptos_build_info::BUILD_OS;
-use async_trait::async_trait;
-use clap::Parser;
-use self_update::{backends::github::Update, cargo_crate_version, Status};
-use std::process::Command;
+use super::{aptos::AptosUpdateTool, revela::RevelaUpdateTool};
+use crate::common::types::{CliCommand, CliResult};
+use clap::Subcommand;
 
-/// Update the CLI itself
-///
-/// This can be used to update the CLI to the latest version. This is useful if you
-/// installed the CLI via the install script / by downloading the binary directly.
-#[derive(Debug, Parser)]
-pub struct UpdateTool {
-    /// The owner of the repo to download the binary from.
-    #[clap(long, default_value = "aptos-labs")]
-    repo_owner: String,
-
-    /// The name of the repo to download the binary from.
-    #[clap(long, default_value = "aptos-core")]
-    repo_name: String,
+/// Update the CLI or other tools it depends on.
+#[derive(Subcommand)]
+pub enum UpdateTool {
+    Aptos(AptosUpdateTool),
+    Revela(RevelaUpdateTool),
 }
 
 impl UpdateTool {
-    // Out of the box this crate assumes that you have releases named a specific way
-    // with the crate name, version, and target triple in a specific format. We don't
-    // do this with our releases, we have other GitHub releases beyond just the CLI,
-    // and we don't build for all major target triples, so we have to do some of the
-    // work ourselves first to figure out what the latest version of the CLI is and
-    // which binary to download based on the current OS. Then we can plug that into
-    // the library which takes care of the rest.
-    fn update(&self) -> CliTypedResult<String> {
-        let installation_method =
-            InstallationMethod::from_env().context("Failed to determine installation method")?;
-        match installation_method {
-            InstallationMethod::Source => {
-                return Err(
-                    anyhow!("Detected this CLI was built from source, refusing to update").into(),
-                );
-            },
-            InstallationMethod::Homebrew => {
-                return Err(anyhow!(
-                    "Detected this CLI comes from homebrew, use `brew upgrade aptos` instead"
-                )
-                .into());
-            },
-            InstallationMethod::Other => {},
+    pub async fn execute(self) -> CliResult {
+        match self {
+            UpdateTool::Aptos(tool) => tool.execute_serialized().await,
+            UpdateTool::Revela(tool) => tool.execute_serialized().await,
         }
-
-        let info = check_if_update_required(&self.repo_owner, &self.repo_name)?;
-        if !info.update_required {
-            return Ok(format!("CLI already up to date (v{})", info.latest_version));
-        }
-
-        // Determine the target we should download. This is necessary because we don't
-        // name our binary releases using the target triples nor do we build specifically
-        // for all major triples, so we have to generalize to one of the binaries we do
-        // happen to build. We figure this out based on what system the CLI was built on.
-        let build_info = cli_build_information();
-        let target = match build_info.get(BUILD_OS).context("Failed to determine build info of current CLI")?.as_str() {
-            "linux-x86_64" => {
-                // In the case of Linux, which build to use depends on the OpenSSL
-                // library on the host machine. So we try to determine that here.
-                // This code below parses the output of the `openssl version` command,
-                // where the version string is the 1th (0-indexing) item in the string
-                // when split by whitespace.
-                let output = Command::new("openssl")
-                .args(["version"])
-                .output();
-                let version = match output {
-                    Ok(output) => {
-                        let stdout = String::from_utf8(output.stdout).unwrap();
-                        stdout.split_whitespace().collect::<Vec<&str>>()[1].to_string()
-                    },
-                    Err(e) => {
-                        println!("Failed to determine OpenSSL version, assuming an older version: {:#}", e);
-                        "1.0.0".to_string()
-                    }
-                };
-                // On Ubuntu < 22.04 the bundled OpenSSL is version 1.x.x, whereas on
-                // 22.04+ it is 3.x.x. Unfortunately if you build the CLI on a system
-                // with one major version of OpenSSL, you cannot use it on a system
-                // with a different version. Accordingly, if the current system uses
-                // OpenSSL 3.x.x, we use the version of the CLI built on a system with
-                // OpenSSL 3.x.x, meaning Ubuntu 22.04. Otherwise we use the one built
-                // on 20.04.
-                if version.starts_with('3') {
-                    "Ubuntu-22.04-x86_64"
-                } else {
-                    "Ubuntu-x86_64"
-                }
-            },
-            "macos-x86_64" => "MacOSX-x86_64",
-            "windows-x86_64" => "Windows-x86_64",
-            wildcard => return Err(anyhow!("Self-updating is not supported on your OS right now, please download the binary manually: {}", wildcard).into()),
-        };
-
-        // Build a new configuration that will direct the library to download the
-        // binary with the target version tag and target that we determined above.
-        let config = Update::configure()
-            .repo_owner(&self.repo_owner)
-            .repo_name(&self.repo_name)
-            .bin_name("aptos")
-            .current_version(cargo_crate_version!())
-            .target_version_tag(&info.latest_version_tag)
-            .target(target)
-            .build()
-            .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))?;
-
-        // Update the binary.
-        let result = config
-            .update()
-            .map_err(|e| anyhow!("Failed to update Aptos CLI: {:#}", e))?;
-
-        let message = match result {
-            Status::UpToDate(_) => panic!("We should have caught this already"),
-            Status::Updated(_) => format!(
-                "Successfully updated from v{} to v{}",
-                info.current_version, info.latest_version
-            ),
-        };
-
-        Ok(message)
-    }
-}
-
-#[async_trait]
-impl CliCommand<String> for UpdateTool {
-    fn command_name(&self) -> &'static str {
-        "Update"
-    }
-
-    async fn execute(self) -> CliTypedResult<String> {
-        tokio::task::spawn_blocking(move || self.update())
-            .await
-            .context("Failed to self-update Aptos CLI")?
     }
 }


### PR DESCRIPTION
## Summary
We are adding support for decompilation to the CLI: https://github.com/aptos-labs/aptos-core/pull/12354. The decompilation requires a separate binary called Revela to operate. We decided that it would be simplest if the CLI itself supported installing the binary it needs, rather than baking this into our release process. This PR evolves the `aptos update` command to support Revela.

As you can see in the test plan, because we instal Revela to a predictable, specific location, the decompile tool can run immediately after we download Revela without having to set the PATH or reload the shell configuration or anything.

The correctness of this behavior relies on:
- The folks who built Revela use a consistent tagging scheme (e.g. like they do now, `v1.0.0`).
- The Revela folks ensuring that `revela --version` always returns a value that matches the tag the binary is from.

**Note**: This is a breaking change because the original `aptos update` is now `aptos update aptos`. I have bumped the CLI version accordingly. We've had some discussions in the past about whether adhering to semver makes sense for the CLI but since we say we do in the changelog, for now I have bumped the major version.

## Test Plan
### Revela
Testing that the revela installation / updating works.
```
$ revela
-bash: revela: command not found
```
```
cargo build -p aptos
```
```
cd /tmp/testing
~/a/core/target/debug/aptos init --network testnet
~/a/core/target/debug/aptos move download --account 0x1 --bytecode --package MoveStdlib
~/a/core/target/debug/aptos move decompile --package-path MoveStdlib/bytecode_modules --assume-yes
```
```
{
  "Error": "Invalid arguments: Cannot locate the decompiler executable. Environment variable `REVELA_EXE` is not set, and `revela` is not in the PATH. Try running `aptos update revela` to download it."
}
```
```
~/a/core/target/debug/aptos update revela
```
```
Checking target-arch... aarch64-apple-darwin
Checking current version... v0.0.0
Looking for tag: v1.0.0-rc3

revela release status:
  * New exe release: "revela-aarch64-apple-darwin"
  * New exe download url: "https://api.github.com/repos/verichains/revela/releases/assets/154920177"
  * Installing to: /Users/dport/.local/bin

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Moving binary file to /Users/dport/.local/bin... Done
{
  "Result": "Successfully installed Revela v1.0.0-rc3"
}
```
```
~/a/core/target/debug/aptos move decompile --package-path MoveStdlib/bytecode_modules --assume-yes
```
```
{
  "Result": "MoveStdlib/bytecode_modules/{hash.mv.move,acl.mv.move,bcs.mv.move,string.mv.move,signer.mv.move,vector.mv.move,error.mv.move,option.mv.move,features.mv.move,fixed_point32.mv.move,bit_vector.mv.move}"
}
```

Not shown but I also tested that updating Revela works if it is already installed.

### Aptos
On a Linux box I built a CLI built from this PR but hard coded the current version to be 2.4.0 to test that the self updating behavior still works.
```
cargo build -p aptos
cp target/debug/aptos ~/.local/bin/aptos
```
```
$ aptos update aptos
Checking target-arch... Ubuntu-22.04-x86_64
Checking current version... v2.4.0
Looking for tag: aptos-cli-v2.5.0

aptos release status:
  * New exe release: "aptos-cli-2.5.0-Ubuntu-22.04-x86_64.zip"
  * New exe download url: "https://api.github.com/repos/aptos-labs/aptos-core/releases/assets/154376160"

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Replacing binary file... Done
{
  "Result": "Successfully updated Aptos CLI from v2.4.0 to v2.5.0"
}
salsal:aptos-core$ aptos update
{
  "Result": "CLI already up to date (v2.5.0)"
}
```