### PR TITLE
add writable volume for the genesis.blob for Forge PFNs

### DIFF
--- a/testsuite/forge/src/backend/k8s/fullnode.rs
+++ b/testsuite/forge/src/backend/k8s/fullnode.rs
@@ -49,6 +49,7 @@ const FULLNODE_CONFIG_MAP_KEY: &str = "fullnode.yaml";
 // the path where the genesis is mounted in the validator
 const GENESIS_CONFIG_VOLUME_NAME: &str = "genesis-config";
 const GENESIS_CONFIG_VOLUME_PATH: &str = "/opt/aptos/genesis";
+const GENESIS_CONFIG_WRITABLE_VOLUME_NAME: &str = "writable-genesis";
 
 // the path where the config file is mounted in the fullnode
 const APTOS_CONFIG_VOLUME_NAME: &str = "aptos-config";
@@ -186,7 +187,7 @@ fn create_fullnode_container(
             },
             VolumeMount {
                 mount_path: GENESIS_CONFIG_VOLUME_PATH.to_string(),
-                name: GENESIS_CONFIG_VOLUME_NAME.to_string(),
+                name: GENESIS_CONFIG_WRITABLE_VOLUME_NAME.to_string(),
                 ..VolumeMount::default()
             },
         ]),
@@ -215,6 +216,11 @@ fn create_fullnode_volumes(
                 name: Some(fullnode_node_config_config_map_name),
                 ..ConfigMapVolumeSource::default()
             }),
+            ..Volume::default()
+        },
+        Volume {
+            name: GENESIS_CONFIG_WRITABLE_VOLUME_NAME.to_string(),
+            empty_dir: Some(Default::default()),
             ..Volume::default()
         },
     ]
@@ -597,7 +603,7 @@ mod tests {
                                 },
                                 VolumeMount {
                                     mount_path: GENESIS_CONFIG_VOLUME_PATH.to_string(),
-                                    name: GENESIS_CONFIG_VOLUME_NAME.to_string(),
+                                    name: GENESIS_CONFIG_WRITABLE_VOLUME_NAME.to_string(),
                                     ..VolumeMount::default()
                                 },
                             ]),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Fix an issue where Forge PFNs weren't able to start up because of a missing genesis.blob. There were some changes I made to the Volumes and VolumeMounts in #12524 that are also needed for PFNs

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Ran Forge for `pfn_const_tps_with_realistic_env`
https://github.com/aptos-labs/aptos-core/actions/runs/8332018633/job/22802583531

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
