### PR TITLE
Fix txn notifier failure due to vtxns

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -222,17 +222,38 @@ impl StateComputer for ExecutionProxy {
                 "Got state compute result, post processing."
             );
             let pipeline_execution_result = fut.await?;
-            let input_txns = pipeline_execution_result.input_txns.clone();
+            let user_txns = &pipeline_execution_result.input_txns;
             let result = &pipeline_execution_result.result;
 
             observe_block(timestamp, BlockStage::EXECUTED);
 
-            // notify mempool about failed transaction
-            if let Err(e) = txn_notifier.notify_failed_txn(input_txns, result).await {
-                error!(
-                    error = ?e, "Failed to notify mempool of rejected txns",
-                );
+            let compute_status = result.compute_status_for_input_txns();
+            // the length of compute_status is user_txns.len() + num_vtxns + 1 due to having blockmetadata
+            if user_txns.len() >= compute_status.len() {
+                // reconfiguration suffix blocks don't have any transactions
+                // otherwise, this is an error
+                if !compute_status.is_empty() {
+                    error!(
+                        "Expected compute_status length and actual compute_status length mismatch! user_txns len: {}, compute_status len: {}, has_reconfiguration: {}",
+                        user_txns.len(),
+                        compute_status.len(),
+                        result.has_reconfiguration(),
+                    );
+                }
+            } else {
+                let user_txn_status = &compute_status[compute_status.len() - user_txns.len()..];
+
+                // notify mempool about failed transaction
+                if let Err(e) = txn_notifier
+                    .notify_failed_txn(user_txns, user_txn_status)
+                    .await
+                {
+                    error!(
+                        error = ?e, "Failed to notify mempool of rejected txns",
+                    );
+                }
             }
+
             Ok(pipeline_execution_result)
         })
     }
@@ -404,7 +425,7 @@ async fn test_commit_sync_race() {
         block_info::BlockInfo,
         ledger_info::LedgerInfo,
         on_chain_config::{TransactionDeduperType, TransactionShufflerType},
-        transaction::SignedTransaction,
+        transaction::{SignedTransaction, TransactionStatus},
     };
 
     struct RecordedCommit {
@@ -467,8 +488,8 @@ async fn test_commit_sync_race() {
     impl TxnNotifier for RecordedCommit {
         async fn notify_failed_txn(
             &self,
-            _txns: Vec<SignedTransaction>,
-            _compute_results: &StateComputeResult,
+            _txns: &[SignedTransaction],
+            _compute_results: &[TransactionStatus],
         ) -> Result<(), MempoolError> {
             Ok(())
         }

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -64,8 +64,8 @@ struct DummyTxnNotifier {}
 impl TxnNotifier for DummyTxnNotifier {
     async fn notify_failed_txn(
         &self,
-        _txns: Vec<SignedTransaction>,
-        _compute_results: &StateComputeResult,
+        _txns: &[SignedTransaction],
+        _statuses: &[TransactionStatus],
     ) -> anyhow::Result<(), MempoolError> {
         Ok(())
     }

--- a/consensus/src/txn_notifier.rs
+++ b/consensus/src/txn_notifier.rs
@@ -4,7 +4,6 @@
 use crate::{error::MempoolError, monitor};
 use anyhow::{format_err, Result};
 use aptos_consensus_types::common::RejectedTransactionSummary;
-use aptos_executor_types::StateComputeResult;
 use aptos_mempool::QuorumStoreRequest;
 use aptos_types::transaction::{SignedTransaction, TransactionStatus};
 use futures::channel::{mpsc, oneshot};
@@ -19,8 +18,8 @@ pub trait TxnNotifier: Send + Sync {
     /// state sync.)
     async fn notify_failed_txn(
         &self,
-        txns: Vec<SignedTransaction>,
-        compute_results: &StateComputeResult,
+        txns: &[SignedTransaction],
+        statuses: &[TransactionStatus],
     ) -> Result<(), MempoolError>;
 }
 
@@ -48,32 +47,12 @@ impl MempoolNotifier {
 impl TxnNotifier for MempoolNotifier {
     async fn notify_failed_txn(
         &self,
-        user_txns: Vec<SignedTransaction>,
-        compute_results: &StateComputeResult,
+        user_txns: &[SignedTransaction],
+        user_txn_statuses: &[TransactionStatus],
     ) -> Result<(), MempoolError> {
         let mut rejected_txns = vec![];
 
-        if user_txns.is_empty() {
-            return Ok(());
-        }
-        let compute_status = compute_results.compute_status_for_input_txns();
-        // the length of compute_status is user_txns.len() + 1 due to having blockmetadata
-        let expected_len = user_txns.len() + 1;
-        if expected_len != compute_status.len() {
-            // reconfiguration suffix blocks don't have any transactions
-            if compute_status.is_empty() {
-                return Ok(());
-            }
-            return Err(format_err!(
-                "Expected compute_status length and actual compute_status length mismatch! user_txns len: {}, expected compute_status len: {}, compute_status len: {}, has_reconfiguration: {}",
-                user_txns.len(),
-                expected_len,
-                compute_status.len(),
-                compute_results.has_reconfiguration(),
-            ).into());
-        }
-        let user_txn_status = &compute_status[1..user_txns.len() + 1];
-        for (txn, status) in user_txns.iter().zip_eq(user_txn_status) {
+        for (txn, status) in user_txns.iter().zip_eq(user_txn_statuses) {
             if let TransactionStatus::Discard(reason) = status {
                 rejected_txns.push(RejectedTransactionSummary {
                     sender: txn.sender(),


### PR DESCRIPTION
## Description
In testing we saw:
Failed to notify mempool of rejected txnsMempoolError { inner: Expected compute_status length and actual compute_status length mismatch! user_txns len: 1, expected compute_status len: 2, compute_status len: 3, has_reconfiguration: false }

appearing because vtxns have changed size of the prefix before user transactions.

txn notifier doesn't need full result, only statuses of user transactions, so simplifying the API. that also removes one clone.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
test via smoke test

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
