### PR TITLE
[CI/CD] Delay windows CLI and protos test until appropriate event.

### DIFF
--- a/.github/workflows/check-protos.yaml
+++ b/.github/workflows/check-protos.yaml
@@ -26,6 +26,13 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: | # Only run on each PR once an appropriate event occurs
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null
+      )
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -136,6 +136,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - name: Run aptos cached packages build test
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         run: scripts/cargo_build_aptos_cached_packages.sh --check

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -12,6 +12,13 @@ on:
 jobs:
   windows-build:
     runs-on: windows-latest-8-core
+    if: | # Only run on each PR once an appropriate event occurs
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-windows-tests') ||
+        github.event.pull_request.auto_merge != null
+      )
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
## Description
This PR:
1. Delays the: (i) windows CLI GHA job; and (ii) the check protos job, to only run on each PR when an appropriate event occurs. This includes: (i) when auto-merge is enabled; or (ii) when the correct label is added to the PR. This should help reduce the number of unnecessary/redundant runs of the job on each PR.
2. Fixes a missing step in `rust-build-cached-packages`.

## Testing Plan
Manual verification and existing test infrastructure.
