### PR TITLE
[Multisig V2][API] Fix the API error for Multisig V2

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -13366,7 +13366,32 @@
       },
       "MultisigTransactionPayload": {
         "type": "object",
-        "anyOf": [
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MultisigTransactionPayload_EntryFunctionPayload"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "entry_function_payload": "#/components/schemas/MultisigTransactionPayload_EntryFunctionPayload"
+          }
+        }
+      },
+      "MultisigTransactionPayload_EntryFunctionPayload": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "example": "entry_function_payload"
+              }
+            }
+          },
           {
             "$ref": "#/components/schemas/EntryFunctionPayload"
           }

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -10072,7 +10072,21 @@ components:
           $ref: '#/components/schemas/MultisigTransactionPayload'
     MultisigTransactionPayload:
       type: object
-      anyOf:
+      oneOf:
+      - $ref: '#/components/schemas/MultisigTransactionPayload_EntryFunctionPayload'
+      discriminator:
+        propertyName: type
+        mapping:
+          entry_function_payload: '#/components/schemas/MultisigTransactionPayload_EntryFunctionPayload'
+    MultisigTransactionPayload_EntryFunctionPayload:
+      allOf:
+      - type: object
+        required:
+        - type
+        properties:
+          type:
+            type: string
+            example: entry_function_payload
       - $ref: '#/components/schemas/EntryFunctionPayload'
     PendingTransaction:
       type: object

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -397,6 +397,7 @@ impl TestContext {
                 "type": "multisig_payload",
                 "multisig_address": multisig_account.to_hex_literal(),
                 "transaction_payload": {
+                    "type": "entry_function_payload",
                     "function": function,
                     "type_arguments": type_args,
                     "arguments": args
@@ -822,6 +823,7 @@ impl TestContext {
                 "type": "multisig_payload",
                 "multisig_address": multisig_account.to_hex_literal(),
                 "transaction_payload": {
+                    "type": "entry_function_payload",
                     "function": function,
                     "type_arguments": type_args,
                     "arguments": args

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -740,6 +740,8 @@ impl TryFrom<Script> for ScriptPayload {
 // We use an enum here for extensibility so we can add Script payload support
 // in the future for example.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Union)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum MultisigTransactionPayload {
     EntryFunctionPayload(EntryFunctionPayload),
 }
@@ -751,6 +753,8 @@ pub struct MultisigPayload {
     pub multisig_address: Address,
 
     // Transaction payload is optional if already stored on chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub transaction_payload: Option<MultisigTransactionPayload>,
 }
 

--- a/ecosystem/typescript/sdk/src/generated/index.ts
+++ b/ecosystem/typescript/sdk/src/generated/index.ts
@@ -58,6 +58,7 @@ export type { MultiEd25519Signature } from './models/MultiEd25519Signature';
 export type { MultiKeySignature } from './models/MultiKeySignature';
 export type { MultisigPayload } from './models/MultisigPayload';
 export type { MultisigTransactionPayload } from './models/MultisigTransactionPayload';
+export type { MultisigTransactionPayload_EntryFunctionPayload } from './models/MultisigTransactionPayload_EntryFunctionPayload';
 export type { PendingTransaction } from './models/PendingTransaction';
 export type { PublicKey } from './models/PublicKey';
 export type { PublicKey_string_HexEncodedBytes_ } from './models/PublicKey_string_HexEncodedBytes_';

--- a/ecosystem/typescript/sdk/src/generated/models/MultisigTransactionPayload.ts
+++ b/ecosystem/typescript/sdk/src/generated/models/MultisigTransactionPayload.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { EntryFunctionPayload } from './EntryFunctionPayload';
+import type { MultisigTransactionPayload_EntryFunctionPayload } from './MultisigTransactionPayload_EntryFunctionPayload';
 
-export type MultisigTransactionPayload = EntryFunctionPayload;
+export type MultisigTransactionPayload = MultisigTransactionPayload_EntryFunctionPayload;
 

--- a/ecosystem/typescript/sdk/src/generated/models/MultisigTransactionPayload_EntryFunctionPayload.ts
+++ b/ecosystem/typescript/sdk/src/generated/models/MultisigTransactionPayload_EntryFunctionPayload.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { EntryFunctionPayload } from './EntryFunctionPayload';
+
+export type MultisigTransactionPayload_EntryFunctionPayload = ({
+    type: string;
+} & EntryFunctionPayload);
+


### PR DESCRIPTION
### Description
- Currently, simulating Multisig payloads fails with the following error message:
```
{
  "Error": "API error: Unknown error error decoding response body: invalid value: map, expected map with a single key at line 1 column 5701"
}
```

- This is caused by the incorrect serialization of the `MultisigTransactionPayload` type.

- For the correct (de)serialization, this PR adds the serde attribute (tag = "type") to the enum type `MultisigTransactionPayload`

This PR resolves https://github.com/aptos-labs/aptos-core/issues/12469,
and partially for https://github.com/aptos-labs/aptos-core/issues/8304.

### Test Plan
tested on the localnet