### PR TITLE
[delayed materialization] Fix propagating errors through

### DIFF
--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -557,7 +557,7 @@ mod test {
             &self,
             _delayed_write_set_keys: &HashSet<Self::Identifier>,
             _skip: &HashSet<Self::ResourceKey>,
-        ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+        ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
             unimplemented!("Irrelevant for the test")
         }
     }

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -203,7 +203,7 @@ pub trait TDelayedFieldView {
         &self,
         delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError>;
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>>;
 }
 
 pub trait DelayedFieldResolver:
@@ -275,7 +275,7 @@ where
         &self,
         _delayed_write_set_ids: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         unimplemented!("get_group_reads_needing_exchange not implemented")
     }
 }

--- a/aptos-move/aptos-aggregator/src/resolver.rs
+++ b/aptos-move/aptos-aggregator/src/resolver.rs
@@ -260,6 +260,12 @@ where
         unimplemented!()
     }
 
+    // get_reads_needing_exchange is local (looks at in-MVHashMap information only)
+    // and all failures are code invariant failures - so we return PanicError.
+    // get_group_reads_needing_exchange needs to additionally get the metadata of the
+    // whole group, which can additionally fail with speculative / storage errors,
+    // so we return PartialVMResult, to be able to distinguish/propagate those errors.
+
     fn get_reads_needing_exchange(
         &self,
         _delayed_write_set_ids: &HashSet<Self::Identifier>,

--- a/aptos-move/aptos-aggregator/src/tests/types.rs
+++ b/aptos-move/aptos-aggregator/src/tests/types.rs
@@ -148,7 +148,7 @@ impl TDelayedFieldView for FakeAggregatorView {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         unimplemented!();
     }
 }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -297,7 +297,7 @@ impl<'e, E: ExecutorView> TDelayedFieldView for StorageAdapter<'e, E> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         self.executor_view
             .get_group_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -107,7 +107,7 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         let aggregator_context: NativeAggregatorContext = extensions.remove();
         let aggregator_change_set = aggregator_context
             .into_change_set()
-            .map_err(|e| PartialVMError::from(e).finish(Location::Undefined))?;
+            .map_err(|e| e.finish(Location::Undefined))?;
 
         let event_context: NativeEventContext = extensions.remove();
         let events = event_context.into_events();

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
@@ -177,7 +177,7 @@ impl<'r> TDelayedFieldView for ExecutorViewWithChangeSet<'r> {
         &self,
         delayed_write_set_keys: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         self.base_executor_view
             .get_group_reads_needing_exchange(delayed_write_set_keys, skip)
     }

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -129,7 +129,7 @@ impl TDelayedFieldView for AptosBlankStorage {
         &self,
         _delayed_write_set_keys: &HashSet<Self::Identifier>,
         _skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         unimplemented!()
     }
 }

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1164,7 +1164,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
         parallel_state: &ParallelState<'a, T, X>,
         delayed_write_set_ids: &HashSet<T::Identifier>,
         skip: &HashSet<T::Key>,
