### PR TITLE
[dependencies] update jemalloc to tikv-jemalloc for better compatilibity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.12.1",
- "jemallocator",
  "maplit",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -320,6 +319,7 @@ dependencies = [
  "shadow-rs",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.7.8",
  "tonic 0.11.0",
@@ -679,12 +679,12 @@ dependencies = [
  "criterion",
  "dashmap",
  "itertools 0.12.1",
- "jemallocator",
  "move-core-types",
  "once_cell",
  "rand 0.7.3",
  "rayon",
  "serde",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1417,7 +1417,6 @@ dependencies = [
  "derivative",
  "indicatif 0.15.0",
  "itertools 0.12.1",
- "jemallocator",
  "move-core-types",
  "num_cpus",
  "once_cell",
@@ -1425,6 +1424,7 @@ dependencies = [
  "rayon",
  "serde",
  "thread_local",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.7.8",
 ]
@@ -1706,12 +1706,12 @@ dependencies = [
  "chrono",
  "clap 4.4.14",
  "futures",
- "jemallocator",
  "once_cell",
  "rand 0.7.3",
  "random_word",
  "reqwest",
  "serde_yaml 0.8.26",
+ "tikv-jemallocator",
  "tokio",
  "url",
 ]
@@ -1969,13 +1969,13 @@ dependencies = [
  "clap 4.4.14",
  "futures",
  "futures-core",
- "jemallocator",
  "once_cell",
  "prost 0.12.3",
  "redis",
  "reqwest",
  "serde",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tonic 0.11.0",
  "tracing",
@@ -1995,12 +1995,12 @@ dependencies = [
  "async-trait",
  "clap 4.4.14",
  "futures",
- "jemallocator",
  "once_cell",
  "prost 0.12.3",
  "redis",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -2021,10 +2021,10 @@ dependencies = [
  "async-trait",
  "clap 4.4.14",
  "futures",
- "jemallocator",
  "once_cell",
  "redis",
  "serde",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -2093,11 +2093,11 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-protos 1.3.0",
  "futures",
- "jemallocator",
  "lazy_static",
  "once_cell",
  "redis",
  "redis-test",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -2990,7 +2990,6 @@ dependencies = [
  "fail",
  "futures",
  "hex",
- "jemallocator",
  "num_cpus",
  "rand 0.7.3",
  "rayon",
@@ -2998,6 +2997,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "tikv-jemallocator",
  "tokio",
  "url",
 ]
@@ -3179,10 +3179,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "jemalloc-sys",
- "jemallocator",
  "pprof",
  "regex",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -3487,12 +3487,12 @@ dependencies = [
  "bitvec 1.0.1",
  "criterion",
  "itertools 0.12.1",
- "jemallocator",
  "once_cell",
  "proptest",
  "rand 0.7.3",
  "rayon",
  "thiserror",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -9430,26 +9430,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"
@@ -15404,6 +15384,26 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -605,11 +605,11 @@ inferno = "0.11.14"
 internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.12"
-jemallocator = { version = "0.5.0", features = [
+jemallocator = { package = "tikv-jemallocator", version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc-sys = "0.5.4"
+jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.5.4" }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"


### PR DESCRIPTION
## Description
List dependencies that are required for this change:
```
jemallocator = { package = "tikv-jemallocator", version = "0.5.0", features = [
    "profiling",
    "unprefixed_malloc_on_supported_platforms",
] }
jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.5.4" }
```

Jemalloc is currently being maintained by [tikv](https://github.com/tikv/jemallocator) and distributed under two names: `jemallloc` and `tikv-jemalloc`, **both do the same thing**. It's recommended to use tikv-xxx versions for better compatibility. 
I am trying to use Aptos as the settlement layer and data availability layer for [Madara Starknet stack](https://github.com/keep-starknet-strange/madara) and have conflict between 2 version of jemalloc.

```
Updating git repository `https://github.com/aptos-labs/aptos-core`
    Updating crates.io index
error: failed to select a version for `jemalloc-sys`.
    ... required by package `jemallocator v0.5.0`
    ... which satisfies dependency `jemallocator = "^0.5.0"` of package `aptos-block-partitioner v0.1.0 (https://github.com/aptos-labs/aptos-core#a270a1be)`
    ... which satisfies git dependency `aptos-block-partitioner` of package `aptos-vm v0.1.0 (https://github.com/aptos-labs/aptos-core#a270a1be)`
    ... which satisfies git dependency `aptos-vm` of package `aptos-api-types v0.0.1 (https://github.com/aptos-labs/aptos-core#a270a1be)`
    ... which satisfies git dependency `aptos-api-types` of package `aptos-sdk v0.0.3 (https://github.com/aptos-labs/aptos-core#a270a1be)`
    ... which satisfies git dependency `aptos-sdk` of package `mc-settlement v0.1.0 (/home/administrator/madara/crates/client/settlement)`
    ... which satisfies path dependency `mc-settlement` (locked to 0.1.0) of package `madara v0.7.0 (/home/administrator/madara/crates/node)`
versions that meet the requirements `^0.5.0` are: 0.5.4+5.3.0-patched, 0.5.3+5.3.0-patched, 0.5.2+5.3.0-patched, 0.5.1+5.3.0-patched, 0.5.0+5.3.0

the package `jemalloc-sys` links to the native library `jemalloc`, but it conflicts with a previous package which links to `jemalloc` as well:
package `tikv-jemalloc-sys v0.5.4+5.3.0-patched`
    ... which satisfies dependency `tikv-jemalloc-sys = "^0.5"` (locked to 0.5.4+5.3.0-patched) of package `librocksdb-sys v0.11.0+8.1.1`
    ... which satisfies dependency `librocksdb-sys = "^0.11.0"` (locked to 0.11.0+8.1.1) of package `rocksdb v0.21.0`
    ... which satisfies dependency `rocksdb = "^0.21"` (locked to 0.21.0) of package `kvdb-rocksdb v0.19.0`
    ... which satisfies dependency `kvdb-rocksdb = "^0.19.0"` (locked to 0.19.0) of package `mc-db v0.7.0 (/home/administrator/madara/crates/client/db)`
    ... which satisfies path dependency `mc-db` (locked to 0.7.0) of package `madara v0.7.0 (/home/administrator/madara/crates/node)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "jemalloc"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `jemalloc-sys` which could resolve this conflict
```

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
