### PR TITLE
[Aptos Data Client] Add metrics for ignored peers.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -362,7 +362,7 @@ impl Default for AptosDataMultiFetchConfig {
             enable_multi_fetch: true,
             additional_requests_per_peer_bucket: 1,
             min_peers_for_multi_fetch: 2,
-            max_peers_for_multi_fetch: 5,
+            max_peers_for_multi_fetch: 3,
             multi_fetch_peer_bucket_size: 10,
         }
     }

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -396,6 +396,8 @@ pub struct AptosDataClientConfig {
     pub data_poller_config: AptosDataPollerConfig,
     /// The aptos data multi-fetch config for the data client
     pub data_multi_fetch_config: AptosDataMultiFetchConfig,
+    /// Whether or not to ignore peers with low peer scores
+    pub ignore_low_score_peers: bool,
     /// The aptos latency filtering config for the data client
     pub latency_filtering_config: AptosLatencyFilteringConfig,
     /// The interval (milliseconds) at which to refresh the latency monitor
@@ -431,6 +433,7 @@ impl Default for AptosDataClientConfig {
         Self {
             data_poller_config: AptosDataPollerConfig::default(),
             data_multi_fetch_config: AptosDataMultiFetchConfig::default(),
+            ignore_low_score_peers: true,
             latency_filtering_config: AptosLatencyFilteringConfig::default(),
             latency_monitor_loop_interval_ms: 100,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,

--- a/state-sync/aptos-data-client/src/metrics.rs
+++ b/state-sync/aptos-data-client/src/metrics.rs
@@ -121,6 +121,16 @@ pub static HIGHEST_ADVERTISED_DATA: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Gauge for tracking the ignored peers (by network)
+pub static IGNORED_PEERS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_data_client_ignored_peers",
+        "Gauge related to the number of ignored peers",
+        &["network"]
+    )
+    .unwrap()
+});
+
 /// Gauge for the lowest advertised data
 pub static LOWEST_ADVERTISED_DATA: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -7,7 +7,10 @@ use crate::{
     logging::{LogEntry, LogEvent, LogSchema},
     metrics,
 };
