### PR TITLE
use ast::Value equivalence, not enum equality, to do constant folding of constants

### DIFF
--- a/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
@@ -1,0 +1,26 @@
+// -- Model dump before bytecode pipeline
+module 0xcafe::Ristretto {
+    public fun test() {
+        {
+          let non_canonical_highbit: vector<u8> = Vector<u8>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128);
+          {
+            let non_canonical_highbit_hex: vector<u8> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+            if Eq<vector<u8>>(non_canonical_highbit, non_canonical_highbit_hex) {
+              Tuple()
+            } else {
+              Abort(1)
+            };
+            Tuple()
+          }
+        }
+    }
+    spec fun $test() {
+        {
+          let non_canonical_highbit: vector<u256> = Vector<u256>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128);
+          {
+            let non_canonical_highbit_hex: vector<u8> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+            Tuple()
+          }
+        }
+    }
+} // end 0xcafe::Ristretto

--- a/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
@@ -14,13 +14,4 @@ module 0xcafe::Ristretto {
           }
         }
     }
-    spec fun $test() {
-        {
-          let non_canonical_highbit: vector<u256> = Vector<u256>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128);
-          {
-            let non_canonical_highbit_hex: vector<u8> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
-            Tuple()
-          }
-        }
-    }
 } // end 0xcafe::Ristretto

--- a/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.move
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.move
@@ -1,0 +1,8 @@
+//# publish --print-bytecode
+module 0xcafe::Ristretto {
+    public fun test() {
+        let non_canonical_highbit = vector[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+        let non_canonical_highbit_hex = x"0000000000000000000000000000000000000000000000000000000000000080";
+        assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
@@ -1,0 +1,20 @@
+// -- Model dump before bytecode pipeline
+module 0xcafe::Ristretto {
+    public fun test() {
+        if true {
+          Tuple()
+        } else {
+          Abort(1)
+        };
+        Tuple()
+    }
+    spec fun $test() {
+        {
+          let non_canonical_highbit: vector<u256> = Vector<u256>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128);
+          {
+            let non_canonical_highbit_hex: vector<u8> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+            Tuple()
+          }
+        }
+    }
+} // end 0xcafe::Ristretto

--- a/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
@@ -8,13 +8,4 @@ module 0xcafe::Ristretto {
         };
         Tuple()
     }
-    spec fun $test() {
-        {
-          let non_canonical_highbit: vector<u256> = Vector<u256>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128);
-          {
-            let non_canonical_highbit_hex: vector<u8> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
-            Tuple()
-          }
-        }
-    }
 } // end 0xcafe::Ristretto

