### PR TITLE
randomness #12: disable randomness-breaking governance functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ dependencies = [
  "aptos-framework",
  "aptos-gas-schedule-updator",
  "aptos-genesis",
+ "aptos-infallible",
  "aptos-keygen",
  "aptos-rest-client",
  "aptos-temppath",

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -21,6 +21,7 @@ aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-schedule-updator = { workspace = true }
 aptos-genesis = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-keygen = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-temppath = { workspace = true }

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/0-features.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/0-features.move
@@ -1,0 +1,26 @@
+// Script hash: a9f09ee9
+// Modifying on-chain feature flags:
+// Enabled Features: [Bls12381Structures]
+// Disabled Features: [Bn254Structures]
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        let enabled_blob: vector<u64> = vector[
+            13,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+            43,
+        ];
+
+        features::change_feature_flags_for_next_epoch(framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/1-consensus-config.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/1-consensus-config.move
@@ -1,0 +1,54 @@
+// Script hash: 5d14ba49
+// Consensus config upgrade proposal
+
+// config: V3 {
+//     alg: Jolteon {
+//         main: ConsensusConfigV1 {
+//             decoupled_execution: true,
+//             back_pressure_limit: 10,
+//             exclude_round: 40,
+//             proposer_election_type: LeaderReputation(
+//                 ProposerAndVoterV2(
+//                     ProposerAndVoterConfig {
+//                         active_weight: 1000,
+//                         inactive_weight: 10,
+//                         failed_weight: 1,
+//                         failure_threshold_percent: 10,
+//                         proposer_window_num_validators_multiplier: 10,
+//                         voter_window_num_validators_multiplier: 1,
+//                         weight_by_voting_power: true,
+//                         use_history_from_previous_epoch_max_count: 5,
+//                     },
+//                 ),
+//             ),
+//             max_failed_authors_to_store: 10,
+//         },
+//         quorum_store_enabled: true,
+//     },
+//     vtxn: V1 {
+//         per_block_limit_txn_count: 3,
+//         per_block_limit_total_bytes: 2097152,
+//     },
+// }
+
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::consensus_config;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        let consensus_blob: vector<u8> = vector[
+            2, 0, 1, 10, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 2,
+            1, 232, 3, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+            0, 0, 0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+            0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1, 1,
+            3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0,
+        ];
+
+        consensus_config::set_for_next_epoch(framework_signer, consensus_blob);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/2-execution-config.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/2-execution-config.move
@@ -1,0 +1,46 @@
+// Script hash: e281bacb
+// Execution config upgrade proposal
+
+// config: V4(
+//     ExecutionConfigV4 {
+//         transaction_shuffler_type: Fairness {
+//             sender_conflict_window_size: 256,
+//             module_conflict_window_size: 2,
+//             entry_fun_conflict_window_size: 3,
+//         },
+//         block_gas_limit_type: ComplexLimitV1 {
+//             effective_block_gas_limit: 80001,
+//             execution_gas_effective_multiplier: 1,
+//             io_gas_effective_multiplier: 1,
+//             conflict_penalty_window: 6,
+//             use_granular_resource_group_conflicts: false,
+//             use_module_publishing_block_conflict: true,
+//             block_output_limit: Some(
+//                 12582912,
+//             ),
+//             include_user_txn_size_in_block_output: true,
+//             add_block_limit_outcome_onchain: false,
+//         },
+//         transaction_deduper_type: TxnHashAndAuthenticatorV1,
+//     },
+// )
+
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::execution_config;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        let execution_blob: vector<u8> = vector[
+            4, 3, 0, 1, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 2, 129, 56, 1, 0, 0,
+            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 6,
+            0, 0, 0, 0, 1, 1, 0, 0, 192, 0, 0, 0, 0, 0, 1, 0, 1,
+        ];
+
+        execution_config::set_for_next_epoch(framework_signer, execution_blob);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/3-version.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/3-version.move
@@ -1,0 +1,14 @@
+// Script hash: c2035ec4
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::version;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        version::set_for_next_epoch(framework_signer, 999);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/4-oidc-provider-ops.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/4-oidc-provider-ops.move
@@ -1,0 +1,15 @@
+// Script hash: 268052ee
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::jwks;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        jwks::upsert_oidc_provider_for_next_epoch(framework_signer, b"https://accounts.google.com", b"https://accounts.google.com/.well-known/openid-configuration");
+        jwks::remove_oidc_provider_for_next_epoch(framework_signer, b"https://www.facebook.com");
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/5-gas-schedule.move
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/output/5-gas-schedule.move
@@ -1,0 +1,1358 @@
+// Script hash: 6688e655
+// source commit hash: d3d3b74193101d949f6c709b24e3a70ddb474197
+
+// Gas schedule upgrade proposal
+
+// Feature version: 15
+//
+// Entries:
+//     instr.nop                                                               : 36
+//     instr.ret                                                               : 220
+//     instr.abort                                                             : 220
+//     instr.br_true                                                           : 441
+//     instr.br_false                                                          : 441
+//     instr.branch                                                            : 294
+//     instr.pop                                                               : 147
+//     instr.ld_u8                                                             : 220
+//     instr.ld_u16                                                            : 220
+//     instr.ld_u32                                                            : 220
+//     instr.ld_u64                                                            : 220
+//     instr.ld_u128                                                           : 294
+//     instr.ld_u256                                                           : 294
+//     instr.ld_true                                                           : 220
+//     instr.ld_false                                                          : 220
+//     instr.ld_const.base                                                     : 2389
+//     instr.ld_const.per_byte                                                 : 128
+//     instr.imm_borrow_loc                                                    : 220
+//     instr.mut_borrow_loc                                                    : 220
+//     instr.imm_borrow_field                                                  : 735
+//     instr.mut_borrow_field                                                  : 735
+//     instr.imm_borrow_field_generic                                          : 735
+//     instr.mut_borrow_field_generic                                          : 735
+//     instr.copy_loc.base                                                     : 294
+//     instr.copy_loc.per_abs_val_unit                                         : 14
+//     instr.move_loc.base                                                     : 441
+//     instr.st_loc.base                                                       : 441
+//     instr.call.base                                                         : 3676
+//     instr.call.per_arg                                                      : 367
+//     instr.call.per_local                                                    : 367
+//     instr.call_generic.base                                                 : 3676
+//     instr.call_generic.per_ty_arg                                           : 367
+//     instr.call_generic.per_arg                                              : 367
+//     instr.call_generic.per_local                                            : 367
+//     instr.pack.base                                                         : 808
+//     instr.pack.per_field                                                    : 147
+//     instr.pack_generic.base                                                 : 808
+//     instr.pack_generic.per_field                                            : 147
+//     instr.unpack.base                                                       : 808
+//     instr.unpack.per_field                                                  : 147
+//     instr.unpack_generic.base                                               : 808
+//     instr.unpack_generic.per_field                                          : 147
+//     instr.read_ref.base                                                     : 735
+//     instr.read_ref.per_abs_val_unit                                         : 14
+//     instr.write_ref.base                                                    : 735
+//     instr.freeze_ref                                                        : 36
+//     instr.cast_u8                                                           : 441
+//     instr.cast_u16                                                          : 441
+//     instr.cast_u32                                                          : 441
+//     instr.cast_u64                                                          : 441
+//     instr.cast_u128                                                         : 441
+//     instr.cast_u256                                                         : 441
+//     instr.add                                                               : 588
+//     instr.sub                                                               : 588
+//     instr.mul                                                               : 588
+//     instr.mod                                                               : 588
+//     instr.div                                                               : 588
+//     instr.bit_or                                                            : 588
+//     instr.bit_and                                                           : 588
+//     instr.bit_xor                                                           : 588
+//     instr.bit_shl                                                           : 588
+//     instr.bit_shr                                                           : 588
+//     instr.or                                                                : 588
+//     instr.and                                                               : 588
+//     instr.not                                                               : 588
+//     instr.lt                                                                : 588
+//     instr.gt                                                                : 588
+//     instr.le                                                                : 588
+//     instr.ge                                                                : 588
+//     instr.eq.base                                                           : 367
+//     instr.eq.per_abs_val_unit                                               : 14
+//     instr.neq.base                                                          : 367
+//     instr.neq.per_abs_val_unit                                              : 14
+//     instr.imm_borrow_global.base                                            : 1838
+//     instr.imm_borrow_global_generic.base                                    : 1838
+//     instr.mut_borrow_global.base                                            : 1838
+//     instr.mut_borrow_global_generic.base                                    : 1838
+//     instr.exists.base                                                       : 919
+//     instr.exists_generic.base                                               : 919
+//     instr.move_from.base                                                    : 1286
+//     instr.move_from_generic.base                                            : 1286
+//     instr.move_to.base                                                      : 1838
+//     instr.move_to_generic.base                                              : 1838
+//     instr.vec_len.base                                                      : 808
+//     instr.vec_imm_borrow.base                                               : 1213
+//     instr.vec_mut_borrow.base                                               : 1213
+//     instr.vec_push_back.base                                                : 1396
+//     instr.vec_pop_back.base                                                 : 955
+//     instr.vec_swap.base                                                     : 1102
+//     instr.vec_pack.base                                                     : 2205
+//     instr.vec_pack.per_elem                                                 : 147
+//     instr.vec_unpack.base                                                   : 1838
+//     instr.vec_unpack.per_expected_elem                                      : 147
+//     instr.subst_ty_per_node                                                 : 400
+//     txn.min_transaction_gas_units                                           : 2760000
+//     txn.large_transaction_cutoff                                            : 600
+//     txn.intrinsic_gas_per_byte                                              : 1158
+//     txn.maximum_number_of_gas_units                                         : 2000000
+//     txn.min_price_per_gas_unit                                              : 100
+//     txn.max_price_per_gas_unit                                              : 10000000000
+//     txn.max_transaction_size_in_bytes                                       : 10485760
+//     txn.gas_unit_scaling_factor                                             : 1000000
+//     txn.storage_io_per_state_slot_read                                      : 302385
+//     txn.storage_io_per_state_byte_read                                      : 151
+//     txn.load_data.failure                                                   : 0
+//     txn.storage_io_per_state_slot_write                                     : 89568
+//     txn.storage_io_per_state_byte_write                                     : 89
+//     txn.memory_quota                                                        : 10000000
+//     txn.free_write_bytes_quota                                              : 1024
+//     txn.legacy_free_event_bytes_quota                                       : 1024
+//     txn.max_bytes_per_write_op                                              : 1048576
+//     txn.max_bytes_all_write_ops_per_transaction                             : 10485760
+//     txn.max_bytes_per_event                                                 : 1048576
+//     txn.max_bytes_all_events_per_transaction                                : 10485760
+//     txn.max_write_ops_per_transaction                                       : 8192
+//     txn.legacy_storage_fee_per_state_slot_create                            : 50000
+//     txn.storage_fee_per_state_slot                                          : 40000
+//     txn.legacy_storage_fee_per_excess_state_byte                            : 50
+//     txn.storage_fee_per_state_byte                                          : 40
+//     txn.legacy_storage_fee_per_event_byte                                   : 20
+//     txn.legacy_storage_fee_per_transaction_byte                             : 20
+//     txn.max_execution_gas                                                   : 9999999999
+//     txn.max_io_gas                                                          : 1000000000
+//     txn.max_storage_fee                                                     : 200000000
+//     misc.abs_val.u8                                                         : 40
+//     misc.abs_val.u16                                                        : 40
+//     misc.abs_val.u32                                                        : 40
+//     misc.abs_val.u64                                                        : 40
+//     misc.abs_val.u128                                                       : 40
+//     misc.abs_val.u256                                                       : 40
+//     misc.abs_val.bool                                                       : 40
+//     misc.abs_val.address                                                    : 40
+//     misc.abs_val.struct                                                     : 40
+//     misc.abs_val.vector                                                     : 40
+//     misc.abs_val.reference                                                  : 40
+//     misc.abs_val.per_u8_packed                                              : 1
+//     misc.abs_val.per_u16_packed                                             : 2
+//     misc.abs_val.per_u32_packed                                             : 4
+//     misc.abs_val.per_u64_packed                                             : 8
+//     misc.abs_val.per_u128_packed                                            : 16
+//     misc.abs_val.per_u256_packed                                            : 32
+//     misc.abs_val.per_bool_packed                                            : 1
+//     misc.abs_val.per_address_packed                                         : 32
+//     move_stdlib.bcs.to_bytes.per_byte_serialized                            : 36
+//     move_stdlib.bcs.to_bytes.failure                                        : 3676
+//     move_stdlib.hash.sha2_256.base                                          : 11028
+//     move_stdlib.hash.sha2_256.per_byte                                      : 183
+//     move_stdlib.hash.sha3_256.base                                          : 14704
+//     move_stdlib.hash.sha3_256.per_byte                                      : 165
+//     move_stdlib.signer.borrow_address.base                                  : 735
+//     move_stdlib.string.check_utf8.base                                      : 1102
+//     move_stdlib.string.check_utf8.per_byte                                  : 29
+//     move_stdlib.string.is_char_boundary.base                                : 1102
+//     move_stdlib.string.sub_string.base                                      : 1470
+//     move_stdlib.string.sub_string.per_byte                                  : 11
+//     move_stdlib.string.index_of.base                                        : 1470
+//     move_stdlib.string.index_of.per_byte_pattern                            : 73
+//     move_stdlib.string.index_of.per_byte_searched                           : 36
+//     table.common.load.base                                                  : 302385
+//     table.common.load.base_new                                              : 302385
+//     table.common.load.per_byte                                              : 151
+//     table.common.load.failure                                               : 0
+//     table.new_table_handle.base                                             : 3676
+//     table.add_box.base                                                      : 4411
+//     table.add_box.per_byte_serialized                                       : 36
+//     table.borrow_box.base                                                   : 4411
+//     table.borrow_box.per_byte_serialized                                    : 36
+//     table.contains_box.base                                                 : 4411
+//     table.contains_box.per_byte_serialized                                  : 36
+//     table.remove_box.base                                                   : 4411
+//     table.remove_box.per_byte_serialized                                    : 36
+//     table.destroy_empty_box.base                                            : 4411
+//     table.drop_unchecked_box.base                                           : 367
+//     aptos_framework.account.create_address.base                             : 1102
+//     aptos_framework.account.create_signer.base                              : 1102
+//     aptos_framework.algebra.ark_bn254_fq12_add                              : 809
+//     aptos_framework.algebra.ark_bn254_fq12_clone                            : 807
+//     aptos_framework.algebra.ark_bn254_fq12_deser                            : 23721
+//     aptos_framework.algebra.ark_bn254_fq12_div                              : 517140
+//     aptos_framework.algebra.ark_bn254_fq12_eq                               : 2231
+//     aptos_framework.algebra.ark_bn254_fq12_from_u64                         : 2658
+//     aptos_framework.algebra.ark_bn254_fq12_inv                              : 398555
+//     aptos_framework.algebra.ark_bn254_fq12_mul                              : 118351
+//     aptos_framework.algebra.ark_bn254_fq12_neg                              : 2446
+//     aptos_framework.algebra.ark_bn254_fq12_one                              : 38
+//     aptos_framework.algebra.ark_bn254_fq12_pow_u256                         : 35449826
+//     aptos_framework.algebra.ark_bn254_fq12_serialize                        : 21566
+//     aptos_framework.algebra.ark_bn254_fq12_square                           : 86193
+//     aptos_framework.algebra.ark_bn254_fq12_sub                              : 5605
+//     aptos_framework.algebra.ark_bn254_fq12_zero                             : 38
+//     aptos_framework.algebra.ark_bn254_fq_add                                : 803
+//     aptos_framework.algebra.ark_bn254_fq_clone                              : 792
+//     aptos_framework.algebra.ark_bn254_fq_deser                              : 3232
+//     aptos_framework.algebra.ark_bn254_fq_div                                : 209631
+//     aptos_framework.algebra.ark_bn254_fq_eq                                 : 803
+//     aptos_framework.algebra.ark_bn254_fq_from_u64                           : 2598
+//     aptos_framework.algebra.ark_bn254_fq_inv                                : 208902
+//     aptos_framework.algebra.ark_bn254_fq_mul                                : 1847
+//     aptos_framework.algebra.ark_bn254_fq_neg                                : 792
+//     aptos_framework.algebra.ark_bn254_fq_one                                : 38
+//     aptos_framework.algebra.ark_bn254_fq_pow_u256                           : 382570
+//     aptos_framework.algebra.ark_bn254_fq_serialize                          : 4767
+//     aptos_framework.algebra.ark_bn254_fq_square                             : 792
+//     aptos_framework.algebra.ark_bn254_fq_sub                                : 1130
+//     aptos_framework.algebra.ark_bn254_fq_zero                               : 38
+//     aptos_framework.algebra.ark_bn254_fr_add                                : 804
+//     aptos_framework.algebra.ark_bn254_fr_deser                              : 3073
+//     aptos_framework.algebra.ark_bn254_fr_div                                : 223857
+//     aptos_framework.algebra.ark_bn254_fr_eq                                 : 807
+//     aptos_framework.algebra.ark_bn254_fr_from_u64                           : 2478
+//     aptos_framework.algebra.ark_bn254_fr_inv                                : 222216
+//     aptos_framework.algebra.ark_bn254_fr_mul                                : 1813
+//     aptos_framework.algebra.ark_bn254_fr_neg                                : 792
+//     aptos_framework.algebra.ark_bn254_fr_one                                : 0
+//     aptos_framework.algebra.ark_bn254_fr_serialize                          : 4732
+//     aptos_framework.algebra.ark_bn254_fr_square                             : 792
+//     aptos_framework.algebra.ark_bn254_fr_sub                                : 1906
+//     aptos_framework.algebra.ark_bn254_fr_zero                               : 38
+//     aptos_framework.algebra.ark_bn254_g1_affine_deser_comp                  : 4318809
+//     aptos_framework.algebra.ark_bn254_g1_affine_deser_uncomp                : 3956976
+//     aptos_framework.algebra.ark_bn254_g1_affine_serialize_comp              : 8257
+//     aptos_framework.algebra.ark_bn254_g1_affine_serialize_uncomp            : 10811
+//     aptos_framework.algebra.ark_bn254_g1_proj_add                           : 19574
+//     aptos_framework.algebra.ark_bn254_g1_proj_double                        : 11704
+//     aptos_framework.algebra.ark_bn254_g1_proj_eq                            : 9745
+//     aptos_framework.algebra.ark_bn254_g1_proj_generator                     : 38
+//     aptos_framework.algebra.ark_bn254_g1_proj_infinity                      : 38
+//     aptos_framework.algebra.ark_bn254_g1_proj_neg                           : 38
+//     aptos_framework.algebra.ark_bn254_g1_proj_scalar_mul                    : 4862683
+//     aptos_framework.algebra.ark_bn254_g1_proj_sub                           : 19648
+//     aptos_framework.algebra.ark_bn254_g1_proj_to_affine                     : 1165
+//     aptos_framework.algebra.ark_bn254_g2_affine_deser_comp                  : 12445138
+//     aptos_framework.algebra.ark_bn254_g2_affine_deser_uncomp                : 11152541
+//     aptos_framework.algebra.ark_bn254_g2_affine_serialize_comp              : 12721
+//     aptos_framework.algebra.ark_bn254_g2_affine_serialize_uncomp            : 18105
+//     aptos_framework.algebra.ark_bn254_g2_proj_add                           : 58491
+//     aptos_framework.algebra.ark_bn254_g2_proj_double                        : 29201
+//     aptos_framework.algebra.ark_bn254_g2_proj_eq                            : 25981
+//     aptos_framework.algebra.ark_bn254_g2_proj_generator                     : 38
+//     aptos_framework.algebra.ark_bn254_g2_proj_infinity                      : 38
+//     aptos_framework.algebra.ark_bn254_g2_proj_neg                           : 38
+//     aptos_framework.algebra.ark_bn254_g2_proj_scalar_mul                    : 14041548
+//     aptos_framework.algebra.ark_bn254_g2_proj_sub                           : 59133
+//     aptos_framework.algebra.ark_bn254_g2_proj_to_affine                     : 230100
+//     aptos_framework.algebra.ark_bn254_multi_pairing_base                    : 23488646
+//     aptos_framework.algebra.ark_bn254_multi_pairing_per_pair                : 12429399
+//     aptos_framework.algebra.ark_bn254_pairing                               : 38543565
+//     aptos_framework.algebra.ark_bls12_381_fq12_add                          : 6686
+//     aptos_framework.algebra.ark_bls12_381_fq12_clone                        : 775
+//     aptos_framework.algebra.ark_bls12_381_fq12_deser                        : 41097
+//     aptos_framework.algebra.ark_bls12_381_fq12_div                          : 921988
+//     aptos_framework.algebra.ark_bls12_381_fq12_eq                           : 2668
+//     aptos_framework.algebra.ark_bls12_381_fq12_from_u64                     : 3312
+//     aptos_framework.algebra.ark_bls12_381_fq12_inv                          : 737122
+//     aptos_framework.algebra.ark_bls12_381_fq12_mul                          : 183380
+//     aptos_framework.algebra.ark_bls12_381_fq12_neg                          : 4341
+//     aptos_framework.algebra.ark_bls12_381_fq12_one                          : 40
+//     aptos_framework.algebra.ark_bls12_381_fq12_pow_u256                     : 53905624
+//     aptos_framework.algebra.ark_bls12_381_fq12_serialize                    : 29694
+//     aptos_framework.algebra.ark_bls12_381_fq12_square                       : 129193
+//     aptos_framework.algebra.ark_bls12_381_fq12_sub                          : 6462
+//     aptos_framework.algebra.ark_bls12_381_fq12_zero                         : 775
+//     aptos_framework.algebra.ark_bls12_381_fr_add                            : 775
+//     aptos_framework.algebra.ark_bls12_381_fr_deser                          : 2764
+//     aptos_framework.algebra.ark_bls12_381_fr_div                            : 218501
+//     aptos_framework.algebra.ark_bls12_381_fr_eq                             : 779
+//     aptos_framework.algebra.ark_bls12_381_fr_from_u64                       : 1815
+//     aptos_framework.algebra.ark_bls12_381_fr_inv                            : 215450
+//     aptos_framework.algebra.ark_bls12_381_fr_mul                            : 1845
+//     aptos_framework.algebra.ark_bls12_381_fr_neg                            : 782
+//     aptos_framework.algebra.ark_bls12_381_fr_one                            : 775
+//     aptos_framework.algebra.ark_bls12_381_fr_serialize                      : 4054
+//     aptos_framework.algebra.ark_bls12_381_fr_square                         : 1746
+//     aptos_framework.algebra.ark_bls12_381_fr_sub                            : 1066
+//     aptos_framework.algebra.ark_bls12_381_fr_zero                           : 775
+//     aptos_framework.algebra.ark_bls12_381_g1_affine_deser_comp              : 3784805
+//     aptos_framework.algebra.ark_bls12_381_g1_affine_deser_uncomp            : 2649065
+//     aptos_framework.algebra.ark_bls12_381_g1_affine_serialize_comp          : 7403
+//     aptos_framework.algebra.ark_bls12_381_g1_affine_serialize_uncomp        : 8943
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_add                       : 39722
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_double                    : 19350
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_eq                        : 18508
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_generator                 : 40
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_infinity                  : 40
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_neg                       : 40
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_scalar_mul                : 9276463
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_sub                       : 40976
+//     aptos_framework.algebra.ark_bls12_381_g1_proj_to_affine                 : 444924
+//     aptos_framework.algebra.ark_bls12_381_g2_affine_deser_comp              : 7572809
+//     aptos_framework.algebra.ark_bls12_381_g2_affine_deser_uncomp            : 3742090
+//     aptos_framework.algebra.ark_bls12_381_g2_affine_serialize_comp          : 12417
+//     aptos_framework.algebra.ark_bls12_381_g2_affine_serialize_uncomp        : 15501
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_add                       : 119106
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_double                    : 54548
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_eq                        : 55709
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_generator                 : 40
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_infinity                  : 40
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_neg                       : 40
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_scalar_mul                : 27667443
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_sub                       : 120826
+//     aptos_framework.algebra.ark_bls12_381_g2_proj_to_affine                 : 473678
+//     aptos_framework.algebra.ark_bls12_381_multi_pairing_base                : 33079033
+//     aptos_framework.algebra.ark_bls12_381_multi_pairing_per_pair            : 16919311
+//     aptos_framework.algebra.ark_bls12_381_pairing                           : 54523240
+//     aptos_framework.algebra.ark_h2c_bls12381g1_xmd_sha256_sswu_base         : 11954142
+//     aptos_framework.algebra.ark_h2c_bls12381g1_xmd_sha256_sswu_per_msg_byte : 176
+//     aptos_framework.algebra.ark_h2c_bls12381g2_xmd_sha256_sswu_base         : 24897555
+//     aptos_framework.algebra.ark_h2c_bls12381g2_xmd_sha256_sswu_per_msg_byte : 176
+//     aptos_framework.bls12381.base                                           : 551
+//     aptos_framework.bls12381.per_pubkey_deserialize                         : 400684
+//     aptos_framework.bls12381.per_pubkey_aggregate                           : 15439
+//     aptos_framework.bls12381.per_pubkey_subgroup_check                      : 1360120
+//     aptos_framework.bls12381.per_sig_deserialize                            : 816072
+//     aptos_framework.bls12381.per_sig_aggregate                              : 42825
+//     aptos_framework.bls12381.per_sig_subgroup_check                         : 1692798
+//     aptos_framework.bls12381.per_sig_verify                                 : 31190860
+//     aptos_framework.bls12381.per_pop_verify                                 : 37862800
+//     aptos_framework.bls12381.per_pairing                                    : 14751788
+//     aptos_framework.bls12381.per_msg_hashing                                : 5661040
+//     aptos_framework.bls12381.per_byte_hashing                               : 183
+//     aptos_framework.signature.base                                          : 551
+//     aptos_framework.signature.per_pubkey_deserialize                        : 139688
+//     aptos_framework.signature.per_pubkey_small_order_check                  : 23342
+//     aptos_framework.signature.per_sig_deserialize                           : 1378
+//     aptos_framework.signature.per_sig_strict_verify                         : 981492
+//     aptos_framework.signature.per_msg_hashing_base                          : 11910
+//     aptos_framework.signature.per_msg_byte_hashing                          : 220
+//     aptos_framework.secp256k1.base                                          : 551
+//     aptos_framework.secp256k1.ecdsa_recover                                 : 5918360
+//     aptos_framework.ristretto255.basepoint_mul                              : 470528
+//     aptos_framework.ristretto255.basepoint_double_mul                       : 1617440
+//     aptos_framework.ristretto255.point_add                                  : 7848
+//     aptos_framework.ristretto255.point_clone                                : 551
+//     aptos_framework.ristretto255.point_compress                             : 147040
+//     aptos_framework.ristretto255.point_decompress                           : 148878
+//     aptos_framework.ristretto255.point_equals                               : 8454
+//     aptos_framework.ristretto255.point_from_64_uniform_bytes                : 299594
+//     aptos_framework.ristretto255.point_identity                             : 551
+//     aptos_framework.ristretto255.point_mul                                  : 1731396
+//     aptos_framework.ristretto255.point_double_mul                           : 1869907
+//     aptos_framework.ristretto255.point_neg                                  : 1323
+//     aptos_framework.ristretto255.point_sub                                  : 7829
+//     aptos_framework.ristretto255.point_parse_arg                            : 551
+//     aptos_framework.ristretto255.scalar_sha512_per_byte                     : 220
+//     aptos_framework.ristretto255.scalar_sha512_per_hash                     : 11910
+//     aptos_framework.ristretto255.scalar_add                                 : 2830
+//     aptos_framework.ristretto255.scalar_reduced_from_32_bytes               : 2609
+//     aptos_framework.ristretto255.scalar_uniform_from_64_bytes               : 4576
+//     aptos_framework.ristretto255.scalar_from_u128                           : 643
+//     aptos_framework.ristretto255.scalar_from_u64                            : 643
+//     aptos_framework.ristretto255.scalar_invert                              : 404360
+//     aptos_framework.ristretto255.scalar_is_canonical                        : 4227
+//     aptos_framework.ristretto255.scalar_mul                                 : 3914
+//     aptos_framework.ristretto255.scalar_neg                                 : 2665
+//     aptos_framework.ristretto255.scalar_sub                                 : 3896
+//     aptos_framework.ristretto255.scalar_parse_arg                           : 551
+//     aptos_framework.hash.sip_hash.base                                      : 3676
+//     aptos_framework.hash.sip_hash.per_byte                                  : 73
+//     aptos_framework.hash.keccak256.base                                     : 14704
+//     aptos_framework.hash.keccak256.per_byte                                 : 165
+//     aptos_framework.bulletproofs.base                                       : 11794651
+//     aptos_framework.bulletproofs.per_bit_rangeproof_verify                  : 1004253
+//     aptos_framework.bulletproofs.per_byte_rangeproof_deserialize            : 121
+//     aptos_framework.type_info.type_of.base                                  : 1102
+//     aptos_framework.type_info.type_of.per_abstract_memory_unit              : 18
+//     aptos_framework.type_info.type_name.base                                : 1102
+//     aptos_framework.type_info.type_name.per_abstract_memory_unit            : 18
+//     aptos_framework.type_info.chain_id.base                                 : 551
+//     aptos_framework.hash.sha2_512.base                                      : 11910
+//     aptos_framework.hash.sha2_512.per_byte                                  : 220
+//     aptos_framework.hash.sha3_512.base                                      : 16542
+//     aptos_framework.hash.sha3_512.per_byte                                  : 183
+//     aptos_framework.hash.ripemd160.base                                     : 11028
+//     aptos_framework.hash.ripemd160.per_byte                                 : 183
+//     aptos_framework.hash.blake2b_256.base                                   : 6433
+//     aptos_framework.hash.blake2b_256.per_byte                               : 55
+//     aptos_framework.util.from_bytes.base                                    : 1102
+//     aptos_framework.util.from_bytes.per_byte                                : 18
+//     aptos_framework.transaction_context.get_txn_hash.base                   : 735
+//     aptos_framework.transaction_context.get_script_hash.base                : 735
+//     aptos_framework.transaction_context.generate_unique_address.base        : 14704
+//     aptos_framework.code.request_publish.base                               : 1838
+//     aptos_framework.code.request_publish.per_byte                           : 7
+//     aptos_framework.event.write_to_event_store.base                         : 20006
+//     aptos_framework.event.write_to_event_store.per_abstract_memory_unit     : 61
+//     aptos_framework.state_storage.get_usage.base                            : 1838
+//     aptos_framework.aggregator.add.base                                     : 1102
+//     aptos_framework.aggregator.read.base                                    : 1102
+//     aptos_framework.aggregator.sub.base                                     : 1102
+//     aptos_framework.aggregator.destroy.base                                 : 1838
+//     aptos_framework.aggregator_factory.new_aggregator.base                  : 1838
+//     aptos_framework.aggregator_v2.create_aggregator.base                    : 1838
+//     aptos_framework.aggregator_v2.try_add.base                              : 1102
+//     aptos_framework.aggregator_v2.try_sub.base                              : 1102
+//     aptos_framework.aggregator_v2.read.base                                 : 2205
+//     aptos_framework.aggregator_v2.snapshot.base                             : 1102
+//     aptos_framework.aggregator_v2.create_snapshot.base                      : 1102
+//     aptos_framework.aggregator_v2.create_snapshot.per_byte                  : 3
+//     aptos_framework.aggregator_v2.copy_snapshot.base                        : 1102
+//     aptos_framework.aggregator_v2.read_snapshot.base                        : 2205
+//     aptos_framework.aggregator_v2.string_concat.base                        : 1102
+//     aptos_framework.aggregator_v2.string_concat.per_byte                    : 3
+//     aptos_framework.object.exists_at.base                                   : 919
+//     aptos_framework.object.exists_at.per_byte_loaded                        : 183
+//     aptos_framework.object.exists_at.per_item_loaded                        : 1470
+//     aptos_framework.string_utils.format.base                                : 1102
+//     aptos_framework.string_utils.format.per_byte                            : 3
+
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::gas_schedule;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        let gas_schedule_blob: vector<u8> = vector[
+            15, 0, 0, 0, 0, 0, 0, 0, 151, 3, 9, 105, 110, 115, 116, 114, 46, 110, 111, 112,
+            36, 0, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46, 114, 101, 116, 220, 0,
+            0, 0, 0, 0, 0, 0, 11, 105, 110, 115, 116, 114, 46, 97, 98, 111, 114, 116, 220, 0,
+            0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114, 46, 98, 114, 95, 116, 114, 117, 101,
+            185, 1, 0, 0, 0, 0, 0, 0, 14, 105, 110, 115, 116, 114, 46, 98, 114, 95, 102, 97,
+            108, 115, 101, 185, 1, 0, 0, 0, 0, 0, 0, 12, 105, 110, 115, 116, 114, 46, 98, 114,
+            97, 110, 99, 104, 38, 1, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46, 112,
+            111, 112, 147, 0, 0, 0, 0, 0, 0, 0, 11, 105, 110, 115, 116, 114, 46, 108, 100, 95,
+            117, 56, 220, 0, 0, 0, 0, 0, 0, 0, 12, 105, 110, 115, 116, 114, 46, 108, 100, 95,
+            117, 49, 54, 220, 0, 0, 0, 0, 0, 0, 0, 12, 105, 110, 115, 116, 114, 46, 108, 100,
+            95, 117, 51, 50, 220, 0, 0, 0, 0, 0, 0, 0, 12, 105, 110, 115, 116, 114, 46, 108,
+            100, 95, 117, 54, 52, 220, 0, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114, 46,
+            108, 100, 95, 117, 49, 50, 56, 38, 1, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116,
+            114, 46, 108, 100, 95, 117, 50, 53, 54, 38, 1, 0, 0, 0, 0, 0, 0, 13, 105, 110,
+            115, 116, 114, 46, 108, 100, 95, 116, 114, 117, 101, 220, 0, 0, 0, 0, 0, 0, 0, 14,
+            105, 110, 115, 116, 114, 46, 108, 100, 95, 102, 97, 108, 115, 101, 220, 0, 0, 0, 0, 0,
+            0, 0, 19, 105, 110, 115, 116, 114, 46, 108, 100, 95, 99, 111, 110, 115, 116, 46, 98, 97,
+            115, 101, 85, 9, 0, 0, 0, 0, 0, 0, 23, 105, 110, 115, 116, 114, 46, 108, 100, 95,
+            99, 111, 110, 115, 116, 46, 112, 101, 114, 95, 98, 121, 116, 101, 128, 0, 0, 0, 0, 0,
+            0, 0, 20, 105, 110, 115, 116, 114, 46, 105, 109, 109, 95, 98, 111, 114, 114, 111, 119, 95,
+            108, 111, 99, 220, 0, 0, 0, 0, 0, 0, 0, 20, 105, 110, 115, 116, 114, 46, 109, 117,
+            116, 95, 98, 111, 114, 114, 111, 119, 95, 108, 111, 99, 220, 0, 0, 0, 0, 0, 0, 0,
+            22, 105, 110, 115, 116, 114, 46, 105, 109, 109, 95, 98, 111, 114, 114, 111, 119, 95, 102, 105,
+            101, 108, 100, 223, 2, 0, 0, 0, 0, 0, 0, 22, 105, 110, 115, 116, 114, 46, 109, 117,
+            116, 95, 98, 111, 114, 114, 111, 119, 95, 102, 105, 101, 108, 100, 223, 2, 0, 0, 0, 0,
+            0, 0, 30, 105, 110, 115, 116, 114, 46, 105, 109, 109, 95, 98, 111, 114, 114, 111, 119, 95,
+            102, 105, 101, 108, 100, 95, 103, 101, 110, 101, 114, 105, 99, 223, 2, 0, 0, 0, 0, 0,
+            0, 30, 105, 110, 115, 116, 114, 46, 109, 117, 116, 95, 98, 111, 114, 114, 111, 119, 95, 102,
+            105, 101, 108, 100, 95, 103, 101, 110, 101, 114, 105, 99, 223, 2, 0, 0, 0, 0, 0, 0,
+            19, 105, 110, 115, 116, 114, 46, 99, 111, 112, 121, 95, 108, 111, 99, 46, 98, 97, 115, 101,
+            38, 1, 0, 0, 0, 0, 0, 0, 31, 105, 110, 115, 116, 114, 46, 99, 111, 112, 121, 95,
+            108, 111, 99, 46, 112, 101, 114, 95, 97, 98, 115, 95, 118, 97, 108, 95, 117, 110, 105, 116,
+            14, 0, 0, 0, 0, 0, 0, 0, 19, 105, 110, 115, 116, 114, 46, 109, 111, 118, 101, 95,
+            108, 111, 99, 46, 98, 97, 115, 101, 185, 1, 0, 0, 0, 0, 0, 0, 17, 105, 110, 115,
+            116, 114, 46, 115, 116, 95, 108, 111, 99, 46, 98, 97, 115, 101, 185, 1, 0, 0, 0, 0,
+            0, 0, 15, 105, 110, 115, 116, 114, 46, 99, 97, 108, 108, 46, 98, 97, 115, 101, 92, 14,
+            0, 0, 0, 0, 0, 0, 18, 105, 110, 115, 116, 114, 46, 99, 97, 108, 108, 46, 112, 101,
+            114, 95, 97, 114, 103, 111, 1, 0, 0, 0, 0, 0, 0, 20, 105, 110, 115, 116, 114, 46,
+            99, 97, 108, 108, 46, 112, 101, 114, 95, 108, 111, 99, 97, 108, 111, 1, 0, 0, 0, 0,
+            0, 0, 23, 105, 110, 115, 116, 114, 46, 99, 97, 108, 108, 95, 103, 101, 110, 101, 114, 105,
+            99, 46, 98, 97, 115, 101, 92, 14, 0, 0, 0, 0, 0, 0, 29, 105, 110, 115, 116, 114,
+            46, 99, 97, 108, 108, 95, 103, 101, 110, 101, 114, 105, 99, 46, 112, 101, 114, 95, 116, 121,
+            95, 97, 114, 103, 111, 1, 0, 0, 0, 0, 0, 0, 26, 105, 110, 115, 116, 114, 46, 99,
+            97, 108, 108, 95, 103, 101, 110, 101, 114, 105, 99, 46, 112, 101, 114, 95, 97, 114, 103, 111,
+            1, 0, 0, 0, 0, 0, 0, 28, 105, 110, 115, 116, 114, 46, 99, 97, 108, 108, 95, 103,
+            101, 110, 101, 114, 105, 99, 46, 112, 101, 114, 95, 108, 111, 99, 97, 108, 111, 1, 0, 0,
+            0, 0, 0, 0, 15, 105, 110, 115, 116, 114, 46, 112, 97, 99, 107, 46, 98, 97, 115, 101,
+            40, 3, 0, 0, 0, 0, 0, 0, 20, 105, 110, 115, 116, 114, 46, 112, 97, 99, 107, 46,
+            112, 101, 114, 95, 102, 105, 101, 108, 100, 147, 0, 0, 0, 0, 0, 0, 0, 23, 105, 110,
+            115, 116, 114, 46, 112, 97, 99, 107, 95, 103, 101, 110, 101, 114, 105, 99, 46, 98, 97, 115,
+            101, 40, 3, 0, 0, 0, 0, 0, 0, 28, 105, 110, 115, 116, 114, 46, 112, 97, 99, 107,
+            95, 103, 101, 110, 101, 114, 105, 99, 46, 112, 101, 114, 95, 102, 105, 101, 108, 100, 147, 0,
+            0, 0, 0, 0, 0, 0, 17, 105, 110, 115, 116, 114, 46, 117, 110, 112, 97, 99, 107, 46,
+            98, 97, 115, 101, 40, 3, 0, 0, 0, 0, 0, 0, 22, 105, 110, 115, 116, 114, 46, 117,
+            110, 112, 97, 99, 107, 46, 112, 101, 114, 95, 102, 105, 101, 108, 100, 147, 0, 0, 0, 0,
+            0, 0, 0, 25, 105, 110, 115, 116, 114, 46, 117, 110, 112, 97, 99, 107, 95, 103, 101, 110,
+            101, 114, 105, 99, 46, 98, 97, 115, 101, 40, 3, 0, 0, 0, 0, 0, 0, 30, 105, 110,
+            115, 116, 114, 46, 117, 110, 112, 97, 99, 107, 95, 103, 101, 110, 101, 114, 105, 99, 46, 112,
+            101, 114, 95, 102, 105, 101, 108, 100, 147, 0, 0, 0, 0, 0, 0, 0, 19, 105, 110, 115,
+            116, 114, 46, 114, 101, 97, 100, 95, 114, 101, 102, 46, 98, 97, 115, 101, 223, 2, 0, 0,
+            0, 0, 0, 0, 31, 105, 110, 115, 116, 114, 46, 114, 101, 97, 100, 95, 114, 101, 102, 46,
+            112, 101, 114, 95, 97, 98, 115, 95, 118, 97, 108, 95, 117, 110, 105, 116, 14, 0, 0, 0,
+            0, 0, 0, 0, 20, 105, 110, 115, 116, 114, 46, 119, 114, 105, 116, 101, 95, 114, 101, 102,
+            46, 98, 97, 115, 101, 223, 2, 0, 0, 0, 0, 0, 0, 16, 105, 110, 115, 116, 114, 46,
+            102, 114, 101, 101, 122, 101, 95, 114, 101, 102, 36, 0, 0, 0, 0, 0, 0, 0, 13, 105,
+            110, 115, 116, 114, 46, 99, 97, 115, 116, 95, 117, 56, 185, 1, 0, 0, 0, 0, 0, 0,
+            14, 105, 110, 115, 116, 114, 46, 99, 97, 115, 116, 95, 117, 49, 54, 185, 1, 0, 0, 0,
+            0, 0, 0, 14, 105, 110, 115, 116, 114, 46, 99, 97, 115, 116, 95, 117, 51, 50, 185, 1,
+            0, 0, 0, 0, 0, 0, 14, 105, 110, 115, 116, 114, 46, 99, 97, 115, 116, 95, 117, 54,
+            52, 185, 1, 0, 0, 0, 0, 0, 0, 15, 105, 110, 115, 116, 114, 46, 99, 97, 115, 116,
+            95, 117, 49, 50, 56, 185, 1, 0, 0, 0, 0, 0, 0, 15, 105, 110, 115, 116, 114, 46,
+            99, 97, 115, 116, 95, 117, 50, 53, 54, 185, 1, 0, 0, 0, 0, 0, 0, 9, 105, 110,
+            115, 116, 114, 46, 97, 100, 100, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116,
+            114, 46, 115, 117, 98, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46,
+            109, 117, 108, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46, 109, 111,
+            100, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46, 100, 105, 118, 76,
+            2, 0, 0, 0, 0, 0, 0, 12, 105, 110, 115, 116, 114, 46, 98, 105, 116, 95, 111, 114,
+            76, 2, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114, 46, 98, 105, 116, 95, 97,
+            110, 100, 76, 2, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114, 46, 98, 105, 116,
+            95, 120, 111, 114, 76, 2, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114, 46, 98,
+            105, 116, 95, 115, 104, 108, 76, 2, 0, 0, 0, 0, 0, 0, 13, 105, 110, 115, 116, 114,
+            46, 98, 105, 116, 95, 115, 104, 114, 76, 2, 0, 0, 0, 0, 0, 0, 8, 105, 110, 115,
+            116, 114, 46, 111, 114, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46,
+            97, 110, 100, 76, 2, 0, 0, 0, 0, 0, 0, 9, 105, 110, 115, 116, 114, 46, 110, 111,
+            116, 76, 2, 0, 0, 0, 0, 0, 0, 8, 105, 110, 115, 116, 114, 46, 108, 116, 76, 2,
+            0, 0, 0, 0, 0, 0, 8, 105, 110, 115, 116, 114, 46, 103, 116, 76, 2, 0, 0, 0,
+            0, 0, 0, 8, 105, 110, 115, 116, 114, 46, 108, 101, 76, 2, 0, 0, 0, 0, 0, 0,
+            8, 105, 110, 115, 116, 114, 46, 103, 101, 76, 2, 0, 0, 0, 0, 0, 0, 13, 105, 110,
+            115, 116, 114, 46, 101, 113, 46, 98, 97, 115, 101, 111, 1, 0, 0, 0, 0, 0, 0, 25,
+            105, 110, 115, 116, 114, 46, 101, 113, 46, 112, 101, 114, 95, 97, 98, 115, 95, 118, 97, 108,
+            95, 117, 110, 105, 116, 14, 0, 0, 0, 0, 0, 0, 0, 14, 105, 110, 115, 116, 114, 46,
+            110, 101, 113, 46, 98, 97, 115, 101, 111, 1, 0, 0, 0, 0, 0, 0, 26, 105, 110, 115,
+            116, 114, 46, 110, 101, 113, 46, 112, 101, 114, 95, 97, 98, 115, 95, 118, 97, 108, 95, 117,
+            110, 105, 116, 14, 0, 0, 0, 0, 0, 0, 0, 28, 105, 110, 115, 116, 114, 46, 105, 109,
+            109, 95, 98, 111, 114, 114, 111, 119, 95, 103, 108, 111, 98, 97, 108, 46, 98, 97, 115, 101,
+            46, 7, 0, 0, 0, 0, 0, 0, 36, 105, 110, 115, 116, 114, 46, 105, 109, 109, 95, 98,
+            111, 114, 114, 111, 119, 95, 103, 108, 111, 98, 97, 108, 95, 103, 101, 110, 101, 114, 105, 99,
+            46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 28, 105, 110, 115, 116, 114, 46,
+            109, 117, 116, 95, 98, 111, 114, 114, 111, 119, 95, 103, 108, 111, 98, 97, 108, 46, 98, 97,
+            115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 36, 105, 110, 115, 116, 114, 46, 109, 117, 116,
+            95, 98, 111, 114, 114, 111, 119, 95, 103, 108, 111, 98, 97, 108, 95, 103, 101, 110, 101, 114,
+            105, 99, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 17, 105, 110, 115, 116,
+            114, 46, 101, 120, 105, 115, 116, 115, 46, 98, 97, 115, 101, 151, 3, 0, 0, 0, 0, 0,
+            0, 25, 105, 110, 115, 116, 114, 46, 101, 120, 105, 115, 116, 115, 95, 103, 101, 110, 101, 114,
+            105, 99, 46, 98, 97, 115, 101, 151, 3, 0, 0, 0, 0, 0, 0, 20, 105, 110, 115, 116,
+            114, 46, 109, 111, 118, 101, 95, 102, 114, 111, 109, 46, 98, 97, 115, 101, 6, 5, 0, 0,
+            0, 0, 0, 0, 28, 105, 110, 115, 116, 114, 46, 109, 111, 118, 101, 95, 102, 114, 111, 109,
+            95, 103, 101, 110, 101, 114, 105, 99, 46, 98, 97, 115, 101, 6, 5, 0, 0, 0, 0, 0,
+            0, 18, 105, 110, 115, 116, 114, 46, 109, 111, 118, 101, 95, 116, 111, 46, 98, 97, 115, 101,
+            46, 7, 0, 0, 0, 0, 0, 0, 26, 105, 110, 115, 116, 114, 46, 109, 111, 118, 101, 95,
+            116, 111, 95, 103, 101, 110, 101, 114, 105, 99, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0,
+            0, 0, 0, 18, 105, 110, 115, 116, 114, 46, 118, 101, 99, 95, 108, 101, 110, 46, 98, 97,
+            115, 101, 40, 3, 0, 0, 0, 0, 0, 0, 25, 105, 110, 115, 116, 114, 46, 118, 101, 99,
+            95, 105, 109, 109, 95, 98, 111, 114, 114, 111, 119, 46, 98, 97, 115, 101, 189, 4, 0, 0,
+            0, 0, 0, 0, 25, 105, 110, 115, 116, 114, 46, 118, 101, 99, 95, 109, 117, 116, 95, 98,
+            111, 114, 114, 111, 119, 46, 98, 97, 115, 101, 189, 4, 0, 0, 0, 0, 0, 0, 24, 105,
+            110, 115, 116, 114, 46, 118, 101, 99, 95, 112, 117, 115, 104, 95, 98, 97, 99, 107, 46, 98,
+            97, 115, 101, 116, 5, 0, 0, 0, 0, 0, 0, 23, 105, 110, 115, 116, 114, 46, 118, 101,
+            99, 95, 112, 111, 112, 95, 98, 97, 99, 107, 46, 98, 97, 115, 101, 187, 3, 0, 0, 0,
+            0, 0, 0, 19, 105, 110, 115, 116, 114, 46, 118, 101, 99, 95, 115, 119, 97, 112, 46, 98,
+            97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 19, 105, 110, 115, 116, 114, 46, 118, 101,
+            99, 95, 112, 97, 99, 107, 46, 98, 97, 115, 101, 157, 8, 0, 0, 0, 0, 0, 0, 23,
+            105, 110, 115, 116, 114, 46, 118, 101, 99, 95, 112, 97, 99, 107, 46, 112, 101, 114, 95, 101,
+            108, 101, 109, 147, 0, 0, 0, 0, 0, 0, 0, 21, 105, 110, 115, 116, 114, 46, 118, 101,
+            99, 95, 117, 110, 112, 97, 99, 107, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0,
+            0, 34, 105, 110, 115, 116, 114, 46, 118, 101, 99, 95, 117, 110, 112, 97, 99, 107, 46, 112,
+            101, 114, 95, 101, 120, 112, 101, 99, 116, 101, 100, 95, 101, 108, 101, 109, 147, 0, 0, 0,
+            0, 0, 0, 0, 23, 105, 110, 115, 116, 114, 46, 115, 117, 98, 115, 116, 95, 116, 121, 95,
+            112, 101, 114, 95, 110, 111, 100, 101, 144, 1, 0, 0, 0, 0, 0, 0, 29, 116, 120, 110,
+            46, 109, 105, 110, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 103, 97, 115,
+            95, 117, 110, 105, 116, 115, 64, 29, 42, 0, 0, 0, 0, 0, 28, 116, 120, 110, 46, 108,
+            97, 114, 103, 101, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 99, 117, 116,
+            111, 102, 102, 88, 2, 0, 0, 0, 0, 0, 0, 26, 116, 120, 110, 46, 105, 110, 116, 114,
+            105, 110, 115, 105, 99, 95, 103, 97, 115, 95, 112, 101, 114, 95, 98, 121, 116, 101, 134, 4,
+            0, 0, 0, 0, 0, 0, 31, 116, 120, 110, 46, 109, 97, 120, 105, 109, 117, 109, 95, 110,
+            117, 109, 98, 101, 114, 95, 111, 102, 95, 103, 97, 115, 95, 117, 110, 105, 116, 115, 128, 132,
+            30, 0, 0, 0, 0, 0, 26, 116, 120, 110, 46, 109, 105, 110, 95, 112, 114, 105, 99, 101,
+            95, 112, 101, 114, 95, 103, 97, 115, 95, 117, 110, 105, 116, 100, 0, 0, 0, 0, 0, 0,
+            0, 26, 116, 120, 110, 46, 109, 97, 120, 95, 112, 114, 105, 99, 101, 95, 112, 101, 114, 95,
+            103, 97, 115, 95, 117, 110, 105, 116, 0, 228, 11, 84, 2, 0, 0, 0, 33, 116, 120, 110,
+            46, 109, 97, 120, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 115, 105, 122,
+            101, 95, 105, 110, 95, 98, 121, 116, 101, 115, 0, 0, 160, 0, 0, 0, 0, 0, 27, 116,
+            120, 110, 46, 103, 97, 115, 95, 117, 110, 105, 116, 95, 115, 99, 97, 108, 105, 110, 103, 95,
+            102, 97, 99, 116, 111, 114, 64, 66, 15, 0, 0, 0, 0, 0, 34, 116, 120, 110, 46, 115,
+            116, 111, 114, 97, 103, 101, 95, 105, 111, 95, 112, 101, 114, 95, 115, 116, 97, 116, 101, 95,
+            115, 108, 111, 116, 95, 114, 101, 97, 100, 49, 157, 4, 0, 0, 0, 0, 0, 34, 116, 120,
+            110, 46, 115, 116, 111, 114, 97, 103, 101, 95, 105, 111, 95, 112, 101, 114, 95, 115, 116, 97,
+            116, 101, 95, 98, 121, 116, 101, 95, 114, 101, 97, 100, 151, 0, 0, 0, 0, 0, 0, 0,
+            21, 116, 120, 110, 46, 108, 111, 97, 100, 95, 100, 97, 116, 97, 46, 102, 97, 105, 108, 117,
+            114, 101, 0, 0, 0, 0, 0, 0, 0, 0, 35, 116, 120, 110, 46, 115, 116, 111, 114, 97,
+            103, 101, 95, 105, 111, 95, 112, 101, 114, 95, 115, 116, 97, 116, 101, 95, 115, 108, 111, 116,
+            95, 119, 114, 105, 116, 101, 224, 93, 1, 0, 0, 0, 0, 0, 35, 116, 120, 110, 46, 115,
+            116, 111, 114, 97, 103, 101, 95, 105, 111, 95, 112, 101, 114, 95, 115, 116, 97, 116, 101, 95,
+            98, 121, 116, 101, 95, 119, 114, 105, 116, 101, 89, 0, 0, 0, 0, 0, 0, 0, 16, 116,
+            120, 110, 46, 109, 101, 109, 111, 114, 121, 95, 113, 117, 111, 116, 97, 128, 150, 152, 0, 0,
+            0, 0, 0, 26, 116, 120, 110, 46, 102, 114, 101, 101, 95, 119, 114, 105, 116, 101, 95, 98,
+            121, 116, 101, 115, 95, 113, 117, 111, 116, 97, 0, 4, 0, 0, 0, 0, 0, 0, 33, 116,
+            120, 110, 46, 108, 101, 103, 97, 99, 121, 95, 102, 114, 101, 101, 95, 101, 118, 101, 110, 116,
+            95, 98, 121, 116, 101, 115, 95, 113, 117, 111, 116, 97, 0, 4, 0, 0, 0, 0, 0, 0,
+            26, 116, 120, 110, 46, 109, 97, 120, 95, 98, 121, 116, 101, 115, 95, 112, 101, 114, 95, 119,
+            114, 105, 116, 101, 95, 111, 112, 0, 0, 16, 0, 0, 0, 0, 0, 43, 116, 120, 110, 46,
+            109, 97, 120, 95, 98, 121, 116, 101, 115, 95, 97, 108, 108, 95, 119, 114, 105, 116, 101, 95,
+            111, 112, 115, 95, 112, 101, 114, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 0,
+            0, 160, 0, 0, 0, 0, 0, 23, 116, 120, 110, 46, 109, 97, 120, 95, 98, 121, 116, 101,
+            115, 95, 112, 101, 114, 95, 101, 118, 101, 110, 116, 0, 0, 16, 0, 0, 0, 0, 0, 40,
+            116, 120, 110, 46, 109, 97, 120, 95, 98, 121, 116, 101, 115, 95, 97, 108, 108, 95, 101, 118,
+            101, 110, 116, 115, 95, 112, 101, 114, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110,
+            0, 0, 160, 0, 0, 0, 0, 0, 33, 116, 120, 110, 46, 109, 97, 120, 95, 119, 114, 105,
+            116, 101, 95, 111, 112, 115, 95, 112, 101, 114, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105,
+            111, 110, 0, 32, 0, 0, 0, 0, 0, 0, 44, 116, 120, 110, 46, 108, 101, 103, 97, 99,
+            121, 95, 115, 116, 111, 114, 97, 103, 101, 95, 102, 101, 101, 95, 112, 101, 114, 95, 115, 116,
+            97, 116, 101, 95, 115, 108, 111, 116, 95, 99, 114, 101, 97, 116, 101, 80, 195, 0, 0, 0,
+            0, 0, 0, 30, 116, 120, 110, 46, 115, 116, 111, 114, 97, 103, 101, 95, 102, 101, 101, 95,
+            112, 101, 114, 95, 115, 116, 97, 116, 101, 95, 115, 108, 111, 116, 64, 156, 0, 0, 0, 0,
+            0, 0, 44, 116, 120, 110, 46, 108, 101, 103, 97, 99, 121, 95, 115, 116, 111, 114, 97, 103,
+            101, 95, 102, 101, 101, 95, 112, 101, 114, 95, 101, 120, 99, 101, 115, 115, 95, 115, 116, 97,
+            116, 101, 95, 98, 121, 116, 101, 50, 0, 0, 0, 0, 0, 0, 0, 30, 116, 120, 110, 46,
+            115, 116, 111, 114, 97, 103, 101, 95, 102, 101, 101, 95, 112, 101, 114, 95, 115, 116, 97, 116,
+            101, 95, 98, 121, 116, 101, 40, 0, 0, 0, 0, 0, 0, 0, 37, 116, 120, 110, 46, 108,
+            101, 103, 97, 99, 121, 95, 115, 116, 111, 114, 97, 103, 101, 95, 102, 101, 101, 95, 112, 101,
+            114, 95, 101, 118, 101, 110, 116, 95, 98, 121, 116, 101, 20, 0, 0, 0, 0, 0, 0, 0,
+            43, 116, 120, 110, 46, 108, 101, 103, 97, 99, 121, 95, 115, 116, 111, 114, 97, 103, 101, 95,
+            102, 101, 101, 95, 112, 101, 114, 95, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95,
+            98, 121, 116, 101, 20, 0, 0, 0, 0, 0, 0, 0, 21, 116, 120, 110, 46, 109, 97, 120,
+            95, 101, 120, 101, 99, 117, 116, 105, 111, 110, 95, 103, 97, 115, 254, 227, 11, 84, 2, 0,
+            0, 0, 14, 116, 120, 110, 46, 109, 97, 120, 95, 105, 111, 95, 103, 97, 115, 0, 202, 154,
+            59, 0, 0, 0, 0, 19, 116, 120, 110, 46, 109, 97, 120, 95, 115, 116, 111, 114, 97, 103,
+            101, 95, 102, 101, 101, 0, 194, 235, 11, 0, 0, 0, 0, 15, 109, 105, 115, 99, 46, 97,
+            98, 115, 95, 118, 97, 108, 46, 117, 56, 40, 0, 0, 0, 0, 0, 0, 0, 16, 109, 105,
+            115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 117, 49, 54, 40, 0, 0, 0, 0, 0,
+            0, 0, 16, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 117, 51, 50, 40,
+            0, 0, 0, 0, 0, 0, 0, 16, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108,
+            46, 117, 54, 52, 40, 0, 0, 0, 0, 0, 0, 0, 17, 109, 105, 115, 99, 46, 97, 98,
+            115, 95, 118, 97, 108, 46, 117, 49, 50, 56, 40, 0, 0, 0, 0, 0, 0, 0, 17, 109,
+            105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 117, 50, 53, 54, 40, 0, 0, 0,
+            0, 0, 0, 0, 17, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 98, 111,
+            111, 108, 40, 0, 0, 0, 0, 0, 0, 0, 20, 109, 105, 115, 99, 46, 97, 98, 115, 95,
+            118, 97, 108, 46, 97, 100, 100, 114, 101, 115, 115, 40, 0, 0, 0, 0, 0, 0, 0, 19,
+            109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 115, 116, 114, 117, 99, 116, 40,
+            0, 0, 0, 0, 0, 0, 0, 19, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108,
+            46, 118, 101, 99, 116, 111, 114, 40, 0, 0, 0, 0, 0, 0, 0, 22, 109, 105, 115, 99,
+            46, 97, 98, 115, 95, 118, 97, 108, 46, 114, 101, 102, 101, 114, 101, 110, 99, 101, 40, 0,
+            0, 0, 0, 0, 0, 0, 26, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46,
+            112, 101, 114, 95, 117, 56, 95, 112, 97, 99, 107, 101, 100, 1, 0, 0, 0, 0, 0, 0,
+            0, 27, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 112, 101, 114, 95, 117,
+            49, 54, 95, 112, 97, 99, 107, 101, 100, 2, 0, 0, 0, 0, 0, 0, 0, 27, 109, 105,
+            115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 112, 101, 114, 95, 117, 51, 50, 95, 112,
+            97, 99, 107, 101, 100, 4, 0, 0, 0, 0, 0, 0, 0, 27, 109, 105, 115, 99, 46, 97,
+            98, 115, 95, 118, 97, 108, 46, 112, 101, 114, 95, 117, 54, 52, 95, 112, 97, 99, 107, 101,
+            100, 8, 0, 0, 0, 0, 0, 0, 0, 28, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118,
+            97, 108, 46, 112, 101, 114, 95, 117, 49, 50, 56, 95, 112, 97, 99, 107, 101, 100, 16, 0,
+            0, 0, 0, 0, 0, 0, 28, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46,
+            112, 101, 114, 95, 117, 50, 53, 54, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0,
+            0, 0, 0, 28, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 112, 101, 114,
+            95, 98, 111, 111, 108, 95, 112, 97, 99, 107, 101, 100, 1, 0, 0, 0, 0, 0, 0, 0,
+            31, 109, 105, 115, 99, 46, 97, 98, 115, 95, 118, 97, 108, 46, 112, 101, 114, 95, 97, 100,
+            100, 114, 101, 115, 115, 95, 112, 97, 99, 107, 101, 100, 32, 0, 0, 0, 0, 0, 0, 0,
+            44, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98, 46, 98, 99, 115, 46, 116, 111, 95,
+            98, 121, 116, 101, 115, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 115, 101, 114, 105, 97,
+            108, 105, 122, 101, 100, 36, 0, 0, 0, 0, 0, 0, 0, 32, 109, 111, 118, 101, 95, 115,
+            116, 100, 108, 105, 98, 46, 98, 99, 115, 46, 116, 111, 95, 98, 121, 116, 101, 115, 46, 102,
+            97, 105, 108, 117, 114, 101, 92, 14, 0, 0, 0, 0, 0, 0, 30, 109, 111, 118, 101, 95,
+            115, 116, 100, 108, 105, 98, 46, 104, 97, 115, 104, 46, 115, 104, 97, 50, 95, 50, 53, 54,
+            46, 98, 97, 115, 101, 20, 43, 0, 0, 0, 0, 0, 0, 34, 109, 111, 118, 101, 95, 115,
+            116, 100, 108, 105, 98, 46, 104, 97, 115, 104, 46, 115, 104, 97, 50, 95, 50, 53, 54, 46,
+            112, 101, 114, 95, 98, 121, 116, 101, 183, 0, 0, 0, 0, 0, 0, 0, 30, 109, 111, 118,
+            101, 95, 115, 116, 100, 108, 105, 98, 46, 104, 97, 115, 104, 46, 115, 104, 97, 51, 95, 50,
+            53, 54, 46, 98, 97, 115, 101, 112, 57, 0, 0, 0, 0, 0, 0, 34, 109, 111, 118, 101,
+            95, 115, 116, 100, 108, 105, 98, 46, 104, 97, 115, 104, 46, 115, 104, 97, 51, 95, 50, 53,
+            54, 46, 112, 101, 114, 95, 98, 121, 116, 101, 165, 0, 0, 0, 0, 0, 0, 0, 38, 109,
+            111, 118, 101, 95, 115, 116, 100, 108, 105, 98, 46, 115, 105, 103, 110, 101, 114, 46, 98, 111,
+            114, 114, 111, 119, 95, 97, 100, 100, 114, 101, 115, 115, 46, 98, 97, 115, 101, 223, 2, 0,
+            0, 0, 0, 0, 0, 34, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98, 46, 115, 116,
+            114, 105, 110, 103, 46, 99, 104, 101, 99, 107, 95, 117, 116, 102, 56, 46, 98, 97, 115, 101,
+            78, 4, 0, 0, 0, 0, 0, 0, 38, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98,
+            46, 115, 116, 114, 105, 110, 103, 46, 99, 104, 101, 99, 107, 95, 117, 116, 102, 56, 46, 112,
+            101, 114, 95, 98, 121, 116, 101, 29, 0, 0, 0, 0, 0, 0, 0, 40, 109, 111, 118, 101,
+            95, 115, 116, 100, 108, 105, 98, 46, 115, 116, 114, 105, 110, 103, 46, 105, 115, 95, 99, 104,
+            97, 114, 95, 98, 111, 117, 110, 100, 97, 114, 121, 46, 98, 97, 115, 101, 78, 4, 0, 0,
+            0, 0, 0, 0, 34, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98, 46, 115, 116, 114,
+            105, 110, 103, 46, 115, 117, 98, 95, 115, 116, 114, 105, 110, 103, 46, 98, 97, 115, 101, 190,
+            5, 0, 0, 0, 0, 0, 0, 38, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98, 46,
+            115, 116, 114, 105, 110, 103, 46, 115, 117, 98, 95, 115, 116, 114, 105, 110, 103, 46, 112, 101,
+            114, 95, 98, 121, 116, 101, 11, 0, 0, 0, 0, 0, 0, 0, 32, 109, 111, 118, 101, 95,
+            115, 116, 100, 108, 105, 98, 46, 115, 116, 114, 105, 110, 103, 46, 105, 110, 100, 101, 120, 95,
+            111, 102, 46, 98, 97, 115, 101, 190, 5, 0, 0, 0, 0, 0, 0, 44, 109, 111, 118, 101,
+            95, 115, 116, 100, 108, 105, 98, 46, 115, 116, 114, 105, 110, 103, 46, 105, 110, 100, 101, 120,
+            95, 111, 102, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 112, 97, 116, 116, 101, 114, 110,
+            73, 0, 0, 0, 0, 0, 0, 0, 45, 109, 111, 118, 101, 95, 115, 116, 100, 108, 105, 98,
+            46, 115, 116, 114, 105, 110, 103, 46, 105, 110, 100, 101, 120, 95, 111, 102, 46, 112, 101, 114,
+            95, 98, 121, 116, 101, 95, 115, 101, 97, 114, 99, 104, 101, 100, 36, 0, 0, 0, 0, 0,
+            0, 0, 22, 116, 97, 98, 108, 101, 46, 99, 111, 109, 109, 111, 110, 46, 108, 111, 97, 100,
+            46, 98, 97, 115, 101, 49, 157, 4, 0, 0, 0, 0, 0, 26, 116, 97, 98, 108, 101, 46,
+            99, 111, 109, 109, 111, 110, 46, 108, 111, 97, 100, 46, 98, 97, 115, 101, 95, 110, 101, 119,
+            49, 157, 4, 0, 0, 0, 0, 0, 26, 116, 97, 98, 108, 101, 46, 99, 111, 109, 109, 111,
+            110, 46, 108, 111, 97, 100, 46, 112, 101, 114, 95, 98, 121, 116, 101, 151, 0, 0, 0, 0,
+            0, 0, 0, 25, 116, 97, 98, 108, 101, 46, 99, 111, 109, 109, 111, 110, 46, 108, 111, 97,
+            100, 46, 102, 97, 105, 108, 117, 114, 101, 0, 0, 0, 0, 0, 0, 0, 0, 27, 116, 97,
+            98, 108, 101, 46, 110, 101, 119, 95, 116, 97, 98, 108, 101, 95, 104, 97, 110, 100, 108, 101,
+            46, 98, 97, 115, 101, 92, 14, 0, 0, 0, 0, 0, 0, 18, 116, 97, 98, 108, 101, 46,
+            97, 100, 100, 95, 98, 111, 120, 46, 98, 97, 115, 101, 59, 17, 0, 0, 0, 0, 0, 0,
+            33, 116, 97, 98, 108, 101, 46, 97, 100, 100, 95, 98, 111, 120, 46, 112, 101, 114, 95, 98,
+            121, 116, 101, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 100, 36, 0, 0, 0, 0, 0,
+            0, 0, 21, 116, 97, 98, 108, 101, 46, 98, 111, 114, 114, 111, 119, 95, 98, 111, 120, 46,
+            98, 97, 115, 101, 59, 17, 0, 0, 0, 0, 0, 0, 36, 116, 97, 98, 108, 101, 46, 98,
+            111, 114, 114, 111, 119, 95, 98, 111, 120, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 115,
+            101, 114, 105, 97, 108, 105, 122, 101, 100, 36, 0, 0, 0, 0, 0, 0, 0, 23, 116, 97,
+            98, 108, 101, 46, 99, 111, 110, 116, 97, 105, 110, 115, 95, 98, 111, 120, 46, 98, 97, 115,
+            101, 59, 17, 0, 0, 0, 0, 0, 0, 38, 116, 97, 98, 108, 101, 46, 99, 111, 110, 116,
+            97, 105, 110, 115, 95, 98, 111, 120, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 115, 101,
+            114, 105, 97, 108, 105, 122, 101, 100, 36, 0, 0, 0, 0, 0, 0, 0, 21, 116, 97, 98,
+            108, 101, 46, 114, 101, 109, 111, 118, 101, 95, 98, 111, 120, 46, 98, 97, 115, 101, 59, 17,
+            0, 0, 0, 0, 0, 0, 36, 116, 97, 98, 108, 101, 46, 114, 101, 109, 111, 118, 101, 95,
+            98, 111, 120, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 115, 101, 114, 105, 97, 108, 105,
+            122, 101, 100, 36, 0, 0, 0, 0, 0, 0, 0, 28, 116, 97, 98, 108, 101, 46, 100, 101,
+            115, 116, 114, 111, 121, 95, 101, 109, 112, 116, 121, 95, 98, 111, 120, 46, 98, 97, 115, 101,
+            59, 17, 0, 0, 0, 0, 0, 0, 29, 116, 97, 98, 108, 101, 46, 100, 114, 111, 112, 95,
+            117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 98, 111, 120, 46, 98, 97, 115, 101, 111, 1,
+            0, 0, 0, 0, 0, 0, 43, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 99, 99, 111, 117, 110, 116, 46, 99, 114, 101, 97, 116, 101, 95, 97, 100,
+            100, 114, 101, 115, 115, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 42, 97,
+            112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 99, 99, 111, 117,
+            110, 116, 46, 99, 114, 101, 97, 116, 101, 95, 115, 105, 103, 110, 101, 114, 46, 98, 97, 115,
+            101, 78, 4, 0, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110,
+            50, 53, 52, 95, 102, 113, 49, 50, 95, 97, 100, 100, 41, 3, 0, 0, 0, 0, 0, 0,
+            44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95,
+            99, 108, 111, 110, 101, 39, 3, 0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95, 100, 101, 115, 101, 114, 169, 92,
+            0, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 102, 113, 49, 50, 95, 100, 105, 118, 20, 228, 7, 0, 0, 0, 0, 0, 41, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95, 101, 113, 183,
+            8, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53,
+            52, 95, 102, 113, 49, 50, 95, 102, 114, 111, 109, 95, 117, 54, 52, 98, 10, 0, 0, 0,
+            0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113,
+            49, 50, 95, 105, 110, 118, 219, 20, 6, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95, 109, 117, 108, 79, 206, 1,
+            0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95,
+            102, 113, 49, 50, 95, 110, 101, 103, 142, 9, 0, 0, 0, 0, 0, 0, 42, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95, 111, 110, 101, 38,
+            0, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53,
+            52, 95, 102, 113, 49, 50, 95, 112, 111, 119, 95, 117, 50, 53, 54, 226, 235, 28, 2, 0,
+            0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113,
+            49, 50, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 62, 84, 0, 0, 0, 0, 0, 0,
+            45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95,
+            115, 113, 117, 97, 114, 101, 177, 80, 1, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 49, 50, 95, 115, 117, 98, 229, 21, 0,
+            0, 0, 0, 0, 0, 43, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95,
+            102, 113, 49, 50, 95, 122, 101, 114, 111, 38, 0, 0, 0, 0, 0, 0, 0, 40, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 97, 100, 100, 35, 3,
+            0, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 102, 113, 95, 99, 108, 111, 110, 101, 24, 3, 0, 0, 0, 0, 0, 0, 42, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 100, 101, 115, 101, 114,
+            160, 12, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50,
+            53, 52, 95, 102, 113, 95, 100, 105, 118, 223, 50, 3, 0, 0, 0, 0, 0, 39, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 101, 113, 35, 3, 0,
+            0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95,
+            102, 113, 95, 102, 114, 111, 109, 95, 117, 54, 52, 38, 10, 0, 0, 0, 0, 0, 0, 40,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101,
+            98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 105, 110, 118,
+            6, 48, 3, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50,
+            53, 52, 95, 102, 113, 95, 109, 117, 108, 55, 7, 0, 0, 0, 0, 0, 0, 40, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 110, 101, 103, 24, 3,
+            0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 102, 113, 95, 111, 110, 101, 38, 0, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 112, 111, 119, 95, 117, 50, 53,
+            54, 106, 214, 5, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110,
+            50, 53, 52, 95, 102, 113, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 159, 18, 0, 0,
+            0, 0, 0, 0, 43, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102,
+            113, 95, 115, 113, 117, 97, 114, 101, 24, 3, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 113, 95, 115, 117, 98, 106, 4, 0,
+            0, 0, 0, 0, 0, 41, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95,
+            102, 113, 95, 122, 101, 114, 111, 38, 0, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 97, 100, 100, 36, 3, 0, 0,
+            0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102,
+            114, 95, 100, 101, 115, 101, 114, 1, 12, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 100, 105, 118, 113, 106, 3, 0,
+            0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102,
+            114, 95, 101, 113, 39, 3, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 102, 114, 111, 109, 95, 117, 54, 52, 174, 9,
+            0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 102, 114, 95, 105, 110, 118, 8, 100, 3, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 109, 117, 108, 21, 7, 0, 0,
+            0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102,
+            114, 95, 110, 101, 103, 24, 3, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 111, 110, 101, 0, 0, 0, 0, 0, 0,
+            0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97,
+            108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95,
+            115, 101, 114, 105, 97, 108, 105, 122, 101, 124, 18, 0, 0, 0, 0, 0, 0, 43, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 115, 113, 117, 97, 114,
+            101, 24, 3, 0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110,
+            50, 53, 52, 95, 102, 114, 95, 115, 117, 98, 114, 7, 0, 0, 0, 0, 0, 0, 41, 97,
+            112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98,
+            114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 102, 114, 95, 122, 101, 114, 111,
+            38, 0, 0, 0, 0, 0, 0, 0, 54, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50,
+            53, 52, 95, 103, 49, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 99,
+            111, 109, 112, 89, 230, 65, 0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95,
+            98, 110, 50, 53, 52, 95, 103, 49, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101, 115, 101,
+            114, 95, 117, 110, 99, 111, 109, 112, 240, 96, 60, 0, 0, 0, 0, 0, 58, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49, 95, 97, 102, 102, 105, 110, 101,
+            95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 95, 99, 111, 109, 112, 65, 32, 0, 0, 0,
+            0, 0, 0, 60, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49,
+            95, 97, 102, 102, 105, 110, 101, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 95, 117, 110,
+            99, 111, 109, 112, 59, 42, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 110, 50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 97, 100, 100, 118, 76,
+            0, 0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 103, 49, 95, 112, 114, 111, 106, 95, 100, 111, 117, 98, 108, 101, 184, 45, 0, 0, 0,
+            0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49,
+            95, 112, 114, 111, 106, 95, 101, 113, 17, 38, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 103,
+            101, 110, 101, 114, 97, 116, 111, 114, 38, 0, 0, 0, 0, 0, 0, 0, 50, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 105,
+            110, 102, 105, 110, 105, 116, 121, 38, 0, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 110, 101,
+            103, 38, 0, 0, 0, 0, 0, 0, 0, 52, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110,
+            50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 115, 99, 97, 108, 97, 114, 95, 109,
+            117, 108, 219, 50, 74, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98,
+            110, 50, 53, 52, 95, 103, 49, 95, 112, 114, 111, 106, 95, 115, 117, 98, 192, 76, 0, 0,
+            0, 0, 0, 0, 51, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103,
+            49, 95, 112, 114, 111, 106, 95, 116, 111, 95, 97, 102, 102, 105, 110, 101, 141, 4, 0, 0,
+            0, 0, 0, 0, 54, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103,
+            50, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 99, 111, 109, 112, 210,
+            229, 189, 0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53,
+            52, 95, 103, 50, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 117, 110,
+            99, 111, 109, 112, 157, 44, 170, 0, 0, 0, 0, 0, 58, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 97, 102, 102, 105, 110, 101, 95, 115, 101, 114,
+            105, 97, 108, 105, 122, 101, 95, 99, 111, 109, 112, 177, 49, 0, 0, 0, 0, 0, 0, 60,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101,
+            98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 97, 102, 102,
+            105, 110, 101, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 95, 117, 110, 99, 111, 109, 112,
+            185, 70, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50,
+            53, 52, 95, 103, 50, 95, 112, 114, 111, 106, 95, 97, 100, 100, 123, 228, 0, 0, 0, 0,
+            0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97,
+            108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 50, 95,
+            112, 114, 111, 106, 95, 100, 111, 117, 98, 108, 101, 17, 114, 0, 0, 0, 0, 0, 0, 44,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101,
+            98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 112, 114, 111,
+            106, 95, 101, 113, 125, 101, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 112, 114, 111, 106, 95, 103, 101, 110, 101, 114,
+            97, 116, 111, 114, 38, 0, 0, 0, 0, 0, 0, 0, 50, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 112, 114, 111, 106, 95, 105, 110, 102, 105, 110,
+            105, 116, 121, 38, 0, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95,
+            98, 110, 50, 53, 52, 95, 103, 50, 95, 112, 114, 111, 106, 95, 110, 101, 103, 38, 0, 0,
+            0, 0, 0, 0, 0, 52, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95,
+            103, 50, 95, 112, 114, 111, 106, 95, 115, 99, 97, 108, 97, 114, 95, 109, 117, 108, 204, 65,
+            214, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 103, 50, 95, 112, 114, 111, 106, 95, 115, 117, 98, 253, 230, 0, 0, 0, 0, 0, 0,
+            51, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 103, 50, 95, 112, 114,
+            111, 106, 95, 116, 111, 95, 97, 102, 102, 105, 110, 101, 212, 130, 3, 0, 0, 0, 0, 0,
+            52, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 109, 117, 108, 116, 105,
+            95, 112, 97, 105, 114, 105, 110, 103, 95, 98, 97, 115, 101, 134, 104, 102, 1, 0, 0, 0,
+            0, 56, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108,
+            103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52, 95, 109, 117, 108, 116,
+            105, 95, 112, 97, 105, 114, 105, 110, 103, 95, 112, 101, 114, 95, 112, 97, 105, 114, 87, 168,
+            189, 0, 0, 0, 0, 0, 41, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 110, 50, 53, 52,
+            95, 112, 97, 105, 114, 105, 110, 103, 205, 32, 76, 2, 0, 0, 0, 0, 46, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95,
+            97, 100, 100, 30, 26, 0, 0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95,
+            98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 99, 108, 111, 110, 101,
+            7, 3, 0, 0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115,
+            49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 100, 101, 115, 101, 114, 137, 160, 0,
+            0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95,
+            51, 56, 49, 95, 102, 113, 49, 50, 95, 100, 105, 118, 132, 17, 14, 0, 0, 0, 0, 0,
+            45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102,
+            113, 49, 50, 95, 101, 113, 108, 10, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 102, 114,
+            111, 109, 95, 117, 54, 52, 240, 12, 0, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 105, 110,
+            118, 98, 63, 11, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108,
+            115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 109, 117, 108, 84, 204, 2, 0,
+            0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51,
+            56, 49, 95, 102, 113, 49, 50, 95, 110, 101, 103, 245, 16, 0, 0, 0, 0, 0, 0, 46,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101,
+            98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113,
+            49, 50, 95, 111, 110, 101, 40, 0, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 112, 111,
+            119, 95, 117, 50, 53, 54, 216, 136, 54, 3, 0, 0, 0, 0, 52, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 115, 101,
+            114, 105, 97, 108, 105, 122, 101, 254, 115, 0, 0, 0, 0, 0, 0, 49, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 115,
+            113, 117, 97, 114, 101, 169, 248, 1, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 115, 117, 98,
+            62, 25, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115,
+            49, 50, 95, 51, 56, 49, 95, 102, 113, 49, 50, 95, 122, 101, 114, 111, 7, 3, 0, 0,
+            0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51,
+            56, 49, 95, 102, 114, 95, 97, 100, 100, 7, 3, 0, 0, 0, 0, 0, 0, 46, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 100,
+            101, 115, 101, 114, 204, 10, 0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 100, 105, 118, 133, 85, 3,
+            0, 0, 0, 0, 0, 43, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95,
+            51, 56, 49, 95, 102, 114, 95, 101, 113, 11, 3, 0, 0, 0, 0, 0, 0, 49, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 102,
+            114, 111, 109, 95, 117, 54, 52, 23, 7, 0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 105, 110, 118,
+            154, 73, 3, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115,
+            49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 109, 117, 108, 53, 7, 0, 0, 0, 0, 0,
+            0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108,
+            103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95,
+            102, 114, 95, 110, 101, 103, 14, 3, 0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97,
+            114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 111, 110, 101, 7,
+            3, 0, 0, 0, 0, 0, 0, 50, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49,
+            50, 95, 51, 56, 49, 95, 102, 114, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 214, 15,
+            0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50,
+            95, 51, 56, 49, 95, 102, 114, 95, 115, 113, 117, 97, 114, 101, 210, 6, 0, 0, 0, 0,
+            0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97,
+            108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49,
+            95, 102, 114, 95, 115, 117, 98, 42, 4, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 102, 114, 95, 122, 101, 114,
+            111, 7, 3, 0, 0, 0, 0, 0, 0, 58, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108,
+            115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101,
+            115, 101, 114, 95, 99, 111, 109, 112, 101, 192, 57, 0, 0, 0, 0, 0, 60, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 97, 102,
+            102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 117, 110, 99, 111, 109, 112, 233, 107, 40,
+            0, 0, 0, 0, 0, 62, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95,
+            51, 56, 49, 95, 103, 49, 95, 97, 102, 102, 105, 110, 101, 95, 115, 101, 114, 105, 97, 108,
+            105, 122, 101, 95, 99, 111, 109, 112, 235, 28, 0, 0, 0, 0, 0, 0, 64, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 97, 102,
+            102, 105, 110, 101, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 95, 117, 110, 99, 111, 109,
+            112, 239, 34, 0, 0, 0, 0, 0, 0, 49, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108,
+            115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 97, 100, 100, 42,
+            155, 0, 0, 0, 0, 0, 0, 52, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49,
+            50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 100, 111, 117, 98, 108, 101,
+            150, 75, 0, 0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115,
+            49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 101, 113, 76, 72, 0,
+            0, 0, 0, 0, 0, 55, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95,
+            51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 103, 101, 110, 101, 114, 97, 116, 111,
+            114, 40, 0, 0, 0, 0, 0, 0, 0, 54, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108,
+            115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 105, 110, 102, 105,
+            110, 105, 116, 121, 40, 0, 0, 0, 0, 0, 0, 0, 49, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107,
+            95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 110,
+            101, 103, 40, 0, 0, 0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98,
+            108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95, 115, 99, 97,
+            108, 97, 114, 95, 109, 117, 108, 47, 140, 141, 0, 0, 0, 0, 0, 49, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111,
+            106, 95, 115, 117, 98, 16, 160, 0, 0, 0, 0, 0, 0, 55, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 49, 95, 112, 114, 111, 106, 95,
+            116, 111, 95, 97, 102, 102, 105, 110, 101, 252, 201, 6, 0, 0, 0, 0, 0, 58, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 97,
+            102, 102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 99, 111, 109, 112, 73, 141, 115, 0,
+            0, 0, 0, 0, 60, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51,
+            56, 49, 95, 103, 50, 95, 97, 102, 102, 105, 110, 101, 95, 100, 101, 115, 101, 114, 95, 117,
+            110, 99, 111, 109, 112, 138, 25, 57, 0, 0, 0, 0, 0, 62, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 97, 102, 102, 105, 110,
+            101, 95, 115, 101, 114, 105, 97, 108, 105, 122, 101, 95, 99, 111, 109, 112, 129, 48, 0, 0,
+            0, 0, 0, 0, 64, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51,
+            56, 49, 95, 103, 50, 95, 97, 102, 102, 105, 110, 101, 95, 115, 101, 114, 105, 97, 108, 105,
+            122, 101, 95, 117, 110, 99, 111, 109, 112, 141, 60, 0, 0, 0, 0, 0, 0, 49, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 112,
+            114, 111, 106, 95, 97, 100, 100, 66, 209, 1, 0, 0, 0, 0, 0, 52, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46,
+            97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 112, 114, 111,
+            106, 95, 100, 111, 117, 98, 108, 101, 20, 213, 0, 0, 0, 0, 0, 0, 48, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97,
+            46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 112, 114,
+            111, 106, 95, 101, 113, 157, 217, 0, 0, 0, 0, 0, 0, 55, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 112, 114, 111, 106, 95,
+            103, 101, 110, 101, 114, 97, 116, 111, 114, 40, 0, 0, 0, 0, 0, 0, 0, 54, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95, 112,
+            114, 111, 106, 95, 105, 110, 102, 105, 110, 105, 116, 121, 40, 0, 0, 0, 0, 0, 0, 0,
+            49, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103,
+            101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103,
+            50, 95, 112, 114, 111, 106, 95, 110, 101, 103, 40, 0, 0, 0, 0, 0, 0, 0, 56, 97,
+            112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98,
+            114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 103, 50, 95,
+            112, 114, 111, 106, 95, 115, 99, 97, 108, 97, 114, 95, 109, 117, 108, 243, 43, 166, 1, 0,
+            0, 0, 0, 49, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56,
+            49, 95, 103, 50, 95, 112, 114, 111, 106, 95, 115, 117, 98, 250, 215, 1, 0, 0, 0, 0,
+            0, 55, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108,
+            103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95,
+            103, 50, 95, 112, 114, 111, 106, 95, 116, 111, 95, 97, 102, 102, 105, 110, 101, 78, 58, 7,
+            0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95,
+            51, 56, 49, 95, 109, 117, 108, 116, 105, 95, 112, 97, 105, 114, 105, 110, 103, 95, 98, 97,
+            115, 101, 249, 190, 248, 1, 0, 0, 0, 0, 60, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 98,
+            108, 115, 49, 50, 95, 51, 56, 49, 95, 109, 117, 108, 116, 105, 95, 112, 97, 105, 114, 105,
+            110, 103, 95, 112, 101, 114, 95, 112, 97, 105, 114, 15, 43, 2, 1, 0, 0, 0, 0, 45,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101,
+            98, 114, 97, 46, 97, 114, 107, 95, 98, 108, 115, 49, 50, 95, 51, 56, 49, 95, 112, 97,
+            105, 114, 105, 110, 103, 104, 245, 63, 3, 0, 0, 0, 0, 63, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114,
+            107, 95, 104, 50, 99, 95, 98, 108, 115, 49, 50, 51, 56, 49, 103, 49, 95, 120, 109, 100,
+            95, 115, 104, 97, 50, 53, 54, 95, 115, 115, 119, 117, 95, 98, 97, 115, 101, 222, 103, 182,
+            0, 0, 0, 0, 0, 71, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 104, 50, 99, 95, 98, 108,
+            115, 49, 50, 51, 56, 49, 103, 49, 95, 120, 109, 100, 95, 115, 104, 97, 50, 53, 54, 95,
+            115, 115, 119, 117, 95, 112, 101, 114, 95, 109, 115, 103, 95, 98, 121, 116, 101, 176, 0, 0,
+            0, 0, 0, 0, 0, 63, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 108, 103, 101, 98, 114, 97, 46, 97, 114, 107, 95, 104, 50, 99, 95, 98, 108,
+            115, 49, 50, 51, 56, 49, 103, 50, 95, 120, 109, 100, 95, 115, 104, 97, 50, 53, 54, 95,
+            115, 115, 119, 117, 95, 98, 97, 115, 101, 19, 232, 123, 1, 0, 0, 0, 0, 71, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 108, 103, 101, 98, 114,
+            97, 46, 97, 114, 107, 95, 104, 50, 99, 95, 98, 108, 115, 49, 50, 51, 56, 49, 103, 50,
+            95, 120, 109, 100, 95, 115, 104, 97, 50, 53, 54, 95, 115, 115, 119, 117, 95, 112, 101, 114,
+            95, 109, 115, 103, 95, 98, 121, 116, 101, 176, 0, 0, 0, 0, 0, 0, 0, 29, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51,
+            56, 49, 46, 98, 97, 115, 101, 39, 2, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51, 56, 49,
+            46, 112, 101, 114, 95, 112, 117, 98, 107, 101, 121, 95, 100, 101, 115, 101, 114, 105, 97, 108,
+            105, 122, 101, 44, 29, 6, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114,
+            95, 112, 117, 98, 107, 101, 121, 95, 97, 103, 103, 114, 101, 103, 97, 116, 101, 79, 60, 0,
+            0, 0, 0, 0, 0, 50, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 112, 117, 98, 107, 101,
+            121, 95, 115, 117, 98, 103, 114, 111, 117, 112, 95, 99, 104, 101, 99, 107, 248, 192, 20, 0,
+            0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 115, 105, 103, 95, 100, 101,
+            115, 101, 114, 105, 97, 108, 105, 122, 101, 200, 115, 12, 0, 0, 0, 0, 0, 42, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51,
+            56, 49, 46, 112, 101, 114, 95, 115, 105, 103, 95, 97, 103, 103, 114, 101, 103, 97, 116, 101,
+            73, 167, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 115, 105,
+            103, 95, 115, 117, 98, 103, 114, 111, 117, 112, 95, 99, 104, 101, 99, 107, 126, 212, 25, 0,
+            0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 115, 105, 103, 95, 118, 101,
+            114, 105, 102, 121, 76, 239, 219, 1, 0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101,
+            114, 95, 112, 111, 112, 95, 118, 101, 114, 105, 102, 121, 144, 189, 65, 2, 0, 0, 0, 0,
+            36, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115,
+            49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 112, 97, 105, 114, 105, 110, 103, 44, 24, 225,
+            0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46, 112, 101, 114, 95, 109, 115, 103, 95, 104,
+            97, 115, 104, 105, 110, 103, 112, 97, 86, 0, 0, 0, 0, 0, 41, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 108, 115, 49, 50, 51, 56, 49, 46,
+            112, 101, 114, 95, 98, 121, 116, 101, 95, 104, 97, 115, 104, 105, 110, 103, 183, 0, 0, 0,
+            0, 0, 0, 0, 30, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 115, 105, 103, 110, 97, 116, 117, 114, 101, 46, 98, 97, 115, 101, 39, 2, 0, 0, 0,
+            0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            115, 105, 103, 110, 97, 116, 117, 114, 101, 46, 112, 101, 114, 95, 112, 117, 98, 107, 101, 121,
+            95, 100, 101, 115, 101, 114, 105, 97, 108, 105, 122, 101, 168, 33, 2, 0, 0, 0, 0, 0,
+            54, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 115, 105, 103,
+            110, 97, 116, 117, 114, 101, 46, 112, 101, 114, 95, 112, 117, 98, 107, 101, 121, 95, 115, 109,
+            97, 108, 108, 95, 111, 114, 100, 101, 114, 95, 99, 104, 101, 99, 107, 46, 91, 0, 0, 0,
+            0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            115, 105, 103, 110, 97, 116, 117, 114, 101, 46, 112, 101, 114, 95, 115, 105, 103, 95, 100, 101,
+            115, 101, 114, 105, 97, 108, 105, 122, 101, 98, 5, 0, 0, 0, 0, 0, 0, 47, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 115, 105, 103, 110, 97, 116,
+            117, 114, 101, 46, 112, 101, 114, 95, 115, 105, 103, 95, 115, 116, 114, 105, 99, 116, 95, 118,
+            101, 114, 105, 102, 121, 244, 249, 14, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 115, 105, 103, 110, 97, 116, 117, 114, 101, 46,
+            112, 101, 114, 95, 109, 115, 103, 95, 104, 97, 115, 104, 105, 110, 103, 95, 98, 97, 115, 101,
+            134, 46, 0, 0, 0, 0, 0, 0, 46, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 115, 105, 103, 110, 97, 116, 117, 114, 101, 46, 112, 101, 114, 95, 109,
+            115, 103, 95, 98, 121, 116, 101, 95, 104, 97, 115, 104, 105, 110, 103, 220, 0, 0, 0, 0,
+            0, 0, 0, 30, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            115, 101, 99, 112, 50, 53, 54, 107, 49, 46, 98, 97, 115, 101, 39, 2, 0, 0, 0, 0,
+            0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 115,
+            101, 99, 112, 50, 53, 54, 107, 49, 46, 101, 99, 100, 115, 97, 95, 114, 101, 99, 111, 118,
+            101, 114, 152, 78, 90, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46,
+            98, 97, 115, 101, 112, 111, 105, 110, 116, 95, 109, 117, 108, 0, 46, 7, 0, 0, 0, 0,
+            0, 49, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105,
+            115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 98, 97, 115, 101, 112, 111, 105, 110, 116,
+            95, 100, 111, 117, 98, 108, 101, 95, 109, 117, 108, 32, 174, 24, 0, 0, 0, 0, 0, 38,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116,
+            114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 97, 100, 100, 168, 30,
+            0, 0, 0, 0, 0, 0, 40, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111, 105, 110,
+            116, 95, 99, 108, 111, 110, 101, 39, 2, 0, 0, 0, 0, 0, 0, 43, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116,
+            111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 99, 111, 109, 112, 114, 101, 115, 115, 96,
+            62, 2, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111, 105,
+            110, 116, 95, 100, 101, 99, 111, 109, 112, 114, 101, 115, 115, 142, 69, 2, 0, 0, 0, 0,
+            0, 41, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105,
+            115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 101, 113, 117,
+            97, 108, 115, 6, 33, 0, 0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53,
+            46, 112, 111, 105, 110, 116, 95, 102, 114, 111, 109, 95, 54, 52, 95, 117, 110, 105, 102, 111,
+            114, 109, 95, 98, 121, 116, 101, 115, 74, 146, 4, 0, 0, 0, 0, 0, 43, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 105, 100, 101, 110, 116, 105, 116, 121,
+            39, 2, 0, 0, 0, 0, 0, 0, 38, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111,
+            105, 110, 116, 95, 109, 117, 108, 68, 107, 26, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116,
+            111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 100, 111, 117, 98, 108, 101, 95, 109, 117,
+            108, 83, 136, 28, 0, 0, 0, 0, 0, 38, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112,
+            111, 105, 110, 116, 95, 110, 101, 103, 43, 5, 0, 0, 0, 0, 0, 0, 38, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 115, 117, 98, 149, 30, 0, 0, 0,
+            0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 112, 111, 105, 110, 116, 95, 112,
+            97, 114, 115, 101, 95, 97, 114, 103, 39, 2, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 115, 104, 97, 53, 49, 50, 95,
+            112, 101, 114, 95, 98, 121, 116, 101, 220, 0, 0, 0, 0, 0, 0, 0, 51, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 115, 104, 97, 53, 49, 50, 95,
+            112, 101, 114, 95, 104, 97, 115, 104, 134, 46, 0, 0, 0, 0, 0, 0, 39, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 97, 100, 100, 14, 11, 0, 0,
+            0, 0, 0, 0, 57, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107,
+            46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114,
+            95, 114, 101, 100, 117, 99, 101, 100, 95, 102, 114, 111, 109, 95, 51, 50, 95, 98, 121, 116,
+            101, 115, 49, 10, 0, 0, 0, 0, 0, 0, 57, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46,
+            115, 99, 97, 108, 97, 114, 95, 117, 110, 105, 102, 111, 114, 109, 95, 102, 114, 111, 109, 95,
+            54, 52, 95, 98, 121, 116, 101, 115, 224, 17, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116,
+            116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 102, 114, 111, 109, 95, 117, 49,
+            50, 56, 131, 2, 0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97,
+            109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46,
+            115, 99, 97, 108, 97, 114, 95, 102, 114, 111, 109, 95, 117, 54, 52, 131, 2, 0, 0, 0,
+            0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95,
+            105, 110, 118, 101, 114, 116, 136, 43, 6, 0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111,
+            50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 105, 115, 95, 99, 97, 110, 111, 110, 105,
+            99, 97, 108, 131, 16, 0, 0, 0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53,
+            46, 115, 99, 97, 108, 97, 114, 95, 109, 117, 108, 74, 15, 0, 0, 0, 0, 0, 0, 39,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116,
+            114, 101, 116, 116, 111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 110, 101, 103, 105,
+            10, 0, 0, 0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116, 111, 50, 53, 53, 46, 115, 99, 97,
+            108, 97, 114, 95, 115, 117, 98, 56, 15, 0, 0, 0, 0, 0, 0, 45, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 114, 105, 115, 116, 114, 101, 116, 116,
+            111, 50, 53, 53, 46, 115, 99, 97, 108, 97, 114, 95, 112, 97, 114, 115, 101, 95, 97, 114,
+            103, 39, 2, 0, 0, 0, 0, 0, 0, 34, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 115, 105, 112, 95, 104, 97, 115, 104, 46,
+            98, 97, 115, 101, 92, 14, 0, 0, 0, 0, 0, 0, 38, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 115, 105, 112, 95, 104, 97,
+            115, 104, 46, 112, 101, 114, 95, 98, 121, 116, 101, 73, 0, 0, 0, 0, 0, 0, 0, 35,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 104, 97, 115, 104,
+            46, 107, 101, 99, 99, 97, 107, 50, 53, 54, 46, 98, 97, 115, 101, 112, 57, 0, 0, 0,
+            0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            104, 97, 115, 104, 46, 107, 101, 99, 99, 97, 107, 50, 53, 54, 46, 112, 101, 114, 95, 98,
+            121, 116, 101, 165, 0, 0, 0, 0, 0, 0, 0, 33, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 98, 117, 108, 108, 101, 116, 112, 114, 111, 111, 102, 115,
+            46, 98, 97, 115, 101, 219, 248, 179, 0, 0, 0, 0, 0, 54, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 117, 108, 108, 101, 116, 112, 114, 111, 111,
+            102, 115, 46, 112, 101, 114, 95, 98, 105, 116, 95, 114, 97, 110, 103, 101, 112, 114, 111, 111,
+            102, 95, 118, 101, 114, 105, 102, 121, 221, 82, 15, 0, 0, 0, 0, 0, 60, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 98, 117, 108, 108, 101, 116, 112,
+            114, 111, 111, 102, 115, 46, 112, 101, 114, 95, 98, 121, 116, 101, 95, 114, 97, 110, 103, 101,
+            112, 114, 111, 111, 102, 95, 100, 101, 115, 101, 114, 105, 97, 108, 105, 122, 101, 121, 0, 0,
+            0, 0, 0, 0, 0, 38, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 116, 121, 112, 101, 95, 105, 110, 102, 111, 46, 116, 121, 112, 101, 95, 111, 102, 46,
+            98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 58, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 116, 121, 112, 101, 95, 105, 110, 102, 111, 46, 116,
+            121, 112, 101, 95, 111, 102, 46, 112, 101, 114, 95, 97, 98, 115, 116, 114, 97, 99, 116, 95,
+            109, 101, 109, 111, 114, 121, 95, 117, 110, 105, 116, 18, 0, 0, 0, 0, 0, 0, 0, 40,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 116, 121, 112, 101,
+            95, 105, 110, 102, 111, 46, 116, 121, 112, 101, 95, 110, 97, 109, 101, 46, 98, 97, 115, 101,
+            78, 4, 0, 0, 0, 0, 0, 0, 60, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 116, 121, 112, 101, 95, 105, 110, 102, 111, 46, 116, 121, 112, 101, 95,
+            110, 97, 109, 101, 46, 112, 101, 114, 95, 97, 98, 115, 116, 114, 97, 99, 116, 95, 109, 101,
+            109, 111, 114, 121, 95, 117, 110, 105, 116, 18, 0, 0, 0, 0, 0, 0, 0, 39, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 116, 121, 112, 101, 95, 105,
+            110, 102, 111, 46, 99, 104, 97, 105, 110, 95, 105, 100, 46, 98, 97, 115, 101, 39, 2, 0,
+            0, 0, 0, 0, 0, 34, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 104, 97, 115, 104, 46, 115, 104, 97, 50, 95, 53, 49, 50, 46, 98, 97, 115, 101,
+            134, 46, 0, 0, 0, 0, 0, 0, 38, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101,
+            119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 115, 104, 97, 50, 95, 53, 49, 50, 46, 112,
+            101, 114, 95, 98, 121, 116, 101, 220, 0, 0, 0, 0, 0, 0, 0, 34, 97, 112, 116, 111,
+            115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 115, 104, 97,
+            51, 95, 53, 49, 50, 46, 98, 97, 115, 101, 158, 64, 0, 0, 0, 0, 0, 0, 38, 97,
+            112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46,
+            115, 104, 97, 51, 95, 53, 49, 50, 46, 112, 101, 114, 95, 98, 121, 116, 101, 183, 0, 0,
+            0, 0, 0, 0, 0, 35, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 104, 97, 115, 104, 46, 114, 105, 112, 101, 109, 100, 49, 54, 48, 46, 98, 97, 115,
+            101, 20, 43, 0, 0, 0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 114, 105, 112, 101, 109, 100, 49, 54, 48,
+            46, 112, 101, 114, 95, 98, 121, 116, 101, 183, 0, 0, 0, 0, 0, 0, 0, 37, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 104, 97, 115, 104, 46, 98,
+            108, 97, 107, 101, 50, 98, 95, 50, 53, 54, 46, 98, 97, 115, 101, 33, 25, 0, 0, 0,
+            0, 0, 0, 41, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            104, 97, 115, 104, 46, 98, 108, 97, 107, 101, 50, 98, 95, 50, 53, 54, 46, 112, 101, 114,
+            95, 98, 121, 116, 101, 55, 0, 0, 0, 0, 0, 0, 0, 36, 97, 112, 116, 111, 115, 95,
+            102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 117, 116, 105, 108, 46, 102, 114, 111, 109, 95,
+            98, 121, 116, 101, 115, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 40, 97,
+            112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 117, 116, 105, 108, 46,
+            102, 114, 111, 109, 95, 98, 121, 116, 101, 115, 46, 112, 101, 114, 95, 98, 121, 116, 101, 18,
+            0, 0, 0, 0, 0, 0, 0, 53, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 99, 111, 110, 116,
+            101, 120, 116, 46, 103, 101, 116, 95, 116, 120, 110, 95, 104, 97, 115, 104, 46, 98, 97, 115,
+            101, 223, 2, 0, 0, 0, 0, 0, 0, 56, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 99, 111,
+            110, 116, 101, 120, 116, 46, 103, 101, 116, 95, 115, 99, 114, 105, 112, 116, 95, 104, 97, 115,
+            104, 46, 98, 97, 115, 101, 223, 2, 0, 0, 0, 0, 0, 0, 64, 97, 112, 116, 111, 115,
+            95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105,
+            111, 110, 95, 99, 111, 110, 116, 101, 120, 116, 46, 103, 101, 110, 101, 114, 97, 116, 101, 95,
+            117, 110, 105, 113, 117, 101, 95, 97, 100, 100, 114, 101, 115, 115, 46, 98, 97, 115, 101, 112,
+            57, 0, 0, 0, 0, 0, 0, 41, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 99, 111, 100, 101, 46, 114, 101, 113, 117, 101, 115, 116, 95, 112, 117, 98,
+            108, 105, 115, 104, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 45, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 99, 111, 100, 101, 46, 114,
+            101, 113, 117, 101, 115, 116, 95, 112, 117, 98, 108, 105, 115, 104, 46, 112, 101, 114, 95, 98,
+            121, 116, 101, 7, 0, 0, 0, 0, 0, 0, 0, 47, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 101, 118, 101, 110, 116, 46, 119, 114, 105, 116, 101, 95,
+            116, 111, 95, 101, 118, 101, 110, 116, 95, 115, 116, 111, 114, 101, 46, 98, 97, 115, 101, 38,
+            78, 0, 0, 0, 0, 0, 0, 67, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119,
+            111, 114, 107, 46, 101, 118, 101, 110, 116, 46, 119, 114, 105, 116, 101, 95, 116, 111, 95, 101,
+            118, 101, 110, 116, 95, 115, 116, 111, 114, 101, 46, 112, 101, 114, 95, 97, 98, 115, 116, 114,
+            97, 99, 116, 95, 109, 101, 109, 111, 114, 121, 95, 117, 110, 105, 116, 61, 0, 0, 0, 0,
+            0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            115, 116, 97, 116, 101, 95, 115, 116, 111, 114, 97, 103, 101, 46, 103, 101, 116, 95, 117, 115,
+            97, 103, 101, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 35, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103, 97,
+            116, 111, 114, 46, 97, 100, 100, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0,
+            36, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103,
+            114, 101, 103, 97, 116, 111, 114, 46, 114, 101, 97, 100, 46, 98, 97, 115, 101, 78, 4, 0,
+            0, 0, 0, 0, 0, 35, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 46, 115, 117, 98, 46, 98, 97, 115,
+            101, 78, 4, 0, 0, 0, 0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109,
+            101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 46, 100, 101, 115,
+            116, 114, 111, 121, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0, 54, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103,
+            97, 116, 111, 114, 95, 102, 97, 99, 116, 111, 114, 121, 46, 110, 101, 119, 95, 97, 103, 103,
+            114, 101, 103, 97, 116, 111, 114, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0, 0,
+            52, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103,
+            114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 99, 114, 101, 97, 116, 101, 95, 97, 103,
+            103, 114, 101, 103, 97, 116, 111, 114, 46, 98, 97, 115, 101, 46, 7, 0, 0, 0, 0, 0,
+            0, 42, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103,
+            103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 116, 114, 121, 95, 97, 100, 100, 46,
+            98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 42, 97, 112, 116, 111, 115, 95, 102,
+            114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 95,
+            118, 50, 46, 116, 114, 121, 95, 115, 117, 98, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0,
+            0, 0, 0, 39, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 114, 101, 97, 100, 46, 98,
+            97, 115, 101, 157, 8, 0, 0, 0, 0, 0, 0, 43, 97, 112, 116, 111, 115, 95, 102, 114,
+            97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118,
+            50, 46, 115, 110, 97, 112, 115, 104, 111, 116, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0,
+            0, 0, 0, 50, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 99, 114, 101, 97, 116, 101,
+            95, 115, 110, 97, 112, 115, 104, 111, 116, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0,
+            0, 0, 54, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97,
+            103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 99, 114, 101, 97, 116, 101, 95,
+            115, 110, 97, 112, 115, 104, 111, 116, 46, 112, 101, 114, 95, 98, 121, 116, 101, 3, 0, 0,
+            0, 0, 0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114,
+            107, 46, 97, 103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 99, 111, 112, 121,
+            95, 115, 110, 97, 112, 115, 104, 111, 116, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0,
+            0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97,
+            103, 103, 114, 101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 114, 101, 97, 100, 95, 115, 110,
+            97, 112, 115, 104, 111, 116, 46, 98, 97, 115, 101, 157, 8, 0, 0, 0, 0, 0, 0, 48,
+            97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114,
+            101, 103, 97, 116, 111, 114, 95, 118, 50, 46, 115, 116, 114, 105, 110, 103, 95, 99, 111, 110,
+            99, 97, 116, 46, 98, 97, 115, 101, 78, 4, 0, 0, 0, 0, 0, 0, 52, 97, 112, 116,
+            111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 97, 103, 103, 114, 101, 103, 97,
+            116, 111, 114, 95, 118, 50, 46, 115, 116, 114, 105, 110, 103, 95, 99, 111, 110, 99, 97, 116,
+            46, 112, 101, 114, 95, 98, 121, 116, 101, 3, 0, 0, 0, 0, 0, 0, 0, 37, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 111, 98, 106, 101, 99, 116,
+            46, 101, 120, 105, 115, 116, 115, 95, 97, 116, 46, 98, 97, 115, 101, 151, 3, 0, 0, 0,
+            0, 0, 0, 48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46,
+            111, 98, 106, 101, 99, 116, 46, 101, 120, 105, 115, 116, 115, 95, 97, 116, 46, 112, 101, 114,
+            95, 98, 121, 116, 101, 95, 108, 111, 97, 100, 101, 100, 183, 0, 0, 0, 0, 0, 0, 0,
+            48, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 111, 98, 106,
+            101, 99, 116, 46, 101, 120, 105, 115, 116, 115, 95, 97, 116, 46, 112, 101, 114, 95, 105, 116,
+            101, 109, 95, 108, 111, 97, 100, 101, 100, 190, 5, 0, 0, 0, 0, 0, 0, 40, 97, 112,
+            116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 46, 115, 116, 114, 105, 110, 103,
+            95, 117, 116, 105, 108, 115, 46, 102, 111, 114, 109, 97, 116, 46, 98, 97, 115, 101, 78, 4,
+            0, 0, 0, 0, 0, 0, 44, 97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111,
+            114, 107, 46, 115, 116, 114, 105, 110, 103, 95, 117, 116, 105, 108, 115, 46, 102, 111, 114, 109,
+            97, 116, 46, 112, 101, 114, 95, 98, 121, 116, 101, 3, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        gas_schedule::set_for_next_epoch(framework_signer, gas_schedule_blob);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/release.yaml
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/release.yaml
@@ -1,0 +1,73 @@
+---
+remote_endpoint: ~
+name: example-after-randomness-enabled
+proposals:
+  - name: all_configs
+    metadata:
+      title: ""
+      description: ""
+      source_code_url: ""
+      discussion_url: ""
+    execution_mode: RootSigner
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - bls12381_structures
+          disabled:
+            - bn254_structures
+      - Consensus:
+          V3:
+            alg:
+              Jolteon:
+                main:
+                  decoupled_execution: true
+                  back_pressure_limit: 10
+                  exclude_round: 40
+                  proposer_election_type:
+                    leader_reputation:
+                      proposer_and_voter_v2:
+                        active_weight: 1000
+                        inactive_weight: 10
+                        failed_weight: 1
+                        failure_threshold_percent: 10
+                        proposer_window_num_validators_multiplier: 10
+                        voter_window_num_validators_multiplier: 1
+                        weight_by_voting_power: true
+                        use_history_from_previous_epoch_max_count: 5
+                  max_failed_authors_to_store: 10
+                quorum_store_enabled: true
+            vtxn:
+              V1:
+                per_block_limit_txn_count: 3
+                per_block_limit_total_bytes: 2097152
+      - Execution:
+          V4:
+            transaction_shuffler_type:
+              fairness:
+                sender_conflict_window_size: 256
+                module_conflict_window_size: 2
+                entry_fun_conflict_window_size: 3
+            block_gas_limit_type:
+              complex_limit_v1:
+                effective_block_gas_limit: 80001
+                execution_gas_effective_multiplier: 1
+                io_gas_effective_multiplier: 1
+                conflict_penalty_window: 6
+                use_granular_resource_group_conflicts: false
+                use_module_publishing_block_conflict: true
+                block_output_limit: 12582912
+                include_user_txn_size_in_block_output: true
+                add_block_limit_outcome_onchain: false
+            transaction_deduper_type: txn_hash_and_authenticator_v1
+      - Version:
+          major: 999
+      - OidcProviderOps:
+          - Upsert:
+              issuer: "https://accounts.google.com"
+              config_url: "https://accounts.google.com/.well-known/openid-configuration"
+          - Remove:
+              issuer: "https://www.facebook.com"
+              keep_observed_jwks: true
+      - DefaultGasWithOverride:
+          - name: "txn.max_execution_gas"
+            value: 9999999998

--- a/aptos-move/aptos-release-builder/data/proposals/enable_randomness.move
+++ b/aptos-move/aptos-release-builder/data/proposals/enable_randomness.move
@@ -1,0 +1,21 @@
+// Enable on-chain randomness.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::randomness_config;
+    use aptos_std::fixed_point64;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+
+        let config = randomness_config::new_v1(
+            fixed_point64::create_from_rational(1, 2), // secrecy_threshold: 1/2
+            fixed_point64::create_from_rational(2, 3), // reconstruct_threshold: 2/3
+        );
+        randomness_config::set_for_next_epoch(&framework, config);
+        aptos_governance::reconfigure(&framework); // The resulting epoch does not have randomness. The one after it does.
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/jwk_consensus_config_migration.move
+++ b/aptos-move/aptos-release-builder/data/proposals/jwk_consensus_config_migration.move
@@ -1,0 +1,23 @@
+// Initialize `aptos_framework::jwk_consensus_config::JWKConsensusConfig` with Google.
+// Start to ignore `aptos_framework::jwks::SupportedOIDCProviders`.
+// Start to ignore move feature flag `std::features::JWK_CONSENSUS`.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::jwk_consensus_config;
+    use std::string::utf8;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+        let provider_google = jwk_consensus_config::new_oidc_provider(
+            utf8(b"https://accounts.google.com"),
+            utf8(b"https://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let config = jwk_consensus_config::new_v1(vector[provider_google]);
+        jwk_consensus_config::initialize(&framework, config);
+        aptos_governance::reconfigure(&framework);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/randomness_framework_initialization.move
+++ b/aptos-move/aptos-release-builder/data/proposals/randomness_framework_initialization.move
@@ -1,0 +1,24 @@
+// Initialize on-chain randomness resources.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::config_buffer;
+    use aptos_framework::dkg;
+    use aptos_framework::randomness;
+    use aptos_framework::randomness_config;
+    use aptos_framework::reconfiguration_state;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+        config_buffer::initialize(&framework); // on-chain config buffer
+        dkg::initialize(&framework); // DKG state holder
+        reconfiguration_state::initialize(&framework); // reconfiguration in progress global indicator
+        randomness::initialize(&framework); // randomness seed holder
+
+        let config = randomness_config::new_off();
+        randomness_config::initialize(&framework, config);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
+++ b/aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
@@ -10,10 +10,11 @@ script {
             {{ script_hash }},
         );
 
-        jwks::upsert_oidc_provider(
+        jwks::upsert_oidc_provider_for_next_epoch(
             &framework_signer,
             b"https://accounts.google.com",
             b"https://accounts.google.com/.well-known/openid-configuration"
         );
+        aptos_governance::reconfigure(&framework_signer);
     }
 }

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,16 +1,26 @@
 ---
 remote_endpoint: ~
-name: "v1.10"
+name: "v1.10-plus"
 proposals:
+  - name: step_1_increase_max_txn_gas
+    metadata:
+      title: "Increase max txn gas temporarily for framework upgrade"
+      description: "Increase max txn gas temporarily for framework upgrade"
+    execution_mode: MultiStep
+    update_sequence:
+      - DefaultGasWithOverrideOld: # Use `DefaultGasWithOverrideOld` in 1.11 and change back to `DefaultGasWithOverride` in 1.12+.
+          - name: "txn.max_execution_gas"
+            value: 3676000000
   - name: step_2_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework to v1.10"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.10"
+      title: "Multi-step proposal to upgrade mainnet framework to v1.10-plus"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.10 plus some others in main."
     execution_mode: MultiStep
     update_sequence:
       - Framework:
           bytecode_version: 6
           git_hash: ~
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/randomness_framework_initialization.move # Keep this in 1.11
       - DefaultGas
   - name: step_3_storage_fee_for_state_bytes_refundable
     metadata:
@@ -159,3 +169,17 @@ proposals:
     execution_mode: MultiStep
     update_sequence:
       - RawScript: aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
+  - name: step_14_migrate_jwk_consensus_config
+    metadata:
+      title: "[1.11] Migrate JWK consensus config"
+      description: "Move JWK consensus on-off control and the supported OIDC provider list to its own resource."
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/jwk_consensus_config_migration.move
+  - name: step_15_enable_randomness # Keep this the last step, so any other governance gets the existing "immediate reconfig" experience (if they need a reconfig).
+    metadata:
+      title: "[1.11] Enable randomness"
+      description: "Move JWK consensus on-off control and the supported OIDC provider list to its own resource."
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/enable_randomness.move

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -2,15 +2,6 @@
 remote_endpoint: ~
 name: "v1.10"
 proposals:
-  - name: step_1_increase_max_txn_gas
-    metadata:
-      title: "Increase max txn gas temporarily for framework upgrade"
-      description: "Increase max txn gas temporarily for framework upgrade"
-    execution_mode: MultiStep
-    update_sequence:
-      - DefaultGasWithOverride:
-          - name: "txn.max_execution_gas"
-            value: 3676000000
   - name: step_2_upgrade_framework
     metadata:
       title: "Multi-step proposal to upgrade mainnet framework to v1.10"

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -176,10 +176,26 @@ proposals:
     execution_mode: MultiStep
     update_sequence:
       - RawScript: aptos-move/aptos-release-builder/data/proposals/jwk_consensus_config_migration.move
-  - name: step_15_enable_randomness # Keep this the last step, so any other governance gets the existing "immediate reconfig" experience (if they need a reconfig).
+  - name: step_15_enable_randomness # Keep this the last step, so the above steps use fast reconfig and we save time.
     metadata:
       title: "[probably 1.11] Enable randomness"
       description: "Move JWK consensus on-off control and the supported OIDC provider list to its own resource."
     execution_mode: MultiStep
     update_sequence:
-      - RawScript: aptos-move/aptos-release-builder/data/proposals/enable_randomness.move
+      - Randomness: # Generated script should be like: aptos-move/aptos-release-builder/data/proposals/enable_randomness.move
+          V1:
+            secrecy_threshold_in_percentage: 50
+            reconstruct_threshold_in_percentage: 66
+  - name: step_16_update_oidc_providers_test_only #
+    metadata:
+      title: "test only step"
+      description: "test only step"
+    execution_mode: MultiStep
+    update_sequence:
+      - JwkConsensus:
+          V1:
+            oidc_providers:
+              - name: "https://www.facebook.com"
+                config_url: "https://www.facebook.com/.well-known/openid-configuration"
+              - name: "https://accounts.google.com"
+                config_url: "https://accounts.google.com/.well-known/openid-configuration"

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -8,7 +8,7 @@ proposals:
       description: "Increase max txn gas temporarily for framework upgrade"
     execution_mode: MultiStep
     update_sequence:
-      - DefaultGasWithOverrideOld: # Use `DefaultGasWithOverrideOld` in 1.11 and change back to `DefaultGasWithOverride` in 1.12+.
+      - DefaultGasWithOverrideOld: # This is translated to `gas_schedule::set_gas_schedule(...)`.
           - name: "txn.max_execution_gas"
             value: 3676000000
   - name: step_2_upgrade_framework
@@ -21,7 +21,7 @@ proposals:
           bytecode_version: 6
           git_hash: ~
       - RawScript: aptos-move/aptos-release-builder/data/proposals/randomness_framework_initialization.move # Keep this in 1.11
-      - DefaultGas
+      - DefaultGas  # [probably 1.11] This is translated to `gas_schedule::set_for_next_epoch(...)`.
   - name: step_3_storage_fee_for_state_bytes_refundable
     metadata:
       title: "AIP-65: Storage Fee for State Bytes refundable"
@@ -29,7 +29,7 @@ proposals:
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/328"
     execution_mode: MultiStep
     update_sequence:
-      - FeatureFlag:
+      - FeatureFlag: # This and the following `FeatureFlag` entries are translated to `features::change_feature_flags_for_next_epoch(...)`.
           enabled:
             - refundable_bytes
   - name: step_4_enable_fairness_shuffler
@@ -171,14 +171,14 @@ proposals:
       - RawScript: aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
   - name: step_14_migrate_jwk_consensus_config
     metadata:
-      title: "[1.11] Migrate JWK consensus config"
+      title: "[probably 1.11] Migrate JWK consensus config"
       description: "Move JWK consensus on-off control and the supported OIDC provider list to its own resource."
     execution_mode: MultiStep
     update_sequence:
       - RawScript: aptos-move/aptos-release-builder/data/proposals/jwk_consensus_config_migration.move
   - name: step_15_enable_randomness # Keep this the last step, so any other governance gets the existing "immediate reconfig" experience (if they need a reconfig).
     metadata:
-      title: "[1.11] Enable randomness"
+      title: "[probably 1.11] Enable randomness"
       description: "Move JWK consensus on-off control and the supported OIDC provider list to its own resource."
     execution_mode: MultiStep
     update_sequence:

--- a/aptos-move/aptos-release-builder/src/components/consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/consensus_config.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils::*;
+use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
 use aptos_types::on_chain_config::OnChainConsensusConfig;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
@@ -11,6 +11,7 @@ pub fn generate_consensus_upgrade_proposal(
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
 ) -> Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
 
     let writer = CodeWriter::new(Loc::default());
@@ -32,17 +33,12 @@ pub fn generate_consensus_upgrade_proposal(
             generate_blob(writer, &consensus_config_blob);
             emitln!(writer, ";\n");
 
-            if is_testnet && next_execution_hash.is_empty() {
-                emitln!(
-                    writer,
-                    "consensus_config::set(framework_signer, consensus_blob);"
-                );
-            } else {
-                emitln!(
-                    writer,
-                    "consensus_config::set(&framework_signer, consensus_blob);"
-                );
-            }
+            emitln!(
+                writer,
+                "consensus_config::set_for_next_epoch({}, consensus_blob);",
+                signer_arg
+            );
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/execution_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/execution_config.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils::*;
+use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
 use aptos_types::on_chain_config::OnChainExecutionConfig;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
@@ -11,6 +11,7 @@ pub fn generate_execution_config_upgrade_proposal(
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
 ) -> Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
 
     let writer = CodeWriter::new(Loc::default());
@@ -32,17 +33,12 @@ pub fn generate_execution_config_upgrade_proposal(
             generate_blob(writer, &execution_config_blob);
             emitln!(writer, ";\n");
 
-            if is_testnet && next_execution_hash.is_empty() {
-                emitln!(
-                    writer,
-                    "execution_config::set(framework_signer, execution_blob);"
-                );
-            } else {
-                emitln!(
-                    writer,
-                    "execution_config::set(&framework_signer, execution_blob);"
-                );
-            }
+            emitln!(
+                writer,
+                "execution_config::set_for_next_epoch({}, execution_blob);",
+                signer_arg
+            );
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils::*;
+use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
 use aptos_types::on_chain_config::{FeatureFlag as AptosFeatureFlag, Features as AptosFeatures};
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
@@ -131,6 +131,7 @@ pub fn generate_feature_upgrade_proposal(
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
 ) -> Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
 
     let enabled = features
@@ -168,19 +169,12 @@ pub fn generate_feature_upgrade_proposal(
             generate_features_blob(writer, &disabled);
             emitln!(writer, ";\n");
 
-            if is_testnet && next_execution_hash.is_empty() {
-                emitln!(
-                    writer,
-                    "features::change_feature_flags(framework_signer, enabled_blob, disabled_blob);"
-                );
-                emitln!(writer, "aptos_governance::reconfigure(framework_signer);");
-            } else {
-                emitln!(
-                    writer,
-                    "features::change_feature_flags(&framework_signer, enabled_blob, disabled_blob);"
-                );
-                emitln!(writer, "aptos_governance::reconfigure(&framework_signer);");
-            }
+            emitln!(
+                writer,
+                "features::change_feature_flags_for_next_epoch({}, enabled_blob, disabled_blob);",
+                signer_arg
+            );
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/gas.rs
+++ b/aptos-move/aptos-release-builder/src/components/gas.rs
@@ -7,6 +7,7 @@ use aptos_types::on_chain_config::GasScheduleV2;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 
 pub fn generate_gas_upgrade_proposal(
+    post_randomness_framework: bool,
     gas_schedule: &GasScheduleV2,
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
@@ -52,16 +53,24 @@ pub fn generate_gas_upgrade_proposal(
             emit!(writer, "let gas_schedule_blob: vector<u8> = ");
             generate_blob(writer, &gas_schedule_blob);
             emitln!(writer, ";\n");
-            // The else statement has & before the framework_signer.
-            // The testnet single-step generation had something like let framework_signer = &core_signer;
-            // so that their framework_signer is of type &signer, but for mainnet single-step and multi-step,
-            // the framework_signer is of type signer.
-            emitln!(
-                writer,
-                "gas_schedule::set_for_next_epoch({}, gas_schedule_blob);",
-                signer_arg
-            );
-            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
+            if !post_randomness_framework {
+                emitln!(
+                    writer,
+                    "gas_schedule::set_gas_schedule({}, gas_schedule_blob)",
+                    signer_arg
+                );
+            } else {
+                // The else statement has & before the framework_signer.
+                // The testnet single-step generation had something like let framework_signer = &core_signer;
+                // so that their framework_signer is of type &signer, but for mainnet single-step and multi-step,
+                // the framework_signer is of type signer.
+                emitln!(
+                    writer,
+                    "gas_schedule::set_for_next_epoch({}, gas_schedule_blob);",
+                    signer_arg
+                );
+                emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
+            }
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
@@ -25,12 +25,12 @@ pub fn generate_jwk_consensus_config_update_proposal(
                     emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, jwk_consensus_config::new_off());", signer_arg);
                 },
                 OnChainJWKConsensusConfig::V1(v1) => {
-                    emitln!(writer, "let v1 = jwk_consensus_config::new_v1(vector[");
+                    emitln!(writer, "let config = jwk_consensus_config::new_v1(vector[");
                     for p in v1.oidc_providers.iter() {
                         emitln!(writer, "jwk_consensus_config::new_oidc_provider(utf8(b\"{}\"), utf8(b\"{}\")),", p.name, p.config_url);
                     }
                     emitln!(writer, "]);");
-                    emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, jwk_consensus_config::new_v1(v1));", signer_arg);
+                    emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, config);", signer_arg);
                 },
             }
             emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);

--- a/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
@@ -30,7 +30,11 @@ pub fn generate_jwk_consensus_config_update_proposal(
                         emitln!(writer, "jwk_consensus_config::new_oidc_provider(utf8(b\"{}\"), utf8(b\"{}\")),", p.name, p.config_url);
                     }
                     emitln!(writer, "]);");
-                    emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, config);", signer_arg);
+                    emitln!(
+                        writer,
+                        "jwk_consensus_config::set_for_next_epoch({}, config);",
+                        signer_arg
+                    );
                 },
             }
             emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);

