### PR TITLE
[cli] Fix override size check flag

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 - Update `self_update` dependency to support situations where relevant directories (e.g. `/tmp`) exist on different filesystems.
+- [bugfix] Rename `--value` back to `--override-size-check` for publishing packages
 
 ## [3.0.2] - 2024/03/12
 - Increased `max_connections` for postgres container created as part of local testnet to address occasional startup failures due to overloaded DB.

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -2148,5 +2148,5 @@ pub struct OverrideSizeCheckOption {
     /// This won't bypass on chain checks, so if you are not allowed to go over the size check, it
     /// will still be blocked from publishing.
     #[clap(long)]
-    pub(crate) value: bool,
+    pub(crate) override_size_check: bool,
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -687,7 +687,7 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
         );
         let size = bcs::serialized_size(&payload)?;
         println!("package size {} bytes", size);
-        if !self.override_size_check_option.value && size > MAX_PUBLISH_PACKAGE_SIZE {
+        if !self.override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::UnexpectedError(format!(
                 "The package is larger than {} bytes ({} bytes)! To lower the size \
                 you may want to include fewer artifacts via `--included-artifacts`. \
@@ -927,7 +927,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
         let size = bcs::serialized_size(&payload)?;
         println!("package size {} bytes", size);
 
-        if !self.override_size_check_option.value && size > MAX_PUBLISH_PACKAGE_SIZE {
+        if !self.override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::UnexpectedError(format!(
                 "The package is larger than {} bytes ({} bytes)! To lower the size \
                 you may want to include less artifacts via `--included-artifacts`. \
@@ -1023,7 +1023,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
         let size = bcs::serialized_size(&payload)?;
         println!("package size {} bytes", size);
 
-        if !self.override_size_check_option.value && size > MAX_PUBLISH_PACKAGE_SIZE {
+        if !self.override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::UnexpectedError(format!(
                 "The package is larger than {} bytes ({} bytes)! To lower the size \
                 you may want to include less artifacts via `--included-artifacts`. \
@@ -1131,7 +1131,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
         );
         let size = bcs::serialized_size(&payload)?;
         println!("package size {} bytes", size);
-        if !override_size_check_option.value && size > MAX_PUBLISH_PACKAGE_SIZE {
+        if !override_size_check_option.override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
             return Err(CliError::UnexpectedError(format!(
                 "The package is larger than {} bytes ({} bytes)! To lower the size \
                 you may want to include less artifacts via `--included-artifacts`. \

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -876,7 +876,9 @@ impl CliTestFramework {
         PublishPackage {
             move_options: self.move_options(account_strs),
             txn_options: self.transaction_options(index, gas_options),
-            override_size_check_option: OverrideSizeCheckOption { value: false },
+            override_size_check_option: OverrideSizeCheckOption {
+                override_size_check: false,
+            },
             included_artifacts_args: IncludedArtifactsArgs {
                 included_artifacts: included_artifacts.unwrap_or(IncludedArtifacts::Sparse),
             },


### PR DESCRIPTION
### Description
It was erroneously renamed to --value

### Test Plan
```
cargo build -p aptos;
./target/debug/aptos move publish --override-size-check
```