### PR TITLE
[smt] remove BranchTracker

### DIFF
--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -101,7 +101,7 @@ use aptos_types::{
 };
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::{Arc, MutexGuard, Weak},
+    sync::Arc,
 };
 use thiserror::Error;
 
@@ -109,76 +109,16 @@ type NodePosition = bitvec::vec::BitVec<u8, bitvec::order::Msb0>;
 const BITS_IN_NIBBLE: usize = 4;
 const BITS_IN_BYTE: usize = 8;
 
-/// To help finding the oldest ancestor of any SMT, a branch tracker is created each time
-/// the chain of SMTs forked (two or more SMTs updating the same parent).
-#[derive(Debug)]
-struct BranchTracker<V: Send + Sync + 'static> {
-    /// Current branch head, n.b. when the head just started dropping, this weak link becomes
-    /// invalid, we fall back to the `next`
-    head: Weak<Inner<V>>,
-    /// Dealing with the edge case where the branch head just started dropping, but the branch
-    /// tracker hasn't been locked and updated yet.
-    next: Weak<Inner<V>>,
-    /// Parent branch, if any.
-    parent: Option<Arc<Mutex<BranchTracker<V>>>>,
-}
-
-impl<V: Send + Sync + 'static> BranchTracker<V> {
-    fn new_head_unknown(
-        parent: Option<Arc<Mutex<Self>>>,
-        _locked_family: &MutexGuard<()>,
-    ) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Self {
-            head: Weak::new(),
-            next: Weak::new(),
-            parent,
-        }))
-    }
-
-    fn set_head(
-        &mut self,
-        head: &Arc<Inner<V>>,
-        next: Option<&Arc<Inner<V>>>,
-        _locked_family: &MutexGuard<()>,
-    ) {
-        // Detach from parent
-        // n.b. the parent branch might not be dropped after this, because whenever a fork
-        //      happens, the first branch shares the parent branch tracker.
-        self.parent = None;
-
-        self.head = Arc::downgrade(head);
-        self.next = next.map_or_else(Weak::new, Arc::downgrade)
-    }
-
-    #[allow(dead_code)]
-    fn parent(&self, _locked_family: &MutexGuard<()>) -> Option<Arc<Mutex<Self>>> {
-        self.parent.clone()
-    }
-
-    #[allow(dead_code)]
-    fn head(&self, _locked_family: &MutexGuard<()>) -> Option<Arc<Inner<V>>> {
-        // if `head.upgrade()` failed, it's that the head is being dropped.
-        //
-        // Notice the starting of the drop a SMT is not protected by the family lock -- but
-        // change of the links between the branch trackers and SMTs are always protected by the
-        // family lock.
-        // see `impl<V: Send + Sync + 'static> Drop for Inner<V>`
-        self.head.upgrade().or_else(|| self.next.upgrade())
-    }
-}
-
 /// Keeps track of references of children and the branch tracker of the current branch.
 #[derive(Debug)]
 struct InnerLinks<V: Send + Sync + 'static> {
     children: Vec<Arc<Inner<V>>>,
-    branch_tracker: Arc<Mutex<BranchTracker<V>>>,
 }
 
 impl<V: Send + Sync + 'static> InnerLinks<V> {
-    fn new(branch_tracker: Arc<Mutex<BranchTracker<V>>>) -> Mutex<Self> {
+    fn new() -> Mutex<Self> {
         Mutex::new(Self {
             children: Vec::new(),
-            branch_tracker,
         })
     }
 }
@@ -192,7 +132,6 @@ struct Inner<V: Send + Sync + 'static> {
     links: Mutex<InnerLinks<V>>,
     family: HashValue,
     generation: u64,
-    family_lock: Arc<Mutex<()>>,
 }
 
 impl<V: Send + Sync + 'static> Drop for Inner<V> {
