### PR TITLE
[compiler-v2] Add bytecode verification to reference safety tests

### DIFF
--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -470,10 +470,13 @@ pub fn disassemble_compiled_units(units: &[CompiledUnit]) -> anyhow::Result<Stri
 }
 
 /// Run the bytecode verifier on the given compiled units and add any diagnostics to the global env.
-pub fn run_bytecode_verifier(units: &[AnnotatedCompiledUnit], env: &mut GlobalEnv) {
+pub fn run_bytecode_verifier(units: &[AnnotatedCompiledUnit], env: &mut GlobalEnv) -> bool {
     let diags = verify_units(units);
     if !diags.is_empty() {
         add_move_lang_diagnostics(env, diags);
+        false
+    } else {
+        true
     }
 }
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-verify-failure/equality.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-verify-failure/equality.exp
@@ -1,17 +1,15 @@
+============ initial bytecode ================
 
-============ disassembled file-format ==================
-// Move bytecode v7
-module c0ffee.m {
-
-
-equality<Ty0>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 0 */ {
-B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
-	2: Eq
-	3: Ret
+[variant baseline]
+fun m::equality<#0>($t0: #0, $t1: #0): bool {
+     var $t2: bool
+  0: $t2 := ==($t0, $t1)
+  1: return $t2
 }
-}
+
+
+============ bytecode verification failed ========
+
 Diagnostics:
 bug: BYTECODE VERIFICATION FAILED
   ┌─ tests/bytecode-verify-failure/equality.move:3:9

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -47,3 +47,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
@@ -51,3 +51,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -92,3 +92,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
@@ -91,3 +91,4 @@ B0:
 	9: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -129,3 +129,4 @@ B0:
 	3: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
@@ -115,3 +115,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -90,3 +90,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.opt.exp
@@ -96,3 +96,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -19,3 +19,4 @@ B0:
 	3: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.opt.exp
@@ -16,3 +16,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -56,3 +56,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
@@ -58,3 +58,4 @@ B0:
 	12: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.exp
@@ -17,3 +17,4 @@ B3:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.opt.exp
@@ -17,3 +17,4 @@ B3:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -83,3 +83,4 @@ B6:
 	35: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
@@ -77,3 +77,4 @@ B6:
 	35: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -141,3 +141,4 @@ B10:
 	34: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
@@ -113,3 +113,4 @@ B8:
 	30: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -177,3 +177,4 @@ B9:
 	32: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.opt.exp
@@ -182,3 +182,4 @@ B9:
 	36: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
@@ -81,3 +81,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.opt.exp
@@ -57,3 +57,4 @@ B0:
 	4: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -41,3 +41,4 @@ B0:
 	11: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
@@ -29,3 +29,4 @@ B0:
 	3: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
@@ -85,3 +85,4 @@ B0:
 	27: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.opt.exp
@@ -85,3 +85,4 @@ B0:
 	27: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -64,3 +64,4 @@ B0:
 	3: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.opt.exp
@@ -46,3 +46,4 @@ B0:
 	3: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -127,3 +127,4 @@ B8:
 	33: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
@@ -116,3 +116,4 @@ B8:
 	29: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
@@ -25,3 +25,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.opt.exp
@@ -25,3 +25,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/eq_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/eq_ref.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/eq_ref.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/eq_ref.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S { x: u64, y: u64 }
+    struct S has drop { x: u64, y: u64 }
 
     fun f1(s: S) {
         s(&mut s.x, &mut s.x)

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_ref_paths.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_ref_paths.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_ref_paths.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_ref_paths.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.move
@@ -1,5 +1,5 @@
 module 0x42::m {
-    struct S { x: u64, y: u64 }
+    struct S has drop { x: u64, y: u64 }
 
     fun t0(s: S) {
         let x = &mut s.x;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/ref_of_same_root.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/return_borrowed.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_field.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/assign_local_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct Outer { s1: Inner, s2: Inner }
-    struct Inner { f1: u64, f2: u64 }
+    struct Outer has drop { s1: Inner, s2: Inner }
+    struct Inner has drop, copy { f1: u64, f2: u64 }
     fun id<T>(r: &T): &T {
         r
     }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_field_invalid.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct Outer { s1: Inner, s2: Inner }
-    struct Inner { f1: u64, f2: u64 }
+    struct Outer has drop { s1: Inner, s2: Inner }
+    struct Inner has drop, copy { f1: u64, f2: u64 }
     fun id<T>(r: &T): &T {
         r
     }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.move
@@ -1,6 +1,6 @@
 module 0x8675309::M {
-    struct Outer { s1: Inner, s2: Inner }
-    struct Inner { f1: u64, f2: u64 }
+    struct Outer has drop { s1: Inner, s2: Inner }
+    struct Inner has drop, copy { f1: u64, f2: u64 }
     fun id<T>(r: &T): &T {
         r
     }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+  ┌─ tests/reference-safety/v1-tests/borrow_global_bad1.move:8:17
+  │
+8 │         let y = borrow_global_mut<T>(addr);
+  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "A",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            5,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+  ┌─ tests/reference-safety/v1-tests/borrow_global_bad1.move:8:17
+  │
+8 │         let y = borrow_global_mut<T>(addr);
+  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "A",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            7,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+  ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
+  │
+9 │         let t2_ref = borrow_global_mut<T>(sender);
+  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "A",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            17,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.no-opt.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+  ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
+  │
+9 │         let t2_ref = borrow_global_mut<T>(sender);
+  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "A",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            17,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_good.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_good.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_good.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_good.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrowed_before_last_usage.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/call_mutual_borrows.move:19:17
+   │
+19 │         mut_imm(&mut s1.f, &s1.g);
+   │                 ^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            5,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(5),
+            24,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move
@@ -1,5 +1,5 @@
 module 0x8675309::M {
-    struct S { f: u64, g: u64 }
+    struct S has drop, copy { f: u64, g: u64 }
     fun id<T>(r: &T): &T {
         r
     }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_combo.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_field.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/dereference_full.move:19:9
+   │
+19 │         *x;
+   │         ^^ ICE failed bytecode verifier: VMError {
+    major_status: READREF_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            2,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(2),
+            20,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
+   │
+13 │         freeze(s);
+   │         ^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            2,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(2),
+            12,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.no-opt.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
+   │
+13 │         freeze(s);
+   │         ^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            2,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(2),
+            12,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_field.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_full_invalid.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_combo.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_field.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_from.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/move_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/mutate_field.move:23:9
+   │
+23 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            2,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(2),
+            38,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_field.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.exp
@@ -1,0 +1,34 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ tests/reference-safety/v1-tests/mutate_full.move:25:9
+   │
+25 │         *x = 0;
+   │         ^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: 0000000000000000000000000000000000000000000000000000000008675309,
+            name: Identifier(
+                "M",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            2,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(2),
+            33,
+        ),
+    ],
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/release_cycle.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_borrowed_local.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/unused_ref.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
@@ -176,3 +176,4 @@ B0:
 	11: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
@@ -125,3 +125,4 @@ B0:
 	11: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -183,3 +183,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
@@ -131,3 +131,4 @@ B0:
 	17: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
@@ -144,3 +144,4 @@ B2:
 	10: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
@@ -103,3 +103,4 @@ B2:
 	10: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
@@ -120,3 +120,4 @@ B3:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.opt.exp
@@ -87,3 +87,4 @@ B3:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
@@ -119,3 +119,4 @@ B3:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.opt.exp
@@ -86,3 +86,4 @@ B3:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
@@ -264,3 +264,4 @@ B6:
 	16: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
@@ -188,3 +188,4 @@ B6:
 	16: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -260,3 +260,4 @@ B6:
 	21: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
@@ -187,3 +187,4 @@ B6:
 	21: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
@@ -174,3 +174,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
@@ -125,3 +125,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
@@ -173,3 +173,4 @@ B0:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
@@ -122,3 +122,4 @@ B0:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -114,3 +114,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -68,3 +68,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -204,3 +204,4 @@ B3:
 	11: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
@@ -145,3 +145,4 @@ B3:
 	11: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -198,3 +198,4 @@ B3:
 	16: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.opt.exp
@@ -77,3 +77,4 @@ B3:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
@@ -356,3 +356,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
@@ -250,3 +250,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
@@ -246,3 +246,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
@@ -172,3 +172,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
@@ -242,3 +242,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
@@ -170,3 +170,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
@@ -286,3 +286,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
@@ -202,3 +202,4 @@ B0:
 	6: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
@@ -473,3 +473,4 @@ B6:
 	21: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
@@ -337,3 +337,4 @@ B6:
 	21: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
@@ -65,3 +65,4 @@ B0:
 	0: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
@@ -45,3 +45,4 @@ B0:
 	0: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
@@ -93,3 +93,4 @@ B0:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.opt.exp
@@ -67,3 +67,4 @@ B0:
 	5: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
@@ -384,3 +384,4 @@ B5:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
@@ -276,3 +276,4 @@ B5:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
@@ -80,3 +80,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.opt.exp
@@ -57,3 +57,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
@@ -59,3 +59,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.opt.exp
@@ -42,3 +42,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
@@ -150,3 +150,4 @@ B3:
 	12: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
@@ -102,3 +102,4 @@ B3:
 	12: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
@@ -299,3 +299,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
@@ -174,3 +174,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
@@ -105,3 +105,4 @@ B0:
 	2: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
@@ -74,3 +74,4 @@ B0:
 	2: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
@@ -137,3 +137,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
@@ -101,3 +101,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.exp
@@ -71,3 +71,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/inlining1.opt.exp
@@ -41,3 +41,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -144,3 +144,4 @@ B0:
 	13: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
@@ -81,3 +81,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
@@ -162,3 +162,4 @@ B0:
 	13: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
@@ -96,3 +96,4 @@ B0:
 	9: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -155,3 +155,4 @@ B0:
 	13: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
@@ -81,3 +81,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -250,3 +250,4 @@ B5:
 	22: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
@@ -181,3 +181,4 @@ B5:
 	22: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
@@ -239,3 +239,4 @@ B5:
 	22: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
@@ -173,3 +173,4 @@ B5:
 	22: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
@@ -88,3 +88,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
@@ -62,3 +62,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -124,3 +124,4 @@ B0:
 	10: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
@@ -90,3 +90,4 @@ B0:
 	10: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -181,3 +181,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
@@ -130,3 +130,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -149,3 +149,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
@@ -105,3 +105,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -149,3 +149,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
@@ -105,3 +105,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -155,3 +155,4 @@ B0:
 	13: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.opt.exp
@@ -41,3 +41,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -120,3 +120,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
@@ -78,3 +78,4 @@ B0:
 	7: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -536,3 +536,4 @@ B5:
 	18: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -384,3 +384,4 @@ B5:
 	18: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -137,3 +137,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
@@ -100,3 +100,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -137,3 +137,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
@@ -100,3 +100,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
@@ -119,3 +119,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.opt.exp
@@ -87,3 +87,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
@@ -113,3 +113,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.opt.exp
@@ -81,3 +81,4 @@ B0:
 	1: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -125,3 +125,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
@@ -91,3 +91,4 @@ B0:
 	15: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
@@ -102,3 +102,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.opt.exp
@@ -74,3 +74,4 @@ B0:
 	8: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
@@ -248,3 +248,4 @@ B5:
 	25: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.opt.exp
@@ -180,3 +180,4 @@ B5:
 	25: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
@@ -121,3 +121,4 @@ B0:
 	4: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.opt.exp
@@ -39,3 +39,4 @@ B0:
 	0: Ret
 }
 }
+============ bytecode verification succeeded ========

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -821,10 +821,13 @@ impl GlobalEnv {
         target_modules
     }
 
-    fn add_backtrace(msg: &str, is_bug: bool) -> String {
+    fn add_backtrace(msg: &str, _is_bug: bool) -> String {
+        // For now, we do not use is_bug, but we could have
+        // another env var MOVE_COMPILER_DEBUG_BUG_ENV_VAR to
+        // only backtrace bugs if the env var is set.
         static DEBUG_COMPILER: Lazy<bool> =
             Lazy::new(|| read_bool_env_var(cli::MOVE_COMPILER_DEBUG_ENV_VAR));
-        if is_bug || *DEBUG_COMPILER {
+        if *DEBUG_COMPILER {
             let bt = Backtrace::capture();
             if BacktraceStatus::Captured == bt.status() {
                 format!("{}\nBacktrace: {:#?}", msg, bt)


### PR DESCRIPTION
## Description

This adds bytecode verification on file format level to the reference safety tests. Some tests needed to be fixed for this to pass ability checks. This also prints into the baseline whether verification succeeded, which is useful for silent tests. (One can now also run up to bytecode verification without dumping the file format).

Various bugs are discovered where ref-safety succeeds but bytecode verification fails. Those are tracked in #12701.

I think this is all what can be done here for closing #12570. Other important tests like the bytecode optimizers already run up to verification.

As another note, this PR *turns off* dumping stack traces into the baseline if RUST_STACKTRACE is set and bug is given. This makes the output stable for people updating baselines locally. Traces can still be added with the compiler debug env var.

Fixes #12570.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

New tests

## Key Areas to Review

baseline files

