### PR TITLE
[Pre-commit] Fork pre-commit-hook dependency.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+# TODO: identify if we can move away from using pre-commit hooks for these checks.
+#
+# See also:
+#  - https://pre-commit.com for more information.
+#  - https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -12,8 +15,8 @@ repos:
         args:
           - --maxkb=2000
   # Once this issue is resolved, we can add the full license check: https://github.com/Lucas-C/pre-commit-hooks/issues/68
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+  - repo: https://github.com/aptos-labs/pre-commit-hooks
+    rev: a30f0d816e5062a67d87c8de753cfe499672b959 # Fix the revision to the v1.5.5 release commit. See: https://github.com/Lucas-C/pre-commit-hooks/releases/tag/v1.5.5
     hooks:
       - id: insert-license
         files: ^(?!third_party/).*\.rs$


### PR DESCRIPTION
## Description
This PR updates the pre-commit CI/CD checks to use the `aptos-labs` fork of `pre-commit-hooks`, here: https://github.com/aptos-labs/pre-commit-hooks. Until we can fully migrate away from using pre-commit checks, maintaining a fork seems safer 😄 

## Testing Plan
Manual verification and existing test infrastructure and CI/CD flows.