### PR TITLE
parameterize jwk consensus config in genesis

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -629,21 +629,6 @@ fn initialize_keyless_accounts(session: &mut SessionExt, chain_id: ChainId) {
             ]),
         );
     }
-    if !chain_id.id() > 100 {
-        exec_function(
-            session,
-            JWKS_MODULE_NAME,
-            "upsert_oidc_provider",
-            vec![],
-            serialize_values(&vec![
-                MoveValue::Signer(CORE_CODE_ADDRESS),
-                "https://accounts.google.com".to_string().as_move_value(),
-                "https://accounts.google.com/.well-known/openid-configuration"
-                    .to_string()
-                    .as_move_value(),
-            ]),
-        );
-    }
 }
 
 fn create_accounts(session: &mut SessionExt, accounts: &[AccountBalance]) {

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -29,14 +29,14 @@ use aptos_jwk_consensus::start_jwk_consensus_runtime;
 use aptos_logger::{prelude::*, telemetry_log_writer::TelemetryLog, Level, LoggerFilterUpdater};
 use aptos_safety_rules::safety_rules_manager::load_consensus_key_from_secure_storage;
 use aptos_state_sync_driver::driver_factory::StateSyncRuntimes;
-use aptos_types::chain_id::ChainId;
+use aptos_types::{chain_id::ChainId, on_chain_config::OnChainJWKConsensusConfig};
 use aptos_validator_transaction_pool::VTxnPoolState;
 use clap::Parser;
 use futures::channel::mpsc;
 use hex::{FromHex, FromHexError};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    fs,
+    env, fs,
     io::Write,
     path::{Path, PathBuf},
     sync::{
@@ -529,6 +529,14 @@ where
             genesis_config.allow_new_validators = true;
             genesis_config.epoch_duration_secs = EPOCH_LENGTH_SECS;
             genesis_config.recurring_lockup_duration_secs = 7200;
+            genesis_config.jwk_consensus_config_override = match env::var("INITIALIZE_JWK_CONSENSUS") {
+                Ok(val) if val.as_str() == "1" => {
+                    let config = OnChainJWKConsensusConfig::default_enabled();
+                    println!("Flag `INITIALIZE_JWK_CONSENSUS` detected, will enable JWK Consensus for all default OIDC providers in genesis: {:?}", config);
+                    Some(config)
+                },
+                _ => None,
+            };
         })))
         .with_randomize_first_validator_ports(random_ports);
     let (root_key, _genesis, genesis_waypoint, mut validators) = builder.build(rng)?;

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -7,7 +7,7 @@ use aptos_types::{
     account_address::{AccountAddress, AccountAddressWithChecks},
     chain_id::ChainId,
     network_address::{DnsName, NetworkAddress, Protocol},
-    on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig},
+    on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig},
     transaction::authenticator::AuthenticationKey,
 };
 use aptos_vm_genesis::{AccountBalance, EmployeePool, Validator, ValidatorWithCommissionRate};
@@ -73,6 +73,9 @@ pub struct Layout {
     /// Onchain Execution Config
     #[serde(default = "OnChainExecutionConfig::default_for_genesis")]
     pub on_chain_execution_config: OnChainExecutionConfig,
+
+    /// An optional JWK consensus config to use, instead of `default_for_genesis()`.
+    pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
 }
 
 impl Layout {
@@ -112,6 +115,7 @@ impl Default for Layout {
             employee_vesting_period_duration: Some(5 * 60), // 5 minutes
             on_chain_consensus_config: OnChainConsensusConfig::default(),
             on_chain_execution_config: OnChainExecutionConfig::default_for_genesis(),
+            jwk_consensus_config_override: None,
         }
     }
 }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -302,7 +302,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             gas_schedule: default_gas_schedule(),
             initial_features_override: None,
             randomness_config_override: None,
-            jwk_consensus_config_override: None,
+            jwk_consensus_config_override: layout.jwk_consensus_config_override.clone(),
         },
     )?)
 }

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -31,6 +31,9 @@ data:
     {{- with .Values.chain.on_chain_execution_config}}
     on_chain_execution_config: {{ . | toJson }}
     {{- end}}
+    {{- with .Values.chain.jwk_consensus_config_override }}
+    jwk_consensus_config_override: {{ . | toJson }}
+    {{- end}}
 
 ---
 

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -31,9 +31,6 @@ data:
     {{- with .Values.chain.on_chain_execution_config}}
     on_chain_execution_config: {{ . | toJson }}
     {{- end}}
-    {{- with .Values.chain.jwk_consensus_config_override }}
-    jwk_consensus_config_override: {{ . | toJson }}
-    {{- end}}
 
 ---
 

--- a/types/src/on_chain_config/jwk_consensus_config.rs
+++ b/types/src/on_chain_config/jwk_consensus_config.rs
@@ -42,7 +42,11 @@ pub enum OnChainJWKConsensusConfig {
 impl OnChainJWKConsensusConfig {
     pub fn default_enabled() -> Self {
         Self::V1(ConfigV1 {
-            oidc_providers: vec![],
+            oidc_providers: vec![OIDCProvider {
+                name: "https://accounts.google.com".to_string(),
+                config_url: "https://accounts.google.com/.well-known/openid-configuration"
+                    .to_string(),
+            }],
         })
     }
 
@@ -55,6 +59,8 @@ impl OnChainJWKConsensusConfig {
     }
 
     pub fn default_for_genesis() -> Self {
+        // Here it is supposed to use `default_enabled()`.
+        // Using an empty list instead to avoid DDoSing the CI infra or the actual providers.
         Self::V1(ConfigV1 {
             oidc_providers: vec![],
         })


### PR DESCRIPTION
## Description

Add a `JWKConsensusConfigOverride` to `GenesisInfo`, to allow control JWK initialization in smoke tests/localnet.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Genesis

## How Has This Been Tested?
Existing tests.

## Key Areas to Review
n.a.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
