### PR TITLE
[doc] Fix documentation warnings for rustdoc

### DIFF
--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -20,7 +20,7 @@ impl Address {
 
     /// Represent an account address in a way that is compliant with the v1 address
     /// standard. The standard is defined as part of AIP-40, read more here:
-    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
+    /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>
     ///
     /// In short, all special addresses MUST be represented in SHORT form, e.g.
     ///

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -30,7 +30,7 @@
 /// - V8
 ///   - Added BLS12-381 operations.
 /// - V7
-///   - Native support for exists<T>
+///   - Native support for `exists<T>`
 ///   - New formulae for storage fees based on fixed APT costs
 ///   - Lower gas price (other than the newly introduced storage fees) by upping the scaling factor
 /// - V6

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -108,7 +108,7 @@ impl VMOutput {
     /// Materializes delta sets.
     /// Guarantees that if deltas are materialized successfully, the output
     /// has an empty delta set.
-    /// TODO[agg_v2](cleanup) Consolidate materialization paths. See either:
+    /// TODO `[agg_v2](cleanup)` Consolidate materialization paths. See either:
     /// - if we can/should move try_materialize_aggregator_v1_delta_set into
     ///   executor.rs
     /// - move all materialization (including delayed fields) into change_set

--- a/aptos-move/e2e-tests/src/loader/mod.rs
+++ b/aptos-move/e2e-tests/src/loader/mod.rs
@@ -169,7 +169,7 @@ impl DependencyGraph {
         }
     }
 
-    /// Set up [`DepGraph`] with the initial state generated in this universe.
+    /// Set up `DepGraph` with the initial state generated in this universe.
     pub fn setup(&self, executor: &mut FakeExecutor) {
         for node in self.graph.raw_nodes().iter() {
             executor.add_account_data(&node.weight.account_data);

--- a/aptos-move/framework/src/natives/cryptography/ristretto255.rs
+++ b/aptos-move/framework/src/natives/cryptography/ristretto255.rs
@@ -24,7 +24,7 @@ pub(crate) const COMPRESSED_POINT_NUM_BYTES: usize = 32;
 
 /// Returns gas costs for a variable-time multiscalar multiplication (MSM) of size-n. The MSM
 /// employed in curve25519 is:
-///  1. Strauss, when n <= 190, see https://www.jstor.org/stable/2310929
+///  1. Strauss, when n <= 190, see <https://www.jstor.org/stable/2310929>
 ///  2. Pippinger, when n > 190, which roughly requires O(n / log_2 n) scalar multiplications
 /// For simplicity, we estimate the complexity as O(n / log_2 n)
 pub fn multi_scalar_mul_gas(

--- a/consensus/src/consensusdb/schema/dag/mod.rs
+++ b/consensus/src/consensusdb/schema/dag/mod.rs
@@ -3,7 +3,6 @@
 
 //! This module defines physical storage schemas for DAG.
 //!
-//! ```
 
 use crate::{
     consensusdb::schema::ensure_slice_len_eq,

--- a/crates/aptos-crypto/src/traits.rs
+++ b/crates/aptos-crypto/src/traits.rs
@@ -14,7 +14,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, hash::Hash};
 use thiserror::Error;
 
-/// An error type for key and signature validation issues, see [`ValidCryptoMaterial`][ValidCryptoMaterial].
+/// An error type for key and signature validation issues, see [`ValidCryptoMaterial`].
 ///
 /// This enum reflects there are two interesting causes of validation
 /// failure for the ingestion of key or signature material: deserialization errors
@@ -52,12 +52,12 @@ pub trait Length {
 ///
 /// A type family for material that knows how to serialize and
 /// deserialize, as well as validate byte-encoded material. The
-/// validation must be implemented as a [`TryFrom`][TryFrom] which
+/// validation must be implemented as a [`TryFrom`] which
 /// classifies its failures against the above
-/// [`CryptoMaterialError`][CryptoMaterialError].
+/// [`CryptoMaterialError`].
 ///
 /// This provides an implementation for a validation that relies on a
-/// round-trip to bytes and corresponding [`TryFrom`][TryFrom].
+/// round-trip to bytes and corresponding [`TryFrom`].
 pub trait ValidCryptoMaterial:
     // The for<'a> exactly matches the assumption "deserializable from any lifetime".
     for<'a> TryFrom<&'a [u8], Error=CryptoMaterialError> + Serialize + DeserializeOwned
@@ -66,9 +66,9 @@ pub trait ValidCryptoMaterial:
     fn to_bytes(&self) -> Vec<u8>;
 }
 
-/// An extension to to/from Strings for [`ValidCryptoMaterial`][ValidCryptoMaterial].
+/// An extension to to/from Strings for [`ValidCryptoMaterial`].
 ///
-/// Relies on [`hex`][::hex] for string encoding / decoding.
+/// Relies on [`hex`] for string encoding / decoding.
 /// No required fields, provides a default implementation.
 pub trait ValidCryptoMaterialStringExt: ValidCryptoMaterial {
     /// When trying to convert from bytes, we simply decode the string into
@@ -96,7 +96,7 @@ pub trait ValidCryptoMaterialStringExt: ValidCryptoMaterial {
 impl<T: ValidCryptoMaterial> ValidCryptoMaterialStringExt for T {}
 
 /// A type family for key material that should remain secret and has an
-/// associated type of the [`PublicKey`][PublicKey] family.
+/// associated type of the [`PublicKey`] family.
 pub trait PrivateKey: Sized {
     /// We require public / private types to be coupled, i.e. their
     /// associated type is each other.
@@ -113,7 +113,7 @@ pub trait PrivateKey: Sized {
 /// This trait has a requirement on a `pub(crate)` marker trait meant to
 /// specifically limit its implementations to the present crate.
 ///
-/// A trait for a [`ValidCryptoMaterial`][ValidCryptoMaterial] which knows how to sign a
+/// A trait for a [`ValidCryptoMaterial`] which knows how to sign a
 /// message, and return an associated `Signature` type.
 pub trait SigningKey:
     PrivateKey<PublicKeyMaterial = <Self as SigningKey>::VerifyingKeyMaterial>
@@ -158,7 +158,7 @@ pub fn signing_message<T: CryptoHash + Serialize>(
 }
 
 /// A type for key material that can be publicly shared, and in asymmetric
-/// fashion, can be obtained from a [`PrivateKey`][PrivateKey]
+/// fashion, can be obtained from a [`PrivateKey`]
 /// reference.
 /// This convertibility requirement ensures the existence of a
 /// deterministic, canonical public key construction from a private key.
@@ -219,7 +219,7 @@ pub trait VerifyingKey:
 /// verify.
 ///
 /// This trait simply requires an association to some type of the
-/// [`PublicKey`][PublicKey] family of which we are the `SignatureMaterial`.
+/// [`PublicKey`] family of which we are the `SignatureMaterial`.
 ///
 /// This trait has a requirement on a `pub(crate)` marker trait meant to
 /// specifically limit its implementations to the present crate.
@@ -228,7 +228,7 @@ pub trait VerifyingKey:
 /// checks signature material passed as `&[u8]` and only returns Ok when
 /// that material de-serializes to a signature of the expected concrete
 /// scheme. This would be done as an extension trait of
-/// [`Signature`][Signature].
+/// [`Signature`].
 pub trait Signature:
     for<'a> TryFrom<&'a [u8], Error = CryptoMaterialError>
     + Sized
@@ -276,7 +276,7 @@ pub trait Signature:
 }
 
 /// A type family for schemes which know how to generate key material from
-/// a cryptographically-secure [`CryptoRng`][::rand::CryptoRng].
+/// a cryptographically-secure [`CryptoRng`].
 pub trait Uniform {
     /// Generate key material from a cryptographically-secure RNG.
     fn generate<R>(rng: &mut R) -> Self

--- a/crates/aptos-dkg/src/algebra/lagrange.rs
+++ b/crates/aptos-dkg/src/algebra/lagrange.rs
@@ -23,7 +23,7 @@ const FFT_THRESH: usize = 64;
 ///
 /// For $X = \alpha$ we get $\ell_i(\alpha) = \frac{(1-\alpha^N) N^{-1} \omega^i}{(\omega^i - \alpha)}$.
 ///
-/// (See https://ethresear.ch/t/kate-commitments-from-the-lagrange-basis-without-ffts/6950/2)
+/// (See <https://ethresear.ch/t/kate-commitments-from-the-lagrange-basis-without-ffts/6950/2>)
 #[allow(non_snake_case)]
 pub fn all_n_lagrange_coefficients(dom: &BatchEvaluationDomain, alpha: &Scalar) -> Vec<Scalar> {
     let alpha_to_N = alpha.pow_vartime([dom.N() as u64]); // \alpha^N
@@ -78,7 +78,7 @@ pub fn all_n_lagrange_coefficients(dom: &BatchEvaluationDomain, alpha: &Scalar) 
 ///
 /// [TAB+20e] Aggregatable Subvector Commitments for Stateless Cryptocurrencies; by Alin Tomescu and
 /// Ittai Abraham and Vitalik Buterin and Justin Drake and Dankrad Feist and Dmitry Khovratovich;
-/// 2020; https://eprint.iacr.org/2020/527
+/// 2020; <https://eprint.iacr.org/2020/527>
 #[allow(non_snake_case)]
 pub fn all_lagrange_denominators(
     batch_dom: &BatchEvaluationDomain,

--- a/crates/aptos-dkg/src/utils/mod.rs
+++ b/crates/aptos-dkg/src/utils/mod.rs
@@ -24,7 +24,7 @@ pub fn is_power_of_two(n: usize) -> bool {
 
 /// Hashes the specified `msg` and domain separation tag `dst` into a `Scalar` by computing a 512-bit
 /// number as SHA3-512(SHA3-512(dst) || msg) and reducing it modulo the order of the field.
-/// (Same design as in `curve25519-dalek` explained here https://crypto.stackexchange.com/questions/88002/how-to-map-output-of-hash-algorithm-to-a-finite-field)
+/// (Same design as in `curve25519-dalek` explained here <https://crypto.stackexchange.com/questions/88002/how-to-map-output-of-hash-algorithm-to-a-finite-field>)
 ///
 /// NOTE: Domain separation from other SHA3-512 calls in our system is left up to the caller.
 pub fn hash_to_scalar(msg: &[u8], dst: &[u8]) -> Scalar {

--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -55,7 +55,7 @@ pub enum AptosLedgerError {
     #[error("Error - {0}")]
     AptosError(AptosLedgerStatusCode),
 
-    /// Unexpected error, the Option<u16> is the retcode received from ledger transport
+    /// Unexpected error, the `Option<u16>` is the retcode received from ledger transport
     #[error("Unexpected Error: {0} (StatusCode {1:?})")]
     UnexpectedError(String, Option<u16>),
 }
@@ -69,8 +69,8 @@ impl From<LedgerHIDError> for AptosLedgerError {
 #[derive(Debug, Copy, Clone)]
 #[repr(u16)]
 /// Status code returned when communicating with ledger
-/// Most Aptos ones defined here https://github.com/aptos-labs/ledger-app-aptos/blob/main/doc/COMMANDS.md#status-words
-/// Some of the ledger status code defined here - https://www.eftlab.com/knowledge-base/complete-list-of-apdu-responses
+/// Most Aptos ones defined here <https://github.com/aptos-labs/ledger-app-aptos/blob/main/doc/COMMANDS.md#status-words>
+/// Some of the ledger status code defined here - <https://www.eftlab.com/knowledge-base/complete-list-of-apdu-responses>
 pub enum AptosLedgerStatusCode {
     /// Aptos ledger app related status code
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -679,8 +679,8 @@ pub struct HardwareWalletOptions {
 
     /// Index of your account in hardware wallet
     ///
-    /// This is the simpler version of derivation path e.g format - [0]
-    /// we will translate this index into [m/44'/637'/0'/0'/0]
+    /// This is the simpler version of derivation path e.g `format - [0]`
+    /// we will translate this index into `[m/44'/637'/0'/0'/0]`
     #[clap(long)]
     pub derivation_index: Option<String>,
 }
@@ -1068,7 +1068,7 @@ pub struct MovePackageDir {
 
     /// Do apply extended checks for Aptos (e.g. `#[view]` attribute) also on test code.
     /// NOTE: this behavior will become the default in the future.
-    /// See https://github.com/aptos-labs/aptos-core/issues/10335
+    /// See <https://github.com/aptos-labs/aptos-core/issues/10335>
     #[clap(long, env = "APTOS_CHECK_TEST_CODE")]
     pub check_test_code: bool,
 }

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -34,14 +34,14 @@ pub mod message_queues;
 #[cfg(test)]
 mod message_queues_test;
 
-/// An [`mpsc::Sender`](futures::channel::mpsc::Sender) with an [`IntGauge`]
+/// An [`mpsc::Sender`] with an [`IntGauge`]
 /// counting the number of currently queued items.
 pub struct Sender<T> {
     inner: mpsc::Sender<T>,
     gauge: IntGauge,
 }
 
-/// An [`mpsc::Receiver`](futures::channel::mpsc::Receiver) with an [`IntGauge`]
+/// An [`mpsc::Receiver`] with an [`IntGauge`]
 /// counting the number of currently queued items.
 pub struct Receiver<T> {
     inner: mpsc::Receiver<T>,
@@ -157,7 +157,7 @@ pub struct UnboundedSender<T> {
     gauge: IntGauge,
 }
 
-/// An [`mpsc::UnboundedReceiver`](futures::channel::mpsc::UnboundedReceiver) with an [`IntGauge`]
+/// An [`mpsc::UnboundedReceiver`] with an [`IntGauge`]
 /// counting the number of currently queued items.
 pub struct UnboundedReceiver<T> {
     inner: mpsc::UnboundedReceiver<T>,

--- a/execution/block-partitioner/src/pre_partition/connected_component/mod.rs
+++ b/execution/block-partitioner/src/pre_partition/connected_component/mod.rs
@@ -16,7 +16,7 @@ use std::{
 
 /// A `PrePartitioner` used in `PartitionerV2` that tries to group conflicting txns together (but a group size limit applied),
 /// then assign the groups to the shards using Longest-processing-time-first (LPT) scheduling.
-/// https://en.wikipedia.org/wiki/Longest-processing-time-first_scheduling
+/// <https://en.wikipedia.org/wiki/Longest-processing-time-first_scheduling>
 ///
 /// Note that the number of groups varies depending on the block:
 /// - if the conflict level is high and group size limit is loose, we may have only 1 group;

--- a/execution/block-partitioner/src/pre_partition/uniform_partitioner/mod.rs
+++ b/execution/block-partitioner/src/pre_partition/uniform_partitioner/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 use rand::thread_rng;
 
 /// A naive partitioner that evenly divide txns into shards.
-/// Example: processing txns 0..11 results in [[0,1,2,3],[4,5,6,7],[8,9,10]].
+/// Example: processing txns 0..11 results in `[[0,1,2,3],[4,5,6,7],[8,9,10]]`.
 pub struct UniformPartitioner {}
 
 impl UniformPartitioner {

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -487,8 +487,8 @@ impl NetbenchSharedState {
         self.sent_pos = (self.sent_pos + 1) % self.sent.capacity();
     }
 
-    /// return the record for the request_counter, or {0, oldest send_micros}
-    /// Option<SendRecord> might seem like it would make sense, but we use the send_micros field to return the oldest known message time when we don't find a request_counter match.
+    /// return the record for the request_counter, or `{0, oldest send_micros}`
+    /// `Option<SendRecord>` might seem like it would make sense, but we use the send_micros field to return the oldest known message time when we don't find a request_counter match.
     pub fn find(&self, request_counter: u64) -> SendRecord {
         if self.sent.is_empty() {
             return SendRecord {

--- a/storage/storage-interface/src/errors.rs
+++ b/storage/storage-interface/src/errors.rs
@@ -2,12 +2,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module defines error types used by [`AptosDB`](crate::AptosDB).
+//! This module defines error types used by `AptosDB`.
 use aptos_types::state_store::errors::StateviewError;
 use std::sync::mpsc::RecvError;
 use thiserror::Error;
 
-/// This enum defines errors commonly used among [`AptosDB`](crate::AptosDB) APIs.
+/// This enum defines errors commonly used among `AptosDB` APIs.
 #[derive(Debug, Error)]
 pub enum AptosDbError {
     /// A requested item is not found.

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -248,7 +248,7 @@ pub trait DbReader: Send + Sync {
         /// ../aptosdb/struct.AptosDB.html#method.get_block_timestamp
         fn get_block_timestamp(&self, version: Version) -> Result<u64>;
 
-        /// See [AptosDB::get_latest_block_events].
+        /// See `AptosDB::get_latest_block_events`.
         fn get_latest_block_events(&self, num_events: usize) -> Result<Vec<EventWithVersion>>;
 
         /// Returns the start_version, end_version and NewBlockEvent of the block containing the input

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -8,7 +8,7 @@
 ///
 /// Moreover, one can activate an experiment in a test source by using a
 /// comment as such in a unit test:
-/// ```
+/// ```text
 ///   // experiment: <name>
 /// ```
 /// This can be repeated an arbitrary number of times. The test will then be run for

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implements a live-variable analysis processor, annotating lifetime information about locals.
-//! See also https://en.wikipedia.org/wiki/Live-variable_analysis
+//! See also <https://en.wikipedia.org/wiki/Live-variable_analysis>
 //!
 //! Prerequisite annotations: none
 //! Side effect: the `LiveVarAnnotation` will be added to the function target annotations.

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -14,7 +14,7 @@
 //! in `r1` and `&s.f` stored in `r2` (edges in the graph should be read as arrows pointing
 //! downwards):
 //!
-//! ```ignore
+//! ```text
 //!              s
 //!              | &
 //!          .g / \ .f
@@ -26,7 +26,7 @@
 //! we call an _implicit choice_, that is the choice between alternatives is down
 //! after a borrow step:
 //!
-//! ```ignore
+//! ```text
 //!              s
 //!           & / \ &
 //!          .g |  | .f
@@ -36,7 +36,7 @@
 //! In general, the graph is a DAG. Joining of nodes represents branching in the code. For
 //! example, the graph below depicts that `r` can either be `&s.f` or `&s.g`:
 //!
-//! ```ignore
+//! ```text
 //!              s
 //!           & / \ &
 //!          .g \ / .f
@@ -72,7 +72,7 @@
 //! after some non-empty common prefix, and do not have a common node where they join again. Here is
 //! an example of two paths with diverging edges:
 //!
-//! ```ignore
+//! ```text
 //!              s
 //!        &mut / \ &mut
 //!      call f |  | call g
@@ -83,7 +83,7 @@
 //! join again. Notice that this is a result of different execution paths from code
 //! like `let r = if (c) f(&mut s) else g(&mut s)`:
 //!
-//! ```ignore
+//! ```text
 //!              s
 //!        &mut / \ &mut
 //!      call f |  | call g
@@ -994,7 +994,7 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
     /// To effectively check the path-oriented conditions of safety here, we need to deal with the fact
     /// that graphs have non-explicit choice nodes, for example:
     ///
-    /// ```ignore
+    /// ```text
     ///                 s
     ///            &mut /\ &mut
     ///             .f /  \ .g

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -67,7 +67,7 @@ impl AccountAddress {
 
     /// Represent an account address in a way that is compliant with the v1 address
     /// standard. The standard is defined as part of AIP-40, read more here:
-    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
+    /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>
     ///
     /// In short, all special addresses MUST be represented in SHORT form, e.g.
     ///
@@ -97,7 +97,7 @@ impl AccountAddress {
     /// the addresses in the range from `0x0` to `0xf` (inclusive) are special.
     ///
     /// For more details see the v1 address standard defined as part of AIP-40:
-    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
+    /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>
     pub fn is_special(&self) -> bool {
         self.0[..Self::LENGTH - 1].iter().all(|x| *x == 0) && self.0[Self::LENGTH - 1] < 0b10000
     }
@@ -205,7 +205,7 @@ impl AccountAddress {
     /// - Any address without a leading 0x.
     ///
     /// Learn more about the different address formats by reading AIP-40:
-    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.
+    /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>.
     pub fn from_str_strict(s: &str) -> Result<Self, AccountAddressParseError> {
         // Assert the string starts with 0x.
         if !s.starts_with("0x") {
@@ -368,7 +368,7 @@ impl FromStr for AccountAddress {
     /// - SHORT is 1 to 63 hex characters inclusive.
     ///
     /// Learn more about the different address formats by reading AIP-40:
-    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.
+    /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>.
     fn from_str(s: &str) -> Result<Self, AccountAddressParseError> {
         if !s.starts_with("0x") {
             if s.is_empty() {

--- a/third_party/move/move-core/types/src/identifier.rs
+++ b/third_party/move/move-core/types/src/identifier.rs
@@ -73,7 +73,7 @@ const fn all_bytes_numeric(b: &[u8], start_offset: usize) -> bool {
 /// Describes what identifiers are allowed.
 ///
 /// For now this is deliberately restrictive -- we would like to evolve this in the future.
-/// TODO: "<SELF>" and "<SELF>_[0-9]+" are coded as exceptions.
+/// TODO: `<SELF>` and `<SELF>_[0-9]+` are coded as exceptions.
 ///       They should be removed once CompiledScript goes away.
 // Note: needs to be pub as it's used in the `ident_str!` macro.
 pub const fn is_valid(s: &str) -> bool {

--- a/third_party/move/move-model/bytecode/abstract_domain_derive/src/lib.rs
+++ b/third_party/move/move-model/bytecode/abstract_domain_derive/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! Currently we can only derive for structs.
 //! For tuple structs, the derived join pair-wise joins each field;
-//! for structs with named fields, the derived join pair-wise joins each field without #[no_join] attribute.
+//! for structs with named fields, the derived join pair-wise joins each field without `#[no_join]` attribute.
 
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};

--- a/types/src/keyless/groth16_sig.rs
+++ b/types/src/keyless/groth16_sig.rs
@@ -35,7 +35,7 @@ pub struct ZeroKnowledgeSig {
     /// The expiration horizon that the circuit should enforce on the expiration date committed in
     /// the nonce. This must be <= `Configuration::max_expiration_horizon_secs`.
     pub exp_horizon_secs: u64,
-    /// An optional extra field (e.g., `"<name>":"<val>") that will be matched publicly in the JWT
+    /// An optional extra field (e.g., `"<name>":"<val>"`) that will be matched publicly in the JWT
     pub extra_field: Option<String>,
     /// Will be set to the override `aud` value that the circuit should match, instead of the `aud`
     /// in the IDC. This will allow users to recover keyless accounts bound to an application that

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -293,7 +293,7 @@ impl TryFrom<&[u8]> for IdCommitment {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct KeylessPublicKey {
     /// The value of the `iss` field from the JWT, indicating the OIDC provider.
-    /// e.g., https://accounts.google.com
+    /// e.g., <https://accounts.google.com>
     pub iss_val: String,
 
     /// SNARK-friendly commitment to:

--- a/types/src/keyless/openid_sig.rs
+++ b/types/src/keyless/openid_sig.rs
@@ -18,10 +18,10 @@ use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash, Serialize)]
 pub struct OpenIdSig {
-    /// The decoded bytes of the JWS signature in the JWT (https://datatracker.ietf.org/doc/html/rfc7515#section-3)
+    /// The decoded bytes of the JWS signature in the JWT (<https://datatracker.ietf.org/doc/html/rfc7515#section-3>)
     #[serde(with = "serde_bytes")]
     pub jwt_sig: Vec<u8>,
-    /// The decoded/plaintext JSON payload of the JWT (https://datatracker.ietf.org/doc/html/rfc7519#section-3)
+    /// The decoded/plaintext JSON payload of the JWT (<https://datatracker.ietf.org/doc/html/rfc7519#section-3>)
     pub jwt_payload_json: String,
     /// The name of the key in the claim that maps to the user identifier; e.g., "sub" or "email"
     pub uid_key: String,


### PR DESCRIPTION
## Description
Cleans up rust doc warnings, so doc build is clean.

However, there's a ton of unused warnings in different parts of the codebase as well.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Documentation only change

## Key Areas to Review
Documentation only change

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
