### PR TITLE
tweak google jwk governance script for 1.10

### DIFF
--- a/aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
+++ b/aptos-move/aptos-release-builder/data/proposals/start_jwk_consensus_for_google.move
@@ -15,5 +15,6 @@ script {
             b"https://accounts.google.com",
             b"https://accounts.google.com/.well-known/openid-configuration"
         );
+        aptos_governance::reconfigure(&framework_signer);
     }
 }


### PR DESCRIPTION
... so JWK consensus starts immediately. Otherwise we would need to wait for 2 hours (until the next epoch).

Manually tested on testnet.