### PR TITLE
[CP to 1.10] Fix RG handling in respawned session (#12372)

### DIFF
--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -784,8 +784,19 @@ impl VMChangeSet {
                                 materialized_size: additional_materialized_size,
                                 ..
                             }),
-                        )
-                        | (
+                        ) => {
+                            // Read cannot change the size (i.e. delayed fields don't modify size)
+                            if materialized_size != &Some(*additional_materialized_size) {
+                                return Err(code_invariant_error(format!(
+                                    "Trying to squash writes where read has different size: {:?}: {:?}",
+                                    materialized_size,
+                                    additional_materialized_size
+                                )));
+                            }
+                            // any newer read should've read the original write and contain all info from it
+                            (false, false)
+                        },
+                        (
                             WriteResourceGroup(GroupWrite {
                                 maybe_group_op_size: materialized_size,
                                 ..
@@ -797,9 +808,17 @@ impl VMChangeSet {
                                 },
                             ),
                         ) => {
-                            // newer read should've read the original write and contain all info from it,
-                            // but could have additional delayed field writes, that change the size.
-                            *materialized_size = Some(*additional_materialized_size);
+                            // Read cannot change the size (i.e. delayed fields don't modify size)
+                            if materialized_size.map(|v| v.get())
+                                != Some(*additional_materialized_size)
+                            {
+                                return Err(code_invariant_error(format!(
+                                    "Trying to squash group writes where read has different size: {:?}: {:?}",
+                                    materialized_size,
+                                    additional_materialized_size
+                                )));
+                            }
+                            // any newer read should've read the original write and contain all info from it
                             (false, false)
                         },
                         // If previous value is a read, newer value overwrites it

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -5,6 +5,7 @@ use super::utils::{mock_tag_0, VMChangeSetBuilder};
 use crate::{
     abstract_write_op::{AbstractResourceWriteOp, GroupWrite},
     change_set::VMChangeSet,
+    resolver::ResourceGroupSize,
     tests::utils::{
         as_bytes, as_state_key, mock_add, mock_create, mock_create_with_layout, mock_delete,
         mock_delete_with_layout, mock_modify, mock_modify_with_layout, mock_tag_1, raw_metadata,
@@ -515,10 +516,18 @@ fn test_resource_groups_squashing() {
     }
 
     let create_tag_0_op = (mock_tag_0(), as_create_op!(5));
+    let single_tag_group_size = ResourceGroupSize::Combined {
+        num_tagged_resources: 1,
+        all_tagged_resources_size: 100,
+    };
+    let two_tag_group_size = ResourceGroupSize::Combined {
+        num_tagged_resources: 2,
+        all_tagged_resources_size: 200,
+    };
     let create_group_write_0 = GroupWrite::new(
         modification_metadata.clone(),
         BTreeMap::from([create_tag_0_op.clone()]),
-        100,
+        single_tag_group_size,
         0,
     );
     let create_tag_0 = ExpandedVMChangeSetBuilder::new()
@@ -528,8 +537,8 @@ fn test_resource_groups_squashing() {
     let modify_group_write_0 = GroupWrite::new(
         modification_metadata.clone(),
         BTreeMap::from([(mock_tag_0(), as_modify_op!(7))]),
-        100,
-        100,
+        single_tag_group_size,
+        single_tag_group_size.get(),
     );
     let modify_tag_0 = ExpandedVMChangeSetBuilder::new()
         .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_0.clone())])
@@ -539,8 +548,8 @@ fn test_resource_groups_squashing() {
     let create_group_write_1 = GroupWrite::new(
         modification_metadata.clone(),
         BTreeMap::from([create_tag_1_op.clone()]),
-        200,
-        100,
+        two_tag_group_size,
+        single_tag_group_size.get(),
     );
     let create_tag_1 = ExpandedVMChangeSetBuilder::new()
         .with_resource_group_write_set(vec![(as_state_key!("1"), create_group_write_1.clone())])
@@ -550,8 +559,8 @@ fn test_resource_groups_squashing() {
     let modify_group_write_1 = GroupWrite::new(
         modification_metadata.clone(),
         BTreeMap::from([modify_tag_1_op.clone()]),
-        200,
-        200,
+        two_tag_group_size,
+        two_tag_group_size.get(),
     );
     let modify_tag_1 = ExpandedVMChangeSetBuilder::new()
         .with_resource_group_write_set(vec![(as_state_key!("1"), modify_group_write_1.clone())])
@@ -569,7 +578,7 @@ fn test_resource_groups_squashing() {
             &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
                 modification_metadata.clone(),
                 BTreeMap::from([(mock_tag_0(), as_create_op!(7))]),
-                100,
+                single_tag_group_size,
                 0,
             ))
         );
@@ -586,7 +595,7 @@ fn test_resource_groups_squashing() {
             &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
                 modification_metadata.clone(),
                 BTreeMap::from([create_tag_0_op.clone(), create_tag_1_op.clone()]),
-                200,
+                two_tag_group_size,
                 0,
             ))
         );
