### PR TITLE
[compiler-v2] Introduces custom rules for checking the freeze operation

### DIFF
--- a/third_party/move/evm/move-to-yul/src/functions.rs
+++ b/third_party/move/evm/move-to-yul/src/functions.rs
@@ -459,7 +459,7 @@ impl<'a> FunctionGenerator<'a> {
                     },
                     // FreezeRef transforms a mutable reference to an immutable one so just
                     // treat it as an assignment.
-                    FreezeRef => {
+                    FreezeRef(_) => {
                         print_loc();
                         self.assign(ctx, target, dest[0], local(&srcs[0]))
                     },

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -577,7 +577,9 @@ impl<'env> Generator<'env> {
     fn gen_call(&mut self, targets: Vec<TempIndex>, id: NodeId, op: &Operation, args: &[Exp]) {
         match op {
             Operation::Vector => self.gen_op_call(targets, id, BytecodeOperation::Vector, args),
-            Operation::Freeze => self.gen_op_call(targets, id, BytecodeOperation::FreezeRef, args),
+            Operation::Freeze(explicit) => {
+                self.gen_op_call(targets, id, BytecodeOperation::FreezeRef(*explicit), args)
+            },
             Operation::Tuple => {
                 if targets.len() != args.len() {
                     self.internal_error(
@@ -911,7 +913,7 @@ impl<'env> Generator<'env> {
                 .new_node(self.env().get_node_loc(id), expected_ty.clone());
             self.env()
                 .set_node_instantiation(freeze_id, vec![et.as_ref().clone()]);
-            ExpData::Call(freeze_id, Operation::Freeze, vec![exp.clone()]).into_exp()
+            ExpData::Call(freeze_id, Operation::Freeze(false), vec![exp.clone()]).into_exp()
         } else {
             exp.clone()
         }

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -507,7 +507,7 @@ impl<'a> FunctionGenerator<'a> {
                     self.gen_builtin(ctx, dest, FF::Bytecode::Pop, source)
                 }
             },
-            Operation::FreezeRef => self.gen_builtin(ctx, dest, FF::Bytecode::FreezeRef, source),
+            Operation::FreezeRef(_) => self.gen_builtin(ctx, dest, FF::Bytecode::FreezeRef, source),
             Operation::CastU8 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU8, source),
             Operation::CastU16 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU16, source),
             Operation::CastU32 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU32, source),

--- a/third_party/move/move-compiler-v2/src/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/inliner.rs
@@ -907,7 +907,11 @@ impl<'env, 'rewriter> InlinedRewriter<'env, 'rewriter> {
                             let new_node = env.new_node(exp_loc, new_type.clone());
                             let new_exp_vec: Vec<Exp> = vec![exp.clone()];
                             (
-                                Exp::from(ExpData::Call(new_node, Operation::Freeze, new_exp_vec)),
+                                Exp::from(ExpData::Call(
+                                    new_node,
+                                    Operation::Freeze(false),
+                                    new_exp_vec,
+                                )),
                                 new_type,
                             )
                         } else {

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
@@ -8,40 +8,40 @@ module 0x42::freeze_mut_ref {
         dummy_field: bool,
     }
     public fun borrow_mut<Element>(map: &mut vector<#0>): &#0 {
-        Freeze(vector::borrow_mut<Element>(map, 0))
+        Freeze(false)(vector::borrow_mut<Element>(map, 0))
     }
     public fun borrow_mut2<Element>(v: &mut #0): &#0 {
-        Freeze(v)
+        Freeze(false)(v)
     }
     public fun borrow_mut3<Element>(v1: &mut #0,v2: &#0): &#0 {
         if true {
-          Freeze(v1)
+          Freeze(false)(v1)
         } else {
           v2
         }
     }
     public fun borrow_mut4<Element>(v: &mut #0): &#0 {
-        return Freeze(v)
+        return Freeze(false)(v)
     }
     private fun t0() {
         {
-          let x: &u64 = Freeze(Borrow(Mutable)(0));
+          let x: &u64 = Freeze(false)(Borrow(Mutable)(0));
           x;
           Tuple()
         }
     }
     private fun t1(s: &mut freeze_mut_ref::S): &freeze_mut_ref::S {
-        Freeze(s)
+        Freeze(false)(s)
     }
     private fun t2(u1: &mut u64,u2: &mut u64): (&u64, &mut u64) {
-        Tuple(Freeze(u1), u2)
+        Tuple(Freeze(false)(u1), u2)
     }
     public fun t4() {
         {
           let x: &u64;
           {
             let y: &u64;
-            (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(Borrow(Mutable)(0)), Freeze(Borrow(Mutable)(0)));
+            (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(false)(Borrow(Mutable)(0)), Freeze(false)(Borrow(Mutable)(0)));
             Tuple()
           }
         }
@@ -60,7 +60,7 @@ module 0x42::freeze_mut_ref {
                 {
                   let z: &u64;
                   f = 0;
-                  z: &u64 = Freeze(y);
+                  z: &u64 = Freeze(false)(y);
                   g = 2;
                   Tuple()
                 }
@@ -73,7 +73,7 @@ module 0x42::freeze_mut_ref {
         {
           let x: &freeze_mut_ref::S;
           if cond {
-            x: &freeze_mut_ref::S = Freeze(Copy(s))
+            x: &freeze_mut_ref::S = Freeze(false)(Copy(s))
           } else {
             x: &freeze_mut_ref::S = other
           };
@@ -84,7 +84,7 @@ module 0x42::freeze_mut_ref {
         {
           let _x: &freeze_mut_ref::S;
           _x: &freeze_mut_ref::S = if cond {
-            Freeze(s)
+            Freeze(false)(s)
           } else {
             other
           };
@@ -94,7 +94,7 @@ module 0x42::freeze_mut_ref {
     private fun t8(cond: bool,s: &mut freeze_mut_ref::S,other: &freeze_mut_ref::S) {
         {
           let _x: &freeze_mut_ref::S = if cond {
-            Freeze(s)
+            Freeze(false)(s)
           } else {
             other
           };
@@ -112,7 +112,7 @@ public fun freeze_mut_ref::borrow_mut<#0>($t0: &mut vector<#0>): &#0 {
      var $t3: u64
   0: $t3 := 0
   1: $t2 := vector::borrow_mut<#0>($t0, $t3)
-  2: $t1 := freeze_ref($t2)
+  2: $t1 := freeze_ref(implicit)($t2)
   3: return $t1
 }
 
@@ -120,7 +120,7 @@ public fun freeze_mut_ref::borrow_mut<#0>($t0: &mut vector<#0>): &#0 {
 [variant baseline]
 public fun freeze_mut_ref::borrow_mut2<#0>($t0: &mut #0): &#0 {
      var $t1: &#0
-  0: $t1 := freeze_ref($t0)
+  0: $t1 := freeze_ref(implicit)($t0)
   1: return $t1
 }
 
@@ -132,7 +132,7 @@ public fun freeze_mut_ref::borrow_mut3<#0>($t0: &mut #0, $t1: &#0): &#0 {
   0: $t3 := true
   1: if ($t3) goto 2 else goto 5
   2: label L0
-  3: $t2 := freeze_ref($t0)
+  3: $t2 := freeze_ref(implicit)($t0)
   4: goto 7
   5: label L1
   6: $t2 := infer($t1)
@@ -144,7 +144,7 @@ public fun freeze_mut_ref::borrow_mut3<#0>($t0: &mut #0, $t1: &#0): &#0 {
 [variant baseline]
 public fun freeze_mut_ref::borrow_mut4<#0>($t0: &mut #0): &#0 {
      var $t1: &#0
-  0: $t1 := freeze_ref($t0)
+  0: $t1 := freeze_ref(implicit)($t0)
   1: return $t1
   2: return $t1
 }
@@ -158,7 +158,7 @@ fun freeze_mut_ref::t0() {
      var $t3: &u64
   0: $t2 := 0
   1: $t1 := borrow_local($t2)
-  2: $t0 := freeze_ref($t1)
+  2: $t0 := freeze_ref(implicit)($t1)
   3: $t3 := infer($t0)
   4: return ()
 }
@@ -167,7 +167,7 @@ fun freeze_mut_ref::t0() {
 [variant baseline]
 fun freeze_mut_ref::t1($t0: &mut freeze_mut_ref::S): &freeze_mut_ref::S {
      var $t1: &freeze_mut_ref::S
-  0: $t1 := freeze_ref($t0)
+  0: $t1 := freeze_ref(implicit)($t0)
   1: return $t1
 }
 
@@ -176,7 +176,7 @@ fun freeze_mut_ref::t1($t0: &mut freeze_mut_ref::S): &freeze_mut_ref::S {
 fun freeze_mut_ref::t2($t0: &mut u64, $t1: &mut u64): (&u64, &mut u64) {
      var $t2: &u64
      var $t3: &mut u64
-  0: $t2 := freeze_ref($t0)
+  0: $t2 := freeze_ref(implicit)($t0)
   1: $t3 := infer($t1)
   2: return ($t2, $t3)
 }
@@ -194,11 +194,11 @@ public fun freeze_mut_ref::t4() {
      var $t7: u64
   0: $t4 := 0
   1: $t3 := borrow_local($t4)
-  2: $t2 := freeze_ref($t3)
+  2: $t2 := freeze_ref(implicit)($t3)
   3: $t0 := infer($t2)
   4: $t7 := 0
   5: $t6 := borrow_local($t7)
-  6: $t5 := freeze_ref($t6)
+  6: $t5 := freeze_ref(implicit)($t6)
   7: $t1 := infer($t5)
   8: return ()
 }
@@ -238,7 +238,7 @@ public fun freeze_mut_ref::t5($t0: &mut freeze_mut_ref::G) {
  13: $t13 := 2
  14: $t15 := 0
  15: write_ref($t2, $t15)
- 16: $t16 := freeze_ref($t10)
+ 16: $t16 := freeze_ref(implicit)($t10)
  17: $t12 := infer($t16)
  18: $t14 := infer($t6)
  19: write_ref($t14, $t13)
@@ -254,7 +254,7 @@ fun freeze_mut_ref::t6($t0: bool, $t1: &mut freeze_mut_ref::S, $t2: &freeze_mut_
   0: if ($t0) goto 1 else goto 6
   1: label L0
   2: $t5 := copy($t1)
-  3: $t4 := freeze_ref($t5)
+  3: $t4 := freeze_ref(implicit)($t5)
   4: $t3 := infer($t4)
   5: goto 8
   6: label L1
@@ -270,7 +270,7 @@ fun freeze_mut_ref::t7($t0: bool, $t1: &mut freeze_mut_ref::S, $t2: &freeze_mut_
      var $t4: &freeze_mut_ref::S
   0: if ($t0) goto 1 else goto 4
   1: label L0
-  2: $t4 := freeze_ref($t1)
+  2: $t4 := freeze_ref(implicit)($t1)
   3: goto 6
   4: label L1
   5: $t4 := infer($t2)
@@ -285,7 +285,7 @@ fun freeze_mut_ref::t8($t0: bool, $t1: &mut freeze_mut_ref::S, $t2: &freeze_mut_
      var $t3: &freeze_mut_ref::S
   0: if ($t0) goto 1 else goto 4
   1: label L0
-  2: $t3 := freeze_ref($t1)
+  2: $t3 := freeze_ref(implicit)($t1)
   3: goto 6
   4: label L1
   5: $t3 := infer($t2)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/mutate_immutable_cmp.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/mutate_immutable_cmp.exp
@@ -18,7 +18,7 @@ module 0x8675309::M {
           {
             let x_ref: &mut u64 = Borrow(Mutable)(x);
             {
-              let x_ref: &u64 = Freeze(x_ref);
+              let x_ref: &u64 = Freeze(false)(x_ref);
               x_ref = 0;
               {
                 let g: M::S = pack M::S(0);

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -9,7 +9,7 @@ module 0x42::reference_conversion {
           {
             let r: &mut u64 = Borrow(Mutable)(x);
             r = 43;
-            reference_conversion::deref(Freeze(r))
+            reference_conversion::deref(Freeze(false)(r))
           }
         }
     }
@@ -36,7 +36,7 @@ fun reference_conversion::use_it(): u64 {
   1: $t2 := borrow_local($t1)
   2: $t3 := 43
   3: write_ref($t2, $t3)
-  4: $t4 := freeze_ref($t2)
+  4: $t4 := freeze_ref(implicit)($t2)
   5: $t0 := reference_conversion::deref($t4)
   6: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/v1-typing/mutate_immutable.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/v1-typing/mutate_immutable.exp
@@ -11,7 +11,7 @@ module 0x8675309::M {
           {
             let x_ref: &mut u64 = Borrow(Mutable)(x);
             {
-              let x_ref: &u64 = Freeze(x_ref);
+              let x_ref: &u64 = Freeze(false)(x_ref);
               x_ref = 0;
               Tuple()
             }

--- a/third_party/move/move-compiler-v2/tests/bytecode-verify-failure/equality.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-verify-failure/equality.exp
@@ -1,13 +1,17 @@
-============ initial bytecode ================
 
-[variant baseline]
-fun m::equality<#0>($t0: #0, $t1: #0): bool {
-     var $t2: bool
-  0: $t2 := ==($t0, $t1)
-  1: return $t2
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+equality<Ty0>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: Ty0)
+	1: MoveLoc[1](Arg1: Ty0)
+	2: Eq
+	3: Ret
 }
-
-
+}
 ============ bytecode verification failed ========
 
 Diagnostics:

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
@@ -11,7 +11,7 @@ module 0xcafe::vectors {
               {
                 let i: u64 = 0;
                 loop {
-                  if Lt<u64>(i, vector::length<u64>(Freeze(v))) {
+                  if Lt<u64>(i, vector::length<u64>(Freeze(false)(v))) {
                     {
                       let (e: &mut u64): (&mut u64) = Tuple(vector::borrow_mut<u64>(v, i));
                       e = s;

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/calls_with_freeze.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/calls_with_freeze.exp
@@ -18,13 +18,13 @@ module 0x42::m {
                 {
                   let p2m: &mut m::S = Borrow(Mutable)(s);
                   {
-                    let x1: u64 = m::sum(Freeze(p1m), p1);
+                    let x1: u64 = m::sum(Freeze(false)(p1m), p1);
                     {
-                      let x2: u64 = m::sum(Freeze(p1m), Freeze(p1m));
+                      let x2: u64 = m::sum(Freeze(false)(p1m), Freeze(false)(p1m));
                       {
-                        let x3: u64 = m::sum(Freeze(p1m), p2);
+                        let x3: u64 = m::sum(Freeze(false)(p1m), p2);
                         {
-                          let x4: u64 = m::sum(Freeze(p2m), Freeze(p2m));
+                          let x4: u64 = m::sum(Freeze(false)(p2m), Freeze(false)(p2m));
                           Add<u64>(Add<u64>(Add<u64>(x1, x2), x3), x4)
                         }
                       }

--- a/third_party/move/move-compiler-v2/tests/checking/specs/conditions_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/conditions_ok.exp
@@ -8,9 +8,9 @@ module 0x42::M {
         Deref(x)
     }
     spec {
-      aborts_if Or(Eq<u64>(Freeze($t0), 0), Eq<u64>(select M::Ghost$some_global.v(global<M::Ghost$some_global>(0x0)), 0));
+      aborts_if Or(Eq<u64>(Freeze(false)($t0), 0), Eq<u64>(select M::Ghost$some_global.v(global<M::Ghost$some_global>(0x0)), 0));
       ensures Gt(Old<u64>($t0), $t0);
-      ensures Eq<u64>(result0(), Freeze($t0));
+      ensures Eq<u64>(result0(), Freeze(false)($t0));
     }
 
     private fun multiple_results(x: u64): (u64, bool) {

--- a/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/update_field_ok.exp
@@ -10,7 +10,7 @@ module 0x42::update_field_ok {
     }
     spec {
       aborts_if false;
-      ensures Eq<update_field_ok::R>(Freeze($t0), update_field_ok::assign_x_1(Old<update_field_ok::R>($t0)));
+      ensures Eq<update_field_ok::R>(Freeze(false)($t0), update_field_ok::assign_x_1(Old<update_field_ok::R>($t0)));
     }
 
     spec fun assign_x_1(r: update_field_ok::R): update_field_ok::R {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_complex_root_expr.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_field_complex_root_expr.exp
@@ -10,14 +10,14 @@ module 0x8675309::M {
           s
         }));
         Borrow(Immutable)(select M::S.f<&M::S>(if cond {
-          Freeze(s_mut)
+          Freeze(false)(s_mut)
         } else {
           s
         }));
         Borrow(Immutable)(select M::S.f<&M::S>(if cond {
           s
         } else {
-          Freeze(s_mut)
+          Freeze(false)(s_mut)
         }));
         Borrow(Immutable)(select M::S.f<&mut M::S>(if cond {
           s_mut

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
@@ -19,16 +19,16 @@ module 0x8675309::M {
         false;
         false;
         Eq<M::S>(Borrow(Immutable)(s), s_ref);
-        Eq<M::S>(Freeze(Borrow(Mutable)(s)), s_ref);
-        Eq<M::S>(Freeze(Borrow(Mutable)(s)), Freeze(s_mut));
-        Eq<M::S>(Borrow(Immutable)(s), Freeze(s_mut));
-        Eq<M::S>(s_ref, Freeze(s_mut));
-        Eq<M::S>(Freeze(s_mut), Freeze(s_mut));
+        Eq<M::S>(Freeze(false)(Borrow(Mutable)(s)), s_ref);
+        Eq<M::S>(Freeze(false)(Borrow(Mutable)(s)), Freeze(false)(s_mut));
+        Eq<M::S>(Borrow(Immutable)(s), Freeze(false)(s_mut));
+        Eq<M::S>(s_ref, Freeze(false)(s_mut));
+        Eq<M::S>(Freeze(false)(s_mut), Freeze(false)(s_mut));
         Eq<M::S>(pack M::S(0), s);
         Eq<M::R>(r, r);
-        Eq<M::R>(Freeze(r_mut), Freeze(r_mut));
-        Eq<M::R>(r, Freeze(r_mut));
-        Eq<M::R>(Freeze(r_mut), r);
+        Eq<M::R>(Freeze(false)(r_mut), Freeze(false)(r_mut));
+        Eq<M::R>(r, Freeze(false)(r_mut));
+        Eq<M::R>(Freeze(false)(r_mut), r);
         Eq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(1));
         Eq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(1));
         Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_ref.exp
@@ -1,11 +1,11 @@
 // -- Model dump before bytecode pipeline
 module 0x42::m {
     private fun mut_ref_to_mut_ref(x: u64,y: u64) {
-        Eq<u64>(Freeze(Borrow(Mutable)(x)), Freeze(Borrow(Mutable)(y)));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(x)), Freeze(false)(Borrow(Mutable)(y)));
         Tuple()
     }
     private fun mut_ref_to_ref(x: u64,y: u64) {
-        Eq<u64>(Freeze(Borrow(Mutable)(x)), Borrow(Immutable)(y));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(x)), Borrow(Immutable)(y));
         Tuple()
     }
     private fun ref_to_ref(x: u64,y: u64) {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/if_branches_subtype.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/if_branches_subtype.exp
@@ -5,19 +5,19 @@ module 0x8675309::M {
           let _: &u64 = if cond {
             u
           } else {
-            Freeze(u_mut)
+            Freeze(false)(u_mut)
           };
           {
             let _: &u64 = if cond {
-              Freeze(u_mut)
+              Freeze(false)(u_mut)
             } else {
               u
             };
             {
               let _: &u64 = if cond {
-                Freeze(u_mut)
+                Freeze(false)(u_mut)
               } else {
-                Freeze(u_mut)
+                Freeze(false)(u_mut)
               };
               Tuple()
             }
@@ -29,19 +29,19 @@ module 0x8675309::M {
           let (_, _): (&u64, &u64) = if cond {
             Tuple(u, u)
           } else {
-            Tuple(Freeze(u_mut), Freeze(u_mut))
+            Tuple(Freeze(false)(u_mut), Freeze(false)(u_mut))
           };
           {
             let (_, _): (&u64, &u64) = if cond {
-              Tuple(Freeze(u_mut), u)
+              Tuple(Freeze(false)(u_mut), u)
             } else {
-              Tuple(u, Freeze(u_mut))
+              Tuple(u, Freeze(false)(u_mut))
             };
             {
               let (_, _): (&u64, &u64) = if cond {
-                Tuple(u, Freeze(u_mut))
+                Tuple(u, Freeze(false)(u_mut))
               } else {
-                Tuple(Freeze(u_mut), u)
+                Tuple(Freeze(false)(u_mut), u)
               };
               Tuple()
             }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_complex_root_expr.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/implicit_deref_borrow_field_complex_root_expr.exp
@@ -10,14 +10,14 @@ module 0x8675309::M {
           s
         });
         select M::S.f<&M::S>(if cond {
-          Freeze(s_mut)
+          Freeze(false)(s_mut)
         } else {
           s
         });
         select M::S.f<&M::S>(if cond {
           s
         } else {
-          Freeze(s_mut)
+          Freeze(false)(s_mut)
         });
         select M::S.f<&mut M::S>(if cond {
           s_mut

--- a/third_party/move/move-compiler-v2/tests/checking/typing/mutable_eq_and_neq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/mutable_eq_and_neq.exp
@@ -12,33 +12,33 @@ module 0x8675309::M {
         g: u64,
     }
     private fun t(r1: &mut u64,r2: &mut u64,s: &mut M::S) {
-        Eq<u64>(Freeze(r1), Freeze(r1));
-        Eq<u64>(Freeze(r1), Freeze(r2));
-        Eq<u64>(Freeze(r2), Freeze(r2));
-        Eq<u64>(Freeze(r2), Freeze(r2));
-        Neq<u64>(Freeze(r1), Freeze(r1));
-        Neq<u64>(Freeze(r1), Freeze(r2));
-        Neq<u64>(Freeze(r2), Freeze(r2));
-        Neq<u64>(Freeze(r2), Freeze(r2));
-        Eq<u64>(Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
-        Eq<u64>(Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
-        Eq<u64>(Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
-        Eq<u64>(Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
-        Neq<u64>(Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
-        Neq<u64>(Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
-        Neq<u64>(Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
-        Neq<u64>(Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
+        Eq<u64>(Freeze(false)(r1), Freeze(false)(r1));
+        Eq<u64>(Freeze(false)(r1), Freeze(false)(r2));
+        Eq<u64>(Freeze(false)(r2), Freeze(false)(r2));
+        Eq<u64>(Freeze(false)(r2), Freeze(false)(r2));
+        Neq<u64>(Freeze(false)(r1), Freeze(false)(r1));
+        Neq<u64>(Freeze(false)(r1), Freeze(false)(r2));
+        Neq<u64>(Freeze(false)(r2), Freeze(false)(r2));
+        Neq<u64>(Freeze(false)(r2), Freeze(false)(r2));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
+        Eq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
+        Neq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
+        Neq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
+        Neq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.f<&mut M::S>(s))));
+        Neq<u64>(Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))), Freeze(false)(Borrow(Mutable)(select M::S.g<&mut M::S>(s))));
         Tuple()
     }
     private fun t1(p: &mut M::P) {
         {
-          let comp: bool = Eq<M::B>(Freeze(Borrow(Mutable)(select M::P.b1<&mut M::P>(p))), Freeze(Borrow(Mutable)(select M::P.b2<&mut M::P>(p))));
+          let comp: bool = Eq<M::B>(Freeze(false)(Borrow(Mutable)(select M::P.b1<&mut M::P>(p))), Freeze(false)(Borrow(Mutable)(select M::P.b2<&mut M::P>(p))));
           select M::B.f<M::B>(select M::P.b1<&mut M::P>(p)) = comp
         }
     }
     private fun t2(p: &mut M::P) {
         {
-          let comp: bool = Neq<M::B>(Freeze(Borrow(Mutable)(select M::P.b1<&mut M::P>(p))), Freeze(Borrow(Mutable)(select M::P.b2<&mut M::P>(p))));
+          let comp: bool = Neq<M::B>(Freeze(false)(Borrow(Mutable)(select M::P.b1<&mut M::P>(p))), Freeze(false)(Borrow(Mutable)(select M::P.b2<&mut M::P>(p))));
           select M::B.f<M::B>(select M::P.b1<&mut M::P>(p)) = comp
         }
     }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
@@ -19,16 +19,16 @@ module 0x8675309::M {
         true;
         true;
         Neq<M::S>(Borrow(Immutable)(s), s_ref);
-        Neq<M::S>(Freeze(Borrow(Mutable)(s)), s_ref);
-        Neq<M::S>(Freeze(Borrow(Mutable)(s)), Freeze(s_mut));
-        Neq<M::S>(Borrow(Immutable)(s), Freeze(s_mut));
-        Neq<M::S>(s_ref, Freeze(s_mut));
-        Neq<M::S>(Freeze(s_mut), Freeze(s_mut));
+        Neq<M::S>(Freeze(false)(Borrow(Mutable)(s)), s_ref);
+        Neq<M::S>(Freeze(false)(Borrow(Mutable)(s)), Freeze(false)(s_mut));
+        Neq<M::S>(Borrow(Immutable)(s), Freeze(false)(s_mut));
+        Neq<M::S>(s_ref, Freeze(false)(s_mut));
+        Neq<M::S>(Freeze(false)(s_mut), Freeze(false)(s_mut));
         Neq<M::S>(pack M::S(0), s);
         Neq<M::R>(r, r);
-        Neq<M::R>(Freeze(r_mut), Freeze(r_mut));
-        Neq<M::R>(r, Freeze(r_mut));
-        Neq<M::R>(Freeze(r_mut), r);
+        Neq<M::R>(Freeze(false)(r_mut), Freeze(false)(r_mut));
+        Neq<M::R>(r, Freeze(false)(r_mut));
+        Neq<M::R>(Freeze(false)(r_mut), r);
         Neq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(2));
         Neq<M::G<u64>>(pack M::G<u64>(1), pack M::G<u64>(2));
         Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/other_builtins.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/other_builtins.exp
@@ -4,8 +4,8 @@ module 0x8675309::M {
         Abort(0)
     }
     private fun foo(x: &mut u64) {
-        Freeze<u64>(x);
-        Freeze<vector<bool>>(Borrow(Mutable)(M::any<vector<bool>>()));
+        Freeze(true)<u64>(x);
+        Freeze(true)<vector<bool>>(Borrow(Mutable)(M::any<vector<bool>>()));
         if false {
           Tuple()
         } else {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_annotation.exp
@@ -5,18 +5,18 @@ module 0x8675309::M {
     }
     private fun t0() {
         Borrow(Mutable)(0);
-        Freeze(Borrow(Mutable)(0));
+        Freeze(false)(Borrow(Mutable)(0));
         Borrow(Immutable)(0);
         Borrow(Mutable)(pack M::S(false));
-        Freeze(Borrow(Mutable)(pack M::S(false)));
+        Freeze(false)(Borrow(Mutable)(pack M::S(false)));
         Borrow(Immutable)(pack M::S(false));
         Tuple()
     }
     private fun t1() {
         Tuple(Borrow(Mutable)(0), Borrow(Mutable)(0));
-        Tuple(Borrow(Mutable)(0), Freeze(Borrow(Mutable)(0)));
-        Tuple(Freeze(Borrow(Mutable)(0)), Borrow(Mutable)(0));
-        Tuple(Freeze(Borrow(Mutable)(0)), Freeze(Borrow(Mutable)(0)));
+        Tuple(Borrow(Mutable)(0), Freeze(false)(Borrow(Mutable)(0)));
+        Tuple(Freeze(false)(Borrow(Mutable)(0)), Borrow(Mutable)(0));
+        Tuple(Freeze(false)(Borrow(Mutable)(0)), Freeze(false)(Borrow(Mutable)(0)));
         Tuple()
     }
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_args.exp
@@ -16,16 +16,16 @@ module 0x8675309::M {
         Tuple()
     }
     private fun t0() {
-        M::imm<u64>(Freeze(Borrow(Mutable)(0)));
+        M::imm<u64>(Freeze(false)(Borrow(Mutable)(0)));
         M::imm<u64>(Borrow(Immutable)(0));
-        M::imm<M::S>(Freeze(Borrow(Mutable)(pack M::S(false))));
+        M::imm<M::S>(Freeze(false)(Borrow(Mutable)(pack M::S(false))));
         M::imm<M::S>(Borrow(Immutable)(pack M::S(false)));
         Tuple()
     }
     private fun t1() {
-        M::imm_mut<u64>(Freeze(Borrow(Mutable)(0)), Borrow(Mutable)(0));
-        M::mut_imm<u64>(Borrow(Mutable)(0), Freeze(Borrow(Mutable)(0)));
-        M::imm_imm<u64>(Freeze(Borrow(Mutable)(0)), Freeze(Borrow(Mutable)(0)));
+        M::imm_mut<u64>(Freeze(false)(Borrow(Mutable)(0)), Borrow(Mutable)(0));
+        M::mut_imm<u64>(Borrow(Mutable)(0), Freeze(false)(Borrow(Mutable)(0)));
+        M::imm_imm<u64>(Freeze(false)(Borrow(Mutable)(0)), Freeze(false)(Borrow(Mutable)(0)));
         Tuple()
     }
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_assign.exp
@@ -6,7 +6,7 @@ module 0x8675309::M {
     private fun t0() {
         {
           let x: &u64;
-          x: &u64 = Freeze(Borrow(Mutable)(0));
+          x: &u64 = Freeze(false)(Borrow(Mutable)(0));
           x;
           Tuple()
         }
@@ -14,17 +14,17 @@ module 0x8675309::M {
     private fun t1() {
         {
           let (x: &mut u64, y: &u64): (&mut u64, &u64);
-          (x: &mut u64, y: &u64): (&mut u64, &u64) = Tuple(Borrow(Mutable)(0), Freeze(Borrow(Mutable)(0)));
+          (x: &mut u64, y: &u64): (&mut u64, &u64) = Tuple(Borrow(Mutable)(0), Freeze(false)(Borrow(Mutable)(0)));
           x;
           y;
           {
             let (x: &u64, y: &mut u64): (&u64, &mut u64);
-            (x: &u64, y: &mut u64): (&u64, &mut u64) = Tuple(Freeze(Borrow(Mutable)(0)), Borrow(Mutable)(0));
+            (x: &u64, y: &mut u64): (&u64, &mut u64) = Tuple(Freeze(false)(Borrow(Mutable)(0)), Borrow(Mutable)(0));
             x;
             y;
             {
               let (x: &u64, y: &u64): (&u64, &u64);
-              (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(Borrow(Mutable)(0)), Freeze(Borrow(Mutable)(0)));
+              (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(false)(Borrow(Mutable)(0)), Freeze(false)(Borrow(Mutable)(0)));
               x;
               y;
               Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_bind.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_bind.exp
@@ -5,22 +5,22 @@ module 0x8675309::M {
     }
     private fun t0() {
         {
-          let x: &u64 = Freeze(Borrow(Mutable)(0));
+          let x: &u64 = Freeze(false)(Borrow(Mutable)(0));
           x;
           Tuple()
         }
     }
     private fun t1() {
         {
-          let (x: &mut u64, y: &u64): (&mut u64, &u64) = Tuple(Borrow(Mutable)(0), Freeze(Borrow(Mutable)(0)));
+          let (x: &mut u64, y: &u64): (&mut u64, &u64) = Tuple(Borrow(Mutable)(0), Freeze(false)(Borrow(Mutable)(0)));
           x;
           y;
           {
-            let (x: &u64, y: &mut u64): (&u64, &mut u64) = Tuple(Freeze(Borrow(Mutable)(0)), Borrow(Mutable)(0));
+            let (x: &u64, y: &mut u64): (&u64, &mut u64) = Tuple(Freeze(false)(Borrow(Mutable)(0)), Borrow(Mutable)(0));
             x;
             y;
             {
-              let (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(Borrow(Mutable)(0)), Freeze(Borrow(Mutable)(0)));
+              let (x: &u64, y: &u64): (&u64, &u64) = Tuple(Freeze(false)(Borrow(Mutable)(0)), Freeze(false)(Borrow(Mutable)(0)));
               x;
               y;
               Tuple()

--- a/third_party/move/move-compiler-v2/tests/checking/typing/subtype_return.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/subtype_return.exp
@@ -4,18 +4,18 @@ module 0x8675309::M {
         dummy_field: bool,
     }
     private fun t0(u: &mut u64): &u64 {
-        Freeze(u)
+        Freeze(false)(u)
     }
     private fun t1(s: &mut M::S): &M::S {
-        Freeze(s)
+        Freeze(false)(s)
     }
     private fun t2(u1: &mut u64,u2: &mut u64): (&u64, &mut u64) {
-        Tuple(Freeze(u1), u2)
+        Tuple(Freeze(false)(u1), u2)
     }
     private fun t3(u1: &mut u64,u2: &mut u64): (&mut u64, &u64) {
-        Tuple(u1, Freeze(u2))
+        Tuple(u1, Freeze(false)(u2))
     }
     private fun t4(u1: &mut u64,u2: &mut u64): (&u64, &u64) {
-        Tuple(Freeze(u1), Freeze(u2))
+        Tuple(Freeze(false)(u1), Freeze(false)(u2))
     }
 } // end 0x8675309::M

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -41,13 +41,13 @@ fun m::foo(): u64 {
   1: $t2 := borrow_local($t1)
   2: $t4 := infer($t2)
   3: $t5 := 0
-  4: $t7 := freeze_ref($t4)
+  4: $t7 := freeze_ref(implicit)($t4)
   5: $t6 := vector::length<u64>($t7)
   6: label L0
   7: $t8 := <($t5, $t6)
   8: if ($t8) goto 9 else goto 27
   9: label L2
- 10: $t13 := freeze_ref($t4)
+ 10: $t13 := freeze_ref(implicit)($t4)
  11: $t12 := vector::borrow<u64>($t13, $t5)
  12: $t11 := infer($t12)
  13: $t14 := read_ref($t11)
@@ -77,7 +77,7 @@ fun m::foo(): u64 {
  37: $t21 := <($t5, $t6)
  38: if ($t21) goto 39 else goto 59
  39: label L10
- 40: $t25 := freeze_ref($t4)
+ 40: $t25 := freeze_ref(implicit)($t4)
  41: $t24 := vector::borrow<u64>($t25, $t5)
  42: $t23 := infer($t24)
  43: $t26 := read_ref($t23)
@@ -102,7 +102,7 @@ fun m::foo(): u64 {
  62: goto 36
  63: label L9
  64: $t3 := infer($t18)
- 65: $t33 := freeze_ref($t2)
+ 65: $t33 := freeze_ref(implicit)($t2)
  66: $t34 := 0
  67: $t32 := vector::borrow<u64>($t33, $t34)
  68: $t0 := read_ref($t32)
@@ -157,7 +157,7 @@ fun m::foo(): u64 {
      # live vars: $t2, $t4
   3: $t5 := 0
      # live vars: $t2, $t4, $t5
-  4: $t7 := freeze_ref($t4)
+  4: $t7 := freeze_ref(implicit)($t4)
      # live vars: $t2, $t4, $t5, $t7
   5: $t6 := vector::length<u64>($t7)
      # live vars: $t2, $t4, $t5, $t6
@@ -169,7 +169,7 @@ fun m::foo(): u64 {
      # live vars: $t2, $t4, $t5, $t6
   9: label L2
      # live vars: $t2, $t4, $t5, $t6
- 10: $t13 := freeze_ref($t4)
+ 10: $t13 := freeze_ref(implicit)($t4)
      # live vars: $t2, $t4, $t5, $t6, $t13
  11: $t12 := vector::borrow<u64>($t13, $t5)
      # live vars: $t2, $t4, $t5, $t6, $t12
@@ -229,7 +229,7 @@ fun m::foo(): u64 {
      # live vars: $t2, $t4, $t5, $t6, $t18
  39: label L10
      # live vars: $t2, $t4, $t5, $t6, $t18
- 40: $t25 := freeze_ref($t4)
+ 40: $t25 := freeze_ref(implicit)($t4)
      # live vars: $t2, $t4, $t5, $t6, $t18, $t25
  41: $t24 := vector::borrow<u64>($t25, $t5)
      # live vars: $t2, $t4, $t5, $t6, $t18, $t24
@@ -279,7 +279,7 @@ fun m::foo(): u64 {
      # live vars: $t2, $t18
  64: $t3 := infer($t18)
      # live vars: $t2
- 65: $t33 := freeze_ref($t2)
+ 65: $t33 := freeze_ref(implicit)($t2)
      # live vars: $t33
  66: $t34 := 0
      # live vars: $t33, $t34

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.exp
@@ -11,9 +11,9 @@ error: cannot freeze local `y`  since multiple mutable references exist
   │                  ^^^^^^^^^ frozen here
 
 error: cannot implicitly freeze local `r` since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/freeze_aliasing.move:28:48
+   ┌─ tests/reference-safety/freeze_aliasing.move:31:48
    │
-28 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+31 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
    │          --------------------------------------^-----
    │          │                                     │
    │          │                                     implicitly frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.exp
@@ -1,0 +1,20 @@
+
+Diagnostics:
+error: cannot freeze local `y`  since multiple mutable references exist
+  ┌─ tests/reference-safety/freeze_aliasing.move:7:18
+  │
+5 │         let r = &mut x;
+  │                 ------ conflicting mutable local borrow
+6 │         let y = &mut x;
+  │                 ------ originating mutable local borrow
+7 │         let _z = freeze(y);
+  │                  ^^^^^^^^^ frozen here
+
+error: cannot implicitly freeze local `r` since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/freeze_aliasing.move:28:48
+   │
+28 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+   │          --------------------------------------^-----
+   │          │                                     │
+   │          │                                     implicitly frozen here
+   │          used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.move
@@ -1,0 +1,30 @@
+
+module 0x42::n {
+    fun dead_store() {
+        let x = 3;
+        let r = &mut x;
+        let y = &mut x;
+        let _z = freeze(y);
+        *r = 4;
+    }
+
+    fun eq(x: &mut u64): bool {
+        x == x
+    }
+
+    fun freeze_indirect() {
+        use std::vector;
+        let x = vector[1, 2, 3];
+        let r = &mut x;
+        let i = *vector::borrow(r, 1);
+        *vector::borrow_mut(r, i) = 4;
+        //*vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+    }
+
+    fun freeze_direct() {
+        use std::vector;
+        let x = vector[1, 2, 3];
+        let r = &mut x;
+        *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.move
@@ -1,5 +1,5 @@
-
 module 0x42::n {
+    // fails
     fun dead_store() {
         let x = 3;
         let r = &mut x;
@@ -8,10 +8,12 @@ module 0x42::n {
         *r = 4;
     }
 
+    // Succeeds
     fun eq(x: &mut u64): bool {
         x == x
     }
 
+    // Succeeds
     fun freeze_indirect() {
         use std::vector;
         let x = vector[1, 2, 3];
@@ -21,6 +23,7 @@ module 0x42::n {
         //*vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
     }
 
+    // Fails
     fun freeze_direct() {
         use std::vector;
         let x = vector[1, 2, 3];

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.no-opt.exp
@@ -11,9 +11,9 @@ error: cannot freeze local `y`  since multiple mutable references exist
   │                  ^^^^^^^^^ frozen here
 
 error: cannot implicitly freeze local `r` since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/freeze_aliasing.move:28:48
+   ┌─ tests/reference-safety/freeze_aliasing.move:31:48
    │
-28 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+31 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
    │          --------------------------------------^-----
    │          │                                     │
    │          │                                     implicitly frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_aliasing.no-opt.exp
@@ -1,0 +1,20 @@
+
+Diagnostics:
+error: cannot freeze local `y`  since multiple mutable references exist
+  ┌─ tests/reference-safety/freeze_aliasing.move:7:18
+  │
+5 │         let r = &mut x;
+  │                 ------ conflicting mutable local borrow
+6 │         let y = &mut x;
+  │                 ------ originating mutable local borrow
+7 │         let _z = freeze(y);
+  │                  ^^^^^^^^^ frozen here
+
+error: cannot implicitly freeze local `r` since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/freeze_aliasing.move:28:48
+   │
+28 │         *vector::borrow_mut(r, *vector::borrow(r, 1)) = 4;
+   │          --------------------------------------^-----
+   │          │                                     │
+   │          │                                     implicitly frozen here
+   │          used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.exp
@@ -1,0 +1,22 @@
+
+Diagnostics:
+error: cannot freeze local `y`  since multiple mutable references exist
+  ┌─ tests/reference-safety/freeze_dead_code.move:8:9
+  │
+5 │         let n = &mut x;
+  │                 ------ conflicting mutable local borrow
+6 │         let y = &mut x;
+  │                 ------ originating mutable local borrow
+7 │         let _m = &mut x;
+8 │         freeze(y);
+  │         ^^^^^^^^^ frozen here
+
+error: cannot freeze local `y`  since multiple mutable references exist
+   ┌─ tests/reference-safety/freeze_dead_code.move:18:9
+   │
+16 │         let y = &mut x;
+   │                 ------ originating mutable local borrow
+17 │         let m = &mut x;
+   │                 ------ conflicting mutable local borrow
+18 │         freeze(y);
+   │         ^^^^^^^^^ frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.move
@@ -1,0 +1,21 @@
+module 0x42::n {
+    // Currently expected to fail both v1 and v2
+    fun test1() {
+        let x = 3;
+        let n = &mut x;
+        let y = &mut x;
+        let _m = &mut x;
+        freeze(y);
+        *n = *n + 1;
+    }
+
+    // Currently expected to fail in v2 but succeeds in v1
+    fun test2() {
+        let x = 3;
+        let _n = &mut x;
+        let y = &mut x;
+        let m = &mut x;
+        freeze(y);
+        *m = *m + 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze_dead_code.no-opt.exp
@@ -1,0 +1,22 @@
+
+Diagnostics:
+error: cannot freeze local `y`  since multiple mutable references exist
+  ┌─ tests/reference-safety/freeze_dead_code.move:8:9
+  │
+5 │         let n = &mut x;
+  │                 ------ conflicting mutable local borrow
+6 │         let y = &mut x;
+  │                 ------ originating mutable local borrow
+7 │         let _m = &mut x;
+8 │         freeze(y);
+  │         ^^^^^^^^^ frozen here
+
+error: cannot freeze local `y`  since multiple mutable references exist
+   ┌─ tests/reference-safety/freeze_dead_code.move:18:9
+   │
+16 │         let y = &mut x;
+   │                 ------ originating mutable local borrow
+17 │         let m = &mut x;
+   │                 ------ conflicting mutable local borrow
+18 │         freeze(y);
+   │         ^^^^^^^^^ frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.exp
@@ -28,3 +28,13 @@ error: same mutable reference in local `r1` is also used in other local `r2` in 
    │                  ------ previous mutable local borrow
 20 │         s(r1, r2)
    │         ^^^^^^^^^ requirement enforced here
+
+error: cannot implicitly freeze local `r1`  since multiple mutable references exist
+   ┌─ tests/reference-safety/multiple_use_invalid.move:27:9
+   │
+25 │         let r1 = &mut x;
+   │                  ------ originating mutable local borrow
+26 │         let r2 = &mut x;
+   │                  ------ conflicting mutable local borrow
+27 │         r1 == r2
+   │         ^^ implicitly frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.no-opt.exp
@@ -28,3 +28,13 @@ error: same mutable reference in local `r1` is also used in other local `r2` in 
    │                  ------ previous mutable local borrow
 20 │         s(r1, r2)
    │         ^^^^^^^^^ requirement enforced here
+
+error: cannot implicitly freeze local `r1`  since multiple mutable references exist
+   ┌─ tests/reference-safety/multiple_use_invalid.move:27:9
+   │
+25 │         let r1 = &mut x;
+   │                  ------ originating mutable local borrow
+26 │         let r2 = &mut x;
+   │                  ------ conflicting mutable local borrow
+27 │         r1 == r2
+   │         ^^ implicitly frozen here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: cannot freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:31:30
+   │
+31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
+   │                              ^^^^^^^^^^^^^^^^^^ frozen here
+32 │         let f1 = &inner.f1;
+   │                  --------- used here
+
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:34:9
    │
@@ -26,6 +34,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 37 │         *c;
    │         -- conflicting reference `c` used here
+
+error: cannot freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:40:33
+   │
+40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
+   │                                 ^^^^^^^^^^^^^^^^^^ frozen here
+41 │         let f1 = &inner.f1;
+   │                  --------- used here
 
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:43:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.no-opt.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: cannot freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:31:30
+   │
+31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
+   │                              ^^^^^^^^^^^^^^^^^^ frozen here
+32 │         let f1 = &inner.f1;
+   │                  --------- used here
+
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:34:9
    │
@@ -26,6 +34,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 37 │         *c;
    │         -- conflicting reference `c` used here
+
+error: cannot freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:40:33
+   │
+40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
+   │                                 ^^^^^^^^^^^^^^^^^^ frozen here
+41 │         let f1 = &inner.f1;
+   │                  --------- used here
 
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:43:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 22 │         *f;
    │         -- conflicting reference `f` used here
 
+error: cannot implicitly freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/dereference_combo.move:28:23
+   │
+28 │         if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
+   │                       ^^^^^^ implicitly frozen here
+29 │         *s;
+   │         -- used here
+
 error: mutable reference in local `s` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo.move:29:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.no-opt.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 22 │         *f;
    │         -- conflicting reference `f` used here
 
+error: cannot implicitly freeze value since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/dereference_combo.move:28:23
+   │
+28 │         if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
+   │                       ^^^^^^ implicitly frozen here
+29 │         *s;
+   │         -- used here
+
 error: mutable reference in local `s` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo.move:29:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.exp
@@ -1,34 +1,9 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
-   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
+error: cannot freeze local `s` since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:27:9
    │
-13 │         freeze(s);
-   │         ^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "M",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            2,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(2),
-            12,
-        ),
-    ],
-}
+27 │         freeze(s);
+   │         ^^^^^^^^^ frozen here
+28 │         *x;
+   │         -- used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/freeze_combo_invalid.no-opt.exp
@@ -1,34 +1,9 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
-   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:13:9
+error: cannot freeze local `s` since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/v1-tests/freeze_combo_invalid.move:27:9
    │
-13 │         freeze(s);
-   │         ^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "M",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            2,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(2),
-            12,
-        ),
-    ],
-}
+27 │         freeze(s);
+   │         ^^^^^^^^^ frozen here
+28 │         *x;
+   │         -- used here

--- a/third_party/move/move-compiler-v2/tests/simplifier/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/bug_11112.exp
@@ -11,7 +11,7 @@ module 0xcafe::vectors {
               {
                 let i: u64 = 0;
                 loop {
-                  if Lt<u64>(i, vector::length<u64>(Freeze(v))) {
+                  if Lt<u64>(i, vector::length<u64>(Freeze(false)(v))) {
                     {
                       let (e: &mut u64): (&mut u64) = Tuple(vector::borrow_mut<u64>(v, i));
                       e = s;

--- a/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test4.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test4.exp
@@ -19,7 +19,7 @@ module 0x8675309::M {
             s));
             if true {
               x: u64 = Add<u64>(x, 1);
-              M::foo(Freeze<M::S>(s), x: u64 = Add<u64>(x, 1);
+              M::foo(Freeze(true)<M::S>(s), x: u64 = Add<u64>(x, 1);
               f = 0;
               1)
             } else {

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -82,8 +82,8 @@ enum StopAfter {
 
 /// Names for 'virtual' processors in the pipeline. This can be used for
 /// filtering via the `config.dump_bytecode_filter` option.
-const INITIAL_BYTECODE_STAGE: &str = "FILE_FORMAT";
-const FILE_FORMAT_STAGE: &str = "INITIAL_BYTECODE";
+const INITIAL_BYTECODE_STAGE: &str = "INITIAL_BYTECODE";
+const FILE_FORMAT_STAGE: &str = "FILE_FORMAT";
 
 /// Active test configurations. A test configuration is selected by
 /// matching the include/exclude path specifications with the test file's path.
@@ -237,6 +237,13 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,
+            // For debugging:
+            // Some(vec![
+            //   INITIAL_BYTECODE_STAGE,
+            //   "ReferenceSafetyProcessor",
+            //   "DeadStoreElimination",
+            //   FILE_FORMAT_STAGE,
+            //]),
         },
         // Reference safety tests (without optimizations on)
         TestConfig {

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -172,7 +172,7 @@ pub enum Operation {
 
     ReadRef,
     WriteRef,
-    FreezeRef,
+    FreezeRef(/*explicit*/ bool),
     Vector,
 
     // Unary
@@ -265,7 +265,7 @@ impl Operation {
             Operation::Release => false,
             Operation::ReadRef => false,
             Operation::WriteRef => false,
-            Operation::FreezeRef => false,
+            Operation::FreezeRef(_) => false,
             Operation::Vector => false,
             Operation::Havoc(_) => false,
             Operation::Stop => false,
@@ -1166,8 +1166,12 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             WriteRef => {
                 write!(f, "write_ref")?;
             },
-            FreezeRef => {
-                write!(f, "freeze_ref")?;
+            FreezeRef(explicit) => {
+                if *explicit {
+                    write!(f, "freeze_ref")?;
+                } else {
+                    write!(f, "freeze_ref(implicit)")?;
+                }
             },
             Vector => {
                 write!(f, "vector")?;

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -352,7 +352,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                         self.local_types
                             .push(Type::Reference(ReferenceKind::Immutable, signature));
                         self.code.push(mk_call(
-                            Operation::FreezeRef,
+                            Operation::FreezeRef(true),
                             vec![immutable_ref_index],
                             vec![mutable_ref_index],
                         ));

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1568,7 +1568,7 @@ pub enum Operation {
     Deref,
     MoveTo,
     MoveFrom,
-    Freeze,
+    Freeze(/*explicit*/ bool),
     Abort,
     Vector,
 
@@ -2417,7 +2417,7 @@ impl Operation {
             Deref => false,            // Move-related
             MoveTo => false,           // Move-related
             MoveFrom => false,         // Move-related
-            Freeze => false,           // Move-related
+            Freeze(_) => false,        // Move-related
             Abort => false,            // Move-related
             Vector => false,           // Move-related
 

--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -569,7 +569,7 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
             trans.builtin_qualified_symbol("freeze"),
             SpecOrBuiltinFunEntry {
                 loc: loc.clone(),
-                oper: Operation::Freeze,
+                oper: Operation::Freeze(true),
                 type_params: vec![param_t_decl.clone()],
                 type_param_constraints: BTreeMap::default(),
                 params: vec![mk_param(trans, 1, mut_ref_param_t)],

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -3366,7 +3366,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             let exp_id = exp.node_id();
             let new_id =
                 self.new_node_id_with_type_loc(expected_ty, &self.env().get_node_loc(exp_id));
-            ExpData::Call(new_id, Operation::Freeze, vec![exp]).into_exp()
+            ExpData::Call(new_id, Operation::Freeze(false), vec![exp]).into_exp()
         } else {
             exp
         }

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1119,7 +1119,7 @@ impl<'env> FunctionTranslator<'env> {
             Call(_, dests, oper, srcs, aa) => {
                 use Operation::*;
                 match oper {
-                    FreezeRef => unreachable!(),
+                    FreezeRef(_) => unreachable!(),
                     UnpackRef | UnpackRefDeep | PackRef | PackRefDeep => {
                         // No effect
                     },

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -939,7 +939,7 @@ impl<'env> SpecTranslator<'env> {
                     "currently `TRACE(..)` cannot be used in spec functions or in lets",
                 )
             },
-            Operation::Freeze => {
+            Operation::Freeze(_) => {
                 // Skip freeze operation
                 self.translate_exp(&args[0])
             },

--- a/third_party/move/move-prover/bytecode-pipeline/src/eliminate_imm_refs.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/eliminate_imm_refs.rs
@@ -93,7 +93,7 @@ impl<'a> EliminateImmRefs<'a> {
                     self.builder
                         .emit(Assign(attr_id, dests[0], srcs[0], AssignKind::Move));
                 },
-                FreezeRef => self.builder.emit(Call(attr_id, dests, ReadRef, srcs, None)),
+                FreezeRef(_) => self.builder.emit(Call(attr_id, dests, ReadRef, srcs, None)),
                 BorrowLoc if self.is_imm_ref(dests[0]) => {
                     self.builder
                         .emit(Assign(attr_id, dests[0], srcs[0], AssignKind::Copy));


### PR DESCRIPTION
## Description

The freeze operation has some unexpected ad-hoc rules in the v1 borrow semantics: when a reference is frozen, there must not exist any other mutable reference pointing to the same location. It is, however, ok if the currently frozen reference is used later again. This seems to be over-restrictive since it shouldn't matter whether copies of the mutable reference exist as long as they aren't passed at the same time as an argument to a function, i.e. as long as they do not create aliasing.

This PR simulates the v1 borrow rules for freeze, so we avoid bytcode verification errors. At later point we may relax the rules in the bytecode verifier, at which point we could remove those rules or guard them behind a flag.

Closes #12554.  Als repairs some of the bugs in #12701, but not all, so keeping this bug open.


<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Fixes existing tests, adds new one

## Key Areas to Review

baseline files

