### PR TITLE
[keyless] update feature gating & match alg field

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,9 +10,12 @@
 /aptos-move/aptos-aggregator/ @georgemitenkov @gelash @zekun000
 /aptos-move/aptos-gas/ @vgao1996
 /aptos-move/aptos-vm/ @davidiw @wrwg @zekun000 @vgao1996 @georgemitenkov
+/aptos-move/aptos-vm/src/keyless_validation.rs @alinush @heliuchuan
 /aptos-move/aptos-vm-types/ @georgemitenkov @gelash @vgao1996
 /aptos-move/framework/ @davidiw @movekevin @wrwg
 /aptos-move/framework/aptos-framework/sources/account.move @alinush
+/aptos-move/framework/aptos-framework/sources/jwks.move @zjma
+/aptos-move/framework/aptos-framework/sources/keyless_account.move @alinush
 /aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush @zjma @mstraka100
 /aptos-move/framework/**/*.spec.move @junkil-park
 /aptos-move/framework/aptos-stdlib/sources/hash.move @alinush
@@ -115,4 +118,5 @@
 # Owners for the `aptos-dkg` crate.
 /crates/aptos-dkg @alinush @rex1fernando
 
+/types/src/keyless/ @alinush @heliuchuan
 /types/src/transaction/authenticator.rs @alinush @mstraka100

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@
 /consensus/src/quorum_store/ @bchocho @sasha8 @gelash
 
 # Owners for the `/crates/aptos` directory and all its subdirectories.
-/crates/aptos @gregnazario @0xjinn @banool
+/crates/aptos @gregnazario @banool
 
 # Owners for the `/crates/aptos-crypto*` directories.
 /crates/aptos-crypto-derive/ @alinush @zjma @mstraka100 @rex1fernando
@@ -89,8 +89,8 @@
 /docker/ @aptos-labs/prod-eng
 
 # Owners for the `SDKs`.
-/ecosystem/python/sdk @davidiw @gregnazario @banool @0xmaayan @0xjinn
-/ecosystem/typescript/sdk @gregnazario @banool @0xmaayan @0xjinn
+/ecosystem/python/sdk @davidiw @gregnazario @banool @0xmaayan
+/ecosystem/typescript/sdk @gregnazario @banool @0xmaayan
 
 # Owners for execution and storage.
 /execution/ @msmouse @lightmark @grao1991

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "derive_more",
  "fail 0.5.1",
  "futures",
+ "hex",
  "jsonwebtoken 8.3.0",
  "move-binary-format",
  "move-bytecode-utils",

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -63,6 +63,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
 tracing = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 aptos-aggregator = { workspace = true, features = ["testing"] }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -46,6 +46,7 @@ dashmap = { workspace = true }
 derive_more = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
 jsonwebtoken = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-utils = { workspace = true }
@@ -63,7 +64,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
 tracing = { workspace = true }
