### PR TITLE
[Compiler-v2] Fix bug in assign_unpack_references

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1264,14 +1264,15 @@ impl<'env> Generator<'env> {
                     } else {
                         ReferenceKind::Mutable
                     };
-                    return self.gen_borrow_field_for_unpack_ref(id, str, arg, temps, ref_kind);
+                    self.gen_borrow_field_for_unpack_ref(id, str, arg, temps, ref_kind);
+                } else {
+                    self.emit_call(
+                        *id,
+                        temps,
+                        BytecodeOperation::Unpack(str.module_id, str.id, str.inst.to_owned()),
+                        vec![arg],
+                    );
                 }
-                self.emit_call(
-                    *id,
-                    temps,
-                    BytecodeOperation::Unpack(str.module_id, str.id, str.inst.to_owned()),
-                    vec![arg],
-                );
                 for (cont_id, cont_pat, cont_temp) in cont_assigns {
                     self.gen_assign_from_temp(cont_id, &cont_pat, cont_temp, next_scope)
                 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_unpack_references.exp
@@ -28,7 +28,7 @@ module 0x8675309::M {
           let f: &u64;
           {
             let s2: &M::S;
-            M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
+            M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: &M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
             f;
             s2;
             f: &u64 = Borrow(Immutable)(0);
@@ -44,7 +44,7 @@ module 0x8675309::M {
           let f: &mut u64;
           {
             let s2: &mut M::S;
-            M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
+            M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: &mut M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
             f;
             s2;
             f: &mut u64 = Borrow(Mutable)(0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_unpack_references.exp
@@ -21,7 +21,7 @@ module 0x8675309::M {
     }
     private fun t1() {
         {
-          let M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
+          let M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: &M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
           f;
           s2;
           f: &u64 = Borrow(Immutable)(0);
@@ -33,7 +33,7 @@ module 0x8675309::M {
     }
     private fun t2() {
         {
-          let M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
+          let M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: &mut M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
           f;
           s2;
           f: &mut u64 = Borrow(Mutable)(0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/decl_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/decl_unpack_references.exp
@@ -19,7 +19,7 @@ module 0x8675309::M {
     }
     private fun t1() {
         {
-          let M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: M::R;
+          let M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: &M::R;
           f: &u64 = Borrow(Immutable)(0);
           f;
           s2: &M::S = Borrow(Immutable)(pack M::S(0));
@@ -29,7 +29,7 @@ module 0x8675309::M {
     }
     private fun t2() {
         {
-          let M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: M::R;
+          let M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: &mut M::R;
           f: &mut u64 = Borrow(Mutable)(0);
           f;
           s2: &mut M::S = Borrow(Mutable)(pack M::S(0));

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/assign_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/assign_unpack_references.exp
@@ -28,7 +28,7 @@ module 0x8675309::M {
           let f: &u64;
           {
             let s2: &M::S;
-            M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
+            M::R{ s1: M::S{ f: f: &u64 }, s2: s2: &M::S }: &M::R = Borrow(Immutable)(pack M::R(pack M::S(0), pack M::S(1)));
             f;
             s2;
             f: &u64 = Borrow(Immutable)(0);
@@ -44,7 +44,7 @@ module 0x8675309::M {
           let f: &mut u64;
           {
             let s2: &mut M::S;
-            M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
+            M::R{ s1: M::S{ f: f: &mut u64 }, s2: s2: &mut M::S }: &mut M::R = Borrow(Mutable)(pack M::R(pack M::S(0), pack M::S(1)));
             f;
             s2;
             f: &mut u64 = Borrow(Mutable)(0);
@@ -59,14 +59,14 @@ module 0x8675309::M {
 
 
 Diagnostics:
-bug: Unpacking a reference to a struct must return the references of fields
-   ┌─ tests/simplifier-elimination/assign_unpack_references.move:17:9
+error: value of type `M::R` does not have the `drop` ability
+   ┌─ tests/simplifier-elimination/assign_unpack_references.move:17:33
    │
 17 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
-   │         ^^^^^^^^^^^^^^^^^^^^^
+   │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ still borrowed but will be implicitly dropped later since it is no longer used
 
-bug: Unpacking a reference to a struct must return the references of fields
-   ┌─ tests/simplifier-elimination/assign_unpack_references.move:27:9
+error: value of type `M::R` does not have the `drop` ability
+   ┌─ tests/simplifier-elimination/assign_unpack_references.move:27:33
    │
 27 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
-   │         ^^^^^^^^^^^^^^^^^^^^^
+   │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ still borrowed but will be implicitly dropped later since it is no longer used

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/assign_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/assign_unpack_references.exp
@@ -1,0 +1,3 @@
+processed 3 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/assign_unpack_references.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/assign_unpack_references.move
@@ -1,0 +1,29 @@
+//# publish
+module 0x42::m {
+    struct S has drop{ f: u64 }
+    struct R has drop{ s1: S, s2: S }
+
+    fun t1() {
+        let f;
+        let s2;
+        R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+        assert!(*f == 0, 0);
+        assert!(s2.f == 1, 1);
+    }
+
+    fun t2() {
+        let f;
+        let s2;
+        R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
+        assert!(*f == 0, 0);
+        assert!(s2.f == 1, 1);
+        f = &mut 5;
+        s2 = &mut S { f: 0 };
+        assert!(*f == 5, 0);
+        assert!(s2.f == 0, 1);
+    }
+}
+
+//# run 0x42::m::t1
+
+//# run 0x42::m::t2

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1813,7 +1813,12 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         &expected_type,
                         context,
                     );
-                    let id = self.new_node_id_with_type_loc(&ty, loc);
+                    let node_ty = if let Some(kind) = ref_expected {
+                        Type::Reference(kind, Box::new(ty.clone()))
+                    } else {
+                        ty.clone()
+                    };
+                    let id = self.new_node_id_with_type_loc(&node_ty, loc);
                     let mut std = struct_id;
                     if let Type::Struct(_, _, types) = ty {
                         std.inst = types;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR fixes the bug revealed in the test case`/simplifier-elimination/assign_unpack_references.move` by 1) changing the type of nodeId generated for the Unpack operation; 2) fixing a bug in the bytecode_generator to recursively handle struct pattern when the unpack target is reference.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

The fix can be validated by the output change in existing tests. Also added a transactional test `assign_unpack_references`.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
