### PR TITLE
[release-builder] allow gas feature version to be overridden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "aptos-build-info",
  "aptos-crypto",
  "aptos-framework",
+ "aptos-gas-schedule",
  "aptos-gas-schedule-updator",
  "aptos-genesis",
  "aptos-infallible",

--- a/aptos-move/aptos-gas-schedule-updator/src/lib.rs
+++ b/aptos-move/aptos-gas-schedule-updator/src/lib.rs
@@ -107,13 +107,16 @@ fn aptos_framework_path() -> PathBuf {
 pub struct GenArgs {
     #[clap(short, long)]
     pub output: Option<String>,
+
+    #[clap(short, long)]
+    pub gas_feature_version: Option<u64>,
 }
 
 /// Constructs the current gas schedule in on-chain format.
-pub fn current_gas_schedule() -> GasScheduleV2 {
+pub fn current_gas_schedule(feature_version: u64) -> GasScheduleV2 {
     GasScheduleV2 {
-        feature_version: LATEST_GAS_FEATURE_VERSION,
-        entries: AptosGasParameters::initial().to_on_chain_gas_schedule(LATEST_GAS_FEATURE_VERSION),
+        feature_version,
+        entries: AptosGasParameters::initial().to_on_chain_gas_schedule(feature_version),
     }
 }
 
@@ -121,9 +124,13 @@ pub fn current_gas_schedule() -> GasScheduleV2 {
 pub fn generate_update_proposal(args: &GenArgs) -> Result<()> {
     let mut pack = PackageBuilder::new("GasScheduleUpdate");
 
+    let feature_version = args
+        .gas_feature_version
+        .unwrap_or(LATEST_GAS_FEATURE_VERSION);
+
     pack.add_source(
         "update_gas_schedule.move",
-        &generate_script(&current_gas_schedule())?,
+        &generate_script(&current_gas_schedule(feature_version))?,
     );
     // TODO: use relative path here
     pack.add_local_dep("AptosFramework", &aptos_framework_path().to_string_lossy());

--- a/aptos-move/aptos-gas-schedule-updator/tests/gen_tests.rs
+++ b/aptos-move/aptos-gas-schedule-updator/tests/gen_tests.rs
@@ -9,6 +9,7 @@ fn can_generate_and_build_update_proposal() {
     let output_dir = tempfile::tempdir().unwrap();
 
     generate_update_proposal(&GenArgs {
+        gas_feature_version: None,
         output: Some(output_dir.path().to_string_lossy().to_string()),
     })
     .unwrap();

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -19,6 +19,7 @@ aptos-api-types = { workspace = true }
 aptos-build-info = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }
+aptos-gas-schedule = { workspace = true }
 aptos-gas-schedule-updator = { workspace = true }
 aptos-genesis = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -9,8 +9,10 @@ proposals:
     execution_mode: MultiStep
     update_sequence:
       - DefaultGasWithOverrideOld: # This is translated to `gas_schedule::set_gas_schedule(...)`.
-          - name: "txn.max_execution_gas"
-            value: 3676000000
+          feature_version: 13
+          overrides:
+            - name: "txn.max_execution_gas"
+              value: 3676000000
   - name: step_2_upgrade_framework
     metadata:
       title: "Multi-step proposal to upgrade mainnet framework to v1.10-plus"
@@ -21,7 +23,8 @@ proposals:
           bytecode_version: 6
           git_hash: ~
       - RawScript: aptos-move/aptos-release-builder/data/proposals/randomness_framework_initialization.move # Keep this in 1.11
-      - DefaultGas  # [probably 1.11] This is translated to `gas_schedule::set_for_next_epoch(...)`.
+      - DefaultGasWithOverride:  # [probably 1.11] This is translated to `gas_schedule::set_for_next_epoch(...)`.
+          feature_version: 13 
   - name: step_3_storage_fee_for_state_bytes_refundable
     metadata:
       title: "AIP-65: Storage Fee for State Bytes refundable"


### PR DESCRIPTION
This allows the gas feature version to be overridden when building a release, which is needed when you don't want to bump it on-chain.