--- a/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.move
+++ b/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.move
@@ -1,0 +1,8 @@
+//# publish --print-bytecode
+module 0xcafe::Ristretto {
+    public fun test() {
+        let non_canonical_highbit = vector[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+        let non_canonical_highbit_hex = x"0000000000000000000000000000000000000000000000000000000000000080";
+        assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -110,49 +110,31 @@ impl TestConfig {
 
         // The bytecode transformation pipeline
         let mut pipeline = FunctionTargetPipeline::default();
+
+        // Get path to allow path-specific test configuration
         let path = path.to_string_lossy();
-        if path.contains("/inlining/")
-            || path.contains("/folding/")
-            || path.contains("/simplifier/")
-        {
+
+        // turn on simplifier unless doing no-simplifier tests.
+        if path.contains("/simplifier-elimination/") {
+            env_pipeline.add("simplifier", |env: &mut GlobalEnv| {
+                ast_simplifier::run_simplifier(
+                    env, true, // Code elimination
+                )
+            });
+        } else if !path.contains("/no-simplifier/") {
             env_pipeline.add("simplifier", |env: &mut GlobalEnv| {
                 ast_simplifier::run_simplifier(
                     env, false, // No code elimination
                 )
             });
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
-            pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(AbilityProcessor {}));
-            Self {
-                stop_before_generating_bytecode: false,
-                dump_ast: AstDumpLevel::EndStage,
-                env_pipeline,
-                pipeline,
-                generate_file_format: false,
-                dump_annotated_targets: false,
-                dump_for_only_some_stages: None,
-            }
-        } else if path.contains("/simplifier-elimination/") {
-            env_pipeline.add("simplifier", |env: &mut GlobalEnv| {
-                ast_simplifier::run_simplifier(
-                    env, true, // Enable code elimination
-                )
-            });
-            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
-            pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));
-            pipeline.add_processor(Box::new(AbilityProcessor {}));
-            Self {
-                stop_before_generating_bytecode: false,
-                dump_ast: AstDumpLevel::EndStage,
-                env_pipeline,
-                pipeline,
-                generate_file_format: false,
-                dump_annotated_targets: false,
-                dump_for_only_some_stages: None,
-            }
-        } else if path.contains("/no-simplifier/") {
+        }
+
+        if path.contains("/inlining/")
+            || path.contains("/folding/")
+            || path.contains("/simplifier/")
+            || path.contains("/simplifier-elimination/")
+            || path.contains("/no-simplifier/")
+        {
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
             pipeline.add_processor(Box::new(ReferenceSafetyProcessor {}));
             pipeline.add_processor(Box::new(ExitStateAnalysisProcessor {}));

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/simplifier/constant_folding_ristretto.exp
@@ -1,0 +1,43 @@
+processed 1 task
+
+task 0 'publish'. lines 1-8:
+
+
+
+==> Compiler v2 delivered same results!
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module cafe.Ristretto {
+
+
+public test() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+}
+== END Bytecode ==
+}
+
+>>> V2 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v7
+module cafe.Ristretto {
+
+
+public test() /* def_idx: 0 */ {
+B0:
+	0: LdTrue
+	1: BrFalse(3)
+B1:
+	2: Branch(5)
+B2:
+	3: LdU64(1)
+	4: Abort
+B3:
+	5: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/simplifier/constant_folding_ristretto.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/simplifier/constant_folding_ristretto.move
@@ -1,0 +1,8 @@
+//# publish --print-bytecode
+module 0xcafe::Ristretto {
+    public fun test() {
+        let non_canonical_highbit = vector[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+        let non_canonical_highbit_hex = x"0000000000000000000000000000000000000000000000000000000000000080";
+        assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
+    }
+}

--- a/third_party/move/move-compiler/transactional-tests/tests/simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/simplifier/constant_folding_ristretto.exp
@@ -1,0 +1,19 @@
+processed 1 task
+
+task 0 'publish'. lines 1-8:
+
+
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module cafe.Ristretto {
+
+
+public test() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler/transactional-tests/tests/simplifier/constant_folding_ristretto.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/simplifier/constant_folding_ristretto.move
@@ -1,0 +1,8 @@
+//# publish --print-bytecode
+module 0xcafe::Ristretto {
+    public fun test() {
+        let non_canonical_highbit = vector[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
+        let non_canonical_highbit_hex = x"0000000000000000000000000000000000000000000000000000000000000080";
+        assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
+    }
+}

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -2199,7 +2199,7 @@ impl Value {
                         Some(false)
                     }
                 },
-                (Value::Vector(x), Value::Vector(y)) => {
+                (Value::Vector(x), Value::Vector(y)) | (Value::Tuple(x), Value::Tuple(y)) => {
                     if x.len() == y.len() {
                         iter::zip(x, y)
                             .map(|(val1, val2)| val1.equivalent(val2))

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -2145,8 +2145,8 @@ impl Value {
                 unequal_addresses_equivalent(a, b)
             }
         };
-        // Reduce with fuzzy AND
-        let option_bool_and = |a: Option<bool>, b: Option<bool>| match (a, b) {
+        // `Option<bool>::and()` operation that treats `None` as "unknown"
+        let fuzzy_and = |a: Option<bool>, b: Option<bool>| match (a, b) {
             (Some(false), _) | (_, Some(false)) => Some(false),
             (Some(true), Some(true)) => Some(true),
             _ => None,
@@ -2183,7 +2183,7 @@ impl Value {
                                     Some(false)
                                 }
                             })
-                            .reduce(&option_bool_and)
+                            .reduce(&fuzzy_and)
                             .unwrap_or(Some(true))
                     } else {
                         Some(false)
@@ -2193,7 +2193,7 @@ impl Value {
                     if x.len() == y.len() {
                         iter::zip(x, y)
                             .map(|(addr1, addr2)| addresses_equivalent(addr1, addr2))
-                            .reduce(&option_bool_and)
+                            .reduce(&fuzzy_and)
                             .unwrap_or(Some(true))
                     } else {
                         Some(false)
@@ -2203,7 +2203,7 @@ impl Value {
                     if x.len() == y.len() {
                         iter::zip(x, y)
                             .map(|(val1, val2)| val1.equivalent(val2))
-                            .reduce(&option_bool_and)
+                            .reduce(&fuzzy_and)
                             .unwrap_or(Some(true))
                     } else {
                         Some(false)
@@ -3174,182 +3174,200 @@ impl<'a> fmt::Display for EnvDisplay<'a, Spec> {
     }
 }
 
-#[test]
-fn test_value_equivalence() {
-    // Some test values
-    let v_true = Value::Bool(true);
-    let v_false = Value::Bool(false);
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ast::{Address, Value},
+        symbol::Symbol,
+        AccountAddress,
+    };
+    use num::BigInt;
+    #[test]
+    fn test_value_equivalence() {
+        // Some test values
+        let v_true = Value::Bool(true);
+        let v_false = Value::Bool(false);
 
-    let v_3 = Value::Number(BigInt::from(3));
-    let v_5 = Value::Number(BigInt::from(5));
-    let v_1000 = Value::Number(BigInt::from(1000));
+        let v_3 = Value::Number(BigInt::from(3));
+        let v_5 = Value::Number(BigInt::from(5));
+        let v_1000 = Value::Number(BigInt::from(1000));
 
-    let bv_empty = Value::ByteArray(vec![]);
-    let bv_3_5 = Value::ByteArray(vec![3, 5]);
-    let bv_5_3 = Value::ByteArray(vec![5, 3]);
-    let bv_3_5_5 = Value::ByteArray(vec![3, 5, 5]);
+        let bv_empty = Value::ByteArray(vec![]);
+        let bv_3_5 = Value::ByteArray(vec![3, 5]);
+        let bv_5_3 = Value::ByteArray(vec![5, 3]);
+        let bv_3_5_5 = Value::ByteArray(vec![3, 5, 5]);
 
-    let addr_01 =
-        Address::Numerical(AccountAddress::from_hex_literal("0xcafebeef").expect("success"));
-    let addr_02 = Address::Numerical(AccountAddress::from_hex_literal("0x01").expect("success"));
-    let addr_s1 = Address::Symbolic(Symbol::new(1));
-    let addr_s2 = Address::Symbolic(Symbol::new(2));
-    let av_01 = Value::Address(addr_01.clone());
-    let av_02 = Value::Address(addr_02.clone());
-    let av_s1 = Value::Address(addr_s1.clone());
-    let av_s2 = Value::Address(addr_s2.clone());
+        let addr_01 =
+            Address::Numerical(AccountAddress::from_hex_literal("0xcafebeef").expect("success"));
+        let addr_02 =
+            Address::Numerical(AccountAddress::from_hex_literal("0x01").expect("success"));
+        let addr_s1 = Address::Symbolic(Symbol::new(1));
+        let addr_s2 = Address::Symbolic(Symbol::new(2));
+        let av_01 = Value::Address(addr_01.clone());
+        let av_02 = Value::Address(addr_02.clone());
+        let av_s1 = Value::Address(addr_s1.clone());
+        let av_s2 = Value::Address(addr_s2.clone());
 
-    let av_empty = Value::AddressArray(vec![]);
-    let av_a1_a2 = Value::AddressArray(vec![addr_01.clone(), addr_02.clone()]);
-    let av_a2_a1 = Value::AddressArray(vec![addr_02.clone(), addr_01.clone()]);
-    let av_a1_a2_a2 = Value::AddressArray(vec![addr_01.clone(), addr_02.clone(), addr_02.clone()]);
+        let av_empty = Value::AddressArray(vec![]);
+        let av_a1_a2 = Value::AddressArray(vec![addr_01.clone(), addr_02.clone()]);
+        let av_a2_a1 = Value::AddressArray(vec![addr_02.clone(), addr_01.clone()]);
+        let av_a1_a2_a2 =
+            Value::AddressArray(vec![addr_01.clone(), addr_02.clone(), addr_02.clone()]);
 
-    let av_s1_s2 = Value::AddressArray(vec![addr_s1.clone(), addr_s2.clone()]);
-    let av_s2_s1 = Value::AddressArray(vec![addr_s2.clone(), addr_s1.clone()]);
-    let av_s1_s2_s2 = Value::AddressArray(vec![addr_s1.clone(), addr_s2.clone(), addr_s2.clone()]);
-    let av_a1_s1_a2 = Value::AddressArray(vec![addr_01.clone(), addr_s1.clone(), addr_02.clone()]);
-    let av_a1_s2_a2 = Value::AddressArray(vec![addr_01.clone(), addr_s2.clone(), addr_02.clone()]);
-    let av_a2_s1_a1 = Value::AddressArray(vec![addr_02.clone(), addr_s1.clone(), addr_01.clone()]);
-    let av_a2_s2_a1 = Value::AddressArray(vec![addr_02.clone(), addr_s2.clone(), addr_01.clone()]);
-    let av_s1_a1_s2 = Value::AddressArray(vec![addr_s1.clone(), addr_01.clone(), addr_s2.clone()]);
-    let av_s1_a2_s2 = Value::AddressArray(vec![addr_s1.clone(), addr_02.clone(), addr_s1.clone()]);
+        let av_s1_s2 = Value::AddressArray(vec![addr_s1.clone(), addr_s2.clone()]);
+        let av_s2_s1 = Value::AddressArray(vec![addr_s2.clone(), addr_s1.clone()]);
+        let av_s1_s2_s2 =
+            Value::AddressArray(vec![addr_s1.clone(), addr_s2.clone(), addr_s2.clone()]);
+        let av_a1_s1_a2 =
+            Value::AddressArray(vec![addr_01.clone(), addr_s1.clone(), addr_02.clone()]);
+        let av_a1_s2_a2 =
+            Value::AddressArray(vec![addr_01.clone(), addr_s2.clone(), addr_02.clone()]);
+        let av_a2_s1_a1 =
+            Value::AddressArray(vec![addr_02.clone(), addr_s1.clone(), addr_01.clone()]);
+        let av_a2_s2_a1 =
+            Value::AddressArray(vec![addr_02.clone(), addr_s2.clone(), addr_01.clone()]);
+        let av_s1_a1_s2 =
+            Value::AddressArray(vec![addr_s1.clone(), addr_01.clone(), addr_s2.clone()]);
+        let av_s1_a2_s2 =
+            Value::AddressArray(vec![addr_s1.clone(), addr_02.clone(), addr_s1.clone()]);
 
-    let vect_empty = Value::Vector(vec![]);
-    let vect_3_5 = Value::Vector(vec![v_3.clone(), v_5.clone()]);
-    let vect_5_3 = Value::Vector(vec![v_5.clone(), v_3.clone()]);
-    let vect_3_5_5 = Value::Vector(vec![v_3.clone(), v_5.clone(), v_5.clone()]);
+        let vect_empty = Value::Vector(vec![]);
+        let vect_3_5 = Value::Vector(vec![v_3.clone(), v_5.clone()]);
+        let vect_5_3 = Value::Vector(vec![v_5.clone(), v_3.clone()]);
+        let vect_3_5_5 = Value::Vector(vec![v_3.clone(), v_5.clone(), v_5.clone()]);
 
-    let vect_a1_a2 = Value::Vector(vec![av_01.clone(), av_02.clone()]);
-    let vect_a2_a1 = Value::Vector(vec![av_02.clone(), av_01.clone()]);
-    let vect_a1_a2_a2 = Value::Vector(vec![av_01.clone(), av_02.clone(), av_02.clone()]);
-    let vect_s1_s2 = Value::Vector(vec![av_s1.clone(), av_s2.clone()]);
-    let vect_s2_s1 = Value::Vector(vec![av_s2.clone(), av_s1.clone()]);
+        let vect_a1_a2 = Value::Vector(vec![av_01.clone(), av_02.clone()]);
+        let vect_a2_a1 = Value::Vector(vec![av_02.clone(), av_01.clone()]);
+        let vect_a1_a2_a2 = Value::Vector(vec![av_01.clone(), av_02.clone(), av_02.clone()]);
+        let vect_s1_s2 = Value::Vector(vec![av_s1.clone(), av_s2.clone()]);
+        let vect_s2_s1 = Value::Vector(vec![av_s2.clone(), av_s1.clone()]);
 
-    let vect_s1_s2_s2 = Value::Vector(vec![av_s1.clone(), av_s2.clone(), av_s2.clone()]);
-    let vect_a1_s1_a2 = Value::Vector(vec![av_01.clone(), av_s1.clone(), av_02.clone()]);
-    let vect_a1_s2_a2 = Value::Vector(vec![av_01.clone(), av_s2.clone(), av_02.clone()]);
-    let vect_a2_s1_a1 = Value::Vector(vec![av_02.clone(), av_s1.clone(), av_01.clone()]);
-    let vect_a2_s2_a1 = Value::Vector(vec![av_02.clone(), av_s2.clone(), av_01.clone()]);
-    let vect_s1_a1_s2 = Value::Vector(vec![av_s1.clone(), av_01.clone(), av_s2.clone()]);
-    let vect_s1_a2_s2 = Value::Vector(vec![av_s1.clone(), av_02.clone(), av_s2.clone()]);
+        let vect_s1_s2_s2 = Value::Vector(vec![av_s1.clone(), av_s2.clone(), av_s2.clone()]);
+        let vect_a1_s1_a2 = Value::Vector(vec![av_01.clone(), av_s1.clone(), av_02.clone()]);
+        let vect_a1_s2_a2 = Value::Vector(vec![av_01.clone(), av_s2.clone(), av_02.clone()]);
+        let vect_a2_s1_a1 = Value::Vector(vec![av_02.clone(), av_s1.clone(), av_01.clone()]);
+        let vect_a2_s2_a1 = Value::Vector(vec![av_02.clone(), av_s2.clone(), av_01.clone()]);
+        let vect_s1_a1_s2 = Value::Vector(vec![av_s1.clone(), av_01.clone(), av_s2.clone()]);
+        let vect_s1_a2_s2 = Value::Vector(vec![av_s1.clone(), av_02.clone(), av_s2.clone()]);
 
-    // Each of these should be different from the others.
-    let distinct_entities = vec![
-        &v_true,
-        &v_false,
-        &v_3,
-        &v_5,
-        &v_1000,
-        &av_01,
-        &av_02,
-        &av_a1_a2,
-        &av_a2_a1,
-        &av_a1_a2_a2,
-        &vect_3_5,
-        &vect_5_3,
-        &vect_3_5_5,
-    ];
+        // Each of these should be different from the others.
+        let distinct_entities = vec![
+            &v_true,
+            &v_false,
+            &v_3,
+            &v_5,
+            &v_1000,
+            &av_01,
+            &av_02,
+            &av_a1_a2,
+            &av_a2_a1,
+            &av_a1_a2_a2,
+            &vect_3_5,
+            &vect_5_3,
+            &vect_3_5_5,
+        ];
 
-    for val1 in &distinct_entities {
-        for val2 in &distinct_entities {
-            assert!(Some(val1 == val2) == val1.equivalent(val2));
-            assert!(Some(val1 == val2) == val2.equivalent(val1));
+        for val1 in &distinct_entities {
+            for val2 in &distinct_entities {
+                assert!(Some(val1 == val2) == val1.equivalent(val2));
+                assert!(Some(val1 == val2) == val2.equivalent(val1));
+            }
         }
-    }
 
-    // These entities are equivalent, although not equal.
-    let overlapping_entities = vec![
-        (&bv_empty, &vect_empty),
-        (&bv_3_5, &vect_3_5),
-        (&bv_5_3, &vect_5_3),
-        (&bv_3_5_5, &vect_3_5_5),
-        (&av_empty, &vect_empty),
-        (&av_a1_a2, &vect_a1_a2),
-        (&av_a2_a1, &vect_a2_a1),
-        (&av_a1_a2_a2, &vect_a1_a2_a2),
-    ];
+        // These entities are equivalent, although not equal.
+        let overlapping_entities = vec![
+            (&bv_empty, &vect_empty),
+            (&bv_3_5, &vect_3_5),
+            (&bv_5_3, &vect_5_3),
+            (&bv_3_5_5, &vect_3_5_5),
+            (&av_empty, &vect_empty),
+            (&av_a1_a2, &vect_a1_a2),
+            (&av_a2_a1, &vect_a2_a1),
+            (&av_a1_a2_a2, &vect_a1_a2_a2),
+        ];
 
-    for (val1, val2) in &overlapping_entities {
-        assert!(val1.equivalent(val2) == Some(true));
-        assert!(val2.equivalent(val1) == Some(true));
-    }
+        for (val1, val2) in &overlapping_entities {
+            assert!(val1.equivalent(val2) == Some(true));
+            assert!(val2.equivalent(val1) == Some(true));
+        }
 
-    // With symbolic addresses, things are not always clear.
+        // With symbolic addresses, things are not always clear.
 
-    // symbolic AddressArrays of different lengths are distinct, as are AddressArrays pairs that
-    // have some distinct numerical address element pairs.
-    let symbolic_entities_distinct = vec![
-        (&av_s1, &av_s1_s2),
-        (&av_s1_s2, &av_s1_s2_s2),
-        (&av_s1_a1_s2, &av_s1_a2_s2),
-        (&av_s1, &av_empty),
-        (&av_s1_s2, &av_empty),
-        (&av_a1_s1_a2, &av_a2_s1_a1),
-        (&av_a1_s1_a2, &av_a2_s2_a1),
-        (&av_s1, &vect_s1_s2),
-        (&av_s1_s2, &vect_s1_s2_s2),
-        (&av_s1_a1_s2, &vect_s1_a2_s2),
-        (&av_s1, &vect_empty),
-        (&av_s1_s2, &vect_empty),
-        (&av_a1_s1_a2, &vect_a2_s1_a1),
-        (&av_a1_s1_a2, &vect_a2_s2_a1),
-        (&vect_s1_s2, &vect_s1_s2_s2),
-        (&vect_s1_a1_s2, &vect_s1_a2_s2),
-        (&vect_s1_s2, &vect_empty),
-        (&vect_a1_s1_a2, &vect_a2_s1_a1),
-        (&vect_a1_s1_a2, &vect_a2_s2_a1),
-    ];
+        // symbolic AddressArrays of different lengths are distinct, as are AddressArrays pairs that
+        // have some distinct numerical address element pairs.
+        let symbolic_entities_distinct = vec![
+            (&av_s1, &av_s1_s2),
+            (&av_s1_s2, &av_s1_s2_s2),
+            (&av_s1_a1_s2, &av_s1_a2_s2),
+            (&av_s1, &av_empty),
+            (&av_s1_s2, &av_empty),
+            (&av_a1_s1_a2, &av_a2_s1_a1),
+            (&av_a1_s1_a2, &av_a2_s2_a1),
+            (&av_s1, &vect_s1_s2),
+            (&av_s1_s2, &vect_s1_s2_s2),
+            (&av_s1_a1_s2, &vect_s1_a2_s2),
+            (&av_s1, &vect_empty),
+            (&av_s1_s2, &vect_empty),
+            (&av_a1_s1_a2, &vect_a2_s1_a1),
+            (&av_a1_s1_a2, &vect_a2_s2_a1),
+            (&vect_s1_s2, &vect_s1_s2_s2),
+            (&vect_s1_a1_s2, &vect_s1_a2_s2),
+            (&vect_s1_s2, &vect_empty),
+            (&vect_a1_s1_a2, &vect_a2_s1_a1),
+            (&vect_a1_s1_a2, &vect_a2_s2_a1),
+        ];
 
-    for (val1, val2) in &symbolic_entities_distinct {
-        assert!(val1.equivalent(val2) == Some(false));
-        assert!(val2.equivalent(val1) == Some(false));
-    }
+        for (val1, val2) in &symbolic_entities_distinct {
+            assert!(val1.equivalent(val2) == Some(false));
+            assert!(val2.equivalent(val1) == Some(false));
+        }
 
-    let ambiguous_pairs = vec![
-        (&av_s1_s2, &av_s2_s1),
-        (&av_s1_s2, &av_a1_a2),
-        (&av_a1_s1_a2, &av_a1_s2_a2),
-        (&av_a1_s1_a2, &av_a1_a2_a2),
-        (&av_s1_s2, &vect_s2_s1),
-        (&av_s1_s2, &vect_a1_a2),
-        (&av_a1_s1_a2, &vect_a1_s2_a2),
-        (&av_a1_s1_a2, &vect_a1_a2_a2),
-        (&vect_s1_s2, &vect_s2_s1),
-        (&vect_s1_s2, &vect_a1_a2),
-        (&vect_a1_s1_a2, &vect_a1_s2_a2),
-        (&vect_a1_s1_a2, &vect_a1_a2_a2),
-    ];
+        let ambiguous_pairs = vec![
+            (&av_s1_s2, &av_s2_s1),
+            (&av_s1_s2, &av_a1_a2),
+            (&av_a1_s1_a2, &av_a1_s2_a2),
+            (&av_a1_s1_a2, &av_a1_a2_a2),
+            (&av_s1_s2, &vect_s2_s1),
+            (&av_s1_s2, &vect_a1_a2),
+            (&av_a1_s1_a2, &vect_a1_s2_a2),
+            (&av_a1_s1_a2, &vect_a1_a2_a2),
+            (&vect_s1_s2, &vect_s2_s1),
+            (&vect_s1_s2, &vect_a1_a2),
+            (&vect_a1_s1_a2, &vect_a1_s2_a2),
+            (&vect_a1_s1_a2, &vect_a1_a2_a2),
+        ];
 
-    for (val1, val2) in &ambiguous_pairs {
-        assert!(val1.equivalent(val2) == None);
-        assert!(val2.equivalent(val1) == None);
-    }
+        for (val1, val2) in &ambiguous_pairs {
+            assert!(val1.equivalent(val2).is_none());
+            assert!(val2.equivalent(val1).is_none());
+        }
 
-    let symbolic_examples = vec![
-        &av_s1,
-        &av_s2,
-        &av_a1_a2,
-        &av_a2_a1,
-        &av_a1_a2_a2,
-        &av_s1_s2,
-        &av_s2_s1,
-        &av_s1_s2_s2,
-        &av_a1_s1_a2,
-        &av_a1_s2_a2,
-        &av_a2_s1_a1,
-        &av_s1_a1_s2,
-        &av_s1_a2_s2,
-        &vect_s1_s2,
-        &vect_s2_s1,
-        &vect_s1_s2_s2,
-        &vect_a1_s1_a2,
-        &vect_a1_s2_a2,
-        &vect_a2_s1_a1,
-        &vect_s1_a1_s2,
-        &vect_s1_a2_s2,
-    ];
+        let symbolic_examples = vec![
+            &av_s1,
+            &av_s2,
+            &av_a1_a2,
+            &av_a2_a1,
+            &av_a1_a2_a2,
+            &av_s1_s2,
+            &av_s2_s1,
+            &av_s1_s2_s2,
+            &av_a1_s1_a2,
+            &av_a1_s2_a2,
+            &av_a2_s1_a1,
+            &av_s1_a1_s2,
+            &av_s1_a2_s2,
+            &vect_s1_s2,
+            &vect_s2_s1,
+            &vect_s1_s2_s2,
+            &vect_a1_s1_a2,
+            &vect_a1_s2_a2,
+            &vect_a2_s1_a1,
+            &vect_s1_a1_s2,
+            &vect_s1_a2_s2,
+        ];
 
-    for val1 in &symbolic_examples {
-        assert!(val1.equivalent(&((*val1).clone())) == Some(true));
+        for val1 in &symbolic_examples {
+            assert!(val1.equivalent(&((*val1).clone())) == Some(true));
+        }
     }
 }

--- a/third_party/move/move-model/src/constant_folder.rs
+++ b/third_party/move/move-model/src/constant_folder.rs
@@ -336,8 +336,8 @@ impl<'env> ConstantFolder<'env> {
                 }
             } else {
                 match oper {
-                    O::Eq => Some(V(id, Bool(val0 == val1)).into_exp()),
-                    O::Neq => Some(V(id, Bool(val0 != val1)).into_exp()),
+                    O::Eq => Some(V(id, Bool(val0.equivalent(val1))).into_exp()),
+                    O::Neq => Some(V(id, Bool(!val0.equivalent(val1))).into_exp()),
                     _ => self.constant_folding_error(id, |_| {
                         "Unknown binary expression in `const`".to_owned()
                     }),

--- a/third_party/move/move-model/src/constant_folder.rs
+++ b/third_party/move/move-model/src/constant_folder.rs
@@ -336,20 +336,12 @@ impl<'env> ConstantFolder<'env> {
                 }
             } else {
                 match oper {
-                    O::Eq => {
-                        if let Some(equivalence) = val0.equivalent(val1) {
-                            Some(V(id, Bool(equivalence)).into_exp())
-                        } else {
-                            None
-                        }
-                    },
-                    O::Neq => {
-                        if let Some(equivalence) = val0.equivalent(val1) {
-                            Some(V(id, Bool(!equivalence)).into_exp())
-                        } else {
-                            None
-                        }
-                    },
+                    O::Eq => val0
+                        .equivalent(val1)
+                        .map(|equivalence| V(id, Bool(equivalence)).into_exp()),
+                    O::Neq => val0
+                        .equivalent(val1)
+                        .map(|equivalence| V(id, Bool(!equivalence)).into_exp()),
                     _ => self.constant_folding_error(id, |_| {
                         "Unknown binary expression in `const`".to_owned()
                     }),

--- a/third_party/move/move-model/src/constant_folder.rs
+++ b/third_party/move/move-model/src/constant_folder.rs
@@ -336,8 +336,20 @@ impl<'env> ConstantFolder<'env> {
                 }
             } else {
                 match oper {
-                    O::Eq => Some(V(id, Bool(val0.equivalent(val1))).into_exp()),
-                    O::Neq => Some(V(id, Bool(!val0.equivalent(val1))).into_exp()),
+                    O::Eq => {
+                        if let Some(equivalence) = val0.equivalent(val1) {
+                            Some(V(id, Bool(equivalence)).into_exp())
+                        } else {
+                            None
+                        }
+                    },
+                    O::Neq => {
+                        if let Some(equivalence) = val0.equivalent(val1) {
+                            Some(V(id, Bool(!equivalence)).into_exp())
+                        } else {
+                            None
+                        }
+                    },
                     _ => self.constant_folding_error(id, |_| {
                         "Unknown binary expression in `const`".to_owned()
                     }),

--- a/third_party/move/move-model/src/symbol.rs
+++ b/third_party/move/move-model/src/symbol.rs
@@ -93,3 +93,10 @@ impl Default for SymbolPool {
         Self::new()
     }
 }
+
+#[cfg(test)]
+impl Symbol {
+    pub fn new(val: usize) -> Symbol {
+        Symbol(val)
+    }
+}


### PR DESCRIPTION
## Description

Fixes issue #12516 by using ast::Value equivalence
(newly exposed through function `Value::equivalent()`),
 rather than struct
equality, when constant-folding equality operations.
(`Value::ByteArray(..)` and `Value::AddressArray(..)` values can
each also be represented by `Value::Vector(..)` instead).

This fixes a failure that shows up in `0x1::ristretto:255`
test case `test_scalar_from_canonical_bytes`.

Fixes #12516.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify)
    V2 compiler
## How Has This Been Tested?
Included thorough unit test for new function `Value::equivalent`,
and a targeted test case `constant_folding_ristretto.move` for
comparison with V1 and V2 without simplification.

Existing V2 CI tests should show the original problem is fixed.

## Key Areas to Review
Consider redundancy and ambiguity of the AST representation, perhaps there are more cases.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
