### PR TITLE
always send json formatted logs to the telemetry service

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -23,8 +23,8 @@ use once_cell::sync::Lazy;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     collections::BTreeMap,
-    env, fmt,
-    fmt::Debug,
+    env,
+    fmt::{self, Debug},
     io::{Stdout, Write},
     ops::{Deref, DerefMut},
     str::FromStr,
@@ -626,7 +626,7 @@ impl LoggerService {
                             .telemetry_filter
                             .enabled(&entry.metadata)
                         {
-                            let s = (self.facade.formatter)(&entry).expect("Unable to format");
+                            let s = json_format(&entry).expect("Unable to format");
                             let _ = writer.write(s);
                         }
                     }
@@ -802,15 +802,17 @@ impl LoggerFilterUpdater {
 
 #[cfg(test)]
 mod tests {
-    use super::{AptosData, LogEntry};
+    use super::{text_format, AptosData, LogEntry};
     use crate::{
         aptos_logger::{json_format, TruncatedLogString, RUST_LOG_TELEMETRY},
         debug, error, info,
         logger::Logger,
+        telemetry_log_writer::TelemetryLog,
         trace, warn, AptosDataBuilder, Event, Key, KeyValue, Level, LoggerFilterUpdater, Metadata,
-        Schema, Value, Visitor,
+        Schema, Value, Visitor, Writer,
     };
     use chrono::{DateTime, Utc};
+    use futures::StreamExt;
     #[cfg(test)]
     use pretty_assertions::assert_eq;
     use serde_json::Value as JsonValue;
@@ -818,10 +820,34 @@ mod tests {
         env,
         sync::{
             mpsc::{self, Receiver, SyncSender},
-            Arc,
+            Arc, Mutex,
         },
         thread,
+        time::Duration,
     };
+    use tokio::time;
+
+    pub struct MockWriter {
+        pub logs: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Writer for MockWriter {
+        fn write(&self, log: String) {
+            let mut logs = self.logs.lock().unwrap();
+            logs.push(log);
+        }
+
+        fn write_buferred(&mut self, log: String) {
+            self.write(log);
+        }
+    }
+
+    impl MockWriter {
+        pub fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+            let logs = Arc::new(Mutex::new(Vec::new()));
+            (Self { logs: logs.clone() }, logs)
+        }
+    }
 
     #[derive(serde::Serialize)]
     #[serde(rename_all = "snake_case")]
@@ -1033,6 +1059,60 @@ mod tests {
             .is_async(true)
             .build_logger();
         (logger_builder, logger)
+    }
+
+    fn new_text_logger() -> (
+        Arc<AptosData>,
+        Arc<Mutex<Vec<String>>>,
+        futures::channel::mpsc::Receiver<TelemetryLog>,
+    ) {
+        let (tx, rx) = futures::channel::mpsc::channel(100);
+        let (mock_writer, logs) = MockWriter::new();
+
+        let logger = AptosDataBuilder::new()
+            .level(Level::Debug)
+            .telemetry_level(Level::Debug)
+            .remote_log_tx(tx)
+            .custom_format(text_format)
+            .printer(Box::new(mock_writer))
+            .is_async(true)
+            .build_logger();
+
+        (logger, logs, rx)
+    }
+
+    #[tokio::test]
+    async fn telemetry_logs_always_json_formatted() {
+        let (logger, local_logs, mut rx) = new_text_logger();
+
+        let metadata = Metadata::new(
+            Level::Info,
+            env!("CARGO_CRATE_NAME"),
+            module_path!(),
+            concat!(file!(), ':', line!()),
+        );
+
+        let event = &Event::new(&metadata, Some(format_args!("This is a log message")), &[]);
+        logger.record(event);
+        logger.flush();
+
+        {
+            let local_logs = local_logs.lock().unwrap();
+            assert!(serde_json::from_str::<JsonValue>(&local_logs[0]).is_err());
+        }
+
+        let timeout_duration = Duration::from_secs(5);
+        if let Ok(Some(TelemetryLog::Log(telemetry_log))) =
+            time::timeout(timeout_duration, rx.next()).await
+        {
+            assert!(
+                serde_json::from_str::<JsonValue>(&telemetry_log).is_ok(),
+                "Telemetry logs not in JSON format: {}",
+                telemetry_log
+            );
+        } else {
+            panic!("Timed out waiting for telemetry log");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Change logger to always send json formatted logs to the telemetry service

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
`cargo test`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
