### PR TITLE
Switch to multi-region Docker repository

### DIFF
--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -20,7 +20,7 @@
 //  - crane - https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation
 //  - pnpm - https://pnpm.io/installation
 // 2. docker login - with authorization to push to the `aptoslabs` org
-// 3. gcloud auth configure-docker us-west1-docker.pkg.dev
+// 3. gcloud auth configure-docker us-docker.pkg.dev
 // 4. gcloud auth login --update-adc
 // 5. AWS CLI credentials configured
 //

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -59,7 +59,7 @@ FORGE_TEST_RUNNER_TEMPLATE_PATH = "forge-test-runner-template.yaml"
 
 MULTIREGION_KUBECONFIG_DIR = "/etc/multiregion-kubeconfig"
 MULTIREGION_KUBECONFIG_PATH = f"{MULTIREGION_KUBECONFIG_DIR}/kubeconfig"
-GAR_REPO_NAME = "us-west1-docker.pkg.dev/aptos-global/aptos-internal"
+GAR_REPO_NAME = "us-docker.pkg.dev/aptos-registry/docker"
 
 
 @dataclass


### PR DESCRIPTION
### Description

Replace references to the old `aptos-internal` repository with the multi-region repo.

### Test Plan

See if the Forge tests run correctly.