### PR TITLE
[WIP] implement BCS stream in Move

### DIFF
--- a/aptos-move/move-examples/bcs-stream/Move.toml
+++ b/aptos-move/move-examples/bcs-stream/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "BCSStream"
+version = "0.0.0"
+
+[addresses]
+bcs_stream = "_"
+
+[dependencies]
+AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosFramework = { local = "../../framework/aptos-framework" }

--- a/aptos-move/move-examples/bcs-stream/sources/stream.move
+++ b/aptos-move/move-examples/bcs-stream/sources/stream.move
@@ -1,0 +1,211 @@
+module bcs_stream::bcs_stream {
+    use std::vector;
+    use aptos_std::from_bcs;
+
+    const EMALFORMED_DATA: u64 = 1;
+    const EOUT_OF_BYTES: u64 = 2;
+
+    struct BCSStream has drop {
+        data: vector<u8>,
+        cur: u64,
+    }
+
+    public fun new(data: vector<u8>): BCSStream {
+        BCSStream {
+            data,
+            cur: 0,
+        }
+    }
+
+    public fun next_length(stream: &mut BCSStream): u64 {
+        let res = 0;
+        let shift = 0;
+
+        while (stream.cur < vector::length(&stream.data)) {
+            let byte = *vector::borrow(&stream.data, stream.cur);
+            stream.cur = stream.cur + 1;
+
+            let val = ((byte & 0x7f) as u64);
+            if (((val << shift) >> shift) != val) {
+                abort EMALFORMED_DATA
+            };
+            res = res | (val << shift);
+
+            if ((byte & 0x80) == 0) {
+                if (shift > 0 && val == 0) {
+                    abort EMALFORMED_DATA
+                };
+                return res
+            };
+
+            shift = shift + 7;
+            if (shift > 64) {
+                abort EMALFORMED_DATA
+            };
+        };
+
+        abort EOUT_OF_BYTES
+    }
+
+    public fun next_bool(stream: &mut BCSStream): bool {
+        assert!(stream.cur < vector::length(&stream.data), EOUT_OF_BYTES);
+        let byte = *vector::borrow(&stream.data, stream.cur);
+        stream.cur = stream.cur + 1;
+        if (byte == 0) {
+            false
+        }
+        else if (byte == 1) {
+            true
+        }
+        else {
+            abort EMALFORMED_DATA
+        }
+    }
+
+    public fun next_address(stream: &mut BCSStream): address {
+        let data = &stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 32 <= vector::length(data), EOUT_OF_BYTES);
+
+        let res = from_bcs::to_address(vector::slice(data, cur, cur + 32));
+        stream.cur = cur + 32;
+        res
+    }
+
+    public fun next_u8(stream: &mut BCSStream): u8 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur < vector::length(data), EOUT_OF_BYTES);
+        let res = *vector::borrow(data, cur);
+        stream.cur = cur + 1;
+        res
+    }
+
+    public fun next_u16(stream: &mut BCSStream): u16 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 2 <= vector::length(data), EOUT_OF_BYTES);
+        let res =
+            (*vector::borrow(data, cur) as u16) |
+            ((*vector::borrow(data, cur + 1) as u16) << 8)
+        ;
+
+        stream.cur = stream.cur + 2;
+        res
+    }
+
+    public fun next_u32(stream: &mut BCSStream): u32 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 4 <= vector::length(data), EOUT_OF_BYTES);
+        let res =
+            (*vector::borrow(data, cur) as u32) |
+            ((*vector::borrow(data, cur + 1) as u32) << 8) |
+            ((*vector::borrow(data, cur + 2) as u32) << 16) |
+            ((*vector::borrow(data, cur + 3) as u32) << 24)
+        ;
+
+        stream.cur = stream.cur + 4;
+        res
+    }
+
+    public fun next_u64(stream: &mut BCSStream): u64 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 8 <= vector::length(data), EOUT_OF_BYTES);
+        let res = from_bcs::to_u64(vector::slice(data, cur, cur + 8));
+        stream.cur = cur + 8;
+
+        res
+    }
+
+    public fun next_u128(stream: &mut BCSStream): u128 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 16 <= vector::length(data), EOUT_OF_BYTES);
+        let res = from_bcs::to_u128(vector::slice(data, cur, cur + 16));
+        stream.cur = cur + 16;
+
+        res
+    }
+
+    public fun next_u256(stream: &mut BCSStream): u256 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 32 <= vector::length(data), EOUT_OF_BYTES);
+        let res = from_bcs::to_u256(vector::slice(data, cur, cur + 32));
+        stream.cur = cur + 32;
+
+        res
+    }
+
+    public inline fun next_vector<E>(stream: &mut BCSStream, next_elem: |&mut BCSStream| E): vector<E> {
+        let len = next_length(stream);
+        let v = vector::empty();
+
+        let i = 0;
+        while (i < len) {
+            vector::push_back(&mut v, next_elem(stream));
+            i = i + 1;
+        };
+
+        v
+    }
+
+    /*
+    public fun next_u64(stream: &mut BCSStream): u64 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 8 <= vector::length(data), EOUT_OF_BYTES);
+        let res =
+            (*vector::borrow(data, cur) as u64) |
+            ((*vector::borrow(data, cur + 1) as u64) << 8) |
+            ((*vector::borrow(data, cur + 2) as u64) << 16) |
+            ((*vector::borrow(data, cur + 3) as u64) << 24) |
+            ((*vector::borrow(data, cur + 4) as u64) << 32) |
+            ((*vector::borrow(data, cur + 5) as u64) << 40) |
+            ((*vector::borrow(data, cur + 6) as u64) << 48) |
+            ((*vector::borrow(data, cur + 7) as u64) << 56)
+        ;
+
+        stream.cur = stream.cur + 8;
+        res
+    }
+
+    public fun next_u128(stream: &mut BCSStream): u128 {
+        let data = &mut stream.data;
+        let cur = stream.cur;
+
+        assert!(cur + 16 <= vector::length(data), EOUT_OF_BYTES);
+        let res =
+            (*vector::borrow(data, cur) as u128) |
+            ((*vector::borrow(data, cur + 1) as u128) << 8) |
+            ((*vector::borrow(data, cur + 2) as u128) << 16) |
+            ((*vector::borrow(data, cur + 3) as u128) << 24) |
+            ((*vector::borrow(data, cur + 4) as u128) << 32) |
+            ((*vector::borrow(data, cur + 5) as u128) << 40) |
+            ((*vector::borrow(data, cur + 6) as u128) << 48) |
+            ((*vector::borrow(data, cur + 7) as u128) << 56) |
+            ((*vector::borrow(data, cur + 8) as u128) << 64) |
+            ((*vector::borrow(data, cur + 9) as u128) << 72) |
+            ((*vector::borrow(data, cur + 10) as u128) << 80) |
+            ((*vector::borrow(data, cur + 11) as u128) << 88) |
+            ((*vector::borrow(data, cur + 12) as u128) << 96) |
+            ((*vector::borrow(data, cur + 13) as u128) << 104) |
+            ((*vector::borrow(data, cur + 14) as u128) << 112) |
+            ((*vector::borrow(data, cur + 15) as u128) << 120)
+        ;
+
+        stream.cur = stream.cur + 16;
+        res
+    }
+    */
+}

