### PR TITLE
[Compiler]  Fix parse error in for(  

### DIFF
--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -947,8 +947,8 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
         },
         Tok::Identifier
             if context.tokens.content() == FOR_IDENT
-                && matches!(context.tokens.lookahead_nth(1), Ok(Tok::LParen))
-                && matches!(context.tokens.lookahead_nth(3), Ok(Tok::Identifier)) =>
+                && matches!(context.tokens.lookahead_nth(0), Ok(Tok::LParen))
+                && matches!(context.tokens.lookahead_nth(2), Ok(Tok::Identifier)) =>
         {
             let (control_exp, _) = parse_for_loop(context)?;
             // for loop isn't useful in an expression, so we ignore second result from


### PR DESCRIPTION
## Description

During the parsing process for the for statement, the original query targeted the second character being '('. However, in cases like for(, this query inadvertently matches the loop variable and the 'in' keyword within the for loop. 

To address this, the revised approach involves checking whether the subsequent token is '(', and simultaneously verifying if the third token corresponds to the loop variable.

```
if context.tokens.content() == FOR_IDENT
                && matches!(context.tokens.lookahead_nth( 1 -> 0 ), Ok(Tok::LParen))
                && matches!(context.tokens.lookahead_nth( 3 -> 2 ), Ok(Tok::Identifier))
```

Fix: #11921 

## Type of Change
- [ ] New feature
- [*] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
 
 
