### PR TITLE
Remove Docker layer cacheing

### DIFF
--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -153,8 +153,6 @@ target "validator-testing" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/validator-testing.Dockerfile"
   target     = "validator-testing"
-  cache-from = generate_cache_from("validator-testing")
-  cache-to   = generate_cache_to("validator-testing")
   tags       = generate_tags("validator-testing")
 }
 
@@ -162,8 +160,6 @@ target "tools" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/tools.Dockerfile"
   target     = "tools"
-  cache-from = generate_cache_from("tools")
-  cache-to   = generate_cache_to("tools")
   tags       = generate_tags("tools")
 }
 
@@ -171,8 +167,6 @@ target "forge" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/forge.Dockerfile"
   target     = "forge"
-  cache-from = generate_cache_from("forge")
-  cache-to   = generate_cache_to("forge")
   tags       = generate_tags("forge")
 }
 
@@ -180,8 +174,6 @@ target "validator" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/validator.Dockerfile"
   target     = "validator"
-  cache-from = generate_cache_from("validator")
-  cache-to   = generate_cache_to("validator")
   tags       = generate_tags("validator")
 }
 
@@ -189,8 +181,6 @@ target "tools" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/tools.Dockerfile"
   target     = "tools"
-  cache-from = generate_cache_from("tools")
-  cache-to   = generate_cache_to("tools")
   tags       = generate_tags("tools")
 }
 
@@ -198,8 +188,6 @@ target "node-checker" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/node-checker.Dockerfile"
   target     = "node-checker"
-  cache-from = generate_cache_from("node-checker")
-  cache-to   = generate_cache_to("node-checker")
   tags       = generate_tags("node-checker")
 }
 
@@ -207,8 +195,6 @@ target "faucet" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/faucet.Dockerfile"
   target     = "faucet"
-  cache-from = generate_cache_from("faucet")
-  cache-to   = generate_cache_to("faucet")
   tags       = generate_tags("faucet")
 }
 
@@ -216,8 +202,6 @@ target "telemetry-service" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/telemetry-service.Dockerfile"
   target     = "telemetry-service"
-  cache-from = generate_cache_from("telemetry-service")
-  cache-to   = generate_cache_to("telemetry-service")
   tags       = generate_tags("telemetry-service")
 }
 
@@ -225,8 +209,6 @@ target "keyless-pepper-service" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/keyless-pepper-service.Dockerfile"
   target     = "keyless-pepper-service"
-  cache-from = generate_cache_from("keyless-pepper-service")
-  cache-to   = generate_cache_to("keyless-pepper-service")
   tags       = generate_tags("keyless-pepper-service")
 }
 
@@ -234,7 +216,6 @@ target "indexer-grpc" {
   inherits   = ["_common"]
   dockerfile = "docker/builder/indexer-grpc.Dockerfile"
   target     = "indexer-grpc"
-  cache-to   = generate_cache_to("indexer-grpc")
   tags       = generate_tags("indexer-grpc")
 }
 
@@ -243,25 +224,6 @@ target "nft-metadata-crawler" {
   target     = "nft-metadata-crawler"
   dockerfile = "docker/builder/nft-metadata-crawler.Dockerfile"
   tags       = generate_tags("nft-metadata-crawler")
-  cache-from = generate_cache_from("nft-metadata-crawler")
-  cache-to   = generate_cache_to("nft-metadata-crawler")
-}
-
-function "generate_cache_from" {
-  params = [target]
-  result = CI == "true" ? [
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}main",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${GIT_SHA}",
-  ] : []
-}
-
-function "generate_cache_to" {
-  params = [target]
-  result = TARGET_REGISTRY != "local" ? [
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${GIT_SHA}"
-  ] : []
 }
 
 function "generate_tags" {


### PR DESCRIPTION
### Description

Docker builds are now running with local cacheing, so pushing cache images to GAR is no longer useful.
