### PR TITLE
refactor discovery setup

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -229,25 +229,7 @@ impl NetworkBuilder {
         );
 
         network_builder.discovery_listeners = Some(Vec::new());
-        for discovery_method in config.discovery_methods() {
-            let reconfig_listener = if *discovery_method == DiscoveryMethod::Onchain {
-                Some(
-                    reconfig_subscription_service
-                        .as_mut()
-                        .expect("An event subscription service is required for on-chain discovery!")
-                        .subscribe_to_reconfigurations()
-                        .expect("On-chain discovery is unable to subscribe to reconfigurations!"),
-                )
-            } else {
-                None
-            };
-
-            network_builder.add_discovery_change_listener(
-                discovery_method,
-                pubkey,
-                reconfig_listener,
-            );
-        }
+        network_builder.setup_discovery(config, reconfig_subscription_service);
 
         // Ensure there are no duplicate source types
         let set: HashSet<_> = network_builder
@@ -372,48 +354,54 @@ impl NetworkBuilder {
         self
     }
 
-    fn add_discovery_change_listener(
+    fn setup_discovery(
         &mut self,
-        discovery_method: &DiscoveryMethod,
-        pubkey: PublicKey,
-        reconfig_events: Option<ReconfigNotificationListener<DbBackedOnChainConfig>>,
+        config: &NetworkConfig,
+        mut reconfig_subscription_service: Option<&mut EventSubscriptionService>,
     ) {
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()
             .expect("ConnectivityManager must exist");
-
-        let listener = match discovery_method {
-            DiscoveryMethod::Onchain => {
-                let reconfig_events =
-                    reconfig_events.expect("Reconfiguration listener is expected!");
-                DiscoveryChangeListener::validator_set(
+        for discovery_method in config.discovery_methods() {
+            let listener = match discovery_method {
+                DiscoveryMethod::Onchain => {
+                    let reconfig_events = reconfig_subscription_service
+                        .as_mut()
+                        .expect("An event subscription service is required for on-chain discovery!")
+                        .subscribe_to_reconfigurations()
+                        .expect("On-chain discovery is unable to subscribe to reconfigurations!");
+                    let identity_key = config.identity_key();
+                    let pubkey = identity_key.public_key();
+                    DiscoveryChangeListener::validator_set(
+                        self.network_context,
+                        conn_mgr_reqs_tx.clone(),
+                        pubkey,
+                        reconfig_events,
+                    )
+                }
+                DiscoveryMethod::File(file_discovery) => DiscoveryChangeListener::file(
                     self.network_context,
-                    conn_mgr_reqs_tx,
-                    pubkey,
-                    reconfig_events,
-                )
-            },
-            DiscoveryMethod::File(file_discovery) => DiscoveryChangeListener::file(
-                self.network_context,
-                conn_mgr_reqs_tx,
-                file_discovery.path.as_path(),
-                Duration::from_secs(file_discovery.interval_secs),
-                self.time_service.clone(),
-            ),
-            DiscoveryMethod::Rest(rest_discovery) => DiscoveryChangeListener::rest(
-                self.network_context,
-                conn_mgr_reqs_tx,
-                rest_discovery.url.clone(),
-                Duration::from_secs(rest_discovery.interval_secs),
-                self.time_service.clone(),
-            ),
-            DiscoveryMethod::None => return,
-        };
-
-        self.discovery_listeners
-            .as_mut()
-            .expect("Can only add listeners before starting")
-            .push(listener);
+                    conn_mgr_reqs_tx.clone(),
+                    file_discovery.path.as_path(),
+                    Duration::from_secs(file_discovery.interval_secs),
+                    self.time_service.clone(),
+                ),
+                DiscoveryMethod::Rest(rest_discovery) => DiscoveryChangeListener::rest(
+                    self.network_context,
+                    conn_mgr_reqs_tx.clone(),
+                    rest_discovery.url.clone(),
+                    Duration::from_secs(rest_discovery.interval_secs),
+                    self.time_service.clone(),
+                ),
+                DiscoveryMethod::None => {
+                    continue;
+                }
+            };
+            self.discovery_listeners
+                .as_mut()
+                .expect("Can only add listeners before starting")
+                .push(listener);
+        }
     }
 
     /// Add a HealthChecker to the network.

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -19,10 +19,7 @@ use aptos_config::{
     },
     network_id::NetworkContext,
 };
-use aptos_crypto::x25519::PublicKey;
-use aptos_event_notifications::{
-    DbBackedOnChainConfig, EventSubscriptionService, ReconfigNotificationListener,
-};
+use aptos_event_notifications::{DbBackedOnChainConfig, EventSubscriptionService};
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::tcp::TCPBufferCfg;
 use aptos_network::{
@@ -170,12 +167,11 @@ impl NetworkBuilder {
         role: RoleType,
         config: &NetworkConfig,
         time_service: TimeService,
-        mut reconfig_subscription_service: Option<&mut EventSubscriptionService>,
+        reconfig_subscription_service: Option<&mut EventSubscriptionService>,
         peers_and_metadata: Arc<PeersAndMetadata>,
     ) -> NetworkBuilder {
         let peer_id = config.peer_id();
         let identity_key = config.identity_key();
-        let pubkey = identity_key.public_key();
 
         let authentication_mode = if config.mutual_authentication {
             AuthenticationMode::Mutual(identity_key)
@@ -378,7 +374,7 @@ impl NetworkBuilder {
                         pubkey,
                         reconfig_events,
                     )
-                }
+                },
                 DiscoveryMethod::File(file_discovery) => DiscoveryChangeListener::file(
                     self.network_context,
                     conn_mgr_reqs_tx.clone(),
@@ -395,7 +391,7 @@ impl NetworkBuilder {
                 ),
                 DiscoveryMethod::None => {
                     continue;
-                }
+                },
             };
             self.discovery_listeners
                 .as_mut()


### PR DESCRIPTION
## Description
Simplify discovery setup.
Merge `if Let` into `match` that was happening anyway.
Move lines of code out of overfull `NetworkBuilder::create()`

_(things found along the way to network2)_

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [X] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [X] Validator Node
- [X] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Existing unit tests. Lint.

## Key Areas to Review
Code is more readable.

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation