### PR TITLE
[move-examples] Add raffle example that supports the latest syntax

### DIFF
--- a/aptos-move/move-examples/raffle/Move.toml
+++ b/aptos-move/move-examples/raffle/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "raffle"
+version = "0.0.1"
+
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }
+AptosStdlib = { local = "../../framework/aptos-stdlib" }
+
+[addresses]
+raffle = "_"

--- a/aptos-move/move-examples/raffle/scripts/test_and_abort_attack_defeated.move
+++ b/aptos-move/move-examples/raffle/scripts/test_and_abort_attack_defeated.move
@@ -1,0 +1,42 @@
+script {
+    use aptos_framework::aptos_coin;
+    use aptos_framework::coin;
+
+    use std::signer;
+
+    /// An example of a **test-and-abort** attack that fails thanks to the use of a private entry function
+    /// being marked as *private* entry function.
+    fun main(attacker: &signer) {
+        let attacker_addr = signer::address_of(attacker);
+
+        let old_balance = coin::balance<aptos_coin::AptosCoin>(attacker_addr);
+
+        // SECURITY: The fact that `randomly_pick_winner` is a *private* entry function is what
+        // prevents this call here. The compiler will output the following error:
+        //
+        // ```
+        //    error[E04001]: restricted visibility
+        //    |- /tmp/aptos-core/aptos-move/move-examples/raffle/scripts/test_and_abort_attack_defeated.move:19:9
+        //    |
+        //    19 |         raffle::raffle::randomly_pick_winner();
+        //    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '(raffle=0xC3BB8488AB1A5815A9D543D7E41B0E0DF46A7396F89B22821F07A4362F75DDC5)::raffle::randomly_pick_winner'
+        //    |
+        //    |- /tmp/aptos-core/aptos-move/move-examples/raffle/sources/raffle.move:122:15
+        //    |
+        //    122 |     entry fun randomly_pick_winner() acquires raffle, Credentials {
+        //    |               -------------- This function is internal to its module. Only 'public' and 'public(friend)' functions can be called outside of their module
+        // ```
+
+        // TODO: Uncomment this call to reproduce the error above & see the attack failing.
+        // (Commented out to ensure this Move example compiles.)
+        //raffle::raffle::randomly_pick_winner_internal();
+
+        let new_balance = coin::balance<aptos_coin::AptosCoin>(attacker_addr);
+
+        // The attacker can see if his balance remained the same. If it did, then
+        // the attacker knows they did NOT win the raffle and can abort everything.
+        if (new_balance == old_balance) {
+            abort (1)
+        };
+    }
+}

--- a/aptos-move/move-examples/raffle/sources/raffle.move
+++ b/aptos-move/move-examples/raffle/sources/raffle.move
@@ -1,0 +1,100 @@
+/// An example of an on-chain raffle using randomness
+///
+/// This example requires CLI version 3.1.0 or later.
+module raffle::raffle {
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin;
+    use aptos_framework::randomness;
+    use aptos_std::smart_vector;
+    use aptos_std::smart_vector::SmartVector;
+    use aptos_framework::coin::Coin;
+    use std::signer;
+
+    // We need this friend declaration so our tests can call `init_module`.
+    friend raffle::raffle_test;
+
+    /// Error code for when a user tries to initate the drawing but no users bought any tickets.
+    const E_NO_TICKETS: u64 = 2;
+
+    /// Error code for when the somebody tries to draw an already-closed raffle
+    const E_RAFFLE_HAS_CLOSED: u64 = 3;
+
+    /// The minimum price of a raffle ticket, in APT.
+    const TICKET_PRICE: u64 = 10_000;
+
+    /// A raffle: a list of users who bought tickets.
+    struct Raffle has key {
+        // A list of users who bought raffle tickets (repeats allowed).
+        tickets: SmartVector<address>,
+        coins: Coin<AptosCoin>,
+        is_closed: bool,
+    }
+
+    /// Initializes the `Raffle` resource, which will maintain the list of raffle tickets bought by users.
+    fun init_module(deployer: &signer) {
+        move_to(
+            deployer,
+            Raffle {
+                tickets: smart_vector::empty(),
+                coins: coin::zero(),
+                is_closed: false,
+            }
+        );
+    }
+
+    #[test_only]
+    public(friend) fun init_module_for_testing(deployer: &signer) {
+        init_module(deployer)
+    }
+
+    /// The price of buying a raffle ticket.
+    public fun get_ticket_price(): u64 { TICKET_PRICE }
+
+    /// Any user can call this to purchase a ticket in the raffle.
+    public entry fun buy_a_ticket(user: &signer) acquires Raffle {
+        let raffle = borrow_global_mut<Raffle>(@raffle);
+
+        // Charge the price of a raffle ticket from the user's balance, and
+        // accumulate it into the raffle's bounty.
+        let coins = coin::withdraw<AptosCoin>(user, TICKET_PRICE);
+        coin::merge(&mut raffle.coins, coins);
+
+        // Issue a ticket for that user
+        smart_vector::push_back(&mut raffle.tickets, signer::address_of(user))
+    }
+
+    #[randomness]
+    /// Can only be called as a top-level call from a TXN, preventing **test-and-abort** attacks (see
+    /// [AIP-41](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-41.md)).
+    entry fun randomly_pick_winner() acquires Raffle {
+        randomly_pick_winner_internal();
+    }
+
+    /// Insecurely wraps around `randomly_pick_winner_internal` allowing this function to
+    /// be called from a Move script or another module, leaving it vulnerable to
+    /// **test-and-abort** attacks (see [AIP-41](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-41.md)).
+    ///
+    /// Commented out for security.
+    //public fun randomly_pick_winner() acquires Raffle, Credentials {
+    //    randomly_pick_winner_internal();
+    //}
+
+    /// Allows anyone to close the raffle (if enough time has elapsed & more than
+    /// 1 user bought tickets) and to draw a random winner.
+    public(friend) fun randomly_pick_winner_internal(): address acquires Raffle {
+        let raffle = borrow_global_mut<Raffle>(@raffle);
+        assert!(!raffle.is_closed, E_RAFFLE_HAS_CLOSED);
+        assert!(!smart_vector::is_empty(&raffle.tickets), E_NO_TICKETS);
+
+        // Pick a random winner in [0, |raffle.tickets|)
+        let winner_idx = randomness::u64_range(0, smart_vector::length(&raffle.tickets));
+        let winner = *smart_vector::borrow(&raffle.tickets, winner_idx);
+
+        // Pay the winner
+        let coins = coin::extract_all(&mut raffle.coins);
+        coin::deposit<AptosCoin>(winner, coins);
+        raffle.is_closed = true;
+
+        winner
+    }
+}

