### PR TITLE
Fix regexp for test file iteration to skip backup files

### DIFF
--- a/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
@@ -77,7 +77,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests/sources", r".*\.move");
+datatest_stable::harness!(test_runner, "tests/sources", r".*\.move$");
 
 // ========================================================================================
 // Test execution

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -653,7 +653,7 @@ fn collect_tests(root: &str) -> Vec<Requirements> {
             // This will appear in the output of cargo test/nextest
             format!("compiler-v2[config={}]", config.name),
             root.to_string(),
-            files.into_iter().join("|"),
+            files.into_iter().map(|s| s + "$").join("|"),
         ));
     }
     reqs

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -110,7 +110,7 @@ fn main() {
                 c.runner,
                 format!("compiler-v2-txn[config={}]", c.name),
                 "tests".to_string(),
-                files.clone().into_iter().join("|"),
+                files.clone().into_iter().map(|s| s + "$").join("|"),
             )
         })
         .collect_vec();

--- a/third_party/move/move-model/bytecode/tests/testsuite.rs
+++ b/third_party/move/move-model/bytecode/tests/testsuite.rs
@@ -63,4 +63,4 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests", r".*\.move");
+datatest_stable::harness!(test_runner, "tests", r".*\.move$");

--- a/third_party/move/move-model/tests/testsuite.rs
+++ b/third_party/move/move-model/tests/testsuite.rs
@@ -45,4 +45,4 @@ fn runner(path: &Path) -> datatest_stable::Result<()> {
     }
 }
 
-datatest_stable::harness!(runner, "tests/sources", r".*\.move");
+datatest_stable::harness!(runner, "tests/sources", r".*\.move$");

--- a/third_party/move/move-prover/bytecode-pipeline/tests/testsuite.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/testsuite.rs
@@ -162,4 +162,4 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests", r".*\.move");
+datatest_stable::harness!(test_runner, "tests", r".*\.move$");

--- a/third_party/move/move-prover/move-abigen/tests/testsuite.rs
+++ b/third_party/move/move-prover/move-abigen/tests/testsuite.rs
@@ -80,4 +80,4 @@ fn test_abigen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Resul
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests/sources", r".*\.move",);
+datatest_stable::harness!(test_runner, "tests/sources", r".*\.move$",);

--- a/third_party/move/move-prover/move-docgen/tests/testsuite.rs
+++ b/third_party/move/move-prover/move-docgen/tests/testsuite.rs
@@ -103,4 +103,4 @@ fn test_docgen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Resul
     Ok(())
 }
 
-datatest_stable::harness!(test_runner, "tests/sources", r".*\.move|.*_template\.md",);
+datatest_stable::harness!(test_runner, "tests/sources", r".*\.move$|.*_template\.md$",);

--- a/third_party/move/move-prover/tests/testsuite.rs
+++ b/third_party/move/move-prover/tests/testsuite.rs
@@ -301,7 +301,7 @@ fn collect_enabled_tests(reqs: &mut Vec<Requirements>, group: &str, feature: &Fe
             feature.runner,
             format!("prover {}[{}]", group, feature.name),
             path.to_string(),
-            files.into_iter().join("|"),
+            files.into_iter().map(|s| s + "$").join("|"),
         ));
     }
 }


### PR DESCRIPTION
## Description

Fix #12657 by adding `$` to the end of regexps like `".*\.move"` trying to match test input files,
so that backup files such as `foo.move~` and `foo.move.bak`are not matched as well.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Run locally in messy environment with backup files.  Happy path will be tested in CI.

## Key Areas to Review
Not a lot of complexity here.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x]  I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
