### PR TITLE
Prepare for ASCII copyrights by using multiple license files in pre-commit script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,26 @@ repos:
           - devtools/assets/license_header.txt
           - --license-filepath
           - devtools/assets/shared_license_header.txt
+          - --license-filepath
+          - devtools/assets/license_header_utf8.txt
+          - --license-filepath
+          - devtools/assets/shared_license_header_utf8.txt
+          - --comment-style
+          - //
+      - id: insert-license
+        files: ^(?=third_party/).*\.rs$
+        args:
+          - --license-filepath
+          - devtools/assets/license_header.txt
+          - --license-filepath
+          - devtools/assets/shared_license_header.txt
+          - --license-filepath
+          - devtools/assets/third_party_license_header.txt
+          - --license-filepath
+          - devtools/assets/third_party_license_header_2.txt
+          - --license-filepath
+          - devtools/assets/license_header_utf8.txt
+          - --license-filepath
+          - devtools/assets/shared_license_header_utf8.txt
           - --comment-style
           - //

--- a/devtools/assets/license_header_utf8.txt
+++ b/devtools/assets/license_header_utf8.txt
@@ -1,2 +1,2 @@
-Copyright (c) Aptos Foundation
+Copyright © Aptos Foundation
 SPDX-License-Identifier: Apache-2.0

--- a/devtools/assets/shared_license_header.txt
+++ b/devtools/assets/shared_license_header.txt
@@ -1,3 +1,3 @@
-Copyright © Aptos Foundation
-Parts of the project are originally copyright © Meta Platforms, Inc.
+Copyright (c) Aptos Foundation
+Parts of the project are originally copyright (c) Meta Platforms, Inc.
 SPDX-License-Identifier: Apache-2.0

--- a/devtools/assets/shared_license_header_utf8.txt
+++ b/devtools/assets/shared_license_header_utf8.txt
@@ -1,0 +1,3 @@
+Copyright © Aptos Foundation
+Parts of the project are originally copyright © Meta Platforms, Inc.
+SPDX-License-Identifier: Apache-2.0

--- a/devtools/assets/third_party_license_header.txt
+++ b/devtools/assets/third_party_license_header.txt
@@ -1,0 +1,3 @@
+Copyright (c) The Diem Core Contributors
+Copyright (c) The Move Contributors
+SPDX-License-Identifier: Apache-2.0

--- a/devtools/assets/third_party_license_header_2.txt
+++ b/devtools/assets/third_party_license_header_2.txt
@@ -1,2 +1,2 @@
-Copyright (c) Aptos Foundation
+Copyright (c) The Move Contributors
 SPDX-License-Identifier: Apache-2.0

--- a/protos/rust/src/pb/aptos.bigquery_schema.transaction.v1.rs
+++ b/protos/rust/src/pb/aptos.bigquery_schema.transaction.v1.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.bigquery_schema.transaction.v1.serde.rs
+++ b/protos/rust/src/pb/aptos.bigquery_schema.transaction.v1.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.indexer.v1.rs
+++ b/protos/rust/src/pb/aptos.indexer.v1.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.indexer.v1.serde.rs
+++ b/protos/rust/src/pb/aptos.indexer.v1.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.indexer.v1.tonic.rs
+++ b/protos/rust/src/pb/aptos.indexer.v1.tonic.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.internal.fullnode.v1.rs
+++ b/protos/rust/src/pb/aptos.internal.fullnode.v1.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.internal.fullnode.v1.serde.rs
+++ b/protos/rust/src/pb/aptos.internal.fullnode.v1.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.internal.fullnode.v1.tonic.rs
+++ b/protos/rust/src/pb/aptos.internal.fullnode.v1.tonic.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.remote_executor.v1.rs
+++ b/protos/rust/src/pb/aptos.remote_executor.v1.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.remote_executor.v1.serde.rs
+++ b/protos/rust/src/pb/aptos.remote_executor.v1.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.remote_executor.v1.tonic.rs
+++ b/protos/rust/src/pb/aptos.remote_executor.v1.tonic.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.transaction.v1.rs
+++ b/protos/rust/src/pb/aptos.transaction.v1.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.transaction.v1.serde.rs
+++ b/protos/rust/src/pb/aptos.transaction.v1.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.util.timestamp.rs
+++ b/protos/rust/src/pb/aptos.util.timestamp.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/aptos.util.timestamp.serde.rs
+++ b/protos/rust/src/pb/aptos.util.timestamp.serde.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/protos/rust/src/pb/mod.rs
+++ b/protos/rust/src/pb/mod.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
+// Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated

--- a/third_party/move/move-model/bytecode/abstract_domain_derive/tests/test.rs
+++ b/third_party/move/move-model/bytecode/abstract_domain_derive/tests/test.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 use abstract_domain_derive::AbstractDomain;
 use move_stackless_bytecode::dataflow_domains::{AbstractDomain, JoinResult};
 

--- a/third_party/move/move-vm/types/src/delayed_values/error.rs
+++ b/third_party/move/move-vm/types/src/delayed_values/error.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
 


### PR DESCRIPTION
## Description

Add multiple allowed license files to pre-commit script, tolerating
existing UTF8-encoded (c) symbols but adding ASCII-only notices if
missing.  Update 3 .rs files that were missing Copyright notices.

Add a section for third_party license notices.

This enables #12687, which will have a  race with other code changes.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Local testing.

## Key Areas to Review



## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
