### PR TITLE
Reset proof manager and batch coordinator without inline payload changes

### DIFF
--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -6,7 +6,6 @@ use crate::{
     quorum_store::{
         batch_store::{BatchStore, BatchWriter},
         counters,
-        proof_manager::ProofManagerCommand,
         types::{Batch, PersistedValue},
     },
 };
@@ -14,10 +13,7 @@ use anyhow::ensure;
 use aptos_logger::prelude::*;
 use aptos_types::PeerId;
 use std::sync::Arc;
-use tokio::sync::{
-    mpsc::{Receiver, Sender},
-    oneshot,
-};
+use tokio::sync::{mpsc::Receiver, oneshot};
 
 #[derive(Debug)]
 pub enum BatchCoordinatorCommand {
@@ -25,11 +21,9 @@ pub enum BatchCoordinatorCommand {
     NewBatches(PeerId, Vec<Batch>),
 }
 
-/// The `BatchCoordinator` is responsible for coordinating the receipt and persistence of batches.
 pub struct BatchCoordinator {
     my_peer_id: PeerId,
     network_sender: Arc<NetworkSender>,
-    sender_to_proof_manager: Arc<Sender<ProofManagerCommand>>,
     batch_store: Arc<BatchStore>,
     max_batch_txns: u64,
     max_batch_bytes: u64,
@@ -41,7 +35,6 @@ impl BatchCoordinator {
     pub(crate) fn new(
         my_peer_id: PeerId,
         network_sender: NetworkSender,
-        sender_to_proof_manager: Sender<ProofManagerCommand>,
         batch_store: Arc<BatchStore>,
         max_batch_txns: u64,
         max_batch_bytes: u64,
@@ -51,7 +44,6 @@ impl BatchCoordinator {
         Self {
             my_peer_id,
             network_sender: Arc::new(network_sender),
-            sender_to_proof_manager: Arc::new(sender_to_proof_manager),
             batch_store,
             max_batch_txns,
             max_batch_bytes,
@@ -67,22 +59,14 @@ impl BatchCoordinator {
 
         let batch_store = self.batch_store.clone();
         let network_sender = self.network_sender.clone();
-        let sender_to_proof_manager = self.sender_to_proof_manager.clone();
         tokio::spawn(async move {
             let peer_id = persist_requests[0].author();
-            let batches = persist_requests
-                .iter()
-                .map(|persisted_value| persisted_value.batch_info().clone())
-                .collect();
             let signed_batch_infos = batch_store.persist(persist_requests);
             if !signed_batch_infos.is_empty() {
                 network_sender
                     .send_signed_batch_info_msg(signed_batch_infos, vec![peer_id])
                     .await;
             }
-            let _ = sender_to_proof_manager
-                .send(ProofManagerCommand::ReceiveBatches(batches))
-                .await;
         });
     }
 

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -1,14 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::batch_store::BatchStore;
 use crate::{
     monitor,
-    quorum_store::{
-        batch_generator::BackPressure,
-        counters,
-        utils::{BatchSortKey, ProofQueue},
-    },
+    quorum_store::{batch_generator::BackPressure, counters, utils::ProofQueue},
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, ProofWithData},
@@ -16,126 +11,24 @@ use aptos_consensus_types::{
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_logger::prelude::*;
-use aptos_types::{transaction::SignedTransaction, PeerId};
+use aptos_types::PeerId;
 use futures::StreamExt;
 use futures_channel::mpsc::Receiver;
-use rand::{seq::SliceRandom, thread_rng};
-use std::{
-    cmp::min,
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub enum ProofManagerCommand {
     ReceiveProofs(ProofOfStoreMsg),
-    ReceiveBatches(Vec<BatchInfo>),
     CommitNotification(u64, Vec<BatchInfo>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
 }
 
-pub struct BatchQueue {
-    batch_store: Arc<BatchStore>,
-    // Queue per peer to ensure fairness between peers and priority within peer
-    author_to_batches: HashMap<PeerId, BTreeMap<BatchSortKey, BatchInfo>>,
-}
-
-impl BatchQueue {
-    pub fn new(batch_store: Arc<BatchStore>) -> Self {
-        Self {
-            batch_store,
-            author_to_batches: HashMap::new(),
-        }
-    }
-
-    pub fn add_batches(&mut self, batches: Vec<BatchInfo>) {
-        for batch in batches.into_iter() {
-            let queue = self.author_to_batches.entry(batch.author()).or_default();
-            queue.insert(BatchSortKey::from_info(&batch), batch.clone());
-        }
-    }
-
-    pub fn remove_batch(&mut self, batch: &BatchInfo) {
-        if let Some(batch_tree) = self.author_to_batches.get_mut(&batch.author()) {
-            batch_tree.remove(&BatchSortKey::from_info(batch));
-        }
-    }
-
-    pub fn remove_expired_batches(&mut self) {
-        let authors = self.author_to_batches.keys().cloned().collect::<Vec<_>>();
-        for author in authors {
-            if let Some(batch_tree) = self.author_to_batches.get_mut(&author) {
-                batch_tree.retain(|_batch_key, batch| !batch.is_expired());
-            }
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.author_to_batches
-            .values()
-            .map(|batch_tree| batch_tree.len())
-            .sum()
-    }
-
-    pub fn pull_batches(
-        &mut self,
-        max_txns: u64,
-        max_bytes: u64,
-        excluded_batches: Vec<BatchInfo>,
-    ) -> Vec<(BatchInfo, Vec<SignedTransaction>)> {
-        let mut result: Vec<(BatchInfo, Vec<SignedTransaction>)> = vec![];
-        let mut num_txns = 0;
-        let mut num_bytes = 0;
-        let mut iters = vec![];
-        let mut full = false;
-        for (_, batches) in self.author_to_batches.iter() {
-            iters.push(batches.iter().rev());
-        }
-        while !iters.is_empty() {
-            iters.shuffle(&mut thread_rng());
-            iters.retain_mut(|iter| {
-                if full {
-                    return false;
-                }
-                if let Some((_sort_key, batch)) = iter.next() {
-                    if excluded_batches.contains(batch) {
-                        true
-                    } else if num_txns + batch.num_txns() <= max_txns
-                        && num_bytes + batch.num_bytes() <= max_bytes
-                    {
-                        if let Ok(mut persisted_value) =
-                            self.batch_store.get_batch_from_local(batch.digest())
-                        {
-                            if let Some(txns) = persisted_value.take_payload() {
-                                num_txns += batch.num_txns();
-                                num_bytes += batch.num_bytes();
-                                result.push((batch.clone(), txns.clone()));
-                            }
-                        } else {
-                            warn!("Couldn't find a batch in local storage while creating inline block: {:?}", batch.digest());
-                        }
-                        true
-                    } else {
-                        full = true;
-                        false
-                    }
-                } else {
-                    false
-                }
-            })
-        }
-        result
-    }
-}
-
 pub struct ProofManager {
     proofs_for_consensus: ProofQueue,
-    batch_queue: BatchQueue,
     back_pressure_total_txn_limit: u64,
     remaining_total_txn_num: u64,
     back_pressure_total_proof_limit: u64,
     remaining_total_proof_num: u64,
-    allow_batches_without_pos_in_proposal: bool,
 }
 
 impl ProofManager {
@@ -143,33 +36,22 @@ impl ProofManager {
         my_peer_id: PeerId,
         back_pressure_total_txn_limit: u64,
         back_pressure_total_proof_limit: u64,
-        batch_store: Arc<BatchStore>,
-        allow_batches_without_pos_in_proposal: bool,
     ) -> Self {
         Self {
             proofs_for_consensus: ProofQueue::new(my_peer_id),
-            batch_queue: BatchQueue::new(batch_store),
             back_pressure_total_txn_limit,
             remaining_total_txn_num: 0,
             back_pressure_total_proof_limit,
             remaining_total_proof_num: 0,
-            allow_batches_without_pos_in_proposal,
         }
     }
 
     pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore>) {
         for proof in proofs.into_iter() {
-            self.batch_queue.remove_batch(proof.info());
             self.proofs_for_consensus.push(proof);
         }
         (self.remaining_total_txn_num, self.remaining_total_proof_num) =
             self.proofs_for_consensus.remaining_txns_and_proofs();
-    }
-
-    pub(crate) fn receive_batches(&mut self, batches: Vec<BatchInfo>) {
-        if self.allow_batches_without_pos_in_proposal {
-            self.batch_queue.add_batches(batches);
-        }
     }
 
     pub(crate) fn handle_commit_notification(
@@ -181,10 +63,7 @@ impl ProofManager {
             "QS: got clean request from execution at block timestamp {}",
             block_timestamp
         );
-        self.batch_queue.remove_expired_batches();
-        for batch in &batches {
-            self.batch_queue.remove_batch(batch);
-        }
+
         self.proofs_for_consensus.mark_committed(batches);
         self.proofs_for_consensus
             .handle_updated_block_timestamp(block_timestamp);
@@ -197,8 +76,8 @@ impl ProofManager {
             GetPayloadCommand::GetPayloadRequest(
                 max_txns,
                 max_bytes,
-                max_inline_txns,
-                max_inline_bytes,
+                _max_inline_txns,
+                _max_inline_bytes,
                 return_non_full,
                 filter,
                 callback,
@@ -211,58 +90,23 @@ impl ProofManager {
                     PayloadFilter::InQuorumStore(proofs) => proofs,
                 };
 
-                let (proof_block, proof_queue_fully_utilized) = self
-                    .proofs_for_consensus
-                    .pull_proofs(&excluded_batches, max_txns, max_bytes, return_non_full);
-
-                counters::NUM_BATCHES_WITHOUT_PROOF_OF_STORE.observe(self.batch_queue.len() as f64);
-                counters::PROOF_QUEUE_FULLY_UTILIZED
-                    .observe(if proof_queue_fully_utilized { 1.0 } else { 0.0 });
-
-                let mut inline_block: Vec<(BatchInfo, Vec<SignedTransaction>)> = vec![];
-                let cur_txns: u64 = proof_block.iter().map(|p| p.num_txns()).sum();
-                let cur_bytes: u64 = proof_block.iter().map(|p| p.num_bytes()).sum();
-
-                if self.allow_batches_without_pos_in_proposal && proof_queue_fully_utilized {
-                    inline_block = self.batch_queue.pull_batches(
-                        min(max_txns - cur_txns, max_inline_txns),
-                        min(max_bytes - cur_bytes, max_inline_bytes),
-                        excluded_batches
-                            .iter()
-                            .cloned()
-                            .chain(proof_block.iter().map(|proof| proof.info().clone()))
-                            .collect(),
-                    );
-                }
-                let inline_txns = inline_block
-                    .iter()
-                    .map(|(_, txns)| txns.len())
-                    .sum::<usize>();
-                counters::NUM_INLINE_BATCHES.observe(inline_block.len() as f64);
-                counters::NUM_INLINE_TXNS.observe(inline_txns as f64);
+                let proof_block = self.proofs_for_consensus.pull_proofs(
+                    &excluded_batches,
+                    max_txns,
+                    max_bytes,
+                    return_non_full,
+                );
 
                 let res = GetPayloadResponse::GetPayloadResponse(
-                    if proof_block.is_empty() && inline_block.is_empty() {
-                        Payload::empty(true, self.allow_batches_without_pos_in_proposal)
-                    } else if inline_block.is_empty() {
+                    if proof_block.is_empty() {
+                        Payload::empty(true, false)
+                    } else {
                         trace!(
                             "QS: GetBlockRequest excluded len {}, block len {}",
                             excluded_batches.len(),
                             proof_block.len()
                         );
                         Payload::InQuorumStore(ProofWithData::new(proof_block))
-                    } else {
-                        trace!(
-                            "QS: GetBlockRequest excluded len {}, block len {}, inline len {}",
-                            excluded_batches.len(),
-                            proof_block.len(),
-                            inline_block.len()
-                        );
-                        Payload::QuorumStoreInlineHybrid(
-                            inline_block,
-                            ProofWithData::new(proof_block),
-                            None,
-                        )
                     },
                 );
                 match callback.send(Ok(res)) {
@@ -319,9 +163,6 @@ impl ProofManager {
                             ProofManagerCommand::ReceiveProofs(proofs) => {
                                 self.receive_proofs(proofs.take());
                             },
-                            ProofManagerCommand::ReceiveBatches(batches) => {
-                                self.receive_batches(batches);
-                            }
                             ProofManagerCommand::CommitNotification(block_timestamp, batches) => {
                                 self.handle_commit_notification(
                                     block_timestamp,

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -311,7 +311,6 @@ impl InnerBuilder {
             let batch_coordinator = BatchCoordinator::new(
                 self.author,
                 self.network_sender.clone(),
-                self.proof_manager_cmd_tx.clone(),
                 self.batch_store.clone().unwrap(),
                 self.config.receiver_max_batch_txns as u64,
                 self.config.receiver_max_batch_bytes as u64,
@@ -351,8 +350,6 @@ impl InnerBuilder {
                 .back_pressure
                 .backlog_per_validator_batch_limit_count
                 * self.num_validators,
-            self.batch_store.clone().unwrap(),
-            self.config.allow_batches_without_pos_in_proposal,
         );
         spawn_named!(
             "proof_manager",

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -1,9 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::quorum_store::{
-    proof_manager::ProofManager, tests::batch_store_test::batch_store_for_test,
-};
+use crate::quorum_store::proof_manager::ProofManager;
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter},
     proof_of_store::{BatchId, BatchInfo, ProofOfStore},
@@ -15,8 +13,7 @@ use futures::channel::oneshot;
 use std::collections::HashSet;
 
 fn create_proof_manager() -> ProofManager {
-    let batch_store = batch_store_for_test(5 * 1024 * 1024);
-    ProofManager::new(PeerId::random(), 10, 10, batch_store, true)
+    ProofManager::new(PeerId::random(), 10, 10)
 }
 
 fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {

--- a/consensus/src/quorum_store/tests/utils.rs
+++ b/consensus/src/quorum_store/tests/utils.rs
@@ -52,7 +52,7 @@ fn test_proof_queue_sorting() {
     }
 
     // Expect: [600, 300]
-    let (pulled, _) = proof_queue.pull_proofs(&hashset![], 2, 2, true);
+    let pulled = proof_queue.pull_proofs(&hashset![], 2, 2, true);
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
     let mut prev: Option<&ProofOfStore> = None;
@@ -73,7 +73,7 @@ fn test_proof_queue_sorting() {
     assert_eq!(count_author_1, 1);
 
     // Expect: [600, 500, 300, 100]
-    let (pulled, _) = proof_queue.pull_proofs(&hashset![], 4, 4, true);
+    let pulled = proof_queue.pull_proofs(&hashset![], 4, 4, true);
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
     let mut prev: Option<&ProofOfStore> = None;

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -142,7 +142,7 @@ impl MempoolProxy {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone)]
-pub struct BatchKey {
+struct BatchKey {
     author: PeerId,
     batch_id: BatchId,
 }
@@ -157,7 +157,7 @@ impl BatchKey {
 }
 
 #[derive(PartialEq, Eq, Clone, Hash)]
-pub struct BatchSortKey {
+struct BatchSortKey {
     batch_key: BatchKey,
     gas_bucket_start: u64,
 }
@@ -277,16 +277,13 @@ impl ProofQueue {
 
     // gets excluded and iterates over the vector returning non excluded or expired entries.
     // return the vector of pulled PoS, and the size of the remaining PoS
-    // The flag in the second return argument is true iff the entire proof queue is fully utilized
-    // when pulling the proofs. If any proof from proof queue cannot be included due to size limits,
-    // this flag is set false.
     pub(crate) fn pull_proofs(
         &mut self,
         excluded_batches: &HashSet<BatchInfo>,
         max_txns: u64,
         max_bytes: u64,
         return_non_full: bool,
-    ) -> (Vec<ProofOfStore>, bool) {
+    ) -> Vec<ProofOfStore> {
         let mut ret = vec![];
         let mut cur_bytes = 0;
         let mut cur_txns = 0;
@@ -349,9 +346,9 @@ impl ProofQueue {
             counters::EXCLUDED_TXNS_WHEN_PULL.observe(excluded_txns as f64);
             // Stable sort, so the order of proofs within an author will not change.
             ret.sort_by_key(|proof| Reverse(proof.gas_bucket_start()));
-            (ret, !full)
+            ret
         } else {
-            (Vec::new(), !full)
+            Vec::new()
         }
     }
 


### PR DESCRIPTION
## Description
I've reset changes related to proof manager and batch coordinator from https://github.com/aptos-labs/aptos-core/pull/12579. This is to reduce the number of changes we make in v1.10.1 release.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
