### PR TITLE
add --repeat-execution-times to aptos-debugger move command

### DIFF
--- a/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
+++ b/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
@@ -72,7 +72,7 @@ impl Command {
             println!("===============================");
             println!(
                 "{:#?}",
-                debugger.execute_past_transactions(version, 1).await?
+                debugger.execute_past_transactions(version, 1, 1).await?
             );
         }
 

--- a/aptos-move/aptos-debugger/src/execute_past_transactions.rs
+++ b/aptos-move/aptos-debugger/src/execute_past_transactions.rs
@@ -21,6 +21,9 @@ pub struct Command {
 
     #[clap(long)]
     skip_result: bool,
+
+    #[clap(long)]
+    repeat_execution_times: Option<u64>,
 }
 
 impl Command {
@@ -36,7 +39,11 @@ impl Command {
         };
 
         let result = debugger
-            .execute_past_transactions(self.begin_version, self.limit)
+            .execute_past_transactions(
+                self.begin_version,
+                self.limit,
+                self.repeat_execution_times.unwrap_or(1),
+            )
             .await?;
 
         if !self.skip_result {

--- a/aptos-move/aptos-debugger/src/execute_pending_block.rs
+++ b/aptos-move/aptos-debugger/src/execute_pending_block.rs
@@ -35,6 +35,9 @@ pub struct Command {
 
     #[clap(long)]
     add_system_txns: bool,
+
+    #[clap(long)]
+    repeat_execution_times: Option<u64>,
 }
 
 impl Command {
@@ -84,7 +87,11 @@ impl Command {
             user_txns
         };
 
-        let txn_outputs = debugger.execute_transactions_at_version(self.begin_version, block)?;
+        let txn_outputs = debugger.execute_transactions_at_version(
+            self.begin_version,
+            block,
+            self.repeat_execution_times.unwrap_or(1),
+        )?;
         println!("{txn_outputs:#?}");
 
         Ok(())

--- a/testsuite/smoke-test/src/aptos/mint_transfer.rs
+++ b/testsuite/smoke-test/src/aptos/mint_transfer.rs
@@ -81,7 +81,7 @@ async fn test_mint_transfer() {
         .unwrap();
 
     let output = debugger
-        .execute_past_transactions(txn_ver, 1)
+        .execute_past_transactions(txn_ver, 1, 1)
         .await
         .unwrap()
         .pop()


### PR DESCRIPTION
When there are infrequent race conditions, it is useful to re-execute same block multiple times

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine]


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