@@ -601,7 +610,7 @@ fn test_resource_groups_squashing() {
             &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
                 modification_metadata.clone(),
                 BTreeMap::from([create_tag_0_op.clone(), (mock_tag_1(), as_create_op!(17))]),
-                200,
+                two_tag_group_size,
                 0,
             ))
         );
@@ -618,15 +627,16 @@ fn test_resource_groups_squashing() {
             &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
                 modification_metadata.clone(),
                 BTreeMap::from([create_tag_0_op.clone(), modify_tag_1_op.clone()]),
-                200,
+                two_tag_group_size,
                 0,
             ))
         );
     }
 
     {
+        // read cannot modify size
         let mut change_set = create_tag_0.clone();
-        assert_ok!(change_set.squash_additional_change_set(
+        assert_err!(change_set.squash_additional_change_set(
             ExpandedVMChangeSetBuilder::new()
                 .with_group_reads_needing_delayed_field_exchange(vec![(
                     as_state_key!("1"),
@@ -635,17 +645,6 @@ fn test_resource_groups_squashing() {
                 .build(),
             &MockChangeSetChecker
         ));
-        assert_eq!(change_set.resource_write_set().len(), 1);
-        // only read size should be updated
-        assert_some_eq!(
-            change_set.resource_write_set().get(&as_state_key!("1")),
-            &AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
-                modification_metadata.clone(),
-                BTreeMap::from([create_tag_0_op.clone()]),
-                400,
-                0,
-            ))
-        );
     }
 }
 
@@ -670,16 +669,24 @@ fn test_write_and_read_discrepancy_caught() {
         data: Bytes::new(),
         metadata: raw_metadata(1000),
     };
-    let group_size = 15;
+    let group_size = ResourceGroupSize::Combined {
+        num_tagged_resources: 1,
+        all_tagged_resources_size: 14,
+    };
 
     assert_err!(ExpandedVMChangeSetBuilder::new()
         .with_resource_group_write_set(vec![(
             as_state_key!("1"),
-            GroupWrite::new(metadata_op.clone(), BTreeMap::new(), group_size, group_size)
+            GroupWrite::new(
+                metadata_op.clone(),
+                BTreeMap::new(),
+                group_size,
+                group_size.get()
+            )
         )])
         .with_group_reads_needing_delayed_field_exchange(vec![(
             as_state_key!("1"),
-            (metadata_op.metadata().clone(), group_size)
+            (metadata_op.metadata().clone(), group_size.get())
         )])
         .try_build());
 }
@@ -720,13 +727,18 @@ mod tests {
     fn group_write(
         metadata_op: WriteOp,
         inner_ops: Vec<(StructTag, (WriteOp, Option<Arc<MoveTypeLayout>>))>,
-        group_size: u64,
+        num_tagged_resources: usize,
+        all_tagged_resources_size: u64,
     ) -> AbstractResourceWriteOp {
+        let group_size = ResourceGroupSize::Combined {
+            num_tagged_resources,
+            all_tagged_resources_size,
+        };
         AbstractResourceWriteOp::WriteResourceGroup(GroupWrite::new(
             metadata_op,
             inner_ops.into_iter().collect(),
             group_size,
-            group_size, // prev_group_size
+            group_size.get(), // prev_group_size
         ))
     }
 
@@ -740,7 +752,7 @@ mod tests {
 
     macro_rules! assert_group_write_size {
         ($op:expr, $s:expr, $exp:expr) => {{
-            let group_write = GroupWrite::new($op, BTreeMap::new(), $s, $s);
+            let group_write = GroupWrite::new($op, BTreeMap::new(), $s, $s.get());
             assert_eq!(group_write.maybe_group_op_size(), $exp);
         }};
     }
@@ -748,16 +760,41 @@ mod tests {
     #[test]
     fn test_group_write_size() {
         // Deletions should lead to size 0.
-        assert_group_write_size!(WriteOp::legacy_deletion(), 0, None);
+        assert_group_write_size!(
+            WriteOp::legacy_deletion(),
+            ResourceGroupSize::zero_combined(),
+            None
+        );
         assert_group_write_size!(
             WriteOp::Deletion {
                 metadata: raw_metadata(10)
             },
-            0,
+            ResourceGroupSize::zero_combined(),
             None
         );
 
-        let sizes = [20, 100, 45279432, 5];
+        let sizes = [
+            ResourceGroupSize::Combined {
+                num_tagged_resources: 1,
+                all_tagged_resources_size: 20,
+            },
+            ResourceGroupSize::Combined {
+                num_tagged_resources: 1,
+                all_tagged_resources_size: 100,
+            },
+            ResourceGroupSize::Combined {
+                num_tagged_resources: 1,
+                all_tagged_resources_size: 45279432,
+            },
+            ResourceGroupSize::Combined {
+                num_tagged_resources: 1,
+                all_tagged_resources_size: 5,
+            },
+            ResourceGroupSize::Combined {
+                num_tagged_resources: 1024,
+                all_tagged_resources_size: 45279432,
+            },
+        ];
         assert_group_write_size!(
             WriteOp::legacy_creation(Bytes::new()),
             sizes[0],
@@ -794,12 +831,12 @@ mod tests {
         let mut base_update = BTreeMap::new();
         base_update.insert(
             key_1.clone(),
-            group_write(write_op_with_metadata(CREATION, 100), vec![], 0),
+            group_write(write_op_with_metadata(CREATION, 100), vec![], 0, 0),
         );
         let mut additional_update = BTreeMap::new();
         additional_update.insert(
             key_2.clone(),
-            group_write(write_op_with_metadata(CREATION, 200), vec![], 0),
+            group_write(write_op_with_metadata(CREATION, 200), vec![], 0, 0),
         );
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
@@ -833,11 +870,16 @@ mod tests {
         let mut additional_update = BTreeMap::new();
         base_update.insert(
             key.clone(),
-            group_write(write_op_with_metadata(base_type_idx, 100), vec![], 0),
+            group_write(write_op_with_metadata(base_type_idx, 100), vec![], 0, 0),
         );
         additional_update.insert(
             key.clone(),
-            group_write(write_op_with_metadata(additional_type_idx, 100), vec![], 0),
+            group_write(
+                write_op_with_metadata(additional_type_idx, 100),
+                vec![],
+                0,
+                0,
+            ),
         );
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
@@ -866,11 +908,16 @@ mod tests {
         let mut additional_update = BTreeMap::new();
         base_update.insert(
             key.clone(),
-            group_write(write_op_with_metadata(base_type_idx, 100), vec![], 0),
+            group_write(write_op_with_metadata(base_type_idx, 100), vec![], 0, 0),
         );
         additional_update.insert(
             key.clone(),
-            group_write(write_op_with_metadata(additional_type_idx, 200), vec![], 0),
+            group_write(
+                write_op_with_metadata(additional_type_idx, 200),
+                vec![],
+                0,
+                0,
+            ),
         );
 
         assert_err!(VMChangeSet::squash_additional_resource_writes(
@@ -891,6 +938,7 @@ mod tests {
                 write_op_with_metadata(CREATION, 100), // create
                 vec![],
                 0,
+                0,
             ),
         );
         additional_update.insert(
@@ -898,6 +946,7 @@ mod tests {
             group_write(
                 write_op_with_metadata(DELETION, 100), // delete
                 vec![],
+                0,
                 0,
             ),
         );
@@ -932,6 +981,7 @@ mod tests {
                     ),
                 ],
                 0,
+                0,
             ),
         );
         additional_update.insert(
@@ -948,6 +998,7 @@ mod tests {
                         (WriteOp::legacy_modification(vec![1].into()), None),
                     ),
                 ],
+                0,
                 0,
             ),
         );
@@ -968,6 +1019,7 @@ mod tests {
                     ),
                 ],
                 0,
+                0,
             ),
         );
         additional_update.insert(
@@ -982,6 +1034,7 @@ mod tests {
                     (mock_tag_1(), (WriteOp::legacy_deletion(), None)),
                     (mock_tag_2(), (WriteOp::legacy_deletion(), None)),
                 ],
+                0,
                 0,
             ),
         );
@@ -1021,6 +1074,7 @@ mod tests {
             group_write(
                 write_op_with_metadata(MODIFICATION, 100),
                 vec![(mock_tag_1(), (WriteOp::legacy_deletion(), None))],
+                0,
                 0,
             ),
         )]);

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -86,7 +86,7 @@ impl<'r, 'l> RespawnedSession<'r, 'l> {
 
         Ok(RespawnedSessionBuilder {
             executor_view,
-            resolver_builder: |executor_view| vm.as_move_resolver(executor_view),
+            resolver_builder: |executor_view| vm.as_move_resolver_with_group_view(executor_view),
             session_builder: |resolver| Some(vm.new_session(resolver, session_id)),
             storage_refund,
         }
@@ -356,10 +356,27 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
 
     fn resource_group_size(
         &self,
-        _group_key: &Self::GroupKey,
+        group_key: &Self::GroupKey,
     ) -> PartialVMResult<ResourceGroupSize> {
-        // In respawned session, gas is irrelevant, so we return 0 (GroupSizeKind::None).
-        Ok(ResourceGroupSize::zero_concrete())
+        use AbstractResourceWriteOp::*;
+
+        if let Some(size) = self
+        .change_set
+        .resource_write_set()
+        .get(group_key)
+        .and_then(|write| match write {
+            WriteResourceGroup(group_write) => Some(Ok(group_write.maybe_group_op_size().unwrap_or(ResourceGroupSize::zero_combined()))),
+            ResourceGroupInPlaceDelayedFieldChange(_) => None,
+            Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
+                // There should be no collisions, we cannot have group key refer to a resource.
+                Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in get_resource_from_group call for key {group_key:?}"))))
+            },
+        })
+        .transpose()? {
+            return Ok(size);
+        }
+
+        self.base_resource_group_view.resource_group_size(group_key)
     }
 
     fn get_resource_from_group(
@@ -377,7 +394,7 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
                 WriteResourceGroup(group_write) => Some(Ok(group_write)),
                 ResourceGroupInPlaceDelayedFieldChange(_) => None,
                 Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
-                    // There should be no colisions, we cannot have group key refer to a resource.
+                    // There should be no collisions, we cannot have group key refer to a resource.
                     Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in get_resource_from_group call for key {group_key:?}"))))
                 },
             })