--- a/aptos-move/move-examples/bcs-stream/sources/tests/tests.move
+++ b/aptos-move/move-examples/bcs-stream/sources/tests/tests.move
@@ -1,0 +1,372 @@
+#[test_only]
+module bcs_stream::tests {
+    use bcs_stream::bcs_stream;
+    use std::vector;
+
+    struct Bar has drop {
+        x: u16,
+        y: bool,
+    }
+
+    struct Foo has drop {
+        a: u8,
+        b: u16,
+        c: u32,
+        d: u64,
+        e: u128,
+        f: u256,
+        g: bool,
+        h: vector<Bar>,
+        i: address,
+    }
+
+    fun deserialize_Bar(stream: &mut bcs_stream::BCSStream): Bar {
+        Bar {
+            x: bcs_stream::next_u16(stream),
+            y: bcs_stream::next_bool(stream),
+        }
+    }
+
+    fun deserialize_Foo(stream: &mut bcs_stream::BCSStream): Foo {
+        Foo {
+            a: bcs_stream::next_u8(stream),
+            b: bcs_stream::next_u16(stream),
+            c: bcs_stream::next_u32(stream),
+            d: bcs_stream::next_u64(stream),
+            e: bcs_stream::next_u128(stream),
+            f: bcs_stream::next_u256(stream),
+            g: bcs_stream::next_bool(stream),
+            h: bcs_stream::next_vector(stream, |stream| {
+                deserialize_Bar(stream)
+            }),
+            i: bcs_stream::next_address(stream),
+        }
+    }
+
+    #[test]
+    fun test_struct_all_types() {
+        let data = vector::empty();
+        vector::append(&mut data, x"01"); // u8
+        vector::append(&mut data, x"0200"); // u16
+        vector::append(&mut data, x"03000000"); // u32
+        vector::append(&mut data, x"0400000000000000"); // u64
+        vector::append(&mut data, x"05000000000000000000000000000000"); // u128
+        vector::append(&mut data, x"0600000000000000000000000000000000000000000000000000000000000000"); // u256
+        vector::append(&mut data, x"01"); // bool
+        vector::append(&mut data, x"02010000020001"); // vector
+        vector::append(&mut data, x"000000000000000000000000000000000000000000000000000000000000ABCD"); // address
+
+        let stream = bcs_stream::new(data);
+        let foo = deserialize_Foo(&mut stream);
+
+        let expected = Foo {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: 5,
+            f: 6,
+            g: true,
+            h: vector[Bar { x: 01, y: false }, Bar { x: 02, y: true }],
+            i: @0xABCD,
+        };
+
+        assert!(foo == expected, 0);
+    }
+
+    #[test]
+    fun test_bool_true() {
+        let data = x"01";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_bool(&mut stream) == true, 0);
+    }
+
+    #[test]
+    fun test_bool_false() {
+        let data = x"00";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_bool(&mut stream) == false, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EMALFORMED_DATA)]
+    fun test_bool_invalid() {
+        let data = x"02";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_bool(&mut stream);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_bool_out_of_bytes() {
+        let data = vector::empty();
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_bool(&mut stream);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_length_no_bytes() {
+        let data = vector::empty();
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_length(&mut stream);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_length_no_ending_group() {
+        let data = x"808080808080808080";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_length(&mut stream);
+    }
+
+    #[test]
+    fun test_length_0() {
+        let data = x"00";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 0, 0);
+    }
+
+    #[test]
+    fun test_length_1() {
+        let data = x"01";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 1, 0);
+    }
+
+    #[test]
+    fun test_length_127() {
+        let data = x"7f";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 127, 0);
+    }
+
+    #[test]
+    fun test_length_128() {
+        let data = x"8001";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 128, 0);
+    }
+
+    #[test]
+    fun test_length_130() {
+        let data = x"8201";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 130, 0);
+    }
+
+    #[test]
+    fun test_length_16383() {
+        let data = x"ff7f";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_length(&mut stream) == 16383, 0);
+    }
+
+    #[test]
+    fun test_length_large() {
+        let data = x"E1D8F9FC06";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 1872653409, 0);
+
+        let data = x"BEC020";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 532542, 0);
+
+        let data = x"B39AEDD084E15D";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 412352463457587, 0);
+    }
+
+    #[test]
+    fun test_length_2_pow_63_minus_1() {
+        let data = x"FFFFFFFFFFFFFFFF7F";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 9223372036854775807, 0);
+    }
+
+    #[test]
+    fun test_length_2_pow_63() {
+        let data = x"80808080808080808001";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 9223372036854775808, 0);
+    }
+
+    #[test]
+    fun test_length_2_pow_64_minus_1() {
+        let data = x"FFFFFFFFFFFFFFFFFF01";
+        let stream = bcs_stream::new(data);
+        let len = bcs_stream::next_length(&mut stream);
+        assert!(len == 18446744073709551615, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EMALFORMED_DATA)]
+    fun test_length_2_pow_64() {
+        let data = x"80808080808080808002";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_length(&mut stream);
+    }
+
+    #[test]
+    fun test_vector_simple() {
+        let data = x"03010203";
+        let stream = bcs_stream::new(data);
+        let v = bcs_stream::next_vector(&mut stream, |stream| {
+            bcs_stream::next_u8(stream)
+        });
+        assert!(v == vector[1, 2, 3], 0);
+    }
+
+    #[test]
+    fun test_vector_empty() {
+        let data = x"00";
+        let stream = bcs_stream::new(data);
+        let v = bcs_stream::next_vector(&mut stream, |stream| {
+            bcs_stream::next_u8(stream)
+        });
+        assert!(v == vector[], 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_vector_not_enough_items() {
+        let data = x"FFFFFFFFFFFFFFFFFF01";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_vector(&mut stream, |stream| {
+            bcs_stream::next_u8(stream)
+        });
+    }
+
+    #[test]
+    fun test_u8() {
+        let data = vector::empty();
+
+        let i = 0;
+        while (i < 256) {
+            vector::push_back(&mut data, (i as u8));
+            i = i + 1;
+        };
+
+        let stream = bcs_stream::new(data);
+        let i = 0;
+        while (i < 256) {
+            assert!(bcs_stream::next_u8(&mut stream) == (i as u8), 0);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u8_out_of_bytes() {
+        let data = vector::empty();
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u8(&mut stream);
+    }
+
+    #[test]
+    fun test_u16() {
+        let data = vector::empty();
+
+        let i = 0;
+        while (i < 65536) {
+            vector::push_back(&mut data, ((i % 256) as u8));
+            vector::push_back(&mut data, ((i / 256) as u8));
+            i = i + 1;
+        };
+
+        let stream = bcs_stream::new(data);
+        let i = 0;
+        while (i < 65536) {
+            assert!(bcs_stream::next_u16(&mut stream) == (i as u16), 0);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u16_out_of_bytes() {
+        let data = x"00";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u16(&mut stream);
+    }
+
+    #[test]
+    fun test_u32() {
+        let data = x"01020304";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_u32(&mut stream) == 0x04030201, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u32_out_of_bytes() {
+        let data = x"000000";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u32(&mut stream);
+    }
+
+    #[test]
+    fun test_u64() {
+        let data = x"0102030405060708";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_u64(&mut stream) == 0x0807060504030201, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u64_out_of_bytes() {
+        let data = x"00000000000000";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u64(&mut stream);
+    }
+
+    #[test]
+    fun test_u128() {
+        let data = x"01020304050607081112131415161718";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_u128(&mut stream) == 0x18171615141312110807060504030201, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u128_out_of_bytes() {
+        let data = x"000000000000000000000000000000";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u128(&mut stream);
+    }
+
+    #[test]
+    fun test_u256() {
+        let data = x"0102030405060708111213141516171821222324252627283132333435363738";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_u256(&mut stream) == 0x3837363534333231282726252423222118171615141312110807060504030201, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_u256_out_of_bytes() {
+        let data = x"00000000000000000000000000000000000000000000000000000000000000";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_u256(&mut stream);
+    }
+
+    #[test]
+    fun test_address() {
+        let data = x"0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+        let stream = bcs_stream::new(data);
+        assert!(bcs_stream::next_address(&mut stream) == @0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bcs_stream::bcs_stream::EOUT_OF_BYTES)]
+    fun test_address_too_short() {
+        let data = x"0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD";
+        let stream = bcs_stream::new(data);
+        bcs_stream::next_address(&mut stream);
+    }
+}


### PR DESCRIPTION
This implements a bcs_stream module in Move that can be used to parse Move values.