### PR TITLE
[aptos channel] always reset counters on new channel

### DIFF
--- a/crates/channel/src/aptos_channel.rs
+++ b/crates/channel/src/aptos_channel.rs
@@ -240,6 +240,9 @@ pub fn new<K: Eq + Hash + Clone, M>(
 ) -> (Sender<K, M>, Receiver<K, M>) {
     let max_queue_size_per_key =
         NonZeroUsize!(max_queue_size_per_key, "aptos_channel cannot be of size 0");
+    if let Some(counters) = counters {
+        counters.reset();
+    }
     let shared_state = Arc::new(Mutex::new(SharedState {
         internal_queue: PerKeyQueue::new(queue_style, max_queue_size_per_key, counters),
         waker: None,


### PR DESCRIPTION
### Description

The consensus queues are recreated per epoch. Without resetting the counters, the "Round manager pending messages" show as increasing number of "stuck" messages, which are simply messages that were in the queue during the epoch change (and hence were not dequeued or dropped).

### Test Plan

Deployed to previewnet and saw round manager pending messages are no longer stuck