@@ -405,6 +422,11 @@ impl<'r> TResourceGroupView for ExecutorViewWithChangeSet<'r> {
         &self,
     ) -> Option<HashMap<Self::GroupKey, BTreeMap<Self::ResourceTag, Bytes>>> {
         unreachable!("Must not be called by RespawnedSession finish");
+    }
+
+    fn is_resource_groups_split_in_change_set_capable(&self) -> bool {
+        self.base_resource_group_view
+            .is_resource_groups_split_in_change_set_capable()
     }
 }
 
@@ -573,7 +595,7 @@ mod test {
                             (WriteOp::legacy_modification(serialize(&300).into()), None),
                         ),
                     ]),
-                    0,
+                    ResourceGroupSize::zero_combined(),
                     0,
                 ),
             ),
@@ -585,7 +607,7 @@ mod test {
                         mock_tag_1(),
                         (WriteOp::legacy_modification(serialize(&5000).into()), None),
                     )]),
-                    0,
+                    ResourceGroupSize::zero_combined(),
                     0,
                 ),
             ),

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -18,6 +18,7 @@ use move_core_types::{
     effects::Op as MoveStorageOp, language_storage::StructTag, value::MoveTypeLayout,
     vm_status::StatusCode,
 };
+use move_vm_types::delayed_values::error::code_invariant_error;
 use std::{collections::BTreeMap, sync::Arc};
 
 pub(crate) struct WriteOpConverter<'r> {
