### PR TITLE
[Docker] Tag Docker images using a retention class naming scheme

### DIFF
--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -1,10 +1,13 @@
 # This is a docker bake file in HCL syntax.
 # It provides a high-level mechenanism to build multiple dockerfiles in one shot.
-# Check https://crazymax.dev/docker-allhands2-buildx-bake and https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition for an intro.
+# Check https://crazymax.dev/docker-allhands2-buildx-bake and
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+# for an intro.
 
 variable "CI" {
-  # whether this build runs in aptos-labs' CI environment which makes certain assumptions about certain registries being available to push to cache layers.
-  # for local builds we simply default to relying on dockers local caching.
+  # Whether this build runs in aptos-labs' CI environment which makes certain
+  # assumptions about certain registries being available to push to cache layers.
+  # For local builds we simply default to relying on Docker's local caching.
   default = "false"
 }
 variable "TARGET_CACHE_ID" {}
@@ -17,8 +20,6 @@ variable "GIT_BRANCH" {}
 variable "GIT_TAG" {}
 
 variable "GIT_CREDENTIALS" {}
-
-variable "BUILT_VIA_BUILDKIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
@@ -37,6 +38,9 @@ variable "ecr_base" {
 
 variable "NORMALIZED_GIT_BRANCH_OR_PR" {}
 variable "IMAGE_TAG_PREFIX" {}
+variable "IMAGE_RETENTION_CLASS" {
+  default = "dev"
+}
 variable "PROFILE" {
   // Cargo compilation profile
   default = "release"
@@ -231,16 +235,21 @@ function "generate_tags" {
   result = TARGET_REGISTRY == "remote-all" ? [
     "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
     "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+    "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_RETENTION_CLASS}${NORMALIZED_GIT_BRANCH_OR_PR}",
     "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
     "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+    "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_RETENTION_CLASS}${NORMALIZED_GIT_BRANCH_OR_PR}",
     "${ecr_base}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
     "${ecr_base}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+    "${ecr_base}/${target}:${IMAGE_RETENTION_CLASS}${NORMALIZED_GIT_BRANCH_OR_PR}",
     ] : (
     TARGET_REGISTRY == "gcp" || TARGET_REGISTRY == "remote" ? [
       "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
       "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+      "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_RETENTION_CLASS}${NORMALIZED_GIT_BRANCH_OR_PR}",
       "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
       "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
+      "${GCP_DOCKER_ARTIFACT_REPO_US}/${target}:${IMAGE_RETENTION_CLASS}${NORMALIZED_GIT_BRANCH_OR_PR}",
       ] : [ // "local" or any other value
       "aptos-core/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}-from-local",
       "aptos-core/${target}:${IMAGE_TAG_PREFIX}from-local",

--- a/docker/builder/docker-bake-rust-all.sh
+++ b/docker/builder/docker-bake-rust-all.sh
@@ -17,7 +17,6 @@ export GIT_BRANCH=$(git symbolic-ref --short HEAD)
 export GIT_TAG=$(git tag -l --contains HEAD)
 export GIT_CREDENTIALS="${GIT_CREDENTIALS:-}"
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-export BUILT_VIA_BUILDKIT="true"
 export NORMALIZED_GIT_BRANCH_OR_PR=$(printf "$TARGET_CACHE_ID" | sed -e 's/[^a-zA-Z0-9]/-/g')
 
 export PROFILE=${PROFILE:-release}
@@ -26,7 +25,7 @@ export NORMALIZED_FEATURES_LIST=$(printf "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/
 export CUSTOM_IMAGE_TAG_PREFIX=${CUSTOM_IMAGE_TAG_PREFIX:-""}
 export CARGO_TARGET_DIR="target/${FEATURES:-"default"}"
 
-if [ "$PROFILE" = "release" ]; then
+if [[ ${PROFILE} == "release" ]]; then
   # Do not prefix image tags if we're building the default profile "release"
   profile_prefix=""
 else
@@ -34,24 +33,30 @@ else
   profile_prefix="${PROFILE}_"
 fi
 
-if [ -n "$CUSTOM_IMAGE_TAG_PREFIX" ]; then
+if [[  ${CI} == "true" ]]; then
+  export IMAGE_RETENTION_CLASS=ci-
+else
+  export IMAGE_RETENTION_CLASS=dev-
+fi
+
+if [[ -n ${CUSTOM_IMAGE_TAG_PREFIX} ]]; then
   export IMAGE_TAG_PREFIX="${CUSTOM_IMAGE_TAG_PREFIX}_"
 else
   export IMAGE_TAG_PREFIX=""
 fi
 
-if [ -n "$FEATURES" ]; then
+if [[ -n ${FEATURES} ]]; then
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}${NORMALIZED_FEATURES_LIST}_"
 else
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}"
 fi
 
-BUILD_TARGET="${1:-all}"
+BUILD_TARGET=${1:-all}
 echo "Building target: ${BUILD_TARGET}"
 echo "To build only a specific target, run: docker/builder/docker-bake-rust-all.sh <target>"
 echo "E.g. docker/builder/docker-bake-rust-all.sh forge-images"
 
-if [ "$CI" == "true" ]; then
+if [[ ${CI} == "true" ]]; then
   docker buildx bake --progress=plain --file docker/builder/docker-bake-rust-all.hcl --push $BUILD_TARGET
 else
   docker buildx bake --file docker/builder/docker-bake-rust-all.hcl $BUILD_TARGET --load


### PR DESCRIPTION
### Description

Introduce 3 retention classes:

* ci: for ephemeral images built on PRs
* dev: for manually triggered builds and outside PRs

These tags will be then used in the GAR cleanup policies.
Release workflows are then supposed to retag images using one of the
long-duration prefixes defined in the cleanup policies, like `release`
or `devnet`.
