### PR TITLE
Make install dir if not present in aptos update revela

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 
+## [3.0.1] - 2024/03/05
+- Fix bug in `aptos update revela` if default install directory doesn't exist.
+
 ## [3.0.0] - 2024/03/05
 - **Breaking Change**: `aptos update` is now `aptos update aptos`.
 - Added `aptos update revela`. This installs / updates the `revela` binary, which is needed for the new `aptos move decompile` subcommand.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "3.0.0"
+version = "3.0.1"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/update/revela.rs
+++ b/crates/aptos/src/update/revela.rs
@@ -97,7 +97,13 @@ impl BinaryUpdater for RevelaUpdateTool {
 
         let install_dir = match self.install_dir.clone() {
             Some(dir) => dir,
-            None => get_additional_binaries_dir(),
+            None => {
+                let dir = get_additional_binaries_dir();
+                // Make the directory if it doesn't already exist.
+                std::fs::create_dir_all(&dir)
+                    .with_context(|| format!("Failed to create directory: {:?}", dir))?;
+                dir
+            },
         };
 
         let current_version = match &info.current_version {


### PR DESCRIPTION
### Description
If the user doesn't already have the default install directory, it would previously fail. Now we make the directory. This is how the Python install script does it.

### Test Plan
First delete the default install dir, e.g. for linux `~/.local/bin`.

Before:
```
$ cargo run -p aptos -- update revela
{
  "Error": "Unexpected error: Failed to build self-update configuration: ConfigError: `bin_install_dir` must be a directory"
}
```

After:
```
Checking target-arch... aarch64-apple-darwin
Checking current version... v0.0.0
Looking for tag: v1.0.0

revela release status:
  * New exe release: "revela-aarch64-apple-darwin"
  * New exe download url: "https://api.github.com/repos/verichains/revela/releases/assets/155171154"
  * Installing to: /Users/dport/.local/bin

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Moving binary file to /Users/dport/.local/bin... Done
{
  "Result": "Successfully installed Revela v1.0.0"
}
```