### PR TITLE
[State Sync] Add max in-flight subscription requests

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -210,10 +210,10 @@ pub struct DataStreamingServiceConfig {
     /// The interval (milliseconds) at which to refresh the global data summary.
     pub global_summary_refresh_interval_ms: u64,
 
-    /// Maximum number of concurrent data client requests (per stream).
+    /// Maximum number of in-flight data client requests (per stream).
     pub max_concurrent_requests: u64,
 
-    /// Maximum number of concurrent data client requests (per stream) for state keys/values.
+    /// Maximum number of in-flight data client requests (per stream) for state keys/values.
     pub max_concurrent_state_requests: u64,
 
     /// Maximum channel sizes for each data stream listener (per stream).
@@ -253,10 +253,10 @@ impl Default for DataStreamingServiceConfig {
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,
             max_data_stream_channel_sizes: 50,
             max_notification_id_mappings: 300,
-            max_num_consecutive_subscriptions: 40, // At ~4 blocks per second, this should last 10 seconds
+            max_num_consecutive_subscriptions: 45, // At ~3 blocks per second, this should last ~15 seconds
             max_pending_requests: 50,
             max_request_retry: 5,
-            max_subscription_stream_lag_secs: 15, // 15 seconds
+            max_subscription_stream_lag_secs: 10, // 10 seconds
             progress_check_interval_ms: 50,
         }
     }