-hex = { workspace = true }
 
 [dev-dependencies]
 aptos-aggregator = { workspace = true, features = ["testing"] }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1526,11 +1526,6 @@ impl AptosVM {
 
         // If there are keyless TXN authenticators, validate them all.
         if !authenticators.is_empty() {
-            // Feature-gating keyless TXNs: if they are *not* enabled, return `FEATURE_UNDER_GATING`,
-            // which will discard the TXN from being put on-chain.
-            if !self.features().is_keyless_enabled() {
-                return Err(VMStatus::error(StatusCode::FEATURE_UNDER_GATING, None));
-            }
             keyless_validation::validate_authenticators(
                 &authenticators,
                 self.features(),

--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -95,6 +95,25 @@ fn get_jwk_for_authenticator(
 
     let jwk = JWK::try_from(jwk_move_struct)
         .map_err(|_| invalid_signature!("Could not unpack Any in JWK Move struct"))?;
+
+    match &jwk {
+        JWK::RSA(rsa_jwk) => {
+            if rsa_jwk.alg != jwt_header.alg {
+                return Err(invalid_signature!(format!(
+                    "JWK alg ({}) does not match JWT header's alg ({})",
+                    rsa_jwk.alg, jwt_header.alg
+                )));
+            }
+        },
+        JWK::Unsupported(jwk) => {
+            return Err(invalid_signature!(format!(
+                "JWK with KID {} and hex-encoded payload {} is not supported",
+                jwt_header.kid,
+                hex::encode(&jwk.payload)
+            )))
+        },
+    }
+
     Ok(jwk)
 }
 

--- a/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
@@ -39,14 +39,14 @@ fn init_feature_gating(
 }
 
 fn test_feature_gating(
-    mut h: &mut MoveHarness,
+    h: &mut MoveHarness,
     recipient: &Account,
     get_sig_and_pk: fn() -> (KeylessSignature, KeylessPublicKey),
     should_succeed: bool,
 ) {
     let (sig, pk) = get_sig_and_pk();
 
-    let transaction = get_keyless_txn(&mut h, sig, pk, *recipient.address());
+    let transaction = get_keyless_txn(h, sig, pk, *recipient.address());
     let output = h.run_raw(transaction);
 
     if !should_succeed {

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -17,7 +17,8 @@ use serde::Serialize;
 use signature::Verifier;
 use std::{cmp::Ordering, fmt};
 
-/// A Secp256r1 ECDSA signature
+/// A secp256r1 ECDSA signature.
+/// NOTE: The max size on this struct is enforced in its `TryFrom<u8>` trait implementation.
 #[derive(DeserializeKey, Clone, SerializeKey)]
 #[key_name("Secp256r1EcdsaSignature")]
 pub struct Signature(pub(crate) p256::ecdsa::Signature);

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -237,6 +237,11 @@ EphemeralPublicKey:
         STRUCT:
           - public_key:
               TYPENAME: Ed25519PublicKey
+    1:
+      Secp256r1Ecdsa:
+        STRUCT:
+          - public_key:
+              TYPENAME: Secp256r1EcdsaPublicKey
 EphemeralSignature:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -214,6 +214,11 @@ EphemeralPublicKey:
         STRUCT:
           - public_key:
               TYPENAME: Ed25519PublicKey
+    1:
+      Secp256r1Ecdsa:
+        STRUCT:
+          - public_key:
+              TYPENAME: Secp256r1EcdsaPublicKey
 EphemeralSignature:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -459,6 +459,11 @@ EphemeralPublicKey:
         STRUCT:
           - public_key:
               TYPENAME: Ed25519PublicKey
+    1:
+      Secp256r1Ecdsa:
+        STRUCT:
+          - public_key:
+              TYPENAME: Secp256r1EcdsaPublicKey
 EphemeralSignature:
   ENUM:
     0:

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -132,7 +132,7 @@ pub struct JWTHeader {
 }
 
 impl KeylessSignature {
-    /// A reasonable upper bound for the number of bytes we expect in a keyless public key. This is
+    /// A reasonable upper bound for the number of bytes we expect in a keyless signature. This is
     /// enforced by our full nodes when they receive TXNs.
     pub const MAX_LEN: usize = 4000;
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -232,7 +232,7 @@ impl Features {
 
     /// Whether the keyless accounts feature is enabled, specifically the ZK path with ZKP-based signatures.
     /// The ZK-less path is controlled via a different `FeatureFlag::KEYLESS_BUT_ZKLESS_ACCOUNTS` flag.
-    pub fn is_keyless_enabled(&self) -> bool {
+    pub fn is_zk_keyless_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::KEYLESS_ACCOUNTS)
     }
 
@@ -242,7 +242,7 @@ impl Features {
     /// safety precaution in case of emergency (e.g., if the ZK-based signatures must be temporarily
     /// turned off due to a zeroday exploit, the ZK-less path will still allow users to transact,
     /// but without privacy).
-    pub fn is_keyless_zkless_enabled(&self) -> bool {
+    pub fn is_zkless_keyless_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::KEYLESS_BUT_ZKLESS_ACCOUNTS)
     }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1164,12 +1164,20 @@ impl<'de> Deserialize<'de> for EphemeralPublicKey {
             #[derive(::serde::Deserialize)]
             #[serde(rename = "EphemeralPublicKey")]
             enum Value {
-                Ed25519 { public_key: Ed25519PublicKey },
+                Ed25519 {
+                    public_key: Ed25519PublicKey,
+                },
+                Secp256r1Ecdsa {
+                    public_key: secp256r1_ecdsa::PublicKey,
+                },
             }
 
             let value = Value::deserialize(deserializer)?;
             Ok(match value {
                 Value::Ed25519 { public_key } => EphemeralPublicKey::Ed25519 { public_key },
+                Value::Secp256r1Ecdsa { public_key } => {
+                    EphemeralPublicKey::Secp256r1Ecdsa { public_key }
+                },
             })
         }
     }


### PR DESCRIPTION
## Description

Two changes:

1. **Fixing feature gating:** We did not allow for the ZKless mode to be enabled while the ZK mode is disabled. This is now fixed.
2. **Match the JWK's `alg` field with the JWT header's `alg` field**: For completeness, this should be done.
3. **Fix an oversight in our `EphemeralPublicKey` deserialization override**

Decided **not** to implement extra size limits of keyless public keys and signatures, since the TXN size limits suffice. The code would have been ugly & confusing, since there are size limits dispersed in too many places.

   -  For the ZK path:
       + `KeylessPublicKey` will not be fixed-size because the IDC field is `Vec<u8>`
       + `KeylessSignature::ZeroKnowledgeSig` has all of its fields constant-sized or size-checked (e.g., the max size of the `String` fields is checked when hashed with Poseidon.) 
       + The only variable-sized field is the `EphemeralSignature` field which could have a passkey-based signature. But this is size-checked when verified via `AnySignature::verify` (pending change is in #12499)
   -  For the ZKless path:
       + `KeylessPublicKey` will not be fixed-size because the IDC field is `Vec<u8>` and because the `iss` field is no longer size-checked (since there is no Poseidon-hashing).
       + `KeylessSignature::OpenIdSig` has all but one of its fields be variable-sized.

In general, we need a more principled way to enforce compile-time known & runtime-known max sizes on deserialized structs.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

1. **Fixing feature gating:**: Updated the `aptos-move/e2e-move-tests` to check that all combinations of ZK & ZKless feature flags are gated properly.

2. **Match the JWK's `alg` field with the JWT header's `alg` field**: Existing tests will cover this.

## Key Areas to Review

 > Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.

I hope that OIDC providers correctly implement the OIDC standard: e.g., it could be that some (incorrect) OIDC providers might issue a JWT header with a different `alg` field than the `alg` field in its associated JWK (even though the `kid` field matches). In that case, TXNs won't verify & we will need to hotfix.

This may be possible because [the `alg` field is technically optional](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4). (But so is the `kid` field.)

If that's the case, we can later disable this check (since it will only lead to previously discarded TXNs now not necessarily being discarded).

 > Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.

No complex logic. The changes to the `e2e-move-tests` might seem large but they actually simplify the testing.

 > Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.

No concerns nor uncertainties.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
     + For the feature gating, yes.
     + For the `alg` field check, did **not** check the negative path (i.e., JWT headers with non-matching `alg` field). This requires better testing infrastructure for keyless TXNs. We will have to do this later.
- [x] I have made corresponding changes to the documentation. (Specifically, no changes are needed.)

<!-- Thank you for your contribution! -->
