### PR TITLE
[Compiler-v2] Fix issue 12198

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1152,6 +1152,48 @@ impl<'env> Generator<'env> {
         }
     }
 
+    /// Generate borrow_field when unpacking a reference to a struct
+    // e.g. `let s = &S; let (a, b, c) = &s`, a, b, and c are references
+    fn gen_borrow_field_for_unpack_ref(
+        &mut self,
+        id: &NodeId,
+        str: &QualifiedInstId<StructId>,
+        arg: TempIndex,
+        temps: Vec<TempIndex>,
+        ref_kind: ReferenceKind,
+    ) {
+        let struct_env = self.env().get_struct(str.to_qualified_id());
+        let mut temp_to_field_offsets = BTreeMap::new();
+        for (field, input_temp) in struct_env.get_fields().zip(temps.clone()) {
+            temp_to_field_offsets.insert(input_temp, field.get_offset());
+        }
+        for (temp, field_offset) in temp_to_field_offsets {
+            self.with_reference_mode(|s, entering| {
+                if entering {
+                    s.reference_mode_kind = ref_kind
+                }
+                if !s.temp_type(temp).is_reference() {
+                    s.env().diag(
+                        Severity::Bug,
+                        &s.env().get_node_loc(*id),
+                        "Unpacking a reference to a struct must return the references of fields",
+                    );
+                }
+                s.emit_call(
+                    *id,
+                    vec![temp],
+                    BytecodeOperation::BorrowField(
+                        str.module_id,
+                        str.id,
+                        str.inst.to_owned(),
+                        field_offset,
+                    ),
+                    vec![arg],
+                );
+            });
+        }
+    }
+
     fn gen_assign_from_temp(
         &mut self,
         id: NodeId,
@@ -1171,6 +1213,15 @@ impl<'env> Generator<'env> {
             },
             Pattern::Struct(id, str, args) => {
                 let (temps, cont_assigns) = self.flatten_patterns(args, next_scope);
+                let ty = self.temp_type(arg);
+                if ty.is_reference() {
+                    let ref_kind = if ty.is_immutable_reference() {
+                        ReferenceKind::Immutable
+                    } else {
+                        ReferenceKind::Mutable
+                    };
+                    return self.gen_borrow_field_for_unpack_ref(id, str, arg, temps, ref_kind);
+                }
                 self.emit_call(
                     *id,
                     temps,

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
@@ -1,0 +1,84 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module 42.pack_unpack_ref {
+struct G {
+	x1: u64,
+	x2: u64,
+	s: S
+}
+struct S {
+	f: u64,
+	g: u64
+}
+
+unpack_mut_ref(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
+L0:	loc1: &mut u64
+B0:
+	0: CopyLoc[0](Arg0: &mut S)
+	1: MutBorrowField[0](S.f: u64)
+	2: CopyLoc[0](Arg0: &mut S)
+	3: MutBorrowField[1](S.g: u64)
+	4: MoveLoc[0](Arg0: &mut S)
+	5: Pop
+	6: StLoc[1](loc0: &mut u64)
+	7: StLoc[2](loc1: &mut u64)
+	8: MoveLoc[2](loc1: &mut u64)
+	9: ReadRef
+	10: MoveLoc[1](loc0: &mut u64)
+	11: ReadRef
+	12: Ret
+}
+unpack_ref(Arg0: &S): u64 * u64 /* def_idx: 1 */ {
+L0:	loc1: &u64
+B0:
+	0: CopyLoc[0](Arg0: &S)
+	1: ImmBorrowField[0](S.f: u64)
+	2: CopyLoc[0](Arg0: &S)
+	3: ImmBorrowField[1](S.g: u64)
+	4: MoveLoc[0](Arg0: &S)
+	5: Pop
+	6: StLoc[1](loc0: &u64)
+	7: StLoc[2](loc1: &u64)
+	8: MoveLoc[2](loc1: &u64)
+	9: ReadRef
+	10: MoveLoc[1](loc0: &u64)
+	11: ReadRef
+	12: Ret
+}
+unpack_ref_G(Arg0: &G): u64 * u64 * u64 * u64 /* def_idx: 2 */ {
+L0:	loc1: &u64
+L1:	loc2: &u64
+L2:	loc3: &u64
+L3:	loc4: &u64
+B0:
+	0: CopyLoc[0](Arg0: &G)
+	1: ImmBorrowField[2](G.x1: u64)
+	2: CopyLoc[0](Arg0: &G)
+	3: ImmBorrowField[3](G.x2: u64)
+	4: CopyLoc[0](Arg0: &G)
+	5: ImmBorrowField[4](G.s: S)
+	6: StLoc[1](loc0: &S)
+	7: MoveLoc[0](Arg0: &G)
+	8: Pop
+	9: CopyLoc[1](loc0: &S)
+	10: ImmBorrowField[0](S.f: u64)
+	11: CopyLoc[1](loc0: &S)
+	12: ImmBorrowField[1](S.g: u64)
+	13: MoveLoc[1](loc0: &S)
+	14: Pop
+	15: StLoc[2](loc1: &u64)
+	16: StLoc[3](loc2: &u64)
+	17: StLoc[4](loc3: &u64)
+	18: StLoc[5](loc4: &u64)
+	19: MoveLoc[5](loc4: &u64)
+	20: ReadRef
+	21: MoveLoc[4](loc3: &u64)
+	22: ReadRef
+	23: MoveLoc[3](loc2: &u64)
+	24: ReadRef
+	25: MoveLoc[2](loc1: &u64)
+	26: ReadRef
+	27: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.move
@@ -1,0 +1,29 @@
+module 0x42::pack_unpack_ref {
+    struct S {
+        f: u64,
+        g: u64
+    }
+
+    struct G {
+        x1: u64,
+        x2: u64,
+        s: S,
+    }
+
+    fun unpack_ref(s: &S): (u64, u64) {
+        let S{f, g} = s;
+        (*f, *g)
+    }
+
+    fun unpack_ref_G(g: &G): (u64, u64, u64, u64) {
+        let G{ x1, x2, s  } = g;
+        let S {f, g} = s;
+        (*x1, *x2, *f, *g)
+    }
+
+    fun unpack_mut_ref(s: &mut S): (u64, u64) {
+        let S{f, g} = s;
+        (*f, *g)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/pack_unpack_ref.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/pack_unpack_ref.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/pack_unpack_ref.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/pack_unpack_ref.move
@@ -1,0 +1,34 @@
+//# publish
+module 0x42::pack_unpack_ref {
+    struct S has drop {
+        f: u64,
+        g: u64
+    }
+
+    struct G has drop {
+        x1: u64,
+        x2: u64,
+        s: S,
+    }
+
+    fun unpack_ref_G() {
+        let s = S {f: 0, g: 1};
+        let g = G {x1: 2, x2: 3, s};
+        let G{ x1, x2, s  } = &mut g;
+        let S {f, g} = s;
+        assert!(*f == 0, 0);
+        assert!(*g == 1, 1);
+        assert!(*x1 == 2, 2);
+        assert!(*x2 == 3, 3);
+        *x1 = *x1 + 1;
+        *x2 = *x2 + 1;
+        *f = *f + 1;
+        *g = *g + 1;
+        assert!(*f == 1, 0);
+        assert!(*g == 2, 1);
+        assert!(*x1 == 3, 2);
+        assert!(*x2 == 4, 3);
+    }
+}
+
+//# run  0x42::pack_unpack_ref::unpack_ref_G


### PR DESCRIPTION
### Description

This PR closes #12198 by generating the borrow_field instruction for each field when unpacking a reference to a struct.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added one unit test and one transactional test to validate the fix.