--- a/aptos-move/move-examples/raffle/sources/raffle_test.move
+++ b/aptos-move/move-examples/raffle/sources/raffle_test.move
@@ -1,0 +1,121 @@
+module raffle::raffle_test {
+    #[test_only]
+    use aptos_framework::account;
+    #[test_only]
+    use aptos_framework::aptos_coin::{Self, AptosCoin};
+    #[test_only]
+    use aptos_framework::coin;
+    #[test_only]
+    use aptos_framework::coin::MintCapability;
+
+    #[test_only]
+    use aptos_std::debug;
+
+    #[test_only]
+    use std::signer;
+    #[test_only]
+    use std::string;
+    #[test_only]
+    use std::vector;
+
+    #[test_only]
+    use raffle::raffle;
+
+    #[test_only]
+    use aptos_std::crypto_algebra::enable_cryptography_algebra_natives;
+    #[test_only]
+    use aptos_framework::randomness;
+
+    #[test_only]
+    fun give_coins(mint_cap: &MintCapability<AptosCoin>, to: &signer) {
+        let to_addr = signer::address_of(to);
+        if (!account::exists_at(to_addr)) {
+            account::create_account_for_test(to_addr);
+        };
+        coin::register<AptosCoin>(to);
+
+        let coins = coin::mint(raffle::get_ticket_price(), mint_cap);
+        coin::deposit(to_addr, coins);
+    }
+
+    #[test(
+        deployer = @raffle,
+        fx = @aptos_framework,
+        u1 = @0xA001, u2 = @0xA002, u3 = @0xA003, u4 = @0xA004
+    )]
+    fun test_raffle(
+        deployer: signer,
+        fx: signer,
+        u1: signer, u2: signer, u3: signer, u4: signer,
+    ) {
+        enable_cryptography_algebra_natives(&fx);
+        randomness::initialize_for_testing(&fx);
+
+        // Deploy the raffle smart contract
+        account::create_account_for_test(signer::address_of(&deployer));
+        raffle::init_module_for_testing(&deployer);
+
+        // Needed to mint coins out of thin air for testing
+        let (burn_cap, mint_cap) = aptos_coin::initialize_for_test(&fx);
+
+        // Create fake coins for users participating in raffle & initialize aptos_framework
+        give_coins(&mint_cap, &u1);
+        give_coins(&mint_cap, &u2);
+        give_coins(&mint_cap, &u3);
+        give_coins(&mint_cap, &u4);
+
+
+        let winner = test_raffle_with_randomness(
+            &u1, &u2, &u3, &u4,
+        );
+
+        let players = vector[
+            signer::address_of(&u1),
+            signer::address_of(&u2),
+            signer::address_of(&u3),
+            signer::address_of(&u4)
+        ];
+
+        // Assert the winner got all the money
+        let i = 0;
+        let num_players = vector::length(&players);
+        while (i < num_players) {
+            let player = *vector::borrow(&players, i);
+
+            if (player == winner) {
+                assert!(coin::balance<AptosCoin>(player) == raffle::get_ticket_price() * num_players, 1);
+            } else {
+                assert!(coin::balance<AptosCoin>(player) == 0, 1);
+            };
+
+            i = i + 1;
+        };
+
+        // Clean up
+        coin::destroy_burn_cap<AptosCoin>(burn_cap);
+        coin::destroy_mint_cap<AptosCoin>(mint_cap);
+    }
+
+    #[test_only]
+    fun test_raffle_with_randomness(
+        u1: &signer, u2: &signer, u3: &signer, u4: &signer,
+    ): address {
+        //
+        // Each user sends a TXN to buy their ticket
+        //
+        raffle::buy_a_ticket(u1);
+        raffle::buy_a_ticket(u2);
+        raffle::buy_a_ticket(u3);
+        raffle::buy_a_ticket(u4);
+
+        //
+        // Send a TXN  to close the raffle and determine the winner
+        //
+        let winner_addr = raffle::randomly_pick_winner_internal();
+
+        debug::print(&string::utf8(b"The winner is: "));
+        debug::print(&winner_addr);
+
+        winner_addr
+    }
+}


### PR DESCRIPTION
## Description
This is to replace the `raffle` example on the `randomnet` branch, as the syntax has changed, and devnet should be developed on rather than `randomnet` for randomness.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify) move examples

## How Has This Been Tested?
Compiled and ran locally

## Key Areas to Review
This copies the existing one on randomnet, and adds the annotation for randomness

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