--- a/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
@@ -1,0 +1,42 @@
+// Copyright © Aptos Foundation
+
+use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use aptos_types::on_chain_config::OnChainJWKConsensusConfig;
+use move_model::{code_writer::CodeWriter, emitln, model::Loc};
+
+pub fn generate_jwk_consensus_config_update_proposal(
+    config: &OnChainJWKConsensusConfig,
+    is_testnet: bool,
+    next_execution_hash: Vec<u8>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
+    let mut result = vec![];
+
+    let writer = CodeWriter::new(Loc::default());
+
+    let proposal = generate_governance_proposal(
+        &writer,
+        is_testnet,
+        next_execution_hash.clone(),
+        &["aptos_framework::jwk_consensus_config", "std::string::utf8"],
+        |writer| {
+            match config {
+                OnChainJWKConsensusConfig::Off => {
+                    emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, jwk_consensus_config::new_off());", signer_arg);
+                },
+                OnChainJWKConsensusConfig::V1(v1) => {
+                    emitln!(writer, "let v1 = jwk_consensus_config::new_v1(vector[");
+                    for p in v1.oidc_providers.iter() {
+                        emitln!(writer, "jwk_consensus_config::new_oidc_provider(utf8(b\"{}\"), utf8(b\"{}\")),", p.name, p.config_url);
+                    }
+                    emitln!(writer, "]);");
+                    emitln!(writer, "jwk_consensus_config::set_for_next_epoch({}, jwk_consensus_config::new_v1(v1));", signer_arg);
+                },
+            }
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
+        },
+    );
+
+    result.push(("jwk-consensus-config".to_string(), proposal));
+    Ok(result)
+}

