### PR TITLE
[CLI] Use updated self_update that supports cross-fs renames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14591,7 +14591,7 @@ dependencies = [
 [[package]]
 name = "self_update"
 version = "0.39.0"
-source = "git+https://github.com/banool/self_update.git?rev=65916eade8b37e90ea5778c62592f20614b56627#65916eade8b37e90ea5778c62592f20614b56627"
+source = "git+https://github.com/banool/self_update.git?rev=8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b#8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b"
 dependencies = [
  "hyper",
  "indicatif 0.17.7",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Update `self_update` dependency to support situations where relevant directories (e.g. `/tmp`) exist on different filesystems.
 
 ## [3.0.2] - 2024/03/12
 - Increased `max_connections` for postgres container created as part of local testnet to address occasional startup failures due to overloaded DB.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -84,7 +84,7 @@ processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git"
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
-self_update = { git = "https://github.com/banool/self_update.git", rev = "65916eade8b37e90ea5778c62592f20614b56627", features = ["archive-zip", "compression-zip-deflate"] }
+self_update = { git = "https://github.com/banool/self_update.git", rev = "8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b", features = ["archive-zip", "compression-zip-deflate"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }


### PR DESCRIPTION
## Description
This fixes an issue reported by @gregnazario where `aptos update revela` doesn't work if `/tmp` is on a different filesystem.

The relevant function in the self_update crate is here: https://github.com/banool/self_update/blob/8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b/src/update.rs#L345.

See also https://stackoverflow.com/q/78175299/3846032.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Before:
```
Checking target-arch... aarch64-apple-darwin
Checking current version... v0.0.0
Looking for tag: v1.0.0

revela release status:
  * New exe release: "revela-aarch64-apple-darwin"
  * New exe download url: "https://api.github.com/repos/verichains/revela/releases/assets/155171154"
  * Installing to: /Volumes/storage

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Moving binary file to /Volumes/storage... {
  "Error": "Unexpected error: Failed to update Revela: IoError: Cross-device link (os error 18)"
}
```

After:
```
Checking target-arch... aarch64-apple-darwin
Checking current version... v0.0.0
Looking for tag: v1.0.0

revela release status:
  * New exe release: "revela-aarch64-apple-darwin"
  * New exe download url: "https://api.github.com/repos/verichains/revela/releases/assets/155171154"
  * Installing to: /Volumes/storage

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Moving binary file to /Volumes/storage... Done
{
  "Result": "Successfully installed Revela v1.0.0"
}
```

## Key Areas to Review
See test plan.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
