### PR TITLE
[compiler-v2] A simple optimization reducing unnecessary temp creation

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/loop_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/loop_abort.exp
@@ -1,7 +1,7 @@
 
 Diagnostics:
 error: local `_x` of type `Test::Impotent` does not have the `drop` ability
-   ┌─ tests/ability-check/loop_abort.move:11:13
+   ┌─ tests/ability-check/loop_abort.move:11:18
    │
 11 │         let _x = Impotent {};
-   │             ^^ implicitly dropped here since it is no longer used
+   │                  ^^^^^^^^^^^ implicitly dropped here since it is no longer used

--- a/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
@@ -4,29 +4,27 @@
 fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      var $t2: u64
      var $t3: &vector<u64>
-     var $t4: &vector<u64>
-     var $t5: bool
-     var $t6: u8
-     var $t7: &m::R
-     var $t8: address
-     var $t9: &u64
-     var $t10: u64
-  0: $t6 := 0
-  1: $t5 := ==($t0, $t6)
-  2: if ($t5) goto 3 else goto 8
+     var $t4: bool
+     var $t5: u8
+     var $t6: &m::R
+     var $t7: address
+     var $t8: &u64
+     var $t9: u64
+  0: $t5 := 0
+  1: $t4 := ==($t0, $t5)
+  2: if ($t4) goto 3 else goto 8
   3: label L0
-  4: $t8 := 0x1
-  5: $t7 := borrow_global<m::R>($t8)
-  6: $t4 := borrow_field<m::R>.data($t7)
+  4: $t7 := 0x1
+  5: $t6 := borrow_global<m::R>($t7)
+  6: $t3 := borrow_field<m::R>.data($t6)
   7: goto 10
   8: label L1
-  9: $t4 := infer($t1)
+  9: $t3 := infer($t1)
  10: label L2
- 11: $t3 := infer($t4)
- 12: $t10 := 0
- 13: $t9 := vector::borrow<u64>($t3, $t10)
- 14: $t2 := read_ref($t9)
- 15: return $t2
+ 11: $t9 := 0
+ 12: $t8 := vector::borrow<u64>($t3, $t9)
+ 13: $t2 := read_ref($t8)
+ 14: return $t2
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -35,45 +33,42 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
 fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      var $t2: u64
      var $t3: &vector<u64>
-     var $t4: &vector<u64>
-     var $t5: bool
-     var $t6: u8
-     var $t7: &m::R
-     var $t8: address
-     var $t9: &u64
-     var $t10: u64
+     var $t4: bool
+     var $t5: u8
+     var $t6: &m::R
+     var $t7: address
+     var $t8: &u64
+     var $t9: u64
      # live vars: $t0, $t1
-  0: $t6 := 0
-     # live vars: $t0, $t1, $t6
-  1: $t5 := ==($t0, $t6)
-     # live vars: $t1, $t5
-  2: if ($t5) goto 3 else goto 8
+  0: $t5 := 0
+     # live vars: $t0, $t1, $t5
+  1: $t4 := ==($t0, $t5)
+     # live vars: $t1, $t4
+  2: if ($t4) goto 3 else goto 8
      # live vars: $t1
   3: label L0
      # live vars:
-  4: $t8 := 0x1
-     # live vars: $t8
-  5: $t7 := borrow_global<m::R>($t8)
+  4: $t7 := 0x1
      # live vars: $t7
-  6: $t4 := borrow_field<m::R>.data($t7)
-     # live vars: $t4
+  5: $t6 := borrow_global<m::R>($t7)
+     # live vars: $t6
+  6: $t3 := borrow_field<m::R>.data($t6)
+     # live vars: $t3
   7: goto 10
      # live vars: $t1
   8: label L1
      # live vars: $t1
-  9: $t4 := infer($t1)
-     # live vars: $t4
- 10: label L2
-     # live vars: $t4
- 11: $t3 := infer($t4)
+  9: $t3 := infer($t1)
      # live vars: $t3
- 12: $t10 := 0
-     # live vars: $t3, $t10
- 13: $t9 := vector::borrow<u64>($t3, $t10)
-     # live vars: $t9
- 14: $t2 := read_ref($t9)
+ 10: label L2
+     # live vars: $t3
+ 11: $t9 := 0
+     # live vars: $t3, $t9
+ 12: $t8 := vector::borrow<u64>($t3, $t9)
+     # live vars: $t8
+ 13: $t2 := read_ref($t8)
      # live vars: $t2
- 15: return $t2
+ 14: return $t2
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -82,31 +77,30 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
 fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      var $t2: u64
      var $t3: &vector<u64>
-     var $t4: &vector<u64>
-     var $t5: bool
-     var $t6: u8
-     var $t7: &m::R
-     var $t8: address
-     var $t9: &u64
-     var $t10: u64
+     var $t4: bool
+     var $t5: u8
+     var $t6: &m::R
+     var $t7: address
+     var $t8: &u64
+     var $t9: u64
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  0: $t6 := 0
-     # live vars: $t0, $t1, $t6
+  0: $t5 := 0
+     # live vars: $t0, $t1, $t5
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  1: $t5 := ==($t0, $t6)
-     # live vars: $t1, $t5
+  1: $t4 := ==($t0, $t5)
+     # live vars: $t1, $t4
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  2: if ($t5) goto 3 else goto 8
+  2: if ($t4) goto 3 else goto 8
      # live vars: $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
@@ -118,22 +112,22 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      # locals: {}
      # globals: {}
      #
-  4: $t8 := 0x1
-     # live vars: $t8
+  4: $t7 := 0x1
+     # live vars: $t7
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  5: $t7 := borrow_global<m::R>($t8)
-     # live vars: $t7
+  5: $t6 := borrow_global<m::R>($t7)
+     # live vars: $t6
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[]}
-     # locals: {$t7=@501}
+     # locals: {$t6=@501}
      # globals: {m::R=@500}
      #
-  6: $t4 := borrow_field<m::R>.data($t7)
-     # live vars: $t4
+  6: $t3 := borrow_field<m::R>.data($t6)
+     # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
-     # locals: {$t4=@601}
+     # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
   7: goto 10
@@ -148,43 +142,37 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  9: $t4 := infer($t1)
-     # live vars: $t4
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t4=@601}
-     # globals: {m::R=@500}
-     #
- 10: label L2
-     # live vars: $t4
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t4=@601}
-     # globals: {m::R=@500}
-     #
- 11: $t3 := infer($t4)
+  9: $t3 := infer($t1)
      # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 12: $t10 := 0
-     # live vars: $t3, $t10
+ 10: label L2
+     # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 13: $t9 := vector::borrow<u64>($t3, $t10)
-     # live vars: $t9
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @D00],@D00=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t9=@D00}
+ 11: $t9 := 0
+     # live vars: $t3, $t9
+     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 14: $t2 := read_ref($t9)
+ 12: $t8 := vector::borrow<u64>($t3, $t9)
+     # live vars: $t8
+     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
+     # locals: {$t8=@C00}
+     # globals: {m::R=@500}
+     #
+ 13: $t2 := read_ref($t8)
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 15: return $t2
+ 14: return $t2
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -193,34 +181,33 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
 fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      var $t2: u64
      var $t3: &vector<u64>
-     var $t4: &vector<u64>
-     var $t5: bool
-     var $t6: u8
-     var $t7: &m::R
-     var $t8: address
-     var $t9: &u64
-     var $t10: u64
+     var $t4: bool
+     var $t5: u8
+     var $t6: &m::R
+     var $t7: address
+     var $t8: &u64
+     var $t9: u64
      # abort state: {returns,aborts}
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  0: $t6 := 0
+  0: $t5 := 0
      # abort state: {returns,aborts}
-     # live vars: $t0, $t1, $t6
+     # live vars: $t0, $t1, $t5
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  1: $t5 := ==($t0, $t6)
+  1: $t4 := ==($t0, $t5)
      # abort state: {returns,aborts}
-     # live vars: $t1, $t5
+     # live vars: $t1, $t4
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  2: if ($t5) goto 3 else goto 8
+  2: if ($t4) goto 3 else goto 8
      # abort state: {returns,aborts}
      # live vars: $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
@@ -234,25 +221,25 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      # locals: {}
      # globals: {}
      #
-  4: $t8 := 0x1
+  4: $t7 := 0x1
      # abort state: {returns,aborts}
-     # live vars: $t8
+     # live vars: $t7
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  5: $t7 := borrow_global<m::R>($t8)
+  5: $t6 := borrow_global<m::R>($t7)
      # abort state: {returns,aborts}
-     # live vars: $t7
+     # live vars: $t6
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[]}
-     # locals: {$t7=@501}
+     # locals: {$t6=@501}
      # globals: {m::R=@500}
      #
-  6: $t4 := borrow_field<m::R>.data($t7)
+  6: $t3 := borrow_field<m::R>.data($t6)
      # abort state: {returns,aborts}
-     # live vars: $t4
+     # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
-     # locals: {$t4=@601}
+     # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
   7: goto 10
@@ -269,49 +256,42 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      # locals: {$t1=@2000000}
      # globals: {}
      #
-  9: $t4 := infer($t1)
-     # abort state: {returns,aborts}
-     # live vars: $t4
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t4=@601}
-     # globals: {m::R=@500}
-     #
- 10: label L2
-     # abort state: {returns,aborts}
-     # live vars: $t4
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t4=@601}
-     # globals: {m::R=@500}
-     #
- 11: $t3 := infer($t4)
+  9: $t3 := infer($t1)
      # abort state: {returns,aborts}
      # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 12: $t10 := 0
+ 10: label L2
      # abort state: {returns,aborts}
-     # live vars: $t3, $t10
+     # live vars: $t3
      # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 13: $t9 := vector::borrow<u64>($t3, $t10)
-     # abort state: {returns}
-     # live vars: $t9
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @D00],@D00=derived[],@1000000=external[borrow(false) -> @601]}
-     # locals: {$t9=@D00}
+ 11: $t9 := 0
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t9
+     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # locals: {$t3=@601}
      # globals: {m::R=@500}
      #
- 14: $t2 := read_ref($t9)
+ 12: $t8 := vector::borrow<u64>($t3, $t9)
+     # abort state: {returns}
+     # live vars: $t8
+     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
+     # locals: {$t8=@C00}
+     # globals: {m::R=@500}
+     #
+ 13: $t2 := read_ref($t8)
      # abort state: {returns}
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 15: return $t2
+ 14: return $t2
 }
 
 ============ after AbilityProcessor: ================
@@ -320,28 +300,26 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
 fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      var $t2: u64
      var $t3: &vector<u64>
-     var $t4: &vector<u64>
-     var $t5: bool
-     var $t6: u8
-     var $t7: &m::R
-     var $t8: address
-     var $t9: &u64
-     var $t10: u64
-  0: $t6 := 0
-  1: $t5 := ==($t0, $t6)
-  2: if ($t5) goto 3 else goto 9
+     var $t4: bool
+     var $t5: u8
+     var $t6: &m::R
+     var $t7: address
+     var $t8: &u64
+     var $t9: u64
+  0: $t5 := 0
+  1: $t4 := ==($t0, $t5)
+  2: if ($t4) goto 3 else goto 9
   3: label L0
   4: drop($t1)
-  5: $t8 := 0x1
-  6: $t7 := borrow_global<m::R>($t8)
-  7: $t4 := borrow_field<m::R>.data($t7)
+  5: $t7 := 0x1
+  6: $t6 := borrow_global<m::R>($t7)
+  7: $t3 := borrow_field<m::R>.data($t6)
   8: goto 11
   9: label L1
- 10: $t4 := move($t1)
+ 10: $t3 := move($t1)
  11: label L2
- 12: $t3 := move($t4)
- 13: $t10 := 0
- 14: $t9 := vector::borrow<u64>($t3, $t10)
- 15: $t2 := read_ref($t9)
- 16: return $t2
+ 12: $t9 := 0
+ 13: $t8 := vector::borrow<u64>($t3, $t9)
+ 14: $t2 := read_ref($t8)
+ 15: return $t2
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
@@ -19,25 +19,23 @@ fun <SELF>_0::check() {
      var $t14: vector<u8>
      var $t15: u64
      var $t16: &mut u64
-     var $t17: &mut u64
+     var $t17: u64
      var $t18: u64
-     var $t19: u64
-     var $t20: &mut vector<u8>
-     var $t21: &mut vector<u8>
-     var $t22: vector<u8>
-     var $t23: vector<u8>
-     var $t24: bool
+     var $t19: &mut vector<u8>
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: bool
+     var $t23: u64
+     var $t24: u64
      var $t25: u64
-     var $t26: u64
-     var $t27: u64
-     var $t28: bool
-     var $t29: vector<u8>
-     var $t30: vector<u8>
+     var $t26: bool
+     var $t27: vector<u8>
+     var $t28: vector<u8>
+     var $t29: u64
+     var $t30: bool
      var $t31: u64
      var $t32: bool
      var $t33: u64
-     var $t34: bool
-     var $t35: u64
   0: $t0 := true
   1: if ($t0) goto 2 else goto 4
   2: label L0
@@ -78,53 +76,51 @@ fun <SELF>_0::check() {
  37: $t15 := 42
  38: abort($t15)
  39: label L11
- 40: $t18 := 0
- 41: $t17 := borrow_local($t18)
- 42: $t16 := infer($t17)
- 43: $t19 := 1
- 44: write_ref($t16, $t19)
- 45: $t22 := [104, 101, 108, 108, 111]
- 46: $t21 := borrow_local($t22)
- 47: $t20 := infer($t21)
- 48: $t23 := [98, 121, 101]
- 49: write_ref($t20, $t23)
- 50: $t25 := read_ref($t16)
- 51: $t26 := 1
- 52: $t24 := ==($t25, $t26)
- 53: if ($t24) goto 54 else goto 56
- 54: label L12
- 55: goto 59
- 56: label L13
- 57: $t27 := 42
- 58: abort($t27)
- 59: label L14
- 60: $t29 := read_ref($t20)
- 61: $t30 := [98, 121, 101]
- 62: $t28 := ==($t29, $t30)
- 63: if ($t28) goto 64 else goto 66
- 64: label L15
- 65: goto 69
- 66: label L16
- 67: $t31 := 42
- 68: abort($t31)
- 69: label L17
- 70: $t32 := true
- 71: if ($t32) goto 72 else goto 74
- 72: label L18
- 73: goto 77
- 74: label L19
- 75: $t33 := 42
- 76: abort($t33)
- 77: label L20
- 78: $t34 := true
- 79: if ($t34) goto 80 else goto 82
- 80: label L21
- 81: goto 85
- 82: label L22
- 83: $t35 := 42
- 84: abort($t35)
- 85: label L23
- 86: return ()
+ 40: $t17 := 0
+ 41: $t16 := borrow_local($t17)
+ 42: $t18 := 1
+ 43: write_ref($t16, $t18)
+ 44: $t20 := [104, 101, 108, 108, 111]
+ 45: $t19 := borrow_local($t20)
+ 46: $t21 := [98, 121, 101]
+ 47: write_ref($t19, $t21)
+ 48: $t23 := read_ref($t16)
+ 49: $t24 := 1
+ 50: $t22 := ==($t23, $t24)
+ 51: if ($t22) goto 52 else goto 54
+ 52: label L12
+ 53: goto 57
+ 54: label L13
+ 55: $t25 := 42
+ 56: abort($t25)
+ 57: label L14
+ 58: $t27 := read_ref($t19)
+ 59: $t28 := [98, 121, 101]
+ 60: $t26 := ==($t27, $t28)
+ 61: if ($t26) goto 62 else goto 64
+ 62: label L15
+ 63: goto 67
+ 64: label L16
+ 65: $t29 := 42
+ 66: abort($t29)
+ 67: label L17
+ 68: $t30 := true
+ 69: if ($t30) goto 70 else goto 72
+ 70: label L18
+ 71: goto 75
+ 72: label L19
+ 73: $t31 := 42
+ 74: abort($t31)
+ 75: label L20
+ 76: $t32 := true
+ 77: if ($t32) goto 78 else goto 80
+ 78: label L21
+ 79: goto 83
+ 80: label L22
+ 81: $t33 := 42
+ 82: abort($t33)
+ 83: label L23
+ 84: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -148,25 +144,23 @@ fun <SELF>_0::check() {
      var $t14: vector<u8>
      var $t15: u64
      var $t16: &mut u64
-     var $t17: &mut u64
+     var $t17: u64
      var $t18: u64
-     var $t19: u64
-     var $t20: &mut vector<u8>
-     var $t21: &mut vector<u8>
-     var $t22: vector<u8>
-     var $t23: vector<u8>
-     var $t24: bool
+     var $t19: &mut vector<u8>
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: bool
+     var $t23: u64
+     var $t24: u64
      var $t25: u64
-     var $t26: u64
-     var $t27: u64
-     var $t28: bool
-     var $t29: vector<u8>
-     var $t30: vector<u8>
+     var $t26: bool
+     var $t27: vector<u8>
+     var $t28: vector<u8>
+     var $t29: u64
+     var $t30: bool
      var $t31: u64
      var $t32: bool
      var $t33: u64
-     var $t34: bool
-     var $t35: u64
      # live vars:
   0: $t0 := true
      # live vars: $t0
@@ -248,99 +242,95 @@ fun <SELF>_0::check() {
      # live vars:
  39: label L11
      # live vars:
- 40: $t18 := 0
-     # live vars: $t18
- 41: $t17 := borrow_local($t18)
+ 40: $t17 := 0
      # live vars: $t17
- 42: $t16 := infer($t17)
+ 41: $t16 := borrow_local($t17)
      # live vars: $t16
- 43: $t19 := 1
+ 42: $t18 := 1
+     # live vars: $t16, $t18
+ 43: write_ref($t16, $t18)
+     # live vars: $t16
+ 44: $t20 := [104, 101, 108, 108, 111]
+     # live vars: $t16, $t20
+ 45: $t19 := borrow_local($t20)
      # live vars: $t16, $t19
- 44: write_ref($t16, $t19)
-     # live vars: $t16
- 45: $t22 := [104, 101, 108, 108, 111]
-     # live vars: $t16, $t22
- 46: $t21 := borrow_local($t22)
-     # live vars: $t16, $t21
- 47: $t20 := infer($t21)
-     # live vars: $t16, $t20
- 48: $t23 := [98, 121, 101]
-     # live vars: $t16, $t20, $t23
- 49: write_ref($t20, $t23)
-     # live vars: $t16, $t20
- 50: $t25 := read_ref($t16)
-     # live vars: $t20, $t25
- 51: $t26 := 1
-     # live vars: $t20, $t25, $t26
- 52: $t24 := ==($t25, $t26)
-     # live vars: $t20, $t24
- 53: if ($t24) goto 54 else goto 56
-     # live vars: $t20
- 54: label L12
-     # live vars: $t20
- 55: goto 59
-     # live vars: $t20
- 56: label L13
+ 46: $t21 := [98, 121, 101]
+     # live vars: $t16, $t19, $t21
+ 47: write_ref($t19, $t21)
+     # live vars: $t16, $t19
+ 48: $t23 := read_ref($t16)
+     # live vars: $t19, $t23
+ 49: $t24 := 1
+     # live vars: $t19, $t23, $t24
+ 50: $t22 := ==($t23, $t24)
+     # live vars: $t19, $t22
+ 51: if ($t22) goto 52 else goto 54
+     # live vars: $t19
+ 52: label L12
+     # live vars: $t19
+ 53: goto 57
+     # live vars: $t19
+ 54: label L13
      # live vars:
- 57: $t27 := 42
+ 55: $t25 := 42
+     # live vars: $t25
+ 56: abort($t25)
+     # live vars: $t19
+ 57: label L14
+     # live vars: $t19
+ 58: $t27 := read_ref($t19)
      # live vars: $t27
- 58: abort($t27)
-     # live vars: $t20
- 59: label L14
-     # live vars: $t20
- 60: $t29 := read_ref($t20)
+ 59: $t28 := [98, 121, 101]
+     # live vars: $t27, $t28
+ 60: $t26 := ==($t27, $t28)
+     # live vars: $t26
+ 61: if ($t26) goto 62 else goto 64
+     # live vars:
+ 62: label L15
+     # live vars:
+ 63: goto 67
+     # live vars:
+ 64: label L16
+     # live vars:
+ 65: $t29 := 42
      # live vars: $t29
- 61: $t30 := [98, 121, 101]
-     # live vars: $t29, $t30
- 62: $t28 := ==($t29, $t30)
-     # live vars: $t28
- 63: if ($t28) goto 64 else goto 66
+ 66: abort($t29)
      # live vars:
- 64: label L15
+ 67: label L17
      # live vars:
- 65: goto 69
+ 68: $t30 := true
+     # live vars: $t30
+ 69: if ($t30) goto 70 else goto 72
      # live vars:
- 66: label L16
+ 70: label L18
      # live vars:
- 67: $t31 := 42
+ 71: goto 75
+     # live vars:
+ 72: label L19
+     # live vars:
+ 73: $t31 := 42
      # live vars: $t31
- 68: abort($t31)
+ 74: abort($t31)
      # live vars:
- 69: label L17
+ 75: label L20
      # live vars:
- 70: $t32 := true
+ 76: $t32 := true
      # live vars: $t32
- 71: if ($t32) goto 72 else goto 74
+ 77: if ($t32) goto 78 else goto 80
      # live vars:
- 72: label L18
+ 78: label L21
      # live vars:
- 73: goto 77
+ 79: goto 83
      # live vars:
- 74: label L19
+ 80: label L22
      # live vars:
- 75: $t33 := 42
+ 81: $t33 := 42
      # live vars: $t33
- 76: abort($t33)
+ 82: abort($t33)
      # live vars:
- 77: label L20
+ 83: label L23
      # live vars:
- 78: $t34 := true
-     # live vars: $t34
- 79: if ($t34) goto 80 else goto 82
-     # live vars:
- 80: label L21
-     # live vars:
- 81: goto 85
-     # live vars:
- 82: label L22
-     # live vars:
- 83: $t35 := 42
-     # live vars: $t35
- 84: abort($t35)
-     # live vars:
- 85: label L23
-     # live vars:
- 86: return ()
+ 84: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -364,25 +354,23 @@ fun <SELF>_0::check() {
      var $t14: vector<u8>
      var $t15: u64
      var $t16: &mut u64
-     var $t17: &mut u64
+     var $t17: u64
      var $t18: u64
-     var $t19: u64
-     var $t20: &mut vector<u8>
-     var $t21: &mut vector<u8>
-     var $t22: vector<u8>
-     var $t23: vector<u8>
-     var $t24: bool
+     var $t19: &mut vector<u8>
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: bool
+     var $t23: u64
+     var $t24: u64
      var $t25: u64
-     var $t26: u64
-     var $t27: u64
-     var $t28: bool
-     var $t29: vector<u8>
-     var $t30: vector<u8>
+     var $t26: bool
+     var $t27: vector<u8>
+     var $t28: vector<u8>
+     var $t29: u64
+     var $t30: bool
      var $t31: u64
      var $t32: bool
      var $t33: u64
-     var $t34: bool
-     var $t35: u64
      # live vars:
      # graph: {}
      # locals: {}
@@ -628,283 +616,271 @@ fun <SELF>_0::check() {
      # locals: {$t7=@1100,$t13=@1D00}
      # globals: {}
      #
- 40: $t18 := 0
-     # live vars: $t18
+ 40: $t17 := 0
+     # live vars: $t17
      # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
      # locals: {$t7=@1100,$t13=@1D00}
      # globals: {}
      #
- 41: $t17 := borrow_local($t18)
-     # live vars: $t17
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2901,$t18=@2900}
-     # globals: {}
-     #
- 42: $t16 := infer($t17)
+ 41: $t16 := borrow_local($t17)
      # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
      # globals: {}
      #
- 43: $t19 := 1
+ 42: $t18 := 1
+     # live vars: $t16, $t18
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 43: write_ref($t16, $t18)
+     # live vars: $t16
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 44: $t20 := [104, 101, 108, 108, 111]
+     # live vars: $t16, $t20
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 45: $t19 := borrow_local($t20)
      # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 44: write_ref($t16, $t19)
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+ 46: $t21 := [98, 121, 101]
+     # live vars: $t16, $t19, $t21
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 45: $t22 := [104, 101, 108, 108, 111]
-     # live vars: $t16, $t22
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+ 47: write_ref($t19, $t21)
+     # live vars: $t16, $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 46: $t21 := borrow_local($t22)
-     # live vars: $t16, $t21
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t21=@2E01,$t22=@2E00}
+ 48: $t23 := read_ref($t16)
+     # live vars: $t19, $t23
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 47: $t20 := infer($t21)
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 49: $t24 := 1
+     # live vars: $t19, $t23, $t24
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 48: $t23 := [98, 121, 101]
-     # live vars: $t16, $t20, $t23
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 50: $t22 := ==($t23, $t24)
+     # live vars: $t19, $t22
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 49: write_ref($t20, $t23)
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 51: if ($t22) goto 52 else goto 54
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 50: $t25 := read_ref($t16)
-     # live vars: $t20, $t25
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 52: label L12
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 51: $t26 := 1
-     # live vars: $t20, $t25, $t26
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 53: goto 57
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 52: $t24 := ==($t25, $t26)
-     # live vars: $t20, $t24
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 53: if ($t24) goto 54 else goto 56
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 54: label L12
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 55: goto 59
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 56: label L13
+ 54: label L13
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 57: $t27 := 42
+ 55: $t25 := 42
+     # live vars: $t25
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 56: abort($t25)
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # globals: {}
+     #
+ 57: label L14
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # globals: {}
+     #
+ 58: $t27 := read_ref($t19)
      # live vars: $t27
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 58: abort($t27)
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 59: $t28 := [98, 121, 101]
+     # live vars: $t27, $t28
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 59: label L14
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+ 60: $t26 := ==($t27, $t28)
+     # live vars: $t26
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 60: $t29 := read_ref($t20)
+ 61: if ($t26) goto 62 else goto 64
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 62: label L15
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 63: goto 67
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 64: label L16
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 65: $t29 := 42
      # live vars: $t29
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 61: $t30 := [98, 121, 101]
-     # live vars: $t29, $t30
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 62: $t28 := ==($t29, $t30)
-     # live vars: $t28
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 63: if ($t28) goto 64 else goto 66
+ 66: abort($t29)
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 64: label L15
+ 67: label L17
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 65: goto 69
+ 68: $t30 := true
+     # live vars: $t30
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 69: if ($t30) goto 70 else goto 72
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 66: label L16
+ 70: label L18
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 67: $t31 := 42
+ 71: goto 75
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 72: label L19
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 73: $t31 := 42
      # live vars: $t31
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 68: abort($t31)
+ 74: abort($t31)
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 69: label L17
+ 75: label L20
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 70: $t32 := true
+ 76: $t32 := true
      # live vars: $t32
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 71: if ($t32) goto 72 else goto 74
+ 77: if ($t32) goto 78 else goto 80
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 72: label L18
+ 78: label L21
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 73: goto 77
+ 79: goto 83
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 74: label L19
+ 80: label L22
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 75: $t33 := 42
+ 81: $t33 := 42
      # live vars: $t33
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 76: abort($t33)
+ 82: abort($t33)
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 77: label L20
+ 83: label L23
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 78: $t34 := true
-     # live vars: $t34
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 79: if ($t34) goto 80 else goto 82
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 80: label L21
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 81: goto 85
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 82: label L22
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 83: $t35 := 42
-     # live vars: $t35
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 84: abort($t35)
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 85: label L23
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 86: return ()
+ 84: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -928,25 +904,23 @@ fun <SELF>_0::check() {
      var $t14: vector<u8>
      var $t15: u64
      var $t16: &mut u64
-     var $t17: &mut u64
+     var $t17: u64
      var $t18: u64
-     var $t19: u64
-     var $t20: &mut vector<u8>
-     var $t21: &mut vector<u8>
-     var $t22: vector<u8>
-     var $t23: vector<u8>
-     var $t24: bool
+     var $t19: &mut vector<u8>
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: bool
+     var $t23: u64
+     var $t24: u64
      var $t25: u64
-     var $t26: u64
-     var $t27: u64
-     var $t28: bool
-     var $t29: vector<u8>
-     var $t30: vector<u8>
+     var $t26: bool
+     var $t27: vector<u8>
+     var $t28: vector<u8>
+     var $t29: u64
+     var $t30: bool
      var $t31: u64
      var $t32: bool
      var $t33: u64
-     var $t34: bool
-     var $t35: u64
      # abort state: {returns,aborts}
      # live vars:
      # graph: {}
@@ -1233,329 +1207,315 @@ fun <SELF>_0::check() {
      # locals: {$t7=@1100,$t13=@1D00}
      # globals: {}
      #
- 40: $t18 := 0
+ 40: $t17 := 0
      # abort state: {returns,aborts}
-     # live vars: $t18
+     # live vars: $t17
      # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
      # locals: {$t7=@1100,$t13=@1D00}
      # globals: {}
      #
- 41: $t17 := borrow_local($t18)
-     # abort state: {returns,aborts}
-     # live vars: $t17
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2901,$t18=@2900}
-     # globals: {}
-     #
- 42: $t16 := infer($t17)
+ 41: $t16 := borrow_local($t17)
      # abort state: {returns,aborts}
      # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
      # globals: {}
      #
- 43: $t19 := 1
+ 42: $t18 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t16, $t18
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 43: write_ref($t16, $t18)
+     # abort state: {returns,aborts}
+     # live vars: $t16
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 44: $t20 := [104, 101, 108, 108, 111]
+     # abort state: {returns,aborts}
+     # live vars: $t16, $t20
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
+     # globals: {}
+     #
+ 45: $t19 := borrow_local($t20)
      # abort state: {returns,aborts}
      # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 44: write_ref($t16, $t19)
+ 46: $t21 := [98, 121, 101]
      # abort state: {returns,aborts}
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # live vars: $t16, $t19, $t21
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 45: $t22 := [104, 101, 108, 108, 111]
+ 47: write_ref($t19, $t21)
      # abort state: {returns,aborts}
-     # live vars: $t16, $t22
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900}
+     # live vars: $t16, $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow(true) -> @2901],@2901=derived[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 46: $t21 := borrow_local($t22)
+ 48: $t23 := read_ref($t16)
      # abort state: {returns,aborts}
-     # live vars: $t16, $t21
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t21=@2E01,$t22=@2E00}
+     # live vars: $t19, $t23
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 47: $t20 := infer($t21)
+ 49: $t24 := 1
      # abort state: {returns,aborts}
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t19, $t23, $t24
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 48: $t23 := [98, 121, 101]
+ 50: $t22 := ==($t23, $t24)
      # abort state: {returns,aborts}
-     # live vars: $t16, $t20, $t23
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t19, $t22
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 49: write_ref($t20, $t23)
+ 51: if ($t22) goto 52 else goto 54
      # abort state: {returns,aborts}
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[borrow(true) -> @2901],@2901=derived[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 50: $t25 := read_ref($t16)
+ 52: label L12
      # abort state: {returns,aborts}
-     # live vars: $t20, $t25
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 51: $t26 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t20, $t25, $t26
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 52: $t24 := ==($t25, $t26)
-     # abort state: {returns,aborts}
-     # live vars: $t20, $t24
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 53: if ($t24) goto 54 else goto 56
-     # abort state: {returns,aborts}
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 54: label L12
-     # abort state: {returns,aborts}
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
-     # globals: {}
-     #
- 55: goto 59
+ 53: goto 57
      # abort state: {aborts}
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
      # globals: {}
      #
- 56: label L13
+ 54: label L13
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 57: $t27 := 42
+ 55: $t25 := 42
      # abort state: {aborts}
+     # live vars: $t25
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 56: abort($t25)
+     # abort state: {returns,aborts}
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # globals: {}
+     #
+ 57: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t19
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow(true) -> @2D01],@2D01=derived[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # globals: {}
+     #
+ 58: $t27 := read_ref($t19)
+     # abort state: {returns,aborts}
      # live vars: $t27
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 58: abort($t27)
+ 59: $t28 := [98, 121, 101]
      # abort state: {returns,aborts}
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t27, $t28
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 59: label L14
+ 60: $t26 := ==($t27, $t28)
      # abort state: {returns,aborts}
-     # live vars: $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[borrow(true) -> @2E01],@2E01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t20=@2E01,$t22=@2E00}
+     # live vars: $t26
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 60: $t29 := read_ref($t20)
+ 61: if ($t26) goto 62 else goto 64
      # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 62: label L15
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 63: goto 67
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 64: label L16
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 65: $t29 := 42
+     # abort state: {aborts}
      # live vars: $t29
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 61: $t30 := [98, 121, 101]
-     # abort state: {returns,aborts}
-     # live vars: $t29, $t30
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 62: $t28 := ==($t29, $t30)
-     # abort state: {returns,aborts}
-     # live vars: $t28
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 63: if ($t28) goto 64 else goto 66
+ 66: abort($t29)
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 64: label L15
+ 67: label L17
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 65: goto 69
+ 68: $t30 := true
+     # abort state: {returns,aborts}
+     # live vars: $t30
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 69: if ($t30) goto 70 else goto 72
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 70: label L18
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # globals: {}
+     #
+ 71: goto 75
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 66: label L16
+ 72: label L19
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 67: $t31 := 42
+ 73: $t31 := 42
      # abort state: {aborts}
      # live vars: $t31
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 68: abort($t31)
+ 74: abort($t31)
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 69: label L17
+ 75: label L20
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 70: $t32 := true
+ 76: $t32 := true
      # abort state: {returns,aborts}
      # live vars: $t32
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 71: if ($t32) goto 72 else goto 74
-     # abort state: {returns,aborts}
+ 77: if ($t32) goto 78 else goto 80
+     # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 72: label L18
-     # abort state: {returns,aborts}
+ 78: label L21
+     # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 73: goto 77
+ 79: goto 83
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 74: label L19
+ 80: label L22
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 75: $t33 := 42
+ 81: $t33 := 42
      # abort state: {aborts}
      # live vars: $t33
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 76: abort($t33)
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 77: label L20
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 78: $t34 := true
-     # abort state: {returns,aborts}
-     # live vars: $t34
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 79: if ($t34) goto 80 else goto 82
+ 82: abort($t33)
      # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 80: label L21
+ 83: label L23
      # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
+     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
+     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
      # globals: {}
      #
- 81: goto 85
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 82: label L22
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 83: $t35 := 42
-     # abort state: {aborts}
-     # live vars: $t35
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 84: abort($t35)
-     # abort state: {returns}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 85: label L23
-     # abort state: {returns}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t18)[],@2E00=local($t22)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t18=@2900,$t22=@2E00}
-     # globals: {}
-     #
- 86: return ()
+ 84: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -1579,25 +1539,23 @@ fun <SELF>_0::check() {
      var $t14: vector<u8>
      var $t15: u64
      var $t16: &mut u64
-     var $t17: &mut u64
+     var $t17: u64
      var $t18: u64
-     var $t19: u64
-     var $t20: &mut vector<u8>
-     var $t21: &mut vector<u8>
-     var $t22: vector<u8>
-     var $t23: vector<u8>
-     var $t24: bool
+     var $t19: &mut vector<u8>
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: bool
+     var $t23: u64
+     var $t24: u64
      var $t25: u64
-     var $t26: u64
-     var $t27: u64
-     var $t28: bool
-     var $t29: vector<u8>
-     var $t30: vector<u8>
+     var $t26: bool
+     var $t27: vector<u8>
+     var $t28: vector<u8>
+     var $t29: u64
+     var $t30: bool
      var $t31: u64
      var $t32: bool
      var $t33: u64
-     var $t34: bool
-     var $t35: u64
   0: $t0 := true
   1: if ($t0) goto 2 else goto 4
   2: label L0
@@ -1638,52 +1596,50 @@ fun <SELF>_0::check() {
  37: $t15 := 42
  38: abort($t15)
  39: label L11
- 40: $t18 := 0
- 41: $t17 := borrow_local($t18)
- 42: $t16 := move($t17)
- 43: $t19 := 1
- 44: write_ref($t16, $t19)
- 45: $t22 := [104, 101, 108, 108, 111]
- 46: $t21 := borrow_local($t22)
- 47: $t20 := move($t21)
- 48: $t23 := [98, 121, 101]
- 49: write_ref($t20, $t23)
- 50: $t25 := read_ref($t16)
- 51: $t26 := 1
- 52: $t24 := ==($t25, $t26)
- 53: if ($t24) goto 54 else goto 56
- 54: label L12
- 55: goto 60
- 56: label L13
- 57: drop($t20)
- 58: $t27 := 42
- 59: abort($t27)
- 60: label L14
- 61: $t29 := read_ref($t20)
- 62: $t30 := [98, 121, 101]
- 63: $t28 := ==($t29, $t30)
- 64: if ($t28) goto 65 else goto 67
- 65: label L15
- 66: goto 70
- 67: label L16
- 68: $t31 := 42
- 69: abort($t31)
- 70: label L17
- 71: $t32 := true
- 72: if ($t32) goto 73 else goto 75
- 73: label L18
- 74: goto 78
- 75: label L19
- 76: $t33 := 42
- 77: abort($t33)
- 78: label L20
- 79: $t34 := true
- 80: if ($t34) goto 81 else goto 83
- 81: label L21
- 82: goto 86
- 83: label L22
- 84: $t35 := 42
- 85: abort($t35)
- 86: label L23
- 87: return ()
+ 40: $t17 := 0
+ 41: $t16 := borrow_local($t17)
+ 42: $t18 := 1
+ 43: write_ref($t16, $t18)
+ 44: $t20 := [104, 101, 108, 108, 111]
+ 45: $t19 := borrow_local($t20)
+ 46: $t21 := [98, 121, 101]
+ 47: write_ref($t19, $t21)
+ 48: $t23 := read_ref($t16)
+ 49: $t24 := 1
+ 50: $t22 := ==($t23, $t24)
+ 51: if ($t22) goto 52 else goto 54
+ 52: label L12
+ 53: goto 58
+ 54: label L13
+ 55: drop($t19)
+ 56: $t25 := 42
+ 57: abort($t25)
+ 58: label L14
+ 59: $t27 := read_ref($t19)
+ 60: $t28 := [98, 121, 101]
+ 61: $t26 := ==($t27, $t28)
+ 62: if ($t26) goto 63 else goto 65
+ 63: label L15
+ 64: goto 68
+ 65: label L16
+ 66: $t29 := 42
+ 67: abort($t29)
+ 68: label L17
+ 69: $t30 := true
+ 70: if ($t30) goto 71 else goto 73
+ 71: label L18
+ 72: goto 76
+ 73: label L19
+ 74: $t31 := 42
+ 75: abort($t31)
+ 76: label L20
+ 77: $t32 := true
+ 78: if ($t32) goto 79 else goto 81
+ 79: label L21
+ 80: goto 84
+ 81: label L22
+ 82: $t33 := 42
+ 83: abort($t33)
+ 84: label L23
+ 85: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
@@ -13,18 +13,14 @@ public fun M::f($t0: M::R): (M::R, u64) {
 [variant baseline]
 public fun M::g($t0: &signer) {
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t3 := 1
-  1: $t2 := pack M::R($t3)
-  2: $t1 := infer($t2)
-  3: $t5 := 3
-  4: $t4 := infer($t5)
-  5: ($t1, $t4) := M::f($t1)
-  6: move_to<M::R>($t0, $t1)
-  7: return ()
+  0: $t2 := 1
+  1: $t1 := pack M::R($t2)
+  2: $t3 := 3
+  3: ($t1, $t3) := M::f($t1)
+  4: move_to<M::R>($t0, $t1)
+  5: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -45,26 +41,20 @@ public fun M::f($t0: M::R): (M::R, u64) {
 [variant baseline]
 public fun M::g($t0: &signer) {
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
      # live vars: $t0
-  0: $t3 := 1
-     # live vars: $t0, $t3
-  1: $t2 := pack M::R($t3)
+  0: $t2 := 1
      # live vars: $t0, $t2
-  2: $t1 := infer($t2)
+  1: $t1 := pack M::R($t2)
      # live vars: $t0, $t1
-  3: $t5 := 3
-     # live vars: $t0, $t1, $t5
-  4: $t4 := infer($t5)
+  2: $t3 := 3
      # live vars: $t0, $t1
-  5: ($t1, $t4) := M::f($t1)
+  3: ($t1, $t3) := M::f($t1)
      # live vars: $t0, $t1
-  6: move_to<M::R>($t0, $t1)
+  4: move_to<M::R>($t0, $t1)
      # live vars:
-  7: return ()
+  5: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -97,58 +87,44 @@ public fun M::f($t0: M::R): (M::R, u64) {
 [variant baseline]
 public fun M::g($t0: &signer) {
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
      # live vars: $t0
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  0: $t3 := 1
-     # live vars: $t0, $t3
-     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
-     # locals: {$t0=@2000000}
-     # globals: {}
-     #
-  1: $t2 := pack M::R($t3)
+  0: $t2 := 1
      # live vars: $t0, $t2
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  2: $t1 := infer($t2)
+  1: $t1 := pack M::R($t2)
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  3: $t5 := 3
-     # live vars: $t0, $t1, $t5
-     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
-     # locals: {$t0=@2000000}
-     # globals: {}
-     #
-  4: $t4 := infer($t5)
+  2: $t3 := 3
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  5: ($t1, $t4) := M::f($t1)
+  3: ($t1, $t3) := M::f($t1)
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  6: move_to<M::R>($t0, $t1)
+  4: move_to<M::R>($t0, $t1)
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  7: return ()
+  5: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -184,66 +160,50 @@ public fun M::f($t0: M::R): (M::R, u64) {
 [variant baseline]
 public fun M::g($t0: &signer) {
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  0: $t3 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t3
-     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
-     # locals: {$t0=@2000000}
-     # globals: {}
-     #
-  1: $t2 := pack M::R($t3)
+  0: $t2 := 1
      # abort state: {returns,aborts}
      # live vars: $t0, $t2
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  2: $t1 := infer($t2)
+  1: $t1 := pack M::R($t2)
      # abort state: {returns,aborts}
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  3: $t5 := 3
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t1, $t5
-     # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
-     # locals: {$t0=@2000000}
-     # globals: {}
-     #
-  4: $t4 := infer($t5)
+  2: $t3 := 3
      # abort state: {returns,aborts}
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  5: ($t1, $t4) := M::f($t1)
+  3: ($t1, $t3) := M::f($t1)
      # abort state: {returns,aborts}
      # live vars: $t0, $t1
      # graph: {@1000000=external[borrow(false) -> @2000000],@2000000=derived[]}
      # locals: {$t0=@2000000}
      # globals: {}
      #
-  6: move_to<M::R>($t0, $t1)
+  4: move_to<M::R>($t0, $t1)
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  7: return ()
+  5: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -261,16 +221,12 @@ public fun M::f($t0: M::R): (M::R, u64) {
 [variant baseline]
 public fun M::g($t0: &signer) {
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t3 := 1
-  1: $t2 := pack M::R($t3)
-  2: $t1 := move($t2)
-  3: $t5 := 3
-  4: $t4 := move($t5)
-  5: ($t1, $t4) := M::f($t1)
-  6: move_to<M::R>($t0, $t1)
-  7: return ()
+  0: $t2 := 1
+  1: $t1 := pack M::R($t2)
+  2: $t3 := 3
+  3: ($t1, $t3) := M::f($t1)
+  4: move_to<M::R>($t0, $t1)
+  5: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
@@ -4,13 +4,11 @@
 fun explicate_drop::test0(): u8 {
      var $t0: u8
      var $t1: &u8
-     var $t2: &u8
-     var $t3: u8
-  0: $t3 := 42
-  1: $t2 := borrow_local($t3)
-  2: $t1 := infer($t2)
-  3: $t0 := read_ref($t1)
-  4: return $t0
+     var $t2: u8
+  0: $t2 := 42
+  1: $t1 := borrow_local($t2)
+  2: $t0 := read_ref($t1)
+  3: return $t0
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -19,18 +17,15 @@ fun explicate_drop::test0(): u8 {
 fun explicate_drop::test0(): u8 {
      var $t0: u8
      var $t1: &u8
-     var $t2: &u8
-     var $t3: u8
+     var $t2: u8
      # live vars:
-  0: $t3 := 42
-     # live vars: $t3
-  1: $t2 := borrow_local($t3)
+  0: $t2 := 42
      # live vars: $t2
-  2: $t1 := infer($t2)
+  1: $t1 := borrow_local($t2)
      # live vars: $t1
-  3: $t0 := read_ref($t1)
+  2: $t0 := read_ref($t1)
      # live vars: $t0
-  4: return $t0
+  3: return $t0
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -39,38 +34,31 @@ fun explicate_drop::test0(): u8 {
 fun explicate_drop::test0(): u8 {
      var $t0: u8
      var $t1: &u8
-     var $t2: &u8
-     var $t3: u8
+     var $t2: u8
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := 42
-     # live vars: $t3
+  0: $t2 := 42
+     # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  1: $t2 := borrow_local($t3)
-     # live vars: $t2
-     # graph: {@100=local($t3)[borrow(false) -> @101],@101=derived[]}
-     # locals: {$t2=@101,$t3=@100}
-     # globals: {}
-     #
-  2: $t1 := infer($t2)
+  1: $t1 := borrow_local($t2)
      # live vars: $t1
-     # graph: {@100=local($t3)[borrow(false) -> @101],@101=derived[]}
-     # locals: {$t1=@101,$t3=@100}
+     # graph: {@100=local($t2)[borrow(false) -> @101],@101=derived[]}
+     # locals: {$t1=@101,$t2=@100}
      # globals: {}
      #
-  3: $t0 := read_ref($t1)
+  2: $t0 := read_ref($t1)
      # live vars: $t0
-     # graph: {@100=local($t3)[]}
-     # locals: {$t3=@100}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  4: return $t0
+  3: return $t0
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -79,43 +67,35 @@ fun explicate_drop::test0(): u8 {
 fun explicate_drop::test0(): u8 {
      var $t0: u8
      var $t1: &u8
-     var $t2: &u8
-     var $t3: u8
+     var $t2: u8
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := 42
+  0: $t2 := 42
      # abort state: {returns}
-     # live vars: $t3
+     # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  1: $t2 := borrow_local($t3)
-     # abort state: {returns}
-     # live vars: $t2
-     # graph: {@100=local($t3)[borrow(false) -> @101],@101=derived[]}
-     # locals: {$t2=@101,$t3=@100}
-     # globals: {}
-     #
-  2: $t1 := infer($t2)
+  1: $t1 := borrow_local($t2)
      # abort state: {returns}
      # live vars: $t1
-     # graph: {@100=local($t3)[borrow(false) -> @101],@101=derived[]}
-     # locals: {$t1=@101,$t3=@100}
+     # graph: {@100=local($t2)[borrow(false) -> @101],@101=derived[]}
+     # locals: {$t1=@101,$t2=@100}
      # globals: {}
      #
-  3: $t0 := read_ref($t1)
+  2: $t0 := read_ref($t1)
      # abort state: {returns}
      # live vars: $t0
-     # graph: {@100=local($t3)[]}
-     # locals: {$t3=@100}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  4: return $t0
+  3: return $t0
 }
 
 ============ after AbilityProcessor: ================
@@ -124,11 +104,9 @@ fun explicate_drop::test0(): u8 {
 fun explicate_drop::test0(): u8 {
      var $t0: u8
      var $t1: &u8
-     var $t2: &u8
-     var $t3: u8
-  0: $t3 := 42
-  1: $t2 := borrow_local($t3)
-  2: $t1 := move($t2)
-  3: $t0 := read_ref($t1)
-  4: return $t0
+     var $t2: u8
+  0: $t2 := 42
+  1: $t1 := borrow_local($t2)
+  2: $t0 := read_ref($t1)
+  3: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
@@ -11,21 +11,15 @@ fun m::f($t0: &mut u64): &mut u64 {
 [variant baseline]
 fun m::g() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &mut u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &u64
-     var $t6: &u64
-  0: $t1 := 22
-  1: $t0 := infer($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := infer($t3)
-  4: $t4 := m::f($t2)
-  5: $t2 := infer($t4)
-  6: $t6 := borrow_local($t0)
-  7: $t5 := infer($t6)
-  8: return ()
+     var $t3: &u64
+  0: $t0 := 22
+  1: $t1 := borrow_local($t0)
+  2: $t2 := m::f($t1)
+  3: $t1 := infer($t2)
+  4: $t3 := borrow_local($t0)
+  5: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -43,30 +37,21 @@ fun m::f($t0: &mut u64): &mut u64 {
 [variant baseline]
 fun m::g() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &mut u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &u64
-     var $t6: &u64
+     var $t3: &u64
      # live vars:
-  0: $t1 := 22
-     # live vars: $t1
-  1: $t0 := infer($t1)
+  0: $t0 := 22
      # live vars: $t0
-  2: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-  3: $t2 := infer($t3)
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  2: $t2 := m::f($t1)
      # live vars: $t0, $t2
-  4: $t4 := m::f($t2)
-     # live vars: $t0, $t4
-  5: $t2 := infer($t4)
+  3: $t1 := infer($t2)
      # live vars: $t0
-  6: $t6 := borrow_local($t0)
-     # live vars: $t6
-  7: $t5 := infer($t6)
+  4: $t3 := borrow_local($t0)
      # live vars:
-  8: return ()
+  5: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -92,66 +77,45 @@ fun m::f($t0: &mut u64): &mut u64 {
 [variant baseline]
 fun m::g() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &mut u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &u64
-     var $t6: &u64
+     var $t3: &u64
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := 22
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := 22
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t3=@201}
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  3: $t2 := infer($t3)
+  2: $t2 := m::f($t1)
      # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true) -> @200],@200=derived[]}
+     # locals: {$t0=@100,$t2=@200}
      # globals: {}
      #
-  4: $t4 := m::f($t2)
-     # live vars: $t0, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
-     # locals: {$t0=@200,$t4=@400}
-     # globals: {}
-     #
-  5: $t2 := infer($t4)
+  3: $t1 := infer($t2)
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
-  6: $t6 := borrow_local($t0)
-     # live vars: $t6
-     # graph: {@200=local($t0)[borrow(false) -> @601],@601=derived[]}
-     # locals: {$t0=@200,$t6=@601}
-     # globals: {}
-     #
-  7: $t5 := infer($t6)
+  4: $t3 := borrow_local($t0)
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
-  8: return ()
+  5: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -179,75 +143,51 @@ fun m::f($t0: &mut u64): &mut u64 {
 [variant baseline]
 fun m::g() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &mut u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &u64
-     var $t6: &u64
+     var $t3: &u64
      # abort state: {returns,aborts}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := 22
-     # abort state: {returns,aborts}
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := 22
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := borrow_local($t0)
+  1: $t1 := borrow_local($t0)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t3
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t3=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  3: $t2 := infer($t3)
-     # abort state: {returns,aborts}
+  2: $t2 := m::f($t1)
+     # abort state: {returns}
      # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true) -> @200],@200=derived[]}
+     # locals: {$t0=@100,$t2=@200}
      # globals: {}
      #
-  4: $t4 := m::f($t2)
-     # abort state: {returns}
-     # live vars: $t0, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
-     # locals: {$t0=@200,$t4=@400}
-     # globals: {}
-     #
-  5: $t2 := infer($t4)
+  3: $t1 := infer($t2)
      # abort state: {returns}
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
-  6: $t6 := borrow_local($t0)
-     # abort state: {returns}
-     # live vars: $t6
-     # graph: {@200=local($t0)[borrow(false) -> @601],@601=derived[]}
-     # locals: {$t0=@200,$t6=@601}
-     # globals: {}
-     #
-  7: $t5 := infer($t6)
+  4: $t3 := borrow_local($t0)
      # abort state: {returns}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
-  8: return ()
+  5: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -263,21 +203,15 @@ fun m::f($t0: &mut u64): &mut u64 {
 [variant baseline]
 fun m::g() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &mut u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &u64
-     var $t6: &u64
-  0: $t1 := 22
-  1: $t0 := move($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := move($t3)
-  4: $t4 := m::f($t2)
-  5: $t2 := move($t4)
-  6: drop($t2)
-  7: $t6 := borrow_local($t0)
-  8: $t5 := move($t6)
-  9: drop($t5)
- 10: return ()
+     var $t3: &u64
+  0: $t0 := 22
+  1: $t1 := borrow_local($t0)
+  2: $t2 := m::f($t1)
+  3: $t1 := move($t2)
+  4: drop($t1)
+  5: $t3 := borrow_local($t0)
+  6: drop($t3)
+  7: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
@@ -3,45 +3,39 @@
 [variant baseline]
 fun m::drop_after_loop() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &mut u64
-     var $t3: &mut u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-     var $t7: bool
-     var $t8: bool
-     var $t9: u64
-     var $t10: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := infer($t3)
-  4: $t5 := true
-  5: $t4 := infer($t5)
-  6: label L0
-  7: if ($t4) goto 8 else goto 14
-  8: label L2
-  9: $t6 := 2
- 10: write_ref($t2, $t6)
- 11: $t7 := false
- 12: $t4 := infer($t7)
- 13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 6
- 18: label L1
- 19: $t9 := 2
- 20: $t8 := ==($t0, $t9)
- 21: if ($t8) goto 22 else goto 24
- 22: label L5
- 23: goto 27
- 24: label L6
- 25: $t10 := 0
- 26: abort($t10)
- 27: label L7
- 28: return ()
+     var $t7: u64
+  0: $t0 := 1
+  1: $t1 := borrow_local($t0)
+  2: $t2 := true
+  3: label L0
+  4: if ($t2) goto 5 else goto 11
+  5: label L2
+  6: $t3 := 2
+  7: write_ref($t1, $t3)
+  8: $t4 := false
+  9: $t2 := infer($t4)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 3
+ 15: label L1
+ 16: $t6 := 2
+ 17: $t5 := ==($t0, $t6)
+ 18: if ($t5) goto 19 else goto 21
+ 19: label L5
+ 20: goto 24
+ 21: label L6
+ 22: $t7 := 0
+ 23: abort($t7)
+ 24: label L7
+ 25: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -49,74 +43,65 @@ fun m::drop_after_loop() {
 [variant baseline]
 fun m::drop_after_loop() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &mut u64
-     var $t3: &mut u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-     var $t7: bool
-     var $t8: bool
-     var $t9: u64
-     var $t10: u64
+     var $t7: u64
      # live vars:
-  0: $t1 := 1
-     # live vars: $t1
-  1: $t0 := infer($t1)
+  0: $t0 := 1
      # live vars: $t0
-  2: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-  3: $t2 := infer($t3)
-     # live vars: $t0, $t2
-  4: $t5 := true
-     # live vars: $t0, $t2, $t5
-  5: $t4 := infer($t5)
-     # live vars: $t0, $t2, $t4
-  6: label L0
-     # live vars: $t0, $t2, $t4
-  7: if ($t4) goto 8 else goto 14
-     # live vars: $t0, $t2
-  8: label L2
-     # live vars: $t0, $t2
-  9: $t6 := 2
-     # live vars: $t0, $t2, $t6
- 10: write_ref($t2, $t6)
-     # live vars: $t0, $t2
- 11: $t7 := false
-     # live vars: $t0, $t2, $t7
- 12: $t4 := infer($t7)
-     # live vars: $t0, $t2, $t4
- 13: goto 16
-     # live vars: $t0, $t2
- 14: label L3
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  2: $t2 := true
+     # live vars: $t0, $t1, $t2
+  3: label L0
+     # live vars: $t0, $t1, $t2
+  4: if ($t2) goto 5 else goto 11
+     # live vars: $t0, $t1
+  5: label L2
+     # live vars: $t0, $t1
+  6: $t3 := 2
+     # live vars: $t0, $t1, $t3
+  7: write_ref($t1, $t3)
+     # live vars: $t0, $t1
+  8: $t4 := false
+     # live vars: $t0, $t1, $t4
+  9: $t2 := infer($t4)
+     # live vars: $t0, $t1, $t2
+ 10: goto 13
+     # live vars: $t0, $t1
+ 11: label L3
      # live vars: $t0
- 15: goto 18
-     # live vars: $t0, $t2, $t4
- 16: label L4
-     # live vars: $t0, $t2, $t4
- 17: goto 6
+ 12: goto 15
+     # live vars: $t0, $t1, $t2
+ 13: label L4
+     # live vars: $t0, $t1, $t2
+ 14: goto 3
      # live vars: $t0
- 18: label L1
+ 15: label L1
      # live vars: $t0
- 19: $t9 := 2
-     # live vars: $t0, $t9
- 20: $t8 := ==($t0, $t9)
-     # live vars: $t8
- 21: if ($t8) goto 22 else goto 24
+ 16: $t6 := 2
+     # live vars: $t0, $t6
+ 17: $t5 := ==($t0, $t6)
+     # live vars: $t5
+ 18: if ($t5) goto 19 else goto 21
      # live vars:
- 22: label L5
+ 19: label L5
      # live vars:
- 23: goto 27
+ 20: goto 24
      # live vars:
- 24: label L6
+ 21: label L6
      # live vars:
- 25: $t10 := 0
-     # live vars: $t10
- 26: abort($t10)
+ 22: $t7 := 0
+     # live vars: $t7
+ 23: abort($t7)
      # live vars:
- 27: label L7
+ 24: label L7
      # live vars:
- 28: return ()
+ 25: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -124,190 +109,169 @@ fun m::drop_after_loop() {
 [variant baseline]
 fun m::drop_after_loop() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &mut u64
-     var $t3: &mut u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-     var $t7: bool
-     var $t8: bool
-     var $t9: u64
-     var $t10: u64
+     var $t7: u64
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := 1
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := 1
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t3=@201}
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  3: $t2 := infer($t3)
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  2: $t2 := true
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  4: $t5 := true
-     # live vars: $t0, $t2, $t5
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  3: label L0
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  5: $t4 := infer($t5)
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  4: if ($t2) goto 5 else goto 11
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  6: label L0
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  5: label L2
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  7: if ($t4) goto 8 else goto 14
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  6: $t3 := 2
+     # live vars: $t0, $t1, $t3
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  8: label L2
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  7: write_ref($t1, $t3)
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  9: $t6 := 2
-     # live vars: $t0, $t2, $t6
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  8: $t4 := false
+     # live vars: $t0, $t1, $t4
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 10: write_ref($t2, $t6)
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+  9: $t2 := infer($t4)
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 11: $t7 := false
-     # live vars: $t0, $t2, $t7
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+ 10: goto 13
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 12: $t4 := infer($t7)
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
-     # globals: {}
-     #
- 13: goto 16
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
-     # globals: {}
-     #
- 14: label L3
+ 11: label L3
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 15: goto 18
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+ 12: goto 15
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 16: label L4
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+ 13: label L4
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 17: goto 6
+ 14: goto 3
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 18: label L1
+ 15: label L1
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 19: $t9 := 2
-     # live vars: $t0, $t9
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+ 16: $t6 := 2
+     # live vars: $t0, $t6
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 20: $t8 := ==($t0, $t9)
-     # live vars: $t8
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+ 17: $t5 := ==($t0, $t6)
+     # live vars: $t5
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 21: if ($t8) goto 22 else goto 24
+ 18: if ($t5) goto 19 else goto 21
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 22: label L5
+ 19: label L5
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 23: goto 27
+ 20: goto 24
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 24: label L6
+ 21: label L6
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 25: $t10 := 0
-     # live vars: $t10
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+ 22: $t7 := 0
+     # live vars: $t7
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 26: abort($t10)
+ 23: abort($t7)
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 27: label L7
+ 24: label L7
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 28: return ()
+ 25: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -315,219 +279,195 @@ fun m::drop_after_loop() {
 [variant baseline]
 fun m::drop_after_loop() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &mut u64
-     var $t3: &mut u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-     var $t7: bool
-     var $t8: bool
-     var $t9: u64
-     var $t10: u64
+     var $t7: u64
      # abort state: {returns,aborts}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := 1
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := borrow_local($t0)
+  1: $t1 := borrow_local($t0)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t3
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t3=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  3: $t2 := infer($t3)
+  2: $t2 := true
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  4: $t5 := true
+  3: label L0
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t5
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  5: $t4 := infer($t5)
+  4: if ($t2) goto 5 else goto 11
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  6: label L0
+  5: label L2
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  7: if ($t4) goto 8 else goto 14
+  6: $t3 := 2
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t3
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  8: label L2
+  7: write_ref($t1, $t3)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  9: $t6 := 2
+  8: $t4 := false
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t6
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t4
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 10: write_ref($t2, $t6)
+  9: $t2 := infer($t4)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 11: $t7 := false
+ 10: goto 13
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t7
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 12: $t4 := infer($t7)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
-     # globals: {}
-     #
- 13: goto 16
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
-     # globals: {}
-     #
- 14: label L3
+ 11: label L3
      # abort state: {returns,aborts}
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 15: goto 18
+ 12: goto 15
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 16: label L4
+ 13: label L4
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t0)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t0=@200,$t2=@201}
+     # live vars: $t0, $t1, $t2
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
- 17: goto 6
-     # abort state: {returns,aborts}
-     # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
-     # globals: {}
-     #
- 18: label L1
+ 14: goto 3
      # abort state: {returns,aborts}
      # live vars: $t0
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 19: $t9 := 2
+ 15: label L1
      # abort state: {returns,aborts}
-     # live vars: $t0, $t9
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # live vars: $t0
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 20: $t8 := ==($t0, $t9)
+ 16: $t6 := 2
      # abort state: {returns,aborts}
-     # live vars: $t8
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # live vars: $t0, $t6
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 21: if ($t8) goto 22 else goto 24
+ 17: $t5 := ==($t0, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t5
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
+     # globals: {}
+     #
+ 18: if ($t5) goto 19 else goto 21
      # abort state: {returns}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 22: label L5
+ 19: label L5
      # abort state: {returns}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 23: goto 27
+ 20: goto 24
      # abort state: {aborts}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 24: label L6
+ 21: label L6
      # abort state: {aborts}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 25: $t10 := 0
+ 22: $t7 := 0
      # abort state: {aborts}
-     # live vars: $t10
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # live vars: $t7
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 26: abort($t10)
+ 23: abort($t7)
      # abort state: {returns}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 27: label L7
+ 24: label L7
      # abort state: {returns}
      # live vars:
-     # graph: {@200=local($t0)[]}
-     # locals: {$t0=@200}
+     # graph: {@100=local($t0)[]}
+     # locals: {$t0=@100}
      # globals: {}
      #
- 28: return ()
+ 25: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -535,44 +475,38 @@ fun m::drop_after_loop() {
 [variant baseline]
 fun m::drop_after_loop() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &mut u64
-     var $t3: &mut u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
      var $t4: bool
      var $t5: bool
      var $t6: u64
-     var $t7: bool
-     var $t8: bool
-     var $t9: u64
-     var $t10: u64
-  0: $t1 := 1
-  1: $t0 := move($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := move($t3)
-  4: $t5 := true
-  5: $t4 := move($t5)
-  6: label L0
-  7: if ($t4) goto 8 else goto 14
-  8: label L2
-  9: $t6 := 2
- 10: write_ref($t2, $t6)
- 11: $t7 := false
- 12: $t4 := move($t7)
- 13: goto 17
- 14: label L3
- 15: drop($t2)
- 16: goto 19
- 17: label L4
- 18: goto 6
- 19: label L1
- 20: $t9 := 2
- 21: $t8 := ==($t0, $t9)
- 22: if ($t8) goto 23 else goto 25
- 23: label L5
- 24: goto 28
- 25: label L6
- 26: $t10 := 0
- 27: abort($t10)
- 28: label L7
- 29: return ()
+     var $t7: u64
+  0: $t0 := 1
+  1: $t1 := borrow_local($t0)
+  2: $t2 := true
+  3: label L0
+  4: if ($t2) goto 5 else goto 11
+  5: label L2
+  6: $t3 := 2
+  7: write_ref($t1, $t3)
+  8: $t4 := false
+  9: $t2 := move($t4)
+ 10: goto 14
+ 11: label L3
+ 12: drop($t1)
+ 13: goto 16
+ 14: label L4
+ 15: goto 3
+ 16: label L1
+ 17: $t6 := 2
+ 18: $t5 := ==($t0, $t6)
+ 19: if ($t5) goto 20 else goto 22
+ 20: label L5
+ 21: goto 25
+ 22: label L6
+ 23: $t7 := 0
+ 24: abort($t7)
+ 25: label L7
+ 26: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
@@ -3,59 +3,49 @@
 [variant baseline]
 fun m::test_for_each_mut() {
      var $t0: vector<u64>
-     var $t1: vector<u64>
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: &vector<u64>
-     var $t7: &mut vector<u64>
-     var $t8: &mut vector<u64>
-     var $t9: bool
-     var $t10: &mut u64
-     var $t11: &mut u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: vector<u64>
      var $t12: u64
-     var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: vector<u64>
-     var $t17: u64
-  0: $t1 := ["1", "2", "3"]
-  1: $t0 := infer($t1)
-  2: $t3 := 0
-  3: $t2 := infer($t3)
-  4: $t6 := borrow_local($t0)
-  5: $t5 := vector::length<u64>($t6)
-  6: $t4 := infer($t5)
-  7: $t8 := borrow_local($t0)
-  8: $t7 := infer($t8)
-  9: label L0
- 10: $t9 := <($t2, $t4)
- 11: if ($t9) goto 12 else goto 21
- 12: label L2
- 13: $t11 := vector::borrow_mut<u64>($t7, $t2)
- 14: $t10 := infer($t11)
- 15: $t12 := 2
- 16: write_ref($t10, $t12)
- 17: $t14 := 1
- 18: $t13 := +($t2, $t14)
- 19: $t2 := infer($t13)
- 20: goto 23
- 21: label L3
- 22: goto 25
- 23: label L4
- 24: goto 9
- 25: label L1
- 26: $t16 := ["2", "3", "4"]
- 27: $t15 := ==($t0, $t16)
- 28: if ($t15) goto 29 else goto 31
- 29: label L5
- 30: goto 34
- 31: label L6
- 32: $t17 := 0
- 33: abort($t17)
- 34: label L7
- 35: return ()
+  0: $t0 := ["1", "2", "3"]
+  1: $t1 := 0
+  2: $t3 := borrow_local($t0)
+  3: $t2 := vector::length<u64>($t3)
+  4: $t4 := borrow_local($t0)
+  5: label L0
+  6: $t5 := <($t1, $t2)
+  7: if ($t5) goto 8 else goto 16
+  8: label L2
+  9: $t6 := vector::borrow_mut<u64>($t4, $t1)
+ 10: $t7 := 2
+ 11: write_ref($t6, $t7)
+ 12: $t9 := 1
+ 13: $t8 := +($t1, $t9)
+ 14: $t1 := infer($t8)
+ 15: goto 18
+ 16: label L3
+ 17: goto 20
+ 18: label L4
+ 19: goto 5
+ 20: label L1
+ 21: $t11 := ["2", "3", "4"]
+ 22: $t10 := ==($t0, $t11)
+ 23: if ($t10) goto 24 else goto 26
+ 24: label L5
+ 25: goto 29
+ 26: label L6
+ 27: $t12 := 0
+ 28: abort($t12)
+ 29: label L7
+ 30: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -63,95 +53,80 @@ fun m::test_for_each_mut() {
 [variant baseline]
 fun m::test_for_each_mut() {
      var $t0: vector<u64>
-     var $t1: vector<u64>
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: &vector<u64>
-     var $t7: &mut vector<u64>
-     var $t8: &mut vector<u64>
-     var $t9: bool
-     var $t10: &mut u64
-     var $t11: &mut u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: vector<u64>
      var $t12: u64
-     var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: vector<u64>
-     var $t17: u64
      # live vars:
-  0: $t1 := ["1", "2", "3"]
-     # live vars: $t1
-  1: $t0 := infer($t1)
+  0: $t0 := ["1", "2", "3"]
      # live vars: $t0
-  2: $t3 := 0
-     # live vars: $t0, $t3
-  3: $t2 := infer($t3)
-     # live vars: $t0, $t2
-  4: $t6 := borrow_local($t0)
-     # live vars: $t0, $t2, $t6
-  5: $t5 := vector::length<u64>($t6)
-     # live vars: $t0, $t2, $t5
-  6: $t4 := infer($t5)
-     # live vars: $t0, $t2, $t4
-  7: $t8 := borrow_local($t0)
+  1: $t1 := 0
+     # live vars: $t0, $t1
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  3: $t2 := vector::length<u64>($t3)
+     # live vars: $t0, $t1, $t2
+  4: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t4
+  5: label L0
+     # live vars: $t0, $t1, $t2, $t4
+  6: $t5 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4, $t5
+  7: if ($t5) goto 8 else goto 16
+     # live vars: $t0, $t1, $t2, $t4
+  8: label L2
+     # live vars: $t0, $t1, $t2, $t4
+  9: $t6 := vector::borrow_mut<u64>($t4, $t1)
+     # live vars: $t0, $t1, $t2, $t4, $t6
+ 10: $t7 := 2
+     # live vars: $t0, $t1, $t2, $t4, $t6, $t7
+ 11: write_ref($t6, $t7)
+     # live vars: $t0, $t1, $t2, $t4
+ 12: $t9 := 1
+     # live vars: $t0, $t1, $t2, $t4, $t9
+ 13: $t8 := +($t1, $t9)
      # live vars: $t0, $t2, $t4, $t8
-  8: $t7 := infer($t8)
-     # live vars: $t0, $t2, $t4, $t7
-  9: label L0
-     # live vars: $t0, $t2, $t4, $t7
- 10: $t9 := <($t2, $t4)
-     # live vars: $t0, $t2, $t4, $t7, $t9
- 11: if ($t9) goto 12 else goto 21
-     # live vars: $t0, $t2, $t4, $t7
- 12: label L2
-     # live vars: $t0, $t2, $t4, $t7
- 13: $t11 := vector::borrow_mut<u64>($t7, $t2)
-     # live vars: $t0, $t2, $t4, $t7, $t11
- 14: $t10 := infer($t11)
-     # live vars: $t0, $t2, $t4, $t7, $t10
- 15: $t12 := 2
-     # live vars: $t0, $t2, $t4, $t7, $t10, $t12
- 16: write_ref($t10, $t12)
-     # live vars: $t0, $t2, $t4, $t7
- 17: $t14 := 1
-     # live vars: $t0, $t2, $t4, $t7, $t14
- 18: $t13 := +($t2, $t14)
-     # live vars: $t0, $t4, $t7, $t13
- 19: $t2 := infer($t13)
-     # live vars: $t0, $t2, $t4, $t7
- 20: goto 23
-     # live vars: $t0, $t2, $t4, $t7
- 21: label L3
+ 14: $t1 := infer($t8)
+     # live vars: $t0, $t1, $t2, $t4
+ 15: goto 18
+     # live vars: $t0, $t1, $t2, $t4
+ 16: label L3
      # live vars: $t0
- 22: goto 25
-     # live vars: $t0, $t2, $t4, $t7
- 23: label L4
-     # live vars: $t0, $t2, $t4, $t7
- 24: goto 9
+ 17: goto 20
+     # live vars: $t0, $t1, $t2, $t4
+ 18: label L4
+     # live vars: $t0, $t1, $t2, $t4
+ 19: goto 5
      # live vars: $t0
- 25: label L1
+ 20: label L1
      # live vars: $t0
- 26: $t16 := ["2", "3", "4"]
-     # live vars: $t0, $t16
- 27: $t15 := ==($t0, $t16)
-     # live vars: $t15
- 28: if ($t15) goto 29 else goto 31
+ 21: $t11 := ["2", "3", "4"]
+     # live vars: $t0, $t11
+ 22: $t10 := ==($t0, $t11)
+     # live vars: $t10
+ 23: if ($t10) goto 24 else goto 26
      # live vars:
- 29: label L5
+ 24: label L5
      # live vars:
- 30: goto 34
+ 25: goto 29
      # live vars:
- 31: label L6
+ 26: label L6
      # live vars:
- 32: $t17 := 0
-     # live vars: $t17
- 33: abort($t17)
+ 27: $t12 := 0
+     # live vars: $t12
+ 28: abort($t12)
      # live vars:
- 34: label L7
+ 29: label L7
      # live vars:
- 35: return ()
+ 30: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -159,239 +134,204 @@ fun m::test_for_each_mut() {
 [variant baseline]
 fun m::test_for_each_mut() {
      var $t0: vector<u64>
-     var $t1: vector<u64>
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: &vector<u64>
-     var $t7: &mut vector<u64>
-     var $t8: &mut vector<u64>
-     var $t9: bool
-     var $t10: &mut u64
-     var $t11: &mut u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: vector<u64>
      var $t12: u64
-     var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: vector<u64>
-     var $t17: u64
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := ["1", "2", "3"]
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := ["1", "2", "3"]
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := 0
-     # live vars: $t0, $t3
+  1: $t1 := 0
+     # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  3: $t2 := infer($t3)
-     # live vars: $t0, $t2
-     # graph: {}
-     # locals: {}
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+     # graph: {@200=local($t0)[borrow(false) -> @201],@201=derived[]}
+     # locals: {$t0=@200,$t3=@201}
      # globals: {}
      #
-  4: $t6 := borrow_local($t0)
-     # live vars: $t0, $t2, $t6
-     # graph: {@400=local($t0)[borrow(false) -> @401],@401=derived[]}
-     # locals: {$t0=@400,$t6=@401}
+  3: $t2 := vector::length<u64>($t3)
+     # live vars: $t0, $t1, $t2
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
-  5: $t5 := vector::length<u64>($t6)
-     # live vars: $t0, $t2, $t5
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+  4: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  6: $t4 := infer($t5)
-     # live vars: $t0, $t2, $t4
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+  5: label L0
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  7: $t8 := borrow_local($t0)
+  6: $t5 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4, $t5
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  7: if ($t5) goto 8 else goto 16
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  8: label L2
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  9: $t6 := vector::borrow_mut<u64>($t4, $t1)
+     # live vars: $t0, $t1, $t2, $t4, $t6
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # locals: {$t0=@200,$t4=@401,$t6=@900}
+     # globals: {}
+     #
+ 10: $t7 := 2
+     # live vars: $t0, $t1, $t2, $t4, $t6, $t7
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # locals: {$t0=@200,$t4=@401,$t6=@900}
+     # globals: {}
+     #
+ 11: write_ref($t6, $t7)
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+ 12: $t9 := 1
+     # live vars: $t0, $t1, $t2, $t4, $t9
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+ 13: $t8 := +($t1, $t9)
      # live vars: $t0, $t2, $t4, $t8
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t8=@701}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  8: $t7 := infer($t8)
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+ 14: $t1 := infer($t8)
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  9: label L0
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+ 15: goto 18
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 10: $t9 := <($t2, $t4)
-     # live vars: $t0, $t2, $t4, $t7, $t9
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 11: if ($t9) goto 12 else goto 21
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 12: label L2
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 13: $t11 := vector::borrow_mut<u64>($t7, $t2)
-     # live vars: $t0, $t2, $t4, $t7, $t11
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t11=@D00}
-     # globals: {}
-     #
- 14: $t10 := infer($t11)
-     # live vars: $t0, $t2, $t4, $t7, $t10
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t10=@D00}
-     # globals: {}
-     #
- 15: $t12 := 2
-     # live vars: $t0, $t2, $t4, $t7, $t10, $t12
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t10=@D00}
-     # globals: {}
-     #
- 16: write_ref($t10, $t12)
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 17: $t14 := 1
-     # live vars: $t0, $t2, $t4, $t7, $t14
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 18: $t13 := +($t2, $t14)
-     # live vars: $t0, $t4, $t7, $t13
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 19: $t2 := infer($t13)
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 20: goto 23
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 21: label L3
+ 16: label L3
      # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 22: goto 25
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+ 17: goto 20
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 23: label L4
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+ 18: label L4
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 24: goto 9
+ 19: goto 5
      # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 25: label L1
+ 20: label L1
      # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 26: $t16 := ["2", "3", "4"]
-     # live vars: $t0, $t16
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+ 21: $t11 := ["2", "3", "4"]
+     # live vars: $t0, $t11
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 27: $t15 := ==($t0, $t16)
-     # live vars: $t15
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+ 22: $t10 := ==($t0, $t11)
+     # live vars: $t10
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 28: if ($t15) goto 29 else goto 31
+ 23: if ($t10) goto 24 else goto 26
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 29: label L5
+ 24: label L5
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 30: goto 34
+ 25: goto 29
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 31: label L6
+ 26: label L6
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 32: $t17 := 0
-     # live vars: $t17
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+ 27: $t12 := 0
+     # live vars: $t12
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 33: abort($t17)
+ 28: abort($t12)
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 34: label L7
+ 29: label L7
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 35: return ()
+ 30: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -399,275 +339,235 @@ fun m::test_for_each_mut() {
 [variant baseline]
 fun m::test_for_each_mut() {
      var $t0: vector<u64>
-     var $t1: vector<u64>
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: &vector<u64>
-     var $t7: &mut vector<u64>
-     var $t8: &mut vector<u64>
-     var $t9: bool
-     var $t10: &mut u64
-     var $t11: &mut u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: vector<u64>
      var $t12: u64
-     var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: vector<u64>
-     var $t17: u64
      # abort state: {returns,aborts}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t1 := ["1", "2", "3"]
-     # abort state: {returns,aborts}
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t0 := infer($t1)
+  0: $t0 := ["1", "2", "3"]
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t3 := 0
+  1: $t1 := 0
      # abort state: {returns,aborts}
-     # live vars: $t0, $t3
+     # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  3: $t2 := infer($t3)
+  2: $t3 := borrow_local($t0)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2
-     # graph: {}
-     # locals: {}
+     # live vars: $t0, $t1, $t3
+     # graph: {@200=local($t0)[borrow(false) -> @201],@201=derived[]}
+     # locals: {$t0=@200,$t3=@201}
      # globals: {}
      #
-  4: $t6 := borrow_local($t0)
+  3: $t2 := vector::length<u64>($t3)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t6
-     # graph: {@400=local($t0)[borrow(false) -> @401],@401=derived[]}
-     # locals: {$t0=@400,$t6=@401}
+     # live vars: $t0, $t1, $t2
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
-  5: $t5 := vector::length<u64>($t6)
+  4: $t4 := borrow_local($t0)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t5
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  6: $t4 := infer($t5)
+  5: label L0
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  7: $t8 := borrow_local($t0)
+  6: $t5 := <($t1, $t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4, $t5
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  7: if ($t5) goto 8 else goto 16
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  8: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+  9: $t6 := vector::borrow_mut<u64>($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4, $t6
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # locals: {$t0=@200,$t4=@401,$t6=@900}
+     # globals: {}
+     #
+ 10: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4, $t6, $t7
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # locals: {$t0=@200,$t4=@401,$t6=@900}
+     # globals: {}
+     #
+ 11: write_ref($t6, $t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+ 12: $t9 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t4, $t9
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
+     # globals: {}
+     #
+ 13: $t8 := +($t1, $t9)
      # abort state: {returns,aborts}
      # live vars: $t0, $t2, $t4, $t8
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t8=@701}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  8: $t7 := infer($t8)
+ 14: $t1 := infer($t8)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
-  9: label L0
+ 15: goto 18
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 10: $t9 := <($t2, $t4)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7, $t9
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 11: if ($t9) goto 12 else goto 21
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 12: label L2
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 13: $t11 := vector::borrow_mut<u64>($t7, $t2)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7, $t11
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t11=@D00}
-     # globals: {}
-     #
- 14: $t10 := infer($t11)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7, $t10
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t10=@D00}
-     # globals: {}
-     #
- 15: $t12 := 2
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7, $t10, $t12
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[call(true) -> @D00],@D00=derived[]}
-     # locals: {$t0=@400,$t7=@701,$t10=@D00}
-     # globals: {}
-     #
- 16: write_ref($t10, $t12)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 17: $t14 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7, $t14
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 18: $t13 := +($t2, $t14)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t4, $t7, $t13
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 19: $t2 := infer($t13)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 20: goto 23
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
-     # globals: {}
-     #
- 21: label L3
+ 16: label L3
      # abort state: {returns,aborts}
      # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 22: goto 25
+ 17: goto 20
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 23: label L4
+ 18: label L4
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t4, $t7
-     # graph: {@400=local($t0)[borrow(true) -> @701],@701=derived[]}
-     # locals: {$t0=@400,$t7=@701}
+     # live vars: $t0, $t1, $t2, $t4
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[]}
+     # locals: {$t0=@200,$t4=@401}
      # globals: {}
      #
- 24: goto 9
-     # abort state: {returns,aborts}
-     # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
-     # globals: {}
-     #
- 25: label L1
+ 19: goto 5
      # abort state: {returns,aborts}
      # live vars: $t0
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 26: $t16 := ["2", "3", "4"]
+ 20: label L1
      # abort state: {returns,aborts}
-     # live vars: $t0, $t16
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # live vars: $t0
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 27: $t15 := ==($t0, $t16)
+ 21: $t11 := ["2", "3", "4"]
      # abort state: {returns,aborts}
-     # live vars: $t15
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # live vars: $t0, $t11
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 28: if ($t15) goto 29 else goto 31
+ 22: $t10 := ==($t0, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t10
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
+     # globals: {}
+     #
+ 23: if ($t10) goto 24 else goto 26
      # abort state: {returns}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 29: label L5
+ 24: label L5
      # abort state: {returns}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 30: goto 34
+ 25: goto 29
      # abort state: {aborts}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 31: label L6
+ 26: label L6
      # abort state: {aborts}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 32: $t17 := 0
+ 27: $t12 := 0
      # abort state: {aborts}
-     # live vars: $t17
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # live vars: $t12
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 33: abort($t17)
+ 28: abort($t12)
      # abort state: {returns}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 34: label L7
+ 29: label L7
      # abort state: {returns}
      # live vars:
-     # graph: {@400=local($t0)[]}
-     # locals: {$t0=@400}
+     # graph: {@200=local($t0)[]}
+     # locals: {$t0=@200}
      # globals: {}
      #
- 35: return ()
+ 30: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -675,60 +575,50 @@ fun m::test_for_each_mut() {
 [variant baseline]
 fun m::test_for_each_mut() {
      var $t0: vector<u64>
-     var $t1: vector<u64>
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-     var $t6: &vector<u64>
-     var $t7: &mut vector<u64>
-     var $t8: &mut vector<u64>
-     var $t9: bool
-     var $t10: &mut u64
-     var $t11: &mut u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: bool
+     var $t11: vector<u64>
      var $t12: u64
-     var $t13: u64
-     var $t14: u64
-     var $t15: bool
-     var $t16: vector<u64>
-     var $t17: u64
-     var $t18: &mut vector<u64>
-  0: $t1 := ["1", "2", "3"]
-  1: $t0 := move($t1)
-  2: $t3 := 0
-  3: $t2 := move($t3)
-  4: $t6 := borrow_local($t0)
-  5: $t5 := vector::length<u64>($t6)
-  6: $t4 := move($t5)
-  7: $t8 := borrow_local($t0)
-  8: $t7 := move($t8)
-  9: label L0
- 10: $t9 := <($t2, $t4)
- 11: if ($t9) goto 12 else goto 22
- 12: label L2
- 13: $t18 := copy($t7)
- 14: $t11 := vector::borrow_mut<u64>($t18, $t2)
- 15: $t10 := move($t11)
- 16: $t12 := 2
- 17: write_ref($t10, $t12)
- 18: $t14 := 1
- 19: $t13 := +($t2, $t14)
- 20: $t2 := move($t13)
- 21: goto 25
- 22: label L3
- 23: drop($t7)
- 24: goto 27
- 25: label L4
- 26: goto 9
- 27: label L1
- 28: $t16 := ["2", "3", "4"]
- 29: $t15 := ==($t0, $t16)
- 30: if ($t15) goto 31 else goto 33
- 31: label L5
- 32: goto 36
- 33: label L6
- 34: $t17 := 0
- 35: abort($t17)
- 36: label L7
- 37: return ()
+     var $t13: &mut vector<u64>
+  0: $t0 := ["1", "2", "3"]
+  1: $t1 := 0
+  2: $t3 := borrow_local($t0)
+  3: $t2 := vector::length<u64>($t3)
+  4: $t4 := borrow_local($t0)
+  5: label L0
+  6: $t5 := <($t1, $t2)
+  7: if ($t5) goto 8 else goto 17
+  8: label L2
+  9: $t13 := copy($t4)
+ 10: $t6 := vector::borrow_mut<u64>($t13, $t1)
+ 11: $t7 := 2
+ 12: write_ref($t6, $t7)
+ 13: $t9 := 1
+ 14: $t8 := +($t1, $t9)
+ 15: $t1 := move($t8)
+ 16: goto 20
+ 17: label L3
+ 18: drop($t4)
+ 19: goto 22
+ 20: label L4
+ 21: goto 5
+ 22: label L1
+ 23: $t11 := ["2", "3", "4"]
+ 24: $t10 := ==($t0, $t11)
+ 25: if ($t10) goto 26 else goto 28
+ 26: label L5
+ 27: goto 31
+ 28: label L6
+ 29: $t12 := 0
+ 30: abort($t12)
+ 31: label L7
+ 32: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
@@ -4,14 +4,12 @@
 public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
-     var $t3: vector<#0>
-     var $t4: &mut vector<#0>
-  0: $t3 := vector($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := borrow_local($t2)
-  3: m::g<#0>($t4)
-  4: $t1 := infer($t2)
-  5: return $t1
+     var $t3: &mut vector<#0>
+  0: $t2 := vector($t0)
+  1: $t3 := borrow_local($t2)
+  2: m::g<#0>($t3)
+  3: $t1 := infer($t2)
+  4: return $t1
 }
 
 
@@ -26,20 +24,17 @@ fun m::g<#0>($t0: &mut vector<#0>) {
 public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
-     var $t3: vector<#0>
-     var $t4: &mut vector<#0>
+     var $t3: &mut vector<#0>
      # live vars: $t0
-  0: $t3 := vector($t0)
-     # live vars: $t3
-  1: $t2 := infer($t3)
+  0: $t2 := vector($t0)
      # live vars: $t2
-  2: $t4 := borrow_local($t2)
-     # live vars: $t2, $t4
-  3: m::g<#0>($t4)
+  1: $t3 := borrow_local($t2)
+     # live vars: $t2, $t3
+  2: m::g<#0>($t3)
      # live vars: $t2
-  4: $t1 := infer($t2)
+  3: $t1 := infer($t2)
      # live vars: $t1
-  5: return $t1
+  4: return $t1
 }
 
 
@@ -55,44 +50,37 @@ fun m::g<#0>($t0: &mut vector<#0>) {
 public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
-     var $t3: vector<#0>
-     var $t4: &mut vector<#0>
+     var $t3: &mut vector<#0>
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := vector($t0)
-     # live vars: $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t2 := infer($t3)
+  0: $t2 := vector($t0)
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t4 := borrow_local($t2)
-     # live vars: $t2, $t4
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t2=@200,$t4=@201}
+  1: $t3 := borrow_local($t2)
+     # live vars: $t2, $t3
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t2=@100,$t3=@101}
      # globals: {}
      #
-  3: m::g<#0>($t4)
+  2: m::g<#0>($t3)
      # live vars: $t2
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  4: $t1 := infer($t2)
+  3: $t1 := infer($t2)
      # live vars: $t1
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  5: return $t1
+  4: return $t1
 }
 
 
@@ -112,50 +100,42 @@ fun m::g<#0>($t0: &mut vector<#0>) {
 public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
-     var $t3: vector<#0>
-     var $t4: &mut vector<#0>
+     var $t3: &mut vector<#0>
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := vector($t0)
-     # abort state: {returns,aborts}
-     # live vars: $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t2 := infer($t3)
+  0: $t2 := vector($t0)
      # abort state: {returns,aborts}
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t4 := borrow_local($t2)
+  1: $t3 := borrow_local($t2)
      # abort state: {returns,aborts}
-     # live vars: $t2, $t4
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t2=@200,$t4=@201}
+     # live vars: $t2, $t3
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t2=@100,$t3=@101}
      # globals: {}
      #
-  3: m::g<#0>($t4)
+  2: m::g<#0>($t3)
      # abort state: {returns}
      # live vars: $t2
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  4: $t1 := infer($t2)
+  3: $t1 := infer($t2)
      # abort state: {returns}
      # live vars: $t1
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  5: return $t1
+  4: return $t1
 }
 
 
@@ -176,14 +156,12 @@ fun m::g<#0>($t0: &mut vector<#0>) {
 public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
-     var $t3: vector<#0>
-     var $t4: &mut vector<#0>
-  0: $t3 := vector($t0)
-  1: $t2 := move($t3)
-  2: $t4 := borrow_local($t2)
-  3: m::g<#0>($t4)
-  4: $t1 := move($t2)
-  5: return $t1
+     var $t3: &mut vector<#0>
+  0: $t2 := vector($t0)
+  1: $t3 := borrow_local($t2)
+  2: m::g<#0>($t3)
+  3: $t1 := move($t2)
+  4: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
@@ -4,22 +4,18 @@
 public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      var $t1: m::Scalar
      var $t2: m::Scalar
-     var $t3: m::Scalar
-     var $t4: &mut u8
-     var $t5: &mut u8
-     var $t6: &mut vector<u8>
-     var $t7: &mut m::Scalar
-     var $t8: u64
-  0: $t3 := m::scalar_zero()
-  1: $t2 := infer($t3)
-  2: $t7 := borrow_local($t2)
-  3: $t6 := borrow_field<m::Scalar>.data($t7)
-  4: $t8 := 0
-  5: $t5 := vector::borrow_mut<u8>($t6, $t8)
-  6: $t4 := infer($t5)
-  7: write_ref($t4, $t0)
-  8: $t1 := infer($t2)
-  9: return $t1
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut m::Scalar
+     var $t6: u64
+  0: $t2 := m::scalar_zero()
+  1: $t5 := borrow_local($t2)
+  2: $t4 := borrow_field<m::Scalar>.data($t5)
+  3: $t6 := 0
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+  5: write_ref($t3, $t0)
+  6: $t1 := infer($t2)
+  7: return $t1
 }
 
 
@@ -38,32 +34,26 @@ public fun m::scalar_zero(): m::Scalar {
 public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      var $t1: m::Scalar
      var $t2: m::Scalar
-     var $t3: m::Scalar
-     var $t4: &mut u8
-     var $t5: &mut u8
-     var $t6: &mut vector<u8>
-     var $t7: &mut m::Scalar
-     var $t8: u64
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut m::Scalar
+     var $t6: u64
      # live vars: $t0
-  0: $t3 := m::scalar_zero()
-     # live vars: $t0, $t3
-  1: $t2 := infer($t3)
+  0: $t2 := m::scalar_zero()
      # live vars: $t0, $t2
-  2: $t7 := borrow_local($t2)
-     # live vars: $t0, $t2, $t7
-  3: $t6 := borrow_field<m::Scalar>.data($t7)
-     # live vars: $t0, $t2, $t6
-  4: $t8 := 0
-     # live vars: $t0, $t2, $t6, $t8
-  5: $t5 := vector::borrow_mut<u8>($t6, $t8)
+  1: $t5 := borrow_local($t2)
      # live vars: $t0, $t2, $t5
-  6: $t4 := infer($t5)
+  2: $t4 := borrow_field<m::Scalar>.data($t5)
      # live vars: $t0, $t2, $t4
-  7: write_ref($t4, $t0)
+  3: $t6 := 0
+     # live vars: $t0, $t2, $t4, $t6
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+     # live vars: $t0, $t2, $t3
+  5: write_ref($t3, $t0)
      # live vars: $t2
-  8: $t1 := infer($t2)
+  6: $t1 := infer($t2)
      # live vars: $t1
-  9: return $t1
+  7: return $t1
 }
 
 
@@ -85,72 +75,58 @@ public fun m::scalar_zero(): m::Scalar {
 public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      var $t1: m::Scalar
      var $t2: m::Scalar
-     var $t3: m::Scalar
-     var $t4: &mut u8
-     var $t5: &mut u8
-     var $t6: &mut vector<u8>
-     var $t7: &mut m::Scalar
-     var $t8: u64
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut m::Scalar
+     var $t6: u64
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := m::scalar_zero()
-     # live vars: $t0, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t2 := infer($t3)
+  0: $t2 := m::scalar_zero()
      # live vars: $t0, $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t7 := borrow_local($t2)
-     # live vars: $t0, $t2, $t7
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t2=@200,$t7=@201}
-     # globals: {}
-     #
-  3: $t6 := borrow_field<m::Scalar>.data($t7)
-     # live vars: $t0, $t2, $t6
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[]}
-     # locals: {$t2=@200,$t6=@301}
-     # globals: {}
-     #
-  4: $t8 := 0
-     # live vars: $t0, $t2, $t6, $t8
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[]}
-     # locals: {$t2=@200,$t6=@301}
-     # globals: {}
-     #
-  5: $t5 := vector::borrow_mut<u8>($t6, $t8)
+  1: $t5 := borrow_local($t2)
      # live vars: $t0, $t2, $t5
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[call(true) -> @500],@500=derived[]}
-     # locals: {$t2=@200,$t5=@500}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t2=@100,$t5=@101}
      # globals: {}
      #
-  6: $t4 := infer($t5)
+  2: $t4 := borrow_field<m::Scalar>.data($t5)
      # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[call(true) -> @500],@500=derived[]}
-     # locals: {$t2=@200,$t4=@500}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
+     # locals: {$t2=@100,$t4=@201}
      # globals: {}
      #
-  7: write_ref($t4, $t0)
+  3: $t6 := 0
+     # live vars: $t0, $t2, $t4, $t6
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
+     # locals: {$t2=@100,$t4=@201}
+     # globals: {}
+     #
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+     # live vars: $t0, $t2, $t3
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
+     # locals: {$t2=@100,$t3=@400}
+     # globals: {}
+     #
+  5: write_ref($t3, $t0)
      # live vars: $t2
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  8: $t1 := infer($t2)
+  6: $t1 := infer($t2)
      # live vars: $t1
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  9: return $t1
+  7: return $t1
 }
 
 
@@ -184,82 +160,66 @@ public fun m::scalar_zero(): m::Scalar {
 public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      var $t1: m::Scalar
      var $t2: m::Scalar
-     var $t3: m::Scalar
-     var $t4: &mut u8
-     var $t5: &mut u8
-     var $t6: &mut vector<u8>
-     var $t7: &mut m::Scalar
-     var $t8: u64
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut m::Scalar
+     var $t6: u64
      # abort state: {returns,aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := m::scalar_zero()
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t2 := infer($t3)
+  0: $t2 := m::scalar_zero()
      # abort state: {returns,aborts}
      # live vars: $t0, $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t7 := borrow_local($t2)
+  1: $t5 := borrow_local($t2)
      # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t7
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[]}
-     # locals: {$t2=@200,$t7=@201}
-     # globals: {}
-     #
-  3: $t6 := borrow_field<m::Scalar>.data($t7)
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t6
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[]}
-     # locals: {$t2=@200,$t6=@301}
-     # globals: {}
-     #
-  4: $t8 := 0
-     # abort state: {returns,aborts}
-     # live vars: $t0, $t2, $t6, $t8
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[]}
-     # locals: {$t2=@200,$t6=@301}
-     # globals: {}
-     #
-  5: $t5 := vector::borrow_mut<u8>($t6, $t8)
-     # abort state: {returns}
      # live vars: $t0, $t2, $t5
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[call(true) -> @500],@500=derived[]}
-     # locals: {$t2=@200,$t5=@500}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[]}
+     # locals: {$t2=@100,$t5=@101}
      # globals: {}
      #
-  6: $t4 := infer($t5)
-     # abort state: {returns}
+  2: $t4 := borrow_field<m::Scalar>.data($t5)
+     # abort state: {returns,aborts}
      # live vars: $t0, $t2, $t4
-     # graph: {@200=local($t2)[borrow(true) -> @201],@201=derived[borrow_field(true) -> @301],@301=derived[call(true) -> @500],@500=derived[]}
-     # locals: {$t2=@200,$t4=@500}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
+     # locals: {$t2=@100,$t4=@201}
      # globals: {}
      #
-  7: write_ref($t4, $t0)
+  3: $t6 := 0
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t4, $t6
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
+     # locals: {$t2=@100,$t4=@201}
+     # globals: {}
+     #
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+     # abort state: {returns}
+     # live vars: $t0, $t2, $t3
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
+     # locals: {$t2=@100,$t3=@400}
+     # globals: {}
+     #
+  5: write_ref($t3, $t0)
      # abort state: {returns}
      # live vars: $t2
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  8: $t1 := infer($t2)
+  6: $t1 := infer($t2)
      # abort state: {returns}
      # live vars: $t1
-     # graph: {@200=local($t2)[]}
-     # locals: {$t2=@200}
+     # graph: {@100=local($t2)[]}
+     # locals: {$t2=@100}
      # globals: {}
      #
-  9: return $t1
+  7: return $t1
 }
 
 
@@ -296,22 +256,18 @@ public fun m::scalar_zero(): m::Scalar {
 public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      var $t1: m::Scalar
      var $t2: m::Scalar
-     var $t3: m::Scalar
-     var $t4: &mut u8
-     var $t5: &mut u8
-     var $t6: &mut vector<u8>
-     var $t7: &mut m::Scalar
-     var $t8: u64
-  0: $t3 := m::scalar_zero()
-  1: $t2 := move($t3)
-  2: $t7 := borrow_local($t2)
-  3: $t6 := borrow_field<m::Scalar>.data($t7)
-  4: $t8 := 0
-  5: $t5 := vector::borrow_mut<u8>($t6, $t8)
-  6: $t4 := move($t5)
-  7: write_ref($t4, $t0)
-  8: $t1 := move($t2)
-  9: return $t1
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut m::Scalar
+     var $t6: u64
+  0: $t2 := m::scalar_zero()
+  1: $t5 := borrow_local($t2)
+  2: $t4 := borrow_field<m::Scalar>.data($t5)
+  3: $t6 := 0
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+  5: write_ref($t3, $t0)
+  6: $t1 := move($t2)
+  7: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/abort-analysis/loop_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/abort-analysis/loop_abort.exp
@@ -3,61 +3,55 @@
 [variant baseline]
 fun Test::test0() {
      var $t0: Test::Impotent
-     var $t1: Test::Impotent
-     var $t2: bool
-  0: $t2 := false
-  1: $t1 := pack Test::Impotent($t2)
-  2: $t0 := infer($t1)
-  3: label L0
-  4: goto 3
-  5: label L1
-  6: return ()
+     var $t1: bool
+  0: $t1 := false
+  1: $t0 := pack Test::Impotent($t1)
+  2: label L0
+  3: goto 2
+  4: label L1
+  5: return ()
 }
 
 
 [variant baseline]
 fun Test::test1() {
      var $t0: Test::Impotent
-     var $t1: Test::Impotent
+     var $t1: bool
      var $t2: bool
-     var $t3: bool
-  0: $t2 := false
-  1: $t1 := pack Test::Impotent($t2)
-  2: $t0 := infer($t1)
-  3: label L0
-  4: $t3 := true
-  5: if ($t3) goto 6 else goto 8
-  6: label L2
-  7: goto 10
-  8: label L3
-  9: goto 12
- 10: label L4
- 11: goto 3
- 12: label L1
- 13: return ()
+  0: $t1 := false
+  1: $t0 := pack Test::Impotent($t1)
+  2: label L0
+  3: $t2 := true
+  4: if ($t2) goto 5 else goto 7
+  5: label L2
+  6: goto 9
+  7: label L3
+  8: goto 11
+  9: label L4
+ 10: goto 2
+ 11: label L1
+ 12: return ()
 }
 
 
 [variant baseline]
 fun Test::test2($t0: bool) {
      var $t1: Test::Impotent
-     var $t2: Test::Impotent
-     var $t3: bool
-     var $t4: u64
-  0: $t3 := false
-  1: $t2 := pack Test::Impotent($t3)
-  2: $t1 := infer($t2)
-  3: if ($t0) goto 4 else goto 9
-  4: label L0
-  5: label L3
-  6: goto 5
-  7: label L4
-  8: goto 12
-  9: label L1
- 10: $t4 := 42
- 11: abort($t4)
- 12: label L2
- 13: return ()
+     var $t2: bool
+     var $t3: u64
+  0: $t2 := false
+  1: $t1 := pack Test::Impotent($t2)
+  2: if ($t0) goto 3 else goto 8
+  3: label L0
+  4: label L3
+  5: goto 4
+  6: label L4
+  7: goto 11
+  8: label L1
+  9: $t3 := 42
+ 10: abort($t3)
+ 11: label L2
+ 12: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -65,269 +59,245 @@ fun Test::test2($t0: bool) {
 [variant baseline]
 fun Test::test0() {
      var $t0: Test::Impotent
-     var $t1: Test::Impotent
-     var $t2: bool
+     var $t1: bool
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t2 := false
-     # abort state: {}
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t1 := pack Test::Impotent($t2)
+  0: $t1 := false
      # abort state: {}
      # live vars: $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t0 := infer($t1)
+  1: $t0 := pack Test::Impotent($t1)
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  3: label L0
+  2: label L0
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  4: goto 3
+  3: goto 2
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  5: label L1
+  4: label L1
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  6: return ()
+  5: return ()
 }
 
 
 [variant baseline]
 fun Test::test1() {
      var $t0: Test::Impotent
-     var $t1: Test::Impotent
+     var $t1: bool
      var $t2: bool
-     var $t3: bool
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t2 := false
-     # abort state: {returns}
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t1 := pack Test::Impotent($t2)
+  0: $t1 := false
      # abort state: {returns}
      # live vars: $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t0 := infer($t1)
+  1: $t0 := pack Test::Impotent($t1)
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  3: label L0
+  2: label L0
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  4: $t3 := true
+  3: $t2 := true
      # abort state: {returns}
-     # live vars: $t3
+     # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  5: if ($t3) goto 6 else goto 8
-     # abort state: {returns}
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  6: label L2
+  4: if ($t2) goto 5 else goto 7
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  7: goto 10
+  5: label L2
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  8: label L3
+  6: goto 9
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  9: goto 12
+  7: label L3
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 10: label L4
+  8: goto 11
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 11: goto 3
+  9: label L4
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 12: label L1
+ 10: goto 2
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 13: return ()
+ 11: label L1
+     # abort state: {returns}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 12: return ()
 }
 
 
 [variant baseline]
 fun Test::test2($t0: bool) {
      var $t1: Test::Impotent
-     var $t2: Test::Impotent
-     var $t3: bool
-     var $t4: u64
+     var $t2: bool
+     var $t3: u64
      # abort state: {aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  0: $t3 := false
-     # abort state: {aborts}
-     # live vars: $t0, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-  1: $t2 := pack Test::Impotent($t3)
+  0: $t2 := false
      # abort state: {aborts}
      # live vars: $t0, $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  2: $t1 := infer($t2)
+  1: $t1 := pack Test::Impotent($t2)
      # abort state: {aborts}
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  3: if ($t0) goto 4 else goto 9
+  2: if ($t0) goto 3 else goto 8
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  4: label L0
+  3: label L0
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  5: label L3
+  4: label L3
      # abort state: {}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  6: goto 5
+  5: goto 4
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  7: label L4
+  6: label L4
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  8: goto 12
+  7: goto 11
      # abort state: {aborts}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
-  9: label L1
+  8: label L1
      # abort state: {aborts}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 10: $t4 := 42
+  9: $t3 := 42
      # abort state: {aborts}
-     # live vars: $t4
+     # live vars: $t3
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 11: abort($t4)
+ 10: abort($t3)
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 12: label L2
+ 11: label L2
      # abort state: {returns}
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 13: return ()
+ 12: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
@@ -67,11 +67,9 @@ module 0x42::borrow {
 fun borrow::field($t0: &borrow::S): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
-  0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := infer($t3)
-  2: $t1 := read_ref($t2)
-  3: return $t1
+  0: $t2 := borrow_field<borrow::S>.f($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
 }
 
 
@@ -79,13 +77,11 @@ fun borrow::field($t0: &borrow::S): u64 {
 fun borrow::local($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
-     var $t4: u64
-  0: $t4 := 33
-  1: $t3 := borrow_local($t4)
-  2: $t2 := infer($t3)
-  3: $t1 := read_ref($t2)
-  4: return $t1
+     var $t3: u64
+  0: $t3 := 33
+  1: $t2 := borrow_local($t3)
+  2: $t1 := read_ref($t2)
+  3: return $t1
 }
 
 
@@ -93,11 +89,9 @@ fun borrow::local($t0: u64): u64 {
 fun borrow::param($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t1 := read_ref($t2)
-  3: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
 }
 
 
@@ -105,14 +99,12 @@ fun borrow::param($t0: u64): u64 {
 fun borrow::mut_field($t0: &mut borrow::S): u64 {
      var $t1: u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: u64
-  0: $t3 := borrow_field<borrow::S>.f($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := 22
-  3: write_ref($t2, $t4)
-  4: $t1 := read_ref($t2)
-  5: return $t1
+     var $t3: u64
+  0: $t2 := borrow_field<borrow::S>.f($t0)
+  1: $t3 := 22
+  2: write_ref($t2, $t3)
+  3: $t1 := read_ref($t2)
+  4: return $t1
 }
 
 
@@ -120,18 +112,14 @@ fun borrow::mut_field($t0: &mut borrow::S): u64 {
 fun borrow::mut_local($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: u64
-  0: $t3 := 33
-  1: $t2 := infer($t3)
-  2: $t5 := borrow_local($t2)
-  3: $t4 := infer($t5)
-  4: $t6 := 22
-  5: write_ref($t4, $t6)
-  6: $t1 := read_ref($t4)
-  7: return $t1
+     var $t3: &mut u64
+     var $t4: u64
+  0: $t2 := 33
+  1: $t3 := borrow_local($t2)
+  2: $t4 := 22
+  3: write_ref($t3, $t4)
+  4: $t1 := read_ref($t3)
+  5: return $t1
 }
 
 
@@ -139,12 +127,10 @@ fun borrow::mut_local($t0: u64): u64 {
 fun borrow::mut_param($t0: u64): u64 {
      var $t1: u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := 22
-  3: write_ref($t2, $t4)
-  4: $t1 := read_ref($t2)
-  5: return $t1
+     var $t3: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := 22
+  2: write_ref($t2, $t3)
+  3: $t1 := read_ref($t2)
+  4: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
@@ -118,99 +118,87 @@ public fun M::test(): u64 {
 fun M::test1($t0: u64): u64 {
      var $t1: u64
      var $t2: &mut u64
-     var $t3: &mut u64
-     var $t4: u64
-     var $t5: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: &mut u64
-     var $t10: &mut u64
+     var $t8: &mut u64
+     var $t9: u64
+     var $t10: u64
      var $t11: u64
      var $t12: u64
-     var $t13: u64
+     var $t13: &mut u64
      var $t14: u64
-     var $t15: &mut u64
-     var $t16: &mut u64
+     var $t15: u64
+     var $t16: u64
      var $t17: u64
      var $t18: u64
      var $t19: u64
-     var $t20: u64
+     var $t20: &mut u64
      var $t21: u64
      var $t22: u64
-     var $t23: &mut u64
-     var $t24: &mut u64
-     var $t25: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: &mut u64
      var $t26: u64
      var $t27: u64
      var $t28: u64
-     var $t29: &mut u64
+     var $t29: u64
      var $t30: &mut u64
      var $t31: u64
      var $t32: u64
      var $t33: u64
      var $t34: u64
-     var $t35: &mut u64
-     var $t36: &mut u64
-     var $t37: u64
-     var $t38: u64
-     var $t39: u64
-     var $t40: u64
-     var $t41: u64
-  0: $t6 := 4
-  1: $t5 := <($t0, $t6)
-  2: if ($t5) goto 3 else goto 6
+     var $t35: u64
+  0: $t5 := 4
+  1: $t4 := <($t0, $t5)
+  2: if ($t4) goto 3 else goto 6
   3: label L0
-  4: $t4 := infer($t0)
+  4: $t3 := infer($t0)
   5: goto 8
   6: label L1
-  7: $t4 := 3
+  7: $t3 := 3
   8: label L2
-  9: $t3 := borrow_local($t4)
- 10: $t2 := infer($t3)
- 11: $t7 := 10
- 12: write_ref($t2, $t7)
- 13: $t8 := infer($t0)
- 14: $t10 := borrow_local($t8)
- 15: $t9 := infer($t10)
- 16: $t12 := read_ref($t9)
- 17: $t13 := 1
- 18: $t11 := +($t12, $t13)
- 19: write_ref($t9, $t11)
- 20: $t14 := infer($t8)
- 21: $t18 := 0
- 22: $t17 := +($t14, $t18)
- 23: $t16 := borrow_local($t17)
- 24: $t15 := infer($t16)
- 25: $t20 := read_ref($t15)
- 26: $t21 := 2
- 27: $t19 := +($t20, $t21)
- 28: write_ref($t15, $t19)
- 29: $t22 := infer($t14)
- 30: $t25 := infer($t22)
- 31: $t24 := borrow_local($t25)
- 32: $t23 := infer($t24)
- 33: $t27 := read_ref($t23)
- 34: $t28 := 4
- 35: $t26 := +($t27, $t28)
- 36: write_ref($t23, $t26)
- 37: $t31 := infer($t22)
- 38: $t30 := borrow_local($t31)
- 39: $t29 := infer($t30)
- 40: $t33 := read_ref($t29)
- 41: $t34 := 8
- 42: $t32 := +($t33, $t34)
- 43: write_ref($t29, $t32)
- 44: $t38 := 3
- 45: $t37 := infer($t22)
- 46: $t36 := borrow_local($t37)
- 47: $t35 := infer($t36)
- 48: $t40 := read_ref($t35)
- 49: $t41 := 16
- 50: $t39 := +($t40, $t41)
- 51: write_ref($t35, $t39)
- 52: $t1 := infer($t22)
- 53: return $t1
+  9: $t2 := borrow_local($t3)
+ 10: $t6 := 10
+ 11: write_ref($t2, $t6)
+ 12: $t7 := infer($t0)
+ 13: $t8 := borrow_local($t7)
+ 14: $t10 := read_ref($t8)
+ 15: $t11 := 1
+ 16: $t9 := +($t10, $t11)
+ 17: write_ref($t8, $t9)
+ 18: $t12 := infer($t7)
+ 19: $t15 := 0
+ 20: $t14 := +($t12, $t15)
+ 21: $t13 := borrow_local($t14)
+ 22: $t17 := read_ref($t13)
+ 23: $t18 := 2
+ 24: $t16 := +($t17, $t18)
+ 25: write_ref($t13, $t16)
+ 26: $t19 := infer($t12)
+ 27: $t21 := infer($t19)
+ 28: $t20 := borrow_local($t21)
+ 29: $t23 := read_ref($t20)
+ 30: $t24 := 4
+ 31: $t22 := +($t23, $t24)
+ 32: write_ref($t20, $t22)
+ 33: $t26 := infer($t19)
+ 34: $t25 := borrow_local($t26)
+ 35: $t28 := read_ref($t25)
+ 36: $t29 := 8
+ 37: $t27 := +($t28, $t29)
+ 38: write_ref($t25, $t27)
+ 39: $t32 := 3
+ 40: $t31 := infer($t19)
+ 41: $t30 := borrow_local($t31)
+ 42: $t34 := read_ref($t30)
+ 43: $t35 := 16
+ 44: $t33 := +($t34, $t35)
+ 45: write_ref($t30, $t33)
+ 46: $t1 := infer($t19)
+ 47: return $t1
 }
 
 
@@ -218,143 +206,129 @@ fun M::test1($t0: u64): u64 {
 fun M::test1b($t0: M::S): u64 {
      var $t1: u64
      var $t2: M::S
-     var $t3: M::S
-     var $t4: u64
-     var $t5: &mut M::S
-     var $t6: &mut M::S
-     var $t7: M::S
-     var $t8: bool
-     var $t9: u64
-     var $t10: &M::S
-     var $t11: &u64
-     var $t12: u64
-     var $t13: u64
-     var $t14: &mut u64
+     var $t3: u64
+     var $t4: &mut M::S
+     var $t5: M::S
+     var $t6: bool
+     var $t7: u64
+     var $t8: &M::S
+     var $t9: &u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: M::S
+     var $t14: &mut M::S
      var $t15: M::S
      var $t16: &mut M::S
-     var $t17: M::S
-     var $t18: &mut M::S
-     var $t19: &mut M::S
-     var $t20: u64
-     var $t21: u64
-     var $t22: M::S
-     var $t23: &M::S
-     var $t24: &u64
-     var $t25: u64
-     var $t26: &mut u64
-     var $t27: M::S
+     var $t17: u64
+     var $t18: u64
+     var $t19: M::S
+     var $t20: &M::S
+     var $t21: &u64
+     var $t22: u64
+     var $t23: &mut u64
+     var $t24: M::S
+     var $t25: &mut M::S
+     var $t26: M::S
+     var $t27: &mut u64
      var $t28: &mut M::S
-     var $t29: M::S
-     var $t30: &mut u64
-     var $t31: &mut u64
-     var $t32: &mut M::S
-     var $t33: u64
+     var $t29: u64
+     var $t30: u64
+     var $t31: u64
+     var $t32: M::S
+     var $t33: &mut u64
      var $t34: u64
-     var $t35: u64
-     var $t36: M::S
-     var $t37: &mut u64
-     var $t38: &mut u64
+     var $t35: &M::S
+     var $t36: &u64
+     var $t37: u64
+     var $t38: u64
      var $t39: u64
-     var $t40: &M::S
-     var $t41: &u64
-     var $t42: u64
-     var $t43: u64
+     var $t40: &mut u64
+     var $t41: u64
+     var $t42: &M::S
+     var $t43: &u64
      var $t44: u64
-     var $t45: &mut u64
-     var $t46: &mut u64
-     var $t47: u64
-     var $t48: &M::S
-     var $t49: &u64
-     var $t50: u64
-     var $t51: u64
+     var $t45: u64
+     var $t46: u64
+     var $t47: &mut u64
+     var $t48: u64
+     var $t49: u64
+     var $t50: &M::S
+     var $t51: &u64
      var $t52: u64
-     var $t53: &mut u64
-     var $t54: &mut u64
-     var $t55: u64
-     var $t56: u64
-     var $t57: &M::S
-     var $t58: &u64
-     var $t59: u64
-     var $t60: u64
-     var $t61: u64
-     var $t62: &M::S
-     var $t63: &u64
-  0: $t4 := 3
-  1: $t3 := pack M::S($t4)
-  2: $t2 := infer($t3)
-  3: $t10 := borrow_local($t0)
-  4: $t11 := borrow_field<M::S>.f($t10)
-  5: $t9 := read_ref($t11)
-  6: $t12 := 4
-  7: $t8 := <($t9, $t12)
-  8: if ($t8) goto 9 else goto 12
-  9: label L0
- 10: $t7 := infer($t0)
- 11: goto 14
- 12: label L1
- 13: $t7 := infer($t2)
- 14: label L2
- 15: $t6 := borrow_local($t7)
- 16: $t5 := infer($t6)
- 17: $t13 := 10
- 18: $t15 := read_ref($t5)
- 19: $t16 := borrow_local($t15)
- 20: $t14 := borrow_field<M::S>.f($t16)
- 21: write_ref($t14, $t13)
- 22: $t17 := infer($t0)
- 23: $t19 := borrow_local($t17)
- 24: $t18 := infer($t19)
- 25: $t22 := read_ref($t18)
- 26: $t23 := borrow_local($t22)
- 27: $t24 := borrow_field<M::S>.f($t23)
- 28: $t21 := read_ref($t24)
- 29: $t25 := 1
- 30: $t20 := +($t21, $t25)
- 31: $t27 := read_ref($t18)
- 32: $t28 := borrow_local($t27)
- 33: $t26 := borrow_field<M::S>.f($t28)
- 34: write_ref($t26, $t20)
- 35: $t29 := infer($t17)
- 36: $t32 := borrow_local($t29)
- 37: $t31 := borrow_field<M::S>.f($t32)
- 38: $t30 := infer($t31)
- 39: $t34 := read_ref($t30)
- 40: $t35 := 1
- 41: $t33 := +($t34, $t35)
- 42: write_ref($t30, $t33)
- 43: $t36 := infer($t29)
- 44: $t40 := borrow_local($t36)
- 45: $t41 := borrow_field<M::S>.f($t40)
- 46: $t39 := read_ref($t41)
- 47: $t38 := borrow_local($t39)
- 48: $t37 := infer($t38)
- 49: $t43 := read_ref($t37)
- 50: $t44 := 1
- 51: $t42 := +($t43, $t44)
- 52: write_ref($t37, $t42)
- 53: $t48 := borrow_local($t36)
- 54: $t49 := borrow_field<M::S>.f($t48)
- 55: $t47 := read_ref($t49)
- 56: $t46 := borrow_local($t47)
- 57: $t45 := infer($t46)
- 58: $t51 := read_ref($t45)
- 59: $t52 := 8
- 60: $t50 := +($t51, $t52)
- 61: write_ref($t45, $t50)
- 62: $t56 := 3
- 63: $t57 := borrow_local($t36)
- 64: $t58 := borrow_field<M::S>.f($t57)
- 65: $t55 := read_ref($t58)
- 66: $t54 := borrow_local($t55)
- 67: $t53 := infer($t54)
- 68: $t60 := read_ref($t53)
- 69: $t61 := 16
- 70: $t59 := +($t60, $t61)
- 71: write_ref($t53, $t59)
- 72: $t62 := borrow_local($t36)
- 73: $t63 := borrow_field<M::S>.f($t62)
- 74: $t1 := read_ref($t63)
- 75: return $t1
+     var $t53: u64
+     var $t54: u64
+     var $t55: &M::S
+     var $t56: &u64
+  0: $t3 := 3
+  1: $t2 := pack M::S($t3)
+  2: $t8 := borrow_local($t0)
+  3: $t9 := borrow_field<M::S>.f($t8)
+  4: $t7 := read_ref($t9)
+  5: $t10 := 4
+  6: $t6 := <($t7, $t10)
+  7: if ($t6) goto 8 else goto 11
+  8: label L0
+  9: $t5 := infer($t0)
+ 10: goto 13
+ 11: label L1
+ 12: $t5 := infer($t2)
+ 13: label L2
+ 14: $t4 := borrow_local($t5)
+ 15: $t11 := 10
+ 16: $t13 := read_ref($t4)
+ 17: $t14 := borrow_local($t13)
+ 18: $t12 := borrow_field<M::S>.f($t14)
+ 19: write_ref($t12, $t11)
+ 20: $t15 := infer($t0)
+ 21: $t16 := borrow_local($t15)
+ 22: $t19 := read_ref($t16)
+ 23: $t20 := borrow_local($t19)
+ 24: $t21 := borrow_field<M::S>.f($t20)
+ 25: $t18 := read_ref($t21)
+ 26: $t22 := 1
+ 27: $t17 := +($t18, $t22)
+ 28: $t24 := read_ref($t16)
+ 29: $t25 := borrow_local($t24)
+ 30: $t23 := borrow_field<M::S>.f($t25)
+ 31: write_ref($t23, $t17)
+ 32: $t26 := infer($t15)
+ 33: $t28 := borrow_local($t26)
+ 34: $t27 := borrow_field<M::S>.f($t28)
+ 35: $t30 := read_ref($t27)
+ 36: $t31 := 1
+ 37: $t29 := +($t30, $t31)
+ 38: write_ref($t27, $t29)
+ 39: $t32 := infer($t26)
+ 40: $t35 := borrow_local($t32)
+ 41: $t36 := borrow_field<M::S>.f($t35)
+ 42: $t34 := read_ref($t36)
+ 43: $t33 := borrow_local($t34)
+ 44: $t38 := read_ref($t33)
+ 45: $t39 := 1
+ 46: $t37 := +($t38, $t39)
+ 47: write_ref($t33, $t37)
+ 48: $t42 := borrow_local($t32)
+ 49: $t43 := borrow_field<M::S>.f($t42)
+ 50: $t41 := read_ref($t43)
+ 51: $t40 := borrow_local($t41)
+ 52: $t45 := read_ref($t40)
+ 53: $t46 := 8
+ 54: $t44 := +($t45, $t46)
+ 55: write_ref($t40, $t44)
+ 56: $t49 := 3
+ 57: $t50 := borrow_local($t32)
+ 58: $t51 := borrow_field<M::S>.f($t50)
+ 59: $t48 := read_ref($t51)
+ 60: $t47 := borrow_local($t48)
+ 61: $t53 := read_ref($t47)
+ 62: $t54 := 16
+ 63: $t52 := +($t53, $t54)
+ 64: write_ref($t47, $t52)
+ 65: $t55 := borrow_local($t32)
+ 66: $t56 := borrow_field<M::S>.f($t55)
+ 67: $t1 := read_ref($t56)
+ 68: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/escape_autoref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/escape_autoref.exp
@@ -39,19 +39,17 @@ fun m::make(): m::Object {
 fun m::owner_correct($t0: m::Object): address {
      var $t1: address
      var $t2: address
-     var $t3: address
-     var $t4: &m::Object
-     var $t5: &address
-     var $t6: &m::ObjectCore
-     var $t7: &address
-  0: $t4 := borrow_local($t0)
-  1: $t5 := borrow_field<m::Object>.inner($t4)
-  2: $t3 := read_ref($t5)
-  3: $t2 := infer($t3)
-  4: $t6 := borrow_global<m::ObjectCore>($t2)
-  5: $t7 := borrow_field<m::ObjectCore>.owner($t6)
-  6: $t1 := read_ref($t7)
-  7: return $t1
+     var $t3: &m::Object
+     var $t4: &address
+     var $t5: &m::ObjectCore
+     var $t6: &address
+  0: $t3 := borrow_local($t0)
+  1: $t4 := borrow_field<m::Object>.inner($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_global<m::ObjectCore>($t2)
+  4: $t6 := borrow_field<m::ObjectCore>.owner($t5)
+  5: $t1 := read_ref($t6)
+  6: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -112,26 +112,24 @@ fun fields::write_generic_val($t0: &mut fields::G<u64>, $t1: u64) {
 fun fields::write_local_direct(): fields::S {
      var $t0: fields::S
      var $t1: fields::S
-     var $t2: fields::S
-     var $t3: u64
-     var $t4: fields::T
+     var $t2: u64
+     var $t3: fields::T
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: &mut u64
-     var $t8: &mut fields::T
-     var $t9: &mut fields::S
-  0: $t3 := 0
-  1: $t5 := 0
-  2: $t4 := pack fields::T($t5)
-  3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := infer($t2)
-  5: $t6 := 42
-  6: $t9 := borrow_local($t1)
-  7: $t8 := borrow_field<fields::S>.g($t9)
-  8: $t7 := borrow_field<fields::T>.h($t8)
-  9: write_ref($t7, $t6)
- 10: $t0 := infer($t1)
- 11: return $t0
+     var $t6: &mut u64
+     var $t7: &mut fields::T
+     var $t8: &mut fields::S
+  0: $t2 := 0
+  1: $t4 := 0
+  2: $t3 := pack fields::T($t4)
+  3: $t1 := pack fields::S($t2, $t3)
+  4: $t5 := 42
+  5: $t8 := borrow_local($t1)
+  6: $t7 := borrow_field<fields::S>.g($t8)
+  7: $t6 := borrow_field<fields::T>.h($t7)
+  8: write_ref($t6, $t5)
+  9: $t0 := infer($t1)
+ 10: return $t0
 }
 
 
@@ -139,28 +137,24 @@ fun fields::write_local_direct(): fields::S {
 fun fields::write_local_via_ref(): fields::S {
      var $t0: fields::S
      var $t1: fields::S
-     var $t2: fields::S
-     var $t3: u64
-     var $t4: fields::T
-     var $t5: u64
-     var $t6: &mut fields::S
-     var $t7: &mut fields::S
-     var $t8: u64
-     var $t9: &mut u64
-     var $t10: &mut fields::T
-  0: $t3 := 0
-  1: $t5 := 0
-  2: $t4 := pack fields::T($t5)
-  3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := infer($t2)
-  5: $t7 := borrow_local($t1)
-  6: $t6 := infer($t7)
-  7: $t8 := 42
-  8: $t10 := borrow_field<fields::S>.g($t6)
-  9: $t9 := borrow_field<fields::T>.h($t10)
- 10: write_ref($t9, $t8)
- 11: $t0 := infer($t1)
- 12: return $t0
+     var $t2: u64
+     var $t3: fields::T
+     var $t4: u64
+     var $t5: &mut fields::S
+     var $t6: u64
+     var $t7: &mut u64
+     var $t8: &mut fields::T
+  0: $t2 := 0
+  1: $t4 := 0
+  2: $t3 := pack fields::T($t4)
+  3: $t1 := pack fields::S($t2, $t3)
+  4: $t5 := borrow_local($t1)
+  5: $t6 := 42
+  6: $t8 := borrow_field<fields::S>.g($t5)
+  7: $t7 := borrow_field<fields::T>.h($t8)
+  8: write_ref($t7, $t6)
+  9: $t0 := infer($t1)
+ 10: return $t0
 }
 
 
@@ -168,28 +162,24 @@ fun fields::write_local_via_ref(): fields::S {
 fun fields::write_local_via_ref_2(): fields::S {
      var $t0: fields::S
      var $t1: fields::S
-     var $t2: fields::S
-     var $t3: u64
-     var $t4: fields::T
-     var $t5: u64
-     var $t6: &mut u64
-     var $t7: &mut u64
-     var $t8: &mut fields::T
-     var $t9: &mut fields::S
-     var $t10: u64
-  0: $t3 := 0
-  1: $t5 := 0
-  2: $t4 := pack fields::T($t5)
-  3: $t2 := pack fields::S($t3, $t4)
-  4: $t1 := infer($t2)
-  5: $t9 := borrow_local($t1)
-  6: $t8 := borrow_field<fields::S>.g($t9)
-  7: $t7 := borrow_field<fields::T>.h($t8)
-  8: $t6 := infer($t7)
-  9: $t10 := 42
- 10: write_ref($t6, $t10)
- 11: $t0 := infer($t1)
- 12: return $t0
+     var $t2: u64
+     var $t3: fields::T
+     var $t4: u64
+     var $t5: &mut u64
+     var $t6: &mut fields::T
+     var $t7: &mut fields::S
+     var $t8: u64
+  0: $t2 := 0
+  1: $t4 := 0
+  2: $t3 := pack fields::T($t4)
+  3: $t1 := pack fields::S($t2, $t3)
+  4: $t7 := borrow_local($t1)
+  5: $t6 := borrow_field<fields::S>.g($t7)
+  6: $t5 := borrow_field<fields::T>.h($t6)
+  7: $t8 := 42
+  8: write_ref($t5, $t8)
+  9: $t0 := infer($t1)
+ 10: return $t0
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
@@ -153,16 +153,14 @@ public fun freeze_mut_ref::borrow_mut4<#0>($t0: &mut #0): &#0 {
 [variant baseline]
 fun freeze_mut_ref::t0() {
      var $t0: &u64
-     var $t1: &u64
-     var $t2: &mut u64
-     var $t3: u64
-     var $t4: &u64
-  0: $t3 := 0
-  1: $t2 := borrow_local($t3)
-  2: $t1 := freeze_ref($t2)
-  3: $t0 := infer($t1)
-  4: $t4 := infer($t0)
-  5: return ()
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &u64
+  0: $t2 := 0
+  1: $t1 := borrow_local($t2)
+  2: $t0 := freeze_ref($t1)
+  3: $t3 := infer($t0)
+  4: return ()
 }
 
 
@@ -209,50 +207,42 @@ public fun freeze_mut_ref::t4() {
 [variant baseline]
 public fun freeze_mut_ref::t5($t0: &mut freeze_mut_ref::G) {
      var $t1: u64
-     var $t2: u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: &mut freeze_mut_ref::G
-     var $t6: u64
-     var $t7: u64
-     var $t8: &mut u64
-     var $t9: &mut u64
-     var $t10: &mut freeze_mut_ref::G
+     var $t2: &mut u64
+     var $t3: &mut freeze_mut_ref::G
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: &mut freeze_mut_ref::G
+     var $t8: u64
+     var $t9: u64
+     var $t10: &mut u64
      var $t11: u64
-     var $t12: u64
-     var $t13: &mut u64
+     var $t12: &u64
+     var $t13: u64
      var $t14: &mut u64
      var $t15: u64
      var $t16: &u64
-     var $t17: u64
-     var $t18: &mut u64
-     var $t19: u64
-     var $t20: &u64
-  0: $t2 := 0
-  1: $t1 := infer($t2)
-  2: $t7 := 1
-  3: $t6 := +($t1, $t7)
-  4: $t1 := infer($t6)
-  5: $t5 := infer($t0)
-  6: $t4 := borrow_field<freeze_mut_ref::G>.f($t5)
-  7: $t3 := infer($t4)
-  8: $t12 := 1
-  9: $t11 := +($t1, $t12)
- 10: $t1 := infer($t11)
- 11: $t10 := infer($t0)
- 12: $t9 := borrow_field<freeze_mut_ref::G>.f($t10)
- 13: $t8 := infer($t9)
- 14: $t15 := 2
- 15: $t14 := borrow_local($t15)
- 16: $t13 := infer($t14)
- 17: $t17 := 2
- 18: $t19 := 0
- 19: write_ref($t3, $t19)
- 20: $t20 := freeze_ref($t13)
- 21: $t16 := infer($t20)
- 22: $t18 := infer($t8)
- 23: write_ref($t18, $t17)
- 24: return ()
+  0: $t1 := 0
+  1: $t5 := 1
+  2: $t4 := +($t1, $t5)
+  3: $t1 := infer($t4)
+  4: $t3 := infer($t0)
+  5: $t2 := borrow_field<freeze_mut_ref::G>.f($t3)
+  6: $t9 := 1
+  7: $t8 := +($t1, $t9)
+  8: $t1 := infer($t8)
+  9: $t7 := infer($t0)
+ 10: $t6 := borrow_field<freeze_mut_ref::G>.f($t7)
+ 11: $t11 := 2
+ 12: $t10 := borrow_local($t11)
+ 13: $t13 := 2
+ 14: $t15 := 0
+ 15: write_ref($t2, $t15)
+ 16: $t16 := freeze_ref($t10)
+ 17: $t12 := infer($t16)
+ 18: $t14 := infer($t6)
+ 19: write_ref($t14, $t13)
+ 20: return ()
 }
 
 
@@ -293,14 +283,12 @@ fun freeze_mut_ref::t7($t0: bool, $t1: &mut freeze_mut_ref::S, $t2: &freeze_mut_
 [variant baseline]
 fun freeze_mut_ref::t8($t0: bool, $t1: &mut freeze_mut_ref::S, $t2: &freeze_mut_ref::S) {
      var $t3: &freeze_mut_ref::S
-     var $t4: &freeze_mut_ref::S
   0: if ($t0) goto 1 else goto 4
   1: label L0
-  2: $t4 := freeze_ref($t1)
+  2: $t3 := freeze_ref($t1)
   3: goto 6
   4: label L1
-  5: $t4 := infer($t2)
+  5: $t3 := infer($t2)
   6: label L2
-  7: $t3 := infer($t4)
-  8: return ()
+  7: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
@@ -27,21 +27,19 @@ fun inline_specs::specs(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t2 := 0
-  1: $t1 := infer($t2)
-  2: spec {
+  0: $t1 := 0
+  1: spec {
   assert Eq<u64>($t1, 0);
 }
 
-  3: $t3 := inline_specs::succ($t1)
-  4: $t1 := infer($t3)
-  5: spec {
+  2: $t2 := inline_specs::succ($t1)
+  3: $t1 := infer($t2)
+  4: spec {
   assert Eq<u64>($t1, 1);
 }
 
-  6: $t0 := infer($t1)
-  7: return $t0
+  5: $t0 := infer($t1)
+  6: return $t0
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -29,18 +29,14 @@ fun reference_conversion::deref($t0: &u64): u64 {
 fun reference_conversion::use_it(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64
-     var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
-     var $t6: &u64
-  0: $t2 := 42
-  1: $t1 := infer($t2)
-  2: $t4 := borrow_local($t1)
-  3: $t3 := infer($t4)
-  4: $t5 := 43
-  5: write_ref($t3, $t5)
-  6: $t6 := freeze_ref($t3)
-  7: $t0 := reference_conversion::deref($t6)
-  8: return $t0
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: &u64
+  0: $t1 := 42
+  1: $t2 := borrow_local($t1)
+  2: $t3 := 43
+  3: write_ref($t2, $t3)
+  4: $t4 := freeze_ref($t2)
+  5: $t0 := reference_conversion::deref($t4)
+  6: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/bug_12068.exp
@@ -3,39 +3,37 @@
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t1 := 0
-  1: $t0 := infer($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 11
-  5: label L2
-  6: $t4 := 1
-  7: $t3 := +($t0, $t4)
-  8: $t0 := infer($t3)
-  9: goto 15
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: $t6 := 1
- 17: $t5 := ==($t0, $t6)
- 18: if ($t5) goto 19 else goto 21
- 19: label L5
- 20: goto 24
- 21: label L6
- 22: $t7 := 42
- 23: abort($t7)
- 24: label L7
- 25: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 10
+  4: label L2
+  5: $t3 := 1
+  6: $t2 := +($t0, $t3)
+  7: $t0 := infer($t2)
+  8: goto 14
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t5 := 1
+ 16: $t4 := ==($t0, $t5)
+ 17: if ($t4) goto 18 else goto 20
+ 18: label L5
+ 19: goto 23
+ 20: label L6
+ 21: $t6 := 42
+ 22: abort($t6)
+ 23: label L7
+ 24: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -43,34 +41,32 @@ fun m::main() {
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t1 := 0
-  1: $t0 := move($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 10
-  5: label L2
-  6: $t4 := 1
-  7: $t3 := +($t0, $t4)
-  8: $t0 := move($t3)
-  9: goto 12
- 10: label L3
- 11: goto 12
- 12: label L1
- 13: $t6 := 1
- 14: $t5 := ==($t0, $t6)
- 15: if ($t5) goto 16 else goto 18
- 16: label L5
- 17: goto 21
- 18: label L6
- 19: $t7 := 42
- 20: abort($t7)
- 21: label L7
- 22: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 9
+  4: label L2
+  5: $t3 := 1
+  6: $t2 := +($t0, $t3)
+  7: $t0 := move($t2)
+  8: goto 11
+  9: label L3
+ 10: goto 11
+ 11: label L1
+ 12: $t5 := 1
+ 13: $t4 := ==($t0, $t5)
+ 14: if ($t4) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t6 := 42
+ 19: abort($t6)
+ 20: label L7
+ 21: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_1.exp
@@ -6,13 +6,11 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t2)
-  3: $t5 := infer($t4)
-  4: $t1 := read_ref($t5)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -23,11 +21,9 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: $t4 := move($t2)
-  3: $t5 := move($t4)
-  4: $t1 := read_ref($t5)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t3 := move($t2)
+  2: $t4 := move($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
@@ -12,17 +12,15 @@ warning: Unused local variable `a`. Consider removing or prefixing with an under
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t0)
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
   3: $t5 := infer($t4)
-  4: $t6 := infer($t5)
-  5: $t1 := infer($t6)
-  6: return $t1
+  4: $t1 := infer($t5)
+  5: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -31,16 +29,14 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: drop($t2)
-  3: $t4 := move($t0)
+  0: $t2 := borrow_local($t0)
+  1: drop($t2)
+  2: $t3 := move($t0)
+  3: $t4 := move($t3)
   4: $t5 := move($t4)
-  5: $t6 := move($t5)
-  6: $t1 := move($t6)
-  7: return $t1
+  5: $t1 := move($t5)
+  6: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_1.exp
@@ -5,33 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: $t5 := 0
-  3: $t4 := infer($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t4, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t2 := infer($t0)
- 10: $t9 := 1
- 11: $t8 := +($t4, $t9)
- 12: $t4 := infer($t8)
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t1 := infer($t2)
- 20: return $t1
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -41,31 +37,27 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-  0: $t3 := 0
-  1: $t2 := move($t3)
-  2: $t5 := 0
-  3: $t4 := move($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t4, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t2 := copy($t0)
- 10: $t9 := 1
- 11: $t8 := +($t4, $t9)
- 12: $t4 := move($t8)
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := move($t6)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t1 := move($t2)
- 20: return $t1
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := move($t2)
+ 18: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/loop_2.exp
@@ -5,31 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
   0: $t2 := infer($t0)
-  1: $t4 := 0
-  2: $t3 := infer($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t3, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := infer($t0)
-  9: $t8 := 1
- 10: $t7 := +($t3, $t8)
- 11: $t3 := infer($t7)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t1 := infer($t2)
- 19: return $t1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -39,29 +37,27 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
   0: $t2 := copy($t0)
-  1: $t4 := 0
-  2: $t3 := move($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t3, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := copy($t0)
-  9: $t8 := 1
- 10: $t7 := +($t3, $t8)
- 11: $t3 := move($t7)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t1 := move($t2)
- 19: return $t1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := move($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := move($t2)
+ 18: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
@@ -5,15 +5,13 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
   0: $t2 := infer($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t3 := infer($t4)
-  3: $t5 := 1
-  4: write_ref($t3, $t5)
-  5: $t1 := infer($t2)
-  6: return $t1
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t1 := infer($t2)
+  5: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -23,13 +21,11 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
   0: $t2 := copy($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t3 := move($t4)
-  3: $t5 := 1
-  4: write_ref($t3, $t5)
-  5: $t1 := move($t2)
-  6: return $t1
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t1 := move($t2)
+  5: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
@@ -6,31 +6,29 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := infer($t0)
   1: $t3 := infer($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t4 := infer($t5)
-  5: $t7 := 0
-  6: write_ref($t4, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t1 := read_ref($t9)
- 10: return $t1
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t1 := read_ref($t8)
+  9: return $t1
 }
 
 
 Diagnostics:
 error: local `p` of type `m::S` does not have the `copy` ability
-   ┌─ tests/copy-propagation/mut_refs_2.move:10:13
+   ┌─ tests/copy-propagation/mut_refs_2.move:10:17
    │
 10 │         let q = p;
-   │             ^ copy needed here because value is still in use
+   │                 ^ copy needed here because value is still in use
 11 │         let ref = &mut p.a;
    │                        - used here
 
@@ -54,20 +52,18 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := move($t0)
   1: $t3 := copy($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t4 := move($t5)
-  5: $t7 := 0
-  6: write_ref($t4, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t1 := read_ref($t9)
- 10: return $t1
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t1 := read_ref($t8)
+  9: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -6,16 +6,14 @@ fun m::test($t0: u64): u64 {
      var $t2: &mut u64
      var $t3: &mut u64
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t2)
-  3: $t5 := infer($t4)
-  4: $t6 := 0
-  5: write_ref($t2, $t6)
-  6: $t1 := read_ref($t5)
-  7: return $t1
+     var $t5: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t5 := 0
+  4: write_ref($t2, $t5)
+  5: $t1 := read_ref($t4)
+  6: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -26,14 +24,12 @@ fun m::test($t0: u64): u64 {
      var $t2: &mut u64
      var $t3: &mut u64
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: $t4 := copy($t2)
-  3: $t5 := move($t4)
-  4: $t6 := 0
-  5: write_ref($t2, $t6)
-  6: $t1 := read_ref($t5)
-  7: return $t1
+     var $t5: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := copy($t2)
+  2: $t4 := move($t3)
+  3: $t5 := 0
+  4: write_ref($t2, $t5)
+  5: $t1 := read_ref($t4)
+  6: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
@@ -4,31 +4,29 @@
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &mut u64
-     var $t3: &mut u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t0)
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
   3: $t5 := infer($t4)
-  4: $t6 := infer($t5)
-  5: $t7 := 0
-  6: write_ref($t2, $t7)
-  7: $t1 := infer($t6)
-  8: return $t1
+  4: $t6 := 0
+  5: write_ref($t2, $t6)
+  6: $t1 := infer($t5)
+  7: return $t1
 }
 
 
 Diagnostics:
 error: cannot copy local `p` which is still mutably borrowed
-  ┌─ tests/copy-propagation/mut_refs_4.move:5:13
+  ┌─ tests/copy-propagation/mut_refs_4.move:5:17
   │
 4 │         let a = &mut p;
   │                 ------ previous mutable local borrow
 5 │         let b = p;
-  │             ^ copied here
+  │                 ^ copied here
   ·
 8 │         *a = 0;
   │         ------ conflicting reference `a` used here
@@ -39,18 +37,16 @@ error: cannot copy local `p` which is still mutably borrowed
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &mut u64
-     var $t3: &mut u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: $t4 := copy($t0)
+  0: $t2 := borrow_local($t0)
+  1: $t3 := copy($t0)
+  2: $t4 := move($t3)
   3: $t5 := move($t4)
-  4: $t6 := move($t5)
-  5: $t7 := 0
-  6: write_ref($t2, $t7)
-  7: $t1 := move($t6)
-  8: return $t1
+  4: $t6 := 0
+  5: write_ref($t2, $t6)
+  6: $t1 := move($t5)
+  7: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -21,75 +21,75 @@ struct S {
 }
 
 field(Arg0: &S): u64 /* def_idx: 0 */ {
-L1:	loc0: &u64
 B0:
 	0: MoveLoc[0](Arg0: &S)
 	1: ImmBorrowField[0](S.f: u64)
-	2: StLoc[1](loc0: &u64)
-	3: MoveLoc[1](loc0: &u64)
-	4: ReadRef
-	5: Ret
+	2: ReadRef
+	3: Ret
 }
 local(Arg0: u64): u64 /* def_idx: 1 */ {
 L1:	loc0: u64
-L2:	loc1: &u64
 B0:
 	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: ImmBorrowLoc[1](loc0: u64)
-	3: StLoc[2](loc1: &u64)
-	4: MoveLoc[2](loc1: &u64)
-	5: ReadRef
-	6: Ret
-}
-param(Arg0: u64): u64 /* def_idx: 2 */ {
-L1:	loc0: &u64
-B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: &u64)
-	2: MoveLoc[1](loc0: &u64)
 	3: ReadRef
 	4: Ret
 }
+param(Arg0: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ReadRef
+	2: Ret
+}
 mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: &mut u64
+L1:	loc0: u64
+L2:	loc1: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[1](loc0: &mut u64)
-	3: LdU64(22)
-	4: CopyLoc[1](loc0: &mut u64)
-	5: WriteRef
-	6: MoveLoc[1](loc0: &mut u64)
-	7: ReadRef
-	8: Ret
+	2: LdU64(22)
+	3: StLoc[1](loc0: u64)
+	4: StLoc[2](loc1: &mut u64)
+	5: MoveLoc[1](loc0: u64)
+	6: CopyLoc[2](loc1: &mut u64)
+	7: WriteRef
+	8: MoveLoc[2](loc1: &mut u64)
+	9: ReadRef
+	10: Ret
 }
 mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
 L1:	loc0: u64
-L2:	loc1: &mut u64
+L2:	loc1: u64
+L3:	loc2: &mut u64
 B0:
 	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[1](loc0: u64)
+	3: LdU64(22)
+	4: StLoc[2](loc1: u64)
+	5: StLoc[3](loc2: &mut u64)
+	6: MoveLoc[2](loc1: u64)
+	7: CopyLoc[3](loc2: &mut u64)
+	8: WriteRef
+	9: MoveLoc[3](loc2: &mut u64)
+	10: ReadRef
+	11: Ret
+}
+mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: LdU64(22)
+	2: StLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &mut u64)
-	4: LdU64(22)
+	4: MoveLoc[1](loc0: u64)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
 	8: ReadRef
 	9: Ret
-}
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: &mut u64
-B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: &mut u64)
-	2: LdU64(22)
-	3: CopyLoc[1](loc0: &mut u64)
-	4: WriteRef
-	5: MoveLoc[1](loc0: &mut u64)
-	6: ReadRef
-	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -73,51 +73,40 @@ module 42.constant {
 
 
 test_constans() /* def_idx: 0 */ {
-L0:	loc0: bool
-L1:	loc1: bool
-L2:	loc2: u8
-L3:	loc3: u16
-L4:	loc4: u32
-L5:	loc5: u64
-L6:	loc6: u128
-L7:	loc7: u256
-L8:	loc8: address
-L9:	loc9: vector<u64>
-L10:	loc10: vector<u8>
 B0:
 	0: LdTrue
 	1: Call u<bool>(bool): bool
-	2: StLoc[0](loc0: bool)
-	3: LdFalse
-	4: Call u<bool>(bool): bool
-	5: StLoc[1](loc1: bool)
-	6: LdU8(1)
-	7: Call u<u8>(u8): u8
-	8: StLoc[2](loc2: u8)
-	9: LdU16(7086)
-	10: Call u<u16>(u16): u16
-	11: StLoc[3](loc3: u16)
-	12: LdU32(14593408)
-	13: Call u<u32>(u32): u32
-	14: StLoc[4](loc4: u32)
-	15: LdU64(51966)
-	16: Call u<u64>(u64): u64
-	17: StLoc[5](loc5: u64)
-	18: LdU128(3735928559)
-	19: Call u<u128>(u128): u128
-	20: StLoc[6](loc6: u128)
-	21: LdU256(301490978409967)
-	22: Call u<u256>(u256): u256
-	23: StLoc[7](loc7: u256)
-	24: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
-	25: Call u<address>(address): address
-	26: StLoc[8](loc8: address)
-	27: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	28: Call u<vector<u64>>(vector<u64>): vector<u64>
-	29: StLoc[9](loc9: vector<u64>)
-	30: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
-	31: Call u<vector<u8>>(vector<u8>): vector<u8>
-	32: StLoc[10](loc10: vector<u8>)
+	2: LdFalse
+	3: Call u<bool>(bool): bool
+	4: LdU8(1)
+	5: Call u<u8>(u8): u8
+	6: LdU16(7086)
+	7: Call u<u16>(u16): u16
+	8: LdU32(14593408)
+	9: Call u<u32>(u32): u32
+	10: LdU64(51966)
+	11: Call u<u64>(u64): u64
+	12: LdU128(3735928559)
+	13: Call u<u128>(u128): u128
+	14: LdU256(301490978409967)
+	15: Call u<u256>(u256): u256
+	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	17: Call u<address>(address): address
+	18: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	19: Call u<vector<u64>>(vector<u64>): vector<u64>
+	20: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	21: Call u<vector<u8>>(vector<u8>): vector<u8>
+	22: Pop
+	23: Pop
+	24: Pop
+	25: Pop
+	26: Pop
+	27: Pop
+	28: Pop
+	29: Pop
+	30: Pop
+	31: Pop
+	32: Pop
 	33: Ret
 }
 u<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -47,8 +47,10 @@ B0:
 }
 write_local_via_ref(): S /* def_idx: 3 */ {
 L0:	loc0: S
-L1:	loc1: &mut S
-L2:	loc2: S
+L1:	loc1: u64
+L2:	loc2: &mut S
+L3:	loc3: &mut u64
+L4:	loc4: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
@@ -56,16 +58,20 @@ B0:
 	3: Pack[1](S)
 	4: StLoc[0](loc0: S)
 	5: MutBorrowLoc[0](loc0: S)
-	6: StLoc[1](loc1: &mut S)
-	7: LdU64(42)
-	8: MoveLoc[1](loc1: &mut S)
-	9: MutBorrowField[0](S.g: T)
-	10: MutBorrowField[1](T.h: u64)
-	11: WriteRef
-	12: MoveLoc[0](loc0: S)
-	13: StLoc[2](loc2: S)
-	14: MoveLoc[2](loc2: S)
-	15: Ret
+	6: LdU64(42)
+	7: StLoc[1](loc1: u64)
+	8: StLoc[2](loc2: &mut S)
+	9: MoveLoc[2](loc2: &mut S)
+	10: MutBorrowField[0](S.g: T)
+	11: MutBorrowField[1](T.h: u64)
+	12: StLoc[3](loc3: &mut u64)
+	13: MoveLoc[1](loc1: u64)
+	14: MoveLoc[3](loc3: &mut u64)
+	15: WriteRef
+	16: MoveLoc[0](loc0: S)
+	17: StLoc[4](loc4: S)
+	18: MoveLoc[4](loc4: S)
+	19: Ret
 }
 write_param(Arg0: &mut S) /* def_idx: 4 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -32,28 +32,31 @@ B0:
 	6: Ret
 }
 read(Arg0: address): u64 /* def_idx: 2 */ {
-L1:	loc0: &R
 B0:
 	0: MoveLoc[0](Arg0: address)
 	1: ImmBorrowGlobal[0](R)
-	2: StLoc[1](loc0: &R)
-	3: MoveLoc[1](loc0: &R)
-	4: ImmBorrowField[0](R.f: u64)
-	5: ReadRef
-	6: Ret
+	2: ImmBorrowField[0](R.f: u64)
+	3: ReadRef
+	4: Ret
 }
 write(Arg0: address, Arg1: u64): u64 /* def_idx: 3 */ {
-L2:	loc0: &mut R
+L2:	loc0: u64
+L3:	loc1: &mut R
+L4:	loc2: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: address)
 	1: MutBorrowGlobal[0](R)
-	2: StLoc[2](loc0: &mut R)
-	3: LdU64(2)
-	4: MoveLoc[2](loc0: &mut R)
-	5: MutBorrowField[0](R.f: u64)
-	6: WriteRef
-	7: LdU64(9)
-	8: Ret
+	2: LdU64(2)
+	3: StLoc[2](loc0: u64)
+	4: StLoc[3](loc1: &mut R)
+	5: MoveLoc[3](loc1: &mut R)
+	6: MutBorrowField[0](R.f: u64)
+	7: StLoc[4](loc2: &mut u64)
+	8: MoveLoc[2](loc0: u64)
+	9: MoveLoc[4](loc2: &mut u64)
+	10: WriteRef
+	11: LdU64(9)
+	12: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -33,8 +33,7 @@ L2:	loc0: E<Ty0>
 L3:	loc1: Ty0
 L4:	loc2: E<Ty0>
 L5:	loc3: E<Ty0>
-L6:	loc4: E<Ty0>
-L7:	loc5: u64
+L6:	loc4: u64
 B0:
 	0: MoveLoc[0](Arg0: E<Ty0>)
 	1: StLoc[2](loc0: E<Ty0>)
@@ -47,14 +46,12 @@ B0:
 	8: MoveLoc[4](loc2: E<Ty0>)
 	9: StLoc[5](loc3: E<Ty0>)
 	10: MoveLoc[5](loc3: E<Ty0>)
-	11: StLoc[6](loc4: E<Ty0>)
-	12: MoveLoc[6](loc4: E<Ty0>)
-	13: UnpackGeneric[1](E<Ty0>)
-	14: LdU64(3)
-	15: StLoc[7](loc5: u64)
-	16: MoveLoc[1](Arg1: &mut Ty0)
-	17: WriteRef
-	18: Ret
+	11: UnpackGeneric[1](E<Ty0>)
+	12: LdU64(3)
+	13: StLoc[6](loc4: u64)
+	14: MoveLoc[1](Arg1: &mut Ty0)
+	15: WriteRef
+	16: Ret
 }
 public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -75,56 +75,50 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: vector<u64>
+L0:	loc0: vector<u64>
+L1:	loc1: u64
 L2:	loc2: u64
 L3:	loc3: u64
 L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	3: StLoc[1](loc1: vector<u64>)
-	4: MutBorrowLoc[1](loc1: vector<u64>)
-	5: Call 1vector::reverse<u64>(&mut vector<u64>)
+	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
+	2: StLoc[0](loc0: vector<u64>)
+	3: MutBorrowLoc[0](loc0: vector<u64>)
+	4: Call 1vector::reverse<u64>(&mut vector<u64>)
+	5: StLoc[1](loc1: u64)
 B1:
-	6: ImmBorrowLoc[1](loc1: vector<u64>)
+	6: ImmBorrowLoc[0](loc0: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: Not
-	9: BrFalse(18)
+	9: BrFalse(16)
 B2:
-	10: MutBorrowLoc[1](loc1: vector<u64>)
+	10: MutBorrowLoc[0](loc0: vector<u64>)
 	11: VecPopBack(5)
 	12: StLoc[2](loc2: u64)
-	13: MoveLoc[2](loc2: u64)
-	14: StLoc[3](loc3: u64)
-	15: LdU64(0)
-	16: StLoc[0](loc0: u64)
-	17: Branch(19)
+	13: LdU64(0)
+	14: StLoc[1](loc1: u64)
+	15: Branch(17)
 B3:
-	18: Branch(20)
+	16: Branch(18)
 B4:
-	19: Branch(6)
+	17: Branch(6)
 B5:
-	20: MoveLoc[0](loc0: u64)
+	18: MoveLoc[1](loc1: u64)
+	19: StLoc[3](loc3: u64)
+	20: LdU64(0)
 	21: StLoc[4](loc4: u64)
-	22: MoveLoc[4](loc4: u64)
-	23: StLoc[5](loc5: u64)
-	24: LdU64(0)
-	25: StLoc[6](loc6: u64)
-	26: MoveLoc[5](loc5: u64)
-	27: MoveLoc[6](loc6: u64)
-	28: Eq
-	29: BrFalse(31)
+	22: MoveLoc[3](loc3: u64)
+	23: MoveLoc[4](loc4: u64)
+	24: Eq
+	25: BrFalse(27)
 B6:
-	30: Branch(33)
+	26: Branch(29)
 B7:
-	31: LdU64(0)
-	32: Abort
+	27: LdU64(0)
+	28: Abort
 B8:
-	33: Ret
+	29: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
@@ -4,69 +4,63 @@
 public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: &vector<u8>
-     var $t5: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: bool
+     var $t5: u64
      var $t6: bool
-     var $t7: u64
-     var $t8: bool
+     var $t7: u8
+     var $t8: &u8
      var $t9: u8
-     var $t10: &u8
-     var $t11: u8
-     var $t12: u64
-     var $t13: u64
-     var $t14: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: bool
+     var $t13: u8
+     var $t14: &u8
      var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
-     var $t20: vector<u8>
-     var $t21: &vector<u8>
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: $t5 := borrow_local($t0)
-  3: $t4 := infer($t5)
-  4: label L0
-  5: $t7 := vector::length<u8>($t4)
-  6: $t6 := <($t2, $t7)
-  7: if ($t6) goto 8 else goto 33
-  8: label L2
-  9: $t10 := vector::borrow<u8>($t4, $t2)
- 10: $t9 := read_ref($t10)
- 11: $t11 := 0
- 12: $t8 := !=($t9, $t11)
- 13: if ($t8) goto 14 else goto 17
- 14: label L5
- 15: goto 37
- 16: goto 18
- 17: label L6
- 18: label L7
- 19: $t13 := 1
- 20: $t12 := +($t2, $t13)
- 21: $t2 := infer($t12)
- 22: $t16 := vector::borrow<u8>($t4, $t2)
- 23: $t15 := read_ref($t16)
- 24: $t17 := 5
- 25: $t14 := ==($t15, $t17)
- 26: if ($t14) goto 27 else goto 30
- 27: label L8
- 28: goto 37
- 29: goto 31
- 30: label L9
- 31: label L10
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: &vector<u8>
+  0: $t2 := 0
+  1: $t3 := borrow_local($t0)
+  2: label L0
+  3: $t5 := vector::length<u8>($t3)
+  4: $t4 := <($t2, $t5)
+  5: if ($t4) goto 6 else goto 31
+  6: label L2
+  7: $t8 := vector::borrow<u8>($t3, $t2)
+  8: $t7 := read_ref($t8)
+  9: $t9 := 0
+ 10: $t6 := !=($t7, $t9)
+ 11: if ($t6) goto 12 else goto 15
+ 12: label L5
+ 13: goto 35
+ 14: goto 16
+ 15: label L6
+ 16: label L7
+ 17: $t11 := 1
+ 18: $t10 := +($t2, $t11)
+ 19: $t2 := infer($t10)
+ 20: $t14 := vector::borrow<u8>($t3, $t2)
+ 21: $t13 := read_ref($t14)
+ 22: $t15 := 5
+ 23: $t12 := ==($t13, $t15)
+ 24: if ($t12) goto 25 else goto 28
+ 25: label L8
+ 26: goto 35
+ 27: goto 29
+ 28: label L9
+ 29: label L10
+ 30: goto 33
+ 31: label L3
  32: goto 35
- 33: label L3
- 34: goto 37
- 35: label L4
- 36: goto 4
- 37: label L1
- 38: $t19 := copy($t0)
- 39: $t18 := infer($t19)
- 40: $t20 := infer($t0)
- 41: $t21 := infer($t4)
- 42: $t1 := vector::length<u8>($t21)
- 43: return $t1
+ 33: label L4
+ 34: goto 2
+ 35: label L1
+ 36: $t16 := copy($t0)
+ 37: $t17 := infer($t0)
+ 38: $t18 := infer($t3)
+ 39: $t1 := vector::length<u8>($t18)
+ 40: return $t1
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -75,111 +69,102 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
 public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: &vector<u8>
-     var $t5: &vector<u8>
+     var $t3: &vector<u8>
+     var $t4: bool
+     var $t5: u64
      var $t6: bool
-     var $t7: u64
-     var $t8: bool
+     var $t7: u8
+     var $t8: &u8
      var $t9: u8
-     var $t10: &u8
-     var $t11: u8
-     var $t12: u64
-     var $t13: u64
-     var $t14: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: bool
+     var $t13: u8
+     var $t14: &u8
      var $t15: u8
-     var $t16: &u8
-     var $t17: u8
-     var $t18: vector<u8>
-     var $t19: vector<u8>
-     var $t20: vector<u8>
-     var $t21: &vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: &vector<u8>
      # live vars: $t0
-  0: $t3 := 0
-     # live vars: $t0, $t3
-  1: $t2 := infer($t3)
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: $t5 := borrow_local($t0)
-     # live vars: $t0, $t2, $t5
-  3: $t4 := infer($t5)
-     # live vars: $t0, $t2, $t4
-  4: label L0
-     # live vars: $t0, $t2, $t4
-  5: $t7 := vector::length<u8>($t4)
-     # live vars: $t0, $t2, $t4, $t7
-  6: $t6 := <($t2, $t7)
-     # live vars: $t0, $t2, $t4, $t6
-  7: if ($t6) goto 8 else goto 33
-     # live vars: $t0, $t2, $t4
-  8: label L2
-     # live vars: $t0, $t2, $t4
-  9: $t10 := vector::borrow<u8>($t4, $t2)
-     # live vars: $t0, $t2, $t4, $t10
- 10: $t9 := read_ref($t10)
-     # live vars: $t0, $t2, $t4, $t9
- 11: $t11 := 0
-     # live vars: $t0, $t2, $t4, $t9, $t11
- 12: $t8 := !=($t9, $t11)
-     # live vars: $t0, $t2, $t4, $t8
- 13: if ($t8) goto 14 else goto 17
-     # live vars: $t0, $t2, $t4
- 14: label L5
-     # live vars: $t0, $t4
- 15: goto 37
-     # live vars: $t0, $t2, $t4
- 16: goto 18
-     # live vars: $t0, $t2, $t4
- 17: label L6
-     # live vars: $t0, $t2, $t4
- 18: label L7
-     # live vars: $t0, $t2, $t4
- 19: $t13 := 1
-     # live vars: $t0, $t2, $t4, $t13
- 20: $t12 := +($t2, $t13)
-     # live vars: $t0, $t4, $t12
- 21: $t2 := infer($t12)
-     # live vars: $t0, $t2, $t4
- 22: $t16 := vector::borrow<u8>($t4, $t2)
-     # live vars: $t0, $t2, $t4, $t16
- 23: $t15 := read_ref($t16)
-     # live vars: $t0, $t2, $t4, $t15
- 24: $t17 := 5
-     # live vars: $t0, $t2, $t4, $t15, $t17
- 25: $t14 := ==($t15, $t17)
-     # live vars: $t0, $t2, $t4, $t14
- 26: if ($t14) goto 27 else goto 30
-     # live vars: $t0, $t2, $t4
- 27: label L8
-     # live vars: $t0, $t4
- 28: goto 37
-     # live vars: $t0, $t2, $t4
- 29: goto 31
-     # live vars: $t0, $t2, $t4
- 30: label L9
-     # live vars: $t0, $t2, $t4
- 31: label L10
-     # live vars: $t0, $t2, $t4
+  1: $t3 := borrow_local($t0)
+     # live vars: $t0, $t2, $t3
+  2: label L0
+     # live vars: $t0, $t2, $t3
+  3: $t5 := vector::length<u8>($t3)
+     # live vars: $t0, $t2, $t3, $t5
+  4: $t4 := <($t2, $t5)
+     # live vars: $t0, $t2, $t3, $t4
+  5: if ($t4) goto 6 else goto 31
+     # live vars: $t0, $t2, $t3
+  6: label L2
+     # live vars: $t0, $t2, $t3
+  7: $t8 := vector::borrow<u8>($t3, $t2)
+     # live vars: $t0, $t2, $t3, $t8
+  8: $t7 := read_ref($t8)
+     # live vars: $t0, $t2, $t3, $t7
+  9: $t9 := 0
+     # live vars: $t0, $t2, $t3, $t7, $t9
+ 10: $t6 := !=($t7, $t9)
+     # live vars: $t0, $t2, $t3, $t6
+ 11: if ($t6) goto 12 else goto 15
+     # live vars: $t0, $t2, $t3
+ 12: label L5
+     # live vars: $t0, $t3
+ 13: goto 35
+     # live vars: $t0, $t2, $t3
+ 14: goto 16
+     # live vars: $t0, $t2, $t3
+ 15: label L6
+     # live vars: $t0, $t2, $t3
+ 16: label L7
+     # live vars: $t0, $t2, $t3
+ 17: $t11 := 1
+     # live vars: $t0, $t2, $t3, $t11
+ 18: $t10 := +($t2, $t11)
+     # live vars: $t0, $t3, $t10
+ 19: $t2 := infer($t10)
+     # live vars: $t0, $t2, $t3
+ 20: $t14 := vector::borrow<u8>($t3, $t2)
+     # live vars: $t0, $t2, $t3, $t14
+ 21: $t13 := read_ref($t14)
+     # live vars: $t0, $t2, $t3, $t13
+ 22: $t15 := 5
+     # live vars: $t0, $t2, $t3, $t13, $t15
+ 23: $t12 := ==($t13, $t15)
+     # live vars: $t0, $t2, $t3, $t12
+ 24: if ($t12) goto 25 else goto 28
+     # live vars: $t0, $t2, $t3
+ 25: label L8
+     # live vars: $t0, $t3
+ 26: goto 35
+     # live vars: $t0, $t2, $t3
+ 27: goto 29
+     # live vars: $t0, $t2, $t3
+ 28: label L9
+     # live vars: $t0, $t2, $t3
+ 29: label L10
+     # live vars: $t0, $t2, $t3
+ 30: goto 33
+     # live vars: $t0, $t2, $t3
+ 31: label L3
+     # live vars: $t0, $t3
  32: goto 35
-     # live vars: $t0, $t2, $t4
- 33: label L3
-     # live vars: $t0, $t4
- 34: goto 37
-     # live vars: $t0, $t2, $t4
- 35: label L4
-     # live vars: $t0, $t2, $t4
- 36: goto 4
-     # live vars: $t0, $t4
- 37: label L1
-     # live vars: $t0, $t4
- 38: $t19 := copy($t0)
-     # live vars: $t0, $t4, $t19
- 39: $t18 := infer($t19)
-     # live vars: $t0, $t4
- 40: $t20 := infer($t0)
-     # live vars: $t4
- 41: $t21 := infer($t4)
-     # live vars: $t21
- 42: $t1 := vector::length<u8>($t21)
+     # live vars: $t0, $t2, $t3
+ 33: label L4
+     # live vars: $t0, $t2, $t3
+ 34: goto 2
+     # live vars: $t0, $t3
+ 35: label L1
+     # live vars: $t0, $t3
+ 36: $t16 := copy($t0)
+     # live vars: $t0, $t3
+ 37: $t17 := infer($t0)
+     # live vars: $t3
+ 38: $t18 := infer($t3)
+     # live vars: $t18
+ 39: $t1 := vector::length<u8>($t18)
      # live vars: $t1
- 43: return $t1
+ 40: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -4,117 +4,109 @@
 fun m::foo(): u64 {
      var $t0: u64
      var $t1: vector<u64>
-     var $t2: vector<u64>
-     var $t3: &mut vector<u64>
+     var $t2: &mut vector<u64>
+     var $t3: u64
      var $t4: &mut vector<u64>
      var $t5: u64
-     var $t6: &mut vector<u64>
-     var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-     var $t11: &vector<u64>
-     var $t12: bool
-     var $t13: bool
-     var $t14: bool
-     var $t15: &u64
-     var $t16: &u64
-     var $t17: &vector<u64>
+     var $t6: u64
+     var $t7: &vector<u64>
+     var $t8: bool
+     var $t9: bool
+     var $t10: bool
+     var $t11: &u64
+     var $t12: &u64
+     var $t13: &vector<u64>
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
      var $t18: u64
      var $t19: u64
      var $t20: u64
-     var $t21: u64
-     var $t22: u64
-     var $t23: u64
-     var $t24: u64
-     var $t25: bool
-     var $t26: bool
-     var $t27: &u64
-     var $t28: &u64
-     var $t29: &vector<u64>
+     var $t21: bool
+     var $t22: bool
+     var $t23: &u64
+     var $t24: &u64
+     var $t25: &vector<u64>
+     var $t26: u64
+     var $t27: u64
+     var $t28: u64
+     var $t29: u64
      var $t30: u64
      var $t31: u64
-     var $t32: u64
-     var $t33: u64
+     var $t32: &u64
+     var $t33: &vector<u64>
      var $t34: u64
-     var $t35: u64
-     var $t36: &u64
-     var $t37: &vector<u64>
-     var $t38: u64
-  0: $t2 := ["1", "2", "3"]
-  1: $t1 := infer($t2)
-  2: $t4 := borrow_local($t1)
-  3: $t3 := infer($t4)
-  4: $t6 := infer($t3)
-  5: $t8 := 0
-  6: $t7 := infer($t8)
-  7: $t11 := freeze_ref($t6)
-  8: $t10 := vector::length<u64>($t11)
-  9: $t9 := infer($t10)
- 10: label L0
- 11: $t12 := <($t7, $t9)
- 12: if ($t12) goto 13 else goto 31
- 13: label L2
- 14: $t17 := freeze_ref($t6)
- 15: $t16 := vector::borrow<u64>($t17, $t7)
- 16: $t15 := infer($t16)
- 17: $t18 := read_ref($t15)
- 18: $t19 := 1
- 19: $t14 := >($t18, $t19)
- 20: $t13 := !($t14)
- 21: if ($t13) goto 22 else goto 25
- 22: label L5
- 23: goto 35
- 24: goto 26
- 25: label L6
- 26: label L7
- 27: $t21 := 1
- 28: $t20 := +($t7, $t21)
- 29: $t7 := infer($t20)
- 30: goto 33
- 31: label L3
- 32: goto 35
- 33: label L4
- 34: goto 10
- 35: label L1
- 36: $t22 := infer($t7)
- 37: $t24 := 1
- 38: $t23 := +($t7, $t24)
- 39: $t7 := infer($t23)
- 40: label L8
- 41: $t25 := <($t7, $t9)
- 42: if ($t25) goto 43 else goto 63
- 43: label L10
- 44: $t29 := freeze_ref($t6)
- 45: $t28 := vector::borrow<u64>($t29, $t7)
- 46: $t27 := infer($t28)
- 47: $t30 := read_ref($t27)
- 48: $t31 := 1
- 49: $t26 := >($t30, $t31)
- 50: if ($t26) goto 51 else goto 57
- 51: label L13
- 52: vector::swap<u64>($t6, $t22, $t7)
- 53: $t33 := 1
- 54: $t32 := +($t22, $t33)
- 55: $t22 := infer($t32)
- 56: goto 58
- 57: label L14
- 58: label L15
- 59: $t35 := 1
- 60: $t34 := +($t7, $t35)
- 61: $t7 := infer($t34)
- 62: goto 65
- 63: label L11
- 64: goto 67
- 65: label L12
- 66: goto 40
- 67: label L9
- 68: $t5 := infer($t22)
- 69: $t37 := freeze_ref($t3)
- 70: $t38 := 0
- 71: $t36 := vector::borrow<u64>($t37, $t38)
- 72: $t0 := read_ref($t36)
- 73: return $t0
+  0: $t1 := ["1", "2", "3"]
+  1: $t2 := borrow_local($t1)
+  2: $t4 := infer($t2)
+  3: $t5 := 0
+  4: $t7 := freeze_ref($t4)
+  5: $t6 := vector::length<u64>($t7)
+  6: label L0
+  7: $t8 := <($t5, $t6)
+  8: if ($t8) goto 9 else goto 27
+  9: label L2
+ 10: $t13 := freeze_ref($t4)
+ 11: $t12 := vector::borrow<u64>($t13, $t5)
+ 12: $t11 := infer($t12)
+ 13: $t14 := read_ref($t11)
+ 14: $t15 := 1
+ 15: $t10 := >($t14, $t15)
+ 16: $t9 := !($t10)
+ 17: if ($t9) goto 18 else goto 21
+ 18: label L5
+ 19: goto 31
+ 20: goto 22
+ 21: label L6
+ 22: label L7
+ 23: $t17 := 1
+ 24: $t16 := +($t5, $t17)
+ 25: $t5 := infer($t16)
+ 26: goto 29
+ 27: label L3
+ 28: goto 31
+ 29: label L4
+ 30: goto 6
+ 31: label L1
+ 32: $t18 := infer($t5)
+ 33: $t20 := 1
+ 34: $t19 := +($t5, $t20)
+ 35: $t5 := infer($t19)
+ 36: label L8
+ 37: $t21 := <($t5, $t6)
+ 38: if ($t21) goto 39 else goto 59
+ 39: label L10
+ 40: $t25 := freeze_ref($t4)
+ 41: $t24 := vector::borrow<u64>($t25, $t5)
+ 42: $t23 := infer($t24)
+ 43: $t26 := read_ref($t23)
+ 44: $t27 := 1
+ 45: $t22 := >($t26, $t27)
+ 46: if ($t22) goto 47 else goto 53
+ 47: label L13
+ 48: vector::swap<u64>($t4, $t18, $t5)
+ 49: $t29 := 1
+ 50: $t28 := +($t18, $t29)
+ 51: $t18 := infer($t28)
+ 52: goto 54
+ 53: label L14
+ 54: label L15
+ 55: $t31 := 1
+ 56: $t30 := +($t5, $t31)
+ 57: $t5 := infer($t30)
+ 58: goto 61
+ 59: label L11
+ 60: goto 63
+ 61: label L12
+ 62: goto 36
+ 63: label L9
+ 64: $t3 := infer($t18)
+ 65: $t33 := freeze_ref($t2)
+ 66: $t34 := 0
+ 67: $t32 := vector::borrow<u64>($t33, $t34)
+ 68: $t0 := read_ref($t32)
+ 69: return $t0
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -123,189 +115,177 @@ fun m::foo(): u64 {
 fun m::foo(): u64 {
      var $t0: u64
      var $t1: vector<u64>
-     var $t2: vector<u64>
-     var $t3: &mut vector<u64>
+     var $t2: &mut vector<u64>
+     var $t3: u64
      var $t4: &mut vector<u64>
      var $t5: u64
-     var $t6: &mut vector<u64>
-     var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-     var $t11: &vector<u64>
-     var $t12: bool
-     var $t13: bool
-     var $t14: bool
-     var $t15: &u64
-     var $t16: &u64
-     var $t17: &vector<u64>
+     var $t6: u64
+     var $t7: &vector<u64>
+     var $t8: bool
+     var $t9: bool
+     var $t10: bool
+     var $t11: &u64
+     var $t12: &u64
+     var $t13: &vector<u64>
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
      var $t18: u64
      var $t19: u64
      var $t20: u64
-     var $t21: u64
-     var $t22: u64
-     var $t23: u64
-     var $t24: u64
-     var $t25: bool
-     var $t26: bool
-     var $t27: &u64
-     var $t28: &u64
-     var $t29: &vector<u64>
+     var $t21: bool
+     var $t22: bool
+     var $t23: &u64
+     var $t24: &u64
+     var $t25: &vector<u64>
+     var $t26: u64
+     var $t27: u64
+     var $t28: u64
+     var $t29: u64
      var $t30: u64
      var $t31: u64
-     var $t32: u64
-     var $t33: u64
+     var $t32: &u64
+     var $t33: &vector<u64>
      var $t34: u64
-     var $t35: u64
-     var $t36: &u64
-     var $t37: &vector<u64>
-     var $t38: u64
      # live vars:
-  0: $t2 := ["1", "2", "3"]
-     # live vars: $t2
-  1: $t1 := infer($t2)
+  0: $t1 := ["1", "2", "3"]
      # live vars: $t1
-  2: $t4 := borrow_local($t1)
-     # live vars: $t4
-  3: $t3 := infer($t4)
-     # live vars: $t3
-  4: $t6 := infer($t3)
-     # live vars: $t3, $t6
-  5: $t8 := 0
-     # live vars: $t3, $t6, $t8
-  6: $t7 := infer($t8)
-     # live vars: $t3, $t6, $t7
-  7: $t11 := freeze_ref($t6)
-     # live vars: $t3, $t6, $t7, $t11
-  8: $t10 := vector::length<u64>($t11)
-     # live vars: $t3, $t6, $t7, $t10
-  9: $t9 := infer($t10)
-     # live vars: $t3, $t6, $t7, $t9
- 10: label L0
-     # live vars: $t3, $t6, $t7, $t9
- 11: $t12 := <($t7, $t9)
-     # live vars: $t3, $t6, $t7, $t9, $t12
- 12: if ($t12) goto 13 else goto 31
-     # live vars: $t3, $t6, $t7, $t9
- 13: label L2
-     # live vars: $t3, $t6, $t7, $t9
- 14: $t17 := freeze_ref($t6)
-     # live vars: $t3, $t6, $t7, $t9, $t17
- 15: $t16 := vector::borrow<u64>($t17, $t7)
-     # live vars: $t3, $t6, $t7, $t9, $t16
- 16: $t15 := infer($t16)
-     # live vars: $t3, $t6, $t7, $t9, $t15
- 17: $t18 := read_ref($t15)
-     # live vars: $t3, $t6, $t7, $t9, $t18
- 18: $t19 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t18, $t19
- 19: $t14 := >($t18, $t19)
-     # live vars: $t3, $t6, $t7, $t9, $t14
- 20: $t13 := !($t14)
-     # live vars: $t3, $t6, $t7, $t9, $t13
- 21: if ($t13) goto 22 else goto 25
-     # live vars: $t3, $t6, $t7, $t9
- 22: label L5
-     # live vars: $t3, $t6, $t7, $t9
- 23: goto 35
-     # live vars: $t3, $t6, $t7, $t9
- 24: goto 26
-     # live vars: $t3, $t6, $t7, $t9
- 25: label L6
-     # live vars: $t3, $t6, $t7, $t9
- 26: label L7
-     # live vars: $t3, $t6, $t7, $t9
- 27: $t21 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t21
- 28: $t20 := +($t7, $t21)
-     # live vars: $t3, $t6, $t9, $t20
- 29: $t7 := infer($t20)
-     # live vars: $t3, $t6, $t7, $t9
- 30: goto 33
-     # live vars: $t3, $t6, $t7, $t9
- 31: label L3
-     # live vars: $t3, $t6, $t7, $t9
- 32: goto 35
-     # live vars: $t3, $t6, $t7, $t9
- 33: label L4
-     # live vars: $t3, $t6, $t7, $t9
- 34: goto 10
-     # live vars: $t3, $t6, $t7, $t9
- 35: label L1
-     # live vars: $t3, $t6, $t7, $t9
- 36: $t22 := infer($t7)
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 37: $t24 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t24
- 38: $t23 := +($t7, $t24)
-     # live vars: $t3, $t6, $t9, $t22, $t23
- 39: $t7 := infer($t23)
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 40: label L8
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 41: $t25 := <($t7, $t9)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t25
- 42: if ($t25) goto 43 else goto 63
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 43: label L10
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 44: $t29 := freeze_ref($t6)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t29
- 45: $t28 := vector::borrow<u64>($t29, $t7)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t28
- 46: $t27 := infer($t28)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t27
- 47: $t30 := read_ref($t27)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t30
- 48: $t31 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t30, $t31
- 49: $t26 := >($t30, $t31)
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t26
- 50: if ($t26) goto 51 else goto 57
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 51: label L13
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 52: vector::swap<u64>($t6, $t22, $t7)
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 53: $t33 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t33
- 54: $t32 := +($t22, $t33)
-     # live vars: $t3, $t6, $t7, $t9, $t32
- 55: $t22 := infer($t32)
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 56: goto 58
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 57: label L14
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 58: label L15
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 59: $t35 := 1
-     # live vars: $t3, $t6, $t7, $t9, $t22, $t35
- 60: $t34 := +($t7, $t35)
-     # live vars: $t3, $t6, $t9, $t22, $t34
- 61: $t7 := infer($t34)
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 62: goto 65
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 63: label L11
-     # live vars: $t3, $t22
- 64: goto 67
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 65: label L12
-     # live vars: $t3, $t6, $t7, $t9, $t22
- 66: goto 40
-     # live vars: $t3, $t22
- 67: label L9
-     # live vars: $t3, $t22
- 68: $t5 := infer($t22)
-     # live vars: $t3
- 69: $t37 := freeze_ref($t3)
-     # live vars: $t37
- 70: $t38 := 0
-     # live vars: $t37, $t38
- 71: $t36 := vector::borrow<u64>($t37, $t38)
-     # live vars: $t36
- 72: $t0 := read_ref($t36)
+  1: $t2 := borrow_local($t1)
+     # live vars: $t2
+  2: $t4 := infer($t2)
+     # live vars: $t2, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t4, $t5
+  4: $t7 := freeze_ref($t4)
+     # live vars: $t2, $t4, $t5, $t7
+  5: $t6 := vector::length<u64>($t7)
+     # live vars: $t2, $t4, $t5, $t6
+  6: label L0
+     # live vars: $t2, $t4, $t5, $t6
+  7: $t8 := <($t5, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t8
+  8: if ($t8) goto 9 else goto 27
+     # live vars: $t2, $t4, $t5, $t6
+  9: label L2
+     # live vars: $t2, $t4, $t5, $t6
+ 10: $t13 := freeze_ref($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t13
+ 11: $t12 := vector::borrow<u64>($t13, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t12
+ 12: $t11 := infer($t12)
+     # live vars: $t2, $t4, $t5, $t6, $t11
+ 13: $t14 := read_ref($t11)
+     # live vars: $t2, $t4, $t5, $t6, $t14
+ 14: $t15 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t14, $t15
+ 15: $t10 := >($t14, $t15)
+     # live vars: $t2, $t4, $t5, $t6, $t10
+ 16: $t9 := !($t10)
+     # live vars: $t2, $t4, $t5, $t6, $t9
+ 17: if ($t9) goto 18 else goto 21
+     # live vars: $t2, $t4, $t5, $t6
+ 18: label L5
+     # live vars: $t2, $t4, $t5, $t6
+ 19: goto 31
+     # live vars: $t2, $t4, $t5, $t6
+ 20: goto 22
+     # live vars: $t2, $t4, $t5, $t6
+ 21: label L6
+     # live vars: $t2, $t4, $t5, $t6
+ 22: label L7
+     # live vars: $t2, $t4, $t5, $t6
+ 23: $t17 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t17
+ 24: $t16 := +($t5, $t17)
+     # live vars: $t2, $t4, $t6, $t16
+ 25: $t5 := infer($t16)
+     # live vars: $t2, $t4, $t5, $t6
+ 26: goto 29
+     # live vars: $t2, $t4, $t5, $t6
+ 27: label L3
+     # live vars: $t2, $t4, $t5, $t6
+ 28: goto 31
+     # live vars: $t2, $t4, $t5, $t6
+ 29: label L4
+     # live vars: $t2, $t4, $t5, $t6
+ 30: goto 6
+     # live vars: $t2, $t4, $t5, $t6
+ 31: label L1
+     # live vars: $t2, $t4, $t5, $t6
+ 32: $t18 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 33: $t20 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t20
+ 34: $t19 := +($t5, $t20)
+     # live vars: $t2, $t4, $t6, $t18, $t19
+ 35: $t5 := infer($t19)
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 36: label L8
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 37: $t21 := <($t5, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t21
+ 38: if ($t21) goto 39 else goto 59
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 39: label L10
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 40: $t25 := freeze_ref($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t25
+ 41: $t24 := vector::borrow<u64>($t25, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t24
+ 42: $t23 := infer($t24)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t23
+ 43: $t26 := read_ref($t23)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t26
+ 44: $t27 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t26, $t27
+ 45: $t22 := >($t26, $t27)
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t22
+ 46: if ($t22) goto 47 else goto 53
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 47: label L13
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 48: vector::swap<u64>($t4, $t18, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 49: $t29 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t29
+ 50: $t28 := +($t18, $t29)
+     # live vars: $t2, $t4, $t5, $t6, $t28
+ 51: $t18 := infer($t28)
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 52: goto 54
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 53: label L14
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 54: label L15
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 55: $t31 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t18, $t31
+ 56: $t30 := +($t5, $t31)
+     # live vars: $t2, $t4, $t6, $t18, $t30
+ 57: $t5 := infer($t30)
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 58: goto 61
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 59: label L11
+     # live vars: $t2, $t18
+ 60: goto 63
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 61: label L12
+     # live vars: $t2, $t4, $t5, $t6, $t18
+ 62: goto 36
+     # live vars: $t2, $t18
+ 63: label L9
+     # live vars: $t2, $t18
+ 64: $t3 := infer($t18)
+     # live vars: $t2
+ 65: $t33 := freeze_ref($t2)
+     # live vars: $t33
+ 66: $t34 := 0
+     # live vars: $t33, $t34
+ 67: $t32 := vector::borrow<u64>($t33, $t34)
+     # live vars: $t32
+ 68: $t0 := read_ref($t32)
      # live vars: $t0
- 73: return $t0
+ 69: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_ref.exp
@@ -3,143 +3,115 @@
 [variant baseline]
 fun m::f1_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: m::some($t3)
-  6: m::some($t3)
-  7: return ()
+     var $t1: u64
+     var $t2: &mut m::R
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: m::some($t2)
+  4: m::some($t2)
+  5: return ()
 }
 
 
 [variant baseline]
 fun m::f1a_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: $t5 := read_ref($t3)
-  6: m::some($t3)
-  7: m::some($t3)
-  8: return ()
+     var $t1: u64
+     var $t2: &mut m::R
+     var $t3: m::R
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: $t3 := read_ref($t2)
+  4: m::some($t2)
+  5: m::some($t2)
+  6: return ()
 }
 
 
 [variant baseline]
 fun m::f1b_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: m::some($t3)
-  6: $t5 := read_ref($t3)
-  7: m::some($t3)
-  8: return ()
+     var $t1: u64
+     var $t2: &mut m::R
+     var $t3: m::R
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: m::some($t2)
+  4: $t3 := read_ref($t2)
+  5: m::some($t2)
+  6: return ()
 }
 
 
 [variant baseline]
 fun m::f2_fail() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: m::some2($t3, $t3)
-  6: return ()
+     var $t1: u64
+     var $t2: &mut m::R
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: m::some2($t2, $t2)
+  4: return ()
 }
 
 
 [variant baseline]
 fun m::f3_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
+     var $t1: u64
+     var $t2: &mut m::R
      var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: &mut m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: m::some($t3)
-  6: $t5 := borrow_local($t0)
-  7: $t3 := infer($t5)
-  8: m::some($t3)
-  9: return ()
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: m::some($t2)
+  4: $t3 := borrow_local($t0)
+  5: $t2 := infer($t3)
+  6: m::some($t2)
+  7: return ()
 }
 
 
 [variant baseline]
 fun m::f4_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
+     var $t1: u64
+     var $t2: &mut m::R
      var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: &mut m::R
-  0: $t2 := 0
-  1: $t1 := pack m::R($t2)
-  2: $t0 := infer($t1)
-  3: $t4 := borrow_local($t0)
-  4: $t3 := infer($t4)
-  5: $t5 := m::id($t3)
-  6: $t3 := infer($t5)
-  7: m::some($t3)
-  8: return ()
+  0: $t1 := 0
+  1: $t0 := pack m::R($t1)
+  2: $t2 := borrow_local($t0)
+  3: $t3 := m::id($t2)
+  4: $t2 := infer($t3)
+  5: m::some($t2)
+  6: return ()
 }
 
 
 [variant baseline]
 fun m::f5_fail($t0: bool) {
      var $t1: m::R
-     var $t2: m::R
-     var $t3: u64
+     var $t2: u64
+     var $t3: &mut m::R
      var $t4: &mut m::R
-     var $t5: &mut m::R
-     var $t6: &mut m::R
-  0: $t3 := 0
-  1: $t2 := pack m::R($t3)
-  2: $t1 := infer($t2)
-  3: $t5 := borrow_local($t1)
-  4: $t4 := infer($t5)
-  5: $t6 := infer($t4)
-  6: if ($t0) goto 7 else goto 11
-  7: label L0
-  8: m::some($t4)
-  9: m::some($t6)
- 10: goto 14
- 11: label L1
- 12: m::some($t6)
- 13: m::some($t4)
- 14: label L2
- 15: return ()
+  0: $t2 := 0
+  1: $t1 := pack m::R($t2)
+  2: $t3 := borrow_local($t1)
+  3: $t4 := infer($t3)
+  4: if ($t0) goto 5 else goto 9
+  5: label L0
+  6: m::some($t3)
+  7: m::some($t4)
+  8: goto 12
+  9: label L1
+ 10: m::some($t4)
+ 11: m::some($t3)
+ 12: label L2
+ 13: return ()
 }
 
 
@@ -167,211 +139,169 @@ fun m::some2($t0: &mut m::R, $t1: &mut m::R) {
 [variant baseline]
 fun m::f1_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
+     var $t1: u64
+     var $t2: &mut m::R
      # live vars:
-  0: $t2 := 0
-     # live vars: $t2
-  1: $t1 := pack m::R($t2)
+  0: $t1 := 0
      # live vars: $t1
-  2: $t0 := infer($t1)
+  1: $t0 := pack m::R($t1)
      # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t4
-  4: $t3 := infer($t4)
-     # live vars: $t3
-  5: m::some($t3)
-     # live vars: $t3
-  6: m::some($t3)
+  2: $t2 := borrow_local($t0)
+     # live vars: $t2
+  3: m::some($t2)
+     # live vars: $t2
+  4: m::some($t2)
      # live vars:
-  7: return ()
+  5: return ()
 }
 
 
 [variant baseline]
 fun m::f1a_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: m::R
+     var $t1: u64
+     var $t2: &mut m::R
+     var $t3: m::R
      # live vars:
-  0: $t2 := 0
-     # live vars: $t2
-  1: $t1 := pack m::R($t2)
+  0: $t1 := 0
      # live vars: $t1
-  2: $t0 := infer($t1)
+  1: $t0 := pack m::R($t1)
      # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t4
-  4: $t3 := infer($t4)
-     # live vars: $t3
-  5: $t5 := read_ref($t3)
-     # live vars: $t3
-  6: m::some($t3)
-     # live vars: $t3
-  7: m::some($t3)
-     # live vars:
-  8: return ()
-}
-
-
-[variant baseline]
-fun m::f1b_ok() {
-     var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: m::R
-     # live vars:
-  0: $t2 := 0
+  2: $t2 := borrow_local($t0)
      # live vars: $t2
-  1: $t1 := pack m::R($t2)
-     # live vars: $t1
-  2: $t0 := infer($t1)
-     # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t4
-  4: $t3 := infer($t4)
-     # live vars: $t3
-  5: m::some($t3)
-     # live vars: $t3
-  6: $t5 := read_ref($t3)
-     # live vars: $t3
-  7: m::some($t3)
-     # live vars:
-  8: return ()
-}
-
-
-[variant baseline]
-fun m::f2_fail() {
-     var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
-     var $t3: &mut m::R
-     var $t4: &mut m::R
-     # live vars:
-  0: $t2 := 0
+  3: $t3 := read_ref($t2)
      # live vars: $t2
-  1: $t1 := pack m::R($t2)
-     # live vars: $t1
-  2: $t0 := infer($t1)
-     # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t4
-  4: $t3 := infer($t4)
-     # live vars: $t3
-  5: m::some2($t3, $t3)
+  4: m::some($t2)
+     # live vars: $t2
+  5: m::some($t2)
      # live vars:
   6: return ()
 }
 
 
 [variant baseline]
+fun m::f1b_ok() {
+     var $t0: m::R
+     var $t1: u64
+     var $t2: &mut m::R
+     var $t3: m::R
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t0 := pack m::R($t1)
+     # live vars: $t0
+  2: $t2 := borrow_local($t0)
+     # live vars: $t2
+  3: m::some($t2)
+     # live vars: $t2
+  4: $t3 := read_ref($t2)
+     # live vars: $t2
+  5: m::some($t2)
+     # live vars:
+  6: return ()
+}
+
+
+[variant baseline]
+fun m::f2_fail() {
+     var $t0: m::R
+     var $t1: u64
+     var $t2: &mut m::R
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t0 := pack m::R($t1)
+     # live vars: $t0
+  2: $t2 := borrow_local($t0)
+     # live vars: $t2
+  3: m::some2($t2, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
 fun m::f3_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
+     var $t1: u64
+     var $t2: &mut m::R
      var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: &mut m::R
      # live vars:
-  0: $t2 := 0
-     # live vars: $t2
-  1: $t1 := pack m::R($t2)
+  0: $t1 := 0
      # live vars: $t1
-  2: $t0 := infer($t1)
+  1: $t0 := pack m::R($t1)
      # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t0, $t4
-  4: $t3 := infer($t4)
-     # live vars: $t0, $t3
-  5: m::some($t3)
+  2: $t2 := borrow_local($t0)
+     # live vars: $t0, $t2
+  3: m::some($t2)
      # live vars: $t0
-  6: $t5 := borrow_local($t0)
-     # live vars: $t5
-  7: $t3 := infer($t5)
+  4: $t3 := borrow_local($t0)
      # live vars: $t3
-  8: m::some($t3)
+  5: $t2 := infer($t3)
+     # live vars: $t2
+  6: m::some($t2)
      # live vars:
-  9: return ()
+  7: return ()
 }
 
 
 [variant baseline]
 fun m::f4_ok() {
      var $t0: m::R
-     var $t1: m::R
-     var $t2: u64
+     var $t1: u64
+     var $t2: &mut m::R
      var $t3: &mut m::R
-     var $t4: &mut m::R
-     var $t5: &mut m::R
      # live vars:
-  0: $t2 := 0
-     # live vars: $t2
-  1: $t1 := pack m::R($t2)
+  0: $t1 := 0
      # live vars: $t1
-  2: $t0 := infer($t1)
+  1: $t0 := pack m::R($t1)
      # live vars: $t0
-  3: $t4 := borrow_local($t0)
-     # live vars: $t4
-  4: $t3 := infer($t4)
+  2: $t2 := borrow_local($t0)
+     # live vars: $t2
+  3: $t3 := m::id($t2)
      # live vars: $t3
-  5: $t5 := m::id($t3)
-     # live vars: $t5
-  6: $t3 := infer($t5)
-     # live vars: $t3
-  7: m::some($t3)
+  4: $t2 := infer($t3)
+     # live vars: $t2
+  5: m::some($t2)
      # live vars:
-  8: return ()
+  6: return ()
 }
 
 
 [variant baseline]
 fun m::f5_fail($t0: bool) {
      var $t1: m::R
-     var $t2: m::R
-     var $t3: u64
+     var $t2: u64
+     var $t3: &mut m::R
      var $t4: &mut m::R
-     var $t5: &mut m::R
-     var $t6: &mut m::R
      # live vars: $t0
-  0: $t3 := 0
-     # live vars: $t0, $t3
-  1: $t2 := pack m::R($t3)
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: $t1 := infer($t2)
+  1: $t1 := pack m::R($t2)
      # live vars: $t0, $t1
-  3: $t5 := borrow_local($t1)
-     # live vars: $t0, $t5
-  4: $t4 := infer($t5)
-     # live vars: $t0, $t4
-  5: $t6 := infer($t4)
-     # live vars: $t0, $t4, $t6
-  6: if ($t0) goto 7 else goto 11
-     # live vars: $t4, $t6
-  7: label L0
-     # live vars: $t4, $t6
-  8: m::some($t4)
-     # live vars: $t6
-  9: m::some($t6)
-     # live vars:
- 10: goto 14
-     # live vars: $t4, $t6
- 11: label L1
-     # live vars: $t4, $t6
- 12: m::some($t6)
+  2: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  3: $t4 := infer($t3)
+     # live vars: $t0, $t3, $t4
+  4: if ($t0) goto 5 else goto 9
+     # live vars: $t3, $t4
+  5: label L0
+     # live vars: $t3, $t4
+  6: m::some($t3)
      # live vars: $t4
- 13: m::some($t4)
+  7: m::some($t4)
      # live vars:
- 14: label L2
+  8: goto 12
+     # live vars: $t3, $t4
+  9: label L1
+     # live vars: $t3, $t4
+ 10: m::some($t4)
+     # live vars: $t3
+ 11: m::some($t3)
      # live vars:
- 15: return ()
+ 12: label L2
+     # live vars:
+ 13: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/no-simplifier/moved_var_not_simplified2.exp
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/moved_var_not_simplified2.exp
@@ -22,4 +22,4 @@ error: cannot move local `x` since it is still in use
 4 │         let y = move x;
   │                 ^^^^^^ attempted to move here
 5 │         let _z = x;
-  │             -- used here
+  │                  - used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
@@ -28,7 +28,7 @@ bug: BYTECODE VERIFICATION FAILED
     offsets: [
         (
             FunctionDefinitionIndex(0),
-            7,
+            4,
         ),
     ],
 }

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/moved_var_not_simplified2.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/moved_var_not_simplified2.exp
@@ -22,4 +22,4 @@ error: cannot move local `x` since it is still in use
 4 │         let y = move x;
   │                 ^^^^^^ attempted to move here
 5 │         let _z = x;
-  │             -- used here
+  │                  - used here

--- a/third_party/move/move-compiler-v2/tests/simplifier/moved_var_not_simplified2.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/moved_var_not_simplified2.exp
@@ -22,4 +22,4 @@ error: cannot move local `x` since it is still in use
 4 │         let y = move x;
   │                 ^^^^^^ attempted to move here
 5 │         let _z = x;
-  │             -- used here
+  │                  - used here

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
@@ -8,19 +8,13 @@ fun m::foo($t0: u64, $t1: u64): u64 {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-  0: $t4 := +($t0, $t1)
-  1: $t3 := infer($t4)
-  2: $t7 := 1
-  3: $t6 := +($t3, $t7)
-  4: $t5 := infer($t6)
-  5: $t10 := 1
-  6: $t9 := +($t5, $t10)
-  7: $t8 := infer($t9)
-  8: $t2 := infer($t8)
-  9: return $t2
+  0: $t3 := +($t0, $t1)
+  1: $t5 := 1
+  2: $t4 := +($t3, $t5)
+  3: $t7 := 1
+  4: $t6 := +($t4, $t7)
+  5: $t2 := infer($t6)
+  6: return $t2
 }
 
 ============ after uninitialized_use_checker: ================
@@ -33,27 +27,18 @@ fun m::foo($t0: u64, $t1: u64): u64 {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: u64
-     # before: { no: $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t3, $t5, $t6, $t7, $t8, $t9, $t10 }
-  0: $t4 := +($t0, $t1)
-     # before: { no: $t2, $t3, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t6, $t7, $t8, $t9, $t10 }
-  1: $t3 := infer($t4)
-     # before: { no: $t2, $t5, $t6, $t7, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t6, $t8, $t9, $t10 }
-  2: $t7 := 1
-     # before: { no: $t2, $t5, $t6, $t8, $t9, $t10 }, after: { no: $t2, $t5, $t8, $t9, $t10 }
-  3: $t6 := +($t3, $t7)
-     # before: { no: $t2, $t5, $t8, $t9, $t10 }, after: { no: $t2, $t8, $t9, $t10 }
-  4: $t5 := infer($t6)
-     # before: { no: $t2, $t8, $t9, $t10 }, after: { no: $t2, $t8, $t9 }
-  5: $t10 := 1
-     # before: { no: $t2, $t8, $t9 }, after: { no: $t2, $t8 }
-  6: $t9 := +($t5, $t10)
-     # before: { no: $t2, $t8 }, after: { no: $t2 }
-  7: $t8 := infer($t9)
+     # before: { no: $t2, $t3, $t4, $t5, $t6, $t7 }, after: { no: $t2, $t4, $t5, $t6, $t7 }
+  0: $t3 := +($t0, $t1)
+     # before: { no: $t2, $t4, $t5, $t6, $t7 }, after: { no: $t2, $t4, $t6, $t7 }
+  1: $t5 := 1
+     # before: { no: $t2, $t4, $t6, $t7 }, after: { no: $t2, $t6, $t7 }
+  2: $t4 := +($t3, $t5)
+     # before: { no: $t2, $t6, $t7 }, after: { no: $t2, $t6 }
+  3: $t7 := 1
+     # before: { no: $t2, $t6 }, after: { no: $t2 }
+  4: $t6 := +($t4, $t7)
      # before: { no: $t2 }, after: all initialized
-  8: $t2 := infer($t8)
+  5: $t2 := infer($t6)
      # before: all initialized, after: all initialized
-  9: return $t2
+  6: return $t2
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/struct_use_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/struct_use_before_assign.exp
@@ -54,19 +54,17 @@ warning: Unused local variable `q`. Consider removing or prefixing with an under
 fun M::main() {
      var $t0: u64
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := 3
-  1: $t2 := pack M::R($t3, $t0)
-  2: $t1 := infer($t2)
-  3: ($t4, $t5) := unpack M::R($t1)
-  4: $t6 := infer($t5)
-  5: $t7 := infer($t4)
-  6: return ()
+  0: $t2 := 3
+  1: $t1 := pack M::R($t2, $t0)
+  2: ($t3, $t4) := unpack M::R($t1)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t3)
+  5: return ()
 }
 
 
@@ -74,19 +72,17 @@ fun M::main() {
 fun M::main2() {
      var $t0: u64
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := 0
-  1: $t2 := pack M::R($t3, $t0)
-  2: $t1 := infer($t2)
-  3: ($t4, $t5) := unpack M::R($t1)
-  4: $t6 := infer($t5)
-  5: $t7 := infer($t4)
-  6: return ()
+  0: $t2 := 0
+  1: $t1 := pack M::R($t2, $t0)
+  2: ($t3, $t4) := unpack M::R($t1)
+  3: $t5 := infer($t4)
+  4: $t6 := infer($t3)
+  5: return ()
 }
 
 
@@ -136,16 +132,16 @@ error: use of unassigned local `r`
    │             ^^^^^^^^^^^^^^^^
 
 error: use of unassigned local `y`
-   ┌─ tests/uninit-use-checker/struct_use_before_assign.move:30:13
+   ┌─ tests/uninit-use-checker/struct_use_before_assign.move:30:17
    │
 30 │         let z = y;
-   │             ^
+   │                 ^
 
 error: use of unassigned local `x`
-   ┌─ tests/uninit-use-checker/struct_use_before_assign.move:31:13
+   ┌─ tests/uninit-use-checker/struct_use_before_assign.move:31:17
    │
 31 │         let q = x;
-   │             ^
+   │                 ^
 
 ============ after uninitialized_use_checker: ================
 
@@ -153,26 +149,23 @@ error: use of unassigned local `x`
 fun M::main() {
      var $t0: u64
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t1, $t2, $t4, $t5, $t6, $t7 }
-  0: $t3 := 3
-     # before: { no: $t0, $t1, $t2, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t1, $t4, $t5, $t6, $t7 }
-  1: $t2 := pack M::R($t3, $t0)
-     # before: { no: $t0, $t1, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t4, $t5, $t6, $t7 }
-  2: $t1 := infer($t2)
-     # before: { no: $t0, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t6, $t7 }
-  3: ($t4, $t5) := unpack M::R($t1)
-     # before: { no: $t0, $t6, $t7 }, after: { no: $t0, $t7 }
-  4: $t6 := infer($t5)
-     # before: { no: $t0, $t7 }, after: { no: $t0 }
-  5: $t7 := infer($t4)
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  0: $t2 := 3
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t3, $t4, $t5, $t6 }
+  1: $t1 := pack M::R($t2, $t0)
+     # before: { no: $t0, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t5, $t6 }
+  2: ($t3, $t4) := unpack M::R($t1)
+     # before: { no: $t0, $t5, $t6 }, after: { no: $t0, $t6 }
+  3: $t5 := infer($t4)
+     # before: { no: $t0, $t6 }, after: { no: $t0 }
+  4: $t6 := infer($t3)
      # before: { no: $t0 }, after: { no: $t0 }
-  6: return ()
+  5: return ()
 }
 
 
@@ -180,26 +173,23 @@ fun M::main() {
 fun M::main2() {
      var $t0: u64
      var $t1: M::R
-     var $t2: M::R
+     var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t1, $t2, $t4, $t5, $t6, $t7 }
-  0: $t3 := 0
-     # before: { no: $t0, $t1, $t2, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t1, $t4, $t5, $t6, $t7 }
-  1: $t2 := pack M::R($t3, $t0)
-     # before: { no: $t0, $t1, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t4, $t5, $t6, $t7 }
-  2: $t1 := infer($t2)
-     # before: { no: $t0, $t4, $t5, $t6, $t7 }, after: { no: $t0, $t6, $t7 }
-  3: ($t4, $t5) := unpack M::R($t1)
-     # before: { no: $t0, $t6, $t7 }, after: { no: $t0, $t7 }
-  4: $t6 := infer($t5)
-     # before: { no: $t0, $t7 }, after: { no: $t0 }
-  5: $t7 := infer($t4)
+     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t1, $t3, $t4, $t5, $t6 }
+  0: $t2 := 0
+     # before: { no: $t0, $t1, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t3, $t4, $t5, $t6 }
+  1: $t1 := pack M::R($t2, $t0)
+     # before: { no: $t0, $t3, $t4, $t5, $t6 }, after: { no: $t0, $t5, $t6 }
+  2: ($t3, $t4) := unpack M::R($t1)
+     # before: { no: $t0, $t5, $t6 }, after: { no: $t0, $t6 }
+  3: $t5 := infer($t4)
+     # before: { no: $t0, $t6 }, after: { no: $t0 }
+  4: $t6 := infer($t3)
      # before: { no: $t0 }, after: { no: $t0 }
-  6: return ()
+  5: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/use_twice_before_assign.exp
@@ -12,10 +12,8 @@ warning: Unused local variable `y`. Consider removing or prefixing with an under
 fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
-     var $t2: u64
-  0: $t2 := +($t0, $t0)
-  1: $t1 := infer($t2)
-  2: return ()
+  0: $t1 := +($t0, $t0)
+  1: return ()
 }
 
 
@@ -32,11 +30,8 @@ error: use of unassigned local `x`
 fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
-     var $t2: u64
-     # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
-  0: $t2 := +($t0, $t0)
      # before: { no: $t0, $t1 }, after: { no: $t0 }
-  1: $t1 := infer($t2)
+  0: $t1 := +($t0, $t0)
      # before: { no: $t0 }, after: { no: $t0 }
-  2: return ()
+  1: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/uses_before_assign.exp
@@ -13,10 +13,8 @@ fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t3 := +($t0, $t1)
-  1: $t2 := infer($t3)
-  2: return ()
+  0: $t2 := +($t0, $t1)
+  1: return ()
 }
 
 
@@ -40,11 +38,8 @@ fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     # before: { no: $t0, $t1, $t2, $t3 }, after: { no: $t0, $t1, $t2 }
-  0: $t3 := +($t0, $t1)
      # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
-  1: $t2 := infer($t3)
+  0: $t2 := +($t0, $t1)
      # before: { no: $t0, $t1 }, after: { no: $t0, $t1 }
-  2: return ()
+  1: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-commands/move_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-commands/move_before_assign.exp
@@ -12,10 +12,8 @@ warning: Unused local variable `y`. Consider removing or prefixing with an under
 fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
-     var $t2: u64
-  0: $t2 := move($t0)
-  1: $t1 := infer($t2)
-  2: return ()
+  0: $t1 := move($t0)
+  1: return ()
 }
 
 
@@ -32,11 +30,8 @@ error: use of unassigned local `x`
 fun <SELF>_0::main() {
      var $t0: u64
      var $t1: u64
-     var $t2: u64
-     # before: { no: $t0, $t1, $t2 }, after: { no: $t0, $t1 }
-  0: $t2 := move($t0)
      # before: { no: $t0, $t1 }, after: { no: $t0 }
-  1: $t1 := infer($t2)
+  0: $t1 := move($t0)
      # before: { no: $t0 }, after: { no: $t0 }
-  2: return ()
+  1: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-commands/use_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-commands/use_before_assign.exp
@@ -19,10 +19,10 @@ fun <SELF>_0::main() {
 
 Diagnostics:
 error: use of unassigned local `x`
-  ┌─ tests/uninit-use-checker/v1-commands/use_before_assign.move:4:9
+  ┌─ tests/uninit-use-checker/v1-commands/use_before_assign.move:4:13
   │
 4 │     let y = x;
-  │         ^
+  │             ^
 
 ============ after uninitialized_use_checker: ================
 

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_loop.exp
@@ -5,17 +5,15 @@ fun M::tborrow1() {
      var $t0: u64
      var $t1: &u64
      var $t2: &u64
-     var $t3: &u64
-     var $t4: u64
+     var $t3: u64
   0: label L0
-  1: $t2 := borrow_local($t0)
-  2: $t1 := infer($t2)
-  3: $t3 := move($t1)
-  4: $t4 := 0
-  5: $t0 := infer($t4)
-  6: goto 0
-  7: label L1
-  8: return ()
+  1: $t1 := borrow_local($t0)
+  2: $t2 := move($t1)
+  3: $t3 := 0
+  4: $t0 := infer($t3)
+  5: goto 0
+  6: label L1
+  7: return ()
 }
 
 
@@ -24,25 +22,23 @@ fun M::tborrow2($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
   0: label L0
-  1: $t3 := borrow_local($t1)
-  2: $t2 := infer($t3)
-  3: $t4 := move($t2)
-  4: if ($t0) goto 5 else goto 9
-  5: label L2
-  6: $t5 := 0
-  7: $t1 := infer($t5)
-  8: goto 10
-  9: label L3
- 10: label L4
- 11: goto 13
- 12: goto 0
- 13: label L1
- 14: $t6 := infer($t1)
- 15: return ()
+  1: $t2 := borrow_local($t1)
+  2: $t3 := move($t2)
+  3: if ($t0) goto 4 else goto 8
+  4: label L2
+  5: $t4 := 0
+  6: $t1 := infer($t4)
+  7: goto 9
+  8: label L3
+  9: label L4
+ 10: goto 12
+ 11: goto 0
+ 12: label L1
+ 13: $t5 := infer($t1)
+ 14: return ()
 }
 
 
@@ -53,23 +49,21 @@ fun M::tcopy($t0: bool) {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
   0: label L0
-  1: $t4 := 1
-  2: $t3 := +($t1, $t4)
-  3: $t2 := infer($t3)
-  4: if ($t0) goto 5 else goto 8
-  5: label L2
-  6: goto 0
-  7: goto 9
-  8: label L3
-  9: label L4
- 10: $t5 := 0
- 11: $t1 := infer($t5)
- 12: $t6 := infer($t2)
- 13: goto 0
- 14: label L1
- 15: return ()
+  1: $t3 := 1
+  2: $t2 := +($t1, $t3)
+  3: if ($t0) goto 4 else goto 7
+  4: label L2
+  5: goto 0
+  6: goto 8
+  7: label L3
+  8: label L4
+  9: $t4 := 0
+ 10: $t1 := infer($t4)
+ 11: $t5 := infer($t2)
+ 12: goto 0
+ 13: label L1
+ 14: return ()
 }
 
 
@@ -81,18 +75,16 @@ fun M::tmove() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
   0: label L0
-  1: $t3 := move($t0)
-  2: $t4 := 1
-  3: $t2 := +($t3, $t4)
-  4: $t1 := infer($t2)
-  5: $t5 := 0
-  6: $t0 := infer($t5)
-  7: $t6 := infer($t1)
-  8: goto 0
-  9: label L1
- 10: return ()
+  1: $t2 := move($t0)
+  2: $t3 := 1
+  3: $t1 := +($t2, $t3)
+  4: $t4 := 0
+  5: $t0 := infer($t4)
+  6: $t5 := infer($t1)
+  7: goto 0
+  8: label L1
+  9: return ()
 }
 
 
@@ -134,24 +126,21 @@ fun M::tborrow1() {
      var $t0: u64
      var $t1: &u64
      var $t2: &u64
-     var $t3: &u64
-     var $t4: u64
-     # before: { maybe: $t0, $t1, $t2, $t3, $t4 }, after: { maybe: $t0, $t1, $t2, $t3, $t4 }
+     var $t3: u64
+     # before: { maybe: $t0, $t1, $t2, $t3 }, after: { maybe: $t0, $t1, $t2, $t3 }
   0: label L0
-     # before: { maybe: $t0, $t1, $t2, $t3, $t4 }, after: { maybe: $t0, $t1, $t3, $t4 }
-  1: $t2 := borrow_local($t0)
-     # before: { maybe: $t0, $t1, $t3, $t4 }, after: { maybe: $t0, $t3, $t4 }
-  2: $t1 := infer($t2)
-     # before: { maybe: $t0, $t3, $t4 }, after: { maybe: $t0, $t4 }
-  3: $t3 := move($t1)
-     # before: { maybe: $t0, $t4 }, after: { maybe: $t0 }
-  4: $t4 := 0
+     # before: { maybe: $t0, $t1, $t2, $t3 }, after: { maybe: $t0, $t2, $t3 }
+  1: $t1 := borrow_local($t0)
+     # before: { maybe: $t0, $t2, $t3 }, after: { maybe: $t0, $t3 }
+  2: $t2 := move($t1)
+     # before: { maybe: $t0, $t3 }, after: { maybe: $t0 }
+  3: $t3 := 0
      # before: { maybe: $t0 }, after: all initialized
-  5: $t0 := infer($t4)
+  4: $t0 := infer($t3)
      # before: all initialized, after: all initialized
-  6: goto 0
-  7: label L1
-  8: return ()
+  5: goto 0
+  6: label L1
+  7: return ()
 }
 
 
@@ -160,40 +149,37 @@ fun M::tborrow2($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-     # before: { no: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t1, $t2, $t3, $t4, $t5, $t6 }
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
   0: label L0
-     # before: { no: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { no: $t1, $t2, $t4, $t5, $t6 }
-  1: $t3 := borrow_local($t1)
-     # before: { no: $t1, $t2, $t4, $t5, $t6 }, after: { no: $t1, $t4, $t5, $t6 }
-  2: $t2 := infer($t3)
-     # before: { no: $t1, $t4, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
-  3: $t4 := move($t2)
-     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
-  4: if ($t0) goto 5 else goto 9
-     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
-  5: label L2
-     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t6 }
-  6: $t5 := 0
-     # before: { no: $t1, $t6 }, after: { no: $t6 }
-  7: $t1 := infer($t5)
-     # before: { no: $t6 }, after: { no: $t6 }
-  8: goto 10
-     # before: { no: $t1, $t5, $t6 }, after: { no: $t1, $t5, $t6 }
-  9: label L3
-     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
- 10: label L4
-     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
- 11: goto 13
- 12: goto 0
-     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { no: $t6 }{ maybe: $t1, $t5 }
- 13: label L1
-     # before: { no: $t6 }{ maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
- 14: $t6 := infer($t1)
-     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
- 15: return ()
+     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t3, $t4, $t5 }
+  1: $t2 := borrow_local($t1)
+     # before: { no: $t1, $t3, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
+  2: $t3 := move($t2)
+     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
+  3: if ($t0) goto 4 else goto 8
+     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
+  4: label L2
+     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t5 }
+  5: $t4 := 0
+     # before: { no: $t1, $t5 }, after: { no: $t5 }
+  6: $t1 := infer($t4)
+     # before: { no: $t5 }, after: { no: $t5 }
+  7: goto 9
+     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
+  8: label L3
+     # before: { no: $t5 }{ maybe: $t1, $t4 }, after: { no: $t5 }{ maybe: $t1, $t4 }
+  9: label L4
+     # before: { no: $t5 }{ maybe: $t1, $t4 }, after: { no: $t5 }{ maybe: $t1, $t4 }
+ 10: goto 12
+ 11: goto 0
+     # before: { no: $t5 }{ maybe: $t1, $t4 }, after: { no: $t5 }{ maybe: $t1, $t4 }
+ 12: label L1
+     # before: { no: $t5 }{ maybe: $t1, $t4 }, after: { maybe: $t1, $t4 }
+ 13: $t5 := infer($t1)
+     # before: { maybe: $t1, $t4 }, after: { maybe: $t1, $t4 }
+ 14: return ()
 }
 
 
@@ -204,36 +190,33 @@ fun M::tcopy($t0: bool) {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
   0: label L0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t5, $t6 }
-  1: $t4 := 1
-     # before: { maybe: $t1, $t2, $t3, $t5, $t6 }, after: { maybe: $t1, $t2, $t5, $t6 }
-  2: $t3 := +($t1, $t4)
-     # before: { maybe: $t1, $t2, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  3: $t2 := infer($t3)
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  4: if ($t0) goto 5 else goto 8
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  5: label L2
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  6: goto 0
-  7: goto 9
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  8: label L3
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
-  9: label L4
-     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t6 }
- 10: $t5 := 0
-     # before: { maybe: $t1, $t6 }, after: { maybe: $t6 }
- 11: $t1 := infer($t5)
-     # before: { maybe: $t6 }, after: all initialized
- 12: $t6 := infer($t2)
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t4, $t5 }
+  1: $t3 := 1
+     # before: { maybe: $t1, $t2, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  2: $t2 := +($t1, $t3)
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  3: if ($t0) goto 4 else goto 7
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  4: label L2
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  5: goto 0
+  6: goto 8
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  7: label L3
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
+  8: label L4
+     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t5 }
+  9: $t4 := 0
+     # before: { maybe: $t1, $t5 }, after: { maybe: $t5 }
+ 10: $t1 := infer($t4)
+     # before: { maybe: $t5 }, after: all initialized
+ 11: $t5 := infer($t2)
      # before: all initialized, after: all initialized
- 13: goto 0
- 14: label L1
- 15: return ()
+ 12: goto 0
+ 13: label L1
+ 14: return ()
 }
 
 
@@ -245,25 +228,22 @@ fun M::tmove() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t2, $t3, $t4, $t5 }
   0: label L0
-     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t4, $t5, $t6 }
-  1: $t3 := move($t0)
-     # before: { maybe: $t0, $t1, $t2, $t4, $t5, $t6 }, after: { maybe: $t0, $t1, $t2, $t5, $t6 }
-  2: $t4 := 1
-     # before: { maybe: $t0, $t1, $t2, $t5, $t6 }, after: { maybe: $t0, $t1, $t5, $t6 }
-  3: $t2 := +($t3, $t4)
-     # before: { maybe: $t0, $t1, $t5, $t6 }, after: { maybe: $t0, $t5, $t6 }
-  4: $t1 := infer($t2)
-     # before: { maybe: $t0, $t5, $t6 }, after: { maybe: $t0, $t6 }
-  5: $t5 := 0
-     # before: { maybe: $t0, $t6 }, after: { maybe: $t6 }
-  6: $t0 := infer($t5)
-     # before: { maybe: $t6 }, after: all initialized
-  7: $t6 := infer($t1)
+     # before: { maybe: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t3, $t4, $t5 }
+  1: $t2 := move($t0)
+     # before: { maybe: $t0, $t1, $t3, $t4, $t5 }, after: { maybe: $t0, $t1, $t4, $t5 }
+  2: $t3 := 1
+     # before: { maybe: $t0, $t1, $t4, $t5 }, after: { maybe: $t0, $t4, $t5 }
+  3: $t1 := +($t2, $t3)
+     # before: { maybe: $t0, $t4, $t5 }, after: { maybe: $t0, $t5 }
+  4: $t4 := 0
+     # before: { maybe: $t0, $t5 }, after: { maybe: $t5 }
+  5: $t0 := infer($t4)
+     # before: { maybe: $t5 }, after: all initialized
+  6: $t5 := infer($t1)
      # before: all initialized, after: all initialized
-  8: goto 0
-  9: label L1
- 10: return ()
+  7: goto 0
+  8: label L1
+  9: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_simple.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_simple.exp
@@ -6,11 +6,9 @@ fun M::tborrow() {
      var $t1: &u64
      var $t2: M::S
      var $t3: &M::S
-     var $t4: &M::S
   0: $t1 := borrow_local($t0)
-  1: $t4 := borrow_local($t2)
-  2: $t3 := infer($t4)
-  3: return ()
+  1: $t3 := borrow_local($t2)
+  2: return ()
 }
 
 
@@ -21,12 +19,10 @@ fun M::tcopy() {
      var $t2: u64
      var $t3: M::S
      var $t4: M::S
-     var $t5: M::S
   0: $t2 := 1
   1: $t1 := +($t0, $t2)
-  2: $t5 := copy($t3)
-  3: $t4 := infer($t5)
-  4: return ()
+  2: $t4 := copy($t3)
+  3: return ()
 }
 
 
@@ -54,10 +50,10 @@ error: use of unassigned local `x`
   │                 ^^^^^^
 
 error: use of unassigned local `s`
-  ┌─ tests/uninit-use-checker/v1-locals/use_before_assign_simple.move:9:13
+  ┌─ tests/uninit-use-checker/v1-locals/use_before_assign_simple.move:9:19
   │
 9 │         let _s2 = s;
-  │             ^^^
+  │                   ^
 
 error: use of unassigned local `x`
    ┌─ tests/uninit-use-checker/v1-locals/use_before_assign_simple.move:14:17
@@ -91,15 +87,12 @@ fun M::tborrow() {
      var $t1: &u64
      var $t2: M::S
      var $t3: &M::S
-     var $t4: &M::S
-     # before: { no: $t0, $t1, $t2, $t3, $t4 }, after: { no: $t0, $t2, $t3, $t4 }
+     # before: { no: $t0, $t1, $t2, $t3 }, after: { no: $t0, $t2, $t3 }
   0: $t1 := borrow_local($t0)
-     # before: { no: $t0, $t2, $t3, $t4 }, after: { no: $t0, $t2, $t3 }
-  1: $t4 := borrow_local($t2)
      # before: { no: $t0, $t2, $t3 }, after: { no: $t0, $t2 }
-  2: $t3 := infer($t4)
+  1: $t3 := borrow_local($t2)
      # before: { no: $t0, $t2 }, after: { no: $t0, $t2 }
-  3: return ()
+  2: return ()
 }
 
 
@@ -110,17 +103,14 @@ fun M::tcopy() {
      var $t2: u64
      var $t3: M::S
      var $t4: M::S
-     var $t5: M::S
-     # before: { no: $t0, $t1, $t2, $t3, $t4, $t5 }, after: { no: $t0, $t1, $t3, $t4, $t5 }
+     # before: { no: $t0, $t1, $t2, $t3, $t4 }, after: { no: $t0, $t1, $t3, $t4 }
   0: $t2 := 1
-     # before: { no: $t0, $t1, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4, $t5 }
+     # before: { no: $t0, $t1, $t3, $t4 }, after: { no: $t0, $t3, $t4 }
   1: $t1 := +($t0, $t2)
-     # before: { no: $t0, $t3, $t4, $t5 }, after: { no: $t0, $t3, $t4 }
-  2: $t5 := copy($t3)
      # before: { no: $t0, $t3, $t4 }, after: { no: $t0, $t3 }
-  3: $t4 := infer($t5)
+  2: $t4 := copy($t3)
      # before: { no: $t0, $t3 }, after: { no: $t0, $t3 }
-  4: return ()
+  3: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_while.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/v1-locals/use_before_assign_while.exp
@@ -5,23 +5,21 @@ fun M::tborrow1($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
+     var $t4: u64
   0: label L0
-  1: if ($t0) goto 2 else goto 9
+  1: if ($t0) goto 2 else goto 8
   2: label L2
-  3: $t3 := borrow_local($t1)
-  4: $t2 := infer($t3)
-  5: $t4 := move($t2)
-  6: $t5 := 0
-  7: $t1 := infer($t5)
-  8: goto 11
-  9: label L3
- 10: goto 13
- 11: label L4
- 12: goto 0
- 13: label L1
- 14: return ()
+  3: $t2 := borrow_local($t1)
+  4: $t3 := move($t2)
+  5: $t4 := 0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L3
+  9: goto 12
+ 10: label L4
+ 11: goto 0
+ 12: label L1
+ 13: return ()
 }
 
 
@@ -30,29 +28,27 @@ fun M::tborrow2($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
+     var $t4: u64
   0: label L0
-  1: if ($t0) goto 2 else goto 15
+  1: if ($t0) goto 2 else goto 14
   2: label L2
-  3: $t3 := borrow_local($t1)
-  4: $t2 := infer($t3)
-  5: $t4 := move($t2)
-  6: if ($t0) goto 7 else goto 11
-  7: label L5
-  8: $t5 := 0
-  9: $t1 := infer($t5)
- 10: goto 12
- 11: label L6
- 12: label L7
- 13: goto 19
- 14: goto 17
- 15: label L3
- 16: goto 19
- 17: label L4
- 18: goto 0
- 19: label L1
- 20: return ()
+  3: $t2 := borrow_local($t1)
+  4: $t3 := move($t2)
+  5: if ($t0) goto 6 else goto 10
+  6: label L5
+  7: $t4 := 0
+  8: $t1 := infer($t4)
+  9: goto 11
+ 10: label L6
+ 11: label L7
+ 12: goto 18
+ 13: goto 16
+ 14: label L3
+ 15: goto 18
+ 16: label L4
+ 17: goto 0
+ 18: label L1
+ 19: return ()
 }
 
 
@@ -64,30 +60,28 @@ fun M::tcopy($t0: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
   0: label L0
-  1: if ($t0) goto 2 else goto 17
+  1: if ($t0) goto 2 else goto 16
   2: label L2
-  3: $t4 := move($t1)
-  4: $t5 := 1
-  5: $t3 := +($t4, $t5)
-  6: $t2 := infer($t3)
-  7: if ($t0) goto 8 else goto 11
-  8: label L5
-  9: goto 0
- 10: goto 12
- 11: label L6
- 12: label L7
- 13: $t6 := 0
- 14: $t1 := infer($t6)
- 15: $t7 := infer($t2)
- 16: goto 19
- 17: label L3
- 18: goto 21
- 19: label L4
- 20: goto 0
- 21: label L1
- 22: return ()
+  3: $t3 := move($t1)
+  4: $t4 := 1
+  5: $t2 := +($t3, $t4)
+  6: if ($t0) goto 7 else goto 10
+  7: label L5
+  8: goto 0
+  9: goto 11
+ 10: label L6
+ 11: label L7
+ 12: $t5 := 0
+ 13: $t1 := infer($t5)
+ 14: $t6 := infer($t2)
+ 15: goto 18
+ 16: label L3
+ 17: goto 20
+ 18: label L4
+ 19: goto 0
+ 20: label L1
+ 21: return ()
 }
 
 
@@ -99,24 +93,22 @@ fun M::tmove($t0: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
   0: label L0
-  1: if ($t0) goto 2 else goto 11
+  1: if ($t0) goto 2 else goto 10
   2: label L2
-  3: $t4 := move($t1)
-  4: $t5 := 1
-  5: $t3 := +($t4, $t5)
-  6: $t2 := infer($t3)
-  7: $t6 := 0
-  8: $t1 := infer($t6)
-  9: $t7 := infer($t2)
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 0
- 15: label L1
- 16: return ()
+  3: $t3 := move($t1)
+  4: $t4 := 1
+  5: $t2 := +($t3, $t4)
+  6: $t5 := 0
+  7: $t1 := infer($t5)
+  8: $t6 := infer($t2)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 0
+ 14: label L1
+ 15: return ()
 }
 
 
@@ -152,38 +144,35 @@ fun M::tborrow1($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+     var $t4: u64
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
   0: label L0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
-  1: if ($t0) goto 2 else goto 9
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+  1: if ($t0) goto 2 else goto 8
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
   2: label L2
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t4, $t5 }
-  3: $t3 := borrow_local($t1)
-     # before: { maybe: $t1, $t2, $t4, $t5 }, after: { maybe: $t1, $t4, $t5 }
-  4: $t2 := infer($t3)
-     # before: { maybe: $t1, $t4, $t5 }, after: { maybe: $t1, $t5 }
-  5: $t4 := move($t2)
-     # before: { maybe: $t1, $t5 }, after: { maybe: $t1 }
-  6: $t5 := 0
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t3, $t4 }
+  3: $t2 := borrow_local($t1)
+     # before: { maybe: $t1, $t3, $t4 }, after: { maybe: $t1, $t4 }
+  4: $t3 := move($t2)
+     # before: { maybe: $t1, $t4 }, after: { maybe: $t1 }
+  5: $t4 := 0
      # before: { maybe: $t1 }, after: all initialized
-  7: $t1 := infer($t5)
+  6: $t1 := infer($t4)
      # before: all initialized, after: all initialized
-  8: goto 11
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
-  9: label L3
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
- 10: goto 13
+  7: goto 10
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+  8: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+  9: goto 12
      # before: all initialized, after: all initialized
- 11: label L4
+ 10: label L4
      # before: all initialized, after: all initialized
- 12: goto 0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
- 13: label L1
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
- 14: return ()
+ 11: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+ 12: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+ 13: return ()
 }
 
 
@@ -192,47 +181,44 @@ fun M::tborrow2($t0: bool) {
      var $t1: u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+     var $t4: u64
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
   0: label L0
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
-  1: if ($t0) goto 2 else goto 15
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+  1: if ($t0) goto 2 else goto 14
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
   2: label L2
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t4, $t5 }
-  3: $t3 := borrow_local($t1)
-     # before: { no: $t1, $t2, $t4, $t5 }, after: { no: $t1, $t4, $t5 }
-  4: $t2 := infer($t3)
-     # before: { no: $t1, $t4, $t5 }, after: { no: $t1, $t5 }
-  5: $t4 := move($t2)
-     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
-  6: if ($t0) goto 7 else goto 11
-     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
-  7: label L5
-     # before: { no: $t1, $t5 }, after: { no: $t1 }
-  8: $t5 := 0
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t3, $t4 }
+  3: $t2 := borrow_local($t1)
+     # before: { no: $t1, $t3, $t4 }, after: { no: $t1, $t4 }
+  4: $t3 := move($t2)
+     # before: { no: $t1, $t4 }, after: { no: $t1, $t4 }
+  5: if ($t0) goto 6 else goto 10
+     # before: { no: $t1, $t4 }, after: { no: $t1, $t4 }
+  6: label L5
+     # before: { no: $t1, $t4 }, after: { no: $t1 }
+  7: $t4 := 0
      # before: { no: $t1 }, after: all initialized
-  9: $t1 := infer($t5)
+  8: $t1 := infer($t4)
      # before: all initialized, after: all initialized
- 10: goto 12
-     # before: { no: $t1, $t5 }, after: { no: $t1, $t5 }
- 11: label L6
-     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
- 12: label L7
-     # before: { maybe: $t1, $t5 }, after: { maybe: $t1, $t5 }
- 13: goto 19
- 14: goto 17
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
- 15: label L3
-     # before: { no: $t1, $t2, $t3, $t4, $t5 }, after: { no: $t1, $t2, $t3, $t4, $t5 }
- 16: goto 19
- 17: label L4
- 18: goto 0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
- 19: label L1
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5 }, after: { maybe: $t1, $t2, $t3, $t4, $t5 }
- 20: return ()
+  9: goto 11
+     # before: { no: $t1, $t4 }, after: { no: $t1, $t4 }
+ 10: label L6
+     # before: { maybe: $t1, $t4 }, after: { maybe: $t1, $t4 }
+ 11: label L7
+     # before: { maybe: $t1, $t4 }, after: { maybe: $t1, $t4 }
+ 12: goto 18
+ 13: goto 16
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+ 14: label L3
+     # before: { no: $t1, $t2, $t3, $t4 }, after: { no: $t1, $t2, $t3, $t4 }
+ 15: goto 18
+ 16: label L4
+ 17: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+ 18: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4 }, after: { maybe: $t1, $t2, $t3, $t4 }
+ 19: return ()
 }
 
 
@@ -244,52 +230,49 @@ fun M::tcopy($t0: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
   0: label L0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
-  1: if ($t0) goto 2 else goto 17
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+  1: if ($t0) goto 2 else goto 16
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
   2: label L2
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }
-  3: $t4 := move($t1)
-     # before: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t6, $t7 }
-  4: $t5 := 1
-     # before: { maybe: $t1, $t2, $t3, $t6, $t7 }, after: { maybe: $t1, $t2, $t6, $t7 }
-  5: $t3 := +($t4, $t5)
-     # before: { maybe: $t1, $t2, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
-  6: $t2 := infer($t3)
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
-  7: if ($t0) goto 8 else goto 11
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
-  8: label L5
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
-  9: goto 0
- 10: goto 12
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
- 11: label L6
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
- 12: label L7
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t7 }
- 13: $t6 := 0
-     # before: { maybe: $t1, $t7 }, after: { maybe: $t7 }
- 14: $t1 := infer($t6)
-     # before: { maybe: $t7 }, after: all initialized
- 15: $t7 := infer($t2)
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t4, $t5, $t6 }
+  3: $t3 := move($t1)
+     # before: { maybe: $t1, $t2, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t5, $t6 }
+  4: $t4 := 1
+     # before: { maybe: $t1, $t2, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  5: $t2 := +($t3, $t4)
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  6: if ($t0) goto 7 else goto 10
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  7: label L5
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  8: goto 0
+  9: goto 11
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+ 10: label L6
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+ 11: label L7
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t6 }
+ 12: $t5 := 0
+     # before: { maybe: $t1, $t6 }, after: { maybe: $t6 }
+ 13: $t1 := infer($t5)
+     # before: { maybe: $t6 }, after: all initialized
+ 14: $t6 := infer($t2)
      # before: all initialized, after: all initialized
- 16: goto 19
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 17: label L3
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 18: goto 21
+ 15: goto 18
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 16: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 17: goto 20
      # before: all initialized, after: all initialized
- 19: label L4
+ 18: label L4
      # before: all initialized, after: all initialized
- 20: goto 0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 21: label L1
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 22: return ()
+ 19: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 20: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 21: return ()
 }
 
 
@@ -301,39 +284,36 @@ fun M::tmove($t0: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
   0: label L0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
-  1: if ($t0) goto 2 else goto 11
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+  1: if ($t0) goto 2 else goto 10
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
   2: label L2
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }
-  3: $t4 := move($t1)
-     # before: { maybe: $t1, $t2, $t3, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t6, $t7 }
-  4: $t5 := 1
-     # before: { maybe: $t1, $t2, $t3, $t6, $t7 }, after: { maybe: $t1, $t2, $t6, $t7 }
-  5: $t3 := +($t4, $t5)
-     # before: { maybe: $t1, $t2, $t6, $t7 }, after: { maybe: $t1, $t6, $t7 }
-  6: $t2 := infer($t3)
-     # before: { maybe: $t1, $t6, $t7 }, after: { maybe: $t1, $t7 }
-  7: $t6 := 0
-     # before: { maybe: $t1, $t7 }, after: { maybe: $t7 }
-  8: $t1 := infer($t6)
-     # before: { maybe: $t7 }, after: all initialized
-  9: $t7 := infer($t2)
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t4, $t5, $t6 }
+  3: $t3 := move($t1)
+     # before: { maybe: $t1, $t2, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t5, $t6 }
+  4: $t4 := 1
+     # before: { maybe: $t1, $t2, $t5, $t6 }, after: { maybe: $t1, $t5, $t6 }
+  5: $t2 := +($t3, $t4)
+     # before: { maybe: $t1, $t5, $t6 }, after: { maybe: $t1, $t6 }
+  6: $t5 := 0
+     # before: { maybe: $t1, $t6 }, after: { maybe: $t6 }
+  7: $t1 := infer($t5)
+     # before: { maybe: $t6 }, after: all initialized
+  8: $t6 := infer($t2)
      # before: all initialized, after: all initialized
- 10: goto 13
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 11: label L3
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 12: goto 15
+  9: goto 12
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 10: label L3
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 11: goto 14
      # before: all initialized, after: all initialized
- 13: label L4
+ 12: label L4
      # before: all initialized, after: all initialized
- 14: goto 0
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 15: label L1
-     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6, $t7 }
- 16: return ()
+ 13: goto 0
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 14: label L1
+     # before: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }, after: { maybe: $t1, $t2, $t3, $t4, $t5, $t6 }
+ 15: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
@@ -7,22 +7,20 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
   0: $t1 := false
-  1: if ($t1) goto 2 else goto 11
+  1: if ($t1) goto 2 else goto 10
   2: label L0
-  3: $t3 := 0
-  4: $t2 := infer($t3)
-  5: $t5 := 1
-  6: $t4 := +($t2, $t5)
-  7: $t2 := infer($t4)
-  8: $t0 := infer($t2)
-  9: return $t0
- 10: goto 12
- 11: label L1
- 12: label L2
- 13: $t0 := 0
- 14: return $t0
+  3: $t2 := 0
+  4: $t4 := 1
+  5: $t3 := +($t2, $t4)
+  6: $t2 := infer($t3)
+  7: $t0 := infer($t2)
+  8: return $t0
+  9: goto 11
+ 10: label L1
+ 11: label L2
+ 12: $t0 := 0
+ 13: return $t0
 }
 
 ============ after UnreachableCodeProcessor: ================
@@ -34,7 +32,6 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
      # live vars:
      # graph: {}
      # locals: {}
@@ -48,7 +45,7 @@ fun m::test(): u64 {
      # globals: {}
      #
      # maybe
-  1: if ($t1) goto 2 else goto 11
+  1: if ($t1) goto 2 else goto 10
      # live vars:
      # graph: {}
      # locals: {}
@@ -62,84 +59,77 @@ fun m::test(): u64 {
      # globals: {}
      #
      # maybe
-  3: $t3 := 0
+  3: $t2 := 0
+     # live vars: $t2
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  4: $t4 := 1
+     # live vars: $t2, $t4
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  5: $t3 := +($t2, $t4)
      # live vars: $t3
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  4: $t2 := infer($t3)
+  6: $t2 := infer($t3)
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  5: $t5 := 1
-     # live vars: $t2, $t5
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  6: $t4 := +($t2, $t5)
-     # live vars: $t4
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  7: $t2 := infer($t4)
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  8: $t0 := infer($t2)
+  7: $t0 := infer($t2)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  9: return $t0
+  8: return $t0
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 10: goto 12
+  9: goto 11
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 11: label L1
+ 10: label L1
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 12: label L2
+ 11: label L2
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 13: $t0 := 0
+ 12: $t0 := 0
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 14: return $t0
+ 13: return $t0
 }
 
 ============ after UnreachableCodeRemover: ================
@@ -151,19 +141,17 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
   0: $t1 := false
-  1: if ($t1) goto 2 else goto 10
+  1: if ($t1) goto 2 else goto 9
   2: label L0
-  3: $t3 := 0
-  4: $t2 := infer($t3)
-  5: $t5 := 1
-  6: $t4 := +($t2, $t5)
-  7: $t2 := infer($t4)
-  8: $t0 := infer($t2)
-  9: return $t0
- 10: label L1
- 11: label L2
- 12: $t0 := 0
- 13: return $t0
+  3: $t2 := 0
+  4: $t4 := 1
+  5: $t3 := +($t2, $t4)
+  6: $t2 := infer($t3)
+  7: $t0 := infer($t2)
+  8: return $t0
+  9: label L1
+ 10: label L2
+ 11: $t0 := 0
+ 12: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
@@ -5,42 +5,40 @@ fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
-     var $t11: u64
-  0: $t1 := 0
-  1: $t0 := infer($t1)
-  2: label L0
-  3: $t3 := 1
-  4: $t2 := +($t0, $t3)
-  5: $t0 := infer($t2)
-  6: $t5 := 10
-  7: $t4 := ==($t0, $t5)
-  8: if ($t4) goto 9 else goto 15
-  9: label L2
- 10: goto 25
- 11: $t7 := 1
- 12: $t6 := +($t0, $t7)
- 13: $t0 := infer($t6)
- 14: goto 20
- 15: label L3
- 16: goto 2
- 17: $t9 := 1
- 18: $t8 := +($t0, $t9)
- 19: $t0 := infer($t8)
- 20: label L4
- 21: $t11 := 1
- 22: $t10 := +($t0, $t11)
- 23: $t0 := infer($t10)
- 24: goto 2
- 25: label L1
- 26: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t2 := 1
+  3: $t1 := +($t0, $t2)
+  4: $t0 := infer($t1)
+  5: $t4 := 10
+  6: $t3 := ==($t0, $t4)
+  7: if ($t3) goto 8 else goto 14
+  8: label L2
+  9: goto 24
+ 10: $t6 := 1
+ 11: $t5 := +($t0, $t6)
+ 12: $t0 := infer($t5)
+ 13: goto 19
+ 14: label L3
+ 15: goto 1
+ 16: $t8 := 1
+ 17: $t7 := +($t0, $t8)
+ 18: $t0 := infer($t7)
+ 19: label L4
+ 20: $t10 := 1
+ 21: $t9 := +($t0, $t10)
+ 22: $t0 := infer($t9)
+ 23: goto 1
+ 24: label L1
+ 25: return ()
 }
 
 ============ after UnreachableCodeProcessor: ================
@@ -50,204 +48,196 @@ fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
-     var $t11: u64
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  0: $t1 := 0
+  0: $t0 := 0
+     # live vars: $t0
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  1: label L0
+     # live vars: $t0
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  2: $t2 := 1
+     # live vars: $t0, $t2
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  3: $t1 := +($t0, $t2)
      # live vars: $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  1: $t0 := infer($t1)
+  4: $t0 := infer($t1)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  2: label L0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  3: $t3 := 1
-     # live vars: $t0, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  4: $t2 := +($t0, $t3)
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  5: $t0 := infer($t2)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  6: $t5 := 10
-     # live vars: $t0, $t5
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  7: $t4 := ==($t0, $t5)
+  5: $t4 := 10
      # live vars: $t0, $t4
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  8: if ($t4) goto 9 else goto 15
+  6: $t3 := ==($t0, $t4)
+     # live vars: $t0, $t3
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  7: if ($t3) goto 8 else goto 14
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  9: label L2
+  8: label L2
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 10: goto 25
+  9: goto 24
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 11: $t7 := 1
-     # live vars: $t0, $t7
+ 10: $t6 := 1
+     # live vars: $t0, $t6
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 12: $t6 := +($t0, $t7)
-     # live vars: $t6
+ 11: $t5 := +($t0, $t6)
+     # live vars: $t5
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 13: $t0 := infer($t6)
+ 12: $t0 := infer($t5)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 14: goto 20
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
- 15: label L3
+ 13: goto 19
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 16: goto 2
+ 14: label L3
+     # live vars: $t0
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+ 15: goto 1
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 17: $t9 := 1
-     # live vars: $t0, $t9
+ 16: $t8 := 1
+     # live vars: $t0, $t8
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 18: $t8 := +($t0, $t9)
-     # live vars: $t8
+ 17: $t7 := +($t0, $t8)
+     # live vars: $t7
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 19: $t0 := infer($t8)
+ 18: $t0 := infer($t7)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 20: label L4
+ 19: label L4
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 21: $t11 := 1
-     # live vars: $t0, $t11
+ 20: $t10 := 1
+     # live vars: $t0, $t10
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 22: $t10 := +($t0, $t11)
-     # live vars: $t10
+ 21: $t9 := +($t0, $t10)
+     # live vars: $t9
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 23: $t0 := infer($t10)
+ 22: $t0 := infer($t9)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 24: goto 2
+ 23: goto 1
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 25: label L1
+ 24: label L1
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 26: return ()
+ 25: return ()
 }
 
 ============ after UnreachableCodeRemover: ================
@@ -257,28 +247,26 @@ fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
-     var $t5: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
      var $t7: u64 [unused]
      var $t8: u64 [unused]
      var $t9: u64 [unused]
      var $t10: u64 [unused]
-     var $t11: u64 [unused]
-  0: $t1 := 0
-  1: $t0 := infer($t1)
-  2: label L0
-  3: $t3 := 1
-  4: $t2 := +($t0, $t3)
-  5: $t0 := infer($t2)
-  6: $t5 := 10
-  7: $t4 := ==($t0, $t5)
-  8: if ($t4) goto 9 else goto 11
-  9: label L2
- 10: goto 13
- 11: label L3
- 12: goto 2
- 13: label L1
- 14: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t2 := 1
+  3: $t1 := +($t0, $t2)
+  4: $t0 := infer($t1)
+  5: $t4 := 10
+  6: $t3 := ==($t0, $t4)
+  7: if ($t3) goto 8 else goto 10
+  8: label L2
+  9: goto 12
+ 10: label L3
+ 11: goto 1
+ 12: label L1
+ 13: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -8,37 +8,33 @@ fun m::test($t0: bool, $t1: bool) {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
   0: label L0
-  1: if ($t0) goto 2 else goto 23
+  1: if ($t0) goto 2 else goto 21
   2: label L2
-  3: if ($t1) goto 4 else goto 14
+  3: if ($t1) goto 4 else goto 13
   4: label L5
   5: label L8
   6: goto 5
   7: label L9
-  8: $t3 := 0
-  9: $t2 := infer($t3)
- 10: $t5 := 1
- 11: $t4 := +($t2, $t5)
- 12: $t2 := infer($t4)
- 13: goto 16
- 14: label L6
- 15: goto 27
- 16: label L7
- 17: $t7 := 0
- 18: $t6 := infer($t7)
- 19: $t9 := 1
- 20: $t8 := +($t6, $t9)
- 21: $t6 := infer($t8)
+  8: $t2 := 0
+  9: $t4 := 1
+ 10: $t3 := +($t2, $t4)
+ 11: $t2 := infer($t3)
+ 12: goto 15
+ 13: label L6
+ 14: goto 25
+ 15: label L7
+ 16: $t5 := 0
+ 17: $t7 := 1
+ 18: $t6 := +($t5, $t7)
+ 19: $t5 := infer($t6)
+ 20: goto 23
+ 21: label L3
  22: goto 25
- 23: label L3
- 24: goto 27
- 25: label L4
- 26: goto 0
- 27: label L1
- 28: return ()
+ 23: label L4
+ 24: goto 0
+ 25: label L1
+ 26: return ()
 }
 
 ============ after UnreachableCodeProcessor: ================
@@ -51,8 +47,6 @@ fun m::test($t0: bool, $t1: bool) {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
@@ -66,7 +60,7 @@ fun m::test($t0: bool, $t1: bool) {
      # globals: {}
      #
      # maybe
-  1: if ($t0) goto 2 else goto 23
+  1: if ($t0) goto 2 else goto 21
      # live vars: $t1
      # graph: {}
      # locals: {}
@@ -80,7 +74,7 @@ fun m::test($t0: bool, $t1: bool) {
      # globals: {}
      #
      # maybe
-  3: if ($t1) goto 4 else goto 14
+  3: if ($t1) goto 4 else goto 13
      # live vars:
      # graph: {}
      # locals: {}
@@ -115,147 +109,133 @@ fun m::test($t0: bool, $t1: bool) {
      # globals: {}
      #
      # no
-  8: $t3 := 0
-     # live vars: $t0, $t1, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # no
-  9: $t2 := infer($t3)
+  8: $t2 := 0
      # live vars: $t0, $t1, $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 10: $t5 := 1
-     # live vars: $t0, $t1, $t2, $t5
+  9: $t4 := 1
+     # live vars: $t0, $t1, $t2, $t4
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 11: $t4 := +($t2, $t5)
-     # live vars: $t0, $t1, $t4
+ 10: $t3 := +($t2, $t4)
+     # live vars: $t0, $t1, $t3
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 12: $t2 := infer($t4)
+ 11: $t2 := infer($t3)
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 13: goto 16
+ 12: goto 15
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 14: label L6
+ 13: label L6
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 15: goto 27
+ 14: goto 25
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 16: label L7
+ 15: label L7
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 17: $t7 := 0
-     # live vars: $t0, $t1, $t7
+ 16: $t5 := 0
+     # live vars: $t0, $t1, $t5
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 18: $t6 := infer($t7)
+ 17: $t7 := 1
+     # live vars: $t0, $t1, $t5, $t7
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # no
+ 18: $t6 := +($t5, $t7)
      # live vars: $t0, $t1, $t6
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 19: $t9 := 1
-     # live vars: $t0, $t1, $t6, $t9
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # no
- 20: $t8 := +($t6, $t9)
-     # live vars: $t0, $t1, $t8
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # no
- 21: $t6 := infer($t8)
+ 19: $t5 := infer($t6)
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 22: goto 25
+ 20: goto 23
      # live vars: $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 23: label L3
+ 21: label L3
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 24: goto 27
+ 22: goto 25
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 25: label L4
+ 23: label L4
      # live vars: $t0, $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # no
- 26: goto 0
+ 24: goto 0
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 27: label L1
+ 25: label L1
      # live vars:
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
- 28: return ()
+ 26: return ()
 }
 
 ============ after UnreachableCodeRemover: ================
@@ -268,8 +248,6 @@ fun m::test($t0: bool, $t1: bool) {
      var $t5: u64 [unused]
      var $t6: u64 [unused]
      var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
   0: label L0
   1: if ($t0) goto 2 else goto 9
   2: label L2

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
@@ -15,15 +15,13 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
   0: m::always_abort()
-  1: $t2 := 0
-  2: $t1 := infer($t2)
-  3: $t4 := 1
-  4: $t3 := +($t1, $t4)
-  5: $t1 := infer($t3)
-  6: $t0 := infer($t1)
-  7: return $t0
+  1: $t1 := 0
+  2: $t3 := 1
+  3: $t2 := +($t1, $t3)
+  4: $t1 := infer($t2)
+  5: $t0 := infer($t1)
+  6: return $t0
 }
 
 ============ after UnreachableCodeProcessor: ================
@@ -61,7 +59,6 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
      # live vars:
      # graph: {}
      # locals: {}
@@ -75,49 +72,42 @@ fun m::test(): u64 {
      # globals: {}
      #
      # maybe
-  1: $t2 := 0
+  1: $t1 := 0
+     # live vars: $t1
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  2: $t3 := 1
+     # live vars: $t1, $t3
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+     # maybe
+  3: $t2 := +($t1, $t3)
      # live vars: $t2
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  2: $t1 := infer($t2)
+  4: $t1 := infer($t2)
      # live vars: $t1
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  3: $t4 := 1
-     # live vars: $t1, $t4
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  4: $t3 := +($t1, $t4)
-     # live vars: $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  5: $t1 := infer($t3)
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
-     # maybe
-  6: $t0 := infer($t1)
+  5: $t0 := infer($t1)
      # live vars: $t0
      # graph: {}
      # locals: {}
      # globals: {}
      #
      # maybe
-  7: return $t0
+  6: return $t0
 }
 
 ============ after UnreachableCodeRemover: ================
@@ -136,13 +126,11 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
   0: m::always_abort()
-  1: $t2 := 0
-  2: $t1 := infer($t2)
-  3: $t4 := 1
-  4: $t3 := +($t1, $t4)
-  5: $t1 := infer($t3)
-  6: $t0 := infer($t1)
-  7: return $t0
+  1: $t1 := 0
+  2: $t3 := 1
+  3: $t2 := +($t1, $t3)
+  4: $t1 := infer($t2)
+  5: $t0 := infer($t1)
+  6: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -3,25 +3,21 @@
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64
-  0: $t1 := 5
-  1: $t0 := infer($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := infer($t3)
-  4: $t4 := infer($t2)
-  5: $t5 := borrow_local($t0)
-  6: $t2 := infer($t5)
-  7: $t7 := read_ref($t2)
-  8: $t8 := 5
-  9: $t6 := ==($t7, $t8)
- 10: return ()
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+  0: $t0 := 5
+  1: $t1 := borrow_local($t0)
+  2: $t2 := infer($t1)
+  3: $t3 := borrow_local($t0)
+  4: $t1 := infer($t3)
+  5: $t5 := read_ref($t1)
+  6: $t6 := 5
+  7: $t4 := ==($t5, $t6)
+  8: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -29,26 +25,22 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64
-  0: $t1 := 5
-  1: $t0 := move($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t2 := move($t3)
-  4: $t4 := move($t2)
-  5: drop($t4)
-  6: $t5 := borrow_local($t0)
-  7: $t2 := move($t5)
-  8: $t7 := read_ref($t2)
-  9: $t8 := 5
- 10: $t6 := ==($t7, $t8)
- 11: return ()
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+  0: $t0 := 5
+  1: $t1 := borrow_local($t0)
+  2: $t2 := move($t1)
+  3: drop($t2)
+  4: $t3 := borrow_local($t0)
+  5: $t1 := move($t3)
+  6: $t5 := read_ref($t1)
+  7: $t6 := 5
+  8: $t4 := ==($t5, $t6)
+  9: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -56,49 +48,40 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     var $t1: u64
+     var $t1: &u64
      var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
      # live vars:
+  0: $t0 := 5
+     # live vars: $t0
      # events: b:$t1
-  0: $t1 := 5
-     # live vars: $t1
-     # events: e:$t1
-  1: $t0 := move($t1)
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+     # events: b:$t2
+  2: $t2 := move($t1)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  3: drop($t2)
      # live vars: $t0
      # events: b:$t3
-  2: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  3: $t2 := move($t3)
-     # live vars: $t0, $t2
-     # events: b:$t4
-  4: $t4 := move($t2)
-     # live vars: $t0, $t4
-     # events: e:$t4
-  5: drop($t4)
-     # live vars: $t0
-     # events: b:$t5
-  6: $t5 := borrow_local($t0)
+  4: $t3 := borrow_local($t0)
+     # live vars: $t3
+     # events: e:$t3
+  5: $t1 := move($t3)
+     # live vars: $t1
+     # events: e:$t1, b:$t5
+  6: $t5 := read_ref($t1)
      # live vars: $t5
-     # events: e:$t5
-  7: $t2 := move($t5)
-     # live vars: $t2
-     # events: e:$t2, b:$t7
-  8: $t7 := read_ref($t2)
-     # live vars: $t7
-     # events: b:$t8
-  9: $t8 := 5
-     # live vars: $t7, $t8
-     # events: e:$t6, e:$t7, e:$t8, b:$t6
- 10: $t6 := ==($t7, $t8)
+     # events: b:$t6
+  7: $t6 := 5
+     # live vars: $t5, $t6
+     # events: e:$t4, e:$t5, e:$t6, b:$t4
+  8: $t4 := ==($t5, $t6)
      # live vars:
- 11: return ()
+  9: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -106,26 +89,22 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &u64 [unused]
-     var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64 [unused]
-     var $t6: bool
-     var $t7: u64 [unused]
-     var $t8: u64
-  0: $t1 := 5
-  1: $t0 := move($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t3 := move($t3)
-  4: $t4 := move($t3)
-  5: drop($t4)
-  6: $t4 := borrow_local($t0)
-  7: $t3 := move($t4)
-  8: $t1 := read_ref($t3)
-  9: $t8 := 5
- 10: $t6 := ==($t1, $t8)
- 11: return ()
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+  0: $t0 := 5
+  1: $t1 := borrow_local($t0)
+  2: $t2 := move($t1)
+  3: drop($t2)
+  4: $t2 := borrow_local($t0)
+  5: $t1 := move($t2)
+  6: $t5 := read_ref($t1)
+  7: $t6 := 5
+  8: $t4 := ==($t5, $t6)
+  9: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -133,25 +112,22 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     var $t1: u64
-     var $t2: &u64 [unused]
-     var $t3: &u64
-     var $t4: &u64
-     var $t5: &u64 [unused]
-     var $t6: bool
-     var $t7: u64 [unused]
-     var $t8: u64
-  0: $t1 := 5
-  1: $t0 := move($t1)
-  2: $t3 := borrow_local($t0)
-  3: $t4 := move($t3)
-  4: drop($t4)
-  5: $t4 := borrow_local($t0)
-  6: $t3 := move($t4)
-  7: $t1 := read_ref($t3)
-  8: $t8 := 5
-  9: $t6 := ==($t1, $t8)
- 10: return ()
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+  0: $t0 := 5
+  1: $t1 := borrow_local($t0)
+  2: $t2 := move($t1)
+  3: drop($t2)
+  4: $t2 := borrow_local($t0)
+  5: $t1 := move($t2)
+  6: $t5 := read_ref($t1)
+  7: $t6 := 5
+  8: $t4 := ==($t5, $t6)
+  9: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
@@ -3,25 +3,23 @@
 [variant baseline]
 fun m::test() {
      var $t0: &u64
-     var $t1: &u64
-     var $t2: u64
+     var $t1: u64
+     var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
-     var $t6: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-  0: $t2 := 5
-  1: $t1 := borrow_local($t2)
-  2: $t0 := infer($t1)
-  3: $t3 := infer($t0)
-  4: $t5 := 5
-  5: $t4 := borrow_local($t5)
-  6: $t0 := infer($t4)
-  7: $t7 := read_ref($t0)
-  8: $t8 := 5
-  9: $t6 := ==($t7, $t8)
- 10: return ()
+  0: $t1 := 5
+  1: $t0 := borrow_local($t1)
+  2: $t2 := infer($t0)
+  3: $t4 := 5
+  4: $t3 := borrow_local($t4)
+  5: $t0 := infer($t3)
+  6: $t6 := read_ref($t0)
+  7: $t7 := 5
+  8: $t5 := ==($t6, $t7)
+  9: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -29,74 +27,68 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: &u64
-     var $t1: &u64
-     var $t2: u64
+     var $t1: u64
+     var $t2: &u64
      var $t3: &u64
-     var $t4: &u64
-     var $t5: u64
-     var $t6: bool
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
      # live vars:
-  0: $t2 := 5
-     # live vars: $t2
-     # events: b:$t1
-  1: $t1 := borrow_local($t2)
+  0: $t1 := 5
      # live vars: $t1
-     # events: e:$t1, b:$t0
-  2: $t0 := move($t1)
+     # events: b:$t0
+  1: $t0 := borrow_local($t1)
      # live vars: $t0
+     # events: b:$t2
+  2: $t2 := move($t0)
+     # live vars: $t2
+     # events: e:$t2
+  3: drop($t2)
+     # live vars:
+  4: $t4 := 5
+     # live vars: $t4
      # events: b:$t3
-  3: $t3 := move($t0)
+  5: $t3 := borrow_local($t4)
      # live vars: $t3
      # events: e:$t3
-  4: drop($t3)
-     # live vars:
-  5: $t5 := 5
-     # live vars: $t5
-     # events: b:$t4
-  6: $t4 := borrow_local($t5)
-     # live vars: $t4
-     # events: e:$t4
-  7: $t0 := move($t4)
+  6: $t0 := move($t3)
      # live vars: $t0
-     # events: e:$t0, b:$t7
-  8: $t7 := read_ref($t0)
-     # live vars: $t7
-     # events: b:$t8
-  9: $t8 := 5
-     # live vars: $t7, $t8
-     # events: e:$t6, e:$t7, e:$t8, b:$t6
- 10: $t6 := ==($t7, $t8)
+     # events: e:$t0, b:$t6
+  7: $t6 := read_ref($t0)
+     # live vars: $t6
+     # events: b:$t7
+  8: $t7 := 5
+     # live vars: $t6, $t7
+     # events: e:$t5, e:$t6, e:$t7, b:$t5
+  9: $t5 := ==($t6, $t7)
      # live vars:
- 11: return ()
+ 10: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: &u64 [unused]
-     var $t1: &u64
-     var $t2: u64
-     var $t3: &u64
-     var $t4: &u64 [unused]
-     var $t5: u64
-     var $t6: bool
+     var $t0: &u64
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-  0: $t2 := 5
-  1: $t1 := borrow_local($t2)
-  2: $t1 := move($t1)
-  3: $t3 := move($t1)
-  4: drop($t3)
-  5: $t5 := 5
-  6: $t3 := borrow_local($t5)
-  7: $t1 := move($t3)
-  8: $t7 := read_ref($t1)
-  9: $t8 := 5
- 10: $t6 := ==($t7, $t8)
- 11: return ()
+  0: $t1 := 5
+  1: $t0 := borrow_local($t1)
+  2: $t2 := move($t0)
+  3: drop($t2)
+  4: $t4 := 5
+  5: $t2 := borrow_local($t4)
+  6: $t0 := move($t2)
+  7: $t6 := read_ref($t0)
+  8: $t7 := 5
+  9: $t5 := ==($t6, $t7)
+ 10: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -3,39 +3,37 @@
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t1 := 0
-  1: $t0 := infer($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 11
-  5: label L2
-  6: $t4 := 1
-  7: $t3 := +($t0, $t4)
-  8: $t0 := infer($t3)
-  9: goto 15
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: $t6 := 1
- 17: $t5 := ==($t0, $t6)
- 18: if ($t5) goto 19 else goto 21
- 19: label L5
- 20: goto 24
- 21: label L6
- 22: $t7 := 42
- 23: abort($t7)
- 24: label L7
- 25: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 10
+  4: label L2
+  5: $t3 := 1
+  6: $t2 := +($t0, $t3)
+  7: $t0 := infer($t2)
+  8: goto 14
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t5 := 1
+ 16: $t4 := ==($t0, $t5)
+ 17: if ($t4) goto 18 else goto 20
+ 18: label L5
+ 19: goto 23
+ 20: label L6
+ 21: $t6 := 42
+ 22: abort($t6)
+ 23: label L7
+ 24: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -43,36 +41,34 @@ fun m::main() {
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t1 := 0
-  1: $t0 := move($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 10
-  5: label L2
-  6: $t4 := 1
-  7: $t3 := +($t0, $t4)
-  8: $t0 := move($t3)
-  9: goto 12
- 10: label L3
- 11: goto 12
- 12: label L1
- 13: $t6 := 1
- 14: $t5 := ==($t0, $t6)
- 15: if ($t5) goto 16 else goto 18
- 16: label L5
- 17: goto 21
- 18: label L6
- 19: $t7 := 42
- 20: abort($t7)
- 21: label L7
- 22: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 9
+  4: label L2
+  5: $t3 := 1
+  6: $t2 := +($t0, $t3)
+  7: $t0 := move($t2)
+  8: goto 11
+  9: label L3
+ 10: goto 11
+ 11: label L1
+ 12: $t5 := 1
+ 13: $t4 := ==($t0, $t5)
+ 14: if ($t4) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t6 := 42
+ 19: abort($t6)
+ 20: label L7
+ 21: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -80,142 +76,135 @@ fun m::main() {
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars:
+     # events: b:$t0
+  0: $t0 := 0
+     # live vars: $t0
+  1: label L0
+     # live vars: $t0
      # events: b:$t1
-  0: $t1 := 0
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+  2: $t1 := true
+     # live vars: $t0, $t1
+     # events: e:$t1
+  3: if ($t1) goto 4 else goto 9
      # live vars: $t0
-  2: label L0
+  4: label L2
      # live vars: $t0
-     # events: b:$t2
-  3: $t2 := true
-     # live vars: $t0, $t2
+     # events: b:$t3
+  5: $t3 := 1
+     # live vars: $t0, $t3
+     # events: e:$t3, b:$t2
+  6: $t2 := +($t0, $t3)
+     # live vars: $t2
      # events: e:$t2
-  4: if ($t2) goto 5 else goto 10
+  7: $t0 := move($t2)
      # live vars: $t0
-  5: label L2
+  8: goto 11
      # live vars: $t0
-     # events: b:$t4
-  6: $t4 := 1
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  7: $t3 := +($t0, $t4)
-     # live vars: $t3
-     # events: e:$t3
-  8: $t0 := move($t3)
+  9: label L3
      # live vars: $t0
-  9: goto 12
+ 10: goto 11
      # live vars: $t0
- 10: label L3
+ 11: label L1
      # live vars: $t0
- 11: goto 12
-     # live vars: $t0
- 12: label L1
-     # live vars: $t0
+     # events: b:$t5
+ 12: $t5 := 1
+     # live vars: $t0, $t5
+     # events: e:$t0, e:$t5, b:$t4
+ 13: $t4 := ==($t0, $t5)
+     # live vars: $t4
+     # events: e:$t4
+ 14: if ($t4) goto 15 else goto 17
+     # live vars:
+ 15: label L5
+     # live vars:
+ 16: goto 20
+     # live vars:
+ 17: label L6
+     # live vars:
      # events: b:$t6
- 13: $t6 := 1
-     # live vars: $t0, $t6
-     # events: e:$t0, e:$t6, b:$t5
- 14: $t5 := ==($t0, $t6)
-     # live vars: $t5
-     # events: e:$t5
- 15: if ($t5) goto 16 else goto 18
+ 18: $t6 := 42
+     # live vars: $t6
+     # events: e:$t6
+ 19: abort($t6)
      # live vars:
- 16: label L5
+ 20: label L7
      # live vars:
- 17: goto 21
-     # live vars:
- 18: label L6
-     # live vars:
-     # events: b:$t7
- 19: $t7 := 42
-     # live vars: $t7
-     # events: e:$t7
- 20: abort($t7)
-     # live vars:
- 21: label L7
-     # live vars:
- 22: return ()
+ 21: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::main() {
-     var $t0: u64 [unused]
-     var $t1: u64
-     var $t2: bool
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool [unused]
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: bool [unused]
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 0
-  1: $t1 := move($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 10
-  5: label L2
-  6: $t4 := 1
-  7: $t4 := +($t1, $t4)
-  8: $t1 := move($t4)
-  9: goto 12
- 10: label L3
- 11: goto 12
- 12: label L1
- 13: $t4 := 1
- 14: $t2 := ==($t1, $t4)
- 15: if ($t2) goto 16 else goto 18
- 16: label L5
- 17: goto 21
- 18: label L6
- 19: $t1 := 42
- 20: abort($t1)
- 21: label L7
- 22: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 9
+  4: label L2
+  5: $t3 := 1
+  6: $t3 := +($t0, $t3)
+  7: $t0 := move($t3)
+  8: goto 11
+  9: label L3
+ 10: goto 11
+ 11: label L1
+ 12: $t3 := 1
+ 13: $t1 := ==($t0, $t3)
+ 14: if ($t1) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t0 := 42
+ 19: abort($t0)
+ 20: label L7
+ 21: return ()
 }
 
 ============ after DeadStoreElimination: ================
 
 [variant baseline]
 fun m::main() {
-     var $t0: u64 [unused]
-     var $t1: u64
-     var $t2: bool
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool [unused]
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: bool [unused]
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 0
+  0: $t0 := 0
   1: label L0
-  2: $t2 := true
-  3: if ($t2) goto 4 else goto 9
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 9
   4: label L2
-  5: $t4 := 1
-  6: $t4 := +($t1, $t4)
-  7: $t1 := move($t4)
+  5: $t3 := 1
+  6: $t3 := +($t0, $t3)
+  7: $t0 := move($t3)
   8: goto 11
   9: label L3
  10: goto 11
  11: label L1
- 12: $t4 := 1
- 13: $t2 := ==($t1, $t4)
- 14: if ($t2) goto 15 else goto 17
+ 12: $t3 := 1
+ 13: $t1 := ==($t0, $t3)
+ 14: if ($t1) goto 15 else goto 17
  15: label L5
  16: goto 20
  17: label L6
- 18: $t1 := 42
- 19: abort($t1)
+ 18: $t0 := 42
+ 19: abort($t0)
  20: label L7
  21: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
@@ -3,39 +3,37 @@
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t1 := 0
-  1: $t0 := infer($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 11
-  5: label L2
-  6: $t4 := 1
-  7: $t3 := +($t0, $t4)
-  8: $t0 := infer($t3)
-  9: goto 15
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: $t6 := 1
- 17: $t5 := ==($t0, $t6)
- 18: if ($t5) goto 19 else goto 21
- 19: label L5
- 20: goto 24
- 21: label L6
- 22: $t7 := 42
- 23: abort($t7)
- 24: label L7
- 25: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 10
+  4: label L2
+  5: $t3 := 1
+  6: $t2 := +($t0, $t3)
+  7: $t0 := infer($t2)
+  8: goto 14
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t5 := 1
+ 16: $t4 := ==($t0, $t5)
+ 17: if ($t4) goto 18 else goto 20
+ 18: label L5
+ 19: goto 23
+ 20: label L6
+ 21: $t6 := 42
+ 22: abort($t6)
+ 23: label L7
+ 24: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -43,108 +41,102 @@ fun m::main() {
 [variant baseline]
 fun m::main() {
      var $t0: u64
-     var $t1: u64
-     var $t2: bool
+     var $t1: bool
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars:
+     # events: b:$t0
+  0: $t0 := 0
+     # live vars: $t0
+  1: label L0
+     # live vars: $t0
      # events: b:$t1
-  0: $t1 := 0
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+  2: $t1 := true
+     # live vars: $t0, $t1
+     # events: e:$t1
+  3: if ($t1) goto 4 else goto 9
      # live vars: $t0
-  2: label L0
+  4: label L2
      # live vars: $t0
-     # events: b:$t2
-  3: $t2 := true
-     # live vars: $t0, $t2
+     # events: b:$t3
+  5: $t3 := 1
+     # live vars: $t0, $t3
+     # events: e:$t3, b:$t2
+  6: $t2 := +($t0, $t3)
+     # live vars: $t2
      # events: e:$t2
-  4: if ($t2) goto 5 else goto 10
+  7: $t0 := move($t2)
      # live vars: $t0
-  5: label L2
+  8: goto 11
      # live vars: $t0
-     # events: b:$t4
-  6: $t4 := 1
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  7: $t3 := +($t0, $t4)
-     # live vars: $t3
-     # events: e:$t3
-  8: $t0 := move($t3)
+  9: label L3
      # live vars: $t0
-  9: goto 12
+ 10: goto 11
      # live vars: $t0
- 10: label L3
+ 11: label L1
      # live vars: $t0
- 11: goto 12
-     # live vars: $t0
- 12: label L1
-     # live vars: $t0
+     # events: b:$t5
+ 12: $t5 := 1
+     # live vars: $t0, $t5
+     # events: e:$t0, e:$t5, b:$t4
+ 13: $t4 := ==($t0, $t5)
+     # live vars: $t4
+     # events: e:$t4
+ 14: if ($t4) goto 15 else goto 17
+     # live vars:
+ 15: label L5
+     # live vars:
+ 16: goto 20
+     # live vars:
+ 17: label L6
+     # live vars:
      # events: b:$t6
- 13: $t6 := 1
-     # live vars: $t0, $t6
-     # events: e:$t0, e:$t6, b:$t5
- 14: $t5 := ==($t0, $t6)
-     # live vars: $t5
-     # events: e:$t5
- 15: if ($t5) goto 16 else goto 18
+ 18: $t6 := 42
+     # live vars: $t6
+     # events: e:$t6
+ 19: abort($t6)
      # live vars:
- 16: label L5
+ 20: label L7
      # live vars:
- 17: goto 21
-     # live vars:
- 18: label L6
-     # live vars:
-     # events: b:$t7
- 19: $t7 := 42
-     # live vars: $t7
-     # events: e:$t7
- 20: abort($t7)
-     # live vars:
- 21: label L7
-     # live vars:
- 22: return ()
+ 21: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::main() {
-     var $t0: u64 [unused]
-     var $t1: u64
-     var $t2: bool
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool [unused]
+     var $t0: u64
+     var $t1: bool
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: bool [unused]
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 0
-  1: $t1 := move($t1)
-  2: label L0
-  3: $t2 := true
-  4: if ($t2) goto 5 else goto 10
-  5: label L2
-  6: $t4 := 1
-  7: $t4 := +($t1, $t4)
-  8: $t1 := move($t4)
-  9: goto 12
- 10: label L3
- 11: goto 12
- 12: label L1
- 13: $t4 := 1
- 14: $t2 := ==($t1, $t4)
- 15: if ($t2) goto 16 else goto 18
- 16: label L5
- 17: goto 21
- 18: label L6
- 19: $t1 := 42
- 20: abort($t1)
- 21: label L7
- 22: return ()
+  0: $t0 := 0
+  1: label L0
+  2: $t1 := true
+  3: if ($t1) goto 4 else goto 9
+  4: label L2
+  5: $t3 := 1
+  6: $t3 := +($t0, $t3)
+  7: $t0 := move($t3)
+  8: goto 11
+  9: label L3
+ 10: goto 11
+ 11: label L1
+ 12: $t3 := 1
+ 13: $t1 := ==($t0, $t3)
+ 14: if ($t1) goto 15 else goto 17
+ 15: label L5
+ 16: goto 20
+ 17: label L6
+ 18: $t0 := 42
+ 19: abort($t0)
+ 20: label L7
+ 21: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -13,14 +13,10 @@ public fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t3 := +($t0, $t0)
-  1: $t2 := infer($t3)
-  2: $t5 := 2
-  3: $t4 := infer($t5)
-  4: $t1 := infer($t4)
-  5: return $t1
+  0: $t2 := +($t0, $t0)
+  1: $t3 := 2
+  2: $t1 := infer($t3)
+  3: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -28,15 +24,12 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t3 := +($t0, $t0)
-  1: $t5 := 2
-  2: $t4 := move($t5)
-  3: $t1 := move($t4)
-  4: return $t1
+  0: $t2 := +($t0, $t0)
+  1: $t3 := 2
+  2: $t1 := move($t3)
+  3: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -44,25 +37,20 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
      # live vars: $t0
-     # events: b:$t0, e:$t0, e:$t3, b:$t3
-  0: $t3 := +($t0, $t0)
+     # events: b:$t0, e:$t0, e:$t2, b:$t2
+  0: $t2 := +($t0, $t0)
      # live vars:
-     # events: b:$t5
-  1: $t5 := 2
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  2: $t4 := move($t5)
-     # live vars: $t4
-     # events: e:$t4, b:$t1
-  3: $t1 := move($t4)
+     # events: b:$t3
+  1: $t3 := 2
+     # live vars: $t3
+     # events: e:$t3, b:$t1
+  2: $t1 := move($t3)
      # live vars: $t1
      # events: e:$t1
-  4: return $t1
+  3: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -70,15 +58,12 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
   0: $t0 := +($t0, $t0)
-  1: $t3 := 2
-  2: $t3 := move($t3)
-  3: $t3 := move($t3)
-  4: return $t3
+  1: $t2 := 2
+  2: $t2 := move($t2)
+  3: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -86,13 +71,11 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64 [unused]
+     var $t2: u64
+     var $t3: u64 [unused]
   0: $t0 := +($t0, $t0)
-  1: $t3 := 2
-  2: return $t3
+  1: $t2 := 2
+  2: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -12,11 +12,9 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 public fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t3 := +($t0, $t0)
-  1: $t2 := infer($t3)
-  2: $t1 := 2
-  3: return $t1
+  0: $t2 := +($t0, $t0)
+  1: $t1 := 2
+  2: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -24,11 +22,10 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: u64 [unused]
-     var $t3: u64
+     var $t2: u64
      # live vars: $t0
-     # events: b:$t0, e:$t0, e:$t3, b:$t3
-  0: $t3 := +($t0, $t0)
+     # events: b:$t0, e:$t0, e:$t2, b:$t2
+  0: $t2 := +($t0, $t0)
      # live vars:
      # events: b:$t1
   1: $t1 := 2
@@ -42,11 +39,10 @@ public fun m::test($t0: u64): u64 {
 [variant baseline]
 public fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
+     var $t2: u64
   0: $t0 := +($t0, $t0)
-  1: $t3 := 2
-  2: return $t3
+  1: $t2 := 2
+  2: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -15,22 +15,20 @@ fun m::test($t0: u64, $t1: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := move($t0)
-  1: $t2 := infer($t3)
-  2: if ($t1) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 13
-  6: label L1
-  7: $t4 := 99
-  8: $t0 := infer($t4)
-  9: $t5 := infer($t2)
- 10: $t7 := 1
- 11: $t6 := +($t5, $t7)
- 12: $t5 := infer($t6)
- 13: label L2
- 14: return ()
+  0: $t2 := move($t0)
+  1: if ($t1) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 12
+  5: label L1
+  6: $t3 := 99
+  7: $t0 := infer($t3)
+  8: $t4 := infer($t2)
+  9: $t6 := 1
+ 10: $t5 := +($t4, $t6)
+ 11: $t4 := infer($t5)
+ 12: label L2
+ 13: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -45,23 +43,21 @@ fun m::consume($t0: u64) {
 [variant baseline]
 fun m::test($t0: u64, $t1: bool) {
      var $t2: u64
-     var $t3: u64
-     var $t4: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := move($t0)
-  1: $t2 := move($t3)
-  2: if ($t1) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 10
-  6: label L1
-  7: $t5 := move($t2)
-  8: $t7 := 1
-  9: $t6 := +($t5, $t7)
- 10: label L2
- 11: return ()
+  0: $t2 := move($t0)
+  1: if ($t1) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 9
+  5: label L1
+  6: $t4 := move($t2)
+  7: $t6 := 1
+  8: $t5 := +($t4, $t6)
+  9: label L2
+ 10: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -78,41 +74,37 @@ fun m::consume($t0: u64) {
 [variant baseline]
 fun m::test($t0: u64, $t1: bool) {
      var $t2: u64
-     var $t3: u64
-     var $t4: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, e:$t0, b:$t3
-  0: $t3 := move($t0)
-     # live vars: $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, e:$t0, b:$t2
+  0: $t2 := move($t0)
      # live vars: $t1, $t2
      # events: e:$t1
-  2: if ($t1) goto 3 else goto 6
+  1: if ($t1) goto 2 else goto 5
      # live vars: $t2
-  3: label L0
+  2: label L0
      # live vars: $t2
-  4: m::consume($t2)
+  3: m::consume($t2)
      # live vars:
-  5: goto 10
+  4: goto 9
      # live vars: $t2
-  6: label L1
+  5: label L1
      # live vars: $t2
-     # events: e:$t2, b:$t5
-  7: $t5 := move($t2)
-     # live vars: $t5
-     # events: b:$t7
-  8: $t7 := 1
-     # live vars: $t5, $t7
-     # events: e:$t5, e:$t6, e:$t7, b:$t6
-  9: $t6 := +($t5, $t7)
+     # events: e:$t2, b:$t4
+  6: $t4 := move($t2)
+     # live vars: $t4
+     # events: b:$t6
+  7: $t6 := 1
+     # live vars: $t4, $t6
+     # events: e:$t4, e:$t5, e:$t6, b:$t5
+  8: $t5 := +($t4, $t6)
      # live vars:
- 10: label L2
+  9: label L2
      # live vars:
- 11: return ()
+ 10: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -130,20 +122,18 @@ fun m::test($t0: u64, $t1: bool) {
      var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64
+     var $t6: u64
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
-  2: if ($t1) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t0)
-  5: goto 10
-  6: label L1
-  7: $t0 := move($t0)
-  8: $t7 := 1
-  9: $t0 := +($t0, $t7)
- 10: label L2
- 11: return ()
+  1: if ($t1) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t0)
+  4: goto 9
+  5: label L1
+  6: $t0 := move($t0)
+  7: $t6 := 1
+  8: $t0 := +($t0, $t6)
+  9: label L2
+ 10: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -161,15 +151,14 @@ fun m::test($t0: u64, $t1: bool) {
      var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64
+     var $t6: u64
   0: if ($t1) goto 1 else goto 4
   1: label L0
   2: m::consume($t0)
   3: goto 7
   4: label L1
-  5: $t7 := 1
-  6: $t0 := +($t0, $t7)
+  5: $t6 := 1
+  6: $t0 := +($t0, $t6)
   7: label L2
   8: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
@@ -15,22 +15,20 @@ fun m::test($t0: u64, $t1: bool) {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := move($t0)
-  1: $t2 := infer($t3)
-  2: if ($t1) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 13
-  6: label L1
-  7: $t4 := 99
-  8: $t0 := infer($t4)
-  9: $t5 := infer($t2)
- 10: $t7 := 1
- 11: $t6 := +($t5, $t7)
- 12: $t5 := infer($t6)
- 13: label L2
- 14: return ()
+  0: $t2 := move($t0)
+  1: if ($t1) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 12
+  5: label L1
+  6: $t3 := 99
+  7: $t0 := infer($t3)
+  8: $t4 := infer($t2)
+  9: $t6 := 1
+ 10: $t5 := +($t4, $t6)
+ 11: $t4 := infer($t5)
+ 12: label L2
+ 13: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -47,41 +45,37 @@ fun m::consume($t0: u64) {
 [variant baseline]
 fun m::test($t0: u64, $t1: bool) {
      var $t2: u64
-     var $t3: u64
-     var $t4: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, e:$t0, b:$t3
-  0: $t3 := move($t0)
-     # live vars: $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, e:$t0, b:$t2
+  0: $t2 := move($t0)
      # live vars: $t1, $t2
      # events: e:$t1
-  2: if ($t1) goto 3 else goto 6
+  1: if ($t1) goto 2 else goto 5
      # live vars: $t2
-  3: label L0
+  2: label L0
      # live vars: $t2
-  4: m::consume($t2)
+  3: m::consume($t2)
      # live vars:
-  5: goto 10
+  4: goto 9
      # live vars: $t2
-  6: label L1
+  5: label L1
      # live vars: $t2
-     # events: e:$t2, b:$t5
-  7: $t5 := move($t2)
-     # live vars: $t5
-     # events: b:$t7
-  8: $t7 := 1
-     # live vars: $t5, $t7
-     # events: e:$t5, e:$t6, e:$t7, b:$t6
-  9: $t6 := +($t5, $t7)
+     # events: e:$t2, b:$t4
+  6: $t4 := move($t2)
+     # live vars: $t4
+     # events: b:$t6
+  7: $t6 := 1
+     # live vars: $t4, $t6
+     # events: e:$t4, e:$t5, e:$t6, b:$t5
+  8: $t5 := +($t4, $t6)
      # live vars:
- 10: label L2
+  9: label L2
      # live vars:
- 11: return ()
+ 10: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -99,20 +93,18 @@ fun m::test($t0: u64, $t1: bool) {
      var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64
+     var $t6: u64
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
-  2: if ($t1) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t0)
-  5: goto 10
-  6: label L1
-  7: $t0 := move($t0)
-  8: $t7 := 1
-  9: $t0 := +($t0, $t7)
- 10: label L2
- 11: return ()
+  1: if ($t1) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t0)
+  4: goto 9
+  5: label L1
+  6: $t0 := move($t0)
+  7: $t6 := 1
+  8: $t0 := +($t0, $t6)
+  9: label L2
+ 10: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -7,24 +7,18 @@ fun m::test($t0: bool): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: u64
-  0: $t3 := 2
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 8
-  3: label L0
-  4: $t5 := 3
-  5: $t4 := infer($t5)
-  6: $t1 := infer($t4)
-  7: goto 13
-  8: label L1
-  9: $t8 := 1
- 10: $t7 := +($t2, $t8)
- 11: $t6 := infer($t7)
- 12: $t1 := infer($t6)
- 13: label L2
- 14: return $t1
+  0: $t2 := 2
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 3
+  4: $t1 := infer($t3)
+  5: goto 10
+  6: label L1
+  7: $t5 := 1
+  8: $t4 := +($t2, $t5)
+  9: $t1 := infer($t4)
+ 10: label L2
+ 11: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -36,24 +30,18 @@ fun m::test($t0: bool): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: u64
-  0: $t3 := 2
-  1: $t2 := move($t3)
-  2: if ($t0) goto 3 else goto 8
-  3: label L0
-  4: $t5 := 3
-  5: $t4 := move($t5)
-  6: $t1 := move($t4)
-  7: goto 13
-  8: label L1
-  9: $t8 := 1
- 10: $t7 := +($t2, $t8)
- 11: $t6 := move($t7)
- 12: $t1 := move($t6)
- 13: label L2
- 14: return $t1
+  0: $t2 := 2
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 3
+  4: $t1 := move($t3)
+  5: goto 10
+  6: label L1
+  7: $t5 := 1
+  8: $t4 := +($t2, $t5)
+  9: $t1 := move($t4)
+ 10: label L2
+ 11: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -65,50 +53,38 @@ fun m::test($t0: bool): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-     var $t8: u64
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 2
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 2
      # live vars: $t0, $t2
      # events: e:$t0
-  2: if ($t0) goto 3 else goto 8
+  1: if ($t0) goto 2 else goto 6
      # live vars: $t2
-  3: label L0
+  2: label L0
      # live vars:
+     # events: b:$t3
+  3: $t3 := 3
+     # live vars: $t3
+     # events: e:$t3, b:$t1
+  4: $t1 := move($t3)
+     # live vars: $t1
+  5: goto 10
+     # live vars: $t2
+  6: label L1
+     # live vars: $t2
      # events: b:$t5
-  4: $t5 := 3
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  5: $t4 := move($t5)
+  7: $t5 := 1
+     # live vars: $t2, $t5
+     # events: e:$t2, e:$t5, b:$t4
+  8: $t4 := +($t2, $t5)
      # live vars: $t4
-     # events: e:$t4, b:$t1
-  6: $t1 := move($t4)
+     # events: e:$t4
+  9: $t1 := move($t4)
      # live vars: $t1
-  7: goto 13
-     # live vars: $t2
-  8: label L1
-     # live vars: $t2
-     # events: b:$t8
-  9: $t8 := 1
-     # live vars: $t2, $t8
-     # events: e:$t2, e:$t8, b:$t7
- 10: $t7 := +($t2, $t8)
-     # live vars: $t7
-     # events: e:$t7, b:$t6
- 11: $t6 := move($t7)
-     # live vars: $t6
-     # events: e:$t6
- 12: $t1 := move($t6)
-     # live vars: $t1
- 13: label L2
+ 10: label L2
      # live vars: $t1
      # events: e:$t1
- 14: return $t1
+ 11: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -116,28 +92,22 @@ fun m::test($t0: bool): u64 {
 [variant baseline]
 fun m::test($t0: bool): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-     var $t8: u64
-  0: $t3 := 2
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 8
-  3: label L0
-  4: $t5 := 3
-  5: $t5 := move($t5)
-  6: $t5 := move($t5)
-  7: goto 13
-  8: label L1
-  9: $t8 := 1
- 10: $t3 := +($t3, $t8)
- 11: $t3 := move($t3)
- 12: $t5 := move($t3)
- 13: label L2
- 14: return $t5
+  0: $t2 := 2
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 3
+  4: $t3 := move($t3)
+  5: goto 10
+  6: label L1
+  7: $t5 := 1
+  8: $t2 := +($t2, $t5)
+  9: $t3 := move($t2)
+ 10: label L2
+ 11: return $t3
 }
 
 ============ after DeadStoreElimination: ================
@@ -145,24 +115,21 @@ fun m::test($t0: bool): u64 {
 [variant baseline]
 fun m::test($t0: bool): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-     var $t8: u64
-  0: $t3 := 2
+  0: $t2 := 2
   1: if ($t0) goto 2 else goto 5
   2: label L0
-  3: $t5 := 3
+  3: $t3 := 3
   4: goto 9
   5: label L1
-  6: $t8 := 1
-  7: $t3 := +($t3, $t8)
-  8: $t5 := move($t3)
+  6: $t5 := 1
+  7: $t2 := +($t2, $t5)
+  8: $t3 := move($t2)
   9: label L2
- 10: return $t5
+ 10: return $t3
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
@@ -15,24 +15,20 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64
-     var $t2: u64
-  0: $t2 := move($t0)
-  1: $t1 := infer($t2)
+  0: $t1 := move($t0)
+  1: m::consume($t1)
   2: m::consume($t1)
-  3: m::consume($t1)
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
-  0: $t2 := move($t0)
-  1: $t1 := infer($t2)
+  0: $t1 := move($t0)
+  1: m::consume_($t1)
   2: m::consume_($t1)
-  3: m::consume_($t1)
-  4: return ()
+  3: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -52,12 +48,10 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64
-     var $t2: u64
-  0: $t2 := move($t0)
-  1: $t1 := move($t2)
+  0: $t1 := move($t0)
+  1: m::consume($t1)
   2: m::consume($t1)
-  3: m::consume($t1)
-  4: return ()
+  3: return ()
 }
 
 
@@ -65,13 +59,11 @@ public fun m::test1($t0: u64) {
 public fun m::test2($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-  0: $t2 := move($t0)
-  1: $t1 := move($t2)
-  2: $t3 := copy($t1)
-  3: m::consume_($t3)
-  4: m::consume_($t1)
-  5: return ()
+  0: $t1 := move($t0)
+  1: $t2 := copy($t1)
+  2: m::consume_($t2)
+  3: m::consume_($t1)
+  4: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -95,20 +87,16 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64
-     var $t2: u64
      # live vars: $t0
-     # events: b:$t0, e:$t0, b:$t2
-  0: $t2 := move($t0)
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, e:$t0, b:$t1
+  0: $t1 := move($t0)
      # live vars: $t1
-  2: m::consume($t1)
+  1: m::consume($t1)
      # live vars: $t1
      # events: e:$t1
-  3: m::consume($t1)
+  2: m::consume($t1)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 
@@ -116,24 +104,20 @@ public fun m::test1($t0: u64) {
 public fun m::test2($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
      # live vars: $t0
-     # events: b:$t0, e:$t0, b:$t2
-  0: $t2 := move($t0)
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, e:$t0, b:$t1
+  0: $t1 := move($t0)
      # live vars: $t1
-     # events: b:$t3
-  2: $t3 := copy($t1)
-     # live vars: $t1, $t3
-     # events: e:$t3
-  3: m::consume_($t3)
+     # events: b:$t2
+  1: $t2 := copy($t1)
+     # live vars: $t1, $t2
+     # events: e:$t2
+  2: m::consume_($t2)
      # live vars: $t1
      # events: e:$t1
-  4: m::consume_($t1)
+  3: m::consume_($t1)
      # live vars:
-  5: return ()
+  4: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -153,26 +137,22 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
+  1: m::consume($t0)
   2: m::consume($t0)
-  3: m::consume($t0)
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: m::W) {
      var $t1: m::W [unused]
-     var $t2: m::W [unused]
-     var $t3: m::W
+     var $t2: m::W
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
-  2: $t3 := copy($t0)
-  3: m::consume_($t3)
-  4: m::consume_($t0)
-  5: return ()
+  1: $t2 := copy($t0)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -192,7 +172,6 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
   0: m::consume($t0)
   1: m::consume($t0)
   2: return ()
@@ -202,10 +181,9 @@ public fun m::test1($t0: u64) {
 [variant baseline]
 public fun m::test2($t0: m::W) {
      var $t1: m::W [unused]
-     var $t2: m::W [unused]
-     var $t3: m::W
-  0: $t3 := copy($t0)
-  1: m::consume_($t3)
+     var $t2: m::W
+  0: $t2 := copy($t0)
+  1: m::consume_($t2)
   2: m::consume_($t0)
   3: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
@@ -15,24 +15,20 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64
-     var $t2: u64
-  0: $t2 := move($t0)
-  1: $t1 := infer($t2)
+  0: $t1 := move($t0)
+  1: m::consume($t1)
   2: m::consume($t1)
-  3: m::consume($t1)
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
-  0: $t2 := move($t0)
-  1: $t1 := infer($t2)
+  0: $t1 := move($t0)
+  1: m::consume_($t1)
   2: m::consume_($t1)
-  3: m::consume_($t1)
-  4: return ()
+  3: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -56,20 +52,16 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64
-     var $t2: u64
      # live vars: $t0
-     # events: b:$t0, e:$t0, b:$t2
-  0: $t2 := move($t0)
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, e:$t0, b:$t1
+  0: $t1 := move($t0)
      # live vars: $t1
-  2: m::consume($t1)
+  1: m::consume($t1)
      # live vars: $t1
      # events: e:$t1
-  3: m::consume($t1)
+  2: m::consume($t1)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 
@@ -77,24 +69,20 @@ public fun m::test1($t0: u64) {
 public fun m::test2($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
      # live vars: $t0
-     # events: b:$t0, e:$t0, b:$t2
-  0: $t2 := move($t0)
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, e:$t0, b:$t1
+  0: $t1 := move($t0)
      # live vars: $t1
-     # events: b:$t3
-  2: $t3 := copy($t1)
-     # live vars: $t1, $t3
-     # events: e:$t3
-  3: m::consume_($t3)
+     # events: b:$t2
+  1: $t2 := copy($t1)
+     # live vars: $t1, $t2
+     # events: e:$t2
+  2: m::consume_($t2)
      # live vars: $t1
      # events: e:$t1
-  4: m::consume_($t1)
+  3: m::consume_($t1)
      # live vars:
-  5: return ()
+  4: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -114,26 +102,22 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test1($t0: u64) {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
+  1: m::consume($t0)
   2: m::consume($t0)
-  3: m::consume($t0)
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: m::W) {
      var $t1: m::W [unused]
-     var $t2: m::W [unused]
-     var $t3: m::W
+     var $t2: m::W
   0: $t0 := move($t0)
-  1: $t0 := move($t0)
-  2: $t3 := copy($t0)
-  3: m::consume_($t3)
-  4: m::consume_($t0)
-  5: return ()
+  1: $t2 := copy($t0)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
@@ -15,24 +15,20 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: u32) {
      var $t1: u32
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: m::consume($t1)
-  3: m::consume($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: m::consume_($t1)
-  3: m::consume_($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -52,24 +48,20 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: u32) {
      var $t1: u32
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: $t1 := move($t2)
-  2: m::consume($t1)
-  3: m::consume($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := move($t2)
-  2: m::consume_($t1)
-  3: m::consume_($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -93,42 +85,34 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: u32) {
      var $t1: u32
-     var $t2: u32
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
      # events: e:$t1
-  2: m::consume($t1)
+  1: m::consume($t1)
      # live vars: $t0
      # events: e:$t0
-  3: m::consume($t0)
+  2: m::consume($t0)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
      # events: e:$t1
-  2: m::consume_($t1)
+  1: m::consume_($t1)
      # live vars: $t0
      # events: e:$t0
-  3: m::consume_($t0)
+  2: m::consume_($t0)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -147,25 +131,21 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: m::consume($t2)
-  3: m::consume($t0)
-  4: return ()
+     var $t1: u32
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: m::consume_($t2)
-  3: m::consume_($t0)
-  4: return ()
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -184,10 +164,9 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: m::consume($t2)
+     var $t1: u32
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
   2: m::consume($t0)
   3: return ()
 }
@@ -195,10 +174,9 @@ public fun m::test($t0: u32) {
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: m::consume_($t2)
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
   2: m::consume_($t0)
   3: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
@@ -15,24 +15,20 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: u32) {
      var $t1: u32
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: m::consume($t1)
-  3: m::consume($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: m::consume_($t1)
-  3: m::consume_($t0)
-  4: return ()
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -56,42 +52,34 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: u32) {
      var $t1: u32
-     var $t2: u32
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
      # events: e:$t1
-  2: m::consume($t1)
+  1: m::consume($t1)
      # live vars: $t0
      # events: e:$t0
-  3: m::consume($t0)
+  2: m::consume($t0)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
      var $t1: m::W
-     var $t2: m::W
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
      # events: e:$t1
-  2: m::consume_($t1)
+  1: m::consume_($t1)
      # live vars: $t0
      # events: e:$t0
-  3: m::consume_($t0)
+  2: m::consume_($t0)
      # live vars:
-  4: return ()
+  3: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -110,25 +98,21 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: m::consume($t2)
-  3: m::consume($t0)
-  4: return ()
+     var $t1: u32
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
+  2: m::consume($t0)
+  3: return ()
 }
 
 
 [variant baseline]
 public fun m::test_($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: m::consume_($t2)
-  3: m::consume_($t0)
-  4: return ()
+     var $t1: m::W
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
+  2: m::consume_($t0)
+  3: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
@@ -16,15 +16,11 @@ fun m::consume_($t0: m::W) {
 public fun m::test($t0: u32) {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-     var $t4: u32
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: $t4 := move($t1)
-  3: $t3 := infer($t4)
-  4: m::consume($t3)
-  5: m::consume($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume($t2)
+  3: m::consume($t0)
+  4: return ()
 }
 
 
@@ -32,15 +28,11 @@ public fun m::test($t0: u32) {
 public fun m::test_struct($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-     var $t4: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: $t4 := move($t1)
-  3: $t3 := infer($t4)
-  4: m::consume_($t3)
-  5: m::consume_($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -61,15 +53,11 @@ fun m::consume_($t0: m::W) {
 public fun m::test($t0: u32) {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-     var $t4: u32
-  0: $t2 := copy($t0)
-  1: $t1 := move($t2)
-  2: $t4 := move($t1)
-  3: $t3 := move($t4)
-  4: m::consume($t3)
-  5: m::consume($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume($t2)
+  3: m::consume($t0)
+  4: return ()
 }
 
 
@@ -77,15 +65,11 @@ public fun m::test($t0: u32) {
 public fun m::test_struct($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-     var $t4: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := move($t2)
-  2: $t4 := move($t1)
-  3: $t3 := move($t4)
-  4: m::consume_($t3)
-  5: m::consume_($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -110,28 +94,20 @@ fun m::consume_($t0: m::W) {
 public fun m::test($t0: u32) {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-     var $t4: u32
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
-     # events: e:$t1, b:$t4
-  2: $t4 := move($t1)
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t0, $t3
-     # events: e:$t3
-  4: m::consume($t3)
+     # events: e:$t1, b:$t2
+  1: $t2 := move($t1)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  2: m::consume($t2)
      # live vars: $t0
      # events: e:$t0
-  5: m::consume($t0)
+  3: m::consume($t0)
      # live vars:
-  6: return ()
+  4: return ()
 }
 
 
@@ -139,28 +115,20 @@ public fun m::test($t0: u32) {
 public fun m::test_struct($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-     var $t4: m::W
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
-     # events: e:$t1, b:$t4
-  2: $t4 := move($t1)
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t0, $t3
-     # events: e:$t3
-  4: m::consume_($t3)
+     # events: e:$t1, b:$t2
+  1: $t2 := move($t1)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  2: m::consume_($t2)
      # live vars: $t0
      # events: e:$t0
-  5: m::consume_($t0)
+  3: m::consume_($t0)
      # live vars:
-  6: return ()
+  4: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -179,33 +147,25 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-     var $t3: u32 [unused]
-     var $t4: u32 [unused]
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: $t2 := move($t2)
-  3: $t2 := move($t2)
-  4: m::consume($t2)
-  5: m::consume($t0)
-  6: return ()
+     var $t1: u32
+     var $t2: u32 [unused]
+  0: $t1 := copy($t0)
+  1: $t1 := move($t1)
+  2: m::consume($t1)
+  3: m::consume($t0)
+  4: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-     var $t3: m::W [unused]
-     var $t4: m::W [unused]
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: $t2 := move($t2)
-  3: $t2 := move($t2)
-  4: m::consume_($t2)
-  5: m::consume_($t0)
-  6: return ()
+     var $t1: m::W
+     var $t2: m::W [unused]
+  0: $t1 := copy($t0)
+  1: $t1 := move($t1)
+  2: m::consume_($t1)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -224,12 +184,10 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-     var $t3: u32 [unused]
-     var $t4: u32 [unused]
-  0: $t2 := copy($t0)
-  1: m::consume($t2)
+     var $t1: u32
+     var $t2: u32 [unused]
+  0: $t1 := copy($t0)
+  1: m::consume($t1)
   2: m::consume($t0)
   3: return ()
 }
@@ -237,12 +195,10 @@ public fun m::test($t0: u32) {
 
 [variant baseline]
 public fun m::test_struct($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-     var $t3: m::W [unused]
-     var $t4: m::W [unused]
-  0: $t2 := copy($t0)
-  1: m::consume_($t2)
+     var $t1: m::W
+     var $t2: m::W [unused]
+  0: $t1 := copy($t0)
+  1: m::consume_($t1)
   2: m::consume_($t0)
   3: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
@@ -16,15 +16,11 @@ fun m::consume_($t0: m::W) {
 public fun m::test($t0: u32) {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-     var $t4: u32
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: $t4 := move($t1)
-  3: $t3 := infer($t4)
-  4: m::consume($t3)
-  5: m::consume($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume($t2)
+  3: m::consume($t0)
+  4: return ()
 }
 
 
@@ -32,15 +28,11 @@ public fun m::test($t0: u32) {
 public fun m::test_struct($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-     var $t4: m::W
-  0: $t2 := copy($t0)
-  1: $t1 := infer($t2)
-  2: $t4 := move($t1)
-  3: $t3 := infer($t4)
-  4: m::consume_($t3)
-  5: m::consume_($t0)
-  6: return ()
+  0: $t1 := copy($t0)
+  1: $t2 := move($t1)
+  2: m::consume_($t2)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -65,28 +57,20 @@ fun m::consume_($t0: m::W) {
 public fun m::test($t0: u32) {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-     var $t4: u32
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
-     # events: e:$t1, b:$t4
-  2: $t4 := move($t1)
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t0, $t3
-     # events: e:$t3
-  4: m::consume($t3)
+     # events: e:$t1, b:$t2
+  1: $t2 := move($t1)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  2: m::consume($t2)
      # live vars: $t0
      # events: e:$t0
-  5: m::consume($t0)
+  3: m::consume($t0)
      # live vars:
-  6: return ()
+  4: return ()
 }
 
 
@@ -94,28 +78,20 @@ public fun m::test($t0: u32) {
 public fun m::test_struct($t0: m::W) {
      var $t1: m::W
      var $t2: m::W
-     var $t3: m::W
-     var $t4: m::W
      # live vars: $t0
-     # events: b:$t0, b:$t2
-  0: $t2 := copy($t0)
-     # live vars: $t0, $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t0, b:$t1
+  0: $t1 := copy($t0)
      # live vars: $t0, $t1
-     # events: e:$t1, b:$t4
-  2: $t4 := move($t1)
-     # live vars: $t0, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t0, $t3
-     # events: e:$t3
-  4: m::consume_($t3)
+     # events: e:$t1, b:$t2
+  1: $t2 := move($t1)
+     # live vars: $t0, $t2
+     # events: e:$t2
+  2: m::consume_($t2)
      # live vars: $t0
      # events: e:$t0
-  5: m::consume_($t0)
+  3: m::consume_($t0)
      # live vars:
-  6: return ()
+  4: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -134,33 +110,25 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: u32) {
-     var $t1: u32 [unused]
-     var $t2: u32
-     var $t3: u32 [unused]
-     var $t4: u32 [unused]
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: $t2 := move($t2)
-  3: $t2 := move($t2)
-  4: m::consume($t2)
-  5: m::consume($t0)
-  6: return ()
+     var $t1: u32
+     var $t2: u32 [unused]
+  0: $t1 := copy($t0)
+  1: $t1 := move($t1)
+  2: m::consume($t1)
+  3: m::consume($t0)
+  4: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: m::W) {
-     var $t1: m::W [unused]
-     var $t2: m::W
-     var $t3: m::W [unused]
-     var $t4: m::W [unused]
-  0: $t2 := copy($t0)
-  1: $t2 := move($t2)
-  2: $t2 := move($t2)
-  3: $t2 := move($t2)
-  4: m::consume_($t2)
-  5: m::consume_($t0)
-  6: return ()
+     var $t1: m::W
+     var $t2: m::W [unused]
+  0: $t1 := copy($t0)
+  1: $t1 := move($t1)
+  2: m::consume_($t1)
+  3: m::consume_($t0)
+  4: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
@@ -15,52 +15,48 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
      var $t2: u32
-     var $t3: u32
-     var $t4: bool
-  0: $t3 := copy($t1)
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 8
-  6: label L1
-  7: m::consume($t1)
-  8: label L2
-  9: $t4 := !($t0)
- 10: if ($t4) goto 11 else goto 14
- 11: label L3
- 12: m::consume($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume($t2)
- 16: label L5
- 17: return ()
+     var $t3: bool
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t3 := !($t0)
+  9: if ($t3) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t2)
+ 15: label L5
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
      var $t2: m::W
-     var $t3: m::W
-     var $t4: bool
-  0: $t3 := copy($t1)
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume_($t2)
-  5: goto 8
-  6: label L1
-  7: m::consume_($t1)
-  8: label L2
-  9: $t4 := !($t0)
- 10: if ($t4) goto 11 else goto 14
- 11: label L3
- 12: m::consume_($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume_($t2)
- 16: label L5
- 17: return ()
+     var $t3: bool
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume_($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume_($t1)
+  7: label L2
+  8: $t3 := !($t0)
+  9: if ($t3) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume_($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume_($t2)
+ 15: label L5
+ 16: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -80,56 +76,52 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
      var $t2: u32
-     var $t3: u32
-     var $t4: bool
-  0: $t3 := copy($t1)
-  1: $t2 := move($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 8
-  6: label L1
-  7: m::consume($t1)
-  8: label L2
-  9: $t4 := !($t0)
- 10: if ($t4) goto 11 else goto 14
- 11: label L3
- 12: m::consume($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume($t2)
- 16: label L5
- 17: return ()
+     var $t3: bool
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t3 := !($t0)
+  9: if ($t3) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t2)
+ 15: label L5
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
      var $t2: m::W
-     var $t3: m::W
-     var $t4: bool
+     var $t3: bool
+     var $t4: m::W
      var $t5: m::W
-     var $t6: m::W
-  0: $t3 := copy($t1)
-  1: $t2 := move($t3)
-  2: if ($t0) goto 3 else goto 7
-  3: label L0
-  4: $t5 := copy($t2)
-  5: m::consume_($t5)
-  6: goto 10
-  7: label L1
-  8: $t6 := copy($t1)
-  9: m::consume_($t6)
- 10: label L2
- 11: $t4 := !($t0)
- 12: if ($t4) goto 13 else goto 16
- 13: label L3
- 14: m::consume_($t1)
- 15: goto 18
- 16: label L4
- 17: m::consume_($t2)
- 18: label L5
- 19: return ()
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := copy($t2)
+  4: m::consume_($t4)
+  5: goto 9
+  6: label L1
+  7: $t5 := copy($t1)
+  8: m::consume_($t5)
+  9: label L2
+ 10: $t3 := !($t0)
+ 11: if ($t3) goto 12 else goto 15
+ 12: label L3
+ 13: m::consume_($t1)
+ 14: goto 17
+ 15: label L4
+ 16: m::consume_($t2)
+ 17: label L5
+ 18: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -153,110 +145,102 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
      var $t2: u32
-     var $t3: u32
-     var $t4: bool
+     var $t3: bool
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, b:$t3
-  0: $t3 := copy($t1)
-     # live vars: $t0, $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, b:$t2
+  0: $t2 := copy($t1)
      # live vars: $t0, $t1, $t2
-  2: if ($t0) goto 3 else goto 6
+  1: if ($t0) goto 2 else goto 5
      # live vars: $t0, $t1, $t2
-  3: label L0
+  2: label L0
      # live vars: $t0, $t1, $t2
-  4: m::consume($t2)
+  3: m::consume($t2)
      # live vars: $t0, $t1, $t2
-  5: goto 8
+  4: goto 7
      # live vars: $t0, $t1, $t2
-  6: label L1
+  5: label L1
      # live vars: $t0, $t1, $t2
-  7: m::consume($t1)
+  6: m::consume($t1)
      # live vars: $t0, $t1, $t2
-  8: label L2
+  7: label L2
      # live vars: $t0, $t1, $t2
-     # events: e:$t0, b:$t4
-  9: $t4 := !($t0)
-     # live vars: $t1, $t2, $t4
-     # events: e:$t4
- 10: if ($t4) goto 11 else goto 14
+     # events: e:$t0, b:$t3
+  8: $t3 := !($t0)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+  9: if ($t3) goto 10 else goto 13
      # live vars: $t1, $t2
- 11: label L3
+ 10: label L3
      # live vars: $t1
- 12: m::consume($t1)
+ 11: m::consume($t1)
      # live vars:
- 13: goto 16
+ 12: goto 15
      # live vars: $t1, $t2
      # events: e:$t1
- 14: label L4
+ 13: label L4
      # live vars: $t2
      # events: e:$t2
- 15: m::consume($t2)
+ 14: m::consume($t2)
      # live vars:
- 16: label L5
+ 15: label L5
      # live vars:
- 17: return ()
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
      var $t2: m::W
-     var $t3: m::W
-     var $t4: bool
+     var $t3: bool
+     var $t4: m::W
      var $t5: m::W
-     var $t6: m::W
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, b:$t3
-  0: $t3 := copy($t1)
-     # live vars: $t0, $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, b:$t2
+  0: $t2 := copy($t1)
      # live vars: $t0, $t1, $t2
-  2: if ($t0) goto 3 else goto 7
+  1: if ($t0) goto 2 else goto 6
      # live vars: $t0, $t1, $t2
-  3: label L0
+  2: label L0
+     # live vars: $t0, $t1, $t2
+     # events: b:$t4
+  3: $t4 := copy($t2)
+     # live vars: $t0, $t1, $t2, $t4
+     # events: e:$t4
+  4: m::consume_($t4)
+     # live vars: $t0, $t1, $t2
+  5: goto 9
+     # live vars: $t0, $t1, $t2
+  6: label L1
      # live vars: $t0, $t1, $t2
      # events: b:$t5
-  4: $t5 := copy($t2)
+  7: $t5 := copy($t1)
      # live vars: $t0, $t1, $t2, $t5
      # events: e:$t5
-  5: m::consume_($t5)
+  8: m::consume_($t5)
      # live vars: $t0, $t1, $t2
-  6: goto 10
+  9: label L2
      # live vars: $t0, $t1, $t2
-  7: label L1
-     # live vars: $t0, $t1, $t2
-     # events: b:$t6
-  8: $t6 := copy($t1)
-     # live vars: $t0, $t1, $t2, $t6
-     # events: e:$t6
-  9: m::consume_($t6)
-     # live vars: $t0, $t1, $t2
- 10: label L2
-     # live vars: $t0, $t1, $t2
-     # events: e:$t0, b:$t4
- 11: $t4 := !($t0)
-     # live vars: $t1, $t2, $t4
-     # events: e:$t4
- 12: if ($t4) goto 13 else goto 16
+     # events: e:$t0, b:$t3
+ 10: $t3 := !($t0)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+ 11: if ($t3) goto 12 else goto 15
      # live vars: $t1, $t2
- 13: label L3
+ 12: label L3
      # live vars: $t1
- 14: m::consume_($t1)
+ 13: m::consume_($t1)
      # live vars:
- 15: goto 18
+ 14: goto 17
      # live vars: $t1, $t2
      # events: e:$t1
- 16: label L4
+ 15: label L4
      # live vars: $t2
      # events: e:$t2
- 17: m::consume_($t2)
+ 16: m::consume_($t2)
      # live vars:
- 18: label L5
+ 17: label L5
      # live vars:
- 19: return ()
+ 18: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -275,57 +259,53 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
-     var $t2: u32 [unused]
-     var $t3: u32
-     var $t4: bool [unused]
-  0: $t3 := copy($t1)
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t3)
-  5: goto 8
-  6: label L1
-  7: m::consume($t1)
-  8: label L2
-  9: $t0 := !($t0)
- 10: if ($t0) goto 11 else goto 14
- 11: label L3
- 12: m::consume($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume($t3)
- 16: label L5
- 17: return ()
+     var $t2: u32
+     var $t3: bool [unused]
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t0 := !($t0)
+  9: if ($t0) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t2)
+ 15: label L5
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
-     var $t2: m::W [unused]
-     var $t3: m::W
-     var $t4: bool [unused]
-     var $t5: m::W
-     var $t6: m::W [unused]
-  0: $t3 := copy($t1)
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 7
-  3: label L0
-  4: $t5 := copy($t3)
-  5: m::consume_($t5)
-  6: goto 10
-  7: label L1
-  8: $t5 := copy($t1)
-  9: m::consume_($t5)
- 10: label L2
- 11: $t0 := !($t0)
- 12: if ($t0) goto 13 else goto 16
- 13: label L3
- 14: m::consume_($t1)
- 15: goto 18
- 16: label L4
- 17: m::consume_($t3)
- 18: label L5
- 19: return ()
+     var $t2: m::W
+     var $t3: bool [unused]
+     var $t4: m::W
+     var $t5: m::W [unused]
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := copy($t2)
+  4: m::consume_($t4)
+  5: goto 9
+  6: label L1
+  7: $t4 := copy($t1)
+  8: m::consume_($t4)
+  9: label L2
+ 10: $t0 := !($t0)
+ 11: if ($t0) goto 12 else goto 15
+ 12: label L3
+ 13: m::consume_($t1)
+ 14: goto 17
+ 15: label L4
+ 16: m::consume_($t2)
+ 17: label L5
+ 18: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -344,13 +324,12 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
-     var $t2: u32 [unused]
-     var $t3: u32
-     var $t4: bool [unused]
-  0: $t3 := copy($t1)
+     var $t2: u32
+     var $t3: bool [unused]
+  0: $t2 := copy($t1)
   1: if ($t0) goto 2 else goto 5
   2: label L0
-  3: m::consume($t3)
+  3: m::consume($t2)
   4: goto 7
   5: label L1
   6: m::consume($t1)
@@ -361,7 +340,7 @@ public fun m::test($t0: bool, $t1: u32) {
  11: m::consume($t1)
  12: goto 15
  13: label L4
- 14: m::consume($t3)
+ 14: m::consume($t2)
  15: label L5
  16: return ()
 }
@@ -369,20 +348,19 @@ public fun m::test($t0: bool, $t1: u32) {
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
-     var $t2: m::W [unused]
-     var $t3: m::W
-     var $t4: bool [unused]
-     var $t5: m::W
-     var $t6: m::W [unused]
-  0: $t3 := copy($t1)
+     var $t2: m::W
+     var $t3: bool [unused]
+     var $t4: m::W
+     var $t5: m::W [unused]
+  0: $t2 := copy($t1)
   1: if ($t0) goto 2 else goto 6
   2: label L0
-  3: $t5 := copy($t3)
-  4: m::consume_($t5)
+  3: $t4 := copy($t2)
+  4: m::consume_($t4)
   5: goto 9
   6: label L1
-  7: $t5 := copy($t1)
-  8: m::consume_($t5)
+  7: $t4 := copy($t1)
+  8: m::consume_($t4)
   9: label L2
  10: $t0 := !($t0)
  11: if ($t0) goto 12 else goto 15
@@ -390,7 +368,7 @@ public fun m::test_struct($t0: bool, $t1: m::W) {
  13: m::consume_($t1)
  14: goto 17
  15: label L4
- 16: m::consume_($t3)
+ 16: m::consume_($t2)
  17: label L5
  18: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
@@ -15,52 +15,48 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
      var $t2: u32
-     var $t3: u32
-     var $t4: bool
-  0: $t3 := copy($t1)
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t2)
-  5: goto 8
-  6: label L1
-  7: m::consume($t1)
-  8: label L2
-  9: $t4 := !($t0)
- 10: if ($t4) goto 11 else goto 14
- 11: label L3
- 12: m::consume($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume($t2)
- 16: label L5
- 17: return ()
+     var $t3: bool
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t3 := !($t0)
+  9: if ($t3) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t2)
+ 15: label L5
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
      var $t2: m::W
-     var $t3: m::W
-     var $t4: bool
-  0: $t3 := copy($t1)
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume_($t2)
-  5: goto 8
-  6: label L1
-  7: m::consume_($t1)
-  8: label L2
-  9: $t4 := !($t0)
- 10: if ($t4) goto 11 else goto 14
- 11: label L3
- 12: m::consume_($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume_($t2)
- 16: label L5
- 17: return ()
+     var $t3: bool
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume_($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume_($t1)
+  7: label L2
+  8: $t3 := !($t0)
+  9: if ($t3) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume_($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume_($t2)
+ 15: label L5
+ 16: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -84,110 +80,102 @@ fun m::consume_($t0: m::W) {
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
      var $t2: u32
-     var $t3: u32
-     var $t4: bool
+     var $t3: bool
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, b:$t3
-  0: $t3 := copy($t1)
-     # live vars: $t0, $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, b:$t2
+  0: $t2 := copy($t1)
      # live vars: $t0, $t1, $t2
-  2: if ($t0) goto 3 else goto 6
+  1: if ($t0) goto 2 else goto 5
      # live vars: $t0, $t1, $t2
-  3: label L0
+  2: label L0
      # live vars: $t0, $t1, $t2
-  4: m::consume($t2)
+  3: m::consume($t2)
      # live vars: $t0, $t1, $t2
-  5: goto 8
+  4: goto 7
      # live vars: $t0, $t1, $t2
-  6: label L1
+  5: label L1
      # live vars: $t0, $t1, $t2
-  7: m::consume($t1)
+  6: m::consume($t1)
      # live vars: $t0, $t1, $t2
-  8: label L2
+  7: label L2
      # live vars: $t0, $t1, $t2
-     # events: e:$t0, b:$t4
-  9: $t4 := !($t0)
-     # live vars: $t1, $t2, $t4
-     # events: e:$t4
- 10: if ($t4) goto 11 else goto 14
+     # events: e:$t0, b:$t3
+  8: $t3 := !($t0)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+  9: if ($t3) goto 10 else goto 13
      # live vars: $t1, $t2
- 11: label L3
+ 10: label L3
      # live vars: $t1
- 12: m::consume($t1)
+ 11: m::consume($t1)
      # live vars:
- 13: goto 16
+ 12: goto 15
      # live vars: $t1, $t2
      # events: e:$t1
- 14: label L4
+ 13: label L4
      # live vars: $t2
      # events: e:$t2
- 15: m::consume($t2)
+ 14: m::consume($t2)
      # live vars:
- 16: label L5
+ 15: label L5
      # live vars:
- 17: return ()
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
      var $t2: m::W
-     var $t3: m::W
-     var $t4: bool
+     var $t3: bool
+     var $t4: m::W
      var $t5: m::W
-     var $t6: m::W
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, b:$t3
-  0: $t3 := copy($t1)
-     # live vars: $t0, $t1, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, b:$t2
+  0: $t2 := copy($t1)
      # live vars: $t0, $t1, $t2
-  2: if ($t0) goto 3 else goto 7
+  1: if ($t0) goto 2 else goto 6
      # live vars: $t0, $t1, $t2
-  3: label L0
+  2: label L0
+     # live vars: $t0, $t1, $t2
+     # events: b:$t4
+  3: $t4 := copy($t2)
+     # live vars: $t0, $t1, $t2, $t4
+     # events: e:$t4
+  4: m::consume_($t4)
+     # live vars: $t0, $t1, $t2
+  5: goto 9
+     # live vars: $t0, $t1, $t2
+  6: label L1
      # live vars: $t0, $t1, $t2
      # events: b:$t5
-  4: $t5 := copy($t2)
+  7: $t5 := copy($t1)
      # live vars: $t0, $t1, $t2, $t5
      # events: e:$t5
-  5: m::consume_($t5)
+  8: m::consume_($t5)
      # live vars: $t0, $t1, $t2
-  6: goto 10
+  9: label L2
      # live vars: $t0, $t1, $t2
-  7: label L1
-     # live vars: $t0, $t1, $t2
-     # events: b:$t6
-  8: $t6 := copy($t1)
-     # live vars: $t0, $t1, $t2, $t6
-     # events: e:$t6
-  9: m::consume_($t6)
-     # live vars: $t0, $t1, $t2
- 10: label L2
-     # live vars: $t0, $t1, $t2
-     # events: e:$t0, b:$t4
- 11: $t4 := !($t0)
-     # live vars: $t1, $t2, $t4
-     # events: e:$t4
- 12: if ($t4) goto 13 else goto 16
+     # events: e:$t0, b:$t3
+ 10: $t3 := !($t0)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+ 11: if ($t3) goto 12 else goto 15
      # live vars: $t1, $t2
- 13: label L3
+ 12: label L3
      # live vars: $t1
- 14: m::consume_($t1)
+ 13: m::consume_($t1)
      # live vars:
- 15: goto 18
+ 14: goto 17
      # live vars: $t1, $t2
      # events: e:$t1
- 16: label L4
+ 15: label L4
      # live vars: $t2
      # events: e:$t2
- 17: m::consume_($t2)
+ 16: m::consume_($t2)
      # live vars:
- 18: label L5
+ 17: label L5
      # live vars:
- 19: return ()
+ 18: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -206,57 +194,53 @@ fun m::consume_($t0: m::W) {
 
 [variant baseline]
 public fun m::test($t0: bool, $t1: u32) {
-     var $t2: u32 [unused]
-     var $t3: u32
-     var $t4: bool [unused]
-  0: $t3 := copy($t1)
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: m::consume($t3)
-  5: goto 8
-  6: label L1
-  7: m::consume($t1)
-  8: label L2
-  9: $t0 := !($t0)
- 10: if ($t0) goto 11 else goto 14
- 11: label L3
- 12: m::consume($t1)
- 13: goto 16
- 14: label L4
- 15: m::consume($t3)
- 16: label L5
- 17: return ()
+     var $t2: u32
+     var $t3: bool [unused]
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: m::consume($t2)
+  4: goto 7
+  5: label L1
+  6: m::consume($t1)
+  7: label L2
+  8: $t0 := !($t0)
+  9: if ($t0) goto 10 else goto 13
+ 10: label L3
+ 11: m::consume($t1)
+ 12: goto 15
+ 13: label L4
+ 14: m::consume($t2)
+ 15: label L5
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test_struct($t0: bool, $t1: m::W) {
-     var $t2: m::W [unused]
-     var $t3: m::W
-     var $t4: bool [unused]
-     var $t5: m::W
-     var $t6: m::W [unused]
-  0: $t3 := copy($t1)
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 7
-  3: label L0
-  4: $t5 := copy($t3)
-  5: m::consume_($t5)
-  6: goto 10
-  7: label L1
-  8: $t5 := copy($t1)
-  9: m::consume_($t5)
- 10: label L2
- 11: $t0 := !($t0)
- 12: if ($t0) goto 13 else goto 16
- 13: label L3
- 14: m::consume_($t1)
- 15: goto 18
- 16: label L4
- 17: m::consume_($t3)
- 18: label L5
- 19: return ()
+     var $t2: m::W
+     var $t3: bool [unused]
+     var $t4: m::W
+     var $t5: m::W [unused]
+  0: $t2 := copy($t1)
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t4 := copy($t2)
+  4: m::consume_($t4)
+  5: goto 9
+  6: label L1
+  7: $t4 := copy($t1)
+  8: m::consume_($t4)
+  9: label L2
+ 10: $t0 := !($t0)
+ 11: if ($t0) goto 12 else goto 15
+ 12: label L3
+ 13: m::consume_($t1)
+ 14: goto 17
+ 15: label L4
+ 16: m::consume_($t2)
+ 17: label L5
+ 18: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
@@ -3,55 +3,51 @@
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t4 := 0
-  1: $t3 := infer($t4)
-  2: label L0
-  3: $t5 := <($t3, $t0)
-  4: if ($t5) goto 5 else goto 12
-  5: label L2
-  6: $t1 := infer($t2)
-  7: $t2 := infer($t1)
-  8: $t7 := 1
-  9: $t6 := +($t3, $t7)
- 10: $t3 := infer($t6)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: return ()
+  0: $t3 := 0
+  1: label L0
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
+  4: label L2
+  5: $t1 := infer($t2)
+  6: $t2 := infer($t1)
+  7: $t6 := 1
+  8: $t5 := +($t3, $t6)
+  9: $t3 := infer($t5)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: label L0
-  3: $t4 := <($t2, $t0)
-  4: if ($t4) goto 5 else goto 11
-  5: label L2
-  6: $t1 := infer($t1)
-  7: $t6 := 1
-  8: $t5 := +($t2, $t6)
-  9: $t2 := infer($t5)
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: return ()
+  0: $t2 := 0
+  1: label L0
+  2: $t3 := <($t2, $t0)
+  3: if ($t3) goto 4 else goto 10
+  4: label L2
+  5: $t1 := infer($t1)
+  6: $t5 := 1
+  7: $t4 := +($t2, $t5)
+  8: $t2 := infer($t4)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -59,54 +55,50 @@ public fun m::test2($t0: u64, $t1: u64) {
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t4 := 0
-  1: $t3 := move($t4)
-  2: label L0
-  3: $t5 := <($t3, $t0)
-  4: if ($t5) goto 5 else goto 12
-  5: label L2
-  6: $t1 := move($t2)
-  7: $t2 := move($t1)
-  8: $t7 := 1
-  9: $t6 := +($t3, $t7)
- 10: $t3 := move($t6)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: return ()
+  0: $t3 := 0
+  1: label L0
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
+  4: label L2
+  5: $t1 := move($t2)
+  6: $t2 := move($t1)
+  7: $t6 := 1
+  8: $t5 := +($t3, $t6)
+  9: $t3 := move($t5)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := 0
-  1: $t2 := move($t3)
-  2: label L0
-  3: $t4 := <($t2, $t0)
-  4: if ($t4) goto 5 else goto 10
-  5: label L2
-  6: $t6 := 1
-  7: $t5 := +($t2, $t6)
-  8: $t2 := move($t5)
-  9: goto 12
- 10: label L3
- 11: goto 14
- 12: label L4
- 13: goto 2
- 14: label L1
- 15: return ()
+  0: $t2 := 0
+  1: label L0
+  2: $t3 := <($t2, $t0)
+  3: if ($t3) goto 4 else goto 9
+  4: label L2
+  5: $t5 := 1
+  6: $t4 := +($t2, $t5)
+  7: $t2 := move($t4)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 1
+ 13: label L1
+ 14: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -114,181 +106,117 @@ public fun m::test2($t0: u64, $t1: u64) {
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0, $t1, $t2
-     # events: b:$t0, b:$t1, b:$t2, b:$t4
-  0: $t4 := 0
-     # live vars: $t0, $t2, $t4
-     # events: e:$t4, b:$t3
-  1: $t3 := move($t4)
+     # events: b:$t0, b:$t1, b:$t2, b:$t3
+  0: $t3 := 0
      # live vars: $t0, $t2, $t3
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2, $t3
-     # events: b:$t5
-  3: $t5 := <($t3, $t0)
-     # live vars: $t0, $t2, $t3, $t5
-     # events: e:$t5
-  4: if ($t5) goto 5 else goto 12
+     # events: b:$t4
+  2: $t4 := <($t3, $t0)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  3: if ($t4) goto 4 else goto 11
      # live vars: $t0, $t2, $t3
-  5: label L2
+  4: label L2
      # live vars: $t0, $t2, $t3
-  6: $t1 := move($t2)
+  5: $t1 := move($t2)
      # live vars: $t0, $t1, $t3
      # events: e:$t1
-  7: $t2 := move($t1)
+  6: $t2 := move($t1)
      # live vars: $t0, $t2, $t3
-     # events: b:$t7
-  8: $t7 := 1
-     # live vars: $t0, $t2, $t3, $t7
-     # events: e:$t7, b:$t6
-  9: $t6 := +($t3, $t7)
-     # live vars: $t0, $t2, $t6
-     # events: e:$t6
- 10: $t3 := move($t6)
+     # events: b:$t6
+  7: $t6 := 1
+     # live vars: $t0, $t2, $t3, $t6
+     # events: e:$t6, b:$t5
+  8: $t5 := +($t3, $t6)
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5
+  9: $t3 := move($t5)
      # live vars: $t0, $t2, $t3
- 11: goto 14
+ 10: goto 13
      # live vars: $t0, $t2, $t3
- 12: label L3
+ 11: label L3
      # live vars:
- 13: goto 16
+ 12: goto 15
      # live vars: $t0, $t2, $t3
- 14: label L4
+ 13: label L4
      # live vars: $t0, $t2, $t3
      # events: e:$t0, e:$t2, e:$t3
- 15: goto 2
+ 14: goto 1
      # live vars:
- 16: label L1
+ 15: label L1
      # live vars:
- 17: return ()
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, e:$t1, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, e:$t1, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2
-     # events: b:$t4
-  3: $t4 := <($t2, $t0)
-     # live vars: $t0, $t2, $t4
+     # events: b:$t3
+  2: $t3 := <($t2, $t0)
+     # live vars: $t0, $t2, $t3
+     # events: e:$t3
+  3: if ($t3) goto 4 else goto 9
+     # live vars: $t0, $t2
+  4: label L2
+     # live vars: $t0, $t2
+     # events: b:$t5
+  5: $t5 := 1
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5, b:$t4
+  6: $t4 := +($t2, $t5)
+     # live vars: $t0, $t4
      # events: e:$t4
-  4: if ($t4) goto 5 else goto 10
+  7: $t2 := move($t4)
      # live vars: $t0, $t2
-  5: label L2
+  8: goto 11
      # live vars: $t0, $t2
-     # events: b:$t6
-  6: $t6 := 1
-     # live vars: $t0, $t2, $t6
-     # events: e:$t6, b:$t5
-  7: $t5 := +($t2, $t6)
-     # live vars: $t0, $t5
-     # events: e:$t5
-  8: $t2 := move($t5)
-     # live vars: $t0, $t2
-  9: goto 12
-     # live vars: $t0, $t2
- 10: label L3
+  9: label L3
      # live vars:
- 11: goto 14
+ 10: goto 13
      # live vars: $t0, $t2
- 12: label L4
+ 11: label L4
      # live vars: $t0, $t2
      # events: e:$t0, e:$t2
- 13: goto 2
+ 12: goto 1
      # live vars:
- 14: label L1
+ 13: label L1
      # live vars:
- 15: return ()
+ 14: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t4 := 0
-  1: $t4 := move($t4)
-  2: label L0
-  3: $t5 := <($t4, $t0)
-  4: if ($t5) goto 5 else goto 12
-  5: label L2
-  6: $t1 := move($t2)
-  7: $t2 := move($t1)
-  8: $t1 := 1
-  9: $t1 := +($t4, $t1)
- 10: $t4 := move($t1)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: return ()
-}
-
-
-[variant baseline]
-public fun m::test2($t0: u64, $t1: u64) {
-     var $t2: u64 [unused]
-     var $t3: u64 [unused]
+     var $t3: u64
      var $t4: bool
      var $t5: u64 [unused]
-     var $t6: u64
-  0: $t1 := 0
-  1: $t1 := move($t1)
-  2: label L0
-  3: $t4 := <($t1, $t0)
-  4: if ($t4) goto 5 else goto 10
-  5: label L2
-  6: $t6 := 1
-  7: $t6 := +($t1, $t6)
-  8: $t1 := move($t6)
-  9: goto 12
- 10: label L3
- 11: goto 14
- 12: label L4
- 13: goto 2
- 14: label L1
- 15: return ()
-}
-
-============ after DeadStoreElimination: ================
-
-[variant baseline]
-public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t4 := 0
+  0: $t3 := 0
   1: label L0
-  2: $t5 := <($t4, $t0)
-  3: if ($t5) goto 4 else goto 11
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
   4: label L2
   5: $t1 := move($t2)
   6: $t2 := move($t1)
   7: $t1 := 1
-  8: $t1 := +($t4, $t1)
-  9: $t4 := move($t1)
+  8: $t1 := +($t3, $t1)
+  9: $t3 := move($t1)
  10: goto 13
  11: label L3
  12: goto 15
@@ -302,18 +230,68 @@ public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: bool
-     var $t5: u64 [unused]
-     var $t6: u64
+     var $t3: bool
+     var $t4: u64 [unused]
+     var $t5: u64
   0: $t1 := 0
   1: label L0
-  2: $t4 := <($t1, $t0)
-  3: if ($t4) goto 4 else goto 9
+  2: $t3 := <($t1, $t0)
+  3: if ($t3) goto 4 else goto 9
   4: label L2
-  5: $t6 := 1
-  6: $t6 := +($t1, $t6)
-  7: $t1 := move($t6)
+  5: $t5 := 1
+  6: $t5 := +($t1, $t5)
+  7: $t1 := move($t5)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 1
+ 13: label L1
+ 14: return ()
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t3 := 0
+  1: label L0
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
+  4: label L2
+  5: $t1 := move($t2)
+  6: $t2 := move($t1)
+  7: $t1 := 1
+  8: $t1 := +($t3, $t1)
+  9: $t3 := move($t1)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64) {
+     var $t2: u64 [unused]
+     var $t3: bool
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t1 := 0
+  1: label L0
+  2: $t3 := <($t1, $t0)
+  3: if ($t3) goto 4 else goto 9
+  4: label L2
+  5: $t5 := 1
+  6: $t5 := +($t1, $t5)
+  7: $t1 := move($t5)
   8: goto 11
   9: label L3
  10: goto 13

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
@@ -3,55 +3,51 @@
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t4 := 0
-  1: $t3 := infer($t4)
-  2: label L0
-  3: $t5 := <($t3, $t0)
-  4: if ($t5) goto 5 else goto 12
-  5: label L2
-  6: $t1 := infer($t2)
-  7: $t2 := infer($t1)
-  8: $t7 := 1
-  9: $t6 := +($t3, $t7)
- 10: $t3 := infer($t6)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: return ()
+  0: $t3 := 0
+  1: label L0
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
+  4: label L2
+  5: $t1 := infer($t2)
+  6: $t2 := infer($t1)
+  7: $t6 := 1
+  8: $t5 := +($t3, $t6)
+  9: $t3 := infer($t5)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: label L0
-  3: $t4 := <($t2, $t0)
-  4: if ($t4) goto 5 else goto 11
-  5: label L2
-  6: $t1 := infer($t1)
-  7: $t6 := 1
-  8: $t5 := +($t2, $t6)
-  9: $t2 := infer($t5)
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: return ()
+  0: $t2 := 0
+  1: label L0
+  2: $t3 := <($t2, $t0)
+  3: if ($t3) goto 4 else goto 10
+  4: label L2
+  5: $t1 := infer($t1)
+  6: $t5 := 1
+  7: $t4 := +($t2, $t5)
+  8: $t2 := infer($t4)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -59,160 +55,148 @@ public fun m::test2($t0: u64, $t1: u64) {
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0, $t1, $t2
-     # events: b:$t0, b:$t1, b:$t2, b:$t4
-  0: $t4 := 0
-     # live vars: $t0, $t2, $t4
-     # events: e:$t4, b:$t3
-  1: $t3 := move($t4)
+     # events: b:$t0, b:$t1, b:$t2, b:$t3
+  0: $t3 := 0
      # live vars: $t0, $t2, $t3
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2, $t3
-     # events: b:$t5
-  3: $t5 := <($t3, $t0)
-     # live vars: $t0, $t2, $t3, $t5
-     # events: e:$t5
-  4: if ($t5) goto 5 else goto 12
+     # events: b:$t4
+  2: $t4 := <($t3, $t0)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  3: if ($t4) goto 4 else goto 11
      # live vars: $t0, $t2, $t3
-  5: label L2
+  4: label L2
      # live vars: $t0, $t2, $t3
-  6: $t1 := move($t2)
+  5: $t1 := move($t2)
      # live vars: $t0, $t1, $t3
      # events: e:$t1
-  7: $t2 := move($t1)
+  6: $t2 := move($t1)
      # live vars: $t0, $t2, $t3
-     # events: b:$t7
-  8: $t7 := 1
-     # live vars: $t0, $t2, $t3, $t7
-     # events: e:$t7, b:$t6
-  9: $t6 := +($t3, $t7)
-     # live vars: $t0, $t2, $t6
-     # events: e:$t6
- 10: $t3 := move($t6)
+     # events: b:$t6
+  7: $t6 := 1
+     # live vars: $t0, $t2, $t3, $t6
+     # events: e:$t6, b:$t5
+  8: $t5 := +($t3, $t6)
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5
+  9: $t3 := move($t5)
      # live vars: $t0, $t2, $t3
- 11: goto 14
+ 10: goto 13
      # live vars: $t0, $t2, $t3
- 12: label L3
+ 11: label L3
      # live vars:
- 13: goto 16
+ 12: goto 15
      # live vars: $t0, $t2, $t3
- 14: label L4
+ 13: label L4
      # live vars: $t0, $t2, $t3
      # events: e:$t0, e:$t2, e:$t3
- 15: goto 2
+ 14: goto 1
      # live vars:
- 16: label L1
+ 15: label L1
      # live vars:
- 17: return ()
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
      # live vars: $t0, $t1
-     # events: b:$t0, b:$t1, e:$t1, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t1, e:$t1, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2
-     # events: b:$t4
-  3: $t4 := <($t2, $t0)
-     # live vars: $t0, $t2, $t4
+     # events: b:$t3
+  2: $t3 := <($t2, $t0)
+     # live vars: $t0, $t2, $t3
+     # events: e:$t3
+  3: if ($t3) goto 4 else goto 9
+     # live vars: $t0, $t2
+  4: label L2
+     # live vars: $t0, $t2
+     # events: b:$t5
+  5: $t5 := 1
+     # live vars: $t0, $t2, $t5
+     # events: e:$t5, b:$t4
+  6: $t4 := +($t2, $t5)
+     # live vars: $t0, $t4
      # events: e:$t4
-  4: if ($t4) goto 5 else goto 10
+  7: $t2 := move($t4)
      # live vars: $t0, $t2
-  5: label L2
+  8: goto 11
      # live vars: $t0, $t2
-     # events: b:$t6
-  6: $t6 := 1
-     # live vars: $t0, $t2, $t6
-     # events: e:$t6, b:$t5
-  7: $t5 := +($t2, $t6)
-     # live vars: $t0, $t5
-     # events: e:$t5
-  8: $t2 := move($t5)
-     # live vars: $t0, $t2
-  9: goto 12
-     # live vars: $t0, $t2
- 10: label L3
+  9: label L3
      # live vars:
- 11: goto 14
+ 10: goto 13
      # live vars: $t0, $t2
- 12: label L4
+ 11: label L4
      # live vars: $t0, $t2
      # events: e:$t0, e:$t2
- 13: goto 2
+ 12: goto 1
      # live vars:
- 14: label L1
+ 13: label L1
      # live vars:
- 15: return ()
+ 14: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 public fun m::test1($t0: u64, $t1: u64, $t2: u64) {
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t4 := 0
-  1: $t4 := move($t4)
-  2: label L0
-  3: $t5 := <($t4, $t0)
-  4: if ($t5) goto 5 else goto 12
-  5: label L2
-  6: $t1 := move($t2)
-  7: $t2 := move($t1)
-  8: $t1 := 1
-  9: $t1 := +($t4, $t1)
- 10: $t4 := move($t1)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: return ()
+  0: $t3 := 0
+  1: label L0
+  2: $t4 := <($t3, $t0)
+  3: if ($t4) goto 4 else goto 11
+  4: label L2
+  5: $t1 := move($t2)
+  6: $t2 := move($t1)
+  7: $t1 := 1
+  8: $t1 := +($t3, $t1)
+  9: $t3 := move($t1)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: return ()
 }
 
 
 [variant baseline]
 public fun m::test2($t0: u64, $t1: u64) {
      var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: bool
-     var $t5: u64 [unused]
-     var $t6: u64
+     var $t3: bool
+     var $t4: u64 [unused]
+     var $t5: u64
   0: $t1 := 0
-  1: $t1 := move($t1)
-  2: label L0
-  3: $t4 := <($t1, $t0)
-  4: if ($t4) goto 5 else goto 10
-  5: label L2
-  6: $t6 := 1
-  7: $t6 := +($t1, $t6)
-  8: $t1 := move($t6)
-  9: goto 12
- 10: label L3
- 11: goto 14
- 12: label L4
- 13: goto 2
- 14: label L1
- 15: return ()
+  1: label L0
+  2: $t3 := <($t1, $t0)
+  3: if ($t3) goto 4 else goto 9
+  4: label L2
+  5: $t5 := 1
+  6: $t5 := +($t1, $t5)
+  7: $t1 := move($t5)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 1
+ 13: label L1
+ 14: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
@@ -5,21 +5,19 @@ public fun m::test($t0: bool): u32 {
      var $t1: u32
      var $t2: u32
      var $t3: u32
-     var $t4: u32
-  0: $t3 := 1
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t2)
-  3: if ($t0) goto 4 else goto 9
-  4: label L0
-  5: $t4 := infer($t4)
-  6: $t4 := infer($t4)
-  7: $t1 := infer($t4)
-  8: goto 12
-  9: label L1
- 10: $t4 := infer($t4)
- 11: $t1 := 9
- 12: label L2
- 13: return $t1
+  0: $t2 := 1
+  1: $t3 := infer($t2)
+  2: if ($t0) goto 3 else goto 8
+  3: label L0
+  4: $t3 := infer($t3)
+  5: $t3 := infer($t3)
+  6: $t1 := infer($t3)
+  7: goto 11
+  8: label L1
+  9: $t3 := infer($t3)
+ 10: $t1 := 9
+ 11: label L2
+ 12: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -29,18 +27,16 @@ public fun m::test($t0: bool): u32 {
      var $t1: u32
      var $t2: u32
      var $t3: u32
-     var $t4: u32
-  0: $t3 := 1
-  1: $t2 := move($t3)
-  2: $t4 := move($t2)
-  3: if ($t0) goto 4 else goto 7
-  4: label L0
-  5: $t1 := move($t4)
-  6: goto 9
-  7: label L1
-  8: $t1 := 9
-  9: label L2
- 10: return $t1
+  0: $t2 := 1
+  1: $t3 := move($t2)
+  2: if ($t0) goto 3 else goto 6
+  3: label L0
+  4: $t1 := move($t3)
+  5: goto 8
+  6: label L1
+  7: $t1 := 9
+  8: label L2
+  9: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -50,36 +46,32 @@ public fun m::test($t0: bool): u32 {
      var $t1: u32
      var $t2: u32
      var $t3: u32
-     var $t4: u32
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 1
      # live vars: $t0, $t2
-     # events: e:$t2, b:$t4
-  2: $t4 := move($t2)
-     # live vars: $t0, $t4
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t0, $t3
      # events: e:$t0
-  3: if ($t0) goto 4 else goto 7
-     # live vars: $t4
-  4: label L0
-     # live vars: $t4
+  2: if ($t0) goto 3 else goto 6
+     # live vars: $t3
+  3: label L0
+     # live vars: $t3
      # events: b:$t1
-  5: $t1 := move($t4)
+  4: $t1 := move($t3)
      # live vars: $t1
-  6: goto 9
-     # live vars: $t4
-     # events: e:$t4
-  7: label L1
+  5: goto 8
+     # live vars: $t3
+     # events: e:$t3
+  6: label L1
      # live vars:
-  8: $t1 := 9
+  7: $t1 := 9
      # live vars: $t1
-  9: label L2
+  8: label L2
      # live vars: $t1
      # events: e:$t1
- 10: return $t1
+  9: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -87,20 +79,18 @@ public fun m::test($t0: bool): u32 {
 [variant baseline]
 public fun m::test($t0: bool): u32 {
      var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
-     var $t4: u32 [unused]
-  0: $t3 := 1
-  1: $t3 := move($t3)
-  2: $t3 := move($t3)
-  3: if ($t0) goto 4 else goto 7
-  4: label L0
-  5: $t1 := move($t3)
-  6: goto 9
-  7: label L1
-  8: $t1 := 9
-  9: label L2
- 10: return $t1
+     var $t2: u32
+     var $t3: u32 [unused]
+  0: $t2 := 1
+  1: $t2 := move($t2)
+  2: if ($t0) goto 3 else goto 6
+  3: label L0
+  4: $t1 := move($t2)
+  5: goto 8
+  6: label L1
+  7: $t1 := 9
+  8: label L2
+  9: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -108,13 +98,12 @@ public fun m::test($t0: bool): u32 {
 [variant baseline]
 public fun m::test($t0: bool): u32 {
      var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
-     var $t4: u32 [unused]
-  0: $t3 := 1
+     var $t2: u32
+     var $t3: u32 [unused]
+  0: $t2 := 1
   1: if ($t0) goto 2 else goto 5
   2: label L0
-  3: $t1 := move($t3)
+  3: $t1 := move($t2)
   4: goto 7
   5: label L1
   6: $t1 := 9

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
@@ -4,20 +4,18 @@
 public fun m::test($t0: bool): u32 {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
-  0: $t3 := 1
-  1: $t2 := infer($t3)
-  2: if ($t0) goto 3 else goto 8
-  3: label L0
+  0: $t2 := 1
+  1: if ($t0) goto 2 else goto 7
+  2: label L0
+  3: $t2 := infer($t2)
   4: $t2 := infer($t2)
-  5: $t2 := infer($t2)
-  6: $t1 := infer($t2)
-  7: goto 11
-  8: label L1
-  9: $t2 := infer($t2)
- 10: $t1 := 9
- 11: label L2
- 12: return $t1
+  5: $t1 := infer($t2)
+  6: goto 10
+  7: label L1
+  8: $t2 := infer($t2)
+  9: $t1 := 9
+ 10: label L2
+ 11: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -26,33 +24,29 @@ public fun m::test($t0: bool): u32 {
 public fun m::test($t0: bool): u32 {
      var $t1: u32
      var $t2: u32
-     var $t3: u32
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 1
      # live vars: $t0, $t2
      # events: e:$t0
-  2: if ($t0) goto 3 else goto 6
+  1: if ($t0) goto 2 else goto 5
      # live vars: $t2
-  3: label L0
+  2: label L0
      # live vars: $t2
      # events: b:$t1
-  4: $t1 := move($t2)
+  3: $t1 := move($t2)
      # live vars: $t1
-  5: goto 8
+  4: goto 7
      # live vars: $t2
      # events: e:$t2
-  6: label L1
+  5: label L1
      # live vars:
-  7: $t1 := 9
+  6: $t1 := 9
      # live vars: $t1
-  8: label L2
+  7: label L2
      # live vars: $t1
      # events: e:$t1
-  9: return $t1
+  8: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -60,18 +54,16 @@ public fun m::test($t0: bool): u32 {
 [variant baseline]
 public fun m::test($t0: bool): u32 {
      var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
-  0: $t3 := 1
-  1: $t3 := move($t3)
-  2: if ($t0) goto 3 else goto 6
-  3: label L0
-  4: $t1 := move($t3)
-  5: goto 8
-  6: label L1
-  7: $t1 := 9
-  8: label L2
-  9: return $t1
+     var $t2: u32
+  0: $t2 := 1
+  1: if ($t0) goto 2 else goto 5
+  2: label L0
+  3: $t1 := move($t2)
+  4: goto 7
+  5: label L1
+  6: $t1 := 9
+  7: label L2
+  8: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
@@ -31,14 +31,10 @@ public fun m::test1(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 3
-  3: $t3 := infer($t4)
-  4: $t0 := infer($t3)
-  5: return $t0
+  0: $t1 := 1
+  1: $t2 := 3
+  2: $t0 := infer($t2)
+  3: return $t0
 }
 
 
@@ -66,11 +62,9 @@ public fun m::test3($t0: u64): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t3 := 1
-  1: $t2 := infer($t3)
-  2: $t1 := infer($t2)
-  3: return $t1
+  0: $t2 := 1
+  1: $t1 := infer($t2)
+  2: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -79,13 +73,10 @@ public fun m::test4($t0: u64): u64 {
 public fun m::test1(): u64 {
      var $t0: u64
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64
-  0: $t4 := 3
-  1: $t3 := move($t4)
-  2: $t0 := move($t3)
-  3: return $t0
+     var $t2: u64
+  0: $t2 := 3
+  1: $t0 := move($t2)
+  2: return $t0
 }
 
 
@@ -111,11 +102,9 @@ public fun m::test3($t0: u64): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t3 := 1
-  1: $t2 := move($t3)
-  2: $t1 := move($t2)
-  3: return $t1
+  0: $t2 := 1
+  1: $t1 := move($t2)
+  2: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -124,21 +113,16 @@ public fun m::test4($t0: u64): u64 {
 public fun m::test1(): u64 {
      var $t0: u64
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64
+     var $t2: u64
      # live vars:
-     # events: b:$t4
-  0: $t4 := 3
-     # live vars: $t4
-     # events: e:$t4, b:$t3
-  1: $t3 := move($t4)
-     # live vars: $t3
-     # events: e:$t3, b:$t0
-  2: $t0 := move($t3)
+     # events: b:$t2
+  0: $t2 := 3
+     # live vars: $t2
+     # events: e:$t2, b:$t0
+  1: $t0 := move($t2)
      # live vars: $t0
      # events: e:$t0
-  3: return $t0
+  2: return $t0
 }
 
 
@@ -172,19 +156,15 @@ public fun m::test3($t0: u64): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
      # live vars: $t0
-     # events: b:$t0, e:$t0, b:$t3
-  0: $t3 := 1
-     # live vars: $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, e:$t0, b:$t2
+  0: $t2 := 1
      # live vars: $t2
      # events: e:$t2, b:$t1
-  2: $t1 := move($t2)
+  1: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
-  3: return $t1
+  2: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -193,13 +173,10 @@ public fun m::test4($t0: u64): u64 {
 public fun m::test1(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: u64
-  0: $t4 := 3
-  1: $t4 := move($t4)
-  2: $t4 := move($t4)
-  3: return $t4
+     var $t2: u64
+  0: $t2 := 3
+  1: $t2 := move($t2)
+  2: return $t2
 }
 
 
@@ -225,11 +202,9 @@ public fun m::test3($t0: u64): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64 [unused]
-     var $t3: u64 [unused]
   0: $t0 := 1
   1: $t0 := move($t0)
-  2: $t0 := move($t0)
-  3: return $t0
+  2: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -238,11 +213,9 @@ public fun m::test4($t0: u64): u64 {
 public fun m::test1(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: u64
-  0: $t4 := 3
-  1: return $t4
+     var $t2: u64
+  0: $t2 := 3
+  1: return $t2
 }
 
 
@@ -267,7 +240,6 @@ public fun m::test3($t0: u64): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64 [unused]
-     var $t3: u64 [unused]
   0: $t0 := 1
   1: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
@@ -6,13 +6,11 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t2)
-  3: $t5 := infer($t4)
-  4: $t1 := read_ref($t5)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -23,13 +21,11 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: $t4 := move($t2)
-  3: $t5 := move($t4)
-  4: $t1 := read_ref($t5)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t3 := move($t2)
+  2: $t4 := move($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -40,25 +36,21 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
      # live vars: $t0
-     # events: b:$t3
-  0: $t3 := borrow_local($t0)
-     # live vars: $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t2
+  0: $t2 := borrow_local($t0)
      # live vars: $t2
-     # events: e:$t2, b:$t4
-  2: $t4 := move($t2)
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
      # live vars: $t4
-     # events: e:$t4, b:$t5
-  3: $t5 := move($t4)
-     # live vars: $t5
-     # events: e:$t5, b:$t1
-  4: $t1 := read_ref($t5)
+     # events: e:$t4, b:$t1
+  3: $t1 := read_ref($t4)
      # live vars: $t1
      # events: e:$t1
-  5: return $t1
+  4: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -66,16 +58,14 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: &u64 [unused]
-     var $t3: &u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
      var $t4: &u64 [unused]
-     var $t5: &u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: $t3 := move($t3)
-  2: $t3 := move($t3)
-  3: $t3 := move($t3)
-  4: $t1 := read_ref($t3)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: $t1 := read_ref($t2)
+  4: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -83,12 +73,11 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: &u64 [unused]
-     var $t3: &u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
      var $t4: &u64 [unused]
-     var $t5: &u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: $t1 := read_ref($t3)
+  0: $t2 := borrow_local($t0)
+  1: $t1 := read_ref($t2)
   2: return $t1
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
@@ -6,13 +6,11 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t2)
-  3: $t5 := infer($t4)
-  4: $t1 := read_ref($t5)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t2)
+  2: $t4 := infer($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -23,25 +21,21 @@ fun m::test($t0: u64): u64 {
      var $t2: &u64
      var $t3: &u64
      var $t4: &u64
-     var $t5: &u64
      # live vars: $t0
-     # events: b:$t3
-  0: $t3 := borrow_local($t0)
-     # live vars: $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t2
+  0: $t2 := borrow_local($t0)
      # live vars: $t2
-     # events: e:$t2, b:$t4
-  2: $t4 := move($t2)
+     # events: e:$t2, b:$t3
+  1: $t3 := move($t2)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  2: $t4 := move($t3)
      # live vars: $t4
-     # events: e:$t4, b:$t5
-  3: $t5 := move($t4)
-     # live vars: $t5
-     # events: e:$t5, b:$t1
-  4: $t1 := read_ref($t5)
+     # events: e:$t4, b:$t1
+  3: $t1 := read_ref($t4)
      # live vars: $t1
      # events: e:$t1
-  5: return $t1
+  4: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -49,16 +43,14 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64
-     var $t2: &u64 [unused]
-     var $t3: &u64
+     var $t2: &u64
+     var $t3: &u64 [unused]
      var $t4: &u64 [unused]
-     var $t5: &u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: $t3 := move($t3)
-  2: $t3 := move($t3)
-  3: $t3 := move($t3)
-  4: $t1 := read_ref($t3)
-  5: return $t1
+  0: $t2 := borrow_local($t0)
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: $t1 := read_ref($t2)
+  4: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
@@ -12,17 +12,15 @@ warning: Unused local variable `a`. Consider removing or prefixing with an under
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t0)
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
   3: $t5 := infer($t4)
-  4: $t6 := infer($t5)
-  5: $t1 := infer($t6)
-  6: return $t1
+  4: $t1 := infer($t5)
+  5: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -31,18 +29,16 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := move($t3)
-  2: drop($t2)
-  3: $t4 := move($t0)
+  0: $t2 := borrow_local($t0)
+  1: drop($t2)
+  2: $t3 := move($t0)
+  3: $t4 := move($t3)
   4: $t5 := move($t4)
-  5: $t6 := move($t5)
-  6: $t1 := move($t6)
-  7: return $t1
+  5: $t1 := move($t5)
+  6: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -51,34 +47,30 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
      # live vars: $t0
-     # events: b:$t3
-  0: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t2
+  0: $t2 := borrow_local($t0)
      # live vars: $t0, $t2
      # events: e:$t2
-  2: drop($t2)
+  1: drop($t2)
      # live vars: $t0
-     # events: b:$t4
-  3: $t4 := move($t0)
+     # events: b:$t3
+  2: $t3 := move($t0)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  3: $t4 := move($t3)
      # live vars: $t4
      # events: e:$t4, b:$t5
   4: $t5 := move($t4)
      # live vars: $t5
-     # events: e:$t5, b:$t6
-  5: $t6 := move($t5)
-     # live vars: $t6
-     # events: e:$t6, b:$t1
-  6: $t1 := move($t6)
+     # events: e:$t5, b:$t1
+  5: $t1 := move($t5)
      # live vars: $t1
      # events: e:$t1
-  7: return $t1
+  6: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -86,19 +78,17 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: &u64 [unused]
-     var $t3: &u64
-     var $t4: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: $t3 := move($t3)
-  2: drop($t3)
-  3: $t4 := move($t0)
-  4: $t4 := move($t4)
-  5: $t4 := move($t4)
-  6: $t4 := move($t4)
-  7: return $t4
+  0: $t2 := borrow_local($t0)
+  1: drop($t2)
+  2: $t3 := move($t0)
+  3: $t3 := move($t3)
+  4: $t3 := move($t3)
+  5: $t3 := move($t3)
+  6: return $t3
 }
 
 ============ after DeadStoreElimination: ================
@@ -106,15 +96,14 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: &u64 [unused]
-     var $t3: &u64
-     var $t4: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: drop($t3)
-  2: $t4 := move($t0)
-  3: return $t4
+  0: $t2 := borrow_local($t0)
+  1: drop($t2)
+  2: $t3 := move($t0)
+  3: return $t3
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
@@ -12,17 +12,15 @@ warning: Unused local variable `a`. Consider removing or prefixing with an under
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := borrow_local($t0)
-  1: $t2 := infer($t3)
-  2: $t4 := infer($t0)
+  0: $t2 := borrow_local($t0)
+  1: $t3 := infer($t0)
+  2: $t4 := infer($t3)
   3: $t5 := infer($t4)
-  4: $t6 := infer($t5)
-  5: $t1 := infer($t6)
-  6: return $t1
+  4: $t1 := infer($t5)
+  5: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -31,34 +29,30 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: &u64
-     var $t3: &u64
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
      # live vars: $t0
-     # events: b:$t3
-  0: $t3 := borrow_local($t0)
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t2
+  0: $t2 := borrow_local($t0)
      # live vars: $t0, $t2
      # events: e:$t2
-  2: drop($t2)
+  1: drop($t2)
      # live vars: $t0
-     # events: b:$t4
-  3: $t4 := move($t0)
+     # events: b:$t3
+  2: $t3 := move($t0)
+     # live vars: $t3
+     # events: e:$t3, b:$t4
+  3: $t4 := move($t3)
      # live vars: $t4
      # events: e:$t4, b:$t5
   4: $t5 := move($t4)
      # live vars: $t5
-     # events: e:$t5, b:$t6
-  5: $t6 := move($t5)
-     # live vars: $t6
-     # events: e:$t6, b:$t1
-  6: $t1 := move($t6)
+     # events: e:$t5, b:$t1
+  5: $t1 := move($t5)
      # live vars: $t1
      # events: e:$t1
-  7: return $t1
+  6: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -66,19 +60,17 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: &u64 [unused]
-     var $t3: &u64
-     var $t4: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-  0: $t3 := borrow_local($t0)
-  1: $t3 := move($t3)
-  2: drop($t3)
-  3: $t4 := move($t0)
-  4: $t4 := move($t4)
-  5: $t4 := move($t4)
-  6: $t4 := move($t4)
-  7: return $t4
+  0: $t2 := borrow_local($t0)
+  1: drop($t2)
+  2: $t3 := move($t0)
+  3: $t3 := move($t3)
+  4: $t3 := move($t3)
+  5: $t3 := move($t3)
+  6: return $t3
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -7,17 +7,13 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := infer($t4)
-  4: $t5 := +($t1, $t3)
-  5: $t1 := infer($t5)
-  6: $t6 := infer($t3)
-  7: $t0 := +($t6, $t3)
-  8: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := +($t1, $t2)
+  3: $t1 := infer($t3)
+  4: $t4 := infer($t2)
+  5: $t0 := +($t4, $t2)
+  6: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -29,16 +25,12 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
-  0: $t2 := 1
-  1: $t1 := move($t2)
-  2: $t4 := 2
-  3: $t3 := move($t4)
-  4: $t5 := +($t1, $t3)
-  5: $t6 := copy($t3)
-  6: $t0 := +($t6, $t3)
-  7: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := +($t1, $t2)
+  3: $t4 := copy($t2)
+  4: $t0 := +($t4, $t2)
+  5: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -50,32 +42,24 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
+     # events: b:$t2
+  1: $t2 := 2
+     # live vars: $t1, $t2
+     # events: e:$t1, e:$t3, b:$t3
+  2: $t3 := +($t1, $t2)
+     # live vars: $t2
      # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-     # events: e:$t1, e:$t5, b:$t5
-  4: $t5 := +($t1, $t3)
-     # live vars: $t3
-     # events: b:$t6
-  5: $t6 := copy($t3)
-     # live vars: $t3, $t6
-     # events: e:$t3, e:$t6, b:$t0
-  6: $t0 := +($t6, $t3)
+  3: $t4 := copy($t2)
+     # live vars: $t2, $t4
+     # events: e:$t2, e:$t4, b:$t0
+  4: $t0 := +($t4, $t2)
      # live vars: $t0
      # events: e:$t0
-  7: return $t0
+  5: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -83,20 +67,16 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64 [unused]
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 2
-  3: $t4 := move($t4)
-  4: $t2 := +($t2, $t4)
-  5: $t5 := copy($t4)
-  6: $t4 := +($t5, $t4)
-  7: return $t4
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t1 := +($t1, $t2)
+  3: $t3 := copy($t2)
+  4: $t2 := +($t3, $t2)
+  5: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -104,18 +84,16 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64
-     var $t6: u64 [unused]
-  0: $t2 := 1
-  1: $t4 := 2
-  2: $t2 := +($t2, $t4)
-  3: $t5 := copy($t4)
-  4: $t4 := +($t5, $t4)
-  5: return $t4
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t1 := +($t1, $t2)
+  3: $t3 := copy($t2)
+  4: $t2 := +($t3, $t2)
+  5: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
@@ -6,14 +6,12 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := +($t1, $t4)
-  4: $t1 := infer($t3)
-  5: $t0 := 4
-  6: return $t0
+  0: $t1 := 1
+  1: $t3 := 2
+  2: $t2 := +($t1, $t3)
+  3: $t1 := infer($t2)
+  4: $t0 := 4
+  5: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -24,25 +22,21 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
-     # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
-     # events: e:$t1, e:$t3, e:$t4, b:$t3
-  3: $t3 := +($t1, $t4)
+     # events: b:$t3
+  1: $t3 := 2
+     # live vars: $t1, $t3
+     # events: e:$t1, e:$t2, e:$t3, b:$t2
+  2: $t2 := +($t1, $t3)
      # live vars:
      # events: b:$t0
-  4: $t0 := 4
+  3: $t0 := 4
      # live vars: $t0
      # events: e:$t0
-  5: return $t0
+  4: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -50,16 +44,14 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 2
-  3: $t2 := +($t2, $t4)
-  4: $t3 := 4
-  5: return $t3
+  0: $t1 := 1
+  1: $t3 := 2
+  2: $t1 := +($t1, $t3)
+  3: $t2 := 4
+  4: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
@@ -8,18 +8,14 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := infer($t4)
-  4: $t6 := 1
-  5: $t5 := +($t1, $t6)
-  6: $t1 := infer($t5)
-  7: $t7 := infer($t3)
-  8: $t0 := +($t7, $t1)
-  9: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t3 := +($t1, $t4)
+  4: $t1 := infer($t3)
+  5: $t5 := infer($t2)
+  6: $t0 := +($t5, $t1)
+  7: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -32,18 +28,14 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := move($t2)
-  2: $t4 := 2
-  3: $t3 := move($t4)
-  4: $t6 := 1
-  5: $t5 := +($t1, $t6)
-  6: $t1 := move($t5)
-  7: $t7 := move($t3)
-  8: $t0 := +($t7, $t1)
-  9: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t3 := +($t1, $t4)
+  4: $t1 := move($t3)
+  5: $t5 := move($t2)
+  6: $t0 := +($t5, $t1)
+  7: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -56,38 +48,30 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
+     # events: b:$t2
+  1: $t2 := 2
+     # live vars: $t1, $t2
      # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
+  2: $t4 := 1
+     # live vars: $t1, $t2, $t4
      # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-     # events: b:$t6
-  4: $t6 := 1
-     # live vars: $t1, $t3, $t6
-     # events: e:$t6, b:$t5
-  5: $t5 := +($t1, $t6)
-     # live vars: $t3, $t5
-     # events: e:$t5
-  6: $t1 := move($t5)
-     # live vars: $t1, $t3
-     # events: e:$t3, b:$t7
-  7: $t7 := move($t3)
-     # live vars: $t1, $t7
-     # events: e:$t1, e:$t7, b:$t0
-  8: $t0 := +($t7, $t1)
+  3: $t3 := +($t1, $t4)
+     # live vars: $t2, $t3
+     # events: e:$t3
+  4: $t1 := move($t3)
+     # live vars: $t1, $t2
+     # events: e:$t2, b:$t5
+  5: $t5 := move($t2)
+     # live vars: $t1, $t5
+     # events: e:$t1, e:$t5, b:$t0
+  6: $t0 := +($t5, $t1)
      # live vars: $t0
      # events: e:$t0
-  9: return $t0
+  7: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -95,23 +79,19 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 2
-  3: $t4 := move($t4)
-  4: $t6 := 1
-  5: $t6 := +($t2, $t6)
-  6: $t2 := move($t6)
-  7: $t4 := move($t4)
-  8: $t2 := +($t4, $t2)
-  9: return $t2
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t4 := +($t1, $t4)
+  4: $t1 := move($t4)
+  5: $t2 := move($t2)
+  6: $t1 := +($t2, $t1)
+  7: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -119,20 +99,18 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t4 := 2
-  2: $t6 := 1
-  3: $t6 := +($t2, $t6)
-  4: $t2 := move($t6)
-  5: $t2 := +($t4, $t2)
-  6: return $t2
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t4 := +($t1, $t4)
+  4: $t1 := move($t4)
+  5: $t1 := +($t2, $t1)
+  6: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
@@ -7,15 +7,13 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 1
-  3: $t3 := +($t1, $t4)
-  4: $t1 := infer($t3)
-  5: $t5 := 2
-  6: $t0 := +($t5, $t1)
-  7: return $t0
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t2 := +($t1, $t3)
+  3: $t1 := infer($t2)
+  4: $t4 := 2
+  5: $t0 := +($t4, $t1)
+  6: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -27,31 +25,27 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
+     # events: b:$t1
+  0: $t1 := 1
+     # live vars: $t1
+     # events: b:$t3
+  1: $t3 := 1
+     # live vars: $t1, $t3
+     # events: e:$t3, b:$t2
+  2: $t2 := +($t1, $t3)
      # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: e:$t2
+  3: $t1 := move($t2)
      # live vars: $t1
      # events: b:$t4
-  2: $t4 := 1
+  4: $t4 := 2
      # live vars: $t1, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := +($t1, $t4)
-     # live vars: $t3
-     # events: e:$t3
-  4: $t1 := move($t3)
-     # live vars: $t1
-     # events: b:$t5
-  5: $t5 := 2
-     # live vars: $t1, $t5
-     # events: e:$t1, e:$t5, b:$t0
-  6: $t0 := +($t5, $t1)
+     # events: e:$t1, e:$t4, b:$t0
+  5: $t0 := +($t4, $t1)
      # live vars: $t0
      # events: e:$t0
-  7: return $t0
+  6: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -59,19 +53,17 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
-     var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64 [unused]
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 1
-  3: $t4 := +($t2, $t4)
-  4: $t2 := move($t4)
-  5: $t4 := 2
-  6: $t2 := +($t4, $t2)
-  7: return $t2
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t3 := +($t1, $t3)
+  3: $t1 := move($t3)
+  4: $t3 := 2
+  5: $t1 := +($t3, $t1)
+  6: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -8,18 +8,14 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := infer($t4)
-  4: $t6 := 1
-  5: $t5 := +($t1, $t6)
-  6: $t1 := infer($t5)
-  7: $t7 := infer($t3)
-  8: $t0 := infer($t7)
-  9: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t3 := +($t1, $t4)
+  4: $t1 := infer($t3)
+  5: $t5 := infer($t2)
+  6: $t0 := infer($t5)
+  7: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -32,17 +28,13 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := move($t2)
-  2: $t4 := 2
-  3: $t3 := move($t4)
-  4: $t6 := 1
-  5: $t5 := +($t1, $t6)
-  6: $t7 := move($t3)
-  7: $t0 := move($t7)
-  8: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t3 := +($t1, $t4)
+  4: $t5 := move($t2)
+  5: $t0 := move($t5)
+  6: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -55,35 +47,27 @@ fun m::test(): u64 {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
+     # events: b:$t2
+  1: $t2 := 2
+     # live vars: $t1, $t2
      # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-     # events: b:$t6
-  4: $t6 := 1
-     # live vars: $t1, $t3, $t6
-     # events: e:$t1, e:$t5, e:$t6, b:$t5
-  5: $t5 := +($t1, $t6)
-     # live vars: $t3
-     # events: e:$t3, b:$t7
-  6: $t7 := move($t3)
-     # live vars: $t7
-     # events: e:$t7, b:$t0
-  7: $t0 := move($t7)
+  2: $t4 := 1
+     # live vars: $t1, $t2, $t4
+     # events: e:$t1, e:$t3, e:$t4, b:$t3
+  3: $t3 := +($t1, $t4)
+     # live vars: $t2
+     # events: e:$t2, b:$t5
+  4: $t5 := move($t2)
+     # live vars: $t5
+     # events: e:$t5, b:$t0
+  5: $t0 := move($t5)
      # live vars: $t0
      # events: e:$t0
-  8: return $t0
+  6: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -91,22 +75,18 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 2
-  3: $t4 := move($t4)
-  4: $t6 := 1
-  5: $t2 := +($t2, $t6)
-  6: $t4 := move($t4)
-  7: $t4 := move($t4)
-  8: return $t4
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t1 := +($t1, $t4)
+  4: $t2 := move($t2)
+  5: $t2 := move($t2)
+  6: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -114,18 +94,16 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64 [unused]
      var $t4: u64
      var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t4 := 2
-  2: $t6 := 1
-  3: $t2 := +($t2, $t6)
-  4: return $t4
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t4 := 1
+  3: $t1 := +($t1, $t4)
+  4: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
@@ -6,14 +6,12 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 1
-  3: $t3 := +($t1, $t4)
-  4: $t1 := infer($t3)
-  5: $t0 := 2
-  6: return $t0
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t2 := +($t1, $t3)
+  3: $t1 := infer($t2)
+  4: $t0 := 2
+  5: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -24,25 +22,21 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
-     # events: b:$t4
-  2: $t4 := 1
-     # live vars: $t1, $t4
-     # events: e:$t1, e:$t3, e:$t4, b:$t3
-  3: $t3 := +($t1, $t4)
+     # events: b:$t3
+  1: $t3 := 1
+     # live vars: $t1, $t3
+     # events: e:$t1, e:$t2, e:$t3, b:$t2
+  2: $t2 := +($t1, $t3)
      # live vars:
      # events: b:$t0
-  4: $t0 := 2
+  3: $t0 := 2
      # live vars: $t0
      # events: e:$t0
-  5: return $t0
+  4: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -50,16 +44,14 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 1
-  3: $t2 := +($t2, $t4)
-  4: $t3 := 2
-  5: return $t3
+  0: $t1 := 1
+  1: $t3 := 1
+  2: $t1 := +($t1, $t3)
+  3: $t2 := 2
+  4: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -5,33 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: $t5 := 0
-  3: $t4 := infer($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t4, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t2 := infer($t0)
- 10: $t9 := 1
- 11: $t8 := +($t4, $t9)
- 12: $t4 := infer($t8)
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t1 := infer($t2)
- 20: return $t1
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -41,33 +37,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-  0: $t3 := 0
-  1: $t2 := move($t3)
-  2: $t5 := 0
-  3: $t4 := move($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t4, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t2 := copy($t0)
- 10: $t9 := 1
- 11: $t8 := +($t4, $t9)
- 12: $t4 := move($t8)
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := move($t6)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t1 := move($t2)
- 20: return $t1
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := move($t2)
+ 18: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -77,67 +69,59 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
+     # events: b:$t3
+  1: $t3 := 0
+     # live vars: $t0, $t2, $t3
+  2: label L0
+     # live vars: $t0, $t2, $t3
      # events: b:$t5
-  2: $t5 := 0
-     # live vars: $t0, $t2, $t5
+  3: $t5 := 10
+     # live vars: $t0, $t2, $t3, $t5
      # events: e:$t5, b:$t4
-  3: $t4 := move($t5)
-     # live vars: $t0, $t2, $t4
-  4: label L0
-     # live vars: $t0, $t2, $t4
+  4: $t4 := <($t3, $t5)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  5: if ($t4) goto 6 else goto 12
+     # live vars: $t0, $t2, $t3
+  6: label L2
+     # live vars: $t0, $t3
+  7: $t2 := copy($t0)
+     # live vars: $t0, $t2, $t3
      # events: b:$t7
-  5: $t7 := 10
-     # live vars: $t0, $t2, $t4, $t7
+  8: $t7 := 1
+     # live vars: $t0, $t2, $t3, $t7
      # events: e:$t7, b:$t6
-  6: $t6 := <($t4, $t7)
-     # live vars: $t0, $t2, $t4, $t6
+  9: $t6 := +($t3, $t7)
+     # live vars: $t0, $t2, $t6
      # events: e:$t6
-  7: if ($t6) goto 8 else goto 14
-     # live vars: $t0, $t2, $t4
-  8: label L2
-     # live vars: $t0, $t4
-  9: $t2 := copy($t0)
-     # live vars: $t0, $t2, $t4
-     # events: b:$t9
- 10: $t9 := 1
-     # live vars: $t0, $t2, $t4, $t9
-     # events: e:$t9, b:$t8
- 11: $t8 := +($t4, $t9)
-     # live vars: $t0, $t2, $t8
-     # events: e:$t8
- 12: $t4 := move($t8)
-     # live vars: $t0, $t2, $t4
+ 10: $t3 := move($t6)
+     # live vars: $t0, $t2, $t3
+ 11: goto 14
+     # live vars: $t0, $t2, $t3
+ 12: label L3
+     # live vars: $t2
  13: goto 16
-     # live vars: $t0, $t2, $t4
- 14: label L3
+     # live vars: $t0, $t2, $t3
+ 14: label L4
+     # live vars: $t0, $t2, $t3
+     # events: e:$t0, e:$t3
+ 15: goto 2
      # live vars: $t2
- 15: goto 18
-     # live vars: $t0, $t2, $t4
- 16: label L4
-     # live vars: $t0, $t2, $t4
-     # events: e:$t0, e:$t4
- 17: goto 4
-     # live vars: $t2
- 18: label L1
+ 16: label L1
      # live vars: $t2
      # events: e:$t2, b:$t1
- 19: $t1 := move($t2)
+ 17: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
- 20: return $t1
+ 18: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -145,35 +129,31 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64 [unused]
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
-  0: $t3 := 0
-  1: $t3 := move($t3)
-  2: $t5 := 0
-  3: $t5 := move($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t5, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t3 := copy($t0)
- 10: $t7 := 1
- 11: $t7 := +($t5, $t7)
- 12: $t5 := move($t7)
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t3 := move($t3)
- 20: return $t3
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t2 := move($t2)
+ 18: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -181,32 +161,30 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64 [unused]
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
-  0: $t3 := 0
-  1: $t5 := 0
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t2 := 0
+  1: $t3 := 0
   2: label L0
-  3: $t7 := 10
-  4: $t6 := <($t5, $t7)
-  5: if ($t6) goto 6 else goto 12
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
   6: label L2
-  7: $t3 := copy($t0)
-  8: $t7 := 1
-  9: $t7 := +($t5, $t7)
- 10: $t5 := move($t7)
+  7: $t2 := copy($t0)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
  11: goto 14
  12: label L3
  13: goto 16
  14: label L4
  15: goto 2
  16: label L1
- 17: return $t3
+ 17: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
@@ -5,33 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: $t5 := 0
-  3: $t4 := infer($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t4, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t2 := infer($t0)
- 10: $t9 := 1
- 11: $t8 := +($t4, $t9)
- 12: $t4 := infer($t8)
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t1 := infer($t2)
- 20: return $t1
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -41,67 +37,59 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
+     # events: b:$t3
+  1: $t3 := 0
+     # live vars: $t0, $t2, $t3
+  2: label L0
+     # live vars: $t0, $t2, $t3
      # events: b:$t5
-  2: $t5 := 0
-     # live vars: $t0, $t2, $t5
+  3: $t5 := 10
+     # live vars: $t0, $t2, $t3, $t5
      # events: e:$t5, b:$t4
-  3: $t4 := move($t5)
-     # live vars: $t0, $t2, $t4
-  4: label L0
-     # live vars: $t0, $t2, $t4
+  4: $t4 := <($t3, $t5)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  5: if ($t4) goto 6 else goto 12
+     # live vars: $t0, $t2, $t3
+  6: label L2
+     # live vars: $t0, $t3
+  7: $t2 := copy($t0)
+     # live vars: $t0, $t2, $t3
      # events: b:$t7
-  5: $t7 := 10
-     # live vars: $t0, $t2, $t4, $t7
+  8: $t7 := 1
+     # live vars: $t0, $t2, $t3, $t7
      # events: e:$t7, b:$t6
-  6: $t6 := <($t4, $t7)
-     # live vars: $t0, $t2, $t4, $t6
+  9: $t6 := +($t3, $t7)
+     # live vars: $t0, $t2, $t6
      # events: e:$t6
-  7: if ($t6) goto 8 else goto 14
-     # live vars: $t0, $t2, $t4
-  8: label L2
-     # live vars: $t0, $t4
-  9: $t2 := copy($t0)
-     # live vars: $t0, $t2, $t4
-     # events: b:$t9
- 10: $t9 := 1
-     # live vars: $t0, $t2, $t4, $t9
-     # events: e:$t9, b:$t8
- 11: $t8 := +($t4, $t9)
-     # live vars: $t0, $t2, $t8
-     # events: e:$t8
- 12: $t4 := move($t8)
-     # live vars: $t0, $t2, $t4
+ 10: $t3 := move($t6)
+     # live vars: $t0, $t2, $t3
+ 11: goto 14
+     # live vars: $t0, $t2, $t3
+ 12: label L3
+     # live vars: $t2
  13: goto 16
-     # live vars: $t0, $t2, $t4
- 14: label L3
+     # live vars: $t0, $t2, $t3
+ 14: label L4
+     # live vars: $t0, $t2, $t3
+     # events: e:$t0, e:$t3
+ 15: goto 2
      # live vars: $t2
- 15: goto 18
-     # live vars: $t0, $t2, $t4
- 16: label L4
-     # live vars: $t0, $t2, $t4
-     # events: e:$t0, e:$t4
- 17: goto 4
-     # live vars: $t2
- 18: label L1
+ 16: label L1
      # live vars: $t2
      # events: e:$t2, b:$t1
- 19: $t1 := move($t2)
+ 17: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
- 20: return $t1
+ 18: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -109,35 +97,31 @@ fun m::test($t0: u64): u64 {
 [variant baseline]
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64 [unused]
+     var $t4: bool
      var $t5: u64
-     var $t6: bool
-     var $t7: u64
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
-  0: $t3 := 0
-  1: $t3 := move($t3)
-  2: $t5 := 0
-  3: $t5 := move($t5)
-  4: label L0
-  5: $t7 := 10
-  6: $t6 := <($t5, $t7)
-  7: if ($t6) goto 8 else goto 14
-  8: label L2
-  9: $t3 := copy($t0)
- 10: $t7 := 1
- 11: $t7 := +($t5, $t7)
- 12: $t5 := move($t7)
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t3 := move($t3)
- 20: return $t3
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t2 := move($t2)
+ 18: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
@@ -5,31 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
   0: $t2 := infer($t0)
-  1: $t4 := 0
-  2: $t3 := infer($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t3, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := infer($t0)
-  9: $t8 := 1
- 10: $t7 := +($t3, $t8)
- 11: $t3 := infer($t7)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t1 := infer($t2)
- 19: return $t1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -39,31 +37,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
   0: $t2 := copy($t0)
-  1: $t4 := 0
-  2: $t3 := move($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t3, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := copy($t0)
-  9: $t8 := 1
- 10: $t7 := +($t3, $t8)
- 11: $t3 := move($t7)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t1 := move($t2)
- 19: return $t1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := move($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := move($t2)
+ 18: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -73,63 +69,59 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
      # live vars: $t0
      # events: b:$t0, b:$t2
   0: $t2 := copy($t0)
      # live vars: $t0, $t2
-     # events: b:$t4
-  1: $t4 := 0
-     # live vars: $t0, $t2, $t4
-     # events: e:$t4, b:$t3
-  2: $t3 := move($t4)
+     # events: b:$t3
+  1: $t3 := 0
      # live vars: $t0, $t2, $t3
-  3: label L0
+  2: label L0
      # live vars: $t0, $t2, $t3
-     # events: b:$t6
-  4: $t6 := 10
-     # live vars: $t0, $t2, $t3, $t6
-     # events: e:$t6, b:$t5
-  5: $t5 := <($t3, $t6)
+     # events: b:$t5
+  3: $t5 := 10
      # live vars: $t0, $t2, $t3, $t5
-     # events: e:$t5
-  6: if ($t5) goto 7 else goto 13
+     # events: e:$t5, b:$t4
+  4: $t4 := <($t3, $t5)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  5: if ($t4) goto 6 else goto 12
      # live vars: $t0, $t2, $t3
-  7: label L2
+  6: label L2
      # live vars: $t0, $t3
-  8: $t2 := copy($t0)
+  7: $t2 := copy($t0)
      # live vars: $t0, $t2, $t3
-     # events: b:$t8
-  9: $t8 := 1
-     # live vars: $t0, $t2, $t3, $t8
-     # events: e:$t8, b:$t7
- 10: $t7 := +($t3, $t8)
-     # live vars: $t0, $t2, $t7
-     # events: e:$t7
- 11: $t3 := move($t7)
+     # events: b:$t7
+  8: $t7 := 1
+     # live vars: $t0, $t2, $t3, $t7
+     # events: e:$t7, b:$t6
+  9: $t6 := +($t3, $t7)
+     # live vars: $t0, $t2, $t6
+     # events: e:$t6
+ 10: $t3 := move($t6)
      # live vars: $t0, $t2, $t3
- 12: goto 15
+ 11: goto 14
      # live vars: $t0, $t2, $t3
- 13: label L3
+ 12: label L3
      # live vars: $t2
- 14: goto 17
+ 13: goto 16
      # live vars: $t0, $t2, $t3
- 15: label L4
+ 14: label L4
      # live vars: $t0, $t2, $t3
      # events: e:$t0, e:$t3
- 16: goto 3
+ 15: goto 2
      # live vars: $t2
- 17: label L1
+ 16: label L1
      # live vars: $t2
      # events: e:$t2, b:$t1
- 18: $t1 := move($t2)
+ 17: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
- 19: return $t1
+ 18: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -138,32 +130,30 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
-     var $t6: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64 [unused]
      var $t7: u64 [unused]
-     var $t8: u64 [unused]
   0: $t2 := copy($t0)
-  1: $t4 := 0
-  2: $t4 := move($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t4, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := copy($t0)
-  9: $t6 := 1
- 10: $t6 := +($t4, $t6)
- 11: $t4 := move($t6)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t2 := move($t2)
- 19: return $t2
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t2 := move($t2)
+ 18: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -172,23 +162,22 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
-     var $t6: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64 [unused]
      var $t7: u64 [unused]
-     var $t8: u64 [unused]
   0: $t2 := copy($t0)
-  1: $t4 := 0
+  1: $t3 := 0
   2: label L0
-  3: $t6 := 10
-  4: $t5 := <($t4, $t6)
-  5: if ($t5) goto 6 else goto 12
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
   6: label L2
   7: $t2 := copy($t0)
-  8: $t6 := 1
-  9: $t6 := +($t4, $t6)
- 10: $t4 := move($t6)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
  11: goto 14
  12: label L3
  13: goto 16

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
@@ -5,31 +5,29 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
   0: $t2 := infer($t0)
-  1: $t4 := 0
-  2: $t3 := infer($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t3, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := infer($t0)
-  9: $t8 := 1
- 10: $t7 := +($t3, $t8)
- 11: $t3 := infer($t7)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t1 := infer($t2)
- 19: return $t1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t0)
+  8: $t7 := 1
+  9: $t6 := +($t3, $t7)
+ 10: $t3 := infer($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t1 := infer($t2)
+ 18: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -39,63 +37,59 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
      # live vars: $t0
      # events: b:$t0, b:$t2
   0: $t2 := copy($t0)
      # live vars: $t0, $t2
-     # events: b:$t4
-  1: $t4 := 0
-     # live vars: $t0, $t2, $t4
-     # events: e:$t4, b:$t3
-  2: $t3 := move($t4)
+     # events: b:$t3
+  1: $t3 := 0
      # live vars: $t0, $t2, $t3
-  3: label L0
+  2: label L0
      # live vars: $t0, $t2, $t3
-     # events: b:$t6
-  4: $t6 := 10
-     # live vars: $t0, $t2, $t3, $t6
-     # events: e:$t6, b:$t5
-  5: $t5 := <($t3, $t6)
+     # events: b:$t5
+  3: $t5 := 10
      # live vars: $t0, $t2, $t3, $t5
-     # events: e:$t5
-  6: if ($t5) goto 7 else goto 13
+     # events: e:$t5, b:$t4
+  4: $t4 := <($t3, $t5)
+     # live vars: $t0, $t2, $t3, $t4
+     # events: e:$t4
+  5: if ($t4) goto 6 else goto 12
      # live vars: $t0, $t2, $t3
-  7: label L2
+  6: label L2
      # live vars: $t0, $t3
-  8: $t2 := copy($t0)
+  7: $t2 := copy($t0)
      # live vars: $t0, $t2, $t3
-     # events: b:$t8
-  9: $t8 := 1
-     # live vars: $t0, $t2, $t3, $t8
-     # events: e:$t8, b:$t7
- 10: $t7 := +($t3, $t8)
-     # live vars: $t0, $t2, $t7
-     # events: e:$t7
- 11: $t3 := move($t7)
+     # events: b:$t7
+  8: $t7 := 1
+     # live vars: $t0, $t2, $t3, $t7
+     # events: e:$t7, b:$t6
+  9: $t6 := +($t3, $t7)
+     # live vars: $t0, $t2, $t6
+     # events: e:$t6
+ 10: $t3 := move($t6)
      # live vars: $t0, $t2, $t3
- 12: goto 15
+ 11: goto 14
      # live vars: $t0, $t2, $t3
- 13: label L3
+ 12: label L3
      # live vars: $t2
- 14: goto 17
+ 13: goto 16
      # live vars: $t0, $t2, $t3
- 15: label L4
+ 14: label L4
      # live vars: $t0, $t2, $t3
      # events: e:$t0, e:$t3
- 16: goto 3
+ 15: goto 2
      # live vars: $t2
- 17: label L1
+ 16: label L1
      # live vars: $t2
      # events: e:$t2, b:$t1
- 18: $t1 := move($t2)
+ 17: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
- 19: return $t1
+ 18: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -104,32 +98,30 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: bool
-     var $t6: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64 [unused]
      var $t7: u64 [unused]
-     var $t8: u64 [unused]
   0: $t2 := copy($t0)
-  1: $t4 := 0
-  2: $t4 := move($t4)
-  3: label L0
-  4: $t6 := 10
-  5: $t5 := <($t4, $t6)
-  6: if ($t5) goto 7 else goto 13
-  7: label L2
-  8: $t2 := copy($t0)
-  9: $t6 := 1
- 10: $t6 := +($t4, $t6)
- 11: $t4 := move($t6)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 3
- 17: label L1
- 18: $t2 := move($t2)
- 19: return $t2
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := 10
+  4: $t4 := <($t3, $t5)
+  5: if ($t4) goto 6 else goto 12
+  6: label L2
+  7: $t2 := copy($t0)
+  8: $t5 := 1
+  9: $t5 := +($t3, $t5)
+ 10: $t3 := move($t5)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t2 := move($t2)
+ 18: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
@@ -5,13 +5,11 @@ fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t3 := 2
-  3: $t1 := infer($t3)
-  4: $t0 := infer($t1)
-  5: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t1 := infer($t2)
+  3: $t0 := infer($t1)
+  4: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -20,10 +18,9 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
-     var $t3: u64
-  0: $t3 := 2
-  1: $t1 := move($t3)
+     var $t2: u64
+  0: $t2 := 2
+  1: $t1 := move($t2)
   2: $t0 := move($t1)
   3: return $t0
 }
@@ -34,14 +31,13 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
-     var $t3: u64
+     var $t2: u64
      # live vars:
-     # events: b:$t3
-  0: $t3 := 2
-     # live vars: $t3
-     # events: e:$t3, b:$t1
-  1: $t1 := move($t3)
+     # events: b:$t2
+  0: $t2 := 2
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1, b:$t0
   2: $t0 := move($t1)
@@ -56,12 +52,11 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-  0: $t3 := 2
-  1: $t3 := move($t3)
-  2: $t3 := move($t3)
-  3: return $t3
+     var $t2: u64
+  0: $t2 := 2
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -70,10 +65,9 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-  0: $t3 := 2
-  1: return $t3
+     var $t2: u64
+  0: $t2 := 2
+  1: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
@@ -5,13 +5,11 @@ fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t3 := 2
-  3: $t1 := infer($t3)
-  4: $t0 := infer($t1)
-  5: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t1 := infer($t2)
+  3: $t0 := infer($t1)
+  4: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -20,14 +18,13 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
-     var $t3: u64
+     var $t2: u64
      # live vars:
-     # events: b:$t3
-  0: $t3 := 2
-     # live vars: $t3
-     # events: e:$t3, b:$t1
-  1: $t1 := move($t3)
+     # events: b:$t2
+  0: $t2 := 2
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1, b:$t0
   2: $t0 := move($t1)
@@ -42,12 +39,11 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-  0: $t3 := 2
-  1: $t3 := move($t3)
-  2: $t3 := move($t3)
-  3: return $t3
+     var $t2: u64
+  0: $t2 := 2
+  1: $t2 := move($t2)
+  2: $t2 := move($t2)
+  3: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -5,15 +5,13 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
   0: $t2 := infer($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t3 := infer($t4)
-  3: $t5 := 1
-  4: write_ref($t3, $t5)
-  5: $t1 := infer($t2)
-  6: return $t1
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t1 := infer($t2)
+  5: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -23,15 +21,13 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
   0: $t2 := copy($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t3 := move($t4)
-  3: $t5 := 1
-  4: write_ref($t3, $t5)
-  5: $t1 := move($t2)
-  6: return $t1
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t1 := move($t2)
+  5: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -41,29 +37,25 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
      # live vars: $t0
      # events: b:$t2
   0: $t2 := copy($t0)
      # live vars: $t0, $t2
-     # events: b:$t4
-  1: $t4 := borrow_local($t0)
-     # live vars: $t2, $t4
-     # events: e:$t4, b:$t3
-  2: $t3 := move($t4)
+     # events: b:$t3
+  1: $t3 := borrow_local($t0)
      # live vars: $t2, $t3
-     # events: b:$t5
-  3: $t5 := 1
-     # live vars: $t2, $t3, $t5
-     # events: e:$t3, e:$t5
-  4: write_ref($t3, $t5)
+     # events: b:$t4
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+     # events: e:$t3, e:$t4
+  3: write_ref($t3, $t4)
      # live vars: $t2
      # events: e:$t2, b:$t1
-  5: $t1 := move($t2)
+  4: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
-  6: return $t1
+  5: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -72,16 +64,14 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: &mut u64 [unused]
-     var $t4: &mut u64
-     var $t5: u64
+     var $t3: &mut u64
+     var $t4: u64
   0: $t2 := copy($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t4 := move($t4)
-  3: $t5 := 1
-  4: write_ref($t4, $t5)
-  5: $t2 := move($t2)
-  6: return $t2
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t2 := move($t2)
+  5: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -90,13 +80,12 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: &mut u64 [unused]
-     var $t4: &mut u64
-     var $t5: u64
+     var $t3: &mut u64
+     var $t4: u64
   0: $t2 := copy($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t5 := 1
-  3: write_ref($t4, $t5)
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
   4: return $t2
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
@@ -5,15 +5,13 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
   0: $t2 := infer($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t3 := infer($t4)
-  3: $t5 := 1
-  4: write_ref($t3, $t5)
-  5: $t1 := infer($t2)
-  6: return $t1
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t1 := infer($t2)
+  5: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -23,29 +21,25 @@ fun m::test($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: &mut u64
-     var $t4: &mut u64
-     var $t5: u64
+     var $t4: u64
      # live vars: $t0
      # events: b:$t2
   0: $t2 := copy($t0)
      # live vars: $t0, $t2
-     # events: b:$t4
-  1: $t4 := borrow_local($t0)
-     # live vars: $t2, $t4
-     # events: e:$t4, b:$t3
-  2: $t3 := move($t4)
+     # events: b:$t3
+  1: $t3 := borrow_local($t0)
      # live vars: $t2, $t3
-     # events: b:$t5
-  3: $t5 := 1
-     # live vars: $t2, $t3, $t5
-     # events: e:$t3, e:$t5
-  4: write_ref($t3, $t5)
+     # events: b:$t4
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+     # events: e:$t3, e:$t4
+  3: write_ref($t3, $t4)
      # live vars: $t2
      # events: e:$t2, b:$t1
-  5: $t1 := move($t2)
+  4: $t1 := move($t2)
      # live vars: $t1
      # events: e:$t1
-  6: return $t1
+  5: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -54,16 +48,14 @@ fun m::test($t0: u64): u64 {
 fun m::test($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: &mut u64 [unused]
-     var $t4: &mut u64
-     var $t5: u64
+     var $t3: &mut u64
+     var $t4: u64
   0: $t2 := copy($t0)
-  1: $t4 := borrow_local($t0)
-  2: $t4 := move($t4)
-  3: $t5 := 1
-  4: write_ref($t4, $t5)
-  5: $t2 := move($t2)
-  6: return $t2
+  1: $t3 := borrow_local($t0)
+  2: $t4 := 1
+  3: write_ref($t3, $t4)
+  4: $t2 := move($t2)
+  5: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -6,22 +6,20 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := infer($t0)
   1: $t3 := infer($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t4 := infer($t5)
-  5: $t7 := 0
-  6: write_ref($t4, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t1 := read_ref($t9)
- 10: return $t1
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t1 := read_ref($t8)
+  9: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -32,22 +30,20 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := move($t0)
   1: $t3 := copy($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t4 := move($t5)
-  5: $t7 := 0
-  6: write_ref($t4, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t1 := read_ref($t9)
- 10: return $t1
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t1 := read_ref($t8)
+  9: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -58,43 +54,39 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
      # live vars: $t0
      # events: b:$t0, e:$t0
   0: $t2 := move($t0)
      # live vars: $t2
   1: $t3 := copy($t2)
      # live vars: $t2, $t3
-     # events: b:$t6
-  2: $t6 := borrow_local($t2)
-     # live vars: $t3, $t6
-     # events: e:$t6, b:$t5
-  3: $t5 := borrow_field<m::S>.a($t6)
+     # events: b:$t5
+  2: $t5 := borrow_local($t2)
      # live vars: $t3, $t5
      # events: e:$t5, b:$t4
-  4: $t4 := move($t5)
+  3: $t4 := borrow_field<m::S>.a($t5)
      # live vars: $t3, $t4
-     # events: b:$t7
-  5: $t7 := 0
-     # live vars: $t3, $t4, $t7
-     # events: e:$t4, e:$t7
-  6: write_ref($t4, $t7)
+     # events: b:$t6
+  4: $t6 := 0
+     # live vars: $t3, $t4, $t6
+     # events: e:$t4, e:$t6
+  5: write_ref($t4, $t6)
      # live vars: $t3
-     # events: b:$t8
-  7: $t8 := borrow_local($t3)
+     # events: b:$t7
+  6: $t7 := borrow_local($t3)
+     # live vars: $t7
+     # events: e:$t7, b:$t8
+  7: $t8 := borrow_field<m::S>.a($t7)
      # live vars: $t8
-     # events: e:$t8, b:$t9
-  8: $t9 := borrow_field<m::S>.a($t8)
-     # live vars: $t9
-     # events: e:$t9, b:$t1
-  9: $t1 := read_ref($t9)
+     # events: e:$t8, b:$t1
+  8: $t1 := read_ref($t8)
      # live vars: $t1
      # events: e:$t1
- 10: return $t1
+  9: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -104,23 +96,21 @@ fun m::test($t0: m::S): u64 {
      var $t1: u64 [unused]
      var $t2: m::S
      var $t3: m::S
-     var $t4: &mut u64 [unused]
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t4: &mut u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := move($t0)
   1: $t3 := copy($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t5 := move($t5)
-  5: $t7 := 0
-  6: write_ref($t5, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t7 := read_ref($t9)
- 10: return $t7
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t6 := read_ref($t8)
+  9: return $t6
 }
 
 ============ after DeadStoreElimination: ================
@@ -130,22 +120,21 @@ fun m::test($t0: m::S): u64 {
      var $t1: u64 [unused]
      var $t2: m::S
      var $t3: m::S
-     var $t4: &mut u64 [unused]
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t4: &mut u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := move($t0)
   1: $t3 := copy($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t7 := 0
-  5: write_ref($t5, $t7)
-  6: $t8 := borrow_local($t3)
-  7: $t9 := borrow_field<m::S>.a($t8)
-  8: $t7 := read_ref($t9)
-  9: return $t7
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t6 := read_ref($t8)
+  9: return $t6
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
@@ -6,22 +6,20 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := infer($t0)
   1: $t3 := infer($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t4 := infer($t5)
-  5: $t7 := 0
-  6: write_ref($t4, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t1 := read_ref($t9)
- 10: return $t1
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t1 := read_ref($t8)
+  9: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -32,43 +30,39 @@ fun m::test($t0: m::S): u64 {
      var $t2: m::S
      var $t3: m::S
      var $t4: &mut u64
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
      # live vars: $t0
      # events: b:$t0, e:$t0
   0: $t2 := move($t0)
      # live vars: $t2
   1: $t3 := copy($t2)
      # live vars: $t2, $t3
-     # events: b:$t6
-  2: $t6 := borrow_local($t2)
-     # live vars: $t3, $t6
-     # events: e:$t6, b:$t5
-  3: $t5 := borrow_field<m::S>.a($t6)
+     # events: b:$t5
+  2: $t5 := borrow_local($t2)
      # live vars: $t3, $t5
      # events: e:$t5, b:$t4
-  4: $t4 := move($t5)
+  3: $t4 := borrow_field<m::S>.a($t5)
      # live vars: $t3, $t4
-     # events: b:$t7
-  5: $t7 := 0
-     # live vars: $t3, $t4, $t7
-     # events: e:$t4, e:$t7
-  6: write_ref($t4, $t7)
+     # events: b:$t6
+  4: $t6 := 0
+     # live vars: $t3, $t4, $t6
+     # events: e:$t4, e:$t6
+  5: write_ref($t4, $t6)
      # live vars: $t3
-     # events: b:$t8
-  7: $t8 := borrow_local($t3)
+     # events: b:$t7
+  6: $t7 := borrow_local($t3)
+     # live vars: $t7
+     # events: e:$t7, b:$t8
+  7: $t8 := borrow_field<m::S>.a($t7)
      # live vars: $t8
-     # events: e:$t8, b:$t9
-  8: $t9 := borrow_field<m::S>.a($t8)
-     # live vars: $t9
-     # events: e:$t9, b:$t1
-  9: $t1 := read_ref($t9)
+     # events: e:$t8, b:$t1
+  8: $t1 := read_ref($t8)
      # live vars: $t1
      # events: e:$t1
- 10: return $t1
+  9: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -78,23 +72,21 @@ fun m::test($t0: m::S): u64 {
      var $t1: u64 [unused]
      var $t2: m::S
      var $t3: m::S
-     var $t4: &mut u64 [unused]
-     var $t5: &mut u64
-     var $t6: &mut m::S
-     var $t7: u64
-     var $t8: &m::S
-     var $t9: &u64
+     var $t4: &mut u64
+     var $t5: &mut m::S
+     var $t6: u64
+     var $t7: &m::S
+     var $t8: &u64
   0: $t2 := move($t0)
   1: $t3 := copy($t2)
-  2: $t6 := borrow_local($t2)
-  3: $t5 := borrow_field<m::S>.a($t6)
-  4: $t5 := move($t5)
-  5: $t7 := 0
-  6: write_ref($t5, $t7)
-  7: $t8 := borrow_local($t3)
-  8: $t9 := borrow_field<m::S>.a($t8)
-  9: $t7 := read_ref($t9)
- 10: return $t7
+  2: $t5 := borrow_local($t2)
+  3: $t4 := borrow_field<m::S>.a($t5)
+  4: $t6 := 0
+  5: write_ref($t4, $t6)
+  6: $t7 := borrow_local($t3)
+  7: $t8 := borrow_field<m::S>.a($t7)
+  8: $t6 := read_ref($t8)
+  9: return $t6
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -8,19 +8,15 @@ fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t0 := infer($t2)
-  5: $t5 := 2
-  6: $t4 := infer($t5)
-  7: $t7 := 1
-  8: $t6 := +($t4, $t7)
-  9: $t4 := infer($t6)
- 10: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t0 := infer($t1)
+  4: $t3 := 2
+  5: $t5 := 1
+  6: $t4 := +($t3, $t5)
+  7: $t3 := infer($t4)
+  8: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -33,17 +29,13 @@ fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := move($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t5 := 2
-  5: $t4 := move($t5)
-  6: $t7 := 1
-  7: $t6 := +($t4, $t7)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t3 := 2
+  4: $t5 := 1
+  5: $t4 := +($t3, $t5)
+  6: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -56,77 +48,63 @@ fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t1
-  0: $t1 := 1
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+     # events: b:$t0
+  0: $t0 := 1
      # live vars: $t0
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t0, $t2
+     # events: e:$t0, e:$t1, e:$t2, b:$t1
+  2: $t1 := +($t0, $t2)
+     # live vars:
      # events: b:$t3
-  2: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t0, e:$t2, e:$t3, b:$t2
-  3: $t2 := +($t0, $t3)
-     # live vars:
+  3: $t3 := 2
+     # live vars: $t3
      # events: b:$t5
-  4: $t5 := 2
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  5: $t4 := move($t5)
-     # live vars: $t4
-     # events: b:$t7
-  6: $t7 := 1
-     # live vars: $t4, $t7
-     # events: e:$t4, e:$t6, e:$t7, b:$t6
-  7: $t6 := +($t4, $t7)
+  4: $t5 := 1
+     # live vars: $t3, $t5
+     # events: e:$t3, e:$t4, e:$t5, b:$t4
+  5: $t4 := +($t3, $t5)
      # live vars:
-  8: return ()
+  6: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u64 [unused]
+     var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 1
-  1: $t1 := move($t1)
-  2: $t3 := 1
-  3: $t1 := +($t1, $t3)
-  4: $t2 := 2
-  5: $t2 := move($t2)
-  6: $t3 := 1
-  7: $t2 := +($t2, $t3)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t1 := 2
+  4: $t2 := 1
+  5: $t1 := +($t1, $t2)
+  6: return ()
 }
 
 ============ after DeadStoreElimination: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u64 [unused]
+     var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 1
-  1: $t3 := 1
-  2: $t1 := +($t1, $t3)
-  3: $t2 := 2
-  4: $t3 := 1
-  5: $t2 := +($t2, $t3)
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t1 := 2
+  4: $t2 := 1
+  5: $t1 := +($t1, $t2)
   6: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
@@ -8,19 +8,15 @@ fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t0 := infer($t2)
-  5: $t5 := 2
-  6: $t4 := infer($t5)
-  7: $t7 := 1
-  8: $t6 := +($t4, $t7)
-  9: $t4 := infer($t6)
- 10: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t0 := infer($t1)
+  4: $t3 := 2
+  5: $t5 := 1
+  6: $t4 := +($t3, $t5)
+  7: $t3 := infer($t4)
+  8: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -33,57 +29,45 @@ fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t1
-  0: $t1 := 1
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+     # events: b:$t0
+  0: $t0 := 1
      # live vars: $t0
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t0, $t2
+     # events: e:$t0, e:$t1, e:$t2, b:$t1
+  2: $t1 := +($t0, $t2)
+     # live vars:
      # events: b:$t3
-  2: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t0, e:$t2, e:$t3, b:$t2
-  3: $t2 := +($t0, $t3)
-     # live vars:
+  3: $t3 := 2
+     # live vars: $t3
      # events: b:$t5
-  4: $t5 := 2
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  5: $t4 := move($t5)
-     # live vars: $t4
-     # events: b:$t7
-  6: $t7 := 1
-     # live vars: $t4, $t7
-     # events: e:$t4, e:$t6, e:$t7, b:$t6
-  7: $t6 := +($t4, $t7)
+  4: $t5 := 1
+     # live vars: $t3, $t5
+     # events: e:$t3, e:$t4, e:$t5, b:$t4
+  5: $t4 := +($t3, $t5)
      # live vars:
-  8: return ()
+  6: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u64 [unused]
+     var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64 [unused]
      var $t5: u64 [unused]
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t1 := 1
-  1: $t1 := move($t1)
-  2: $t3 := 1
-  3: $t1 := +($t1, $t3)
-  4: $t2 := 2
-  5: $t2 := move($t2)
-  6: $t3 := 1
-  7: $t2 := +($t2, $t3)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t1 := 2
+  4: $t2 := 1
+  5: $t1 := +($t1, $t2)
+  6: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -5,22 +5,18 @@ fun m::test() {
      var $t0: u32
      var $t1: u32
      var $t2: u32
-     var $t3: u32
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t0 := infer($t2)
-  5: $t5 := 2
-  6: $t4 := infer($t5)
-  7: $t7 := 1
-  8: $t6 := +($t4, $t7)
-  9: $t4 := infer($t6)
- 10: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t0 := infer($t1)
+  4: $t3 := 2
+  5: $t5 := 1
+  6: $t4 := +($t3, $t5)
+  7: $t3 := infer($t4)
+  8: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -30,20 +26,16 @@ fun m::test() {
      var $t0: u32
      var $t1: u32
      var $t2: u32
-     var $t3: u32
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := move($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t5 := 2
-  5: $t4 := move($t5)
-  6: $t7 := 1
-  7: $t6 := +($t4, $t7)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t3 := 2
+  4: $t5 := 1
+  5: $t4 := +($t3, $t5)
+  6: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -53,80 +45,66 @@ fun m::test() {
      var $t0: u32
      var $t1: u32
      var $t2: u32
-     var $t3: u32
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t1
-  0: $t1 := 1
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+     # events: b:$t0
+  0: $t0 := 1
      # live vars: $t0
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t0, $t2
+     # events: e:$t0, e:$t1, e:$t2, b:$t1
+  2: $t1 := +($t0, $t2)
+     # live vars:
      # events: b:$t3
-  2: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t0, e:$t2, e:$t3, b:$t2
-  3: $t2 := +($t0, $t3)
-     # live vars:
+  3: $t3 := 2
+     # live vars: $t3
      # events: b:$t5
-  4: $t5 := 2
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  5: $t4 := move($t5)
-     # live vars: $t4
-     # events: b:$t7
-  6: $t7 := 1
-     # live vars: $t4, $t7
-     # events: e:$t4, e:$t6, e:$t7, b:$t6
-  7: $t6 := +($t4, $t7)
+  4: $t5 := 1
+     # live vars: $t3, $t5
+     # events: e:$t3, e:$t4, e:$t5, b:$t4
+  5: $t4 := +($t3, $t5)
      # live vars:
-  8: return ()
+  6: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u32 [unused]
-     var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
+     var $t0: u32
+     var $t1: u32 [unused]
+     var $t2: u32
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64
-  0: $t1 := 1
-  1: $t1 := move($t1)
-  2: $t3 := 1
-  3: $t1 := +($t1, $t3)
-  4: $t5 := 2
-  5: $t5 := move($t5)
-  6: $t7 := 1
-  7: $t5 := +($t5, $t7)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t3 := 2
+  4: $t5 := 1
+  5: $t3 := +($t3, $t5)
+  6: return ()
 }
 
 ============ after DeadStoreElimination: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u32 [unused]
-     var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
+     var $t0: u32
+     var $t1: u32 [unused]
+     var $t2: u32
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64
-  0: $t1 := 1
-  1: $t3 := 1
-  2: $t1 := +($t1, $t3)
-  3: $t5 := 2
-  4: $t7 := 1
-  5: $t5 := +($t5, $t7)
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t3 := 2
+  4: $t5 := 1
+  5: $t3 := +($t3, $t5)
   6: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
@@ -5,22 +5,18 @@ fun m::test() {
      var $t0: u32
      var $t1: u32
      var $t2: u32
-     var $t3: u32
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := 1
-  3: $t2 := +($t0, $t3)
-  4: $t0 := infer($t2)
-  5: $t5 := 2
-  6: $t4 := infer($t5)
-  7: $t7 := 1
-  8: $t6 := +($t4, $t7)
-  9: $t4 := infer($t6)
- 10: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t1 := +($t0, $t2)
+  3: $t0 := infer($t1)
+  4: $t3 := 2
+  5: $t5 := 1
+  6: $t4 := +($t3, $t5)
+  7: $t3 := infer($t4)
+  8: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -30,60 +26,48 @@ fun m::test() {
      var $t0: u32
      var $t1: u32
      var $t2: u32
-     var $t3: u32
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t1
-  0: $t1 := 1
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+     # events: b:$t0
+  0: $t0 := 1
      # live vars: $t0
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t0, $t2
+     # events: e:$t0, e:$t1, e:$t2, b:$t1
+  2: $t1 := +($t0, $t2)
+     # live vars:
      # events: b:$t3
-  2: $t3 := 1
-     # live vars: $t0, $t3
-     # events: e:$t0, e:$t2, e:$t3, b:$t2
-  3: $t2 := +($t0, $t3)
-     # live vars:
+  3: $t3 := 2
+     # live vars: $t3
      # events: b:$t5
-  4: $t5 := 2
-     # live vars: $t5
-     # events: e:$t5, b:$t4
-  5: $t4 := move($t5)
-     # live vars: $t4
-     # events: b:$t7
-  6: $t7 := 1
-     # live vars: $t4, $t7
-     # events: e:$t4, e:$t6, e:$t7, b:$t6
-  7: $t6 := +($t4, $t7)
+  4: $t5 := 1
+     # live vars: $t3, $t5
+     # events: e:$t3, e:$t4, e:$t5, b:$t4
+  5: $t4 := +($t3, $t5)
      # live vars:
-  8: return ()
+  6: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 fun m::test() {
-     var $t0: u32 [unused]
-     var $t1: u32
-     var $t2: u32 [unused]
-     var $t3: u32
+     var $t0: u32
+     var $t1: u32 [unused]
+     var $t2: u32
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64
-  0: $t1 := 1
-  1: $t1 := move($t1)
-  2: $t3 := 1
-  3: $t1 := +($t1, $t3)
-  4: $t5 := 2
-  5: $t5 := move($t5)
-  6: $t7 := 1
-  7: $t5 := +($t5, $t7)
-  8: return ()
+  0: $t0 := 1
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: $t3 := 2
+  4: $t5 := 1
+  5: $t3 := +($t3, $t5)
+  6: return ()
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -7,18 +7,12 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := infer($t4)
-  4: $t6 := 3
-  5: $t5 := infer($t6)
-  6: $t7 := +($t1, $t3)
-  7: $t0 := +($t7, $t5)
-  8: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t4 := +($t1, $t2)
+  4: $t0 := +($t4, $t3)
+  5: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -30,18 +24,12 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
-  0: $t2 := 1
-  1: $t1 := move($t2)
-  2: $t4 := 2
-  3: $t3 := move($t4)
-  4: $t6 := 3
-  5: $t5 := move($t6)
-  6: $t7 := +($t1, $t3)
-  7: $t0 := +($t7, $t5)
-  8: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t4 := +($t1, $t2)
+  4: $t0 := +($t4, $t3)
+  5: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -53,36 +41,24 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     var $t5: u64
-     var $t6: u64
-     var $t7: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 1
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 1
      # live vars: $t1
-     # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
-     # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-     # events: b:$t6
-  4: $t6 := 3
-     # live vars: $t1, $t3, $t6
-     # events: e:$t6, b:$t5
-  5: $t5 := move($t6)
-     # live vars: $t1, $t3, $t5
-     # events: e:$t1, e:$t3, b:$t7
-  6: $t7 := +($t1, $t3)
-     # live vars: $t5, $t7
-     # events: e:$t5, e:$t7, b:$t0
-  7: $t0 := +($t7, $t5)
+     # events: b:$t2
+  1: $t2 := 2
+     # live vars: $t1, $t2
+     # events: b:$t3
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+     # events: e:$t1, e:$t2, b:$t4
+  3: $t4 := +($t1, $t2)
+     # live vars: $t3, $t4
+     # events: e:$t3, e:$t4, b:$t0
+  4: $t0 := +($t4, $t3)
      # live vars: $t0
      # events: e:$t0
-  8: return $t0
+  5: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -90,22 +66,16 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t2 := move($t2)
-  2: $t4 := 2
-  3: $t4 := move($t4)
-  4: $t6 := 3
-  5: $t6 := move($t6)
-  6: $t2 := +($t2, $t4)
-  7: $t2 := +($t2, $t6)
-  8: return $t2
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t1 := +($t1, $t2)
+  4: $t1 := +($t1, $t3)
+  5: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -113,19 +83,16 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64 [unused]
-     var $t6: u64
-     var $t7: u64 [unused]
-  0: $t2 := 1
-  1: $t4 := 2
-  2: $t6 := 3
-  3: $t2 := +($t2, $t4)
-  4: $t2 := +($t2, $t6)
-  5: return $t2
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t1 := +($t1, $t2)
+  4: $t1 := +($t1, $t3)
+  5: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -6,16 +6,12 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t4 := 2
-  3: $t3 := infer($t4)
-  4: $t5 := 9
-  5: $t1 := infer($t5)
-  6: $t0 := +($t1, $t3)
-  7: return $t0
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 9
+  3: $t1 := infer($t3)
+  4: $t0 := +($t1, $t2)
+  5: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -24,16 +20,13 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t4 := 2
-  1: $t3 := move($t4)
-  2: $t5 := 9
-  3: $t1 := move($t5)
-  4: $t0 := +($t1, $t3)
-  5: return $t0
+  0: $t2 := 2
+  1: $t3 := 9
+  2: $t1 := move($t3)
+  3: $t0 := +($t1, $t2)
+  4: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -42,28 +35,23 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: u64
      # live vars:
-     # events: b:$t4
-  0: $t4 := 2
-     # live vars: $t4
-     # events: e:$t4, b:$t3
-  1: $t3 := move($t4)
-     # live vars: $t3
-     # events: b:$t5
-  2: $t5 := 9
-     # live vars: $t3, $t5
-     # events: e:$t5, b:$t1
-  3: $t1 := move($t5)
-     # live vars: $t1, $t3
-     # events: e:$t1, e:$t3, b:$t0
-  4: $t0 := +($t1, $t3)
+     # events: b:$t2
+  0: $t2 := 2
+     # live vars: $t2
+     # events: b:$t3
+  1: $t3 := 9
+     # live vars: $t2, $t3
+     # events: e:$t3, b:$t1
+  2: $t1 := move($t3)
+     # live vars: $t1, $t2
+     # events: e:$t1, e:$t2, b:$t0
+  3: $t0 := +($t1, $t2)
      # live vars: $t0
      # events: e:$t0
-  5: return $t0
+  4: return $t0
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -72,16 +60,13 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64
-  0: $t4 := 2
-  1: $t4 := move($t4)
-  2: $t5 := 9
-  3: $t5 := move($t5)
-  4: $t4 := +($t5, $t4)
-  5: return $t4
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 2
+  1: $t3 := 9
+  2: $t3 := move($t3)
+  3: $t2 := +($t3, $t2)
+  4: return $t2
 }
 
 ============ after DeadStoreElimination: ================
@@ -90,14 +75,12 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64 [unused]
-     var $t4: u64
-     var $t5: u64
-  0: $t4 := 2
-  1: $t5 := 9
-  2: $t4 := +($t5, $t4)
-  3: return $t4
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 2
+  1: $t3 := 9
+  2: $t2 := +($t3, $t2)
+  3: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
@@ -6,14 +6,12 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t2 := 1
-  1: $t1 := infer($t2)
-  2: $t3 := 9
-  3: $t1 := infer($t3)
-  4: $t4 := 2
-  5: $t0 := +($t1, $t4)
-  6: return $t0
+  0: $t1 := 1
+  1: $t2 := 9
+  2: $t1 := infer($t2)
+  3: $t3 := 2
+  4: $t0 := +($t1, $t3)
+  5: return $t0
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -22,21 +20,20 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
      # live vars:
-     # events: b:$t3
-  0: $t3 := 9
-     # live vars: $t3
-     # events: e:$t3, b:$t1
-  1: $t1 := move($t3)
+     # events: b:$t2
+  0: $t2 := 9
+     # live vars: $t2
+     # events: e:$t2, b:$t1
+  1: $t1 := move($t2)
      # live vars: $t1
-     # events: b:$t4
-  2: $t4 := 2
-     # live vars: $t1, $t4
-     # events: e:$t1, e:$t4, b:$t0
-  3: $t0 := +($t1, $t4)
+     # events: b:$t3
+  2: $t3 := 2
+     # live vars: $t1, $t3
+     # events: e:$t1, e:$t3, b:$t0
+  3: $t0 := +($t1, $t3)
      # live vars: $t0
      # events: e:$t0
   4: return $t0
@@ -48,14 +45,13 @@ fun m::test(): u64 {
 fun m::test(): u64 {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-  0: $t3 := 9
-  1: $t3 := move($t3)
-  2: $t4 := 2
-  3: $t3 := +($t3, $t4)
-  4: return $t3
+  0: $t2 := 9
+  1: $t2 := move($t2)
+  2: $t3 := 2
+  3: $t2 := +($t2, $t3)
+  4: return $t2
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -21,33 +21,29 @@ public fun m::test3(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: u64
-  0: $t2 := 0
-  1: $t1 := infer($t2)
-  2: $t4 := 1
-  3: $t3 := infer($t4)
-  4: label L0
-  5: $t6 := 42
-  6: $t5 := <($t1, $t6)
-  7: if ($t5) goto 8 else goto 14
-  8: label L2
-  9: $t3 := infer($t3)
- 10: $t8 := 1
- 11: $t7 := +($t1, $t8)
- 12: $t1 := infer($t7)
+  0: $t1 := 0
+  1: $t2 := 1
+  2: label L0
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t2)
+  8: $t6 := 1
+  9: $t5 := +($t1, $t6)
+ 10: $t1 := infer($t5)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t0 := infer($t3)
- 20: return $t0
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t0 := infer($t2)
+ 18: return $t0
 }
 
 
@@ -55,30 +51,28 @@ public fun m::test3(): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: label L0
-  3: $t5 := 42
-  4: $t4 := <($t2, $t5)
-  5: if ($t4) goto 6 else goto 12
-  6: label L2
-  7: $t0 := infer($t0)
-  8: $t7 := 1
-  9: $t6 := +($t2, $t7)
- 10: $t2 := infer($t6)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: $t1 := infer($t0)
- 18: return $t1
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 11
+  5: label L2
+  6: $t0 := infer($t0)
+  7: $t6 := 1
+  8: $t5 := +($t2, $t6)
+  9: $t2 := infer($t5)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: $t1 := infer($t0)
+ 17: return $t1
 }
 
 ============ after DeadStoreElimination: ================
@@ -102,32 +96,28 @@ public fun m::test3(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: u64
-  0: $t2 := 0
-  1: $t1 := move($t2)
-  2: $t4 := 1
-  3: $t3 := move($t4)
-  4: label L0
-  5: $t6 := 42
-  6: $t5 := <($t1, $t6)
-  7: if ($t5) goto 8 else goto 13
-  8: label L2
-  9: $t8 := 1
- 10: $t7 := +($t1, $t8)
- 11: $t1 := move($t7)
+  0: $t1 := 0
+  1: $t2 := 1
+  2: label L0
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 11
+  6: label L2
+  7: $t6 := 1
+  8: $t5 := +($t1, $t6)
+  9: $t1 := move($t5)
+ 10: goto 13
+ 11: label L3
  12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 4
- 17: label L1
- 18: $t0 := move($t3)
- 19: return $t0
+ 13: label L4
+ 14: goto 2
+ 15: label L1
+ 16: $t0 := move($t2)
+ 17: return $t0
 }
 
 
@@ -135,29 +125,27 @@ public fun m::test3(): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := 0
-  1: $t2 := move($t3)
-  2: label L0
-  3: $t5 := 42
-  4: $t4 := <($t2, $t5)
-  5: if ($t4) goto 6 else goto 11
-  6: label L2
-  7: $t7 := 1
-  8: $t6 := +($t2, $t7)
-  9: $t2 := move($t6)
- 10: goto 13
- 11: label L3
- 12: goto 15
- 13: label L4
- 14: goto 2
- 15: label L1
- 16: $t1 := move($t0)
- 17: return $t1
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 10
+  5: label L2
+  6: $t6 := 1
+  7: $t5 := +($t2, $t6)
+  8: $t2 := move($t5)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t1 := move($t0)
+ 16: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -187,65 +175,57 @@ public fun m::test3(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 0
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 0
      # live vars: $t1
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t1, $t2
+  2: label L0
+     # live vars: $t1, $t2
      # events: b:$t4
-  2: $t4 := 1
-     # live vars: $t1, $t4
+  3: $t4 := 42
+     # live vars: $t1, $t2, $t4
      # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-  4: label L0
-     # live vars: $t1, $t3
+  4: $t3 := <($t1, $t4)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+  5: if ($t3) goto 6 else goto 11
+     # live vars: $t1, $t2
+  6: label L2
+     # live vars: $t1, $t2
      # events: b:$t6
-  5: $t6 := 42
-     # live vars: $t1, $t3, $t6
+  7: $t6 := 1
+     # live vars: $t1, $t2, $t6
      # events: e:$t6, b:$t5
-  6: $t5 := <($t1, $t6)
-     # live vars: $t1, $t3, $t5
+  8: $t5 := +($t1, $t6)
+     # live vars: $t2, $t5
      # events: e:$t5
-  7: if ($t5) goto 8 else goto 13
-     # live vars: $t1, $t3
-  8: label L2
-     # live vars: $t1, $t3
-     # events: b:$t8
-  9: $t8 := 1
-     # live vars: $t1, $t3, $t8
-     # events: e:$t8, b:$t7
- 10: $t7 := +($t1, $t8)
-     # live vars: $t3, $t7
-     # events: e:$t7
- 11: $t1 := move($t7)
-     # live vars: $t1, $t3
+  9: $t1 := move($t5)
+     # live vars: $t1, $t2
+ 10: goto 13
+     # live vars: $t1, $t2
+ 11: label L3
+     # live vars: $t2
  12: goto 15
-     # live vars: $t1, $t3
- 13: label L3
-     # live vars: $t3
- 14: goto 17
-     # live vars: $t1, $t3
- 15: label L4
-     # live vars: $t1, $t3
+     # live vars: $t1, $t2
+ 13: label L4
+     # live vars: $t1, $t2
      # events: e:$t1
- 16: goto 4
-     # live vars: $t3
- 17: label L1
-     # live vars: $t3
-     # events: e:$t3, b:$t0
- 18: $t0 := move($t3)
+ 14: goto 2
+     # live vars: $t2
+ 15: label L1
+     # live vars: $t2
+     # events: e:$t2, b:$t0
+ 16: $t0 := move($t2)
      # live vars: $t0
      # events: e:$t0
- 19: return $t0
+ 17: return $t0
 }
 
 
@@ -253,58 +233,54 @@ public fun m::test3(): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2
-     # events: b:$t5
-  3: $t5 := 42
-     # live vars: $t0, $t2, $t5
-     # events: e:$t5, b:$t4
-  4: $t4 := <($t2, $t5)
+     # events: b:$t4
+  2: $t4 := 42
      # live vars: $t0, $t2, $t4
-     # events: e:$t4
-  5: if ($t4) goto 6 else goto 11
+     # events: e:$t4, b:$t3
+  3: $t3 := <($t2, $t4)
+     # live vars: $t0, $t2, $t3
+     # events: e:$t3
+  4: if ($t3) goto 5 else goto 10
      # live vars: $t0, $t2
-  6: label L2
+  5: label L2
      # live vars: $t0, $t2
-     # events: b:$t7
-  7: $t7 := 1
-     # live vars: $t0, $t2, $t7
-     # events: e:$t7, b:$t6
-  8: $t6 := +($t2, $t7)
-     # live vars: $t0, $t6
-     # events: e:$t6
-  9: $t2 := move($t6)
+     # events: b:$t6
+  6: $t6 := 1
+     # live vars: $t0, $t2, $t6
+     # events: e:$t6, b:$t5
+  7: $t5 := +($t2, $t6)
+     # live vars: $t0, $t5
+     # events: e:$t5
+  8: $t2 := move($t5)
      # live vars: $t0, $t2
- 10: goto 13
+  9: goto 12
      # live vars: $t0, $t2
- 11: label L3
+ 10: label L3
      # live vars: $t0
- 12: goto 15
+ 11: goto 14
      # live vars: $t0, $t2
- 13: label L4
+ 12: label L4
      # live vars: $t0, $t2
      # events: e:$t2
- 14: goto 2
+ 13: goto 1
      # live vars: $t0
- 15: label L1
+ 14: label L1
      # live vars: $t0
      # events: e:$t0, b:$t1
- 16: $t1 := move($t0)
+ 15: $t1 := move($t0)
      # live vars: $t1
      # events: e:$t1
- 17: return $t1
+ 16: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -326,64 +302,58 @@ public fun m::test2($t0: u64): u64 {
 [variant baseline]
 public fun m::test3(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
-     var $t6: u64
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-  0: $t2 := 0
-  1: $t2 := move($t2)
-  2: $t4 := 1
-  3: $t4 := move($t4)
-  4: label L0
-  5: $t6 := 42
-  6: $t5 := <($t2, $t6)
-  7: if ($t5) goto 8 else goto 13
-  8: label L2
-  9: $t6 := 1
- 10: $t6 := +($t2, $t6)
- 11: $t2 := move($t6)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 4
- 17: label L1
- 18: $t4 := move($t4)
- 19: return $t4
-}
-
-
-[variant baseline]
-public fun m::test4($t0: u64): u64 {
-     var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: bool
-     var $t5: u64
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t3 := 0
-  1: $t3 := move($t3)
+  0: $t1 := 0
+  1: $t2 := 1
   2: label L0
-  3: $t5 := 42
-  4: $t4 := <($t3, $t5)
-  5: if ($t4) goto 6 else goto 11
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 11
   6: label L2
-  7: $t5 := 1
-  8: $t5 := +($t3, $t5)
-  9: $t3 := move($t5)
+  7: $t4 := 1
+  8: $t4 := +($t1, $t4)
+  9: $t1 := move($t4)
  10: goto 13
  11: label L3
  12: goto 15
  13: label L4
  14: goto 2
  15: label L1
- 16: $t0 := move($t0)
- 17: return $t0
+ 16: $t2 := move($t2)
+ 17: return $t2
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 10
+  5: label L2
+  6: $t4 := 1
+  7: $t4 := +($t2, $t4)
+  8: $t2 := move($t4)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t0 := move($t0)
+ 16: return $t0
 }
 
 ============ after DeadStoreElimination: ================
@@ -404,52 +374,49 @@ public fun m::test2($t0: u64): u64 {
 [variant baseline]
 public fun m::test3(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
-     var $t6: u64
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-  0: $t2 := 0
-  1: $t4 := 1
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t1 := 0
+  1: $t2 := 1
   2: label L0
-  3: $t6 := 42
-  4: $t5 := <($t2, $t6)
-  5: if ($t5) goto 6 else goto 11
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 11
   6: label L2
-  7: $t6 := 1
-  8: $t6 := +($t2, $t6)
-  9: $t2 := move($t6)
+  7: $t4 := 1
+  8: $t4 := +($t1, $t4)
+  9: $t1 := move($t4)
  10: goto 13
  11: label L3
  12: goto 15
  13: label L4
  14: goto 2
  15: label L1
- 16: return $t4
+ 16: return $t2
 }
 
 
 [variant baseline]
 public fun m::test4($t0: u64): u64 {
      var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: bool
-     var $t5: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t3 := 0
+  0: $t2 := 0
   1: label L0
-  2: $t5 := 42
-  3: $t4 := <($t3, $t5)
-  4: if ($t4) goto 5 else goto 10
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 10
   5: label L2
-  6: $t5 := 1
-  7: $t5 := +($t3, $t5)
-  8: $t3 := move($t5)
+  6: $t4 := 1
+  7: $t4 := +($t2, $t4)
+  8: $t2 := move($t4)
   9: goto 12
  10: label L3
  11: goto 14

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -21,33 +21,29 @@ public fun m::test3(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: u64
-  0: $t2 := 0
-  1: $t1 := infer($t2)
-  2: $t4 := 1
-  3: $t3 := infer($t4)
-  4: label L0
-  5: $t6 := 42
-  6: $t5 := <($t1, $t6)
-  7: if ($t5) goto 8 else goto 14
-  8: label L2
-  9: $t3 := infer($t3)
- 10: $t8 := 1
- 11: $t7 := +($t1, $t8)
- 12: $t1 := infer($t7)
+  0: $t1 := 0
+  1: $t2 := 1
+  2: label L0
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 12
+  6: label L2
+  7: $t2 := infer($t2)
+  8: $t6 := 1
+  9: $t5 := +($t1, $t6)
+ 10: $t1 := infer($t5)
+ 11: goto 14
+ 12: label L3
  13: goto 16
- 14: label L3
- 15: goto 18
- 16: label L4
- 17: goto 4
- 18: label L1
- 19: $t0 := infer($t3)
- 20: return $t0
+ 14: label L4
+ 15: goto 2
+ 16: label L1
+ 17: $t0 := infer($t2)
+ 18: return $t0
 }
 
 
@@ -55,30 +51,28 @@ public fun m::test3(): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
-  0: $t3 := 0
-  1: $t2 := infer($t3)
-  2: label L0
-  3: $t5 := 42
-  4: $t4 := <($t2, $t5)
-  5: if ($t4) goto 6 else goto 12
-  6: label L2
-  7: $t0 := infer($t0)
-  8: $t7 := 1
-  9: $t6 := +($t2, $t7)
- 10: $t2 := infer($t6)
- 11: goto 14
- 12: label L3
- 13: goto 16
- 14: label L4
- 15: goto 2
- 16: label L1
- 17: $t1 := infer($t0)
- 18: return $t1
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 11
+  5: label L2
+  6: $t0 := infer($t0)
+  7: $t6 := 1
+  8: $t5 := +($t2, $t6)
+  9: $t2 := infer($t5)
+ 10: goto 13
+ 11: label L3
+ 12: goto 15
+ 13: label L4
+ 14: goto 1
+ 15: label L1
+ 16: $t1 := infer($t0)
+ 17: return $t1
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -108,65 +102,57 @@ public fun m::test3(): u64 {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: u64
      # live vars:
-     # events: b:$t2
-  0: $t2 := 0
-     # live vars: $t2
-     # events: e:$t2, b:$t1
-  1: $t1 := move($t2)
+     # events: b:$t1
+  0: $t1 := 0
      # live vars: $t1
+     # events: b:$t2
+  1: $t2 := 1
+     # live vars: $t1, $t2
+  2: label L0
+     # live vars: $t1, $t2
      # events: b:$t4
-  2: $t4 := 1
-     # live vars: $t1, $t4
+  3: $t4 := 42
+     # live vars: $t1, $t2, $t4
      # events: e:$t4, b:$t3
-  3: $t3 := move($t4)
-     # live vars: $t1, $t3
-  4: label L0
-     # live vars: $t1, $t3
+  4: $t3 := <($t1, $t4)
+     # live vars: $t1, $t2, $t3
+     # events: e:$t3
+  5: if ($t3) goto 6 else goto 11
+     # live vars: $t1, $t2
+  6: label L2
+     # live vars: $t1, $t2
      # events: b:$t6
-  5: $t6 := 42
-     # live vars: $t1, $t3, $t6
+  7: $t6 := 1
+     # live vars: $t1, $t2, $t6
      # events: e:$t6, b:$t5
-  6: $t5 := <($t1, $t6)
-     # live vars: $t1, $t3, $t5
+  8: $t5 := +($t1, $t6)
+     # live vars: $t2, $t5
      # events: e:$t5
-  7: if ($t5) goto 8 else goto 13
-     # live vars: $t1, $t3
-  8: label L2
-     # live vars: $t1, $t3
-     # events: b:$t8
-  9: $t8 := 1
-     # live vars: $t1, $t3, $t8
-     # events: e:$t8, b:$t7
- 10: $t7 := +($t1, $t8)
-     # live vars: $t3, $t7
-     # events: e:$t7
- 11: $t1 := move($t7)
-     # live vars: $t1, $t3
+  9: $t1 := move($t5)
+     # live vars: $t1, $t2
+ 10: goto 13
+     # live vars: $t1, $t2
+ 11: label L3
+     # live vars: $t2
  12: goto 15
-     # live vars: $t1, $t3
- 13: label L3
-     # live vars: $t3
- 14: goto 17
-     # live vars: $t1, $t3
- 15: label L4
-     # live vars: $t1, $t3
+     # live vars: $t1, $t2
+ 13: label L4
+     # live vars: $t1, $t2
      # events: e:$t1
- 16: goto 4
-     # live vars: $t3
- 17: label L1
-     # live vars: $t3
-     # events: e:$t3, b:$t0
- 18: $t0 := move($t3)
+ 14: goto 2
+     # live vars: $t2
+ 15: label L1
+     # live vars: $t2
+     # events: e:$t2, b:$t0
+ 16: $t0 := move($t2)
      # live vars: $t0
      # events: e:$t0
- 19: return $t0
+ 17: return $t0
 }
 
 
@@ -174,58 +160,54 @@ public fun m::test3(): u64 {
 public fun m::test4($t0: u64): u64 {
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
      # live vars: $t0
-     # events: b:$t0, b:$t3
-  0: $t3 := 0
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  1: $t2 := move($t3)
+     # events: b:$t0, b:$t2
+  0: $t2 := 0
      # live vars: $t0, $t2
-  2: label L0
+  1: label L0
      # live vars: $t0, $t2
-     # events: b:$t5
-  3: $t5 := 42
-     # live vars: $t0, $t2, $t5
-     # events: e:$t5, b:$t4
-  4: $t4 := <($t2, $t5)
+     # events: b:$t4
+  2: $t4 := 42
      # live vars: $t0, $t2, $t4
-     # events: e:$t4
-  5: if ($t4) goto 6 else goto 11
+     # events: e:$t4, b:$t3
+  3: $t3 := <($t2, $t4)
+     # live vars: $t0, $t2, $t3
+     # events: e:$t3
+  4: if ($t3) goto 5 else goto 10
      # live vars: $t0, $t2
-  6: label L2
+  5: label L2
      # live vars: $t0, $t2
-     # events: b:$t7
-  7: $t7 := 1
-     # live vars: $t0, $t2, $t7
-     # events: e:$t7, b:$t6
-  8: $t6 := +($t2, $t7)
-     # live vars: $t0, $t6
-     # events: e:$t6
-  9: $t2 := move($t6)
+     # events: b:$t6
+  6: $t6 := 1
+     # live vars: $t0, $t2, $t6
+     # events: e:$t6, b:$t5
+  7: $t5 := +($t2, $t6)
+     # live vars: $t0, $t5
+     # events: e:$t5
+  8: $t2 := move($t5)
      # live vars: $t0, $t2
- 10: goto 13
+  9: goto 12
      # live vars: $t0, $t2
- 11: label L3
+ 10: label L3
      # live vars: $t0
- 12: goto 15
+ 11: goto 14
      # live vars: $t0, $t2
- 13: label L4
+ 12: label L4
      # live vars: $t0, $t2
      # events: e:$t2
- 14: goto 2
+ 13: goto 1
      # live vars: $t0
- 15: label L1
+ 14: label L1
      # live vars: $t0
      # events: e:$t0, b:$t1
- 16: $t1 := move($t0)
+ 15: $t1 := move($t0)
      # live vars: $t1
      # events: e:$t1
- 17: return $t1
+ 16: return $t1
 }
 
 ============ after VariableCoalescingTransformer: ================
@@ -247,64 +229,58 @@ public fun m::test2($t0: u64): u64 {
 [variant baseline]
 public fun m::test3(): u64 {
      var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: bool
      var $t4: u64
-     var $t5: bool
-     var $t6: u64
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-  0: $t2 := 0
-  1: $t2 := move($t2)
-  2: $t4 := 1
-  3: $t4 := move($t4)
-  4: label L0
-  5: $t6 := 42
-  6: $t5 := <($t2, $t6)
-  7: if ($t5) goto 8 else goto 13
-  8: label L2
-  9: $t6 := 1
- 10: $t6 := +($t2, $t6)
- 11: $t2 := move($t6)
- 12: goto 15
- 13: label L3
- 14: goto 17
- 15: label L4
- 16: goto 4
- 17: label L1
- 18: $t4 := move($t4)
- 19: return $t4
-}
-
-
-[variant baseline]
-public fun m::test4($t0: u64): u64 {
-     var $t1: u64 [unused]
-     var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: bool
-     var $t5: u64
+     var $t5: u64 [unused]
      var $t6: u64 [unused]
-     var $t7: u64 [unused]
-  0: $t3 := 0
-  1: $t3 := move($t3)
+  0: $t1 := 0
+  1: $t2 := 1
   2: label L0
-  3: $t5 := 42
-  4: $t4 := <($t3, $t5)
-  5: if ($t4) goto 6 else goto 11
+  3: $t4 := 42
+  4: $t3 := <($t1, $t4)
+  5: if ($t3) goto 6 else goto 11
   6: label L2
-  7: $t5 := 1
-  8: $t5 := +($t3, $t5)
-  9: $t3 := move($t5)
+  7: $t4 := 1
+  8: $t4 := +($t1, $t4)
+  9: $t1 := move($t4)
  10: goto 13
  11: label L3
  12: goto 15
  13: label L4
  14: goto 2
  15: label L1
- 16: $t0 := move($t0)
- 17: return $t0
+ 16: $t2 := move($t2)
+ 17: return $t2
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := 42
+  3: $t3 := <($t2, $t4)
+  4: if ($t3) goto 5 else goto 10
+  5: label L2
+  6: $t4 := 1
+  7: $t4 := +($t2, $t4)
+  8: $t2 := move($t4)
+  9: goto 12
+ 10: label L3
+ 11: goto 14
+ 12: label L4
+ 13: goto 1
+ 14: label L1
+ 15: $t0 := move($t0)
+ 16: return $t0
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
@@ -13,16 +13,10 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64
-     var $t5: u64
-  0: $t1 := 1
-  1: $t0 := infer($t1)
-  2: $t3 := 2
-  3: $t2 := infer($t3)
-  4: $t5 := +($t0, $t2)
-  5: $t4 := infer($t5)
-  6: return ()
+  0: $t0 := 1
+  1: $t1 := 2
+  2: $t2 := +($t0, $t1)
+  3: return ()
 }
 
 ============ after DeadStoreElimination: ================
@@ -32,15 +26,10 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64
-  0: $t1 := 1
-  1: $t0 := move($t1)
-  2: $t3 := 2
-  3: $t2 := move($t3)
-  4: $t5 := +($t0, $t2)
-  5: return ()
+  0: $t0 := 1
+  1: $t1 := 2
+  2: $t2 := +($t0, $t1)
+  3: return ()
 }
 
 ============ after VariableCoalescingAnnotator: ================
@@ -50,59 +39,42 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64
      # live vars:
-     # events: b:$t1
-  0: $t1 := 1
-     # live vars: $t1
-     # events: e:$t1, b:$t0
-  1: $t0 := move($t1)
+     # events: b:$t0
+  0: $t0 := 1
      # live vars: $t0
-     # events: b:$t3
-  2: $t3 := 2
-     # live vars: $t0, $t3
-     # events: e:$t3, b:$t2
-  3: $t2 := move($t3)
-     # live vars: $t0, $t2
-     # events: e:$t0, e:$t2, e:$t5, b:$t5
-  4: $t5 := +($t0, $t2)
+     # events: b:$t1
+  1: $t1 := 2
+     # live vars: $t0, $t1
+     # events: e:$t0, e:$t1, e:$t2, b:$t2
+  2: $t2 := +($t0, $t1)
      # live vars:
-  5: return ()
+  3: return ()
 }
 
 ============ after VariableCoalescingTransformer: ================
 
 [variant baseline]
 public fun m::test() {
-     var $t0: u64 [unused]
+     var $t0: u64
      var $t1: u64
      var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64 [unused]
-  0: $t1 := 1
-  1: $t1 := move($t1)
-  2: $t3 := 2
-  3: $t3 := move($t3)
-  4: $t1 := +($t1, $t3)
-  5: return ()
+  0: $t0 := 1
+  1: $t1 := 2
+  2: $t0 := +($t0, $t1)
+  3: return ()
 }
 
 ============ after DeadStoreElimination: ================
 
 [variant baseline]
 public fun m::test() {
-     var $t0: u64 [unused]
+     var $t0: u64
      var $t1: u64
      var $t2: u64 [unused]
-     var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64 [unused]
-  0: $t1 := 1
-  1: $t3 := 2
-  2: $t1 := +($t1, $t3)
+  0: $t0 := 1
+  1: $t1 := 2
+  2: $t0 := +($t0, $t1)
   3: return ()
 }
 

--- a/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
@@ -14,7 +14,9 @@ error: caller does not have permission to modify `A::S` at given address
    =     at tests/sources/functional/ModifiesSchemaTest.move:12: mutate_at
    =         addr = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:13: mutate_at
-   =         addr = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:14: mutate_at
+   =         addr = <redacted>
+   =         <redacted> = <redacted>
+   =         s = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:15: mutate_at
    =     at tests/sources/functional/ModifiesSchemaTest.move:31: mutate_at_wrapper2

--- a/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
@@ -45,8 +45,9 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:76: test_not_using_min_incorrect
    =         v = <redacted>
    =     at tests/sources/functional/choice.move:77: test_not_using_min_incorrect
-   =         v_ref = <redacted>
    =     at tests/sources/functional/choice.move:78: test_not_using_min_incorrect
+   =         <redacted> = <redacted>
+   =         v_ref = <redacted>
    =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =         <redacted> = <redacted>
@@ -145,9 +146,8 @@ error: post-condition does not hold
     =     at tests/sources/functional/choice.move:275: new_ballot_id
     =         result = <redacted>
     =     at tests/sources/functional/choice.move:278: new_ballot_id
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/choice.move:287: create_ballot
-    =         ballot_id = <redacted>
+    =         <redacted> = <redacted>
     =     at tests/sources/functional/choice.move:282: create_ballot
     =         result = <redacted>
     =     at tests/sources/functional/choice.move:288: create_ballot

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.v2_exp
@@ -26,7 +26,6 @@ error: data invariant does not hold
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:26: push_2
   =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:27: push_2
-  =         s = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:28: push_2
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:22: push_2
   =         s = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
@@ -7,9 +7,9 @@ error: data invariant does not hold
   │
   =     at tests/sources/functional/data_invariant_in_map.move:20: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:21: violation_1
-  =         t = <redacted>
   =     at tests/sources/functional/data_invariant_in_map.move:22: violation_1
+  =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
   =         <redacted> = <redacted>
   =         s = <redacted>
-  =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
+  =         <redacted> = <redacted>
   =     at tests/sources/functional/data_invariant_in_map.move:8

--- a/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
@@ -81,15 +81,14 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:149: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         x = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y = <redacted>
-    =         y_raw_val = <redacted>
+    =         <redacted> = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
+    =         y_raw_val = <redacted>
     =         <redacted> = <redacted>
-    =         z = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
@@ -111,15 +110,14 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:149: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         x = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y = <redacted>
-    =         y_raw_val = <redacted>
+    =         <redacted> = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
+    =         y_raw_val = <redacted>
     =         <redacted> = <redacted>
-    =         z = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/hash_model.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/hash_model.v2_exp
@@ -9,12 +9,12 @@ error: post-condition does not hold
    =         v1 = <redacted>
    =         v2 = <redacted>
    =     at tests/sources/functional/hash_model.move:41: hash_test1_incorrect
-   =         v1 = <redacted>
    =     at tests/sources/functional/hash_model.move:42: hash_test1_incorrect
-   =         v2 = <redacted>
    =     at tests/sources/functional/hash_model.move:43: hash_test1_incorrect
-   =         h1 = <redacted>
+   =         v1 = <redacted>
+   =         v2 = <redacted>
    =         h2 = <redacted>
+   =         h1 = <redacted>
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model.move:44: hash_test1_incorrect
@@ -31,12 +31,12 @@ error: post-condition does not hold
    =         v1 = <redacted>
    =         v2 = <redacted>
    =     at tests/sources/functional/hash_model.move:84: hash_test2_incorrect
-   =         v1 = <redacted>
    =     at tests/sources/functional/hash_model.move:85: hash_test2_incorrect
-   =         v2 = <redacted>
    =     at tests/sources/functional/hash_model.move:86: hash_test2_incorrect
-   =         h1 = <redacted>
+   =         v1 = <redacted>
+   =         v2 = <redacted>
    =         h2 = <redacted>
+   =         h1 = <redacted>
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model.move:87: hash_test2_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/hash_model_invalid.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/hash_model_invalid.v2_exp
@@ -9,12 +9,12 @@ error: post-condition does not hold
    =         v1 = <redacted>
    =         v2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:13: hash_test1
-   =         v1 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:14: hash_test1
-   =         v2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:15: hash_test1
-   =         h1 = <redacted>
+   =         v1 = <redacted>
+   =         v2 = <redacted>
    =         h2 = <redacted>
+   =         h1 = <redacted>
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:16: hash_test1
@@ -31,12 +31,12 @@ error: post-condition does not hold
    =         v1 = <redacted>
    =         v2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:28: hash_test2
-   =         v1 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:29: hash_test2
-   =         v2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:30: hash_test2
-   =         h1 = <redacted>
+   =         v1 = <redacted>
+   =         v2 = <redacted>
    =         h2 = <redacted>
+   =         h1 = <redacted>
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:31: hash_test2

--- a/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
@@ -19,10 +19,10 @@ error: data invariant does not hold
    =     at tests/sources/functional/invariants.move:113: lifetime_invalid_R
    =         r = <redacted>
    =     at tests/sources/functional/invariants.move:114: lifetime_invalid_R
-   =         r_ref = <redacted>
    =     at tests/sources/functional/invariants.move:115: lifetime_invalid_R
-   =         x_ref = <redacted>
    =     at tests/sources/functional/invariants.move:116: lifetime_invalid_R
+   =         <redacted> = <redacted>
+   =         x_ref = <redacted>
    =     at tests/sources/functional/invariants.move:15
 
 error: data invariant does not hold
@@ -50,8 +50,6 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
     =         cond = <redacted>
     =         b_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:150

--- a/third_party/move/move-prover/tests/sources/functional/is_txn_signer.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/is_txn_signer.v2_exp
@@ -55,8 +55,8 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/is_txn_signer.move:60: ADMIN_ADDRESS
    =         result = <redacted>
    =     at tests/sources/functional/is_txn_signer.move:61: ADMIN_ADDRESS
-   =         _account = <redacted>
    =     at tests/sources/functional/is_txn_signer.move:85: increment_incorrect
+   =         _account = <redacted>
    =     at tests/sources/functional/is_txn_signer.move:83: increment_incorrect
    =     at tests/sources/functional/is_txn_signer.move:85: increment_incorrect
    =     at tests/sources/functional/is_txn_signer.move:90

--- a/third_party/move/move-prover/tests/sources/functional/let.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/let.v2_exp
@@ -17,10 +17,8 @@ error: function does not abort under this condition
    =         a = <redacted>
    =         b = <redacted>
    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
-   =         a = <redacted>
    =     at tests/sources/functional/let.move:71: spec_let_with_abort_incorrect
    =     at tests/sources/functional/let.move:72: spec_let_with_abort_incorrect
-   =         b = <redacted>
    =     at tests/sources/functional/let.move:69: spec_let_with_abort_incorrect
    =         a = <redacted>
    =         b = <redacted>
@@ -58,7 +56,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         a = <redacted>
    =         b = <redacted>
    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
-   =         a = <redacted>
    =     at tests/sources/functional/let.move:71: spec_let_with_abort_incorrect
    =         ABORTED
    =     at tests/sources/functional/let.move:77: spec_let_with_abort_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
@@ -40,6 +40,7 @@ error: data invariant does not hold
   =         result = <redacted>
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:92: return_ref_different_path_vec2
+  =     at tests/sources/functional/mut_ref.move:122: call_return_ref_different_path_vec2_incorrect
   =         <redacted> = <redacted>
   =     at tests/sources/functional/mut_ref.move:122: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8

--- a/third_party/move/move-prover/tests/sources/functional/nested_invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/nested_invariants.v2_exp
@@ -13,8 +13,10 @@ error: data invariant does not hold
    =     at tests/sources/functional/nested_invariants.move:64: mutate_inner_data_invariant_invalid
    =         o = <redacted>
    =     at tests/sources/functional/nested_invariants.move:65: mutate_inner_data_invariant_invalid
-   =         r = <redacted>
    =     at tests/sources/functional/nested_invariants.move:66: mutate_inner_data_invariant_invalid
+   =         <redacted> = <redacted>
+   =         r = <redacted>
+   =         <redacted> = <redacted>
    =     at tests/sources/functional/nested_invariants.move:29
    =     at tests/sources/functional/nested_invariants.move:32
    =     at tests/sources/functional/nested_invariants.move:16
@@ -42,8 +44,10 @@ error: data invariant does not hold
    =     at tests/sources/functional/nested_invariants.move:58: mutate_outer_data_invariant_invalid
    =         o = <redacted>
    =     at tests/sources/functional/nested_invariants.move:59: mutate_outer_data_invariant_invalid
-   =         r = <redacted>
    =     at tests/sources/functional/nested_invariants.move:60: mutate_outer_data_invariant_invalid
+   =         <redacted> = <redacted>
+   =         r = <redacted>
+   =         <redacted> = <redacted>
    =     at tests/sources/functional/nested_invariants.move:29
    =     at tests/sources/functional/nested_invariants.move:32
 

--- a/third_party/move/move-prover/tests/sources/functional/references.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/references.v2_exp
@@ -8,8 +8,8 @@ error: function does not abort under this condition
    =     at tests/sources/functional/references.move:69: mut_ref_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/references.move:70: mut_ref_incorrect
-   =         b_ref = <redacted>
    =     at tests/sources/functional/references.move:71: mut_ref_incorrect
+   =         b_ref = <redacted>
    =         <redacted> = <redacted>
    =     at tests/sources/functional/references.move:50: mut_b
    =         b = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/serialize_model.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/serialize_model.v2_exp
@@ -9,12 +9,12 @@ error: post-condition does not hold
    =         v1 = <redacted>
    =         v2 = <redacted>
    =     at tests/sources/functional/serialize_model.move:28: bcs_test1_incorrect
-   =         v1 = <redacted>
    =     at tests/sources/functional/serialize_model.move:29: bcs_test1_incorrect
-   =         v2 = <redacted>
    =     at tests/sources/functional/serialize_model.move:30: bcs_test1_incorrect
-   =         s1 = <redacted>
+   =         v1 = <redacted>
+   =         v2 = <redacted>
    =         s2 = <redacted>
+   =         s1 = <redacted>
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/serialize_model.move:31: bcs_test1_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
@@ -10,8 +10,10 @@ error: post-condition does not hold
    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
    =         addr = <redacted>
    =     at tests/sources/functional/strong_edges.move:48: glob_and_field_edges_incorrect
-   =         addr = <redacted>
    =     at tests/sources/functional/strong_edges.move:49: glob_and_field_edges_incorrect
+   =         addr = <redacted>
+   =         <redacted> = <redacted>
+   =         s = <redacted>
    =     at tests/sources/functional/strong_edges.move:50: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:55: glob_and_field_edges_incorrect (spec)
    =     at tests/sources/functional/strong_edges.move:54: glob_and_field_edges_incorrect (spec)
@@ -25,7 +27,8 @@ error: unknown assertion failed
    =     at tests/sources/functional/strong_edges.move:60: loc__edge_incorrect
    =         r = <redacted>
    =     at tests/sources/functional/strong_edges.move:61: loc__edge_incorrect
-   =         r_ref = <redacted>
    =     at tests/sources/functional/strong_edges.move:62: loc__edge_incorrect
+   =         <redacted> = <redacted>
+   =         r_ref = <redacted>
    =         r = <redacted>
    =     at tests/sources/functional/strong_edges.move:64: loc__edge_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/type_dependent_code.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/type_dependent_code.v2_exp
@@ -60,9 +60,8 @@ error: post-condition does not hold
    =     at ../move-stdlib/sources/signer.move:13: address_of
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
-   =         account = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:47: test1
-   =         x = <redacted>
+   =         account = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:48: test1
    =     at tests/sources/functional/type_dependent_code.move:50: test1 (spec)
 
@@ -83,8 +82,7 @@ error: post-condition does not hold
    =     at ../move-stdlib/sources/signer.move:13: address_of
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
-   =         account = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:63: test2
-   =         t1 = <redacted>
+   =         account = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:64: test2
    =     at tests/sources/functional/type_dependent_code.move:66: test2 (spec)


### PR DESCRIPTION
## Description

I came along this while investigating the freeze bug, but it is worth its own PR because a lot of baselines are changed.

Before this PR, when we had `let x = e; s`, the bytecode generator create a useless temporary and generate code like this `t := e; x := t; s`. Now it detects the special case of a simple variable let and directly generates `x := e; s`.

Consequently, this leads to a lot of baseline changes as we now generate less code. All semantic (transactional, move-unit, e2e) pass with this. Note that the change wouldn't work before Vineeth landed #12586. In fact the old treatment masked more instances of the bg fixed in that PR because the unnecessary temps avoided it.

Notice that coalescing may have elminated some of those temps but not in all cases because of over-approximation of borrowing. Also it appears that borrow semantics in the byetcode verifier is unfortunately sensitive regards duplication of values in temps (that's why I came along this when looking at the freeze bug), so we want to avoid those unneeded temps for the case we compile without optimizations.

Closes https://github.com/aptos-labs/aptos-core/issues/11599

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Existing tests

## Key Areas to Review

`bytecode_generator.rs` is the only code which changed. The rest are baseline files