@@ -60,11 +61,8 @@ fn decrement_size_for_remove_tag(
     old_tagged_resource_size: u64,
 ) -> PartialVMResult<()> {
     match size {
-        ResourceGroupSize::Concrete(_) => Err(PartialVMError::new(
-            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-        )
-        .with_message(
-            "Unexpected ResourceGroupSize::Concrete in decrement_size_for_remove_tag".to_string(),
+        ResourceGroupSize::Concrete(_) => Err(code_invariant_error(
+            "Unexpected ResourceGroupSize::Concrete in decrement_size_for_remove_tag",
         )),
         ResourceGroupSize::Combined {
             num_tagged_resources,
@@ -251,7 +249,7 @@ impl<'r> WriteOpConverter<'r> {
         Ok(GroupWrite::new(
             self.convert(state_value_metadata, metadata_op, false)?,
             inner_ops,
-            post_group_size.get(),
+            post_group_size,
             pre_group_size.get(),
         ))
     }
@@ -440,7 +438,7 @@ mod tests {
         let resolver = as_resolver_with_group_size_kind(&s, GroupSizeKind::AsSum);
 
         assert_eq!(resolver.resource_group_size(&key).unwrap(), expected_size);
-        // TODO: Layout hardcoded to None. Test with layout = Some(..)
+        // TODO[agg_v2](test): Layout hardcoded to None. Test with layout = Some(..)
         let group_changes = BTreeMap::from([
             (mock_tag_0(), MoveStorageOp::Delete),
             (
@@ -454,10 +452,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(group_write.metadata_op().metadata(), &metadata);
-        let expected_new_size = bcs::serialized_size(&mock_tag_1()).unwrap()
-            + bcs::serialized_size(&mock_tag_2()).unwrap()
-            + 7; // values bytes size: 2 + 5
-        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size as u64);
+        let expected_new_size =
+            group_size_as_sum(vec![(&mock_tag_1(), 2), (&mock_tag_2(), 5)].into_iter()).unwrap();
+        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size);
         assert_eq!(group_write.inner_ops().len(), 2);
         assert_some_eq!(
             group_write.inner_ops().get(&mock_tag_0()),
@@ -501,11 +498,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(group_write.metadata_op().metadata(), &metadata);
-        let expected_new_size = bcs::serialized_size(&mock_tag_0()).unwrap()
-            + bcs::serialized_size(&mock_tag_1()).unwrap()
-            + bcs::serialized_size(&mock_tag_2()).unwrap()
-            + 6; // values bytes size: 1 + 2 + 3.
-        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size as u64);
+        let expected_new_size = group_size_as_sum(
+            vec![(&mock_tag_0(), 1), (&mock_tag_1(), 2), (&mock_tag_2(), 3)].into_iter(),
+        )
+        .unwrap();
+        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size);
         assert_eq!(group_write.inner_ops().len(), 1);
         assert_some_eq!(
             group_write.inner_ops().get(&mock_tag_2()),
@@ -520,7 +517,7 @@ mod tests {
         let s = MockStateView::new(BTreeMap::new());
         let resolver = as_resolver_with_group_size_kind(&s, GroupSizeKind::AsSum);
 
-        // TODO: Layout hardcoded to None. Test with layout = Some(..)
+        // TODO[agg_v2](test): Layout hardcoded to None. Test with layout = Some(..)
         let group_changes =
             BTreeMap::from([(mock_tag_1(), MoveStorageOp::New((vec![2, 2].into(), None)))]);
         let key = StateKey::raw(vec![0]);
@@ -530,8 +527,8 @@ mod tests {
             .unwrap();
 
         assert!(group_write.metadata_op().metadata().is_none());
-        let expected_new_size = bcs::serialized_size(&mock_tag_1()).unwrap() + 2;
-        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size as u64);
+        let expected_new_size = group_size_as_sum(vec![(&mock_tag_1(), 2)].into_iter()).unwrap();
+        assert_some_eq!(group_write.maybe_group_op_size(), expected_new_size);
         assert_eq!(group_write.inner_ops().len(), 1);
         assert_some_eq!(
             group_write.inner_ops().get(&mock_tag_1()),


### PR DESCRIPTION
Respowned session had two issues:
- incorrect view was being passed (one without resource group handling for split flag)
- size was set to 0, which breaks code afterwards

e2e tests didn't catch this, because epilogue is always the same - no matter what user transaction executes.

### Test Plan
Unit test provided by Aaron.