-use aptos_config::{config::AptosDataClientConfig, network_id::PeerNetworkId};
+use aptos_config::{
+    config::AptosDataClientConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
 use aptos_logger::prelude::*;
 use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServerSummary,
@@ -130,12 +133,17 @@ impl PeerState {
     }
 
     /// Returns the storage summary iff the peer is not below the ignore threshold
-    pub(crate) fn get_storage_summary_if_not_ignored(&self) -> Option<&StorageServerSummary> {
-        if self.score <= IGNORE_PEER_THRESHOLD {
+    pub fn get_storage_summary_if_not_ignored(&self) -> Option<&StorageServerSummary> {
+        if self.is_ignored() {
             None
         } else {
             self.storage_summary.as_ref()
         }
+    }
+
+    /// Returns true iff the peer is currently ignored
+    fn is_ignored(&self) -> bool {
+        self.score <= IGNORE_PEER_THRESHOLD
     }
 
     /// Updates the score of the peer according to a successful operation
@@ -247,6 +255,12 @@ impl PeerStates {
         sample!(
             SampleRate::Duration(Duration::from_secs(LOGS_FREQUENCY_SECS)),
             update_peer_request_logs(self.peer_to_state.clone());
+        );
+
+        // Periodically update the metrics for ignored peers
+        sample!(
+            SampleRate::Duration(Duration::from_secs(METRICS_FREQUENCY_SECS)),
+            update_peer_ignored_metrics(self.peer_to_state.clone());
         );
     }
 
@@ -433,6 +447,37 @@ fn median_or_max<T: Ord + Copy>(mut values: Vec<T>, max_value: T) -> T {
 pub fn get_bucket_id_for_peer(peer: PeerNetworkId) -> u8 {
     let peer_id_bytes = peer.peer_id().into_bytes();
     peer_id_bytes[0] % NUM_PEER_BUCKETS_FOR_METRICS
+}
+
+/// Updates the metrics for the number of ignored peers
+fn update_peer_ignored_metrics(peer_to_state: Arc<DashMap<PeerNetworkId, PeerState>>) {
+    // Collect the ignored peer counts by network
+    let mut ignored_peer_counts_by_network: BTreeMap<NetworkId, u64> = BTreeMap::new();
+    for peer_state_entry in peer_to_state.iter() {
+        // Get the peer and state
+        let peer = *peer_state_entry.key();
+        let network_id = peer.network_id();
+        let peer_state = peer_state_entry.value();
+
+        // Get (or initialize) the network count entry
+        let network_count_entry = ignored_peer_counts_by_network
+            .entry(network_id)
+            .or_default();
+
+        // If the peer is ignored, increment the count
+        if peer_state.is_ignored() {
+            *network_count_entry += 1;
+        }
+    }
+
+    // Update the ignored peer metrics
+    for (network_id, ignored_peer_count) in ignored_peer_counts_by_network.iter() {
+        metrics::set_gauge(
+            &metrics::IGNORED_PEERS,
+            &network_id.to_string(),
+            *ignored_peer_count,
+        );
+    }
 }
 
 /// Updates the logs for the peer requests and responses by bucket

--- a/state-sync/aptos-data-client/src/tests/peers.rs
+++ b/state-sync/aptos-data-client/src/tests/peers.rs
@@ -388,7 +388,7 @@ async fn disable_ignoring_low_score_peers() {
         };
 
         // Create the mock network, mock time, client and poller
-        let (mut mock_network, mock_time, client, poller) =
+        let (mut mock_network, mut mock_time, client, poller) =
             MockNetwork::new(Some(base_config), Some(data_client_config), None);
 
         // Add a connected peer
@@ -425,12 +425,8 @@ async fn disable_ignoring_low_score_peers() {
         });
 
         // Advance time so the poller sends data summary requests
-        let poll_loop_interval_ms = data_client_config.data_poller_config.poll_loop_interval_ms;
         for _ in 0..10 {
-            tokio::task::yield_now().await;
-            mock_time
-                .advance_async(Duration::from_millis(poll_loop_interval_ms))
-                .await;
+            utils::advance_polling_timer(&mut mock_time, &data_client_config).await;
         }
 
         // Verify that this request range is serviceable by the peer

--- a/state-sync/aptos-data-client/src/tests/peers.rs
+++ b/state-sync/aptos-data-client/src/tests/peers.rs
@@ -98,8 +98,13 @@ async fn bad_peer_is_eventually_banned_internal() {
         // Create a base config for a validator
         let base_config = utils::create_validator_base_config();
 
+        // Create a data client config with peer ignoring enabled
+        let data_client_config = AptosDataClientConfig {
+            ignore_low_score_peers: true,
+            ..Default::default()
+        };
+
         // Create the mock network and client
-        let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, _, client, _) =
             MockNetwork::new(Some(base_config), Some(data_client_config), None);
 
@@ -189,8 +194,13 @@ async fn bad_peer_is_eventually_banned_callback() {
         let base_config = utils::create_fullnode_base_config();
         let networks = vec![NetworkId::Vfn, NetworkId::Public];
 
+        // Create a data client config with peer ignoring enabled
+        let data_client_config = AptosDataClientConfig {
+            ignore_low_score_peers: true,
+            ..Default::default()
+        };
+
         // Create the mock network and client
-        let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, _, client, _) =
             MockNetwork::new(Some(base_config), Some(data_client_config), Some(networks));
 
@@ -267,8 +277,13 @@ async fn bad_peer_is_eventually_added_back() {
         // Create a base config for a validator
         let base_config = utils::create_validator_base_config();
 
+        // Create a data client config with peer ignoring enabled
+        let data_client_config = AptosDataClientConfig {
+            ignore_low_score_peers: true,
+            ..Default::default()
+        };
+
         // Create the mock network, mock time, client and poller
-        let data_client_config = AptosDataClientConfig::default();
         let (mut mock_network, mut mock_time, client, poller) =
             MockNetwork::new(Some(base_config), Some(data_client_config), None);
 
@@ -356,6 +371,100 @@ async fn bad_peer_is_eventually_added_back() {
             transaction_range,
         )
         .await;
+    }
+}
+
+#[tokio::test]
+async fn disable_ignoring_low_score_peers() {
+    // Ensure the properties hold for all peer priorities
+    for peer_priority in PeerPriority::get_all_ordered_priorities() {
+        // Create a base config for a validator
+        let base_config = utils::create_validator_base_config();
+
+        // Create a data client config with peer ignoring disabled
+        let data_client_config = AptosDataClientConfig {
+            ignore_low_score_peers: false,
+            ..Default::default()
+        };
+
+        // Create the mock network, mock time, client and poller
+        let (mut mock_network, mock_time, client, poller) =
+            MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+        // Add a connected peer
+        let (_, network_id) = utils::add_peer_to_network(peer_priority, &mut mock_network);
+
+        // Start the poller
+        tokio::spawn(poller::start_poller(poller));
+
+        // Spawn a handler for the peer
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                // Determine the data response based on the request
+                let data_response = match network_request.storage_service_request.data_request {
+                    DataRequest::GetTransactionsWithProof(_) => {
+                        DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty())
+                    },
+                    DataRequest::GetStorageServerSummary => {
+                        DataResponse::StorageServerSummary(utils::create_storage_summary(200))
+                    },
+                    _ => panic!(
+                        "Unexpected storage request: {:?}",
+                        network_request.storage_service_request
+                    ),
+                };
+
+                // Send the response
+                let storage_response = StorageServiceResponse::new(
+                    data_response,
+                    network_request.storage_service_request.use_compression,
+                )
+                .unwrap();
+                network_request.response_sender.send(Ok(storage_response));
+            }
+        });
+
+        // Advance time so the poller sends data summary requests
+        let poll_loop_interval_ms = data_client_config.data_poller_config.poll_loop_interval_ms;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+            mock_time
+                .advance_async(Duration::from_millis(poll_loop_interval_ms))
+                .await;
+        }
+
+        // Verify that this request range is serviceable by the peer
+        let global_summary = client.get_global_data_summary();
+        let transaction_range = CompleteDataRange::new(0, 200).unwrap();
+        assert!(global_summary
+            .advertised_data
+            .transactions
+            .contains(&transaction_range));
+
+        // Keep decreasing this peer's score by considering its responses bad
+        for _ in 0..1000 {
+            // Send a request to fetch transactions from the peer
+            let request_timeout = data_client_config.response_timeout_ms;
+            let result = client
+                .get_transactions_with_proof(200, 0, 200, false, request_timeout)
+                .await;
+
+            // Notify the client that the response was bad
+            if let Ok(response) = result {
+                response
+                    .context
+                    .response_callback
+                    .notify_bad_response(crate::interface::ResponseError::ProofVerificationError);
+            }
+        }
+
+        // Verify that the peer is not ignored, despite many bad responses
+        client.update_global_summary_cache().unwrap();
+        let global_summary = client.get_global_data_summary();
+        assert!(global_summary
+            .advertised_data
+            .transactions
+            .contains(&transaction_range));
     }
 }
 


### PR DESCRIPTION
## Description
This PR makes three small changes to the Aptos Data Client (each in their own commit):
1. Add metrics to track the number of ignored peers.
2. Add a config flag to enable/disable ignoring peers. The default is true (as it is today).
3. Reduce the maximum number of multi-fetch requests from 5 to 3. Under high-load, the additional multi-fetches increase CPU usage unnecessarily.

## Testing Plan
New and existing test infrastructure.