@@ -204,9 +143,7 @@ impl<V: Send + Sync + 'static> Drop for Inner<V> {
         let mut processed_descendants = Vec::new();
 
         {
-            let locked_family = self.family_lock.lock();
-
-            let mut stack = self.drain_children_for_drop(&locked_family);
+            let mut stack = self.drain_children_for_drop();
 
             while let Some(descendant) = stack.pop() {
                 if Arc::strong_count(&descendant) == 1 {
@@ -217,7 +154,7 @@ impl<V: Send + Sync + 'static> Drop for Inner<V> {
                     // of such structures being dropped recursively and that might trigger a stack
                     // overflow. To prevent that we follow the chain further to disconnect things
                     // beforehand.
-                    stack.extend(descendant.drain_children_for_drop(&locked_family));
+                    stack.extend(descendant.drain_children_for_drop());
                     // Note: After the above call, there is not even weak refs to `descendant`
                     // because all relevant `BranchTrackers` now point their heads to one of the
                     // children.
@@ -240,17 +177,13 @@ impl<V: Send + Sync + 'static> Drop for Inner<V> {
 impl<V: Send + Sync + 'static> Inner<V> {
     fn new(root: SubTree<V>, usage: StateStorageUsage) -> Arc<Self> {
         let family = HashValue::random();
-        let family_lock = Arc::new(Mutex::new(()));
-        let branch_tracker = BranchTracker::new_head_unknown(None, &family_lock.lock());
         let me = Arc::new(Self {
             root: Some(root),
             usage,
-            links: InnerLinks::new(branch_tracker.clone()),
+            links: InnerLinks::new(),
             family,
             generation: 0,
-            family_lock,
         });
-        branch_tracker.lock().head = Arc::downgrade(&me);
 
         me
     }
@@ -260,33 +193,13 @@ impl<V: Send + Sync + 'static> Inner<V> {
         self.root.as_ref().expect("Root must exist.")
     }
 
-    fn become_oldest(self: Arc<Self>, locked_family: &MutexGuard<()>) -> Arc<Self> {
-        {
-            let links_locked = self.links.lock();
-            let mut branch_tracker_locked = links_locked.branch_tracker.lock();
-            branch_tracker_locked.set_head(
-                &self,                         /* head */
-                links_locked.children.first(), /* next */
-                locked_family,
-            );
-        }
-        self
-    }
-
-    fn spawn_impl(
-        &self,
-        child_root: SubTree<V>,
-        child_usage: StateStorageUsage,
-        branch_tracker: Arc<Mutex<BranchTracker<V>>>,
-        family_lock: Arc<Mutex<()>>,
-    ) -> Arc<Self> {
+    fn spawn_impl(&self, child_root: SubTree<V>, child_usage: StateStorageUsage) -> Arc<Self> {
         Arc::new(Self {
             root: Some(child_root),
             usage: child_usage,
-            links: InnerLinks::new(branch_tracker),
+            links: InnerLinks::new(),
             family: self.family,
             generation: self.generation + 1,
-            family_lock,
         })
     }
 
@@ -295,77 +208,16 @@ impl<V: Send + Sync + 'static> Inner<V> {
         child_root: SubTree<V>,
         child_usage: StateStorageUsage,
     ) -> Arc<Self> {
-        let locked_family = self.family_lock.lock();
         let mut links_locked = self.links.lock();
 
-        let child = if links_locked.children.is_empty() {
-            let child = self.spawn_impl(
-                child_root,
-                child_usage,
-                links_locked.branch_tracker.clone(),
-                self.family_lock.clone(),
-            );
-            let mut branch_tracker_locked = links_locked.branch_tracker.lock();
-            if branch_tracker_locked.next.upgrade().is_none() {
-                branch_tracker_locked.next = Arc::downgrade(&child);
-            }
-            child
-        } else {
-            // forking a new branch
-            let branch_tracker = BranchTracker::new_head_unknown(
-                Some(links_locked.branch_tracker.clone()),
-                &locked_family,
-            );
-            let child = self.spawn_impl(
-                child_root,
-                child_usage,
-                branch_tracker.clone(),
-                self.family_lock.clone(),
-            );
-            branch_tracker.lock().head = Arc::downgrade(&child);
-            child
-        };
+        let child = self.spawn_impl(child_root, child_usage);
         links_locked.children.push(child.clone());
 
         child
     }
 
-    #[allow(dead_code)]
-    fn get_oldest_ancestor(self: &Arc<Self>) -> Arc<Self> {
-        // Under the protection of family_lock, the branching structure won't change,
-        // so we can follow the links and find the head of the oldest branch tracker.
-        let locked_family = self.family_lock.lock();
-        let (mut ret, mut parent) = {
-            let branch_tracker = self.links.lock().branch_tracker.clone();
-            let branch_tracker_locked = branch_tracker.lock();
-            (
-                branch_tracker_locked
-                    .head(&locked_family)
-                    .expect("Leaf must have a head."),
-                branch_tracker_locked.parent(&locked_family),
-            )
-        };
-
-        while let Some(parent_bt) = parent {
-            let parent_bt_locked = parent_bt.lock();
-            if let Some(parent_bt_head) = parent_bt_locked.head(&locked_family) {
-                ret = parent_bt_head;
-                parent = parent_bt_locked.parent(&locked_family);
-                continue;
-            }
-            break;
-        }
-
-        ret
-    }
-
-    fn drain_children_for_drop(&self, locked_family: &MutexGuard<()>) -> Vec<Arc<Self>> {
-        self.links
-            .lock()
-            .children
-            .drain(..)
-            .map(|child| child.become_oldest(locked_family))
-            .collect()
+    fn drain_children_for_drop(&self) -> Vec<Arc<Self>> {
+        self.links.lock().children.drain(..).collect()
     }
 
     fn log_generation(&self, name: &'static str) {
@@ -412,13 +264,6 @@ where
 
     pub fn has_same_root_hash(&self, other: &Self) -> bool {
         self.root_hash() == other.root_hash()
-    }
-
-    #[allow(dead_code)]
-    fn get_oldest_ancestor(&self) -> Self {
-        Self {
-            inner: self.inner.get_oldest_ancestor(),
-        }
     }
 
     pub fn freeze(&self, base_smt: &SparseMerkleTree<V>) -> FrozenSparseMerkleTree<V> {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The whole BranchTracker / family lock thing was designed so that we can
get_oldest_ancestor() on any SMT to get to the "root smt".

No longer needed since https://github.com/aptos-labs/aptos-core/pull/10665 where we let FrozenSmt hold the smt at the latest
persisted version via `SmtAncestors.get_youngest()`, instead of the absolutely oldest
in mem version, which can result in memory bloating because of now we
have more than one threads that holds ancestor smts. (see https://github.com/aptos-labs/aptos-core/pull/10665 for
details)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing unit tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

This should be straightforward refactor. See that all change were relevant to removal of already `allow(dead_code)` code.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [N/A] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
