### PR TITLE
[passkeys] Enforce MAX_WEBAUTHN_SIGNATURE_BYTES during `verify`

### DIFF
--- a/types/src/transaction/webauthn.rs
+++ b/types/src/transaction/webauthn.rs
@@ -923,6 +923,6 @@ mod tests {
             vec![0u8; MAX_WEBAUTHN_SIGNATURE_BYTES],
         );
         let verification_result = bad_paar.verify(&raw_txn, &any_public_key);
-        assert!(verification_result.is_err());
+        assert!(verification_result.err().unwrap().to_string().contains("The PartialAuthenticatorAssertionResponse content length is greater than the maximum number of"));
     }
 }

--- a/types/src/transaction/webauthn.rs
+++ b/types/src/transaction/webauthn.rs
@@ -4,7 +4,8 @@
 use crate::transaction::authenticator::AnyPublicKey;
 use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::{
-    hash::CryptoHash, secp256r1_ecdsa, signing_message, CryptoMaterialError, HashValue, Length, Signature,
+    hash::CryptoHash, secp256r1_ecdsa, signing_message, CryptoMaterialError, HashValue, Length,
+    Signature,
 };
 use passkey_types::{crypto::sha256, webauthn::CollectedClientData, Bytes};
 use serde::{Deserialize, Serialize};
@@ -132,7 +133,8 @@ impl PartialAuthenticatorAssertionResponse {
         let signature_len = match self.signature() {
             AssertionSignature::Secp256r1Ecdsa { signature } => signature.length(),
         };
-        let payload_len = signature_len + self.authenticator_data().len() + self.client_data_json().len();
+        let payload_len =
+            signature_len + self.authenticator_data().len() + self.client_data_json().len();
         ensure!(
             payload_len <= MAX_WEBAUTHN_SIGNATURE_BYTES,
             format!("The PartialAuthenticatorAssertionResponse content length is greater than the maximum number of {} bytes: found {} bytes.", MAX_WEBAUTHN_SIGNATURE_BYTES, payload_len)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Adding a `MAX_WEBAUTHN_SIGNATURE_BYTES` check. This check is completed both for BCS serialized and JSON serialized transactions, unlike `VerifyInput` which is only done for JSON serialized transactions.

Note: if needed, `MAX_WEBAUTHN_SIGNATURE_BYTES` should ONLY be increased in the future (NOT decreased) otherwise it will not be backwards compatible

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Provided unit tests to test that the `MAX_WEBAUTHN_SIGNATURE_BYTES` works as expected during verification of the `PartialAuthenticatorAssertionResponse`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
