### PR TITLE
Update Move examples README.md to explain usage

### DIFF
--- a/aptos-move/move-examples/README.md
+++ b/aptos-move/move-examples/README.md
@@ -4,7 +4,7 @@ To play with these examples:
 1. Clone this repo by running `git clone https://github.com/aptos-labs/aptos-core.git`
 2. Open a new terminal and navigate to this folder by running `cd aptos-move/move-examples`
 3. Navigate into the specific tutorial you are interested (ex. `cd hello_blockchain`)
-4. You can use the Aptos CLI to compile, test, publish, and run these contracts by using the commands outlined here: https://aptos.dev/move/move-on-aptos/cli/#multisig-governance
+4. You can use the Aptos CLI to compile, test, publish, and run these contracts by using the commands outlined here: https://aptos.dev/move/move-on-aptos/cli/
      - If you need to install the Aptos CLI, you can follow these instructions: https://aptos.dev/tools/aptos-cli/install-cli/
 
 **WARNING:** These Move examples have NOT been audited. If you are using them in a production system, proceed at your own risk.

--- a/aptos-move/move-examples/README.md
+++ b/aptos-move/move-examples/README.md
@@ -1,7 +1,16 @@
 # README
 
-**WARNING:** These Move examples have NOT been audited. If using it in a production system, proceed at your own risk.
+To play with these examples:
+1. Clone this repo by running `git clone https://github.com/aptos-labs/aptos-core.git`
+2. Open a new terminal and navigate to this folder by running `cd aptos-move/move-examples`
+3. Navigate into the specific tutorial you are interested (ex. `cd hello_blockchain`)
+4. You can use the Aptos CLI to compile, test, publish, and run these contracts by using the commands outlined here: https://aptos.dev/move/move-on-aptos/cli/#multisig-governance
+     - If you need to install the Aptos CLI, you can follow these instructions: https://aptos.dev/tools/aptos-cli/install-cli/
+
+**WARNING:** These Move examples have NOT been audited. If you are using them in a production system, proceed at your own risk.
 Particular care should be taken with Move examples that contain complex cryptographic code (e.g., `drand`, `veiled_coin`).
+
+# Contributing
 
 ## Writing a Move example
 


### PR DESCRIPTION
## Description
These Move examples are referenced several times in the docs, but the README doesn't explain how to use them. The docs are also very sparse in describing *how* to actually use these examples (even though they show example input / output for running a specific command relating to the example). 

This PR adds the little bit of missing in-between context so users can know where to run the commands like `aptos move compile` to actually get them working as the docs say they will. 

Additionally this PR links out to the Aptos CLI docs as they're necessary to work with these examples, and it puts the intimidating warning at the end of the steps to avoid discouraging developers from even trying to use the examples. 

## Type of Change
- [X] Documentation update

## Which Components or Systems Does This Change Impact?
- [X] Aptos CLI/SDK

## How Has This Been Tested?
Inspection

## Key Areas to Review
- I moved the warning lower, but still in the primary section. 
- The rest of the README was all contributing guidelines, so I gave them their own section.

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
