### PR TITLE
Update target Revela version to 1.0.0

### DIFF
--- a/crates/aptos/src/update/revela.rs
+++ b/crates/aptos/src/update/revela.rs
@@ -14,7 +14,7 @@ use self_update::{backends::github::Update, update::ReleaseUpdate};
 use std::path::PathBuf;
 
 const REVELA_BINARY_NAME: &str = "revela";
-const TARGET_REVELA_VERSION: &str = "1.0.0-rc3";
+const TARGET_REVELA_VERSION: &str = "1.0.0";
 
 const REVELA_EXE_ENV: &str = "REVELA_EXE";
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
### Description
Fast follow from #12362.

### Test Plan
```
cargo build -p aptos
```
```
 ~/a/core/target/debug/aptos update revela
```
```
Checking target-arch... aarch64-apple-darwin
Checking current version... v1.0.0-rc3
Looking for tag: v1.0.0

revela release status:
  * New exe release: "revela-aarch64-apple-darwin"
  * New exe download url: "https://api.github.com/repos/verichains/revela/releases/assets/155171154"
  * Installing to: /Users/dport/.local/bin

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Moving binary file to /Users/dport/.local/bin... Done
{
  "Result": "Successfully updated Revela from v1.0.0-rc3 to v1.0.0"
}
```