-    ) -> Result<BTreeMap<T::Key, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<T::Key, (StateValueMetadata, u64)>> {
         let reads_with_delayed_fields = parallel_state
             .captured_reads
             .borrow()
@@ -1174,7 +1174,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
 
         reads_with_delayed_fields
             .into_iter()
-            .flat_map(|(key, group_read)| {
+            .map(|(key, group_read)| -> PartialVMResult<_> {
                 let GroupRead { inner_reads, .. } = group_read;
 
                 // TODO[agg_v2](clean-up): Once ids can be extracted without possible failure,
@@ -1182,47 +1182,44 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                 let mut resources_needing_delayed_field_exchange = false;
                 for data_read in inner_reads.values() {
                     if let DataRead::Versioned(_version, value, Some(layout)) = data_read {
-                        // TODO[agg_v2](optimize): Is it possible to avoid clones here?
-                        match does_value_need_exchange::<T>(
+                        let needs_exchange = does_value_need_exchange::<T>(
                             value,
                             layout.as_ref(),
                             delayed_write_set_ids,
-                        ) {
-                            Ok(needs_exchange) => {
-                                if needs_exchange {
-                                    resources_needing_delayed_field_exchange = true;
-                                    break;
-                                }
-                            },
-                            Err(e) => {
-                                return Some(Err(e));
-                            },
+                        )
+                        .map_err(PartialVMError::from)?;
+
+                        if needs_exchange {
+                            resources_needing_delayed_field_exchange = true;
+                            break;
                         }
                     }
                 }
                 if !resources_needing_delayed_field_exchange {
-                    return None;
+                    return Ok(None);
                 }
 
-                if let Ok(Some(metadata)) = self.get_resource_state_value_metadata(&key) {
-                    return Some(
-                        if let Ok(GroupReadResult::Size(group_size)) =
-                            parallel_state.read_group_size(&key, self.txn_idx)
-                        {
-                            Ok((key.clone(), (metadata, group_size.get())))
-                        } else {
+                match self.get_resource_state_value_metadata(&key)? {
+                    Some(metadata) => match parallel_state.read_group_size(&key, self.txn_idx)? {
+                        GroupReadResult::Size(group_size) => {
+                            Ok(Some((key, (metadata, group_size.get()))))
+                        },
+                        GroupReadResult::Value(_, _) | GroupReadResult::Uninitialized => {
                             Err(code_invariant_error(format!(
                                 "Cannot compute metadata op size for the group read {:?}",
                                 key
-                            )))
+                            ))
+                            .into())
                         },
-                    );
+                    },
+                    None => Err(code_invariant_error(format!(
+                        "Metadata op not present for the group read {:?}",
+                        key
+                    ))
+                    .into()),
                 }
-                Some(Err(code_invariant_error(format!(
-                    "Cannot compute metadata op for the group read {:?}",
-                    key
-                ))))
             })
+            .flat_map(Result::transpose)
             .collect()
     }
 
@@ -1267,27 +1264,42 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                     if !resources_needing_delayed_field_exchange {
                         return None;
                     }
-                    if let Ok(Some(metadata)) = self.get_resource_state_value_metadata(key) {
-                        if let Ok(GroupReadResult::Size(group_size)) =
-                            unsync_map.get_group_size(key)
-                        {
-                            return Some(Ok((key.clone(), (metadata, group_size.get()))));
-                        } else {
-                            // TODO[agg_v2](cleanup): `get_group_size` can fail on group tag serialization. Do
-                            //       we want to propagate this error? This is somewhat an invariant
-                            //       violation so PanicError is also ok?
-                            return Some(Err(code_invariant_error(format!(
-                                "Cannot compute metadata op size for the group read {:?}",
-                                key
-                            ))));
+                    match self.get_resource_state_value_metadata(key) {
+                        Ok(Some(metadata)) => {
+                            match unsync_map.get_group_size(key) {
+                                Ok(GroupReadResult::Size(group_size)) => {
+                                    Some(Ok((key.clone(), (metadata, group_size.get()))))
+                                },
+                                Ok(GroupReadResult::Value(_, _)) => {
+                                    unreachable!("get_group_size cannot return GroupReadResult::Value type")
+                                }
+                                Ok(GroupReadResult::Uninitialized) => {
+                                    Some(Err(code_invariant_error(format!(
+                                        "Sequential Cannot find metadata op size for the group read {:?}",
+                                        key
+                                    ))))
+                                },
+                                // TODO[agg_v2](cleanup): `get_group_size` can fail on group tag serialization. Do
+                                //       we want to propagate this error? This is somewhat an invariant
+                                //       violation so PanicError is also ok?
+                                Err(e) => Some(Err(code_invariant_error(format!(
+                                    "Sequential Cannot compute metadata op size for the group read {:?}, error: {:?}",
+                                    key, e
+                                ))))
+                            }
                         }
+                        Ok(None) => Some(Err(code_invariant_error(format!(
+                            "Sequential cannot find metadata op for the group read {:?}",
+                            key,
+                        )))),
+                        Err(e) => Some(Err(code_invariant_error(format!(
+                            "Sequential cannot compute metadata op for the group read {:?}, error: {:?}",
+                            key, e,
+                        ))))
                     }
-                    return Some(Err(code_invariant_error(format!(
-                        "Cannot compute metadata op for the group read {:?}",
-                        key
-                    ))));
+                } else {
+                    None
                 }
-                None
             })
             .collect()
     }
@@ -1352,10 +1364,11 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                 StatusCode::SPECULATIVE_EXECUTION_ABORT_ERROR,
             )
             .with_message(msg)),
-            ReadResult::Uninitialized => {
-                unreachable!("base value must already be recorded in the MV data structure")
-            },
-            _ => Ok(ret),
+            ReadResult::Uninitialized => Err(code_invariant_error(
+                "base value must already be recorded in the MV data structure",
+            )
+            .into()),
+            ReadResult::Exists(_) | ReadResult::Metadata(_) | ReadResult::Value(_, _) => Ok(ret),
         }
     }
 
@@ -1746,19 +1759,19 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TDelayedFie
         &self,
         delayed_write_set_ids: &HashSet<Self::Identifier>,
         skip: &HashSet<Self::ResourceKey>,
-    ) -> Result<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>, PanicError> {
+    ) -> PartialVMResult<BTreeMap<Self::ResourceKey, (StateValueMetadata, u64)>> {
         match &self.latest_view {
             ViewState::Sync(state) => {
                 self.get_group_reads_needing_exchange_parallel(state, delayed_write_set_ids, skip)
             },
             ViewState::Unsync(state) => {
                 let read_set = state.read_set.borrow();
-                self.get_group_reads_needing_exchange_sequential(
+                Ok(self.get_group_reads_needing_exchange_sequential(
                     &read_set.group_reads,
                     state.unsync_map,
                     delayed_write_set_ids,
                     skip,
-                )
+                )?)
             },
         }
     }

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -9,11 +9,9 @@ use aptos_aggregator::{
     delta_change_set::DeltaOp,
     resolver::{AggregatorV1Resolver, DelayedFieldResolver},
 };
-use aptos_types::{
-    delayed_fields::PanicError,
-    state_store::{state_key::StateKey, state_value::StateValueMetadata},
-};
+use aptos_types::state_store::{state_key::StateKey, state_value::StateValueMetadata};
 use better_any::{Tid, TidAble};
+use move_binary_format::errors::PartialVMResult;
 use move_core_types::value::MoveTypeLayout;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
@@ -79,7 +77,7 @@ impl<'a> NativeAggregatorContext<'a> {
 
     /// Returns all changes made within this context (i.e. by a single
     /// transaction).
-    pub fn into_change_set(self) -> Result<AggregatorChangeSet, PanicError> {
+    pub fn into_change_set(self) -> PartialVMResult<AggregatorChangeSet> {
         let NativeAggregatorContext {
             aggregator_v1_data,
             delayed_field_data,


### PR DESCRIPTION
## Description
When execution is halted (i.e. due to module publish or other reasons), get_resource_state_value_metadata will return speculative error.
We shouldn't transform that into a code panic - as it is not.

This is alternative implementation to the #12676

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
error propagation

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
