### PR TITLE
[CI/CD] Split up rust lint and cached packages scripts.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -122,6 +122,26 @@ jobs:
       - run: echo "Skipping rust unit tests! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
+  # Run the cached packages build. This is a PR required job.
+  rust-build-cached-packages:
+    needs: file_change_determinator
+    if: | # Only run on each PR once an appropriate event occurs
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null
+      )
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v4
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - name: Run aptos cached packages build test
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        run: scripts/cargo_build_aptos_cached_packages.sh --check
+      - run: echo "Skipping cached packages test! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
   # Run the consensus only unit tests
   rust-consensus-only-unit-test:
     runs-on: high-perf-docker

--- a/scripts/cargo_build_aptos_cached_packages.sh
+++ b/scripts/cargo_build_aptos_cached_packages.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# This script ensures that aptos-cached-packages has been built correctly.
+#
+# If you want to run this from anywhere in aptos-core, try adding the wrapper
+# script to your path:
+# https://gist.github.com/banool/e6a2b85e2fff067d3a215cbfaf808032
+
+# Make sure we're in the root of the repo.
+if [ ! -d ".github" ]
+then
+    echo "Please run this from the root of aptos-core!"
+    exit 1
+fi
+
+# Run in check mode if requested.
+CHECK_ARG=""
+if [ "$1" = "--check" ]; then
+    CHECK_ARG="--check"
+fi
+
+# Set appropriate script flags
+set -e
+set -x
+
+# Ensure that aptos-cached-packages have been built correctly.
+unset SKIP_FRAMEWORK_BUILD
+cargo build -p aptos-cached-packages
+if [ -n "$CHECK_ARG" ]; then
+    if [ -n "$(git status --porcelain -uno aptos-move)" ]; then
+      git diff
+      echo "There are unstaged changes after running 'cargo build -p aptos-cached-packages'! Are you sure aptos-cached-packages is up-to-date?"
+      exit 1
+    fi
+fi

--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -5,14 +5,14 @@
 #
 # The best way to do this however is to run scripts/dev_setup.sh
 #
-# If you want to run this from anywhere in aptos-core, try adding this wrapepr
+# If you want to run this from anywhere in aptos-core, try adding the wrapper
 # script to your path:
 # https://gist.github.com/banool/e6a2b85e2fff067d3a215cbfaf808032
 
 # Make sure we're in the root of the repo.
 if [ ! -d ".github" ]
 then
-    echo "Please run this from the root of aptos-core"
+    echo "Please run this from the root of aptos-core!"
     exit 1
 fi
 
@@ -22,9 +22,11 @@ if [ "$1" = "--check" ]; then
     CHECK_ARG="--check"
 fi
 
+# Set appropriate script flags
 set -e
 set -x
 
+# Run clippy with the aptos-core specific configuration.
 cargo xclippy
 
 # We require the nightly build of cargo fmt
@@ -35,14 +37,3 @@ cargo +nightly fmt $CHECK_ARG
 # we can move to cleaner workspace dependency notation.
 # See: https://github.com/DevinR528/cargo-sort/issues/47
 cargo sort --grouped --workspace $CHECK_ARG
-
-# Ensure that aptos-cached-packages have been built correctly.
-unset SKIP_FRAMEWORK_BUILD
-cargo build -p aptos-cached-packages
-if [ -n "$CHECK_ARG" ]; then
-    if [ -n "$(git status --porcelain -uno aptos-move)" ]; then
-      git diff
-      echo "There are unstaged changes after running 'cargo build -p aptos-cached-packages'! Are you sure aptos-cached-packages is up-to-date?"
-      exit 1
-    fi
-fi


### PR DESCRIPTION
## Description
This PR removes the step to build the cached packages from `rust_lint.sh` and migrates it to a separate script, to be invoked separately. This has the benefit that it: (i) reduces the lint script time (the lint script is run much more frequently); and (ii) only invokes the cached package build when required (most folks don't need to run this alongside the linter).

## Testing plan
Manual verification and existing test infrastructure.