### PR TITLE
[State Sync] Small metrics and performance improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,7 +3908,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
- "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
  "aptos-crypto",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -147,8 +147,6 @@ impl Default for StateSyncDriverConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageServiceConfig {
-    /// Maximum number of concurrent storage server tasks
-    pub max_concurrent_requests: u64,
     /// Maximum number of epoch ending ledger infos per chunk
     pub max_epoch_chunk_size: u64,
     /// Maximum number of invalid requests per peer
@@ -182,7 +180,6 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
-            max_concurrent_requests: 4000,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_invalid_requests_per_peer: 500,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB

--- a/network/framework/src/protocols/rpc/error.rs
+++ b/network/framework/src/protocols/rpc/error.rs
@@ -53,6 +53,7 @@ impl From<PeerManagerError> for RpcError {
         }
     }
 }
+
 impl From<oneshot::Canceled> for RpcError {
     fn from(_: oneshot::Canceled) -> Self {
         RpcError::UnexpectedResponseChannelCancel
@@ -62,5 +63,11 @@ impl From<oneshot::Canceled> for RpcError {
 impl From<tokio::time::error::Elapsed> for RpcError {
     fn from(_err: tokio::time::error::Elapsed) -> RpcError {
         RpcError::TimedOut
+    }
+}
+
+impl From<tokio::task::JoinError> for RpcError {
+    fn from(err: tokio::task::JoinError) -> RpcError {
+        RpcError::Error(anyhow!("JoinError: {:?}", err))
     }
 }

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -695,7 +695,7 @@ impl AptosDataClient {
         request_timeout_ms: u64,
     ) -> crate::error::Result<Response<T>>
     where
-        T: TryFrom<StorageServiceResponse, Error = E>,
+        T: TryFrom<StorageServiceResponse, Error = E> + Send + 'static,
         E: Into<Error>,
     {
         // Start the timer for the request
@@ -733,17 +733,22 @@ impl AptosDataClient {
             )));
         }
 
-        // Try to convert the storage service enum into the exact variant we're expecting
-        match T::try_from(storage_response) {
-            Ok(new_payload) => Ok(Response::new(context, new_payload)),
-            // If the variant doesn't match what we're expecting, report the issue
-            Err(err) => {
-                context
-                    .response_callback
-                    .notify_bad_response(ResponseError::InvalidPayloadDataType);
-                Err(err.into())
-            },
-        }
+        // Try to convert the storage service enum into the exact variant we're expecting.
+        // We do this using spawn_blocking because it involves serde and compression.
+        tokio::task::spawn_blocking(move || {
+            match T::try_from(storage_response) {
+                Ok(new_payload) => Ok(Response::new(context, new_payload)),
+                // If the variant doesn't match what we're expecting, report the issue
+                Err(err) => {
+                    context
+                        .response_callback
+                        .notify_bad_response(ResponseError::InvalidPayloadDataType);
+                    Err(err.into())
+                },
+            }
+        })
+        .await
+        .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?
     }
 
     /// Sends a request to a specific peer

--- a/state-sync/aptos-data-client/src/tests/advertise.rs
+++ b/state-sync/aptos-data-client/src/tests/advertise.rs
@@ -15,8 +15,11 @@ use aptos_storage_service_types::{
     requests::{DataRequest, TransactionsWithProofRequest},
     responses::{CompleteDataRange, DataResponse, StorageServerSummary, StorageServiceResponse},
 };
+use aptos_time_service::MockTimeService;
 use aptos_types::transaction::{TransactionListWithProof, Version};
 use claims::assert_matches;
+use std::time::Duration;
+use tokio::time::timeout;
 
 #[tokio::test]
 async fn request_works_only_when_data_available() {
@@ -79,12 +82,7 @@ async fn request_works_only_when_data_available() {
         });
 
         // Verify the peer's state has been updated
-        let peer_state = peer_to_states.get(&peer).unwrap().value().clone();
-        let peer_storage_summary = peer_state
-            .get_storage_summary_if_not_ignored()
-            .unwrap()
-            .clone();
-        assert_eq!(peer_storage_summary, storage_summary);
+        verify_peer_state(&client, peer, storage_summary).await;
 
         // Request transactions and verify the request succeeds
         let request_timeout = data_client_config.response_timeout_ms;
@@ -141,18 +139,29 @@ async fn update_global_data_summary() {
         utils::advance_polling_timer(&mut mock_time, &data_client_config).await;
 
         // Verify that the advertised data ranges are valid
-        verify_advertised_transaction_data(&client, peer_version, index + 1, true);
+        verify_advertised_transaction_data(
+            &mut mock_time,
+            &data_client_config,
+            &client,
+            peer_version,
+            index + 1,
+            true,
+        )
+        .await;
     }
 
     // Verify that the advertised data ranges are all present
     for (index, peer_version) in advertised_peer_versions.iter().enumerate() {
         let is_highest_version = index == advertised_peer_versions.len() - 1;
         verify_advertised_transaction_data(
+            &mut mock_time,
+            &data_client_config,
             &client,
             *peer_version,
             advertised_peer_versions.len(),
             is_highest_version,
-        );
+        )
+        .await;
     }
 }
 