--- a/aptos-move/aptos-release-builder/src/components/oidc_providers.rs
+++ b/aptos-move/aptos-release-builder/src/components/oidc_providers.rs
@@ -1,0 +1,77 @@
+// Copyright © Aptos Foundation
+
+use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use move_model::{code_writer::CodeWriter, emitln, model::Loc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub enum OidcProviderOp {
+    Upsert {
+        issuer: String,
+        config_url: String,
+    },
+    Remove {
+        issuer: String,
+        keep_observed_jwks: bool,
+    },
+}
+
+pub fn generate_oidc_provider_ops_proposal(
+    ops: &[OidcProviderOp],
+    is_testnet: bool,
+    next_execution_hash: Vec<u8>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
+    let mut result = vec![];
+
+    let writer = CodeWriter::new(Loc::default());
+
+    let proposal = generate_governance_proposal(
+        &writer,
+        is_testnet,
+        next_execution_hash.clone(),
+        &["aptos_framework::jwks"],
+        |writer| {
+            for op in ops {
+                write_op(writer, signer_arg, op);
+            }
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
+        },
+    );
+
+    result.push(("oidc-provider-ops".to_string(), proposal));
+    Ok(result)
+}
+
+fn write_op(writer: &CodeWriter, signer_arg: &str, op: &OidcProviderOp) {
+    match op {
+        OidcProviderOp::Upsert { issuer, config_url } => {
+            emitln!(
+                writer,
+                "jwks::upsert_oidc_provider_for_next_epoch({}, b\"{}\", b\"{}\");",
+                signer_arg,
+                issuer,
+                config_url
+            );
+        },
+        OidcProviderOp::Remove {
+            issuer,
+            keep_observed_jwks,
+        } => {
+            emitln!(
+                writer,
+                "jwks::remove_oidc_provider_for_next_epoch({}, b\"{}\");",
+                signer_arg,
+                issuer
+            );
+            if !keep_observed_jwks {
+                emitln!(
+                    writer,
+                    "jwks::remove_issuer_from_observed_jwks({}, b\"{}\");",
+                    signer_arg,
+                    issuer
+                );
+            }
+        },
+    }
+}

--- a/aptos-move/aptos-release-builder/src/components/randomness_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/randomness_config.rs
@@ -1,0 +1,88 @@
+// Copyright © Aptos Foundation
+
+use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use aptos_types::on_chain_config::OnChainRandomnessConfig;
+use move_model::{code_writer::CodeWriter, emitln, model::Loc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum ReleaseFriendlyRandomnessConfig {
+    Off,
+    V1 {
+        secrecy_threshold_in_percentage: u64,
+        reconstruct_threshold_in_percentage: u64,
+    },
+}
+
+impl From<ReleaseFriendlyRandomnessConfig> for OnChainRandomnessConfig {
+    fn from(value: ReleaseFriendlyRandomnessConfig) -> Self {
+        match value {
+            ReleaseFriendlyRandomnessConfig::Off => OnChainRandomnessConfig::Off,
+            ReleaseFriendlyRandomnessConfig::V1 {
+                secrecy_threshold_in_percentage,
+                reconstruct_threshold_in_percentage,
+            } => OnChainRandomnessConfig::new_v1(
+                secrecy_threshold_in_percentage,
+                reconstruct_threshold_in_percentage,
+            ),
+        }
+    }
+}
+
+pub fn generate_randomness_config_update_proposal(
+    config: &ReleaseFriendlyRandomnessConfig,
+    is_testnet: bool,
+    next_execution_hash: Vec<u8>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
+    let mut result = vec![];
+
+    let writer = CodeWriter::new(Loc::default());
+
+    let proposal = generate_governance_proposal(
+        &writer,
+        is_testnet,
+        next_execution_hash.clone(),
+        &[
+            "aptos_framework::randomness_config",
+            "aptos_std::fixed_point64",
+        ],
+        |writer| {
+            match config {
+                ReleaseFriendlyRandomnessConfig::Off => {
+                    emitln!(
+                        writer,
+                        "randomness_config::set_for_next_epoch({}, randomness_config::new_off());",
+                        signer_arg
+                    );
+                },
+                ReleaseFriendlyRandomnessConfig::V1 {
+                    secrecy_threshold_in_percentage,
+                    reconstruct_threshold_in_percentage,
+                } => {
+                    emitln!(writer, "let v1 = randomness_config::new_v1(");
+                    emitln!(
+                        writer,
+                        "    fixed_point64::create_from_rational({}, 100),",
+                        secrecy_threshold_in_percentage
+                    );
+                    emitln!(
+                        writer,
+                        "    fixed_point64::create_from_rational({}, 100),",
+                        reconstruct_threshold_in_percentage
+                    );
+                    emitln!(writer, ");");
+                    emitln!(
+                        writer,
+                        "randomness_config::set_for_next_epoch({}, v1);",
+                        signer_arg
+                    );
+                },
+            }
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
+        },
+    );
+
+    result.push(("randomness-config".to_string(), proposal));
+    Ok(result)
+}

--- a/aptos-move/aptos-release-builder/src/components/version.rs
+++ b/aptos-move/aptos-release-builder/src/components/version.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils::*;
+use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
 use aptos_types::on_chain_config::Version;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
@@ -11,6 +11,7 @@ pub fn generate_version_upgrade_proposal(
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
 ) -> Result<Vec<(String, String)>> {
+    let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
 
     let writer = CodeWriter::new(Loc::default());
@@ -21,19 +22,13 @@ pub fn generate_version_upgrade_proposal(
         next_execution_hash.clone(),
         &["aptos_framework::version"],
         |writer| {
-            if is_testnet && next_execution_hash.is_empty() {
-                emitln!(
-                    writer,
-                    "version::set_version(framework_signer, {});",
-                    version.major,
-                );
-            } else {
-                emitln!(
-                    writer,
-                    "version::set_version(&framework_signer, {});",
-                    version.major,
-                );
-            }
+            emitln!(
+                writer,
+                "version::set_for_next_epoch({}, {});",
+                signer_arg,
+                version.major,
+            );
+            emitln!(writer, "aptos_governance::reconfigure({});", signer_arg);
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -9,7 +9,11 @@ use aptos_release_builder::{
     initialize_aptos_core_path,
     validate::{DEFAULT_RESOLUTION_TIME, FAST_RESOLUTION_TIME},
 };
-use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use aptos_types::{
+    account_address::AccountAddress,
+    chain_id::ChainId,
+    jwks::{ObservedJWKs, SupportedOIDCProviders},
+};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -228,6 +232,24 @@ async fn main() -> anyhow::Result<()> {
                     &aptos_release_builder::components::feature_flags::Features::from(&features)
                 )?
             );
+
+            let oidc_providers = fetch_config::<SupportedOIDCProviders>(&client);
+            let observed_jwks = fetch_config::<ObservedJWKs>(&client);
+            let jwk_consensus_config = fetch_config::<OnChainJWKConsensusConfig>(&client);
+            let randomness_config = fetch_config::<RandomnessConfigMoveStruct>(&client)
+                .and_then(OnChainRandomnessConfig::try_from);
+            println!();
+            println!("SupportedOIDCProviders");
+            println!("{:?}", oidc_providers);
+            println!();
+            println!("ObservedJWKs");
+            println!("{:?}", observed_jwks);
+            println!();
+            println!("JWKConsensusConfig");
+            println!("{:?}", jwk_consensus_config);
+            println!();
+            println!("RandomnessConfig");
+            println!("{:?}", randomness_config);
             Ok(())
         },
         Commands::PrintPackageMetadata {

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -734,7 +734,7 @@ impl MoveHarness {
         let enabled = enabled.into_iter().map(|f| f as u64).collect::<Vec<_>>();
         let disabled = disabled.into_iter().map(|f| f as u64).collect::<Vec<_>>();
         self.executor
-            .exec("features", "change_feature_flags", vec![], vec![
+            .exec("features", "change_feature_flags_internal", vec![], vec![
                 MoveValue::Signer(*acc.address())
                     .simple_serialize()
                     .unwrap(),
@@ -764,14 +764,19 @@ impl MoveHarness {
             entries,
         };
         let schedule_bytes = bcs::to_bytes(&gas_schedule).expect("bcs");
+        let core_signer_arg = MoveValue::Signer(AccountAddress::ONE)
+            .simple_serialize()
+            .unwrap();
         self.executor
-            .exec("gas_schedule", "set_gas_schedule", vec![], vec![
-                MoveValue::Signer(AccountAddress::ONE)
-                    .simple_serialize()
-                    .unwrap(),
+            .exec("gas_schedule", "set_for_next_epoch", vec![], vec![
+                core_signer_arg.clone(),
                 MoveValue::vector_u8(schedule_bytes)
                     .simple_serialize()
                     .unwrap(),
+            ]);
+        self.executor
+            .exec("aptos_governance", "force_end_epoch", vec![], vec![
+                core_signer_arg,
             ]);
     }
 

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
@@ -1,5 +1,6 @@
 module 0x1::chain_id_test {
     use aptos_std::type_info;
+    use aptos_framework::aptos_governance;
     use aptos_framework::chain_id;
     use std::features;
 
@@ -18,7 +19,8 @@ module 0x1::chain_id_test {
             }
         );
 
-        features::change_feature_flags(sender, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
+        features::change_feature_flags_for_next_epoch(sender, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
+        aptos_governance::force_end_epoch(sender);
     }
 
     /// Fetches the chain ID (via aptos_framework::chain_id::get()) and stores it in the ChainIdStore resource.

--- a/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
@@ -17,7 +17,7 @@ script {
             fixed_point64::create_from_rational(50, 100),
         );
         let feature = features::get_periodical_reward_rate_decrease_feature();
-        features::change_feature_flags(&framework_signer, vector[feature], vector[]);
+        features::change_feature_flags_for_next_epoch(&framework_signer, vector[feature], vector[]);
         reconfigure(&framework_signer);
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/transaction_fee.data/disable_collection/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_fee.data/disable_collection/sources/main.move
@@ -10,6 +10,6 @@ script {
         aptos_governance::reconfigure(&framework_signer);
 
         // Then, disable the feature.
-        features::change_feature_flags(&framework_signer, vector[], vector[feature]);
+        features::change_feature_flags_for_next_epoch(&framework_signer, vector[], vector[feature]);
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/transaction_fee.data/enable_collection/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_fee.data/enable_collection/sources/main.move
@@ -5,7 +5,7 @@ script {
     fun main(core_resources: &signer) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
         let feature = features::get_collect_and_distribute_gas_fees_feature();
-        features::change_feature_flags(&framework_signer, vector[feature], vector[]);
+        features::change_feature_flags_for_next_epoch(&framework_signer, vector[feature], vector[]);
 
         // Make sure to trigger a reconfiguration!
         aptos_governance::reconfigure(&framework_signer);

--- a/aptos-move/e2e-move-tests/src/tests/vote.data/enable_partial_governance_voting/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/vote.data/enable_partial_governance_voting/sources/main.move
@@ -7,7 +7,7 @@ script {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
         aptos_governance::initialize_partial_voting(&framework_signer);
         let feature = features::get_partial_governance_voting();
-        features::change_feature_flags(&framework_signer, vector[feature], vector[]);
+        features::change_feature_flags_for_next_epoch(&framework_signer, vector[feature], vector[]);
         reconfigure(&framework_signer);
     }
 }

--- a/aptos-move/e2e-testsuite/src/tests/invariant_violation.rs
+++ b/aptos-move/e2e-testsuite/src/tests/invariant_violation.rs
@@ -39,7 +39,7 @@ fn invariant_violation_error() {
     );
 
     // Disable the CHARGE_INVARIANT_VIOLATION flag.
-    executor.exec("features", "change_feature_flags", vec![], vec![
+    executor.exec("features", "change_feature_flags_internal", vec![], vec![
         MoveValue::Signer(AccountAddress::ONE)
             .simple_serialize()
             .unwrap(),

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -1535,10 +1535,11 @@ TODO: migrate these tests to be aware of async reconfiguration.
 
 ## Function `force_end_epoch_test_only`
 
-<code><a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>()</code> used in some move tests.
+<code><a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>()</code> equivalent but only called in testnet,
+where the core resources account exists and has been granted power to mint Aptos coins.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1547,8 +1548,8 @@ TODO: migrate these tests to be aware of async reconfiguration.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="aptos_governance.md#0x1_aptos_governance_GovernanceResponsbility">GovernanceResponsbility</a> {
-    <b>let</b> core_signer = <a href="aptos_governance.md#0x1_aptos_governance_get_signer_testnet_only">get_signer_testnet_only</a>(admin, @0x1);
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="aptos_governance.md#0x1_aptos_governance_GovernanceResponsbility">GovernanceResponsbility</a> {
+    <b>let</b> core_signer = <a href="aptos_governance.md#0x1_aptos_governance_get_signer_testnet_only">get_signer_testnet_only</a>(aptos_framework, @0x1);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(&core_signer);
     <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_finish">reconfiguration_with_dkg::finish</a>(&core_signer);
 }
@@ -2733,7 +2734,7 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 ### Function `force_end_epoch_test_only`
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -49,6 +49,7 @@ on a proposal multiple times as long as the total voting power of these votes do
 -  [Function `remove_approved_hash`](#0x1_aptos_governance_remove_approved_hash)
 -  [Function `reconfigure`](#0x1_aptos_governance_reconfigure)
 -  [Function `force_end_epoch`](#0x1_aptos_governance_force_end_epoch)
+-  [Function `force_end_epoch_test_only`](#0x1_aptos_governance_force_end_epoch_test_only)
 -  [Function `toggle_features`](#0x1_aptos_governance_toggle_features)
 -  [Function `get_signer_testnet_only`](#0x1_aptos_governance_get_signer_testnet_only)
 -  [Function `get_voting_power`](#0x1_aptos_governance_get_voting_power)
@@ -81,6 +82,7 @@ on a proposal multiple times as long as the total voting power of these votes do
     -  [Function `remove_approved_hash`](#@Specification_1_remove_approved_hash)
     -  [Function `reconfigure`](#@Specification_1_reconfigure)
     -  [Function `force_end_epoch`](#@Specification_1_force_end_epoch)
+    -  [Function `force_end_epoch_test_only`](#@Specification_1_force_end_epoch_test_only)
     -  [Function `toggle_features`](#@Specification_1_toggle_features)
     -  [Function `get_signer_testnet_only`](#@Specification_1_get_signer_testnet_only)
     -  [Function `get_voting_power`](#@Specification_1_get_voting_power)
@@ -1475,7 +1477,7 @@ This behavior affects when an update of an on-chain config (e.g. <code>Consensus
 since such updates are applied whenever we enter an new epoch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1484,7 +1486,7 @@ since such updates are applied whenever we enter an new epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>if</b> (<a href="consensus_config.md#0x1_consensus_config_validator_txn_enabled">consensus_config::validator_txn_enabled</a>() && <a href="randomness_config.md#0x1_randomness_config_enabled">randomness_config::enabled</a>()) {
         <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_try_start">reconfiguration_with_dkg::try_start</a>();
@@ -1510,7 +1512,7 @@ WARNING: currently only used by tests. In most cases you should use <code><a hre
 TODO: migrate these tests to be aware of async reconfiguration.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -1519,9 +1521,36 @@ TODO: migrate these tests to be aware of async reconfiguration.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_finish">reconfiguration_with_dkg::finish</a>(aptos_framework);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aptos_governance_force_end_epoch_test_only"></a>
+
+## Function `force_end_epoch_test_only`
+
+<code><a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>()</code> used in some move tests.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="aptos_governance.md#0x1_aptos_governance_GovernanceResponsbility">GovernanceResponsbility</a> {
+    <b>let</b> core_signer = <a href="aptos_governance.md#0x1_aptos_governance_get_signer_testnet_only">get_signer_testnet_only</a>(admin, @0x1);
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(&core_signer);
+    <a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg_finish">reconfiguration_with_dkg::finish</a>(&core_signer);
 }
 </code></pre>
 
@@ -2646,7 +2675,7 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 ### Function `reconfigure`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_reconfigure">reconfigure</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -2673,7 +2702,7 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 ### Function `force_end_epoch`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch">force_end_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -2695,6 +2724,22 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 <pre><code><b>schema</b> <a href="aptos_governance.md#0x1_aptos_governance_VotingInitializationAbortIfs">VotingInitializationAbortIfs</a> {
     <b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_partial_governance_voting_enabled">features::spec_partial_governance_voting_enabled</a>() && !<b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
 }
+</code></pre>
+
+
+
+<a id="@Specification_1_force_end_epoch_test_only"></a>
+
+### Function `force_end_epoch_test_only`
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_force_end_epoch_test_only">force_end_epoch_test_only</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/config_buffer.md
+++ b/aptos-move/framework/aptos-framework/doc/config_buffer.md
@@ -32,6 +32,7 @@ NOTE: on-chain config <code>0x1::state::ValidatorSet</code> implemented its own 
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map">0x1::simple_map</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info">0x1::type_info</a>;
 </code></pre>
 
@@ -95,6 +96,7 @@ Config buffer operations failed with permission denied.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>if</b> (!<b>exists</b>&lt;<a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a>&gt;(@aptos_framework)) {
         <b>move_to</b>(aptos_framework, <a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a> {
             configs: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_new">simple_map::new</a>(),

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -26,7 +26,8 @@ Reconfiguration, and may be updated by root.
     -  [Function `validator_txn_enabled_internal`](#@Specification_1_validator_txn_enabled_internal)
 
 
-<pre><code><b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
@@ -125,6 +126,7 @@ TODO: update all the tests that reference this function, then disable this funct
 
 <pre><code><b>public</b> <b>fun</b> <a href="consensus_config.md#0x1_consensus_config_set">set</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(<a href="account.md#0x1_account">account</a>);
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config) &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="consensus_config.md#0x1_consensus_config_EINVALID_CONFIG">EINVALID_CONFIG</a>));
 
     <b>let</b> config_ref = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework).config;

--- a/aptos-move/framework/aptos-framework/doc/dkg.md
+++ b/aptos-move/framework/aptos-framework/doc/dkg.md
@@ -435,7 +435,6 @@ Return the dealer epoch of a <code><a href="dkg.md#0x1_dkg_DKGSessionState">DKGS
 
 <pre><code><b>let</b> aptos_framework_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> aptos_framework_addr != @aptos_framework;
-<b>aborts_if</b> <b>exists</b>&lt;<a href="dkg.md#0x1_dkg_DKGState">DKGState</a>&gt;(@aptos_framework);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/dkg.md
+++ b/aptos-move/framework/aptos-framework/doc/dkg.md
@@ -232,13 +232,15 @@ Called in genesis to initialize on-chain states.
 
 <pre><code><b>public</b> <b>fun</b> <a href="dkg.md#0x1_dkg_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>move_to</b>&lt;<a href="dkg.md#0x1_dkg_DKGState">DKGState</a>&gt;(
-        aptos_framework,
-        <a href="dkg.md#0x1_dkg_DKGState">DKGState</a> {
-            last_completed: std::option::none(),
-            in_progress: std::option::none(),
-        }
-    );
+    <b>if</b> (!<b>exists</b>&lt;<a href="dkg.md#0x1_dkg_DKGState">DKGState</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>&lt;<a href="dkg.md#0x1_dkg_DKGState">DKGState</a>&gt;(
+            aptos_framework,
+            <a href="dkg.md#0x1_dkg_DKGState">DKGState</a> {
+                last_completed: std::option::none(),
+                in_progress: std::option::none(),
+            }
+        );
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/execution_config.md
+++ b/aptos-move/framework/aptos-framework/doc/execution_config.md
@@ -18,7 +18,8 @@ Reconfiguration, and may be updated by root.
     -  [Function `on_new_epoch`](#@Specification_1_on_new_epoch)
 
 
-<pre><code><b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
@@ -90,6 +91,8 @@ TODO: update all the tests that reference this function, then disable this funct
 
 <pre><code><b>public</b> <b>fun</b> <a href="execution_config.md#0x1_execution_config_set">set</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(<a href="account.md#0x1_account">account</a>);
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
+
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&config) &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="execution_config.md#0x1_execution_config_EINVALID_CONFIG">EINVALID_CONFIG</a>));
 
     <b>if</b> (<b>exists</b>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;(@aptos_framework)) {

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -28,7 +28,8 @@ it costs to execute Move on the network.
     -  [Function `set_storage_gas_config_for_next_epoch`](#@Specification_1_set_storage_gas_config_for_next_epoch)
 
 
-<pre><code><b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="storage_gas.md#0x1_storage_gas">0x1::storage_gas</a>;
@@ -210,6 +211,7 @@ TODO: update all the tests that reference this function, then disable this funct
 <pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x1_gas_schedule_set_gas_schedule">set_gas_schedule</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_schedule_blob: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="gas_schedule.md#0x1_gas_schedule_GasSchedule">GasSchedule</a>, <a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&gas_schedule_blob), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_SCHEDULE">EINVALID_GAS_SCHEDULE</a>));
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
     <b>if</b> (<b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework)) {
         <b>let</b> <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a> = <b>borrow_global_mut</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -873,7 +873,7 @@ The last step of genesis.
         rewards_rate_denominator,
         voting_power_increase_limit
     );
-    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags">features::change_feature_flags</a>(aptos_framework, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[1, 2], <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_verification">features::change_feature_flags_for_verification</a>(aptos_framework, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[1, 2], <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
     <a href="genesis.md#0x1_genesis_initialize_aptos_coin">initialize_aptos_coin</a>(aptos_framework);
     <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">aptos_governance::initialize_for_verification</a>(
         aptos_framework,

--- a/aptos-move/framework/aptos-framework/doc/jwks.md
+++ b/aptos-move/framework/aptos-framework/doc/jwks.md
@@ -57,7 +57,8 @@ have a simple layout which is easily accessible in Rust.
 -  [Function `apply_patch`](#0x1_jwks_apply_patch)
 
 
-<pre><code><b>use</b> <a href="../../aptos-stdlib/doc/comparator.md#0x1_comparator">0x1::comparator</a>;
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/comparator.md#0x1_comparator">0x1::comparator</a>;
 <b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any">0x1::copyable_any</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
@@ -780,6 +781,7 @@ TODO: update all the tests that reference this function, then disable this funct
 
 <pre><code><b>public</b> <b>fun</b> <a href="jwks.md#0x1_jwks_upsert_oidc_provider">upsert_oidc_provider</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, config_url: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; <b>acquires</b> <a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
     <b>let</b> provider_set = <b>borrow_global_mut</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework);
 
@@ -858,6 +860,7 @@ TODO: update all the tests that reference this function, then disable this funct
 
 <pre><code><b>public</b> <b>fun</b> <a href="jwks.md#0x1_jwks_remove_oidc_provider">remove_oidc_provider</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; <b>acquires</b> <a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
     <b>let</b> provider_set = <b>borrow_global_mut</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework);
     <a href="jwks.md#0x1_jwks_remove_oidc_provider_internal">remove_oidc_provider_internal</a>(provider_set, name)

--- a/aptos-move/framework/aptos-framework/doc/randomness.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness.md
@@ -218,11 +218,13 @@ Must be called in tests to initialize the <code><a href="randomness.md#0x1_rando
 
 <pre><code><b>public</b> <b>fun</b> <a href="randomness.md#0x1_randomness_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
-    <b>move_to</b>(framework, <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
-        epoch: 0,
-        round: 0,
-        seed: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
-    });
+    <b>if</b> (!<b>exists</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>(framework, <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
+            epoch: 0,
+            round: 0,
+            seed: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
+        });
+    }
 }
 </code></pre>
 
@@ -1019,8 +1021,6 @@ function as its payload.
 
 <pre><code><b>let</b> framework_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(framework);
 <b>aborts_if</b> framework_addr != @aptos_framework;
-<b>aborts_if</b> <b>exists</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(framework_addr);
-<b>ensures</b> <b>global</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(framework_addr).seed == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_spec_none">option::spec_none</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;();
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/randomness_config.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness_config.md
@@ -155,7 +155,9 @@ Initialize the configuration. Used in genesis or governance.
 
 <pre><code><b>public</b> <b>fun</b> <a href="randomness_config.md#0x1_randomness_config_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, config: <a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
-    <b>move_to</b>(framework, config)
+    <b>if</b> (!<b>exists</b>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>(framework, config)
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -24,7 +24,8 @@ Maintains the version number for the blockchain.
     -  [Function `initialize_for_test`](#@Specification_1_initialize_for_test)
 
 
-<pre><code><b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<pre><code><b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
+<b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -165,6 +166,7 @@ TODO: update all the tests that reference this function, then disable this funct
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_version">set_version</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
     <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
+    <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
     <b>let</b> old_major = <b>borrow_global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major;
     <b>assert</b>!(old_major &lt; major, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="version.md#0x1_version_EINVALID_MAJOR_VERSION_NUMBER">EINVALID_MAJOR_VERSION_NUMBER</a>));
@@ -187,13 +189,11 @@ TODO: update all the tests that reference this function, then disable this funct
 
 Used in on-chain governances to update the major version for the next epoch.
 Example usage:
-```
-aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);
-aptos_framework::aptos_governance::reconfigure(&framework_signer);
-```
+- <code>aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);</code>
+- <code>aptos_framework::aptos_governance::reconfigure(&framework_signer);</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64)
 </code></pre>
 
 
@@ -202,7 +202,7 @@ aptos_framework::aptos_governance::reconfigure(&framework_signer);
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
+<pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
     <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
     <b>let</b> old_major = <b>borrow_global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major;
     <b>assert</b>!(old_major &lt; major, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="version.md#0x1_version_EINVALID_MAJOR_VERSION_NUMBER">EINVALID_MAJOR_VERSION_NUMBER</a>));
@@ -373,7 +373,7 @@ Abort if resource already exists in <code>@aptos_framwork</code> when initializi
 ### Function `set_for_next_epoch`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -567,9 +567,10 @@ module aptos_framework::aptos_governance {
         reconfiguration_with_dkg::finish(aptos_framework);
     }
 
-    /// `force_end_epoch()` used in some move tests.
-    public entry fun force_end_epoch_test_only(admin: &signer) acquires GovernanceResponsbility {
-        let core_signer = get_signer_testnet_only(admin, @0x1);
+    /// `force_end_epoch()` equivalent but only called in testnet,
+    /// where the core resources account exists and has been granted power to mint Aptos coins.
+    public entry fun force_end_epoch_test_only(aptos_framework: &signer) acquires GovernanceResponsbility {
+        let core_signer = get_signer_testnet_only(aptos_framework, @0x1);
         system_addresses::assert_aptos_framework(&core_signer);
         reconfiguration_with_dkg::finish(&core_signer);
     }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -547,7 +547,7 @@ module aptos_framework::aptos_governance {
     ///
     /// This behavior affects when an update of an on-chain config (e.g. `ConsensusConfig`, `Features`) takes effect,
     /// since such updates are applied whenever we enter an new epoch.
-    public fun reconfigure(aptos_framework: &signer) {
+    public entry fun reconfigure(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
         if (consensus_config::validator_txn_enabled() && randomness_config::enabled()) {
             reconfiguration_with_dkg::try_start();
@@ -562,9 +562,16 @@ module aptos_framework::aptos_governance {
     ///
     /// WARNING: currently only used by tests. In most cases you should use `reconfigure()` instead.
     /// TODO: migrate these tests to be aware of async reconfiguration.
-    public fun force_end_epoch(aptos_framework: &signer) {
+    public entry fun force_end_epoch(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
         reconfiguration_with_dkg::finish(aptos_framework);
+    }
+
+    /// `force_end_epoch()` used in some move tests.
+    public entry fun force_end_epoch_test_only(admin: &signer) acquires GovernanceResponsbility {
+        let core_signer = get_signer_testnet_only(admin, @0x1);
+        system_addresses::assert_aptos_framework(&core_signer);
+        reconfiguration_with_dkg::finish(&core_signer);
     }
 
     /// Update feature flags and also trigger reconfiguration.
@@ -966,7 +973,7 @@ module aptos_framework::aptos_governance {
         assert!(get_remaining_voting_power(voter_2_addr, 0) == 10, 2);
 
         initialize_partial_voting(&aptos_framework);
-        features::change_feature_flags(&aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
+        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
 
         coin::register<AptosCoin>(&voter_1);
         coin::register<AptosCoin>(&voter_2);
@@ -1125,7 +1132,7 @@ module aptos_framework::aptos_governance {
         voter_2: &signer,
     ) acquires GovernanceResponsbility {
         initialize_partial_voting(aptos_framework);
-        features::change_feature_flags(aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
         setup_voting(aptos_framework, proposer, voter_1, voter_2);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
@@ -847,4 +847,8 @@ spec aptos_framework::aptos_governance {
     spec schema VotingInitializationAbortIfs {
         aborts_if features::spec_partial_governance_voting_enabled() && !exists<VotingRecordsV2>(@aptos_framework);
     }
+
+    spec force_end_epoch_test_only {
+        pragma verify = false;
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
@@ -16,6 +16,7 @@ module aptos_framework::config_buffer {
     use aptos_std::simple_map;
     use aptos_std::simple_map::SimpleMap;
     use aptos_std::type_info;
+    use aptos_framework::system_addresses;
 
     friend aptos_framework::consensus_config;
     friend aptos_framework::execution_config;
@@ -33,6 +34,7 @@ module aptos_framework::config_buffer {
     }
 
     public fun initialize(aptos_framework: &signer) {
+        system_addresses::assert_aptos_framework(aptos_framework);
         if (!exists<PendingConfigs>(@aptos_framework)) {
             move_to(aptos_framework, PendingConfigs {
                 configs: simple_map::new(),

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
@@ -3,6 +3,7 @@
 module aptos_framework::consensus_config {
     use std::error;
     use std::vector;
+    use aptos_framework::chain_status;
     use aptos_framework::config_buffer;
 
     use aptos_framework::reconfiguration;
@@ -32,6 +33,7 @@ module aptos_framework::consensus_config {
     /// TODO: update all the tests that reference this function, then disable this function.
     public fun set(account: &signer, config: vector<u8>) acquires ConsensusConfig {
         system_addresses::assert_aptos_framework(account);
+        chain_status::assert_genesis();
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
 
         let config_ref = &mut borrow_global_mut<ConsensusConfig>(@aptos_framework).config;

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
@@ -4,6 +4,7 @@ module aptos_framework::execution_config {
     use aptos_framework::config_buffer;
     use std::error;
     use std::vector;
+    use aptos_framework::chain_status;
 
     use aptos_framework::reconfiguration;
     use aptos_framework::system_addresses;
@@ -24,6 +25,8 @@ module aptos_framework::execution_config {
     /// TODO: update all the tests that reference this function, then disable this function.
     public fun set(account: &signer, config: vector<u8>) acquires ExecutionConfig {
         system_addresses::assert_aptos_framework(account);
+        chain_status::assert_genesis();
+
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
 
         if (exists<ExecutionConfig>(@aptos_framework)) {

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -4,6 +4,7 @@ module aptos_framework::gas_schedule {
     use std::error;
     use std::string::String;
     use std::vector;
+    use aptos_framework::chain_status;
     use aptos_framework::config_buffer;
 
     use aptos_framework::reconfiguration;
@@ -51,6 +52,7 @@ module aptos_framework::gas_schedule {
     public fun set_gas_schedule(aptos_framework: &signer, gas_schedule_blob: vector<u8>) acquires GasSchedule, GasScheduleV2 {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
+        chain_status::assert_genesis();
 
         if (exists<GasScheduleV2>(@aptos_framework)) {
             let gas_schedule = borrow_global_mut<GasScheduleV2>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
@@ -34,7 +34,9 @@ module aptos_framework::randomness_config {
     /// Initialize the configuration. Used in genesis or governance.
     public fun initialize(framework: &signer, config: RandomnessConfig) {
         system_addresses::assert_aptos_framework(framework);
-        move_to(framework, config)
+        if (!exists<RandomnessConfig>(@aptos_framework)) {
+            move_to(framework, config)
+        }
     }
 
     /// This can be called by on-chain governance to update on-chain consensus configs for the next epoch.

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -510,7 +510,7 @@ module aptos_framework::staking_config {
     #[test(account = @0x123, aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
     public entry fun test_update_rewards_config_unauthorized_should_fail(account: signer, aptos_framework: signer) acquires StakingRewardsConfig {
-        features::change_feature_flags(&aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
         update_rewards_config(
             &account,
             create_from_rational(1, 100),
@@ -610,7 +610,7 @@ module aptos_framework::staking_config {
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x3000B, location = Self)]
     public entry fun test_feature_flag_disabled_get_epoch_rewards_rate_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
-        features::change_feature_flags(&aptos_framework, vector[], vector[features::get_periodical_reward_rate_decrease_feature()]);
+        features::change_feature_flags_for_testing(&aptos_framework, vector[], vector[features::get_periodical_reward_rate_decrease_feature()]);
         calculate_and_save_latest_epoch_rewards_rate();
     }
 
@@ -665,7 +665,7 @@ module aptos_framework::staking_config {
         last_rewards_rate_period_start_in_secs: u64,
         rewards_rate_decrease_rate: FixedPoint64,
     ) {
-        features::change_feature_flags(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
         timestamp::set_time_has_started_for_testing(aptos_framework);
         timestamp::update_global_time_for_test_secs(last_rewards_rate_period_start_in_secs);
         initialize_rewards(

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -2,6 +2,7 @@
 module aptos_framework::version {
     use std::error;
     use std::signer;
+    use aptos_framework::chain_status;
     use aptos_framework::config_buffer;
 
     use aptos_framework::reconfiguration;
@@ -39,6 +40,7 @@ module aptos_framework::version {
     /// TODO: update all the tests that reference this function, then disable this function.
     public entry fun set_version(account: &signer, major: u64) acquires Version {
         assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
+        chain_status::assert_genesis();
 
         let old_major = borrow_global<Version>(@aptos_framework).major;
         assert!(old_major < major, error::invalid_argument(EINVALID_MAJOR_VERSION_NUMBER));
@@ -52,11 +54,9 @@ module aptos_framework::version {
 
     /// Used in on-chain governances to update the major version for the next epoch.
     /// Example usage:
-    /// ```
-    /// aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);
-    /// aptos_framework::aptos_governance::reconfigure(&framework_signer);
-    /// ```
-    public fun set_for_next_epoch(account: &signer, major: u64) acquires Version {
+    /// - `aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);`
+    /// - `aptos_framework::aptos_governance::reconfigure(&framework_signer);`
+    public entry fun set_for_next_epoch(account: &signer, major: u64) acquires Version {
         assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
         let old_major = borrow_global<Version>(@aptos_framework).major;
         assert!(old_major < major, error::invalid_argument(EINVALID_MAJOR_VERSION_NUMBER));

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.move
@@ -1870,7 +1870,7 @@ module aptos_framework::delegation_pool {
             voting_power_increase_limit,
         );
         reconfiguration::initialize_for_test(aptos_framework);
-        features::change_feature_flags(aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE, COMMISSION_CHANGE_DELEGATION_POOL], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE, COMMISSION_CHANGE_DELEGATION_POOL], vector[]);
     }
 
     #[test_only]
@@ -1938,7 +1938,7 @@ module aptos_framework::delegation_pool {
         validator: &signer,
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
-        features::change_feature_flags(aptos_framework, vector[], vector[DELEGATION_POOLS]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[], vector[DELEGATION_POOLS]);
 
         initialize_delegation_pool(validator, 0, vector::empty<u8>());
     }
@@ -2153,7 +2153,7 @@ module aptos_framework::delegation_pool {
             reward_period_start_time_in_sec,
             fixed_point64::create_from_rational(50, 100),
         );
-        features::change_feature_flags(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
 
         // add more stake from delegator 1
         stake::mint(delegator1, 20000 * ONE_APT);
@@ -3707,7 +3707,7 @@ module aptos_framework::delegation_pool {
             1000,
         );
         aptos_governance::initialize_partial_voting(aptos_framework);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]);
@@ -3752,7 +3752,7 @@ module aptos_framework::delegation_pool {
             1000,
         );
         aptos_governance::initialize_partial_voting(aptos_framework);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]);
@@ -3800,7 +3800,7 @@ module aptos_framework::delegation_pool {
             1000,
         );
         aptos_governance::initialize_partial_voting(aptos_framework);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -3969,7 +3969,7 @@ module aptos_framework::delegation_pool {
         add_stake(delegator1, pool_address, 10 * ONE_APT);
 
         // Enable partial governance voting feature flag.
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -4024,7 +4024,7 @@ module aptos_framework::delegation_pool {
             1000,
         );
         aptos_governance::initialize_partial_voting(aptos_framework);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -4131,7 +4131,7 @@ module aptos_framework::delegation_pool {
         aptos_governance::vote(validator, pool_address, proposal1_id, true);
 
         // Enable partial governance voting feature flag.
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -4191,7 +4191,7 @@ module aptos_framework::delegation_pool {
         aptos_governance::vote(validator, pool_address, proposal1_id, true);
 
         // Enable partial governance voting feature flag.
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -4225,7 +4225,7 @@ module aptos_framework::delegation_pool {
         end_aptos_epoch();
 
         // Enable partial governance voting feature flag.
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
             vector[]
@@ -4373,7 +4373,7 @@ module aptos_framework::delegation_pool {
             true,
         );
         if (enable_partial_voting) {
-            features::change_feature_flags(
+            features::change_feature_flags_for_testing(
                 aptos_framework,
                 vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting()],
                 vector[]);

--- a/aptos-move/framework/aptos-framework/sources/dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/dkg.move
@@ -45,13 +45,15 @@ module aptos_framework::dkg {
     /// Called in genesis to initialize on-chain states.
     public fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
-        move_to<DKGState>(
-            aptos_framework,
-            DKGState {
-                last_completed: std::option::none(),
-                in_progress: std::option::none(),
-            }
-        );
+        if (!exists<DKGState>(@aptos_framework)) {
+            move_to<DKGState>(
+                aptos_framework,
+                DKGState {
+                    last_completed: std::option::none(),
+                    in_progress: std::option::none(),
+                }
+            );
+        }
     }
 
     /// Mark on-chain DKG state as in-progress. Notify validators to start DKG.

--- a/aptos-move/framework/aptos-framework/sources/dkg.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/dkg.spec.move
@@ -9,7 +9,6 @@ spec aptos_framework::dkg {
         use std::signer;
         let aptos_framework_addr = signer::address_of(aptos_framework);
         aborts_if aptos_framework_addr != @aptos_framework;
-        aborts_if exists<DKGState>(@aptos_framework);
     }
 
     spec start(

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -858,7 +858,7 @@ module aptos_framework::fungible_asset {
     ) acquires Supply, ConcurrentSupply, FungibleStore {
         let feature = features::get_concurrent_fungible_assets_feature();
         let agg_feature = features::get_aggregator_v2_api_feature();
-        features::change_feature_flags(fx, vector[], vector[feature, agg_feature]);
+        features::change_feature_flags_for_testing(fx, vector[], vector[feature, agg_feature]);
 
         let (creator_ref, token_object) = create_test_token(creator);
         let (mint_ref, transfer_ref, _burn) = init_test_metadata(&creator_ref);
@@ -870,7 +870,7 @@ module aptos_framework::fungible_asset {
 
         deposit_with_ref(&transfer_ref, creator_store, fa);
 
-        features::change_feature_flags(fx, vector[feature, agg_feature], vector[]);
+        features::change_feature_flags_for_testing(fx, vector[feature, agg_feature], vector[]);
 
         let extend_ref = object::generate_extend_ref(&creator_ref);
         upgrade_to_concurrent(&extend_ref);

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -422,7 +422,7 @@ module aptos_framework::genesis {
             rewards_rate_denominator,
             voting_power_increase_limit
         );
-        features::change_feature_flags(aptos_framework, vector[1, 2], vector[]);
+        features::change_feature_flags_for_verification(aptos_framework, vector[1, 2], vector[]);
         initialize_aptos_coin(aptos_framework);
         aptos_governance::initialize_for_verification(
             aptos_framework,

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -14,6 +14,7 @@ module aptos_framework::jwks {
     use aptos_std::comparator::{compare_u8_vector, is_greater_than, is_equal};
     use aptos_std::copyable_any;
     use aptos_std::copyable_any::Any;
+    use aptos_framework::chain_status;
     use aptos_framework::config_buffer;
     use aptos_framework::event::emit;
     use aptos_framework::reconfiguration;
@@ -178,6 +179,7 @@ module aptos_framework::jwks {
     /// TODO: update all the tests that reference this function, then disable this function.
     public fun upsert_oidc_provider(fx: &signer, name: vector<u8>, config_url: vector<u8>): Option<vector<u8>> acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(fx);
+        chain_status::assert_genesis();
 
         let provider_set = borrow_global_mut<SupportedOIDCProviders>(@aptos_framework);
 
@@ -216,6 +218,7 @@ module aptos_framework::jwks {
     /// TODO: update all the tests that reference this function, then disable this function.
     public fun remove_oidc_provider(fx: &signer, name: vector<u8>): Option<vector<u8>> acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(fx);
+        chain_status::assert_genesis();
 
         let provider_set = borrow_global_mut<SupportedOIDCProviders>(@aptos_framework);
         remove_oidc_provider_internal(provider_set, name)

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -1317,7 +1317,7 @@ module aptos_framework::multisig_account {
     #[test_only]
     fun setup() {
         let framework_signer = &create_signer(@0x1);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             framework_signer, vector[features::get_multisig_accounts_feature(), features::get_multisig_v2_enhancement_feature()], vector[]);
         timestamp::set_time_has_started_for_testing(framework_signer);
         chain_id::initialize_for_test(framework_signer, 1);
@@ -1326,7 +1326,7 @@ module aptos_framework::multisig_account {
     #[test_only]
     fun setup_disabled() {
         let framework_signer = &create_signer(@0x1);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             framework_signer, vector[], vector[features::get_multisig_accounts_feature()]);
         timestamp::set_time_has_started_for_testing(framework_signer);
         chain_id::initialize_for_test(framework_signer, 1);

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -749,7 +749,7 @@ module aptos_framework::object {
     fun test_correct_auid(fx: signer) {
         use std::features;
         let feature = features::get_auids();
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let auid1 = aptos_framework::transaction_context::generate_auid_address();
         let bytes = aptos_framework::transaction_context::get_transaction_hash();
@@ -816,7 +816,7 @@ module aptos_framework::object {
         use std::features;
         let feature = features::get_max_object_nesting_check_feature();
         let fx = account::create_signer_for_test(@0x1);
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
@@ -856,7 +856,7 @@ module aptos_framework::object {
         use std::features;
         let feature = features::get_max_object_nesting_check_feature();
         let fx = account::create_signer_for_test(@0x1);
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
@@ -887,7 +887,7 @@ module aptos_framework::object {
         use std::features;
         let feature = features::get_max_object_nesting_check_feature();
         let fx = account::create_signer_for_test(@0x1);
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let obj1 = create_simple_object(creator, b"1");
         // This creates a cycle (self-loop) in ownership.
@@ -902,7 +902,7 @@ module aptos_framework::object {
         use std::features;
         let feature = features::get_max_object_nesting_check_feature();
         let fx = account::create_signer_for_test(@0x1);
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let obj1 = create_simple_object(creator, b"1");
         // This creates a cycle (self-loop) in ownership.

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -45,11 +45,13 @@ module aptos_framework::randomness {
     /// Must be called in tests to initialize the `PerBlockRandomness` resource.
     public fun initialize(framework: &signer) {
         system_addresses::assert_aptos_framework(framework);
-        move_to(framework, PerBlockRandomness {
-            epoch: 0,
-            round: 0,
-            seed: option::none(),
-        });
+        if (!exists<PerBlockRandomness>(@aptos_framework)) {
+            move_to(framework, PerBlockRandomness {
+                epoch: 0,
+                round: 0,
+                seed: option::none(),
+            });
+        }
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-framework/sources/randomness.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.spec.move
@@ -24,12 +24,9 @@ spec aptos_framework::randomness {
     spec fun spec_is_unbiasable(): bool;
 
     spec initialize(framework: &signer) {
-        use std::option;
         use std::signer;
         let framework_addr = signer::address_of(framework);
         aborts_if framework_addr != @aptos_framework;
-        aborts_if exists<PerBlockRandomness>(framework_addr);
-        ensures global<PerBlockRandomness>(framework_addr).seed == option::spec_none<vector<u8>>();
     }
 
     spec on_new_block(vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>) {

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -2762,7 +2762,7 @@ module aptos_framework::stake {
             genesis_time_in_secs,
             fixed_point64::create_from_rational(50, 100),
         );
-        features::change_feature_flags(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
 
         // For some reason, this epoch is very long. It has been 1 year since genesis when the epoch ends.
         timestamp::fast_forward_seconds(one_year_in_secs - EPOCH_DURATION * 3);
@@ -3027,7 +3027,7 @@ module aptos_framework::stake {
         validator_3: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Make sure that fees collection and distribution is enabled.
-        features::change_feature_flags(aptos_framework, vector[COLLECT_AND_DISTRIBUTE_GAS_FEES], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[COLLECT_AND_DISTRIBUTE_GAS_FEES], vector[]);
         assert!(features::collect_and_distribute_gas_fees(), 0);
 
         // Initialize staking and validator fees table.

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -867,7 +867,7 @@ module aptos_framework::staking_contract {
 
         // Voter is initially set to operator but then updated to be staker.
         create_staking_contract(staker, operator_address, operator_address, amount, commission, vector::empty<u8>());
-        std::features::change_feature_flags(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
+        std::features::change_feature_flags_for_testing(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -52,7 +52,7 @@ module aptos_framework::transaction_context {
         use std::vector;
 
         let feature = features::get_auids();
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let auids: vector<address> = vector<address>[];
         let i: u64 = 0;

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1038,7 +1038,7 @@ module aptos_framework::vesting {
             };
         });
 
-        std::features::change_feature_flags(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
+        std::features::change_feature_flags_for_testing(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
@@ -79,7 +79,7 @@ module aptos_framework::delegation_pool_integration_tests {
             voting_power_increase_limit
         );
         reconfiguration::initialize_for_test(aptos_framework);
-        features::change_feature_flags(aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT], vector[]);
+        features::change_feature_flags_for_testing(aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT], vector[]);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
@@ -283,7 +283,7 @@ module aptos_std::crypto_algebra {
 
     #[test_only]
     public fun enable_cryptography_algebra_natives(fx: &signer) {
-        std::features::change_feature_flags(fx, vector[std::features::get_cryptography_algebra_natives_feature()], vector[]);
+        std::features::change_feature_flags_for_testing(fx, vector[std::features::get_cryptography_algebra_natives_feature()], vector[]);
     }
 
     fun handles_from_elements<S>(elements: &vector<Element<S>>): vector<u64> {

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
@@ -365,7 +365,7 @@ module aptos_std::multi_ed25519 {
 
     #[test(fx = @std)]
     fun bugfix_validated_pk_from_zero_subpks(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
         let bytes = vector<u8>[1u8];
         assert!(vector::length(&bytes) == 1, 1);
 
@@ -383,7 +383,7 @@ module aptos_std::multi_ed25519 {
 
     #[test(fx = @std)]
     fun test_validated_pk_without_threshold_byte(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
 
         let (_, subpk) = ed25519::generate_keys();
         let bytes = ed25519::validated_public_key_to_bytes(&subpk);
@@ -402,7 +402,7 @@ module aptos_std::multi_ed25519 {
 
     #[test(fx = @std)]
     fun test_validated_pk_from_small_order_subpk(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
         let torsion_point_with_threshold_1 = vector<u8>[
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 1,

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
@@ -907,7 +907,7 @@ module aptos_std::ristretto255 {
 
     #[test(fx = @std)]
     fun test_basepoint_double_mul(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let expected = option::extract(&mut new_point_from_bytes(x"be5d615d8b8f996723cdc6e1895b8b6d312cc75d1ffb0259873b99396a38c05a"));
 

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
@@ -166,7 +166,7 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010003, location = Self)]
     fun test_unsupported_ranges(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);
         let comm = std::option::extract(&mut comm);
@@ -179,7 +179,7 @@ module aptos_std::ristretto255_bulletproofs {
 
     #[test(fx = @std)]
     fun test_prover(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let v = ristretto255::new_scalar_from_u64(59);
         let r = ristretto255::new_scalar_from_bytes(A_BLINDER);
@@ -197,7 +197,7 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010001, location = Self)]
     fun test_empty_range_proof(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let proof = &range_proof_from_bytes(vector[ ]);
         let num_bits = 64;
@@ -212,7 +212,7 @@ module aptos_std::ristretto255_bulletproofs {
 
     #[test(fx = @std)]
     fun test_valid_range_proof_verifies_against_comm(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let value = ristretto255::new_scalar_from_bytes(A_VALUE);
         let value = std::option::extract(&mut value);
@@ -232,7 +232,7 @@ module aptos_std::ristretto255_bulletproofs {
 
     #[test(fx = @std)]
     fun test_invalid_range_proof_fails_verification(fx: signer) {
-        features::change_feature_flags(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);
         let comm = std::option::extract(&mut comm);

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -125,7 +125,7 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun sha2_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
 
         let inputs = vector[
         b"testing",
@@ -153,7 +153,7 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun sha3_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
         let inputs = vector[
         b"testing",
         b"",
@@ -180,7 +180,7 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun ripemd160_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
         let inputs = vector[
         b"testing",
         b"",
@@ -208,7 +208,7 @@ module aptos_std::aptos_hash {
     #[expected_failure(abort_code = 196609, location = Self)]
     fun blake2b_256_aborts(fx: signer) {
         // We disable the feature to make sure the `blake2b_256` call aborts
-        features::change_feature_flags(&fx, vector[], vector[features::get_blake2b_256_feature()]);
+        features::change_feature_flags_for_testing(&fx, vector[], vector[features::get_blake2b_256_feature()]);
 
         blake2b_256(b"This will abort");
     }
@@ -216,7 +216,7 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun blake2b_256_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_blake2b_256_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[features::get_blake2b_256_feature()], vector[]);
         let inputs = vector[
         b"",
         b"testing",

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -91,7 +91,7 @@ module aptos_std::type_info {
     #[test(fx = @std)]
     fun test_chain_id(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
 
         // The testing environment chain ID is 4u8.
         assert!(chain_id() == 4u8, 1);

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -620,7 +620,7 @@ module aptos_token_objects::collection {
     #[test(fx = @aptos_framework, creator = @0x123)]
     fun test_create_mint_burn_for_unlimited(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let feature = features::get_concurrent_token_v2_feature();
-        features::change_feature_flags(fx, vector[], vector[feature]);
+        features::change_feature_flags_for_testing(fx, vector[], vector[feature]);
 
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
@@ -639,7 +639,7 @@ module aptos_token_objects::collection {
     #[test(fx = @aptos_framework, creator = @0x123)]
     fun test_create_mint_burn_for_fixed(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let feature = features::get_concurrent_token_v2_feature();
-        features::change_feature_flags(fx, vector[], vector[feature]);
+        features::change_feature_flags_for_testing(fx, vector[], vector[feature]);
 
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
@@ -658,7 +658,7 @@ module aptos_token_objects::collection {
     #[test(fx = @aptos_framework, creator = @0x123)]
     fun test_create_mint_burn_for_concurrent(fx: &signer, creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let feature = features::get_concurrent_token_v2_feature();
-        features::change_feature_flags(fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(fx, vector[feature], vector[]);
 
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -751,7 +751,7 @@ module aptos_token_objects::token {
         use std::features;
 
         let feature = features::get_auids();
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -782,7 +782,7 @@ module aptos_token_objects::token {
         let agg_feature = features::get_aggregator_v2_api_feature();
         let auid_feature = features::get_auids();
         let module_event_feature = features::get_module_event_feature();
-        features::change_feature_flags(fx, vector[auid_feature, module_event_feature], vector[feature, agg_feature]);
+        features::change_feature_flags_for_testing(fx, vector[auid_feature, module_event_feature], vector[feature, agg_feature]);
 
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -793,7 +793,7 @@ module aptos_token_objects::token {
         debug::print(&token_1_name);
         assert!(token_1_name == std::string::utf8(b"token name1"), 1);
 
-        features::change_feature_flags(fx, vector[feature, agg_feature], vector[]);
+        features::change_feature_flags_for_testing(fx, vector[feature, agg_feature], vector[]);
         collection::upgrade_to_concurrent(&extend_ref);
 
         let token_2_ref = create_numbered_token_helper(creator, collection_name, token_name);

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -235,7 +235,8 @@ pub enum EntryFunctionCall {
     /// TODO: migrate these tests to be aware of async reconfiguration.
     AptosGovernanceForceEndEpoch {},
 
-    /// `force_end_epoch()` used in some move tests.
+    /// `force_end_epoch()` equivalent but only called in testnet,
+    /// where the core resources account exists and has been granted power to mint Aptos coins.
     AptosGovernanceForceEndEpochTestOnly {},
 
     /// Vote on proposal with `proposal_id` and specified voting power from `stake_pool`.
@@ -2071,7 +2072,8 @@ pub fn aptos_governance_force_end_epoch() -> TransactionPayload {
     ))
 }
 
-/// `force_end_epoch()` used in some move tests.
+/// `force_end_epoch()` equivalent but only called in testnet,
+/// where the core resources account exists and has been granted power to mint Aptos coins.
 pub fn aptos_governance_force_end_epoch_test_only() -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -105,6 +105,7 @@ return true.
 -  [Function `get_multisig_v2_enhancement_feature`](#0x1_features_get_multisig_v2_enhancement_feature)
 -  [Function `multisig_v2_enhancement_feature_enabled`](#0x1_features_multisig_v2_enhancement_feature_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
+-  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
 -  [Function `on_new_epoch`](#0x1_features_on_new_epoch)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
@@ -112,13 +113,14 @@ return true.
 -  [Function `contains`](#0x1_features_contains)
 -  [Function `apply_diff`](#0x1_features_apply_diff)
 -  [Function `ensure_vm_or_framework_signer`](#0x1_features_ensure_vm_or_framework_signer)
+-  [Function `change_feature_flags_for_verification`](#0x1_features_change_feature_flags_for_verification)
 -  [Specification](#@Specification_1)
     -  [Resource `Features`](#@Specification_1_Features)
     -  [Resource `PendingFeatures`](#@Specification_1_PendingFeatures)
     -  [Function `periodical_reward_rate_decrease_enabled`](#@Specification_1_periodical_reward_rate_decrease_enabled)
     -  [Function `partial_governance_voting_enabled`](#@Specification_1_partial_governance_voting_enabled)
     -  [Function `module_event_enabled`](#@Specification_1_module_event_enabled)
-    -  [Function `change_feature_flags`](#@Specification_1_change_feature_flags)
+    -  [Function `change_feature_flags_internal`](#@Specification_1_change_feature_flags_internal)
     -  [Function `change_feature_flags_for_next_epoch`](#@Specification_1_change_feature_flags_for_next_epoch)
     -  [Function `on_new_epoch`](#@Specification_1_on_new_epoch)
     -  [Function `is_enabled`](#@Specification_1_is_enabled)
@@ -390,6 +392,15 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING">DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING</a>: u64 = 21;
+</code></pre>
+
+
+
+<a id="0x1_features_EAPI_DISABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_EAPI_DISABLED">EAPI_DISABLED</a>: u64 = 2;
 </code></pre>
 
 
@@ -2418,10 +2429,14 @@ Lifetime: transient
 
 ## Function `change_feature_flags`
 
-Function to enable and disable features. Can only be called by a signer of @std.
+Deprecated to prevent validator set changes during DKG.
+
+Genesis/tests should use <code><a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>()</code> for feature vec initialization.
+
+Governance proposals should use <code><a href="features.md#0x1_features_change_feature_flags_for_next_epoch">change_feature_flags_for_next_epoch</a>()</code> to enable/disable features.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags">change_feature_flags</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags">change_feature_flags</a>(_framework: &<a href="signer.md#0x1_signer">signer</a>, _enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, _disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -2430,8 +2445,32 @@ Function to enable and disable features. Can only be called by a signer of @std.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags">change_feature_flags</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
-<b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags">change_feature_flags</a>(_framework: &<a href="signer.md#0x1_signer">signer</a>, _enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, _disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;) {
+    <b>abort</b>(<a href="error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="features.md#0x1_features_EAPI_DISABLED">EAPI_DISABLED</a>))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_change_feature_flags_internal"></a>
+
+## Function `change_feature_flags_internal`
+
+Update feature flags directly. Only used in genesis/tests.
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;) <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <b>assert</b>!(<a href="signer.md#0x1_signer_address_of">signer::address_of</a>(framework) == @std, <a href="error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="features.md#0x1_features_EFRAMEWORK_SIGNER_NEEDED">EFRAMEWORK_SIGNER_NEEDED</a>));
     <b>if</b> (!<b>exists</b>&lt;<a href="features.md#0x1_features_Features">Features</a>&gt;(@std)) {
         <b>move_to</b>&lt;<a href="features.md#0x1_features_Features">Features</a>&gt;(framework, <a href="features.md#0x1_features_Features">Features</a> { <a href="features.md#0x1_features">features</a>: <a href="vector.md#0x1_vector">vector</a>[] })
@@ -2454,12 +2493,7 @@ Function to enable and disable features. Can only be called by a signer of @std.
 
 ## Function `change_feature_flags_for_next_epoch`
 
-Enable and disable features *for the next epoch*.
-
-NOTE: when it takes effects depend on feature <code><a href="features.md#0x1_features_RECONFIGURE_WITH_DKG">RECONFIGURE_WITH_DKG</a></code>.
-See <code>aptos_framework::aptos_governance::reconfigure()</code> for more details.
-
-Can only be called by a signer of @std.
+Enable and disable features for the next epoch.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags_for_next_epoch">change_feature_flags_for_next_epoch</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
@@ -2671,6 +2705,31 @@ Helper to check whether a feature flag is enabled.
 
 </details>
 
+<a id="0x1_features_change_feature_flags_for_verification"></a>
+
+## Function `change_feature_flags_for_verification`
+
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags_for_verification">change_feature_flags_for_verification</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags_for_verification">change_feature_flags_for_verification</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;) <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>(framework, enable, disable)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -2793,12 +2852,12 @@ Helper to check whether a feature flag is enabled.
 
 
 
-<a id="@Specification_1_change_feature_flags"></a>
+<a id="@Specification_1_change_feature_flags_internal"></a>
 
-### Function `change_feature_flags`
+### Function `change_feature_flags_internal`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags">change_feature_flags</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -28,6 +28,7 @@ module std::features {
     use std::vector;
 
     const EINVALID_FEATURE: u64 = 1;
+    const EAPI_DISABLED: u64 = 2;
 
     // --------------------------------------------------------------------------------------------
     // Code Publishing
@@ -452,9 +453,17 @@ module std::features {
         features: vector<u8>,
     }
 
-    /// Function to enable and disable features. Can only be called by a signer of @std.
-    public fun change_feature_flags(framework: &signer, enable: vector<u64>, disable: vector<u64>)
-    acquires Features {
+    /// Deprecated to prevent validator set changes during DKG.
+    ///
+    /// Genesis/tests should use `change_feature_flags_internal()` for feature vec initialization.
+    ///
+    /// Governance proposals should use `change_feature_flags_for_next_epoch()` to enable/disable features.
+    public fun change_feature_flags(_framework: &signer, _enable: vector<u64>, _disable: vector<u64>) {
+        abort(error::invalid_state(EAPI_DISABLED))
+    }
+
+    /// Update feature flags directly. Only used in genesis/tests.
+    fun change_feature_flags_internal(framework: &signer, enable: vector<u64>, disable: vector<u64>) acquires Features {
         assert!(signer::address_of(framework) == @std, error::permission_denied(EFRAMEWORK_SIGNER_NEEDED));
         if (!exists<Features>(@std)) {
             move_to<Features>(framework, Features { features: vector[] })
@@ -468,12 +477,7 @@ module std::features {
         });
     }
 
-    /// Enable and disable features *for the next epoch*.
-    ///
-    /// NOTE: when it takes effects depend on feature `RECONFIGURE_WITH_DKG`.
-    /// See `aptos_framework::aptos_governance::reconfigure()` for more details.
-    ///
-    /// Can only be called by a signer of @std.
+    /// Enable and disable features for the next epoch.
     public fun change_feature_flags_for_next_epoch(framework: &signer, enable: vector<u64>, disable: vector<u64>) acquires PendingFeatures, Features {
         assert!(signer::address_of(framework) == @std, error::permission_denied(EFRAMEWORK_SIGNER_NEEDED));
 
@@ -549,6 +553,16 @@ module std::features {
         assert!(addr == @std || addr == @vm, error::permission_denied(EFRAMEWORK_SIGNER_NEEDED));
     }
 
+    #[verify_only]
+    public fun change_feature_flags_for_verification(framework: &signer, enable: vector<u64>, disable: vector<u64>) acquires Features {
+        change_feature_flags_internal(framework, enable, disable)
+    }
+
+    #[test_only]
+    public fun change_feature_flags_for_testing(framework: &signer, enable: vector<u64>, disable: vector<u64>) acquires Features {
+        change_feature_flags_internal(framework, enable, disable)
+    }
+
     #[test]
     fun test_feature_sets() {
         let features = vector[];
@@ -570,11 +584,11 @@ module std::features {
 
     #[test(fx = @std)]
     fun test_change_feature_txn(fx: signer) acquires Features {
-        change_feature_flags(&fx, vector[1, 9, 23], vector[]);
+        change_feature_flags_for_testing(&fx, vector[1, 9, 23], vector[]);
         assert!(is_enabled(1), 1);
         assert!(is_enabled(9), 2);
         assert!(is_enabled(23), 3);
-        change_feature_flags(&fx, vector[17], vector[9]);
+        change_feature_flags_for_testing(&fx, vector[17], vector[9]);
         assert!(is_enabled(1), 1);
         assert!(!is_enabled(9), 2);
         assert!(is_enabled(17), 3);

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -40,7 +40,7 @@ spec std::features {
             && (feature / 8) < len(features)
     }
 
-    spec change_feature_flags(framework: &signer, enable: vector<u64>, disable: vector<u64>) {
+    spec change_feature_flags_internal(framework: &signer, enable: vector<u64>, disable: vector<u64>) {
         pragma opaque;
         modifies global<Features>(@std);
         aborts_if signer::address_of(framework) != @std;

--- a/aptos-move/move-examples/token_objects/guild/sources/guild.move
+++ b/aptos-move/move-examples/token_objects/guild/sources/guild.move
@@ -265,7 +265,7 @@ module guild::guild {
         use std::features;
 
         let feature = features::get_auids();
-        features::change_feature_flags(&fx, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
 
         // This test assumes that the creator's address is equal to @token_objects.
         assert!(signer::address_of(admin) == @guild, 0);

--- a/aptos-move/move-examples/veiled_coin/sources/veiled_coin_tests.move
+++ b/aptos-move/move-examples/veiled_coin/sources/veiled_coin_tests.move
@@ -59,7 +59,7 @@ module veiled_coin::veiled_coin_tests {
         // Initialize the `veiled_coin` module & enable the feature
         veiled_coin::init_module_for_testing(veiled_coin);
         println(b"Initialized module.");
-        features::change_feature_flags(&aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
+        features::change_feature_flags_for_testing(&aptos_fx, vector[features::get_bulletproofs_feature()], vector[]);
         println(b"Enabled feature flags.");
 
         // Set up an account for the framework address

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -463,7 +463,7 @@ fn initialize_features(session: &mut SessionExt, features_override: Option<Vec<F
     exec_function(
         session,
         "features",
-        "change_feature_flags",
+        "change_feature_flags_internal",
         vec![],
         serialized_values,
     );

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -129,8 +129,9 @@ pub fn test_execution_with_storage_impl_inner(
     let txn6 =
         account1.sign_with_transaction_builder(txn_factory.transfer(account3.address(), 70 * B));
 
-    let reconfig1 = core_resources_account
-        .sign_with_transaction_builder(txn_factory.payload(aptos_stdlib::version_set_version(100)));
+    let reconfig1 = core_resources_account.sign_with_transaction_builder(
+        txn_factory.payload(aptos_stdlib::aptos_governance_force_end_epoch_test_only()),
+    );
 
     let block1: Vec<_> = into_signature_verified_block(vec![
         block1_meta,
@@ -156,8 +157,9 @@ pub fn test_execution_with_storage_impl_inner(
         vec![],
         2,
     ));
-    let reconfig2 = core_resources_account
-        .sign_with_transaction_builder(txn_factory.payload(aptos_stdlib::version_set_version(200)));
+    let reconfig2 = core_resources_account.sign_with_transaction_builder(
+        txn_factory.payload(aptos_stdlib::aptos_governance_force_end_epoch_test_only()),
+    );
     let block2 = vec![block2_meta, UserTransaction(reconfig2)];
 
     let block3_id = gen_block_id(3);

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -132,16 +132,24 @@ fn test_reconfiguration() {
         300000001,
     ));
 
-    // txn3 = set the aptos version
+    // txn3 = set the aptos version for next epoch
     let txn3 = get_test_signed_transaction(
         aptos_test_root_address(),
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(aptos_stdlib::version_set_version(42)),
+        Some(aptos_stdlib::version_set_for_next_epoch(42)),
     );
 
-    let txn_block = into_signature_verified_block(vec![txn1, txn2, txn3]);
+    let txn4 = get_test_signed_transaction(
+        aptos_test_root_address(),
+        2,
+        genesis_key.clone(),
+        genesis_key.public_key(),
+        Some(aptos_stdlib::aptos_governance_force_end_epoch_test_only()),
+    );
+
+    let txn_block = into_signature_verified_block(vec![txn1, txn2, txn3, txn4]);
     let block_id = gen_block_id(1);
     let vm_output = executor
         .execute_block(
@@ -165,11 +173,11 @@ fn test_reconfiguration() {
     let latest_li = state_proof.latest_ledger_info();
     let current_version = latest_li.version();
 
-    let t3 = db
+    let t4 = db
         .reader
-        .get_transaction_by_version(3, current_version, /*fetch_events=*/ true)
+        .get_transaction_by_version(4, current_version, /*fetch_events=*/ true)
         .unwrap();
-    verify_committed_txn_status(latest_li, &t3, &txn_block[2]).unwrap();
+    verify_committed_txn_status(latest_li, &t4, &txn_block[3]).unwrap();
 
     let db_state_view = db
         .reader

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -73,7 +73,8 @@ async fn update_consensus_config(
         fun main(core_resources: &signer) {{
             let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
             let config_bytes = {};
-            consensus_config::set(&framework_signer, config_bytes);
+            consensus_config::set_for_next_epoch(&framework_signer, config_bytes);
+            aptos_governance::force_end_epoch(&framework_signer);
         }}
     }}
     "#,

--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -59,7 +59,7 @@ async fn test_upgrade_flow() {
     };
 
     let (_, update_gas_script) =
-        generate_gas_upgrade_proposal(&gas_schedule, true, "".to_owned().into_bytes())
+        generate_gas_upgrade_proposal(true, &gas_schedule, true, "".to_owned().into_bytes())
             .unwrap()
             .pop()
             .unwrap();

--- a/types/src/jwks/mod.rs
+++ b/types/src/jwks/mod.rs
@@ -63,9 +63,17 @@ impl From<crate::on_chain_config::OIDCProvider> for OIDCProvider {
     }
 }
 
+impl Debug for OIDCProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OIDCProvider")
+            .field("name", &String::from_utf8(self.name.clone()))
+            .field("config_url", &String::from_utf8(self.config_url.clone()))
+            .finish()
+    }
+}
 /// Move type `0x1::jwks::SupportedOIDCProviders` in rust.
 /// See its doc in Move for more details.
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SupportedOIDCProviders {
     pub providers: Vec<OIDCProvider>,
 }

--- a/types/src/jwks/mod.rs
+++ b/types/src/jwks/mod.rs
@@ -63,6 +63,17 @@ impl From<crate::on_chain_config::OIDCProvider> for OIDCProvider {
     }
 }
 
+impl TryFrom<OIDCProvider> for crate::on_chain_config::OIDCProvider {
+    type Error = anyhow::Error;
+
+    fn try_from(value: OIDCProvider) -> Result<Self, Self::Error> {
+        let OIDCProvider { name, config_url } = value;
+        let name = String::from_utf8(name)?;
+        let config_url = String::from_utf8(config_url)?;
+        Ok(crate::on_chain_config::OIDCProvider { name, config_url })
+    }
+}
+
 impl Debug for OIDCProvider {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OIDCProvider")

--- a/types/src/on_chain_config/jwk_consensus_config.rs
+++ b/types/src/on_chain_config/jwk_consensus_config.rs
@@ -1,9 +1,10 @@
 // Copyright © Aptos Foundation
 
 use crate::{
+    jwks::SupportedOIDCProviders,
     move_any::{Any as MoveAny, Any, AsMoveAny},
     move_utils::as_move_value::AsMoveValue,
-    on_chain_config::OnChainConfig,
+    on_chain_config::{FeatureFlag, Features, OnChainConfig},
 };
 use anyhow::anyhow;
 use move_core_types::value::{MoveStruct, MoveValue};
@@ -97,5 +98,28 @@ impl AsMoveValue for OnChainJWKConsensusConfig {
             OnChainJWKConsensusConfig::V1(v1) => v1.as_move_any(),
         };
         MoveValue::Struct(MoveStruct::Runtime(vec![packed_variant.as_move_value()]))
+    }
+}
+
+/// Before `JWKConsensusConfig` is initialized, convert from `Features` and `SupportedOIDCProviders` instead.
+impl From<(Option<Features>, Option<SupportedOIDCProviders>)> for OnChainJWKConsensusConfig {
+    fn from(
+        (features, supported_oidc_providers): (Option<Features>, Option<SupportedOIDCProviders>),
+    ) -> Self {
+        if let Some(features) = features {
+            if features.is_enabled(FeatureFlag::JWK_CONSENSUS) {
+                let oidc_providers = supported_oidc_providers
+                    .unwrap_or_default()
+                    .providers
+                    .into_iter()
+                    .filter_map(|deprecated| OIDCProvider::try_from(deprecated).ok())
+                    .collect();
+                OnChainJWKConsensusConfig::V1(ConfigV1 { oidc_providers })
+            } else {
+                OnChainJWKConsensusConfig::Off
+            }
+        } else {
+            OnChainJWKConsensusConfig::Off
+        }
     }
 }

--- a/types/src/on_chain_config/randomness_config.rs
+++ b/types/src/on_chain_config/randomness_config.rs
@@ -52,6 +52,24 @@ pub enum OnChainRandomnessConfig {
     V1(ConfigV1),
 }
 
+impl OnChainRandomnessConfig {
+    pub fn new_v1(
+        secrecy_threshold_in_percentage: u64,
+        reconstruct_threshold_in_percentage: u64,
+    ) -> Self {
+        let secrecy_threshold = FixedPoint64MoveStruct::from_u64f64(
+            U64F64::from_num(secrecy_threshold_in_percentage) / U64F64::from_num(100),
+        );
+        let reconstruction_threshold = FixedPoint64MoveStruct::from_u64f64(
+            U64F64::from_num(reconstruct_threshold_in_percentage) / U64F64::from_num(100),
+        );
+        Self::V1(ConfigV1 {
+            secrecy_threshold,
+            reconstruction_threshold,
+        })
+    }
+}
+
 impl TryFrom<RandomnessConfigMoveStruct> for OnChainRandomnessConfig {
     type Error = anyhow::Error;
 


### PR DESCRIPTION
### Disable governance functions that breaks randomness

The following governance functions need to be disabled (except some genesis/test usage), because they internally call `aptos_framework::reconfiguration::reconfigure()` which break randomness for an epoch.

- `aptos_framework::consensus_config::set()`
- `aptos_framework::execution_config::set()`
- `aptos_framework::version::set()`
- `aptos_framework::gas_schedule::set_gas_schedule()`
- `std::features::change_feature_flags()`
- `aptos_framework::jwks::upsert_oidc_provider()`
- `aptos_framework::jwks::remove_oidc_provider()`

The new way to update these on-chain configs is to write the change(s) into a buffer, and immediately trigger `aptos_governance::reconfigure` (which maybe immediate/async, depending on whether randomness is enabled): buffered change will be applied at the end of the reconfig. Typically a governance proposal script will look like:
```
onchain_config_x::set_for_next_epoch(&framework);
onchain_config_y::set_for_next_epoch(&framework);
// ...
aptos_governance::reconfigure(&framework);
```
See `aptos-move/aptos-release-builder/data/example-release-with-randomness-framework` for full details.

### Release builder updates
`aptos-release-builder` is updated accordingly to use the new governance functions when translating release entries.

NOTE that a new entry `DefaultGasWithOverrideOld` is temporarily added to support the following release proposal sequence:
1. update `txn.max_execution_gas` using the old governance function `aptos_framework::gas_schedule::update_gas_schedule()` (so the next txn can fit).
2. framework upgrade (old governance functions are now disabled)
3. Restore to default gas using the new governance function `aptos_framework::gas_schedule::update_for_next_epoch()`

### Update some existing tests accordingly

### Added release entries for randomness release