### PR TITLE
[move-vm] Enable the constructor for vectors of values

### DIFF
--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -2412,7 +2412,7 @@ mod test {
     }
 
     fn create_vector_value(inner: Vec<Value>) -> Value {
-        Value::vector_for_testing_only(inner)
+        Value::vector_value(inner)
     }
 
     fn create_state_value(value: &Value, layout: &MoveTypeLayout) -> StateValue {
@@ -2561,7 +2561,7 @@ mod test {
             "The counter should have been updated to 9"
         );
         let patched_value =
-            Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
+            Value::struct_(Struct::pack(vec![Value::vector_value(vec![
                 Value::struct_(Struct::pack(vec![
                     Value::u64(DelayedFieldID::new_with_width(6, 8).as_u64()),
                     Value::u64(50),
@@ -2627,7 +2627,7 @@ mod test {
             "The counter should have been updated to 12"
         );
         let patched_value =
-            Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
+            Value::struct_(Struct::pack(vec![Value::vector_value(vec![
                 create_snapshot_value(Value::u128(
                     DelayedFieldID::new_with_width(9, 16).as_u64() as u128
                 )),
@@ -2689,7 +2689,7 @@ mod test {
         );
 
         let patched_value =
-            Value::struct_(Struct::pack(vec![Value::vector_for_testing_only(vec![
+            Value::struct_(Struct::pack(vec![Value::vector_value(vec![
                 DelayedFieldID::new_with_width(12, 60)
                     .into_derived_string_struct()
                     .unwrap(),

--- a/aptos-move/framework/move-stdlib/src/natives/unit_test.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/unit_test.rs
@@ -36,7 +36,7 @@ fn native_create_signers_for_testing(
 
     let num_signers = safely_pop_arg!(args, u64);
 
-    let signers = Value::vector_for_testing_only(
+    let signers = Value::vector_value(
         (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -159,7 +159,7 @@ fn native_emitted_events_by_handle(
             })
         })
         .collect::<SafeNativeResult<Vec<Value>>>()?;
-    Ok(smallvec![Value::vector_for_testing_only(events)])
+    Ok(smallvec![Value::vector_value(events)])
 }
 
 #[cfg(feature = "testing")]
@@ -187,7 +187,7 @@ fn native_emitted_events(
             })
         })
         .collect::<SafeNativeResult<Vec<Value>>>()?;
-    Ok(smallvec![Value::vector_for_testing_only(events)])
+    Ok(smallvec![Value::vector_value(events)])
 }
 
 #[inline]

--- a/third_party/move/move-stdlib/src/natives/unit_test.rs
+++ b/third_party/move/move-stdlib/src/natives/unit_test.rs
@@ -44,7 +44,7 @@ fn native_create_signers_for_testing(
     debug_assert!(args.len() == 1);
 
     let num_signers = pop_arg!(args, u64);
-    let signers = Value::vector_for_testing_only(
+    let signers = Value::vector_value(
         (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 

--- a/third_party/move/move-vm/types/src/value_traversal.rs
+++ b/third_party/move/move-vm/types/src/value_traversal.rs
@@ -108,7 +108,7 @@ mod test {
         let x = Value::delayed_value(DelayedFieldID::from(1));
         let y = Value::delayed_value(DelayedFieldID::from(2));
         let z = Value::delayed_value(DelayedFieldID::from(3));
-        let d = Value::vector_for_testing_only(vec![x, y, z]);
+        let d = Value::vector_value(vec![x, y, z]);
 
         let e = Value::struct_(Struct::pack(vec![c, d]));
 

--- a/third_party/move/move-vm/types/src/values/value_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Value::vector_value([]),
+        Value::vector_value([Value::u8(0), Value::u8(1)]),
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -1251,8 +1251,7 @@ impl Value {
         ))))
     }
 
-    // REVIEW: This API can break
-    pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
+    pub fn vector_value(it: impl IntoIterator<Item = Value>) -> Self {
         Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
             it.into_iter().map(|v| v.0).collect(),
         )))))


### PR DESCRIPTION
## Description

The generic constructor called `vector_for_testing_only` was marked as "testing_only." This commit enables it by removing the "testing_only" suffix.
