### PR TITLE
[compiler-v2] Add test_smart_data_structures_gas back to test Compiler v2

### DIFF
--- a/.github/actions/move-tests-compiler-v2/action.yaml
+++ b/.github/actions/move-tests-compiler-v2/action.yaml
@@ -23,7 +23,7 @@ runs:
 
     # Run Aptos Move tests with compiler V2
     - name: Run Aptos Move tests with compiler V2
-      run: cargo nextest run --release -E 'not (test(test_smart_data_structures_gas))' --profile ci --locked -p e2e-move-tests -p aptos-framework --retries 3 --no-fail-fast
+      run: cargo nextest run --release --profile ci --locked -p e2e-move-tests -p aptos-framework --retries 3 --no-fail-fast
       shell: bash
       env:
         MOVE_COMPILER_V2: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR brings back the test `test_smart_data_structures_gas` for testing the compiler V2. 

