### PR TITLE
[CLI] Increase max_connections for postgres in local testnet

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Increased `max_connections` for postgres container created as part of local testnet to address occasional startup failures due to overloaded DB.
 
 ## [3.0.1] - 2024/03/05
 - Fix bug in `aptos update revela` if default install directory doesn't exist.

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -25,7 +25,7 @@ use tracing::{info, warn};
 
 pub const POSTGRES_CONTAINER_NAME: &str = "local-testnet-postgres";
 const POSTGRES_VOLUME_NAME: &str = "local-testnet-postgres-data";
-const POSTGRES_IMAGE: &str = "postgres:14.9";
+const POSTGRES_IMAGE: &str = "postgres:14.11";
 const DATA_PATH_IN_CONTAINER: &str = "/var/lib/mydata";
 const POSTGRES_DEFAULT_PORT: u16 = 5432;
 
@@ -271,6 +271,23 @@ impl ServiceManager for PostgresManager {
                 // directory inside the container that is mounted from the host system.
                 format!("PGDATA={}", DATA_PATH_IN_CONTAINER),
             ]),
+            cmd: Some(
+                vec![
+                    "postgres",
+                    "-c",
+                    // The default is 100 as of Postgres 14.11. Given the local testnet
+                    // can be composed of many different processors all with their own
+                    // connection pools, 100 is insufficient.
+                    "max_connections=200",
+                    "-c",
+                    // The default is 128MB as of Postgres 14.11. We 2x that value to
+                    // match the fact that we 2x'd max_connections.
+                    "shared_buffers=256MB",
+                ]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+            ),
             ..Default::default()
         };
 

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -98,7 +98,9 @@ impl ProcessorManager {
             ending_version: None,
             number_concurrent_processing_tasks: None,
             enable_verbose_logging: None,
-            db_pool_size: None,
+            // The default at the time of writing is 30 but we don't need that
+            // many in a local testnet environment.
+            db_pool_size: Some(8),
             gap_detection_batch_size: 50,
         };
         let manager = Self {


### PR DESCRIPTION
## Description
The local testnet sometimes fails to start because the number of connections is greater than the max the DB allows. This PR configures the postgres container to have a higher max connections count.

While here I upgrade the minor version of postgres.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-indexer-api
```
The local testnet comes up happily.

See also:
```
postgres=> SHOW max_connections;
250
```

I ran the TS SDK v2 tests and they all passed.

## Key Areas to Review
N/A

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
