### PR TITLE
[Data Service] Push metrics parameterized by identifier, not API key name + email

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
@@ -7,12 +7,15 @@ use aptos_metrics_core::{
 };
 use once_cell::sync::Lazy;
 
+// The `identifier` label at the time of writing (2024-04-08) is always the
+// application ID, a globally unique ID.
+
 /// Latest processed transaction version.
 pub static LATEST_PROCESSED_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "indexer_grpc_data_service_with_user_latest_processed_version",
         "Latest processed transaction version",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -22,7 +25,7 @@ pub static PROCESSED_VERSIONS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "indexer_grpc_data_service_with_user_processed_versions",
         "Number of transactions that have been processed by data service",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -42,7 +45,7 @@ pub static PROCESSED_LATENCY_IN_SECS: Lazy<GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(
         "indexer_grpc_data_service_with_user_latest_data_latency_in_secs",
         "Latency of data service based on latest processed transaction",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -52,7 +55,7 @@ pub static PROCESSED_LATENCY_IN_SECS_ALL: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "indexer_grpc_data_service_latest_data_latency_in_secs_all",
         "Latency of data service based on latest processed transaction",
-        &["request_token"]
+        &[]
     )
     .unwrap()
 });
@@ -62,7 +65,7 @@ pub static PROCESSED_BATCH_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "indexer_grpc_data_service_with_user_processed_batch_size",
         "Size of latest processed batch by data service",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -72,7 +75,7 @@ pub static CONNECTION_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "indexer_grpc_data_service_connection_count_v2",
         "Count of connections that data service has established",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -82,7 +85,7 @@ pub static SHORT_CONNECTION_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "indexer_grpc_data_service_short_connection_by_user_processor_count",
         "Count of the short connections; i.e., < 10 seconds",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });
@@ -93,7 +96,7 @@ pub static BYTES_READY_TO_TRANSFER_FROM_SERVER: Lazy<IntCounterVec> = Lazy::new(
     register_int_counter_vec!(
         "indexer_grpc_data_service_bytes_ready_to_transfer_from_server",
         "Count of bytes ready to transfer to the client",
-        &["request_token", "email", "processor"],
+        &["identifier", "processor"],
     )
     .unwrap()
 });

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/constants.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/constants.rs
@@ -17,9 +17,8 @@ pub const MESSAGE_SIZE_LIMIT: usize = 1024 * 1024 * 15;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct IndexerGrpcRequestMetadata {
     pub processor_name: String,
-    pub request_email: String,
-    pub request_user_classification: String,
-    pub request_api_key_name: String,
+    /// See `REQUEST_HEADER_APTOS_IDENTIFIER` for more information.
+    pub request_identifier: String,
     pub request_connection_id: String,
     // Token is no longer needed behind api gateway.
     #[deprecated]

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -278,12 +278,9 @@ pub fn log_grpc_step(
             duration_in_secs,
             size_in_bytes,
             // Request metadata variables
-            request_name = &request_metadata.processor_name,
-            request_email = &request_metadata.request_email,
-            request_api_key_name = &request_metadata.request_api_key_name,
+            request_identifier = &request_metadata.request_identifier,
             processor_name = &request_metadata.processor_name,
             connection_id = &request_metadata.request_connection_id,
-            request_user_classification = &request_metadata.request_user_classification,
             service_type,
             step = step.get_step(),
             "{}",


### PR DESCRIPTION
## Description
As we introduce the concept of applications to API Gateway, we no longer rate limit by email but by application. The metrics from data service should align with that. Rather than "keying" by email + key name, we now key by application ID (which we call an `identifier`). This is a uuid4.

I will only land this when we're ready to land https://github.com/aptos-labs/api-gateway/pull/109 and its children.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify) TSS

## How Has This Been Tested?
I looked at the following dashboards and can see that the request_token, api_key_name, and email labels are not used for any queries:
- https://aptoslabs.grafana.net/d/fa76529f-4cfe-49bb-8d03-97e9e898f32b/indexer-grpc-debug?orgId=1&refresh=5s
- https://aptoslabs.grafana.net/d/b409aee0-50ba-4530-ba28-7326d868afee/indexer-grpc-sla-dashboard?orgId=1&refresh=5s
- https://aptoslabs.grafana.net/d/da2d4398-c3d0-435f-abce-030c23f10e05/indexer-grpc-usage?orgId=1
- https://aptoslabs.grafana.net/d/eae1398c-620e-49ff-ae9e-89f066aa6476/indexer-infra-utilization?orgId=1

Except for the following:
- https://aptoslabs.grafana.net/d/fa76529f-4cfe-49bb-8d03-97e9e898f32b/indexer-grpc-debug?orgId=1&refresh=5s&editPanel=28
- https://aptoslabs.grafana.net/d/da2d4398-c3d0-435f-abce-030c23f10e05/indexer-grpc-usage?orgId=1&editPanel=2

I will adjust these once the PR lands.

I also checked the alarms, same thing. It seems only API Gateway needs them, which is perfect because I'm making this change for API Gateway (so I will update all of these accordingly separately: https://aptoslabs.grafana.net/d/b5c57876-85a6-4346-9ea8-e6ae3f071a79/api-gateway?orgId=1).

More testing en route.

## Key Areas to Review
Verify that we truly don't need the classification / API key name / email / etc.

I removed the `request_name` logging key because it is the same as `processor_name`. I could undo this if we need it.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
