### PR TITLE
check gas version in `gas_schedule::set_for_next_epoch`

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -260,10 +260,15 @@ aptos_framework::aptos_governance::reconfigure(&framework_signer);
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x1_gas_schedule_set_for_next_epoch">set_for_next_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_schedule_blob: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="gas_schedule.md#0x1_gas_schedule_set_for_next_epoch">set_for_next_epoch</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, gas_schedule_blob: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&gas_schedule_blob), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_SCHEDULE">EINVALID_GAS_SCHEDULE</a>));
     <b>let</b> new_gas_schedule: <a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a> = from_bytes(gas_schedule_blob);
+    <b>let</b> cur_gas_schedule = <b>borrow_global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
+    <b>assert</b>!(
+        new_gas_schedule.feature_version &gt;= cur_gas_schedule.feature_version,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_FEATURE_VERSION">EINVALID_GAS_FEATURE_VERSION</a>)
+    );
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(new_gas_schedule);
 }
 </code></pre>
@@ -479,10 +484,14 @@ Only used in reconfigurations to apply the pending <code><a href="gas_schedule.m
 
 
 
-<pre><code><b>include</b> <a href="config_buffer.md#0x1_config_buffer_SetForNextEpochAbortsIf">config_buffer::SetForNextEpochAbortsIf</a> {
+<pre><code><b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
+<b>include</b> <a href="config_buffer.md#0x1_config_buffer_SetForNextEpochAbortsIf">config_buffer::SetForNextEpochAbortsIf</a> {
     <a href="account.md#0x1_account">account</a>: aptos_framework,
     config: gas_schedule_blob
 };
+<b>let</b> new_gas_schedule = <a href="util.md#0x1_util_spec_from_bytes">util::spec_from_bytes</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(gas_schedule_blob);
+<b>let</b> cur_gas_schedule = <b>global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
+<b>aborts_if</b> <b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) && new_gas_schedule.feature_version &lt; cur_gas_schedule.feature_version;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -266,11 +266,13 @@ aptos_framework::aptos_governance::reconfigure(&framework_signer);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&gas_schedule_blob), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_SCHEDULE">EINVALID_GAS_SCHEDULE</a>));
     <b>let</b> new_gas_schedule: <a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a> = from_bytes(gas_schedule_blob);
-    <b>let</b> cur_gas_schedule = <b>borrow_global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
-    <b>assert</b>!(
-        new_gas_schedule.feature_version &gt;= cur_gas_schedule.feature_version,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_FEATURE_VERSION">EINVALID_GAS_FEATURE_VERSION</a>)
-    );
+    <b>if</b> (<b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework)) {
+        <b>let</b> cur_gas_schedule = <b>borrow_global</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework);
+        <b>assert</b>!(
+            new_gas_schedule.feature_version &gt;= cur_gas_schedule.feature_version,
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="gas_schedule.md#0x1_gas_schedule_EINVALID_GAS_FEATURE_VERSION">EINVALID_GAS_FEATURE_VERSION</a>)
+        );
+    };
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(new_gas_schedule);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -244,6 +244,8 @@ TODO: update all the tests that reference this function, then disable this funct
 ## Function `set_for_next_epoch`
 
 Set the gas schedule for the next epoch, typically called by on-chain governance.
+Abort if the version of the given schedule is lower than the current version.
+
 Example usage:
 ```
 aptos_framework::gas_schedule::set_for_next_epoch(&framework_signer, some_gas_schedule_blob);

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -89,11 +89,13 @@ module aptos_framework::gas_schedule {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
         let new_gas_schedule: GasScheduleV2 = from_bytes(gas_schedule_blob);
-        let cur_gas_schedule = borrow_global<GasScheduleV2>(@aptos_framework);
-        assert!(
-            new_gas_schedule.feature_version >= cur_gas_schedule.feature_version,
-            error::invalid_argument(EINVALID_GAS_FEATURE_VERSION)
-        );
+        if (exists<GasScheduleV2>(@aptos_framework)) {
+            let cur_gas_schedule = borrow_global<GasScheduleV2>(@aptos_framework);
+            assert!(
+                new_gas_schedule.feature_version >= cur_gas_schedule.feature_version,
+                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION)
+            );
+        };
         config_buffer::upsert(new_gas_schedule);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -13,8 +13,6 @@ module aptos_framework::gas_schedule {
     use aptos_framework::storage_gas::StorageGasConfig;
     use aptos_framework::storage_gas;
     #[test_only]
-    use std::bcs;
-    #[test_only]
     use std::bcs::to_bytes;
 
     friend aptos_framework::genesis;
@@ -80,6 +78,8 @@ module aptos_framework::gas_schedule {
     }
 
     /// Set the gas schedule for the next epoch, typically called by on-chain governance.
+    /// Abort if the version of the given schedule is lower than the current version.
+    ///
     /// Example usage:
     /// ```
     /// aptos_framework::gas_schedule::set_for_next_epoch(&framework_signer, some_gas_schedule_blob);

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -81,10 +81,15 @@ module aptos_framework::gas_schedule {
     /// aptos_framework::gas_schedule::set_for_next_epoch(&framework_signer, some_gas_schedule_blob);
     /// aptos_framework::aptos_governance::reconfigure(&framework_signer);
     /// ```
-    public fun set_for_next_epoch(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
+    public fun set_for_next_epoch(aptos_framework: &signer, gas_schedule_blob: vector<u8>) acquires GasScheduleV2 {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
         let new_gas_schedule: GasScheduleV2 = from_bytes(gas_schedule_blob);
+        let cur_gas_schedule = borrow_global<GasScheduleV2>(@aptos_framework);
+        assert!(
+            new_gas_schedule.feature_version >= cur_gas_schedule.feature_version,
+            error::invalid_argument(EINVALID_GAS_FEATURE_VERSION)
+        );
         config_buffer::upsert(new_gas_schedule);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
@@ -93,10 +93,16 @@ spec aptos_framework::gas_schedule {
     }
 
     spec set_for_next_epoch(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
+        use aptos_framework::util;
+
+        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
         include config_buffer::SetForNextEpochAbortsIf {
             account: aptos_framework,
             config: gas_schedule_blob
         };
+        let new_gas_schedule = util::spec_from_bytes<GasScheduleV2>(gas_schedule_blob);
+        let cur_gas_schedule = global<GasScheduleV2>(@aptos_framework);
+        aborts_if exists<GasScheduleV2>(@aptos_framework) && new_gas_schedule.feature_version < cur_gas_schedule.feature_version;
     }
 
     spec on_new_epoch() {


### PR DESCRIPTION
## Description

fix the gas update function in the new randomness framework: it's supposed to verify the gas version as the deprecated `gas_sechedule::set_gas_schedule()` does.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## How Has This Been Tested?
UT

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
