### PR TITLE
[WIP][Compiler-v2]] Fix "no error reported in the presence of multiple active mutable references"

### DIFF
--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -18,13 +18,13 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-error: cannot write to reference in local `a` which is still borrowed
+error: cannot write local `a` since other mutable usages for this reference exist
   ┌─ tests/copy-propagation/mut_refs_3.move:7:9
   │
 7 │         *a = 0;
   │         ^^^^^^ written here
 8 │         *c
-  │         -- conflicting reference `c` used here
+  │         -- used here
 
 ============ after DeadStoreElimination: ================
 

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -16,6 +16,16 @@ fun m::test($t0: u64): u64 {
   6: return $t1
 }
 
+
+Diagnostics:
+error: cannot write to reference in local `a` which is still borrowed
+  ┌─ tests/copy-propagation/mut_refs_3.move:7:9
+  │
+7 │         *a = 0;
+  │         ^^^^^^ written here
+8 │         *c
+  │         -- conflicting reference `c` used here
+
 ============ after DeadStoreElimination: ================
 
 [variant baseline]

--- a/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: cannot write to reference in local `a` which is still borrowed
+  ┌─ tests/reference-safety/debug_12301.move:6:9
+  │
+6 │         *a = 0;
+  │         ^^^^^^ written here
+7 │         *c
+  │         -- conflicting reference `c` used here
+
+error: cannot write to reference in local `a` which is still borrowed
+   ┌─ tests/reference-safety/debug_12301.move:15:9
+   │
+15 │         *a = 0;
+   │         ^^^^^^ written here
+16 │         *k = 1;
+17 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: cannot write to reference in local `a` which is still borrowed
+error: cannot write local `a` since other mutable usages for this reference exist
   ┌─ tests/reference-safety/debug_12301.move:6:9
   │
 6 │         *a = 0;
   │         ^^^^^^ written here
 7 │         *c
-  │         -- conflicting reference `c` used here
+  │         -- used here
 
-error: cannot write to reference in local `a` which is still borrowed
+error: cannot write local `a` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/debug_12301.move:15:9
    │
 15 │         *a = 0;
    │         ^^^^^^ written here
 16 │         *k = 1;
 17 │         *c
-   │         -- conflicting reference `c` used here
+   │         -- used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.move
@@ -1,0 +1,20 @@
+module 0xc0ffee::m {
+    public fun test1(p: u64): u64 {
+        let a = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *c
+    }
+
+    public fun test2(p: u64): u64 {
+        let a = &mut p;
+        let k = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *k = 1;
+        *c
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.no-opt.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: cannot write to reference in local `a` which is still borrowed
+  ┌─ tests/reference-safety/debug_12301.move:6:9
+  │
+6 │         *a = 0;
+  │         ^^^^^^ written here
+7 │         *c
+  │         -- conflicting reference `c` used here
+
+error: cannot write to reference in local `a` which is still borrowed
+   ┌─ tests/reference-safety/debug_12301.move:15:9
+   │
+15 │         *a = 0;
+   │         ^^^^^^ written here
+16 │         *k = 1;
+17 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/debug_12301.no-opt.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: cannot write to reference in local `a` which is still borrowed
+error: cannot write local `a` since other mutable usages for this reference exist
   ┌─ tests/reference-safety/debug_12301.move:6:9
   │
 6 │         *a = 0;
   │         ^^^^^^ written here
 7 │         *c
-  │         -- conflicting reference `c` used here
+  │         -- used here
 
-error: cannot write to reference in local `a` which is still borrowed
+error: cannot write local `a` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/debug_12301.move:15:9
    │
 15 │         *a = 0;
    │         ^^^^^^ written here
 16 │         *k = 1;
 17 │         *c
-   │         -- conflicting reference `c` used here
+   │         -- used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -40,13 +40,15 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 24 │         *f;
    │         -- conflicting reference `f` used here
 
-error: cannot write to reference in local `s` which is still borrowed
+error: cannot write local `s` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
    │
 32 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 33 │         *f;
-   │         -- conflicting reference `f` used here
+   │         -- used here
+34 │         s;
+   │         - used here
 
 error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -41,6 +41,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
    │         -- conflicting reference `f` used here
 
 error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
+   │
+32 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+33 │         *f;
+   │         -- conflicting reference `f` used here
+
+error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9
    │
 40 │         if (cond) f = id_mut(s) else f = other;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
@@ -40,13 +40,15 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 24 │         *f;
    │         -- conflicting reference `f` used here
 
-error: cannot write to reference in local `s` which is still borrowed
+error: cannot write local `s` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
    │
 32 │         *s = S { f: 0, g: 0 };
    │         ^^^^^^^^^^^^^^^^^^^^^ written here
 33 │         *f;
-   │         -- conflicting reference `f` used here
+   │         -- used here
+34 │         s;
+   │         - used here
 
 error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
@@ -41,6 +41,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
    │         -- conflicting reference `f` used here
 
 error: cannot write to reference in local `s` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
+   │
+32 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ written here
+33 │         *f;
+   │         -- conflicting reference `f` used here
+
+error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9
    │
 40 │         if (cond) f = id_mut(s) else f = other;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: cannot write to reference in local `x` which is still borrowed
+error: cannot write local `x` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
    │
 13 │         *x = 0;
    │         ^^^^^^ written here
 14 │         *f;
-   │         -- conflicting reference `f` used here
+   │         -- used here
 
 error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
@@ -1,6 +1,14 @@
 
 Diagnostics:
 error: cannot write to reference in local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
+   │
+13 │         *x = 0;
+   │         ^^^^^^ written here
+14 │         *f;
+   │         -- conflicting reference `f` used here
+
+error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9
    │
 17 │         let f = freeze(x);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: cannot write to reference in local `x` which is still borrowed
+error: cannot write local `x` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
    │
 13 │         *x = 0;
    │         ^^^^^^ written here
 14 │         *f;
-   │         -- conflicting reference `f` used here
+   │         -- used here
 
 error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
@@ -1,6 +1,14 @@
 
 Diagnostics:
 error: cannot write to reference in local `x` which is still borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
+   │
+13 │         *x = 0;
+   │         ^^^^^^ written here
+14 │         *f;
+   │         -- conflicting reference `f` used here
+
+error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9
    │
 17 │         let f = freeze(x);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #12301 by checking whether there are other existing mutable references during for WriteRef.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) Evaluation of changes in existing test files;
2) A new test is added.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
