### PR TITLE
[Multisig V2] Merged Multisig payload simulation with execution

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -114,6 +114,7 @@ pub enum FeatureFlag {
     PrimaryAPTFungibleStoreAtUserAddress,
     ObjectNativeDerivedAddress,
     DispatchableFungibleAsset,
+    MultisigV2Fix,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -292,6 +293,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::OBJECT_NATIVE_DERIVED_ADDRESS
             },
             FeatureFlag::DispatchableFungibleAsset => AptosFeatureFlag::DISPATCHABLE_FUNGIBLE_ASSET,
+            FeatureFlag::MultisigV2Fix => AptosFeatureFlag::MULTISIG_V2_FIX,
         }
     }
 }
@@ -399,6 +401,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::ObjectNativeDerivedAddress
             },
             AptosFeatureFlag::DISPATCHABLE_FUNGIBLE_ASSET => FeatureFlag::DispatchableFungibleAsset,
+            AptosFeatureFlag::MULTISIG_V2_FIX => FeatureFlag::MultisigV2Fix,
         }
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -118,6 +118,8 @@ return true.
 -  [Function `object_native_derived_address_enabled`](#0x1_features_object_native_derived_address_enabled)
 -  [Function `get_dispatchable_fungible_asset_feature`](#0x1_features_get_dispatchable_fungible_asset_feature)
 -  [Function `dispatchable_fungible_asset_enabled`](#0x1_features_dispatchable_fungible_asset_enabled)
+-  [Function `get_multisig_v2_fix_feature`](#0x1_features_get_multisig_v2_fix_feature)
+-  [Function `multisig_v2_fix_enabled`](#0x1_features_multisig_v2_fix_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -134,6 +136,7 @@ return true.
     -  [Function `periodical_reward_rate_decrease_enabled`](#@Specification_1_periodical_reward_rate_decrease_enabled)
     -  [Function `partial_governance_voting_enabled`](#@Specification_1_partial_governance_voting_enabled)
     -  [Function `module_event_enabled`](#@Specification_1_module_event_enabled)
+    -  [Function `multisig_v2_fix_enabled`](#@Specification_1_multisig_v2_fix_enabled)
     -  [Function `change_feature_flags_internal`](#@Specification_1_change_feature_flags_internal)
     -  [Function `change_feature_flags_for_next_epoch`](#@Specification_1_change_feature_flags_for_next_epoch)
     -  [Function `on_new_epoch`](#@Specification_1_on_new_epoch)
@@ -611,6 +614,18 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_MULTISIG_V2_ENHANCEMENT">MULTISIG_V2_ENHANCEMENT</a>: u64 = 55;
+</code></pre>
+
+
+
+<a id="0x1_features_MULTISIG_V2_FIX"></a>
+
+Whether the multisig v2 fix is enabled.
+
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_MULTISIG_V2_FIX">MULTISIG_V2_FIX</a>: u64 = 64;
 </code></pre>
 
 
@@ -2841,6 +2856,52 @@ Lifetime: transient
 
 </details>
 
+<a id="0x1_features_get_multisig_v2_fix_feature"></a>
+
+## Function `get_multisig_v2_fix_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_multisig_v2_fix_feature">get_multisig_v2_fix_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_multisig_v2_fix_feature">get_multisig_v2_fix_feature</a>(): u64 { <a href="features.md#0x1_features_MULTISIG_V2_FIX">MULTISIG_V2_FIX</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_multisig_v2_fix_enabled"></a>
+
+## Function `multisig_v2_fix_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multisig_v2_fix_enabled">multisig_v2_fix_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multisig_v2_fix_enabled">multisig_v2_fix_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_MULTISIG_V2_FIX">MULTISIG_V2_FIX</a>)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_features_change_feature_flags"></a>
 
 ## Function `change_feature_flags`
@@ -3276,6 +3337,35 @@ Helper to check whether a feature flag is enabled.
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] result == <a href="features.md#0x1_features_spec_module_event_enabled">spec_module_event_enabled</a>();
+</code></pre>
+
+
+
+
+<a id="0x1_features_spec_multisig_v2_fix_enabled"></a>
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_spec_multisig_v2_fix_enabled">spec_multisig_v2_fix_enabled</a>(): bool {
+   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_MULTISIG_V2_FIX">MULTISIG_V2_FIX</a>)
+}
+</code></pre>
+
+
+
+<a id="@Specification_1_multisig_v2_fix_enabled"></a>
+
+### Function `multisig_v2_fix_enabled`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multisig_v2_fix_enabled">multisig_v2_fix_enabled</a>(): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] result == <a href="features.md#0x1_features_spec_multisig_v2_fix_enabled">spec_multisig_v2_fix_enabled</a>();
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -530,6 +530,17 @@ module std::features {
         is_enabled(DISPATCHABLE_FUNGIBLE_ASSET)
     }
 
+    /// Whether the multisig v2 fix is enabled.
+    ///
+    /// Lifetime: transient
+    const MULTISIG_V2_FIX: u64 = 64;
+
+    public fun get_multisig_v2_fix_feature(): u64 { MULTISIG_V2_FIX }
+
+    public fun multisig_v2_fix_enabled(): bool acquires Features {
+        is_enabled(MULTISIG_V2_FIX)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -96,6 +96,16 @@ spec std::features {
         ensures [abstract] result == spec_module_event_enabled();
     }
 
+    spec fun spec_multisig_v2_fix_enabled(): bool {
+        spec_is_enabled(MULTISIG_V2_FIX)
+    }
+
+    spec multisig_v2_fix_enabled {
+        pragma opaque;
+        aborts_if [abstract] false;
+        ensures [abstract] result == spec_multisig_v2_fix_enabled();
+    }
+
     spec on_new_epoch(framework: &signer) {
         requires @std == signer::address_of(framework);
         let features_pending = global<PendingFeatures>(@std).features;

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_account.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_account.ts
@@ -83,12 +83,6 @@ const { AccountAddress, EntryFunction, MultiSig, MultiSigTransactionPayload, Tra
   const multisigTxExecution = new TransactionPayloadMultisig(
     new MultiSig(AccountAddress.fromHex(multisigAddress), transferTxPayload),
   );
-  // We can simulate the transaction to see if it will succeed without having to create it on chain.
-  const [simulationResp] = await client.simulateTransaction(
-    owner2,
-    await client.generateRawTransaction(owner2.address(), multisigTxExecution),
-  );
-  assert(simulationResp.success);
 
   // Create the multisig tx on chain.
   const createMultisigTx = await client.generateTransaction(owner2.address(), {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -80,6 +80,7 @@ pub enum FeatureFlag {
     PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS = 61,
     OBJECT_NATIVE_DERIVED_ADDRESS = 62,
     DISPATCHABLE_FUNGIBLE_ASSET = 63,
+    MULTISIG_V2_FIX = 64,
 }
 
 impl FeatureFlag {
@@ -142,6 +143,7 @@ impl FeatureFlag {
             FeatureFlag::DISPATCHABLE_FUNGIBLE_ASSET,
             FeatureFlag::REMOVE_DETAILED_ERROR_FROM_HASH,
             FeatureFlag::CONCURRENT_FUNGIBLE_ASSETS,
+            FeatureFlag::MULTISIG_V2_FIX,
         ]
     }
 }
@@ -296,6 +298,10 @@ impl Features {
         } else {
             file_format_common::VERSION_5
         }
+    }
+
+    pub fn is_multisig_v2_fix_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::MULTISIG_V2_FIX)
     }
 }
 


### PR DESCRIPTION
Currently, the Multisig payload simulation path is separate from the execution path. This causes the following issues in simulation:
* The simulation path does not retrieve a payload stored onchain: https://github.com/aptos-labs/aptos-core/issues/12703
* The simulation path does not estimate the gas cost accurately: https://github.com/aptos-labs/aptos-core/issues/12704

This PR merges the Multisig payload simulation path with the execution path, and makes them consistent.

The changes in this PR have been tested on the localnet.

This PR resolves https://github.com/aptos-labs/aptos-core/issues/12703, and https://github.com/aptos-labs/aptos-core/issues/12704.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [X] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [X] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Testnet with the localnet

<!-- Thank you for your contribution! -->
