### PR TITLE
[api] add a long poll API /transactions/wait_by_hash/:txn_hash

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -8406,6 +8406,530 @@
         "operationId": "get_transaction_by_hash"
       }
     },
+    "/transactions/wait_by_hash/{txn_hash}": {
+      "get": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Wait for transaction by hash",
+        "description": "Same as /transactions/by_hash, but will wait for a pending transaction to be committed. To be used as a long\npoll optimization by clients, to reduce latency caused by polling. The \"long\" poll is generally a second or\nless but dictated by the server; the client must deal with the result as if the request was a normal\n/transactions/by_hash request, e.g., by retrying if the transaction is pending.",
+        "parameters": [
+          {
+            "name": "txn_hash",
+            "schema": {
+              "$ref": "#/components/schemas/HashValue"
+            },
+            "in": "path",
+            "description": "Hash of transaction to retrieve",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              },
+              "application/x-bcs": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "uint8"
+                  }
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "required": true,
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-CURSOR": {
+                "description": "Cursor to be used for endpoints that support cursor-based\npagination. Pass this to the `start` field of the endpoint\non the next call to get the next page of results.",
+                "deprecated": false,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AptosError"
+                }
+              }
+            },
+            "headers": {
+              "X-APTOS-CHAIN-ID": {
+                "description": "Chain ID of the current chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint8"
+                }
+              },
+              "X-APTOS-LEDGER-VERSION": {
+                "description": "Current ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-OLDEST-VERSION": {
+                "description": "Oldest non-pruned ledger version of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-LEDGER-TIMESTAMPUSEC": {
+                "description": "Current timestamp of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-EPOCH": {
+                "description": "Current epoch of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-BLOCK-HEIGHT": {
+                "description": "Current block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              },
+              "X-APTOS-OLDEST-BLOCK-HEIGHT": {
+                "description": "Oldest non-pruned block height of the chain",
+                "deprecated": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "uint64"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "wait_transaction_by_hash"
+      }
+    },
     "/transactions/by_version/{txn_version}": {
       "get": {
         "tags": [

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -6285,6 +6285,391 @@ paths:
                 type: integer
                 format: uint64
       operationId: get_transaction_by_hash
+  /transactions/wait_by_hash/{txn_hash}:
+    get:
+      tags:
+      - Transactions
+      summary: Wait for transaction by hash
+      description: |-
+        Same as /transactions/by_hash, but will wait for a pending transaction to be committed. To be used as a long
+        poll optimization by clients, to reduce latency caused by polling. The "long" poll is generally a second or
+        less but dictated by the server; the client must deal with the result as if the request was a normal
+        /transactions/by_hash request, e.g., by retrying if the transaction is pending.
+      parameters:
+      - name: txn_hash
+        schema:
+          $ref: '#/components/schemas/HashValue'
+        in: path
+        description: Hash of transaction to retrieve
+        required: true
+        deprecated: false
+        explode: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+            application/x-bcs:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: uint8
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              required: true
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-CURSOR:
+              description: |-
+                Cursor to be used for endpoints that support cursor-based
+                pagination. Pass this to the `start` field of the endpoint
+                on the next call to get the next page of results.
+              deprecated: false
+              schema:
+                type: string
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+        '503':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AptosError'
+          headers:
+            X-APTOS-CHAIN-ID:
+              description: Chain ID of the current chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint8
+            X-APTOS-LEDGER-VERSION:
+              description: Current ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-OLDEST-VERSION:
+              description: Oldest non-pruned ledger version of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-LEDGER-TIMESTAMPUSEC:
+              description: Current timestamp of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-EPOCH:
+              description: Current epoch of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-BLOCK-HEIGHT:
+              description: Current block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+            X-APTOS-OLDEST-BLOCK-HEIGHT:
+              description: Oldest non-pruned block height of the chain
+              deprecated: false
+              schema:
+                type: integer
+                format: uint64
+      operationId: wait_transaction_by_hash
   /transactions/by_version/{txn_version}:
     get:
       tags:

--- a/api/goldens/aptos_api__tests__transactions_test__test_wait_pending_transaction_by_hash.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_wait_pending_transaction_by_hash.json
@@ -1,0 +1,5 @@
+{
+  "message": "Transaction not found by Transaction hash(0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d)",
+  "error_code": "transaction_not_found",
+  "vm_error_code": null
+}

--- a/api/goldens/aptos_api__tests__transactions_test__test_wait_transaction_by_hash_not_found.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_wait_transaction_by_hash_not_found.json
@@ -1,0 +1,5 @@
+{
+  "message": "Transaction not found by Transaction hash(0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d)",
+  "error_code": "transaction_not_found",
+  "vm_error_code": null
+}

--- a/api/goldens/aptos_api__tests__transactions_test__test_wait_transaction_by_invalid_hash.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_wait_transaction_by_invalid_hash.json
@@ -1,0 +1,5 @@
+{
+  "message": "failed to parse path `txn_hash`: failed to parse \"string(HashValue)\": unable to parse HashValue",
+  "error_code": "web_framework_error",
+  "vm_error_code": null
+}

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -59,7 +59,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     ops::{Bound::Included, Deref},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc, RwLock, RwLockWriteGuard,
     },
     time::Instant,
@@ -78,6 +78,7 @@ pub struct Context {
     view_function_stats: Arc<FunctionStats>,
     simulate_txn_stats: Arc<FunctionStats>,
     pub table_info_reader: Option<Arc<dyn TableInfoReader>>,
+    pub wait_for_hash_active_connections: Arc<AtomicUsize>,
 }
 
 impl std::fmt::Debug for Context {
@@ -130,6 +131,7 @@ impl Context {
             view_function_stats,
             simulate_txn_stats,
             table_info_reader,
+            wait_for_hash_active_connections: Arc::new(AtomicUsize::new(0)),
         }
     }
 

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -4,8 +4,8 @@
 
 use aptos_global_constants::DEFAULT_BUCKETS;
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
-    IntCounterVec,
+    exponential_buckets, register_histogram_vec, register_int_counter_vec, register_int_gauge,
+    HistogramVec, IntCounterVec, IntGauge,
 };
 use once_cell::sync::Lazy;
 
@@ -84,6 +84,14 @@ pub static GAS_USED: Lazy<HistogramVec> = Lazy::new(|| {
         "Amount of gas used by each API operation",
         &["operation_id"],
         BYTE_BUCKETS.clone()
+    )
+    .unwrap()
+});
+
+pub static WAIT_TRANSACTION_GAUGE: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_api_wait_transaction",
+        "Number of transactions waiting to be processed"
     )
     .unwrap()
 });

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -95,3 +95,13 @@ pub static WAIT_TRANSACTION_GAUGE: Lazy<IntGauge> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static WAIT_TRANSACTION_POLL_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_api_wait_transaction_poll_time",
+        "Time spent on long poll for transactions, or 0 on short poll",
+        &["poll_type"],
+        SUB_MS_BUCKETS.to_vec()
+    )
+    .unwrap()
+});

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -573,7 +573,9 @@ async fn test_get_pending_transaction_by_hash() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_wait_transaction_by_hash() {
-    let mut context = new_test_context(current_function_name!());
+    let mut node_config = NodeConfig::default();
+    node_config.api.wait_by_hash_timeout_ms = 2_000;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
     context.commit_block(&vec![txn.clone()]).await;
@@ -581,34 +583,47 @@ async fn test_wait_transaction_by_hash() {
     let txns = context.get("/transactions?start=2&limit=1").await;
     assert_eq!(1, txns.as_array().unwrap().len());
 
+    let start_time = std::time::Instant::now();
     let resp = context
         .get(&format!(
             "/transactions/wait_by_hash/{}",
             txns[0]["hash"].as_str().unwrap()
         ))
         .await;
+    // return immediately
+    assert!(start_time.elapsed().as_millis() < 2_000);
     assert_json(resp, txns[0].clone());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_wait_transaction_by_hash_not_found() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.wait_by_hash_timeout_ms = 2_000;
     let mut context = new_test_context(current_function_name!());
 
+    let start_time = std::time::Instant::now();
     let resp = context
         .expect_status_code(404)
         .get("/transactions/wait_by_hash/0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d")
         .await;
+    // return immediately
+    assert!(start_time.elapsed().as_millis() < 2_000);
     context.check_golden_output(resp);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_wait_transaction_by_invalid_hash() {
-    let mut context = new_test_context(current_function_name!());
+    let mut node_config = NodeConfig::default();
+    node_config.api.wait_by_hash_timeout_ms = 2_000;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
 
+    let start_time = std::time::Instant::now();
     let resp = context
         .expect_status_code(400)
         .get("/transactions/wait_by_hash/0x1")
         .await;
+    // return immediately
+    assert!(start_time.elapsed().as_millis() < 2_000);
     context.check_golden_output(resp);
 }
 
@@ -631,6 +646,7 @@ async fn test_wait_pending_transaction_by_hash() {
     let mut txn = context
         .get(&format!("/transactions/wait_by_hash/{}", txn_hash))
         .await;
+    // return after waiting for pending to become committed
     assert!(start_time.elapsed().as_millis() > 2_000);
 
     // The pending txn response from the POST request doesn't the type field,

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -572,6 +572,86 @@ async fn test_get_pending_transaction_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wait_transaction_by_hash() {
+    let mut context = new_test_context(current_function_name!());
+    let account = context.gen_account();
+    let txn = context.create_user_account(&account).await;
+    context.commit_block(&vec![txn.clone()]).await;
+
+    let txns = context.get("/transactions?start=2&limit=1").await;
+    assert_eq!(1, txns.as_array().unwrap().len());
+
+    let resp = context
+        .get(&format!(
+            "/transactions/wait_by_hash/{}",
+            txns[0]["hash"].as_str().unwrap()
+        ))
+        .await;
+    assert_json(resp, txns[0].clone());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wait_transaction_by_hash_not_found() {
+    let mut context = new_test_context(current_function_name!());
+
+    let resp = context
+        .expect_status_code(404)
+        .get("/transactions/wait_by_hash/0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d")
+        .await;
+    context.check_golden_output(resp);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wait_transaction_by_invalid_hash() {
+    let mut context = new_test_context(current_function_name!());
+
+    let resp = context
+        .expect_status_code(400)
+        .get("/transactions/wait_by_hash/0x1")
+        .await;
+    context.check_golden_output(resp);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wait_pending_transaction_by_hash() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.wait_by_hash_timeout_ms = 2_000;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+    let account = context.gen_account();
+    let txn = context.create_user_account(&account).await;
+    let body = bcs::to_bytes(&txn).unwrap();
+    let pending_txn = context
+        .expect_status_code(202)
+        .post_bcs_txn("/transactions", body)
+        .await;
+
+    let txn_hash = pending_txn["hash"].as_str().unwrap();
+
+    let start_time = std::time::Instant::now();
+    let mut txn = context
+        .get(&format!("/transactions/wait_by_hash/{}", txn_hash))
+        .await;
+    assert!(start_time.elapsed().as_millis() > 2_000);
+
+    // The pending txn response from the POST request doesn't the type field,
+    // since it is a PendingTransaction, not a Transaction. Remove it from the
+    // response from the GET request and confirm it is correct before doing the
+    // JSON comparison.
+    assert_eq!(
+        txn.as_object_mut().unwrap().remove("type").unwrap(),
+        "pending_transaction"
+    );
+
+    assert_json(txn, pending_txn);
+
+    let not_found = context
+        .expect_status_code(404)
+        .get("/transactions/by_hash/0xdadfeddcca7cb6396c735e9094c76c6e4e9cb3e3ef814730693aed59bd87b31d")
+        .await;
+    context.check_golden_output(not_found);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_signing_message_with_entry_function_payload() {
     let mut context = new_test_context(current_function_name!());
     let account = context.gen_account();

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -85,6 +85,8 @@ pub struct ApiConfig {
     pub wait_by_hash_timeout_ms: u64,
     /// The interval at which wait_by_hash will poll the storage for the transaction.
     pub wait_by_hash_poll_interval_ms: u64,
+    /// The number of active wait_by_hash requests that can be active at any given time.
+    pub wait_by_hash_max_active_connections: usize,
 }
 
 const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -135,6 +137,7 @@ impl Default for ApiConfig {
             periodic_function_stats_sec: Some(60),
             wait_by_hash_timeout_ms: 2_000,
             wait_by_hash_poll_interval_ms: 20,
+            wait_by_hash_max_active_connections: 100,
         }
     }
 }

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -135,7 +135,7 @@ impl Default for ApiConfig {
             simulation_filter: Filter::default(),
             view_filter: ViewFilter::default(),
             periodic_function_stats_sec: Some(60),
-            wait_by_hash_timeout_ms: 2_000,
+            wait_by_hash_timeout_ms: 1_000,
             wait_by_hash_poll_interval_ms: 20,
             wait_by_hash_max_active_connections: 100,
         }

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -81,6 +81,10 @@ pub struct ApiConfig {
     pub view_filter: ViewFilter,
     /// Periodically log stats for view function and simulate transaction usage
     pub periodic_function_stats_sec: Option<u64>,
+    /// The time wait_by_hash will wait before returning 404.
+    pub wait_by_hash_timeout_ms: u64,
+    /// The interval at which wait_by_hash will poll the storage for the transaction.
+    pub wait_by_hash_poll_interval_ms: u64,
 }
 
 const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -129,6 +133,8 @@ impl Default for ApiConfig {
             simulation_filter: Filter::default(),
             view_filter: ViewFilter::default(),
             periodic_function_stats_sec: Some(60),
+            wait_by_hash_timeout_ms: 2_000,
+            wait_by_hash_poll_interval_ms: 20,
         }
     }
 }


### PR DESCRIPTION
### Description

The motivation is to reduce e2e latencies by learning of committed responses immediately. Currently, it is up to the client to poll /transactions/by_hash and there is overhead on the poll intervals and the RTT of the poll.

There is concern around holding large numbers of connections for an extended time -- to alleviate this we put a limit on active long polls, and simply return immediately when that limit is reached. The API does not give guarantees about how long the long poll will wait.

### Test Plan

Added unit tests. Deployed locally and in previewnet and tested long poll behavior.