@@ -190,7 +199,7 @@ async fn update_peer_states() {
     tokio::task::yield_now().await;
 
     // Verify that the high priority peer's state has been updated
-    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary);
+    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary).await;
 
     // Add a medium priority peer
     let (medium_priority_peer, medium_priority_network) =
@@ -215,12 +224,13 @@ async fn update_peer_states() {
     tokio::task::yield_now().await;
 
     // Verify that the peer's states have been set
-    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary);
+    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary).await;
     verify_peer_state(
         &client,
         medium_priority_peer,
         medium_priority_storage_summary,
-    );
+    )
+    .await;
 
     // Add a low priority peer
     let (low_priority_peer, low_priority_network) =
@@ -250,13 +260,14 @@ async fn update_peer_states() {
     tokio::task::yield_now().await;
 
     // Verify that the peer's states have been set
-    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary);
+    verify_peer_state(&client, high_priority_peer, high_priority_storage_summary).await;
     verify_peer_state(
         &client,
         medium_priority_peer,
         medium_priority_storage_summary,
-    );
-    verify_peer_state(&client, low_priority_peer, low_priority_storage_summary);
+    )
+    .await;
+    verify_peer_state(&client, low_priority_peer, low_priority_storage_summary).await;
 }
 
 #[tokio::test]
@@ -341,51 +352,78 @@ async fn fetch_transactions_and_verify_failure(
 }
 
 /// Verifies that the advertised transaction data is valid
