### PR TITLE
[CI/CD] Only run the move compiler v2 tests when neccessary.

### DIFF
--- a/.github/actions/file-change-determinator/action.yaml
+++ b/.github/actions/file-change-determinator/action.yaml
@@ -1,6 +1,9 @@
 name: File Change Determinator
 description: Runs the file change determinator (to identify which files changed in a pull request)
 outputs:
+  move_compiler_v2_changes:
+    description: "Returns true if changes were detected that require the move compiler v2 tests to run"
+    value: ${{ !steps.move_compiler_v2_determinator.outputs.should_skip }}
   only_docs_changed:
     description: "Returns true if only docs files were changed in the pull request"
     value: ${{ steps.doc_change_determinator.outputs.should_skip }}
@@ -15,3 +18,18 @@ runs:
       with:
         skip_after_successful_duplicate: false # Don't skip if the action is a duplicate (this may cause false positives)
         paths_ignore: '["**/*.md"]'
+    # Run the move compiler v2 change determinator
+    - id: move_compiler_v2_determinator
+      continue-on-error: true # Avoid skipping any checks if this job fails (see: https://github.com/fkirc/skip-duplicate-actions/issues/301)
+      uses: fkirc/skip-duplicate-actions@v5
+      with:
+          skip_after_successful_duplicate: false # Don't skip if the action is a duplicate (this may cause false positives)
+          paths: '[
+                    "aptos-move/aptos-transactional-test-harness",
+                    "aptos-move/e2e-move-tests/**",
+                    "aptos-move/framework/**",
+                    "aptos-move/move-examples",
+                    "third_party/move/**",
+                    ".github/workflows/move-test-compiler-v2.yaml",
+                    ".github/actions/move-tests-compiler-v2/**"
+                  ]'

--- a/.github/workflows/move-test-compiler-v2.yaml
+++ b/.github/workflows/move-test-compiler-v2.yaml
@@ -24,12 +24,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Run Aptos Move tests.
+  # This job determines which files were changed
+  file_change_determinator:
+    runs-on: ubuntu-latest
+    outputs:
+      move_compiler_v2_changes: ${{ steps.determine_file_changes.outputs.move_compiler_v2_changes }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the file change determinator
+        id: determine_file_changes
+        uses: ./.github/actions/file-change-determinator
+
+  # Run Aptos Move Compiler v2 tests. This is a PR required job.
   rust-move-tests:
+    needs: file_change_determinator
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
+        if: needs.file_change_determinator.outputs.move_compiler_v2_changes == 'true'
       - name: Run Aptos Move tests with compiler V2
         uses: ./.github/actions/move-tests-compiler-v2
+        if: needs.file_change_determinator.outputs.move_compiler_v2_changes == 'true'
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping move compiler v2 tests! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.move_compiler_v2_changes != 'true'


### PR DESCRIPTION
## Description
This PR updates the move compiler v2 GHA jobs to only run on each PR when necessary. When a PR doesn't modify relevant code to trigger the job, the job "passes trivially" (skipping the compiler v2 tests).

## Testing Plan
Manual verification and existing test infrastructure. Here is a run where the tests were skipped: https://github.com/aptos-labs/aptos-core/actions/runs/8459568568