### PR TITLE
demote noisiest info! logs to trace!

### DIFF
--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -271,7 +271,7 @@ impl BufferManager {
             .find_elem_from(cursor.or_else(|| *self.buffer.head_cursor()), |item| {
                 item.is_ordered()
             });
-        info!(
+        trace!(
             "Advance execution root from {:?} to {:?}",
             cursor, self.execution_root
         );
@@ -302,7 +302,7 @@ impl BufferManager {
             .find_elem_from(cursor.or_else(|| *self.buffer.head_cursor()), |item| {
                 item.is_executed()
             });
-        info!(
+        trace!(
             "Advance signing root from {:?} to {:?}",
             cursor, self.signing_root
         );
@@ -542,7 +542,7 @@ impl BufferManager {
                 // find the corresponding item
                 let author = vote.author();
                 let commit_info = vote.commit_info().clone();
-                info!("Receive commit vote {} from {}", commit_info, author);
+                trace!("Receive commit vote {} from {}", commit_info, author);
                 let target_block_id = vote.commit_info().id();
                 let current_cursor = self
                     .buffer
@@ -581,7 +581,7 @@ impl BufferManager {
             },
             CommitMessage::Decision(commit_proof) => {
                 let target_block_id = commit_proof.ledger_info().commit_info().id();
-                info!(
+                trace!(
                     "Receive commit decision {}",
                     commit_proof.ledger_info().commit_info()
                 );

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -928,7 +928,7 @@ impl RoundManager {
     async fn process_vote(&mut self, vote: &Vote) -> anyhow::Result<()> {
         let round = vote.vote_data().proposed().round();
 
-        info!(
+        trace!(
             self.new_log(LogEvent::ReceiveVote)
                 .remote_peer(vote.author()),
             vote = %vote,


### PR DESCRIPTION
### Description

5 very noisy info! logs demoted to trace!

In a recent hour long run with 2_646_264 log lines

1_082_466 consensus/src/pipeline/buffer_manager.rs:546
	info!("Receive commit vote {} from {}", commit_info, author);
850_852 consensus/src/round_manager.rs:931
	process_vote() ... info!(ReceiveVote, ...)
87_547 consensus/src/pipeline/buffer_manager.rs:598
	info!("Receive commit decision {}",...)
24_262 consensus/src/pipeline/buffer_manager.rs:305
	info!("Advance signing root from {:?} to {:?}",...)
24_167 consensus/src/pipeline/buffer_manager.rs:274
	info!("Advance execution root from {:?} to {:?}",...)

### Test Plan

Pass existing tests.