-fn verify_advertised_transaction_data(
+async fn verify_advertised_transaction_data(
+    mock_time: &mut MockTimeService,
+    data_client_config: &AptosDataClientConfig,
     client: &AptosDataClient,
     advertised_version: Version,
     expected_num_advertisements: usize,
     is_highest_version: bool,
 ) {
-    // Get the advertised data
-    let global_data_summary = client.get_global_data_summary();
-    let advertised_data = global_data_summary.advertised_data;
+    // Wait for the advertised data to be updated
+    timeout(Duration::from_secs(10), async {
+        loop {
+            // Advance time so the poller updates the global data summary
+            utils::advance_polling_timer(mock_time, data_client_config).await;
 
-    // Verify the number of advertised entries
-    assert_eq!(
-        advertised_data.transactions.len(),
-        expected_num_advertisements
-    );
+            // Sleep for a while before retrying
+            tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Verify that the advertised transaction data contains an entry for the given version
-    assert!(advertised_data
-        .transactions
-        .contains(&CompleteDataRange::new(0, advertised_version).unwrap()));
+            // Get the advertised data
+            let global_data_summary = client.get_global_data_summary();
+            let advertised_data = global_data_summary.advertised_data;
 
-    // Verify that the highest synced ledger info is valid (if this is the highest advertised version)
-    if is_highest_version {
-        let highest_synced_ledger_info = advertised_data.highest_synced_ledger_info().unwrap();
-        assert_eq!(
-            highest_synced_ledger_info.ledger_info().version(),
-            advertised_version
-        );
-    }
+            // Verify the number of advertised entries
+            if advertised_data.transactions.len() != expected_num_advertisements {
+                continue; // The advertised data has not been updated yet
+            }
+
+            // Verify that the advertised transaction data contains an entry for the given version
+            let transaction_range = CompleteDataRange::new(0, advertised_version).unwrap();
+            if !advertised_data.transactions.contains(&transaction_range) {
+                continue; // The advertised data has not been updated yet
+            }
+
+            // Verify that the highest synced ledger info is valid (if this is the highest advertised version)
+            if is_highest_version {
+                let highest_synced_ledger_info =
+                    advertised_data.highest_synced_ledger_info().unwrap();
+                if highest_synced_ledger_info.ledger_info().version() != advertised_version {
+                    continue; // The advertised data has not been updated yet
+                }
+            }
+
+            // All checks passed
+            return;
+        }
+    })
+    .await
+    .expect("The advertised data was not updated correctly! Timed out!");
 }
 
-/// Verifies that the peer's state is valid (i.e., the storage summary is correct)
-fn verify_peer_state(
+/// Verifies that the peer's state is updated to the correct value
+async fn verify_peer_state(
     client: &AptosDataClient,
     peer: PeerNetworkId,
     expected_storage_summary: StorageServerSummary,
 ) {
-    // Get the peer's state
-    let peer_to_states = client.get_peer_states().get_peer_to_states();
-    let peer_state = peer_to_states.get(&peer).unwrap().value().clone();
+    // Wait for the peer's state to be updated to the expected storage summary
+    timeout(Duration::from_secs(10), async {
+        loop {
+            // Check if the peer's state has been updated
+            let peer_to_states = client.get_peer_states().get_peer_to_states();
+            if let Some(peer_state) = peer_to_states.get(&peer) {
+                if let Some(storage_summary) = peer_state.get_storage_summary_if_not_ignored() {
+                    if storage_summary == &expected_storage_summary {
+                        return; // The peer's state has been updated correctly
+                    }
+                }
+            }
 
-    // Verify that the peer's storage summary is valid
-    let peer_storage_summary = peer_state
-        .get_storage_summary_if_not_ignored()
-        .unwrap()
-        .clone();
-    assert_eq!(peer_storage_summary, expected_storage_summary);
+            // Sleep for a while before retrying
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("The peer state was not updated to the expected storage summary! Timed out!");
 }

--- a/state-sync/aptos-data-client/src/tests/compression.rs
+++ b/state-sync/aptos-data-client/src/tests/compression.rs
@@ -12,7 +12,7 @@ use aptos_config::{config::AptosDataClientConfig, network_id::NetworkId};
 use aptos_network::protocols::wire::handshake::v1::ProtocolId;
 use aptos_storage_service_types::{
     requests::{DataRequest, TransactionsWithProofRequest},
-    responses::{DataResponse, StorageServiceResponse},
+    responses::{CompleteDataRange, DataResponse, StorageServiceResponse},
 };
 use aptos_types::transaction::TransactionListWithProof;
 use claims::assert_matches;
@@ -44,22 +44,47 @@ async fn compression_mismatch_disabled() {
         utils::advance_polling_timer(&mut mock_time, &data_client_config).await;
 
         // Receive their request and respond
+        let highest_synced_version = 100;
         let network_request = utils::get_network_request(&mut mock_network, network_id).await;
-        let data_response = DataResponse::StorageServerSummary(utils::create_storage_summary(200));
+        let data_response = DataResponse::StorageServerSummary(utils::create_storage_summary(
+            highest_synced_version,
+        ));
         network_request.response_sender.send(Ok(
             StorageServiceResponse::new(data_response, false).unwrap()
         ));
 
-        // Let the poller finish processing the response
-        tokio::task::yield_now().await;
+        // Wait for the poller to process the response
+        let transaction_range = CompleteDataRange::new(0, highest_synced_version).unwrap();
+        utils::wait_for_transaction_advertisement(
+            &client,
+            &mut mock_time,
+            &data_client_config,
+            transaction_range,
+        )
+        .await;
 
         // Handle the client's transactions request using compression
         tokio::spawn(async move {
-            let network_request = utils::get_network_request(&mut mock_network, network_id).await;
-            assert!(!network_request.storage_service_request.use_compression);
+            loop {
+                // Verify the received network request
+                let network_request =
+                    utils::get_network_request(&mut mock_network, network_id).await;
+                assert!(!network_request.storage_service_request.use_compression);
 
-            // Compress the response
-            utils::handle_transactions_request(network_request, true);
+                // Fulfill the request if it is for transactions
+                if matches!(
+                    network_request.storage_service_request.data_request,
+                    DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+                        start_version: 50,
+                        end_version: 100,
+                        proof_version: 100,
+                        include_events: false,
+                    })
+                ) {
+                    // Compress the response
+                    utils::handle_transactions_request(network_request, true);
+                }
+            }
         });
 
         // The client should receive a compressed response and return an error
@@ -99,19 +124,45 @@ async fn compression_mismatch_enabled() {
         utils::advance_polling_timer(&mut mock_time, &data_client_config).await;
 
         // Receive their request and respond
+        let highest_synced_version = 200;
         let network_request = utils::get_network_request(&mut mock_network, network_id).await;
-        utils::handle_storage_summary_request(network_request, utils::create_storage_summary(200));
+        utils::handle_storage_summary_request(
+            network_request,
+            utils::create_storage_summary(highest_synced_version),
+        );
 
-        // Let the poller finish processing the response
-        tokio::task::yield_now().await;
+        // Wait for the poller to process the response
+        let transaction_range = CompleteDataRange::new(0, highest_synced_version).unwrap();
+        utils::wait_for_transaction_advertisement(
+            &client,
+            &mut mock_time,
+            &data_client_config,
+            transaction_range,
+        )
+        .await;
 
         // Handle the client's transactions request without compression
         tokio::spawn(async move {
-            let network_request = utils::get_network_request(&mut mock_network, network_id).await;
-            assert!(network_request.storage_service_request.use_compression);
+            loop {
+                // Verify the received network request
+                let network_request =
+                    utils::get_network_request(&mut mock_network, network_id).await;
+                assert!(network_request.storage_service_request.use_compression);
 
-            // Don't compress the response
-            utils::handle_transactions_request(network_request, false);
+                // Fulfill the request if it is for transactions
+                if matches!(
+                    network_request.storage_service_request.data_request,
+                    DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+                        start_version: 50,
+                        end_version: 100,
+                        proof_version: 100,
+                        include_events: false,
+                    })
+                ) {
+                    // Don't compress the response
+                    utils::handle_transactions_request(network_request, false);
+                }
+            }
         });
 
         // The client should receive a compressed response and return an error
@@ -165,40 +216,50 @@ async fn disable_compression() {
         );
 
         // Fulfill their request
-        let data_response = DataResponse::StorageServerSummary(utils::create_storage_summary(200));
+        let highest_synced_version = 200;
+        let data_response = DataResponse::StorageServerSummary(utils::create_storage_summary(
+            highest_synced_version,
+        ));
         network_request.response_sender.send(Ok(
             StorageServiceResponse::new(data_response, false).unwrap()
         ));
 
-        // Let the poller finish processing the response
-        tokio::task::yield_now().await;
+        // Wait for the poller to process the response
+        let transaction_range = CompleteDataRange::new(0, highest_synced_version).unwrap();
+        utils::wait_for_transaction_advertisement(
+            &client,
+            &mut mock_time,
+            &data_client_config,
+            transaction_range,
+        )
+        .await;
 
-        // Handle the client's transactions request
+        // Handle the client's requests
         tokio::spawn(async move {
-            // Verify the received network request
-            let network_request = utils::get_network_request(&mut mock_network, network_id).await;
-            assert_eq!(network_request.peer_network_id, peer);
-            assert_eq!(network_request.protocol_id, ProtocolId::StorageServiceRpc);
-            assert!(!network_request.storage_service_request.use_compression);
-            assert_matches!(
-                network_request.storage_service_request.data_request,
-                DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
-                    start_version: 50,
-                    end_version: 100,
-                    proof_version: 100,
-                    include_events: false,
-                })
-            );
+            loop {
+                // Verify the received network request
+                let network_request =
+                    utils::get_network_request(&mut mock_network, network_id).await;
+                assert_eq!(network_request.peer_network_id, peer);
+                assert_eq!(network_request.protocol_id, ProtocolId::StorageServiceRpc);
+                assert!(!network_request.storage_service_request.use_compression);
 
-            // Fulfill the request
-            let data_response =
-                DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
-            let storage_response = StorageServiceResponse::new(data_response, false).unwrap();
-            network_request.response_sender.send(Ok(storage_response));
+                // Fulfill the request if it is for transactions
+                if matches!(
+                    network_request.storage_service_request.data_request,
+                    DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+                        start_version: 50,
+                        end_version: 100,
+                        proof_version: 100,
+                        include_events: false,
+                    })
+                ) {
+                    utils::handle_transactions_request(network_request, false);
+                }
+            }
         });
 
