### PR TITLE
[Multisig V2] Fix the feature flag for MULTISIG_V2_ENHANCEMENT

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -105,7 +105,7 @@ pub enum FeatureFlag {
     ObjectCodeDeployment,
     MaxObjectNestingCheck,
     KeylessAccountsWithPasskeys,
-    TransactionContextExtension,
+    MultisinV2Enhancement,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -271,9 +271,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::KeylessAccountsWithPasskeys => {
                 AptosFeatureFlag::KEYLESS_ACCOUNTS_WITH_PASSKEYS
             },
-            FeatureFlag::TransactionContextExtension => {
-                AptosFeatureFlag::TRANSACTION_CONTEXT_EXTENSION
-            },
+            FeatureFlag::MultisinV2Enhancement => AptosFeatureFlag::MULTISIG_V2_ENHANCEMENT,
         }
     }
 }
@@ -362,9 +360,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::KEYLESS_ACCOUNTS_WITH_PASSKEYS => {
                 FeatureFlag::KeylessAccountsWithPasskeys
             },
-            AptosFeatureFlag::TRANSACTION_CONTEXT_EXTENSION => {
-                FeatureFlag::TransactionContextExtension
-            },
+            AptosFeatureFlag::MULTISIG_V2_ENHANCEMENT => FeatureFlag::MultisinV2Enhancement,
         }
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -66,7 +66,7 @@ pub enum FeatureFlag {
     OBJECT_CODE_DEPLOYMENT = 52,
     MAX_OBJECT_NESTING_CHECK = 53,
     KEYLESS_ACCOUNTS_WITH_PASSKEYS = 54,
-    TRANSACTION_CONTEXT_EXTENSION = 55,
+    MULTISIG_V2_ENHANCEMENT = 55,
 }
 
 impl FeatureFlag {
@@ -119,7 +119,7 @@ impl FeatureFlag {
             FeatureFlag::OBJECT_CODE_DEPLOYMENT,
             FeatureFlag::MAX_OBJECT_NESTING_CHECK,
             FeatureFlag::KEYLESS_ACCOUNTS_WITH_PASSKEYS,
-            FeatureFlag::TRANSACTION_CONTEXT_EXTENSION,
+            FeatureFlag::MULTISIG_V2_ENHANCEMENT,
         ]
     }
 }


### PR DESCRIPTION
## Description
Fix the feature flag for the multisig v2 enhancement (`MULTISIG_V2_ENHANCEMENT`)

`TransactionContextExtension` is the next feature to come. It didn't land yet.
