### PR TITLE
Sync Terraform & Helm

### DIFF
--- a/terraform/fullnode/aws/kubernetes.tf
+++ b/terraform/fullnode/aws/kubernetes.tf
@@ -28,6 +28,7 @@ resource "helm_release" "fullnode" {
       }
       storage = {
         class = var.fullnode_storage_class
+        size  = var.fullnode_storage_size
       }
       service = {
         type = "LoadBalancer"

--- a/terraform/fullnode/aws/variables.tf
+++ b/terraform/fullnode/aws/variables.tf
@@ -171,6 +171,12 @@ variable "fullnode_storage_class" {
   }
 }
 
+variable "fullnode_storage_size" {
+  description = "Disk size for fullnodes"
+  type        = string
+  default     = "2000Gi"
+}
+
 variable "manage_via_tf" {
   description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   type        = bool

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -75,6 +75,7 @@ subjects:
 
 ---
 
+{{- if .Values.enabled  }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -190,3 +191,4 @@ spec:
       imagePullSecrets:
       - name: {{.Values.imagePullSecret}}
       {{- end }}
+{{- end }}

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -1,3 +1,5 @@
+# -- Used to toggle on and off the automatic genesis job
+enabled: true
 chain:
   # -- Internal: name of the testnet to connect to
   name: testnet

--- a/terraform/modules/resources/instance.tf
+++ b/terraform/modules/resources/instance.tf
@@ -6,7 +6,7 @@ variable "instance_type" {
   default     = ""
 
   validation {
-    condition     = can(regex("^(e2|n2d|t2d)-standard-(4|8|16|32|48|60)$", var.instance_type))
+    condition     = can(regex("^(c2|e2|n2d|t2d)-standard-(4|8|16|32|48|60)$", var.instance_type))
     error_message = "Unknown machine type"
   }
 }
@@ -17,7 +17,7 @@ variable "utility_instance_type" {
   default     = "e2-standard-8"
 
   validation {
-    condition     = can(regex("^(e2|n2d|t2d)-standard-(4|8|16|32|48|60)$", var.utility_instance_type))
+    condition     = can(regex("^(c2|e2|n2d|t2d)-standard-(4|8|16|32|48|60)$", var.utility_instance_type))
     error_message = "Unknown machine type"
   }
 }
@@ -40,6 +40,7 @@ locals {
   machine_family         = split("-", var.instance_type)[0]
   utility_machine_family = split("-", var.utility_instance_type)[0]
   machine_shapes = {
+    "c2-standard-60"  = { cores = 60, memory = 240 }
     "t2d-standard-8"  = { cores = 8, memory = 32 }
     "t2d-standard-16" = { cores = 16, memory = 64 }
     "t2d-standard-32" = { cores = 32, memory = 128 }


### PR DESCRIPTION
Sync Terraform & Helm changes

* set default disk size for the `fullnode` chart to 2.5TBi
* add a toggle to the `genesis` chart to disable running automatically (thus avoiding to potentially overwrite an already existing genesis)
* Add `c2-standard-60` to the list of approved instance types