-        // The client's request should succeed since a peer finally has advertised
-        // data for this range.
+        // The request should succeed since a peer has advertised the data
         let request_timeout = data_client_config.response_timeout_ms;
         let response = client
             .get_transactions_with_proof(100, 50, 100, false, request_timeout)

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::AptosDataClient, error::Error, priority::PeerPriority, tests::mock::MockNetwork,
+    client::AptosDataClient, error::Error, interface::AptosDataClientInterface,
+    priority::PeerPriority, tests::mock::MockNetwork,
 };
 use aptos_config::{
     config::{AptosDataClientConfig, BaseConfig, RoleType},
@@ -38,6 +39,7 @@ use std::{
     collections::{BinaryHeap, HashMap, HashSet},
     time::Duration,
 };
+use tokio::time::timeout;
 
 // Useful test constants
 pub const NUM_SELECTION_ITERATIONS: u64 = 15_000;
@@ -101,6 +103,7 @@ pub async fn advance_polling_timer(
 ) {
     let poll_loop_interval_ms = data_client_config.data_poller_config.poll_loop_interval_ms;
     for _ in 0..10 {
+        tokio::task::yield_now().await;
         mock_time
             .advance_async(Duration::from_millis(poll_loop_interval_ms))
             .await;
@@ -260,7 +263,11 @@ pub async fn get_network_request(
     mock_network: &mut MockNetwork,
     network_id: NetworkId,
 ) -> NetworkRequest {
-    mock_network.next_request(network_id).await.unwrap()
+    timeout(Duration::from_secs(10), async {
+        mock_network.next_request(network_id).await.unwrap()
+    })
+    .await
+    .expect("Failed to get network request! Timed out!")
 }
 
 /// Returns the peer distance from validators for the given peer
@@ -565,4 +572,30 @@ pub fn verify_selected_peers_from_set(
     // Verify the selected peers
     assert_eq!(selected_peers.len(), num_expected_peers);
     assert!(peers.is_superset(&selected_peers));
+}
+
+/// Waits until the transaction range is advertised by the peers
+pub async fn wait_for_transaction_advertisement(
+    client: &AptosDataClient,
+    mock_time: &mut MockTimeService,
+    data_client_config: &AptosDataClientConfig,
+    transaction_range: CompleteDataRange<u64>,
+) {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            // Check if the transaction range is serviceable
+            let advertised_data = client.get_global_data_summary().advertised_data;
+            if advertised_data.transactions.contains(&transaction_range) {
+                return; // The request range is serviceable
+            }
+
+            // Advance time so the poller sends a data summary request and gets the response
+            advance_polling_timer(mock_time, data_client_config).await;
+
+            // Sleep for a while before retrying
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("The transaction range is not advertised! Timed out!");
 }

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -597,11 +597,8 @@ impl<
 
     /// Processes any notifications already pending on the active stream
     async fn process_active_stream_notifications(&mut self) -> Result<(), Error> {
-        for _ in 0..self
-            .driver_configuration
-            .config
-            .max_consecutive_stream_notifications
-        {
+        let state_sync_driver_config = &self.driver_configuration.config;
+        for _ in 0..state_sync_driver_config.max_consecutive_stream_notifications {
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -203,11 +203,8 @@ impl<
         &mut self,
         consensus_sync_request: Arc<Mutex<Option<ConsensusSyncRequest>>>,
     ) -> Result<(), Error> {
-        for _ in 0..self
-            .driver_configuration
-            .config
-            .max_consecutive_stream_notifications
-        {
+        let state_sync_driver_config = &self.driver_configuration.config;
+        for _ in 0..state_sync_driver_config.max_consecutive_stream_notifications {
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {

--- a/state-sync/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-driver/src/notification_handlers.rs
@@ -99,16 +99,13 @@ impl CommitNotification {
 
         // Notify mempool of the committed transactions
         mempool_notification_handler
-            .notify_mempool_of_committed_transactions(
-                transactions.clone(),
-                blockchain_timestamp_usecs,
-            )
+            .notify_mempool_of_committed_transactions(transactions, blockchain_timestamp_usecs)
             .await?;
 
         // Notify the event subscription service of the events
         event_subscription_service
             .lock()
-            .notify_events(latest_synced_version, events.clone())?;
+            .notify_events(latest_synced_version, events)?;
 
         Ok(())
     }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-aptos-bounded-executor = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -11,7 +11,6 @@ use crate::{
     subscription::SubscriptionStreamRequests,
     utils, LogEntry, LogSchema,
 };
-use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::{
     config::StorageServiceConfig,
     network_id::{NetworkId, PeerNetworkId},
@@ -32,6 +31,7 @@ use dashmap::DashMap;
 use futures::future::join_all;
 use mini_moka::sync::Cache;
 use std::{cmp::min, collections::HashMap, ops::Deref, sync::Arc, time::Instant};
+use tokio::runtime::Handle;
 
 /// An optimistic fetch request from a peer
 pub struct OptimisticFetchRequest {
@@ -183,7 +183,7 @@ impl OptimisticFetchRequest {
 
 /// Handles active and ready optimistic fetches
 pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
-    bounded_executor: BoundedExecutor,
+    runtime: Handle,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
@@ -198,7 +198,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 
     // Identify the peers with ready optimistic fetches
     let peers_with_ready_optimistic_fetches = get_peers_with_ready_optimistic_fetches(
-        bounded_executor.clone(),
+        runtime.clone(),
         config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -212,7 +212,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 
     // Remove and handle the ready optimistic fetches
     handle_ready_optimistic_fetches(
-        bounded_executor,
+        runtime,
         cached_storage_server_summary,
         config,
         optimistic_fetches,
@@ -231,7 +231,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 /// Handles the ready optimistic fetches by removing them from the
 /// active map and notifying the peer of the new data.
 pub(crate) async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
-    bounded_executor: BoundedExecutor,
+    runtime: Handle,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
@@ -264,48 +264,46 @@ pub(crate) async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
             let time_service = time_service.clone();
 
             // Spawn a blocking task to handle the optimistic fetch
-            bounded_executor
-                .spawn_blocking(move || {
-                    // Get the fetch start time and request
-                    let optimistic_fetch_start_time = optimistic_fetch.fetch_start_time;
-                    let optimistic_fetch_request = optimistic_fetch.request.clone();
+            runtime.spawn_blocking(move || {
+                // Get the fetch start time and request
+                let optimistic_fetch_start_time = optimistic_fetch.fetch_start_time;
+                let optimistic_fetch_request = optimistic_fetch.request.clone();
 
-                    // Handle the optimistic fetch request and time the operation
-                    let handle_request = || {
-                        // Get the storage service request for the missing data
-                        let missing_data_request = optimistic_fetch
-                            .get_storage_request_for_missing_data(config, &target_ledger_info)?;
+                // Handle the optimistic fetch request and time the operation
+                let handle_request = || {
+                    // Get the storage service request for the missing data
+                    let missing_data_request = optimistic_fetch
+                        .get_storage_request_for_missing_data(config, &target_ledger_info)?;
 
-                        // Notify the peer of the new data
-                        utils::notify_peer_of_new_data(
-                            cached_storage_server_summary.clone(),
-                            optimistic_fetches.clone(),
-                            subscriptions.clone(),
-                            lru_response_cache.clone(),
-                            request_moderator.clone(),
-                            storage.clone(),
-                            time_service.clone(),
-                            &peer_network_id,
-                            missing_data_request,
-                            target_ledger_info,
-                            optimistic_fetch.take_response_sender(),
-                        )
-                    };
-                    let result = utils::execute_and_time_duration(
-                        &metrics::OPTIMISTIC_FETCH_LATENCIES,
-                        Some((&peer_network_id, &optimistic_fetch_request)),
-                        None,
-                        handle_request,
-                        Some(optimistic_fetch_start_time),
-                    );
+                    // Notify the peer of the new data
+                    utils::notify_peer_of_new_data(
+                        cached_storage_server_summary.clone(),
+                        optimistic_fetches.clone(),
+                        subscriptions.clone(),
+                        lru_response_cache.clone(),
+                        request_moderator.clone(),
+                        storage.clone(),
+                        time_service.clone(),
+                        &peer_network_id,
+                        missing_data_request,
+                        target_ledger_info,
+                        optimistic_fetch.take_response_sender(),
+                    )
+                };
+                let result = utils::execute_and_time_duration(
+                    &metrics::OPTIMISTIC_FETCH_LATENCIES,
+                    Some((&peer_network_id, &optimistic_fetch_request)),
+                    None,
+                    handle_request,
+                    Some(optimistic_fetch_start_time),
+                );
 
-                    // Log an error if the handler failed
-                    if let Err(error) = result {
-                        warn!(LogSchema::new(LogEntry::OptimisticFetchResponse)
-                            .error(&Error::UnexpectedErrorEncountered(error.to_string())));
-                    }
-                })
-                .await;
+                // Log an error if the handler failed
+                if let Err(error) = result {
+                    warn!(LogSchema::new(LogEntry::OptimisticFetchResponse)
+                        .error(&Error::UnexpectedErrorEncountered(error.to_string())));
+                }
+            });
         }
     }
 }
@@ -314,7 +312,7 @@ pub(crate) async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
 /// Returns the list of peers that made those optimistic fetches
 /// alongside the ledger info at the target version for the peer.
 pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>(
-    bounded_executor: BoundedExecutor,
+    runtime: Handle,
     config: StorageServiceConfig,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
@@ -337,7 +335,7 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
         peers_with_invalid_optimistic_fetches,
         peers_with_ready_optimistic_fetches,
     ) = identify_expired_invalid_and_ready_fetches(
-        bounded_executor,
+        runtime,
         config,
         cached_storage_server_summary,
         optimistic_fetches.clone(),
@@ -366,7 +364,7 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
 /// Identifies the expired, invalid and ready optimistic fetches
 /// from the active map. Returns each peer list separately.
 async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
-    bounded_executor: BoundedExecutor,
+    runtime: Handle,
     config: StorageServiceConfig,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
@@ -408,7 +406,7 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
     // Identify the peers with ready and invalid optimistic fetches
     let (peers_with_ready_optimistic_fetches, peers_with_invalid_optimistic_fetches) =
         identify_ready_and_invalid_optimistic_fetches(
-            bounded_executor,
+            runtime,
             cached_storage_server_summary,
             optimistic_fetches,
             subscriptions,
@@ -432,7 +430,7 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
 /// Identifies the ready and invalid optimistic fetches from the given
 /// map of peers and their highest synced versions and epochs.
 async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface>(
-    bounded_executor: BoundedExecutor,
+    runtime: Handle,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
     subscriptions: Arc<DashMap<PeerNetworkId, SubscriptionStreamRequests>>,
@@ -460,6 +458,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
         peers_and_highest_synced_data.into_iter()
     {
         // Clone all required components for the task
+        let runtime = runtime.clone();
         let cached_storage_server_summary = cached_storage_server_summary.clone();
         let highest_synced_ledger_info = highest_synced_ledger_info.clone();
         let optimistic_fetches = optimistic_fetches.clone();
@@ -473,58 +472,55 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
 
         // Spawn a blocking task to determine if the optimistic fetch is ready or
         // invalid. We do this because each entry may require reading from storage.
-        let active_task = bounded_executor
-            .spawn_blocking(move || {
-                // Check if we have synced beyond the highest known version
-                if highest_known_version < highest_synced_version {
-                    if highest_known_epoch < highest_synced_epoch {
-                        // Fetch the epoch ending ledger info from storage (the
-                        // peer needs to sync to their epoch ending ledger info).
-                        let epoch_ending_ledger_info = match utils::get_epoch_ending_ledger_info(
-                            cached_storage_server_summary.clone(),
-                            optimistic_fetches.clone(),
-                            subscriptions.clone(),
-                            highest_known_epoch,
-                            lru_response_cache.clone(),
-                            request_moderator.clone(),
-                            &peer_network_id,
-                            storage.clone(),
-                            time_service.clone(),
-                        ) {
-                            Ok(epoch_ending_ledger_info) => epoch_ending_ledger_info,
-                            Err(error) => {
-                                // Log the failure to fetch the epoch ending ledger info
-                                error!(LogSchema::new(LogEntry::OptimisticFetchRefresh)
-                                    .error(&error)
-                                    .message(&format!(
+        let active_task = runtime.spawn_blocking(move || {
+            // Check if we have synced beyond the highest known version
+            if highest_known_version < highest_synced_version {
+                if highest_known_epoch < highest_synced_epoch {
+                    // Fetch the epoch ending ledger info from storage (the
+                    // peer needs to sync to their epoch ending ledger info).
+                    let epoch_ending_ledger_info = match utils::get_epoch_ending_ledger_info(
+                        cached_storage_server_summary.clone(),
+                        optimistic_fetches.clone(),
+                        subscriptions.clone(),
+                        highest_known_epoch,
+                        lru_response_cache.clone(),
+                        request_moderator.clone(),
+                        &peer_network_id,
+                        storage.clone(),
+                        time_service.clone(),
+                    ) {
+                        Ok(epoch_ending_ledger_info) => epoch_ending_ledger_info,
+                        Err(error) => {
+                            // Log the failure to fetch the epoch ending ledger info
+                            error!(LogSchema::new(LogEntry::OptimisticFetchRefresh)
+                                .error(&error)
+                                .message(&format!(
                                     "Failed to get the epoch ending ledger info for epoch: {:?} !",
                                     highest_known_epoch
                                 )));
 
-                                return;
-                            },
-                        };
+                            return;
+                        },
+                    };
 
-                        // Check that we haven't been sent an invalid optimistic fetch request
-                        // (i.e., a request that does not respect an epoch boundary).
-                        if epoch_ending_ledger_info.ledger_info().version() <= highest_known_version
-                        {
-                            peers_with_invalid_optimistic_fetches
-                                .lock()
-                                .push(peer_network_id);
-                        } else {
-                            peers_with_ready_optimistic_fetches
-                                .lock()
-                                .push((peer_network_id, epoch_ending_ledger_info));
-                        }
+                    // Check that we haven't been sent an invalid optimistic fetch request
+                    // (i.e., a request that does not respect an epoch boundary).
+                    if epoch_ending_ledger_info.ledger_info().version() <= highest_known_version {
+                        peers_with_invalid_optimistic_fetches
+                            .lock()
+                            .push(peer_network_id);
                     } else {
                         peers_with_ready_optimistic_fetches
                             .lock()
-                            .push((peer_network_id, highest_synced_ledger_info.clone()));
-                    };
-                }
-            })
-            .await;
+                            .push((peer_network_id, epoch_ending_ledger_info));
+                    }
+                } else {
+                    peers_with_ready_optimistic_fetches
+                        .lock()
+                        .push((peer_network_id, highest_synced_ledger_info.clone()));
+                };
+            }
+        });
 
         // Add the task to the list of active tasks
         active_tasks.push(active_task);

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -9,7 +9,6 @@ use crate::{
     storage::StorageReader,
     tests::{mock, utils},
 };
-use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::{
     config::{AptosDataClientConfig, StorageServiceConfig},
     network_id::PeerNetworkId,
@@ -66,7 +65,6 @@ async fn test_peers_with_ready_optimistic_fetches() {
     let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let lru_response_cache = Cache::new(0);
@@ -82,7 +80,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
     // Verify that there are no peers with ready optimistic fetches
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -103,7 +101,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
     // Verify that optimistic fetch 1 is ready
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -130,7 +128,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
     // Verify that optimistic fetch 2 is not returned because it was invalid
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor,
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary,
             optimistic_fetches,
@@ -172,7 +170,6 @@ async fn test_peers_with_ready_optimistic_fetches_update() {
     let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let lru_response_cache = Cache::new(0);
@@ -196,7 +193,7 @@ async fn test_peers_with_ready_optimistic_fetches_update() {
     // Verify that optimistic fetch 1 is ready
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -223,7 +220,7 @@ async fn test_peers_with_ready_optimistic_fetches_update() {
 
     // Handle the ready optimistic fetches
     optimistic_fetch::handle_ready_optimistic_fetches(
-        bounded_executor.clone(),
+        Handle::current(),
         cached_storage_server_summary.clone(),
         storage_service_config,
         optimistic_fetches.clone(),
@@ -250,7 +247,7 @@ async fn test_peers_with_ready_optimistic_fetches_update() {
     // Verify that optimistic fetch 1 is ready (again!)
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -283,7 +280,6 @@ async fn test_remove_expired_optimistic_fetches() {
     let time_service = TimeService::mock();
 
     // Create the test components
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let lru_response_cache = Cache::new(0);
@@ -317,7 +313,7 @@ async fn test_remove_expired_optimistic_fetches() {
     // Remove the expired optimistic fetches and verify none were removed
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -351,7 +347,7 @@ async fn test_remove_expired_optimistic_fetches() {
     // Remove the expired optimistic fetches and verify the first batch was removed
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor.clone(),
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
@@ -372,7 +368,7 @@ async fn test_remove_expired_optimistic_fetches() {
     // Remove the expired optimistic fetches and verify the second batch was removed
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            bounded_executor,
+            Handle::current(),
             storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),

--- a/state-sync/storage-service/server/src/tests/subscription.rs
+++ b/state-sync/storage-service/server/src/tests/subscription.rs
@@ -10,7 +10,6 @@ use crate::{
     subscription::{SubscriptionRequest, SubscriptionStreamRequests},
     tests::{mock, mock::MockClient, utils},
 };
-use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::{
     config::{AptosDataClientConfig, StorageServiceConfig},
     network_id::PeerNetworkId,
@@ -74,7 +73,6 @@ async fn test_peers_with_ready_subscriptions() {
     let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let optimistic_fetches = Arc::new(DashMap::new());
@@ -89,7 +87,7 @@ async fn test_peers_with_ready_subscriptions() {
 
     // Verify that there are no peers with ready subscriptions
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -109,7 +107,7 @@ async fn test_peers_with_ready_subscriptions() {
 
     // Verify that peer 1 has a ready subscription
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -135,7 +133,7 @@ async fn test_peers_with_ready_subscriptions() {
 
     // Verify that peer 2 has a ready subscription
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -161,7 +159,7 @@ async fn test_peers_with_ready_subscriptions() {
     // Verify that subscription 3 is not returned because it was invalid
     // (i.e., the epoch ended at version 9, but the peer didn't respect it).
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -194,7 +192,6 @@ async fn test_remove_expired_subscriptions_no_new_data() {
     let time_service = TimeService::mock();
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let optimistic_fetches = Arc::new(DashMap::new());
@@ -227,7 +224,7 @@ async fn test_remove_expired_subscriptions_no_new_data() {
 
     // Remove the expired subscriptions and verify none were removed
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -257,7 +254,7 @@ async fn test_remove_expired_subscriptions_no_new_data() {
 
     // Remove the expired subscriptions and verify the first batch was removed
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -277,7 +274,7 @@ async fn test_remove_expired_subscriptions_no_new_data() {
 
     // Remove the expired subscriptions and verify the second batch was removed
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -326,7 +323,6 @@ async fn test_remove_expired_subscriptions_blocked_stream() {
     }
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let optimistic_fetches = Arc::new(DashMap::new());
@@ -348,7 +344,7 @@ async fn test_remove_expired_subscriptions_blocked_stream() {
 
     // Handle the active subscriptions
     subscription::handle_active_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         cached_storage_server_summary.clone(),
         storage_service_config,
         optimistic_fetches.clone(),
@@ -383,7 +379,7 @@ async fn test_remove_expired_subscriptions_blocked_stream() {
 
     // Remove the expired subscriptions and verify the second batch was removed
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -427,7 +423,6 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
     }
 
     // Create test data with an empty storage server summary
-    let bounded_executor = BoundedExecutor::new(100, Handle::current());
     let cached_storage_server_summary =
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let optimistic_fetches = Arc::new(DashMap::new());
@@ -450,7 +445,7 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
 
     // Verify that all peers have ready subscriptions (but don't serve them!)
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -472,7 +467,7 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
 
     // Remove the expired subscriptions and verify they were all removed
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -511,7 +506,7 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
 
     // Verify that none of the subscriptions are ready to be served (they are blocked)
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -540,7 +535,7 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
 
     // Verify that the first peer subscription stream is unblocked
     let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
@@ -559,7 +554,7 @@ async fn test_remove_expired_subscriptions_blocked_stream_index() {
 
     // Remove the expired subscriptions and verify all but one were removed
     let _ = subscription::get_peers_with_ready_subscriptions(
-        bounded_executor.clone(),
+        Handle::current(),
         storage_service_config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),


### PR DESCRIPTION
## Description
This PR offers several small metrics and performance improvements to the networking and state sync code. It also cleans up the use of an `unbounded_executor` in the storage service (this is no longer needed now that we [bound](https://github.com/aptos-labs/aptos-core/blob/6a2fee68cce24e6bf0b8e64bf23dfb545df35bfb/crates/aptos-runtimes/src/lib.rs#L27) our tokio runtimes).

The PR offers the following commits:
1. Small metrics and performance improvements to networking and state sync.
2. Remove `unbounded_executor` in the storage service.
3. Update the affected unit tests.

## Testing
New and existing test infrastructure.