### PR TITLE
[CLI] Update processor dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,11 +274,11 @@ dependencies = [
  "codespan-reporting",
  "dashmap",
  "diesel",
- "diesel-async",
+ "diesel-async 0.4.1 (git+https://github.com/weiznich/diesel_async.git?rev=d02798c67065d763154d7272dd0c09b39757d0f2)",
  "dirs",
  "futures",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jemallocator",
  "maplit",
  "move-binary-format",
@@ -423,7 +423,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "mime",
  "mini-moka",
  "move-core-types",
@@ -570,7 +570,7 @@ dependencies = [
  "clap 4.4.14",
  "csv",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-bytecode-verifier",
  "num_cpus",
@@ -659,7 +659,7 @@ dependencies = [
  "dashmap",
  "derivative",
  "fail 0.5.1",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
@@ -688,7 +688,7 @@ dependencies = [
  "clap 4.4.14",
  "criterion",
  "dashmap",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jemallocator",
  "move-core-types",
  "once_cell",
@@ -795,7 +795,7 @@ dependencies = [
  "bcs 0.1.4",
  "clap 4.4.14",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lru 0.7.8",
  "move-binary-format",
  "move-cli",
@@ -925,7 +925,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
  "mirai-annotations",
  "move-core-types",
@@ -980,7 +980,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "mirai-annotations",
  "once_cell",
  "proptest",
@@ -1095,7 +1095,7 @@ dependencies = [
  "claims",
  "dashmap",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
  "mockall",
  "ordered-float 3.9.2",
@@ -1167,7 +1167,7 @@ dependencies = [
  "clap 4.4.14",
  "dashmap",
  "either",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lru 0.7.8",
  "move-core-types",
  "move-resource-viewer",
@@ -1237,7 +1237,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "clap 4.4.14",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "owo-colors",
  "tokio",
 ]
@@ -1422,7 +1422,7 @@ dependencies = [
  "bytes",
  "dashmap",
  "fail 0.5.1",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-core-types",
  "num_cpus",
  "once_cell",
@@ -1466,7 +1466,7 @@ dependencies = [
  "clap 4.4.14",
  "derivative",
  "indicatif 0.15.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jemallocator",
  "move-core-types",
  "num_cpus",
@@ -1504,7 +1504,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "dashmap",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "num_cpus",
  "once_cell",
  "rand 0.7.3",
@@ -1552,7 +1552,7 @@ dependencies = [
  "bcs 0.1.4",
  "criterion",
  "dashmap",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "serde",
  "thiserror",
@@ -1741,7 +1741,7 @@ dependencies = [
  "hex",
  "hyper",
  "hyper-tls",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "json-patch",
  "k8s-openapi",
  "kube",
@@ -1828,7 +1828,7 @@ dependencies = [
  "flate2",
  "hex",
  "include_dir 0.7.3",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "libsecp256k1",
  "log",
  "lru 0.7.8",
@@ -2111,7 +2111,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "google-cloud-storage",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "prometheus",
  "prost 0.12.3",
@@ -2233,7 +2233,7 @@ dependencies = [
  "goldenfile",
  "hex",
  "hyper",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-core-types",
  "move-package",
@@ -2273,7 +2273,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "prometheus",
  "prost 0.12.3",
@@ -2377,7 +2377,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "prometheus",
  "prost 0.12.3",
@@ -2446,7 +2446,7 @@ dependencies = [
  "arr_macro",
  "bcs 0.1.4",
  "byteorder",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -2720,7 +2720,7 @@ dependencies = [
  "enum_dispatch",
  "fail 0.5.1",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
  "once_cell",
  "proptest",
@@ -2872,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a11f0b6532349aa6b9a80c9a1d77524f02d8a013#a11f0b6532349aa6b9a80c9a1d77524f02d8a013"
 dependencies = [
  "chrono",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "maplit",
  "once_cell",
  "ordered-float 3.9.2",
@@ -3281,7 +3281,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-framework",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-command-line-common",
  "move-package",
  "tempfile",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c#5d1cefad0ea0d37fb08e9aec7847080745c83f9c"
+source = "git+https://github.com/aptos-labs/aptos-core.git?tag=aptos-node-v1.10.0#b24f6cd08f84b179e49090c7e51a501c535096ca"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -3569,7 +3569,7 @@ dependencies = [
  "clap 4.4.14",
  "futures",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-core-types",
  "once_cell",
  "percent-encoding",
@@ -3666,7 +3666,7 @@ dependencies = [
  "aptos-types",
  "bitvec 1.0.1",
  "criterion",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jemallocator",
  "once_cell",
  "proptest",
@@ -3857,7 +3857,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "dashmap",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-core-types",
  "once_cell",
  "parking_lot 0.12.1",
@@ -4088,7 +4088,7 @@ dependencies = [
  "csv",
  "futures",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "rand 0.7.3",
  "reqwest",
  "serde_json",
@@ -4168,7 +4168,7 @@ dependencies = [
  "async-trait",
  "clap 4.4.14",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "once_cell",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -4254,7 +4254,7 @@ dependencies = [
  "derivative",
  "fixed",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "jsonwebtoken 8.3.0",
  "move-binary-format",
  "move-core-types",
@@ -4309,7 +4309,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs 0.1.4",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "lru 0.7.8",
  "move-binary-format",
@@ -7114,6 +7114,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
 dependencies = [
  "async-trait",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.4.1"
+source = "git+https://github.com/weiznich/diesel_async.git?rev=d02798c67065d763154d7272dd0c09b39757d0f2#d02798c67065d763154d7272dd0c09b39757d0f2"
+dependencies = [
+ "async-trait",
  "bb8",
  "diesel",
  "futures-util",
@@ -7128,7 +7141,7 @@ version = "0.11.0"
 source = "git+https://github.com/niroco/diesel_async_migrations?rev=11f331b73c5cfcc894380074f748d8fda710ac12#11f331b73c5cfcc894380074f748d8fda710ac12"
 dependencies = [
  "diesel",
- "diesel-async",
+ "diesel-async 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros",
  "scoped-futures",
  "tracing",
@@ -7342,7 +7355,7 @@ dependencies = [
  "bcs 0.1.4",
  "claims",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
@@ -8757,9 +8770,9 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114a100a9aa9f4c468a7b9e96626cdab267bb652660d8408e8f6d56d4c310edd"
+checksum = "34e99a7734579b834a076ef11789783c153c6eb5fb3520ed15bc41f483f0f317"
 dependencies = [
  "ahash 0.8.8",
  "camino",
@@ -8769,8 +8782,8 @@ dependencies = [
  "fixedbitset 0.4.2",
  "guppy-summaries",
  "guppy-workspace-hack",
- "indexmap 2.1.0",
- "itertools 0.12.0",
+ "indexmap 2.2.5",
+ "itertools 0.12.1",
  "nested",
  "once_cell",
  "pathdiff",
@@ -8818,7 +8831,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -9469,9 +9482,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -9521,7 +9534,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "is-terminal",
  "itoa",
  "log",
@@ -9665,9 +9678,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -9963,7 +9976,7 @@ dependencies = [
  "bcs 0.1.4",
  "claims",
  "fail 0.5.1",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
@@ -12369,7 +12382,7 @@ dependencies = [
  "ciborium",
  "coset",
  "data-encoding",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -12534,7 +12547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -13205,12 +13218,12 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a11f0b6532349aa6b9a80c9a1d77524f02d8a013#a11f0b6532349aa6b9a80c9a1d77524f02d8a013"
 dependencies = [
  "ahash 0.8.8",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352)",
- "aptos-protos 1.3.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=5d1cefad0ea0d37fb08e9aec7847080745c83f9c)",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a11f0b6532349aa6b9a80c9a1d77524f02d8a013)",
+ "aptos-protos 1.3.0 (git+https://github.com/aptos-labs/aptos-core.git?tag=aptos-node-v1.10.0)",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -13218,7 +13231,7 @@ dependencies = [
  "chrono",
  "clap 4.4.14",
  "diesel",
- "diesel-async",
+ "diesel-async 0.4.1 (git+https://github.com/weiznich/diesel_async.git?rev=d02798c67065d763154d7272dd0c09b39757d0f2)",
  "diesel_async_migrations",
  "diesel_migrations",
  "enum_dispatch",
@@ -13229,6 +13242,7 @@ dependencies = [
  "google-cloud-googleapis",
  "google-cloud-pubsub",
  "hex",
+ "itertools 0.12.1",
  "kanal",
  "native-tls",
  "num_cpus",
@@ -13307,7 +13321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
 dependencies = [
  "chrono",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "once_cell",
  "regex",
 ]
@@ -13737,9 +13751,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -13747,9 +13761,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -14632,9 +14646,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -14717,9 +14731,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -14728,11 +14742,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -14801,7 +14815,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -14838,7 +14852,7 @@ version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -14868,7 +14882,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d44b2d209f57872ac593299c34751a5531b51352#d44b2d209f57872ac593299c34751a5531b51352"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=a11f0b6532349aa6b9a80c9a1d77524f02d8a013#a11f0b6532349aa6b9a80c9a1d77524f02d8a013"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15197,9 +15211,9 @@ checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"
@@ -15633,9 +15647,9 @@ checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "target-spec"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b81540ee78bd9de9f7dca2378f264cf1f4193da6e2d09b54c0d595131a48f1"
+checksum = "36a8e795b1824524d13cdf04f73cf8b4f244ce86c96b4d2a83a6ca1a753d2752"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
@@ -16209,7 +16223,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -16222,7 +16236,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,7 +515,9 @@ derivative = "2.2.0"
 determinator = "0.12.0"
 derive_more = "0.99.11"
 diesel = "2.1"
-diesel-async = { version = "0.4", features = ["postgres", "tokio"] }
+# Use the crate version once this feature gets released on crates.io:
+# https://github.com/weiznich/diesel_async/commit/e165e8c96a6c540ebde2d6d7c52df5c5620a4bf1
+diesel-async = { git = "https://github.com/weiznich/diesel_async.git", rev = "d02798c67065d763154d7272dd0c09b39757d0f2", features = ["async-connection-wrapper", "postgres", "bb8", "tokio"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"
 dir-diff = "0.3.2"
@@ -544,7 +546,7 @@ glob = "0.3.0"
 goldenfile = "1.5.2"
 google-cloud-storage = "0.13.0"
 group = "0.13"
-guppy = "0.17.0"
+guppy = "0.17.5"
 handlebars = "4.2.2"
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
@@ -560,7 +562,7 @@ indicatif = "0.15.0"
 indoc = "1.0.6"
 inferno = "0.11.14"
 ipnet = "2.5.0"
-itertools = "0.10.3"
+itertools = "0.12"
 jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## Unreleased
 - Update `self_update` dependency to support situations where relevant directories (e.g. `/tmp`) exist on different filesystems.
 - [bugfix] Rename `--value` back to `--override-size-check` for publishing packages
+- Upgraded indexer processors for local testnet from cc764f83e26aed1d83ccad0cee3ab579792a0538. This adds support for the `TransactionMetadataProcessor` among other improvements.
 
 ## [3.0.2] - 2024/03/12
 - Increased `max_connections` for postgres container created as part of local testnet to address occasional startup failures due to overloaded DB.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -80,7 +80,9 @@ move-vm-runtime = { workspace = true, features = ["testing"] }
 once_cell = { workspace = true }
 pathsearch = { workspace = true }
 poem = { workspace = true }
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d44b2d209f57872ac593299c34751a5531b51352" }
+# We set default-features to false so we don't onboard the libpq dep. See more here:
+# https://github.com/aptos-labs/aptos-core/pull/12568
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "a11f0b6532349aa6b9a80c9a1d77524f02d8a013", default-features = false }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -88,7 +90,7 @@ self_update = { git = "https://github.com/banool/self_update.git", rev = "830615
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d44b2d209f57872ac593299c34751a5531b51352" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "a11f0b6532349aa6b9a80c9a1d77524f02d8a013" }
 tempfile = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Description
This update required more than just bumping the rev, a few things changed:
- To ensure we don't onboard the libpq dep, we set `default-features = false`. See more here: https://github.com/aptos-labs/aptos-indexer-processors/pull/325.
- In the new version of the library `run_pending_migrations` takes in a generic DB object. To support this, `run_migrations` was updated to use `AsyncConnectionWrapper` since async connection itself doesn't impl the relevant traits. This required some changes to how we run migrations on our side.
- There is a new processor, TransactionMetadataProcessor. We add support for it here and enable it by default.
- Some processors (those with lookups) now take additional configuration.
- Some deps were updated in aptos-indexer-processors, we make necessary updates in aptos-core accordingly.

This PR has a secondary goal of making sure we're using an in-tree rev to avoid this problem: https://github.com/rust-lang/cargo/issues/13555. The rev we depend on is in main of aptos-indexer-processors, it doesn't come from a branch.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Run a local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --with-indexer-api --assume-yes
```

Run the TS SDK v2 tests against it:
```
pnpm test
```

Besides that, just CI.

## Key Areas to Review
Ensure updating other deps won't cause issues.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
