### PR TITLE
add a test to show that ref_cell is cloned correctly

### DIFF
--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -182,3 +182,38 @@ fn compiler_exp_var() -> Vec<String> {
     });
     (*EXP_VAR).clone()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_options_ref_cell_clone() {
+        let test_key = "foo".to_owned();
+        let options1 = Options::default();
+
+        options1
+            .experiment_cache
+            .borrow_mut()
+            .insert(test_key.clone(), false);
+
+        let options2 = options1.clone();
+
+        options1
+            .experiment_cache
+            .borrow_mut()
+            .insert(test_key.clone(), true);
+
+        if let Some(on) = options1.experiment_cache.borrow().get(&test_key) {
+            assert!(on);
+        } else {
+            assert!(false);
+        }
+
+        if let Some(on) = options2.experiment_cache.borrow().get(&test_key) {
+            assert!(!on);
+        } else {
+            assert!(false);
+        };
+    }
+}

--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -204,16 +204,18 @@ mod tests {
             .borrow_mut()
             .insert(test_key.clone(), true);
 
-        if let Some(on) = options1.experiment_cache.borrow().get(&test_key) {
-            assert!(on);
-        } else {
-            assert!(false);
-        }
+        let x1 = *(options1
+            .experiment_cache
+            .borrow()
+            .get(&test_key)
+            .expect("we just set foo"));
+        assert!(x1);
 
-        if let Some(on) = options2.experiment_cache.borrow().get(&test_key) {
-            assert!(!on);
-        } else {
-            assert!(false);
-        };
+        let x2 = *(options2
+            .experiment_cache
+            .borrow()
+            .get(&test_key)
+            .expect("we just set foo"));
+        assert!(!x2);
     }
 }


### PR DESCRIPTION
## Description
Add a test case for `Options` to verify that the `RefCell` is cloned
correctly.  Since there is a lof of conflicting info on the web it
seemed worth double-checking.

This confirms that Issue #12655 was not a bug.  (Already closed).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Run locally.

## Key Areas to Review
Confirm that the test shows the map underlying the `experiment_cache`
is cloned when the `Options` object is cloned.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
