### PR TITLE
Fix INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE description

### DIFF
--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -514,7 +514,8 @@ pub enum StatusCode {
     SEQUENCE_NUMBER_TOO_OLD = 3,
     // Sequence number is too new
     SEQUENCE_NUMBER_TOO_NEW = 4,
-    // Insufficient balance to pay minimum transaction fee
+    // Insufficient balance to pay for max_gas specified in the transaction.
+    // Balance needs to be above max_gas_amount * gas_unit_price to proceed.
     INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE = 5,
     // The transaction has expired
     TRANSACTION_EXPIRED = 6,


### PR DESCRIPTION
As far as I understand, INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE is thrown when accounts balance is not enough for the max_gas specified in the transaction. but current description is not conveying that, so trying to clarify it.

Is https://aptos.dev/reference/error-codes/ showing directly what is written here, or is there a separate change needed for that?

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