@@ -270,6 +270,9 @@ pub struct DynamicPrefetchingConfig {
 
     /// The initial number of concurrent prefetching requests
     pub initial_prefetching_value: u64,
+
+    /// Maximum number of in-flight subscription requests
+    pub max_in_flight_subscription_requests: u64,
 
     /// The maximum number of concurrent prefetching requests
     pub max_prefetching_value: u64,
@@ -292,6 +295,7 @@ impl Default for DynamicPrefetchingConfig {
         Self {
             enable_dynamic_prefetching: true,
             initial_prefetching_value: 3,
+            max_in_flight_subscription_requests: 9, // At ~3 blocks per second, this should last ~3 seconds
             max_prefetching_value: 30,
             min_prefetching_value: 3,
             prefetching_value_increase: 1,
@@ -431,15 +435,15 @@ impl Default for AptosDataClientConfig {
             latency_monitor_loop_interval_ms: 100,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_num_output_reductions: 0,
-            max_optimistic_fetch_lag_secs: 30, // 30 seconds
+            max_optimistic_fetch_lag_secs: 20, // 20 seconds
             max_response_timeout_ms: 60_000,   // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
-            max_subscription_lag_secs: 30, // 30 seconds
+            max_subscription_lag_secs: 20, // 20 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             optimistic_fetch_timeout_ms: 5000,        // 5 seconds
             response_timeout_ms: 10_000,              // 10 seconds
-            subscription_response_timeout_ms: 20_000, // 20 seconds (must be longer than a regular timeout because of pre-fetching)
+            subscription_response_timeout_ms: 15_000, // 15 seconds (longer than a regular timeout because of prefetching)
             use_compression: true,
         }
     }

--- a/state-sync/aptos-data-client/src/tests/advertise.rs
+++ b/state-sync/aptos-data-client/src/tests/advertise.rs
@@ -135,14 +135,11 @@ async fn update_global_data_summary() {
             .response_sender
             .send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
 
-        // Advance time so the poller updates the global data summary
-        utils::advance_polling_timer(&mut mock_time, &data_client_config).await;
-
         // Verify that the advertised data ranges are valid
         verify_advertised_transaction_data(
-            &mut mock_time,
             &data_client_config,
             &client,
+            &mut mock_time,
             peer_version,
             index + 1,
             true,
@@ -154,9 +151,9 @@ async fn update_global_data_summary() {
     for (index, peer_version) in advertised_peer_versions.iter().enumerate() {
         let is_highest_version = index == advertised_peer_versions.len() - 1;
         verify_advertised_transaction_data(
-            &mut mock_time,
             &data_client_config,
             &client,
+            &mut mock_time,
             *peer_version,
             advertised_peer_versions.len(),
             is_highest_version,
@@ -353,9 +350,9 @@ async fn fetch_transactions_and_verify_failure(
 
 /// Verifies that the advertised transaction data is valid
 async fn verify_advertised_transaction_data(
-    mock_time: &mut MockTimeService,
     data_client_config: &AptosDataClientConfig,
     client: &AptosDataClient,
+    mock_time: &mut MockTimeService,
     advertised_version: Version,
     expected_num_advertisements: usize,
     is_highest_version: bool,

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -264,7 +264,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
         Ok(())
     }
 
-    /// Creates and sends a batch of aptos data client requests to the network
+    /// Creates and sends a batch of data client requests to the network
     fn create_and_send_client_requests(
         &mut self,
         global_data_summary: &GlobalDataSummary,
@@ -277,26 +277,25 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
 
         // Calculate the max number of requests that can be sent now
         let max_pending_requests = self.streaming_service_config.max_pending_requests;
-        let max_num_requests_to_send = if num_pending_requests >= max_pending_requests {
-            0 // We're already at the max number of pending requests (don't do anything)
-        } else {
-            // Otherwise, calculate the max number of requests to send based on
-            // the max concurrent requests and the number of pending request slots.
-            let remaining_concurrent_requests = self
-                .dynamic_prefetching_state
-                .get_max_concurrent_requests(&self.stream_engine)
-                .saturating_sub(num_in_flight_requests);
-            let remaining_request_slots = max_pending_requests.saturating_sub(num_pending_requests);
-            min(remaining_concurrent_requests, remaining_request_slots)
-        };
+        let max_num_requests_to_send = max_pending_requests.saturating_sub(num_pending_requests);
 
-        // Send the client requests
+        // Send the client requests iff we have enough room in the queue
         if max_num_requests_to_send > 0 {
+            // Get the max number of in-flight requests from the prefetching state
+            let max_in_flight_requests = self
+                .dynamic_prefetching_state
+                .get_max_concurrent_requests(&self.stream_engine);
+
+            // Create the client requests
             let client_requests = self.stream_engine.create_data_client_requests(
                 max_num_requests_to_send,
+                max_in_flight_requests,
+                num_in_flight_requests,
                 global_data_summary,
                 self.notification_id_generator.clone(),
             )?;
+
+            // Add the client requests to the sent data requests queue
             for client_request in &client_requests {
                 // Send the client request
                 let pending_client_response =
@@ -307,6 +306,7 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
                     .push_back(pending_client_response);
             }
 
+            // Log the number of sent data requests
             sample!(
                 SampleRate::Duration(Duration::from_secs(SENT_REQUESTS_LOG_FREQ_SECS)),
                 debug!(

--- a/state-sync/data-streaming-service/src/tests/client_requests.rs
+++ b/state-sync/data-streaming-service/src/tests/client_requests.rs
@@ -1,0 +1,450 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    stream_engine::{DataStreamEngine, StreamEngine},
+    streaming_client::{
+        ContinuouslyStreamTransactionOutputsRequest, GetAllEpochEndingLedgerInfosRequest,
+        GetAllStatesRequest, GetAllTransactionsRequest, StreamRequest,
+    },
+    tests::utils::create_ledger_info,
+};
+use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
+use aptos_data_client::global_summary::GlobalDataSummary;
+use aptos_id_generator::U64IdGenerator;
+use aptos_storage_service_types::responses::CompleteDataRange;
+use std::sync::Arc;
+
+#[test]
+fn create_client_requests_epoch_ending_stream() {
+    // Create an epoch ending stream request
+    let start_epoch = 100;
+    let stream_request =
+        StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+            start_epoch,
+        });
+
+    // Create a global data summary with a single epoch range
+    let end_epoch = 1000;
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary
+        .advertised_data
+        .epoch_ending_ledger_infos = vec![CompleteDataRange::new(start_epoch, end_epoch).unwrap()];
+    global_data_summary.optimal_chunk_sizes.epoch_chunk_size = 1;
+
+    // Create a new epoch ending stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::EpochEndingStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected epoch ending stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Verify that client requests are bound by the appropriate limits
+    verify_data_client_requests(&mut global_data_summary, &mut stream_engine);
+}
+
+#[test]
+fn create_client_requests_state_values_stream() {
+    // Create a state values stream request
+    let version = 100;
+    let start_index = 0;
+    let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
+        version,
+        start_index,
+    });
+
+    // Create a global data summary with a single state range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.states =
+        vec![CompleteDataRange::new(start_index, start_index).unwrap()];
+    global_data_summary.optimal_chunk_sizes.state_chunk_size = 1;
+
+    // Create a new state values stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::StateStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected state values stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Update the number of states for the stream
+    stream_engine.number_of_states = Some(1_000_000);
+
+    // Verify that client requests are bound by the appropriate limits
+    verify_data_client_requests(&mut global_data_summary, &mut stream_engine);
+}
+
+#[test]
+fn create_client_requests_transaction_stream() {
+    // Create a transactions stream request
+    let start_version = 0;
+    let end_version = 1_000_000;
+    let stream_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
+        start_version,
+        end_version,
+        proof_version: end_version,
+        include_events: true,
+    });
+
+    // Create a global data summary with a single transaction range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transactions =
+        vec![CompleteDataRange::new(start_version, end_version).unwrap()];
+    global_data_summary
+        .optimal_chunk_sizes
+        .transaction_chunk_size = 1;
+
+    // Create a new transactions stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::TransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected transactions stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Verify that client requests are bound by the appropriate limits
+    verify_data_client_requests(&mut global_data_summary, &mut stream_engine);
+}
+
+#[test]
+fn create_client_requests_continuous_output_stream() {
+    // Create a continuous outputs stream request
+    let known_version = 1;
+    let known_epoch = 1;
+    let stream_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            known_version,
+            known_epoch,
+            target: None,
+        },
+    );
+
+    // Create a global data summary with a single transaction range
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transaction_outputs =
+        vec![CompleteDataRange::new(0, 1_000_000).unwrap()];
+    global_data_summary
+        .optimal_chunk_sizes
+        .transaction_output_chunk_size = 1;
+
+    // Create a new continuous outputs stream engine
+    let mut stream_engine = match StreamEngine::new(
+        DataStreamingServiceConfig::default(),
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected continuous outputs stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Set the target ledger info for the stream
+    stream_engine.current_target_ledger_info = Some(create_ledger_info(
+        known_version + 500_000,
+        known_epoch,
+        false,
+    ));
+
+    // Verify that client requests are bound by the appropriate limits
+    verify_data_client_requests(&mut global_data_summary, &mut stream_engine)
+}
+
+#[test]
+fn create_client_requests_continuous_output_stream_optimistic_fetch() {
+    // Create a data streaming service with subscriptions disabled
+    let streaming_service_config = DataStreamingServiceConfig {
+        enable_subscription_streaming: false,
+        ..Default::default()
+    };
+
+    // Create a continuous outputs stream request
+    let known_version = 100;
+    let known_epoch = 10;
+    let stream_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            known_version,
+            known_epoch,
+            target: None,
+        },
+    );
+
+    // Create a global data summary at the highest known version
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transaction_outputs =
+        vec![CompleteDataRange::new(0, known_version).unwrap()];
+    global_data_summary.advertised_data.synced_ledger_infos =
+        vec![create_ledger_info(known_version, known_epoch, false)];
+
+    // Create a new continuous outputs stream engine
+    let mut stream_engine = match StreamEngine::new(
+        streaming_service_config,
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected continuous outputs stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Set the next request version and epoch to the known version and epoch
+    stream_engine.next_request_version_and_epoch = (known_version + 1, known_epoch);
+
+    // Create client requests and verify that a single request is always returned
+    for max_number_of_requests in 0..10 {
+        // Create and verify the client requests
+        let client_requests = stream_engine
+            .create_data_client_requests(
+                max_number_of_requests,
+                1_000_000, // Allow a large number of in-flight requests
+                0,
+                &global_data_summary,
+                create_notification_id_generator(),
+            )
+            .unwrap();
+        assert_eq!(client_requests.len() as u64, 1);
+
+        // Reset the pending optimistic fetch request flag
+        stream_engine.optimistic_fetch_requested = false;
+    }
+}
+
+#[test]
+fn create_client_requests_continuous_output_stream_subscriptions() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
+    // Create a data streaming service with subscriptions enabled
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_num_consecutive_subscriptions: 1_000_000, // Allow a large number of subscriptions
+        max_concurrent_state_requests: 1_000_000,     // Allow a large number of in-flight requests
+        max_pending_requests: 1_000_000,              // Allow a large number of pending requests
+        ..Default::default()
+    };
+
+    // Create a continuous outputs stream request
+    let known_version = 100;
+    let known_epoch = 10;
+    let stream_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            known_version,
+            known_epoch,
+            target: None,
+        },
+    );
+
+    // Create a global data summary at the highest known version
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transaction_outputs =
+        vec![CompleteDataRange::new(0, known_version).unwrap()];
+    global_data_summary.advertised_data.synced_ledger_infos =
+        vec![create_ledger_info(known_version, known_epoch, false)];
+
+    // Create a new continuous outputs stream engine
+    let mut stream_engine = match StreamEngine::new(
+        streaming_service_config,
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected continuous outputs stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Set the next request version and epoch to the known version and epoch
+    stream_engine.next_request_version_and_epoch = (known_version + 1, known_epoch);
+
+    // Verify that client requests are bound by the appropriate limits
+    verify_data_client_requests(&mut global_data_summary, &mut stream_engine)
+}
+
+#[test]
+fn create_client_requests_continuous_output_stream_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 20;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a data streaming service with subscriptions enabled
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_num_consecutive_subscriptions: 1_000_000, // Allow a large number of subscriptions
+        max_pending_requests: 1_000_000,              // Allow a large number of pending requests
+        ..Default::default()
+    };
+
+    // Create a continuous outputs stream request
+    let known_version = 100;
+    let known_epoch = 10;
+    let stream_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            known_version,
+            known_epoch,
+            target: None,
+        },
+    );
+
+    // Create a global data summary at the highest known version
+    let mut global_data_summary = GlobalDataSummary::empty();
+    global_data_summary.advertised_data.transaction_outputs =
+        vec![CompleteDataRange::new(0, known_version).unwrap()];
+    global_data_summary.advertised_data.synced_ledger_infos =
+        vec![create_ledger_info(known_version, known_epoch, false)];
+
+    // Create a new continuous outputs stream engine
+    let mut stream_engine = match StreamEngine::new(
+        streaming_service_config,
+        &stream_request,
+        &global_data_summary.advertised_data,
+    )
+    .unwrap()
+    {
+        StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => stream_engine,
+        unexpected_engine => {
+            panic!(
+                "Expected continuous outputs stream engine but got {:?}",
+                unexpected_engine
+            );
+        },
+    };
+
+    // Set the next request version and epoch to the known version and epoch
+    stream_engine.next_request_version_and_epoch = (known_version + 1, known_epoch);
+
+    // Create client requests and verify they are bound by the maximum number of requests
+    for max_number_of_requests in 0..15 {
+        let client_requests = stream_engine
+            .create_data_client_requests(
+                max_number_of_requests,
+                1_000_000, // Allow a large number of in-flight requests
+                0,
+                &global_data_summary,
+                create_notification_id_generator(),
+            )
+            .unwrap();
+        assert_eq!(client_requests.len(), max_number_of_requests as usize);
+    }
+
+    // Create client requests and verify that the number of in-flight requests is
+    // bound by the maximum defined in the dynamic prefetching config.
+    for max_in_flight_requests in 0..15 {
+        for num_in_flight_requests in 0..15 {
+            let client_requests = stream_engine
+                .create_data_client_requests(
+                    1_000_000, // Allow a large number of maximum requests
+                    max_in_flight_requests,
+                    num_in_flight_requests,
+                    &global_data_summary,
+                    create_notification_id_generator(),
+                )
+                .unwrap();
+            println!(
+                "max_in_flight_requests: {}, num_in_flight_requests: {}",
+                max_in_flight_requests, num_in_flight_requests
+            );
+            assert_eq!(
+                client_requests.len() as u64,
+                max_in_flight_subscription_requests.saturating_sub(num_in_flight_requests)
+            );
+        }
+    }
+}
+
+/// Returns a simple notification ID generator for testing purposes
+fn create_notification_id_generator() -> Arc<U64IdGenerator> {
+    Arc::new(U64IdGenerator::new())
+}
+
+/// Verifies that the created client requests are bound by the maximum number of
+/// requests and the maximum number of in-flight requests (when specified).
+fn verify_data_client_requests<T: DataStreamEngine>(
+    global_data_summary: &mut GlobalDataSummary,
+    stream_engine: &mut T,
+) {
+    // Create client requests and verify they are bound by the maximum number of requests
+    for max_number_of_requests in 0..10 {
+        let client_requests = stream_engine
+            .create_data_client_requests(
+                max_number_of_requests,
+                1_000_000, // Allow a large number of in-flight requests
+                0,
+                global_data_summary,
+                create_notification_id_generator(),
+            )
+            .unwrap();
+        assert_eq!(client_requests.len(), max_number_of_requests as usize);
+    }
+
+    // Create client requests and verify they are bound by the maximum number of in-flight requests
+    for max_in_flight_requests in 0..10 {
+        for num_in_flight_requests in 0..15 {
+            let client_requests = stream_engine
+                .create_data_client_requests(
+                    1_000_000, // Allow a large number of maximum requests
+                    max_in_flight_requests,
+                    num_in_flight_requests,
+                    global_data_summary,
+                    create_notification_id_generator(),
+                )
+                .unwrap();
+            assert_eq!(
+                client_requests.len() as u64,
+                max_in_flight_requests.saturating_sub(num_in_flight_requests)
+            );
+        }
+    }
+}

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -1520,10 +1520,17 @@ async fn test_continuous_stream_optimistic_fetch_timeout() {
 
 #[tokio::test]
 async fn test_continuous_stream_subscription_failures() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
     // Create a test streaming service config with subscriptions enabled
     let max_request_retry = 3;
     let max_concurrent_requests = 3;
     let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
         enable_subscription_streaming: true,
         max_concurrent_requests,
         max_request_retry,
@@ -1633,8 +1640,7 @@ async fn test_continuous_stream_subscription_failures() {
             0,
         );
 
-        // Set a timeout response for the subscription request and process it.
-        // This will cause the same request to be re-sent.
+        // Set a timeout response for the subscription request and process it
         set_timeout_response_in_queue(&mut data_stream, 0);
         process_data_responses(&mut data_stream, &global_data_summary).await;
 
@@ -1651,11 +1657,158 @@ async fn test_continuous_stream_subscription_failures() {
 }
 
 #[tokio::test]
+async fn test_continuous_stream_subscription_failures_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 5;
+    let initial_prefetching_value = 7;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        initial_prefetching_value,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_request_retry = 3;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_request_retry,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (
+        mut data_stream,
+        mut stream_listener,
+        _,
+        transactions_only,
+        allow_transactions_or_outputs,
+    ) in continuous_data_streams
+    {
+        // Initialize the data stream
+        let global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Fetch the subscription stream ID from the first pending request
+        let mut subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Verify the pending requests are for the correct data and correctly formed
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            0,
+            subscription_stream_id,
+            0,
+        );
+
+        // Set a failure response for the first subscription request and process it
+        set_failure_response_in_queue(&mut data_stream, 0);
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_none!(stream_listener.select_next_some().now_or_never());
+
+        // Handle multiple timeouts and retries
+        for _ in 0..max_request_retry * 3 {
+            // Set a timeout response for the first request and process it
+            set_timeout_response_in_queue(&mut data_stream, 0);
+            process_data_responses(&mut data_stream, &global_data_summary).await;
+
+            // Fetch the subscription stream ID from the first pending request
+            let next_subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+            // Verify the next stream ID is different from the previous one
+            assert_ne!(subscription_stream_id, next_subscription_stream_id);
+            subscription_stream_id = next_subscription_stream_id;
+
+            // Verify the pending requests are for the correct data and correctly formed
+            verify_pending_subscription_requests(
+                &mut data_stream,
+                max_in_flight_subscription_requests,
+                allow_transactions_or_outputs,
+                transactions_only,
+                0,
+                subscription_stream_id,
+                0,
+            );
+        }
+
+        // Set a failure response for the first request and process it
+        set_failure_response_in_queue(&mut data_stream, 0);
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Fetch the next subscription stream ID from the first pending request
+        let next_subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Verify the next stream ID is different from the previous one
+        assert_ne!(subscription_stream_id, next_subscription_stream_id);
+        subscription_stream_id = next_subscription_stream_id;
+
+        // Verify the pending requests are for the correct data and correctly formed
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            0,
+            subscription_stream_id,
+            0,
+        );
+
+        // Set a subscription response in the queue and process it
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            MAX_ADVERTISED_TRANSACTION + 1,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Verify the pending requests are for the correct data and correctly formed
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            1,
+            subscription_stream_id, // The subscription stream ID should be the same
+            0,
+        );
+
+        // Set a timeout response for the subscription request and process it
+        set_timeout_response_in_queue(&mut data_stream, 0);
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Advertise new data and verify the data is requested
+        advertise_new_data_and_verify_requests(
+            &mut data_stream,
+            global_data_summary,
+            transactions_only,
+            allow_transactions_or_outputs,
+            initial_prefetching_value,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
 async fn test_continuous_stream_subscription_lag() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
     // Create a test streaming service config with subscriptions enabled
     let max_concurrent_requests = 3;
     let max_subscription_stream_lag_secs = 10;
     let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
         enable_subscription_streaming: true,
         max_subscription_stream_lag_secs,
         max_concurrent_requests,
@@ -1910,10 +2063,17 @@ async fn test_continuous_stream_subscription_lag_bounded() {
 
 #[tokio::test]
 async fn test_continuous_stream_subscription_lag_catch_up() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
     // Create a test streaming service config with subscriptions enabled
     let max_concurrent_requests = 3;
     let max_subscription_stream_lag_secs = 10;
     let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
         enable_subscription_streaming: true,
         max_subscription_stream_lag_secs,
         max_concurrent_requests,
@@ -2024,6 +2184,243 @@ async fn test_continuous_stream_subscription_lag_catch_up() {
 }
 
 #[tokio::test]
+async fn test_continuous_stream_subscription_lag_catch_up_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 4;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_subscription_stream_lag_secs = 10;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_subscription_stream_lag_secs,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (
+        mut data_stream,
+        mut stream_listener,
+        time_service,
+        transactions_only,
+        allow_transactions_or_outputs,
+    ) in continuous_data_streams
+    {
+        // Initialize the data stream
+        let mut global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Fetch the subscription stream ID from the first pending request
+        let subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Update the global data summary to be ahead of the subscription stream
+        let highest_advertised_version = MAX_ADVERTISED_TRANSACTION + 1000;
+        global_data_summary.advertised_data.synced_ledger_infos = vec![create_ledger_info(
+            highest_advertised_version,
+            MAX_ADVERTISED_EPOCH_END,
+            false,
+        )];
+
+        // Set a valid response for the first subscription request and process it
+        let highest_response_version = highest_advertised_version - 500; // Behind the advertised version
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_response_version,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Verify the stream is now tracking the subscription lag
+        let subscription_stream_lag = data_stream.get_subscription_stream_lag().unwrap();
+        assert_eq!(subscription_stream_lag.start_time, time_service.now());
+        assert_eq!(
+            subscription_stream_lag.version_lag,
+            highest_advertised_version - highest_response_version
+        );
+
+        // Elapse enough time for the stream to be killed
+        let time_service = time_service.into_mock();
+        time_service.advance_secs(max_subscription_stream_lag_secs);
+
+        // Update the global data summary to be further ahead (by 1)
+        let highest_advertised_version = highest_advertised_version + 1;
+        global_data_summary.advertised_data.synced_ledger_infos = vec![create_ledger_info(
+            highest_advertised_version,
+            MAX_ADVERTISED_EPOCH_END,
+            false,
+        )];
+
+        // Set a valid response for the first subscription request and process it
+        let highest_response_version = highest_response_version + 1; // Still behind, but not worse
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_response_version,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Verify that we still have pending subscription requests (the stream hasn't fallen further behind)
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            2,
+            subscription_stream_id,
+            0,
+        );
+
+        // Verify the state of the subscription stream lag
+        let subscription_stream_lag = data_stream.get_subscription_stream_lag().unwrap();
+        assert_eq!(
+            subscription_stream_lag.version_lag,
+            highest_advertised_version - highest_response_version
+        );
+
+        // Set a valid response for the first subscription request and process it
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_advertised_version, // Catch the stream up to the advertised version
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Verify that the subscription stream lag has now been reset (the stream caught up)
+        assert!(data_stream.get_subscription_stream_lag().is_none());
+    }
+}
+
+#[tokio::test]
+async fn test_continuous_stream_subscription_lag_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 7;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_subscription_stream_lag_secs = 10;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_subscription_stream_lag_secs,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (
+        mut data_stream,
+        mut stream_listener,
+        time_service,
+        transactions_only,
+        allow_transactions_or_outputs,
+    ) in continuous_data_streams
+    {
+        // Initialize the data stream
+        let mut global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Fetch the subscription stream ID from the first pending request
+        let subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Verify the pending subscription requests
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            0,
+            subscription_stream_id,
+            0,
+        );
+
+        // Update the global data summary to be ahead of the subscription stream
+        let highest_advertised_version = MAX_ADVERTISED_TRANSACTION + 1000;
+        global_data_summary.advertised_data.synced_ledger_infos = vec![create_ledger_info(
+            highest_advertised_version,
+            MAX_ADVERTISED_EPOCH_END,
+            false,
+        )];
+
+        // Set a valid response for the first subscription request and process it
+        let highest_response_version = highest_advertised_version - 900; // Behind the advertised version
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_response_version,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Update the global data summary to be further ahead of the subscription stream
+        let highest_advertised_version = MAX_ADVERTISED_TRANSACTION + 2000;
+        global_data_summary.advertised_data.synced_ledger_infos = vec![create_ledger_info(
+            highest_advertised_version,
+            MAX_ADVERTISED_EPOCH_END,
+            false,
+        )];
+
+        // Elapse some time (but not enough for the stream to be killed)
+        let time_service = time_service.into_mock();
+        time_service.advance_secs(max_subscription_stream_lag_secs / 2);
+
+        // Set a valid response for the first subscription request and process it
+        let highest_response_version = highest_advertised_version - 1000; // Further behind the advertised
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_response_version,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Elapse enough time for the stream to be killed
+        time_service.advance_secs(max_subscription_stream_lag_secs);
+
+        // Set a valid response for the first subscription request and process it
+        let highest_response_version = highest_advertised_version - 901; // Behind the initial lag
+        set_new_data_response_in_queue(
+            &mut data_stream,
+            0,
+            highest_response_version,
+            transactions_only,
+        );
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+        assert_some!(stream_listener.select_next_some().now_or_never());
+
+        // Verify that we no longer have pending subscription requests (the stream was killed)
+        let client_request = get_pending_client_request(&mut data_stream, 0);
+        assert!(!client_request.is_subscription_request());
+
+        // Verify that the subscription stream lag has been reset
+        assert!(data_stream.get_subscription_stream_lag().is_none());
+    }
+}
+
+#[tokio::test]
 async fn test_continuous_stream_subscription_lag_time() {
     // Create a test streaming service config with subscriptions enabled
     let max_subscription_stream_lag_secs = 100;
@@ -2128,10 +2525,17 @@ async fn test_continuous_stream_subscription_lag_time() {
 
 #[tokio::test]
 async fn test_continuous_stream_subscription_max() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
     // Create a test streaming service config with subscriptions enabled
     let max_concurrent_requests = 3;
     let max_num_consecutive_subscriptions = 5;
     let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
         enable_subscription_streaming: true,
         max_concurrent_requests,
         max_num_consecutive_subscriptions,
@@ -2204,6 +2608,297 @@ async fn test_continuous_stream_subscription_max() {
     }
 }
 
+#[tokio::test]
+async fn test_continuous_stream_subscription_max_pending() {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: false,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_concurrent_requests = 4;
+    let max_num_consecutive_subscriptions = 1000;
+    let max_pending_requests = 10;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_concurrent_requests,
+        max_num_consecutive_subscriptions,
+        max_pending_requests,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (mut data_stream, _stream_listener, _, transactions_only, allow_transactions_or_outputs) in
+        continuous_data_streams
+    {
+        // Initialize the data stream
+        let global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Fetch the subscription stream ID from the first pending request
+        let subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Verify the pending requests are for the correct data and correctly formed
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_concurrent_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            0,
+            subscription_stream_id,
+            0,
+        );
+
+        // Set valid responses for all pending requests except the first
+        for request_index in 1..max_concurrent_requests {
+            set_new_data_response_in_queue(
+                &mut data_stream,
+                request_index as usize,
+                MAX_ADVERTISED_TRANSACTION + request_index,
+                transactions_only,
+            );
+        }
+
+        // Process the responses
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Verify more requests are sent
+        let num_pending_requests = (max_concurrent_requests * 2) - 1;
+        verify_num_sent_requests(&mut data_stream, num_pending_requests);
+
+        // Set valid responses for all pending requests except the first
+        for request_index in 1..num_pending_requests {
+            set_new_data_response_in_queue(
+                &mut data_stream,
+                request_index as usize,
+                MAX_ADVERTISED_TRANSACTION + request_index,
+                transactions_only,
+            );
+        }
+
+        // Process the responses
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Verify more requests are sent (but not more than the max pending requests)
+        verify_num_sent_requests(&mut data_stream, max_pending_requests);
+
+        // Set responses and process them multiple times
+        for _ in 0..10 {
+            // Set valid responses for all pending requests except the first
+            for request_index in 1..max_pending_requests {
+                set_new_data_response_in_queue(
+                    &mut data_stream,
+                    request_index as usize,
+                    MAX_ADVERTISED_TRANSACTION + request_index,
+                    transactions_only,
+                );
+            }
+
+            // Process the responses
+            process_data_responses(&mut data_stream, &global_data_summary).await;
+
+            // Verify more requests are sent (but not more than the max pending requests)
+            verify_num_sent_requests(&mut data_stream, max_pending_requests);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_continuous_stream_subscription_max_pending_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 5;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_num_consecutive_subscriptions = 1000;
+    let max_pending_requests = 11;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_num_consecutive_subscriptions,
+        max_pending_requests,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (mut data_stream, _stream_listener, _, transactions_only, allow_transactions_or_outputs) in
+        continuous_data_streams
+    {
+        // Initialize the data stream
+        let global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Fetch the subscription stream ID from the first pending request
+        let subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+        // Verify the pending requests are for the correct data and correctly formed
+        verify_pending_subscription_requests(
+            &mut data_stream,
+            max_in_flight_subscription_requests,
+            allow_transactions_or_outputs,
+            transactions_only,
+            0,
+            subscription_stream_id,
+            0,
+        );
+
+        // Set valid responses for all pending requests except the first
+        for request_index in 1..max_in_flight_subscription_requests {
+            set_new_data_response_in_queue(
+                &mut data_stream,
+                request_index as usize,
+                MAX_ADVERTISED_TRANSACTION + request_index,
+                transactions_only,
+            );
+        }
+
+        // Process the responses
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Verify more requests are sent
+        let num_pending_requests = (max_in_flight_subscription_requests * 2) - 1;
+        verify_num_sent_requests(&mut data_stream, num_pending_requests);
+
+        // Set valid responses for all pending requests except the first
+        for request_index in 1..num_pending_requests {
+            set_new_data_response_in_queue(
+                &mut data_stream,
+                request_index as usize,
+                MAX_ADVERTISED_TRANSACTION + request_index,
+                transactions_only,
+            );
+        }
+
+        // Process the responses
+        process_data_responses(&mut data_stream, &global_data_summary).await;
+
+        // Verify more requests are sent (but not more than the max pending requests)
+        verify_num_sent_requests(&mut data_stream, max_pending_requests);
+
+        // Set responses and process them multiple times
+        for _ in 0..10 {
+            // Set valid responses for all pending requests except the first
+            for request_index in 1..max_pending_requests {
+                set_new_data_response_in_queue(
+                    &mut data_stream,
+                    request_index as usize,
+                    MAX_ADVERTISED_TRANSACTION + request_index,
+                    transactions_only,
+                );
+            }
+
+            // Process the responses
+            process_data_responses(&mut data_stream, &global_data_summary).await;
+
+            // Verify more requests are sent (but not more than the max pending requests)
+            verify_num_sent_requests(&mut data_stream, max_pending_requests);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_continuous_stream_subscription_max_prefetching() {
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 8;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_num_consecutive_subscriptions = 9;
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        max_num_consecutive_subscriptions,
+        ..Default::default()
+    };
+
+    // Test all types of continuous data streams
+    let continuous_data_streams = enumerate_continuous_data_streams(
+        AptosDataClientConfig::default(),
+        streaming_service_config,
+    );
+    for (mut data_stream, _stream_listener, _, transactions_only, allow_transactions_or_outputs) in
+        continuous_data_streams
+    {
+        // Initialize the data stream
+        let global_data_summary = create_global_data_summary(1);
+        initialize_data_requests(&mut data_stream, &global_data_summary);
+
+        // Iterate through several changes in subscription streams
+        let num_subscription_stream_changes = 5;
+        for stream_number in 0..num_subscription_stream_changes {
+            // Fetch the subscription stream ID from the first pending request
+            let subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+            // Verify the pending requests are for the correct data and correctly formed
+            verify_pending_subscription_requests(
+                &mut data_stream,
+                max_in_flight_subscription_requests,
+                allow_transactions_or_outputs,
+                transactions_only,
+                0,
+                subscription_stream_id,
+                stream_number * max_num_consecutive_subscriptions,
+            );
+
+            // Set valid responses for all pending requests and process the responses
+            for request_index in 0..max_in_flight_subscription_requests {
+                set_new_data_response_in_queue(
+                    &mut data_stream,
+                    request_index as usize,
+                    MAX_ADVERTISED_TRANSACTION + request_index,
+                    transactions_only,
+                );
+            }
+            process_data_responses(&mut data_stream, &global_data_summary).await;
+
+            // Verify the number of pending requests
+            verify_num_sent_requests(
+                &mut data_stream,
+                max_num_consecutive_subscriptions - max_in_flight_subscription_requests,
+            );
+
+            // Set valid responses for all pending requests and process the responses
+            for request_index in
+                0..(max_num_consecutive_subscriptions - max_in_flight_subscription_requests)
+            {
+                set_new_data_response_in_queue(
+                    &mut data_stream,
+                    request_index as usize,
+                    MAX_ADVERTISED_TRANSACTION
+                        + request_index
+                        + max_in_flight_subscription_requests,
+                    transactions_only,
+                );
+            }
+            process_data_responses(&mut data_stream, &global_data_summary).await;
+
+            // Fetch the next subscription stream ID from the first pending request
+            let next_subscription_stream_id = get_subscription_stream_id(&mut data_stream, 0);
+
+            // Verify the subscription stream ID has changed (because we hit the max number of requests)
+            assert_ne!(subscription_stream_id, next_subscription_stream_id);
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_continuous_stream_subscription_timeout() {
     // Create a test data client config
@@ -2212,16 +2907,18 @@ async fn test_continuous_stream_subscription_timeout() {
         ..Default::default()
     };
 
-    // Create a test streaming service config with subscriptions
-    // enabled, but dynamic prefetching disabled.
-    let dynamic_prefetching_config = DynamicPrefetchingConfig {
+    // Create a dynamic prefetching config with prefetching disabled
+    let dynamic_prefetching = DynamicPrefetchingConfig {
         enable_dynamic_prefetching: false,
         ..Default::default()
     };
+
+    // Create a test streaming service config with subscriptions enabled
+    let max_concurrent_requests = 3;
     let streaming_service_config = DataStreamingServiceConfig {
-        dynamic_prefetching: dynamic_prefetching_config,
+        dynamic_prefetching,
         enable_subscription_streaming: true,
-        max_concurrent_requests: 7,
+        max_concurrent_requests,
         ..Default::default()
     };
 
@@ -2229,7 +2926,39 @@ async fn test_continuous_stream_subscription_timeout() {
     verify_continuous_stream_request_timeouts(
         data_client_config,
         streaming_service_config,
-        streaming_service_config.max_concurrent_requests,
+        max_concurrent_requests,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_continuous_stream_subscription_timeout_prefetching() {
+    // Create a test data client config
+    let data_client_config = AptosDataClientConfig {
+        subscription_response_timeout_ms: 500,
+        ..Default::default()
+    };
+
+    // Create a dynamic prefetching config with prefetching enabled
+    let max_in_flight_subscription_requests = 6;
+    let dynamic_prefetching = DynamicPrefetchingConfig {
+        enable_dynamic_prefetching: true,
+        max_in_flight_subscription_requests,
+        ..Default::default()
+    };
+
+    // Create a test streaming service config with subscriptions enabled
+    let streaming_service_config = DataStreamingServiceConfig {
+        dynamic_prefetching,
+        enable_subscription_streaming: true,
+        ..Default::default()
+    };
+
+    // Verify the timeouts of all continuous data streams
+    verify_continuous_stream_request_timeouts(
+        data_client_config,
+        streaming_service_config,
+        max_in_flight_subscription_requests,
     )
     .await;
 }

--- a/state-sync/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/data-streaming-service/src/tests/missing_data.rs
@@ -454,7 +454,13 @@ fn transform_epoch_ending_stream_notifications() {
     // Create a single data client request
     let notification_id_generator = create_notification_id_generator();
     let data_client_request = stream_engine
-        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .create_data_client_requests(
+            1,
+            1,
+            0,
+            &global_data_summary,
+            notification_id_generator.clone(),
+        )
         .unwrap();
     assert_eq!(data_client_request.len(), 1);
 
@@ -562,7 +568,13 @@ fn transform_state_values_stream_notifications() {
     // Create a single data client request
     let notification_id_generator = create_notification_id_generator();
     let data_client_request = stream_engine
-        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .create_data_client_requests(
+            1,
+            1,
+            0,
+            &global_data_summary,
+            notification_id_generator.clone(),
+        )
         .unwrap();
     assert_eq!(data_client_request.len(), 1);
 
@@ -675,7 +687,13 @@ fn transform_transactions_stream_notifications() {
     // Create a single data client request
     let notification_id_generator = create_notification_id_generator();
     let data_client_request = stream_engine
-        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .create_data_client_requests(
+            1,
+            1,
+            0,
+            &global_data_summary,
+            notification_id_generator.clone(),
+        )
         .unwrap();
     assert_eq!(data_client_request.len(), 1);
 
@@ -776,7 +794,13 @@ fn transform_continuous_outputs_stream_notifications() {
     // Create a single data client request
     let notification_id_generator = create_notification_id_generator();
     let data_client_request = stream_engine
-        .create_data_client_requests(1, &global_data_summary, notification_id_generator.clone())
+        .create_data_client_requests(
+            1,
+            1,
+            0,
+            &global_data_summary,
+            notification_id_generator.clone(),
+        )
         .unwrap();
     assert_eq!(data_client_request.len(), 1);
 

--- a/state-sync/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/data-streaming-service/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod client_requests;
 mod data_stream;
 mod missing_data;
 mod stream_engine;

--- a/state-sync/data-streaming-service/src/tests/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/tests/stream_engine.rs
@@ -30,6 +30,8 @@ fn test_create_epoch_ending_requests() {
     let client_requests = stream_engine
         .create_data_client_requests(
             5,
+            5,
+            0,
             &create_epoch_ending_chunk_sizes(10000),
             create_notification_id_generator(),
         )
@@ -48,6 +50,8 @@ fn test_create_epoch_ending_requests() {
     let client_requests = stream_engine
         .create_data_client_requests(
             3,
+            3,
+            0,
             &create_epoch_ending_chunk_sizes(chunk_size),
             create_notification_id_generator(),
         )
@@ -68,6 +72,8 @@ fn test_create_epoch_ending_requests() {
     let client_requests = stream_engine
         .create_data_client_requests(
             100,
+            100,
+            0,
             &create_epoch_ending_chunk_sizes(chunk_size),
             create_notification_id_generator(),
         )
@@ -96,6 +102,8 @@ fn test_create_epoch_ending_requests_dynamic() {
     let client_requests = stream_engine
         .create_data_client_requests(
             5,
+            5,
+            0,
             &create_epoch_ending_chunk_sizes(700),
             create_notification_id_generator(),
         )
@@ -120,6 +128,8 @@ fn test_create_epoch_ending_requests_dynamic() {
     let client_requests = stream_engine
         .create_data_client_requests(
             10,
+            10,
+            0,
             &create_epoch_ending_chunk_sizes(chunk_size),
             create_notification_id_generator(),
         )
@@ -141,6 +151,8 @@ fn test_create_epoch_ending_requests_dynamic() {
     let client_requests = stream_engine
         .create_data_client_requests(
             5,
+            5,
+            0,
             &create_epoch_ending_chunk_sizes(700),
             create_notification_id_generator(),
         )
@@ -159,6 +171,8 @@ fn test_create_epoch_ending_requests_dynamic() {
     // Create a batch of client requests and verify no error
     let client_requests = stream_engine.create_data_client_requests(
         10,
+        10,
+        0,
         &create_epoch_ending_chunk_sizes(50),
         create_notification_id_generator(),
     );


### PR DESCRIPTION
Note: (i) most of this PR is just updating/adding tests; and (ii) this PR is built on https://github.com/aptos-labs/aptos-core/pull/12481.

## Description

This PR adds a configurable maximum number of in-flight subscription requests to the data streaming service. This is required to bound the number of subscription requests that can be sent at any one time. The default is `9` (at ~3 blocks per second, this means we can prefetch ~3 seconds of data). Before this, the maximum was determined by the dynamic prefetching value, which is suboptimal in practice. A constant configurable number seems to perform more steadily.

The PR offers several commits:
1. Add the new maximum config value.
2. Add/update the unit tests.

## Testing
New and existing test infrastructure.