### PR TITLE
[move][vm] Use a single type builder to construct runtime types 

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1510,7 +1510,7 @@ impl Frame {
                 let constant = resolver.constant_at(*i);
                 interpreter
                     .operand_stack
-                    .push_ty(Type::from_const_signature(&constant.type_)?)?;
+                    .push_ty(TypeBuilder::create_constant_ty(&constant.type_)?)?;
             },
             Bytecode::CopyLoc(idx) => {
                 let ty = local_tys[*idx as usize].clone();

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -6,7 +6,7 @@ use super::StructNameCache;
 use crate::{
     loader::{
         function::{Function, FunctionHandle, FunctionInstantiation},
-        type_loader::intern_type,
+        type_loader::create_ty_from_sig_token,
         BinaryCache,
     },
     native_functions::NativeFunctions,
@@ -319,7 +319,11 @@ impl Module {
                         .0
                         .iter()
                         .map(|sig| {
-                            intern_type(BinaryIndexedView::Module(&module), sig, &struct_idxs)
+                            create_ty_from_sig_token(
+                                BinaryIndexedView::Module(&module),
+                                sig,
+                                &struct_idxs,
+                            )
                         })
                         .collect::<PartialVMResult<Vec<_>>>()?,
                 )
@@ -388,7 +392,7 @@ impl Module {
                                     };
                                     single_signature_token_map.insert(
                                         *si,
-                                        intern_type(
+                                        create_ty_from_sig_token(
                                             BinaryIndexedView::Module(&module),
                                             ty,
                                             &struct_idxs,
@@ -500,7 +504,7 @@ impl Module {
 
         let mut field_tys = vec![];
         for field in fields {
-            let ty = intern_type(
+            let ty = create_ty_from_sig_token(
                 BinaryIndexedView::Module(module),
                 &field.signature.0,
                 struct_name_table,

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation,
+    create_ty_from_sig_token, BinaryCache, Function, FunctionHandle, FunctionInstantiation,
     ModuleStorageAdapter, Scope, ScriptHash, StructNameCache,
 };
 use move_binary_format::{
@@ -89,7 +89,7 @@ impl Script {
             let mut instantiation = vec![];
             for ty in &script.signature_at(func_inst.type_parameters).0 {
                 instantiation.push(
-                    intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
+                    create_ty_from_sig_token(BinaryIndexedView::Script(&script), ty, &struct_names)
                         .map_err(|e| e.finish(Location::Script))?,
                 );
             }
@@ -107,7 +107,9 @@ impl Script {
         let parameter_tys = parameters
             .0
             .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .map(|tok| {
+                create_ty_from_sig_token(BinaryIndexedView::Script(&script), tok, &struct_names)
+            })
             .collect::<PartialVMResult<Vec<_>>>()
             .map_err(|err| err.finish(Location::Undefined))?;
         let locals = Signature(
@@ -121,14 +123,18 @@ impl Script {
         let local_tys = locals
             .0
             .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .map(|tok| {
+                create_ty_from_sig_token(BinaryIndexedView::Script(&script), tok, &struct_names)
+            })
             .collect::<PartialVMResult<Vec<_>>>()
             .map_err(|err| err.finish(Location::Undefined))?;
         let return_ = Signature(vec![]);
         let return_tys = return_
             .0
             .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .map(|tok| {
+                create_ty_from_sig_token(BinaryIndexedView::Script(&script), tok, &struct_names)
+            })
             .collect::<PartialVMResult<Vec<_>>>()
             .map_err(|err| err.finish(Location::Undefined))?;
         let type_parameters = script.type_parameters.clone();
@@ -179,8 +185,12 @@ impl Script {
                         };
                         single_signature_token_map.insert(
                             *si,
-                            intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
-                                .map_err(|e| e.finish(Location::Script))?,
+                            create_ty_from_sig_token(
+                                BinaryIndexedView::Script(&script),
+                                ty,
+                                &struct_names,
+                            )
+                            .map_err(|e| e.finish(Location::Script))?,
                         );
                     }
                 },

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_access_specifiers_prop_tests.rs
@@ -5,7 +5,7 @@ use crate::loaded_data::{
     runtime_access_specifier::{
         AccessInstance, AccessSpecifier, AccessSpecifierClause, AddressSpecifier, ResourceSpecifier,
     },
-    runtime_types::{StructIdentifier, Type},
+    runtime_types::{StructIdentifier, Type, TypeBuilder},
 };
 use move_binary_format::file_format::AccessKind;
 use move_core_types::{
@@ -118,8 +118,11 @@ fn address_specifier_strategy() -> impl Strategy<Value = AddressSpecifier> {
 fn type_args_strategy() -> impl Strategy<Value = Vec<Type>> {
     prop_oneof![
         Just(vec![]),
-        Just(vec![Type::U8]),
-        Just(vec![Type::U16, Type::U32])
+        Just(vec![TypeBuilder::create_u8_ty()]),
+        Just(vec![
+            TypeBuilder::create_u16_ty(),
+            TypeBuilder::create_u32_ty()
+        ])
     ]
 }
 

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -638,6 +638,10 @@ impl TypeBuilder {
         Ok(Type::MutableReference(Box::new(ty)))
     }
 
+    pub fn create_signer_reference_ty() -> PartialVMResult<Type> {
+        Self::create_reference_ty(Self::create_signer_ty())
+    }
+
     pub fn create_constant_ty(constant_tok: &SignatureToken) -> PartialVMResult<Type> {
         use SignatureToken::*;
 

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -624,6 +624,78 @@ impl fmt::Display for Type {
     }
 }
 
+pub struct TypeBuilder;
+
+impl TypeBuilder {
+    pub fn create_u8_ty() -> Type {
+        Type::U8
+    }
+
+    pub fn create_u16_ty() -> Type {
+        Type::U16
+    }
+
+    pub fn create_u32_ty() -> Type {
+        Type::U32
+    }
+
+    pub fn create_u64_ty() -> Type {
+        Type::U64
+    }
+
+    pub fn create_u128_ty() -> Type {
+        Type::U128
+    }
+
+    pub fn create_u256_ty() -> Type {
+        Type::U256
+    }
+
+    pub fn create_bool_ty() -> Type {
+        Type::Bool
+    }
+
+    pub fn create_address_ty() -> Type {
+        Type::Address
+    }
+
+    pub fn create_signer_ty() -> Type {
+        Type::Signer
+    }
+
+    pub fn create_struct_ty(idx: StructNameIndex, ability: AbilityInfo) -> Type {
+        Type::Struct { idx, ability }
+    }
+
+    // TODO: The signature of these functions return a result because it is not
+    //       always possible to construct a nested type - the type can be too deep
+    //       or too large. Shift the checks from runtime to construction time.
+
+    pub fn create_struct_instantiation_ty(
+        idx: StructNameIndex,
+        ability: AbilityInfo,
+        ty_args: Vec<Type>,
+    ) -> PartialVMResult<Type> {
+        Ok(Type::StructInstantiation {
+            idx,
+            ty_args: TriompheArc::new(ty_args),
+            ability,
+        })
+    }
+
+    pub fn create_vector_ty(elem_ty: Type) -> PartialVMResult<Type> {
+        Ok(Type::Vector(TriompheArc::new(elem_ty)))
+    }
+
+    pub fn create_reference_ty(ty: Type) -> PartialVMResult<Type> {
+        Ok(Type::Reference(Box::new(ty)))
+    }
+
+    pub fn create_mut_reference_ty(ty: Type) -> PartialVMResult<Type> {
+        Ok(Type::MutableReference(Box::new(ty)))
+    }
+}
+
 #[cfg(test)]
 mod unit_tests {
     use super::*;

--- a/third_party/move/move-vm/types/src/natives/function.rs
+++ b/third_party/move/move-vm/types/src/natives/function.rs
@@ -13,7 +13,7 @@
 //! ) -> PartialVMResult<NativeResult>;`
 //!
 //! arguments are passed with first argument at position 0 and so forth.
-//! Popping values from `arguments` gives the aguments in reverse order (last first).
+//! Popping values from `arguments` gives the arguments in reverse order (last first).
 //! This module contains the declarations and utilities to implement a native
 //! function.
 
@@ -56,7 +56,7 @@ impl NativeResult {
 
     /// Failed execution. The failure is a runtime failure in the function and not an invariant
     /// failure of the VM which would raise a `PartialVMError` error directly.
-    /// The only thing the funciton can specify is its abort code, as if it had invoked the `Abort`
+    /// The only thing the function can specify is its abort code, as if it had invoked the `Abort`
     /// bytecode instruction
     pub fn err(cost: InternalGas, abort_code: u64) -> Self {
         NativeResult::Abort { cost, abort_code }

--- a/third_party/move/move-vm/types/src/values/value_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{loaded_data::runtime_types::Type, values::*, views::*};
+use crate::{loaded_data::runtime_types::TypeBuilder, values::*, views::*};
 use move_binary_format::errors::*;
 use move_core_types::{account_address::AccountAddress, u256::U256};
 
@@ -151,7 +151,7 @@ fn legacy_ref_abstract_memory_size_consistency() -> PartialVMResult<()> {
     assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
 
     let r: VectorRef = r.value_as()?;
-    let r = r.borrow_elem(0, &Type::U8)?;
+    let r = r.borrow_elem(0, &TypeBuilder::create_u8_ty())?;
     assert_eq!(r.legacy_abstract_memory_size(), r.legacy_size());
 
     locals.store_loc(2, Value::struct_(Struct::pack([])), false)?;

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -2330,7 +2330,7 @@ impl Vector {
     }
 
     pub fn to_vec_u8(self) -> PartialVMResult<Vec<u8>> {
-        check_elem_layout(&Type::U8, &self.0)?;
+        check_elem_layout(&TypeBuilder::create_u8_ty(), &self.0)?;
         if let Container::VecU8(r) = self.0 {
             Ok(take_unique_ownership(r)?.into_iter().collect())
         } else {
@@ -3820,7 +3820,9 @@ pub mod prop {
     }
 }
 
-use crate::delayed_values::delayed_field_id::DelayedFieldID;
+use crate::{
+    delayed_values::delayed_field_id::DelayedFieldID, loaded_data::runtime_types::TypeBuilder,
+};
 use move_core_types::value::{MoveStruct, MoveValue};
 
 impl ValueImpl {


### PR DESCRIPTION
## Description

This PR introduces `TypeBuilder` which is to be used for all `Type`s construction. The rationale to have a builder class is to ensure proper encapsulation: only builder instance can create new types, and not loader, interpreter, etc. This allows to move all type bounds to a single common place.

Note: this is a first, purely refactoring change, and more logic can be moved into `TypeBuilder` to fix existing encapsulation issues.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Existing tests.

## Key Areas to Review

N/A.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
