### PR TITLE
[compiler-v2] Adapt reference safety to quirks of v1 bytecode verifier semantics

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -159,6 +159,14 @@ pub struct LifetimeState {
     temp_to_label_map: BTreeMap<TempIndex, LifetimeLabel>,
     /// A map from globals to labels. Represents root states of the active graph.
     global_to_label_map: BTreeMap<QualifiedInstId<StructId>, LifetimeLabel>,
+    /// A map indicating which nodes have been derived from the given set of temporaries.
+    /// For example, if we have `label <- borrow_field(f)(src)`, then `label -> src` will be in
+    /// this map. This map is used to deal with a quirk of v1 borrow semantics which allows
+    /// a temporary which was used to derive a node to be used after the borrow again, but
+    /// does not allow the same thing with a temporary which contains a copy of this reference.
+    /// Once we update the v1 bytecode verifier, this should go away, because there is no safety
+    /// reason to not allow the copy.
+    derived_from: BTreeMap<LifetimeLabel, BTreeSet<TempIndex>>,
 }
 
 /// Represents a node of the borrow graph.
@@ -208,13 +216,14 @@ struct BorrowEdge {
 enum BorrowEdgeKind {
     /// Borrows the local at the MemoryLocation in the source node.
     BorrowLocal(bool),
-    /// Borrows the global at the MemoryLocation in the source node.
-    BorrowGlobal(bool),
+    /// Borrows the global at the MemoryLocation in the source node. Since the address
+    /// from which we borrow can be different for each call, they are distinguished by code offset
+    /// -- two borrow_global edges are never the same.
+    BorrowGlobal(bool, CodeOffset),
     /// Borrows a field from a reference.
     BorrowField(bool, FieldId),
-    /// Calls an operation, where the incoming references are used to derive outgoing references. Since every
-    /// call outcome can be different, they are distinguished by code offset -- two call edges are never the
-    /// same.
+    /// Calls an operation, where the incoming references are used to derive outgoing references. Similar
+    /// as for BorrowGlobal, a call offset is used to distinguish different results of calls.
     Call(bool, Operation, CodeOffset),
     /// Freezes a mutable reference.
     Freeze,
@@ -225,7 +234,7 @@ impl BorrowEdgeKind {
         use BorrowEdgeKind::*;
         match self {
             BorrowLocal(is_mut)
-            | BorrowGlobal(is_mut)
+            | BorrowGlobal(is_mut, _)
             | BorrowField(is_mut, _)
             | Call(is_mut, _, _) => *is_mut,
             Freeze => false,
@@ -504,6 +513,11 @@ impl LifetimeState {
         self.node(label).children.iter()
     }
 
+    /// Returns true if the node has incoming mut edges.
+    fn is_mut(&self, label: &LifetimeLabel) -> bool {
+        self.parent_edges(label).any(|(_, e)| e.kind.is_mut())
+    }
+
     /// Returns the children grouped by their edge kind.
     fn grouped_children(
         &self,
@@ -640,6 +654,9 @@ impl LifetimeState {
         if in_use.contains(label) {
             return;
         }
+        // Remove any information about temporaries used to derive this node.
+        self.derived_from.remove(label);
+        // Rempve the node from the graph.
         if let Some(node) = self.graph.remove(label) {
             debug_assert!(node.children.is_empty());
             removed.extend(node.locations.iter().cloned());
@@ -676,7 +693,7 @@ impl LifetimeState {
                 let in_use = self.leaves().keys().cloned().collect();
                 let mut indirectly_removed = BTreeSet::new();
                 self.drop_leaf_node(&label, &in_use, &mut indirectly_removed);
-                // Remove memory locations not longer borrowed.
+                // Remove memory locations no longer borrowed.
                 for location in indirectly_removed {
                     use MemoryLocation::*;
                     match location {
@@ -723,8 +740,9 @@ impl LifetimeState {
     /// Copies a reference from source to destination. This create a new lifetime node and clones the edges
     /// leading into the node associated with the source reference.
     fn copy_ref(&mut self, dest: TempIndex, src: TempIndex) {
-        if let Some(label) = self.label_for_temp(src) {
-            self.temp_to_label_map.insert(dest, *label);
+        if let Some(label) = self.label_for_temp(src).cloned() {
+            self.temp_to_label_map.insert(dest, label);
+            self.derived_from.entry(label).or_default().insert(src);
         }
     }
 
@@ -1019,21 +1037,24 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
     ///
     /// If we walk this graph now from the root to the leaves, we can determine safety by directly comparing
     /// hyper edge siblings.
-    fn check_borrow_safety(&mut self, temps_vec: &[TempIndex]) {
+    fn check_borrow_safety(&mut self, exclusive_temps_vec: &[TempIndex]) {
         // First check direct duplicates
-        for (i, temp) in temps_vec.iter().enumerate() {
-            if self.ty(*temp).is_mutable_reference() && temps_vec[i + 1..].contains(temp) {
+        for (i, temp) in exclusive_temps_vec.iter().enumerate() {
+            if self.ty(*temp).is_mutable_reference() && exclusive_temps_vec[i + 1..].contains(temp)
+            {
                 self.exclusive_access_direct_dup_error(*temp)
             }
         }
         // Now build and analyze the hyper graph
-        let temps = &temps_vec.iter().cloned().collect::<BTreeSet<_>>();
+        let exclusive_temps =
+            // Temps which need to be exclusive at this program point.
+            exclusive_temps_vec.iter().cloned().collect::<BTreeSet<_>>();
         let filtered_leaves = self
             .state
             .leaves()
             .into_iter()
             .filter_map(|(l, mut ts)| {
-                ts = ts.intersection(temps).cloned().collect();
+                ts = ts.intersection(&exclusive_temps).cloned().collect();
                 if !ts.is_empty() {
                     Some((l, ts))
                 } else {
@@ -1091,8 +1112,10 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
                     targets.insert(target);
                     if edge.kind.is_mut() {
                         if let Some(ts) = filtered_leaves.get(&target) {
-                            let mut inter =
-                                ts.intersection(temps).cloned().collect::<BTreeSet<_>>();
+                            let mut inter = ts
+                                .intersection(&exclusive_temps)
+                                .cloned()
+                                .collect::<BTreeSet<_>>();
                             if !inter.is_empty() {
                                 if !self.state.is_leaf(&target) {
                                     // A mut leaf node must have exclusive access
@@ -1108,6 +1131,35 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
                     self.exclusive_access_indirect_dup_error(&hyper, &mapped_temps)
                 }
                 hyper_nodes.insert(targets);
+            }
+        }
+        // Temps containing mut refs alive after this program point and referring to nodes
+        // in the exclusive set are not allowed in v1 borrow semantics unless they are used to
+        // derive the exclusive nodes. Consider
+        // `let r = &mut s; let r1 = r; let x = &mut r.f; *x; *r1`: this is not allowed in v1.
+        // In contrast, `let r = &mut s; let x = &mut r.f; *x; *r` *is* allowed. The reason
+        // is that `x` is derived from `r` but not (for the first example) from `r1`.
+        let derived = self
+            .state
+            .derived_from
+            .values()
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        for mut_alive_after in self.alive.after.keys().cloned().filter(|t| {
+            self.ty(*t).is_mutable_reference()
+                && !exclusive_temps.contains(t)
+                && !derived.contains(t)
+        }) {
+            if let Some(label) = self.state.label_for_temp(mut_alive_after) {
+                if let Some(conflict) = filtered_leaves.keys().find(|exclusive_label| {
+                    self.state.is_mut(exclusive_label)
+                        && self.state.is_ancestor(label, exclusive_label)
+                }) {
+                    self.exclusive_access_borrow_error(
+                        conflict,
+                        filtered_leaves.get(conflict).unwrap(),
+                    )
+                }
             }
         }
     }
@@ -1282,7 +1334,7 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
             e.loc.clone(),
             format!("{}{}{}", prefix, mut_prefix, match &e.kind {
                 BorrowLocal(_) => "local borrow",
-                BorrowGlobal(_) => "global borrow",
+                BorrowGlobal(..) => "global borrow",
                 BorrowField(..) => "field borrow",
                 Call(..) => "call result",
                 Freeze => "freeze",
@@ -1397,7 +1449,11 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
         let is_mut = self.ty(dest).is_mutable_reference();
         self.state.add_edge(
             label,
-            BorrowEdge::new(BorrowEdgeKind::BorrowGlobal(is_mut), loc, child),
+            BorrowEdge::new(
+                BorrowEdgeKind::BorrowGlobal(is_mut, self.code_offset),
+                loc,
+                child,
+            ),
         );
     }
 
@@ -1411,6 +1467,11 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
     ) {
         let label = self.state.make_temp(src, self.code_offset, 0, false);
         let child = self.state.replace_ref(dest, self.code_offset, 1);
+        self.state
+            .derived_from
+            .entry(child)
+            .or_default()
+            .insert(src);
         let loc = self.cur_loc();
         let is_mut = self.ty(dest).is_mutable_reference();
         let struct_env = self.global_env().get_struct(struct_.to_qualified_id());
@@ -1457,6 +1518,11 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
                             false,
                         );
                         let child = &dest_labels[dest];
+                        self.state
+                            .derived_from
+                            .entry(*child)
+                            .or_default()
+                            .insert(*src);
                         self.state.add_edge(
                             label,
                             BorrowEdge::new(
@@ -1515,7 +1581,18 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
             let qualifier = if explicit { "" } else { "implicitly " };
             for (parent, edge) in self.state.parent_edges(label) {
                 for sibling_edge in self.state.children(&parent) {
-                    if &sibling_edge.target == label {
+                    if &sibling_edge.target == label
+                        || sibling_edge.kind == edge.kind
+                            && matches!(edge.kind, BorrowEdgeKind::Call(..))
+                        || !sibling_edge.kind.overlaps(&edge.kind)
+                    {
+                        // The sibling edge is harmless if
+                        // (a) it is not actually a sibling but leads to the same target
+                        // (b) the kind is the same and stems from a call This happens e.g. for a
+                        //     call which returns multiple references, as in `(r1, r2) = foo(r)`,
+                        //     then even though we have different edges with different targets,
+                        //     they stem from the same borrow.
+                        // (c) if the sibling has no overlap, as in `&mut r.f1` and `&mut r.f2`.
                         continue;
                     }
                     if self.state.is_mut_path(sibling_edge) {
@@ -1538,15 +1615,22 @@ impl<'env, 'state> LifetimeAnalysisStep<'env, 'state> {
             }
             // Handle case (b): check whether there is any alive mutable reference
             // which overlaps with the frozen reference.
+            let derived = self
+                .state
+                .derived_from
+                .values()
+                .flatten()
+                .collect::<BTreeSet<_>>();
             for (temp, other_label) in self.state.temp_to_label_map.iter() {
-                if temp == &src || !self.ty(*temp).is_mutable_reference() {
+                if temp == &src || !self.ty(*temp).is_mutable_reference() || derived.contains(temp)
+                {
                     continue;
                 }
                 if other_label == label {
                     // Compute all visible usages at leaves to show the conflict.
                     // It is not enough to just show the usage of `temp`, because the
                     // actual usage might be something derived from it, and `temp`
-                    // is not longer used.
+                    // is no longer used.
                     let leaves = self.state.leaves();
                     let mut show: BTreeSet<(bool, Loc)> = BTreeSet::new();
                     let mut todo = vec![*other_label];
@@ -1693,7 +1777,7 @@ impl<'env> TransferFunctions for LifeTimeAnalysis<'env> {
         // Construct step context
         let mut step = self.new_step(code_offset, instr.get_attr_id(), state);
 
-        // Preprocessing: release all temps in the label map which are not longer alive at this point.
+        // Preprocessing: release all temps in the label map which are no longer alive at this point.
         step.state.debug_print("before enter release");
         let alive_temps = step.alive.before_set();
         for temp in step
@@ -1735,6 +1819,9 @@ impl<'env> TransferFunctions for LifeTimeAnalysis<'env> {
                     .cloned()
                     .collect_vec();
                 step.check_borrow_safety(&exclusive_refs)
+            },
+            Assign(_, _, src, _) if step.ty(*src).is_mutable_reference() => {
+                step.check_borrow_safety(&[*src])
             },
             _ => {},
         }
@@ -1922,9 +2009,9 @@ impl<'a> Display for BorrowEdgeDisplay<'a> {
         use BorrowEdgeKind::*;
         (match &edge.kind {
             BorrowLocal(is_mut) => write!(f, "borrow({})", is_mut),
-            BorrowGlobal(is_mut) => write!(f, "borrow_global({})", is_mut),
+            BorrowGlobal(is_mut, offs) => write!(f, "borrow_global({}, {})", is_mut, offs),
             BorrowField(is_mut, _) => write!(f, "borrow_field({})", is_mut),
-            Call(is_mut, _, _) => write!(f, "call({})", is_mut),
+            Call(is_mut, _, offs) => write!(f, "call({}, {})", is_mut, offs),
             Freeze => write!(f, "freeze"),
         })?;
         if display_child {
@@ -2006,6 +2093,7 @@ impl<'a> Display for LifetimeStateDisplay<'a> {
             graph,
             temp_to_label_map,
             global_to_label_map,
+            derived_from,
         } = &self.1;
         let pool = self.0.global_env().symbol_pool();
         writeln!(
@@ -2032,7 +2120,26 @@ impl<'a> Display for LifetimeStateDisplay<'a> {
                 .iter()
                 .map(|(str, label)| format!("{}={}", self.0.global_env().display(str), label))
                 .join(",")
-        )
+        )?;
+        if !derived_from.is_empty() {
+            writeln!(
+                f,
+                "derived-from: {}",
+                derived_from
+                    .iter()
+                    .map(|(l, ts)| {
+                        format!(
+                            "{}={}",
+                            l,
+                            ts.iter()
+                                .map(|t| self.0.get_local_raw_name(*t).display(pool).to_string())
+                                .join(",")
+                        )
+                    })
+                    .join(",")
+            )?
+        }
+        Ok(())
     }
 }
 

--- a/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
@@ -120,15 +120,16 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      #
   5: $t6 := borrow_global<m::R>($t7)
      # live vars: $t6
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[]}
      # locals: {$t6=@501}
      # globals: {m::R=@500}
      #
   6: $t3 := borrow_field<m::R>.data($t6)
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
   7: goto 10
      # live vars: $t1
@@ -144,27 +145,31 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      #
   9: $t3 := infer($t1)
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  10: label L2
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  11: $t9 := 0
      # live vars: $t3, $t9
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  12: $t8 := vector::borrow<u64>($t3, $t9)
      # live vars: $t8
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false, 12) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t8=@C00}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6,@C00=$t3
      #
  13: $t2 := read_ref($t8)
      # live vars: $t2
@@ -231,16 +236,17 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
   5: $t6 := borrow_global<m::R>($t7)
      # abort state: {returns,aborts}
      # live vars: $t6
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[]}
      # locals: {$t6=@501}
      # globals: {m::R=@500}
      #
   6: $t3 := borrow_field<m::R>.data($t6)
      # abort state: {returns,aborts}
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
   7: goto 10
      # abort state: {returns,aborts}
@@ -259,30 +265,34 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
   9: $t3 := infer($t1)
      # abort state: {returns,aborts}
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  10: label L2
      # abort state: {returns,aborts}
      # live vars: $t3
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  11: $t9 := 0
      # abort state: {returns,aborts}
      # live vars: $t3, $t9
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t3=@601}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6
      #
  12: $t8 := vector::borrow<u64>($t3, $t9)
      # abort state: {returns}
      # live vars: $t8
-     # graph: {@500=global<m::R>[borrow_global(false) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
+     # graph: {@500=global<m::R>[borrow_global(false, 5) -> @501],@501=derived[borrow_field(false) -> @601],@601=derived[call(false, 12) -> @C00],@C00=derived[],@1000000=external[borrow(false) -> @601]}
      # locals: {$t8=@C00}
      # globals: {m::R=@500}
+     # derived-from: @601=$t6,@C00=$t3
      #
  13: $t2 := read_ref($t8)
      # abort state: {returns}

--- a/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
@@ -99,9 +99,10 @@ fun m::g() {
      #
   2: $t2 := m::f($t1)
      # live vars: $t0, $t2
-     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true) -> @200],@200=derived[]}
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true, 2) -> @200],@200=derived[]}
      # locals: {$t0=@100,$t2=@200}
      # globals: {}
+     # derived-from: @200=$t1
      #
   3: $t1 := infer($t2)
      # live vars: $t0
@@ -169,9 +170,10 @@ fun m::g() {
   2: $t2 := m::f($t1)
      # abort state: {returns}
      # live vars: $t0, $t2
-     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true) -> @200],@200=derived[]}
+     # graph: {@100=local($t0)[borrow(true) -> @101],@101=derived[call(true, 2) -> @200],@200=derived[]}
      # locals: {$t0=@100,$t2=@200}
      # globals: {}
+     # derived-from: @200=$t1
      #
   3: $t1 := infer($t2)
      # abort state: {returns}

--- a/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
@@ -207,15 +207,17 @@ fun m::test_for_each_mut() {
      #
   9: $t6 := vector::borrow_mut<u64>($t4, $t1)
      # live vars: $t0, $t1, $t2, $t4, $t6
-     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true, 9) -> @900],@900=derived[]}
      # locals: {$t0=@200,$t4=@401,$t6=@900}
      # globals: {}
+     # derived-from: @900=$t4
      #
  10: $t7 := 2
      # live vars: $t0, $t1, $t2, $t4, $t6, $t7
-     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true, 9) -> @900],@900=derived[]}
      # locals: {$t0=@200,$t4=@401,$t6=@900}
      # globals: {}
+     # derived-from: @900=$t4
      #
  11: write_ref($t6, $t7)
      # live vars: $t0, $t1, $t2, $t4
@@ -423,16 +425,18 @@ fun m::test_for_each_mut() {
   9: $t6 := vector::borrow_mut<u64>($t4, $t1)
      # abort state: {returns,aborts}
      # live vars: $t0, $t1, $t2, $t4, $t6
-     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true, 9) -> @900],@900=derived[]}
      # locals: {$t0=@200,$t4=@401,$t6=@900}
      # globals: {}
+     # derived-from: @900=$t4
      #
  10: $t7 := 2
      # abort state: {returns,aborts}
      # live vars: $t0, $t1, $t2, $t4, $t6, $t7
-     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true) -> @900],@900=derived[]}
+     # graph: {@200=local($t0)[borrow(true) -> @401],@401=derived[call(true, 9) -> @900],@900=derived[]}
      # locals: {$t0=@200,$t4=@401,$t6=@900}
      # globals: {}
+     # derived-from: @900=$t4
      #
  11: write_ref($t6, $t7)
      # abort state: {returns,aborts}

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
@@ -101,18 +101,21 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
      # locals: {$t2=@100,$t4=@201}
      # globals: {}
+     # derived-from: @201=$t5
      #
   3: $t6 := 0
      # live vars: $t0, $t2, $t4, $t6
      # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
      # locals: {$t2=@100,$t4=@201}
      # globals: {}
+     # derived-from: @201=$t5
      #
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
      # live vars: $t0, $t2, $t3
-     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true, 4) -> @400],@400=derived[]}
      # locals: {$t2=@100,$t3=@400}
      # globals: {}
+     # derived-from: @201=$t5,@400=$t4
      #
   5: write_ref($t3, $t0)
      # live vars: $t2
@@ -190,6 +193,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
      # locals: {$t2=@100,$t4=@201}
      # globals: {}
+     # derived-from: @201=$t5
      #
   3: $t6 := 0
      # abort state: {returns,aborts}
@@ -197,13 +201,15 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[]}
      # locals: {$t2=@100,$t4=@201}
      # globals: {}
+     # derived-from: @201=$t5
      #
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
      # abort state: {returns}
      # live vars: $t0, $t2, $t3
-     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true) -> @400],@400=derived[]}
+     # graph: {@100=local($t2)[borrow(true) -> @101],@101=derived[borrow_field(true) -> @201],@201=derived[call(true, 4) -> @400],@400=derived[]}
      # locals: {$t2=@100,$t3=@400}
      # globals: {}
+     # derived-from: @201=$t5,@400=$t4
      #
   5: write_ref($t3, $t0)
      # abort state: {returns}

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -16,6 +16,16 @@ fun m::test($t0: u64): u64 {
   6: return $t1
 }
 
+
+Diagnostics:
+error: mutable reference in local `a` requires exclusive access but is borrowed
+  ┌─ tests/copy-propagation/mut_refs_3.move:7:9
+  │
+7 │         *a = 0;
+  │         ^^^^^^ requirement enforced here
+8 │         *c
+  │         -- conflicting reference `c` used here
+
 ============ after DeadStoreElimination: ================
 
 [variant baseline]

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: mutable reference in local `a` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/multiple_use_bug_12301.move:8:9
+  │
+8 │         *a = 0;
+  │         ^^^^^^ requirement enforced here
+9 │         *c
+  │         -- conflicting reference `c` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/multiple_use_bug_12301.move:17:9
+   │
+17 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+18 │         *k = 1;
+19 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.move
@@ -1,0 +1,21 @@
+// See also #12301
+module 0x42::m {
+    // Expected to be invalid
+    public fun test1(p: u64): u64 {
+        let a = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *c
+    }
+    // Expected to be invalid
+    public fun test2(p: u64): u64 {
+        let a = &mut p;
+        let k = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *k = 1;
+        *c
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_bug_12301.no-opt.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: mutable reference in local `a` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/multiple_use_bug_12301.move:8:9
+  │
+8 │         *a = 0;
+  │         ^^^^^^ requirement enforced here
+9 │         *c
+  │         -- conflicting reference `c` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/multiple_use_bug_12301.move:17:9
+   │
+17 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+18 │         *k = 1;
+19 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: mutable reference in local `f` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/mut_borrow_after_invalid.move:8:9
+  │
+8 │         *f;
+  │         ^^ requirement enforced here
+9 │         *s1;
+  │         --- conflicting reference `s1` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/mut_borrow_after_invalid.move:16:9
+   │
+16 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+17 │         *b
+   │         -- conflicting reference `b` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/mut_borrow_after_invalid.move:25:9
+   │
+25 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+26 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.move
@@ -1,0 +1,40 @@
+module 0x42::m {
+    struct S has copy, drop { f: u64, g: u64 }
+
+    // bytecode verification fails
+    fun t1(s: &mut S) {
+        let s1 = s;
+        let f = &mut s.f;
+        *f;
+        *s1;
+    }
+
+    // bytecode verification fails
+    fun t3(p: u64): u64 {
+        let a = &mut p;
+        let b = a;
+        *a = 0;
+        *b
+    }
+
+    // bytecode verification fails
+    fun t4(p: u64): u64 {
+        let a = &mut p;
+        let b = a;
+        let c = b;
+        *a = 0;
+        *c
+    }
+
+    fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    // bytecode verification fails
+    fun t5() {
+        let x = &mut 0;
+        let y = id_mut(x);
+        *y;
+        *x;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_invalid.no-opt.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: mutable reference in local `f` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/mut_borrow_after_invalid.move:8:9
+  │
+8 │         *f;
+  │         ^^ requirement enforced here
+9 │         *s1;
+  │         --- conflicting reference `s1` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/mut_borrow_after_invalid.move:16:9
+   │
+16 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+17 │         *b
+   │         -- conflicting reference `b` used here
+
+error: mutable reference in local `a` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/mut_borrow_after_invalid.move:25:9
+   │
+25 │         *a = 0;
+   │         ^^^^^^ requirement enforced here
+26 │         *c
+   │         -- conflicting reference `c` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.move
@@ -1,0 +1,10 @@
+module 0x42::m {
+    struct S has copy, drop { f: u64, g: u64 }
+
+    // bytecode verification succeeds
+    fun t0(s: &mut S) {
+        let f = &mut s.f;
+        *f;
+        *s;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/mut_borrow_after_valid.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.exp
@@ -1,13 +1,5 @@
 
 Diagnostics:
-error: cannot freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:31:30
-   │
-31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
-   │                              ^^^^^^^^^^^^^^^^^^ frozen here
-32 │         let f1 = &inner.f1;
-   │                  --------- used here
-
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:34:9
    │
@@ -34,14 +26,6 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 37 │         *c;
    │         -- conflicting reference `c` used here
-
-error: cannot freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:40:33
-   │
-40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
-   │                                 ^^^^^^^^^^^^^^^^^^ frozen here
-41 │         let f1 = &inner.f1;
-   │                  --------- used here
 
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:43:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo.no-opt.exp
@@ -1,13 +1,5 @@
 
 Diagnostics:
-error: cannot freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:31:30
-   │
-31 │         let c; if (cond) c = freeze(copy inner) else c = &other.s1;
-   │                              ^^^^^^^^^^^^^^^^^^ frozen here
-32 │         let f1 = &inner.f1;
-   │                  --------- used here
-
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:34:9
    │
@@ -34,14 +26,6 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 37 │         *c;
    │         -- conflicting reference `c` used here
-
-error: cannot freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:40:33
-   │
-40 │         let c; if (cond) c = id(freeze(copy inner)) else c = &other.s1; // error in v2
-   │                                 ^^^^^^^^^^^^^^^^^^ frozen here
-41 │         let f1 = &inner.f1;
-   │                  --------- used here
 
 error: mutable reference in local `inner` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo.move:43:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
 17 │         *f1;
    │         --- conflicting reference `f1` used here
 
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:18:9
+   │
+18 │         *inner;
+   │         ^^^^^^ requirement enforced here
+19 │         *c;
+   │         -- conflicting reference `c` used here
+
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:18
    │
@@ -111,6 +119,23 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 39 │         *f1;
    │         --- conflicting reference `f1` used here
+
+error: mutable reference in local `f1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:39:9
+   │
+39 │         *f1;
+   │         ^^^ requirement enforced here
+40 │         *inner;
+41 │         *c;
+   │         -- conflicting reference `c` used here
+
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:40:9
+   │
+40 │         *inner;
+   │         ^^^^^^ requirement enforced here
+41 │         *c;
+   │         -- conflicting reference `c` used here
 
 error: cannot mutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:18

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_combo_invalid.no-opt.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
 17 │         *f1;
    │         --- conflicting reference `f1` used here
 
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:18:9
+   │
+18 │         *inner;
+   │         ^^^^^^ requirement enforced here
+19 │         *c;
+   │         -- conflicting reference `c` used here
+
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:25:18
    │
@@ -111,6 +119,23 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 39 │         *f1;
    │         --- conflicting reference `f1` used here
+
+error: mutable reference in local `f1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:39:9
+   │
+39 │         *f1;
+   │         ^^^ requirement enforced here
+40 │         *inner;
+41 │         *c;
+   │         -- conflicting reference `c` used here
+
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:40:9
+   │
+40 │         *inner;
+   │         ^^^^^^ requirement enforced here
+41 │         *c;
+   │         -- conflicting reference `c` used here
 
 error: cannot mutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_combo_invalid.move:47:18

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
 17 │         *f1;
    │         --- conflicting reference `f1` used here
 
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:18:9
+   │
+18 │         *inner;
+   │         ^^^^^^ requirement enforced here
+19 │         *c;
+   │         -- conflicting reference `c` used here
+
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:18
    │
@@ -111,6 +119,23 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 35 │         *f1;
    │         --- conflicting reference `f1` used here
+
+error: mutable reference in local `f1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:35:9
+   │
+35 │         *f1;
+   │         ^^^ requirement enforced here
+36 │         *inner;
+37 │         *c;
+   │         -- conflicting reference `c` used here
+
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:36:9
+   │
+36 │         *inner;
+   │         ^^^^^^ requirement enforced here
+37 │         *c;
+   │         -- conflicting reference `c` used here
 
 error: cannot mutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:18

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_field_full_invalid.no-opt.exp
@@ -22,6 +22,14 @@ error: mutable reference in local `inner` requires exclusive access but is borro
 17 │         *f1;
    │         --- conflicting reference `f1` used here
 
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:18:9
+   │
+18 │         *inner;
+   │         ^^^^^^ requirement enforced here
+19 │         *c;
+   │         -- conflicting reference `c` used here
+
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:23:18
    │
@@ -111,6 +119,23 @@ error: mutable reference in local `inner` requires exclusive access but is borro
    │         ^^^^^^ requirement enforced here
 35 │         *f1;
    │         --- conflicting reference `f1` used here
+
+error: mutable reference in local `f1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:35:9
+   │
+35 │         *f1;
+   │         ^^^ requirement enforced here
+36 │         *inner;
+37 │         *c;
+   │         -- conflicting reference `c` used here
+
+error: mutable reference in local `inner` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:36:9
+   │
+36 │         *inner;
+   │         ^^^^^^ requirement enforced here
+37 │         *c;
+   │         -- conflicting reference `c` used here
 
 error: cannot mutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_field_full_invalid.move:41:18

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.exp
@@ -1,34 +1,11 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
+error: cannot mutably borrow since mutable references exist
   ┌─ tests/reference-safety/v1-tests/borrow_global_bad1.move:8:17
   │
+7 │         let x = borrow_global_mut<T>(sender);
+  │                 ---------------------------- previous mutable global borrow
 8 │         let y = borrow_global_mut<T>(addr);
-  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "A",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            0,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(0),
-            5,
-        ),
-    ],
-}
+  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+9 │         x;
+  │         - requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad1.no-opt.exp
@@ -1,34 +1,11 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
+error: cannot mutably borrow since mutable references exist
   ┌─ tests/reference-safety/v1-tests/borrow_global_bad1.move:8:17
   │
+7 │         let x = borrow_global_mut<T>(sender);
+  │                 ---------------------------- previous mutable global borrow
 8 │         let y = borrow_global_mut<T>(addr);
-  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "A",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            0,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(0),
-            4,
-        ),
-    ],
-}
+  │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+9 │         x;
+  │         - requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.exp
@@ -1,34 +1,11 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
-  ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
-  │
-9 │         let t2_ref = borrow_global_mut<T>(sender);
-  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "A",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            0,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(0),
-            17,
-        ),
-    ],
-}
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
+   │
+ 8 │         let t1_ref = if (b) borrow_global_mut<T>(sender) else &mut t;
+   │                             ---------------------------- previous mutable global borrow
+ 9 │         let t2_ref = borrow_global_mut<T>(sender);
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+10 │         t1_ref;
+   │         ------ requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_bad5.no-opt.exp
@@ -1,34 +1,11 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
-  ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
-  │
-9 │         let t2_ref = borrow_global_mut<T>(sender);
-  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "A",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            0,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(0),
-            17,
-        ),
-    ],
-}
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_bad5.move:9:22
+   │
+ 8 │         let t1_ref = if (b) borrow_global_mut<T>(sender) else &mut t;
+   │                             ---------------------------- previous mutable global borrow
+ 9 │         let t2_ref = borrow_global_mut<T>(sender);
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+10 │         t1_ref;
+   │         ------ requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.exp
@@ -1,17 +1,44 @@
 
 Diagnostics:
-error: cannot immutably borrow since mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:13:14
+error: cannot mutably borrow since mutable references exist
+  ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:6:18
+  │
+5 │         let r1 = borrow_global_mut<R>(addr);
+  │                  -------------------------- previous mutable global borrow
+6 │         let r2 = borrow_global_mut<R>(addr);
+  │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+7 │         r1.f = r2.f
+  │         ----   ---- requirement enforced here
+  │         │
+  │         conflicting reference `r1` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:12:18
    │
 11 │         let f = &mut borrow_global_mut<R>(addr).f;
-   │                 --------------------------------- previous mutable field borrow
+   │                 ---------------------------------
+   │                 │    │
+   │                 │    previous mutable global borrow
+   │                 used by mutable field borrow
 12 │         let r2 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 13 │         *f = r2.f
-   │         -----^^^^
+   │         ---------
    │         │    │
-   │         │    immutable borrow attempted here
    │         │    requirement enforced here
    │         conflicting reference `f` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:18:22
+   │
+17 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+18 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+19 │         r1.f = *f
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here
 
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:24:18
@@ -37,3 +64,27 @@ error: cannot mutably borrow since immutable references exist
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 31 │         r2.f = *f
    │                -- requirement enforced here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:36:18
+   │
+35 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+36 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+37 │         r1.f = *f
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:43:18
+   │
+42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+43 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+44 │         r1.f = *f;
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/borrow_global_mut_invalid.no-opt.exp
@@ -1,17 +1,44 @@
 
 Diagnostics:
-error: cannot immutably borrow since mutable references exist
-   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:13:14
+error: cannot mutably borrow since mutable references exist
+  ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:6:18
+  │
+5 │         let r1 = borrow_global_mut<R>(addr);
+  │                  -------------------------- previous mutable global borrow
+6 │         let r2 = borrow_global_mut<R>(addr);
+  │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+7 │         r1.f = r2.f
+  │         ----   ---- requirement enforced here
+  │         │
+  │         conflicting reference `r1` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:12:18
    │
 11 │         let f = &mut borrow_global_mut<R>(addr).f;
-   │                 --------------------------------- previous mutable field borrow
+   │                 ---------------------------------
+   │                 │    │
+   │                 │    previous mutable global borrow
+   │                 used by mutable field borrow
 12 │         let r2 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 13 │         *f = r2.f
-   │         -----^^^^
+   │         ---------
    │         │    │
-   │         │    immutable borrow attempted here
    │         │    requirement enforced here
    │         conflicting reference `f` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:18:22
+   │
+17 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+18 │         let f = &mut borrow_global_mut<R>(addr).f;
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+19 │         r1.f = *f
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here
 
 error: cannot immutably borrow since mutable references exist
    ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:24:18
@@ -37,3 +64,27 @@ error: cannot mutably borrow since immutable references exist
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 31 │         r2.f = *f
    │                -- requirement enforced here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:36:18
+   │
+35 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
+36 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+37 │         r1.f = *f
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here
+
+error: cannot mutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-tests/borrow_global_mut_invalid.move:43:18
+   │
+42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+43 │         let f = &borrow_global_mut<R>(addr).f;
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
+44 │         r1.f = *f;
+   │         ----   -- requirement enforced here
+   │         │
+   │         conflicting reference `r1` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.exp
@@ -22,14 +22,6 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 22 │         *f;
    │         -- conflicting reference `f` used here
 
-error: cannot implicitly freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/dereference_combo.move:28:23
-   │
-28 │         if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
-   │                       ^^^^^^ implicitly frozen here
-29 │         *s;
-   │         -- used here
-
 error: mutable reference in local `s` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo.move:29:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo.no-opt.exp
@@ -22,14 +22,6 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 22 │         *f;
    │         -- conflicting reference `f` used here
 
-error: cannot implicitly freeze value since other mutable usages for this reference exist
-   ┌─ tests/reference-safety/v1-tests/dereference_combo.move:28:23
-   │
-28 │         if (cond) x = copy s else x = other; // error in v2 because of copy of mut ref
-   │                       ^^^^^^ implicitly frozen here
-29 │         *s;
-   │         -- used here
-
 error: mutable reference in local `s` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_combo.move:29:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.exp
@@ -21,3 +21,11 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
    │         ^^ requirement enforced here
 21 │         *f;
    │         -- conflicting reference `f` used here
+
+error: mutable reference in local `s` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:27:9
+   │
+27 │         *s;
+   │         ^^ requirement enforced here
+28 │         *x;
+   │         -- conflicting reference `x` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_combo_invalid.no-opt.exp
@@ -21,3 +21,11 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
    │         ^^ requirement enforced here
 21 │         *f;
    │         -- conflicting reference `f` used here
+
+error: mutable reference in local `s` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_combo_invalid.move:27:9
+   │
+27 │         *s;
+   │         ^^ requirement enforced here
+28 │         *x;
+   │         -- conflicting reference `x` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.exp
@@ -1,6 +1,14 @@
 
 Diagnostics:
 error: mutable reference in local `x` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:13:9
+   │
+13 │         *x;
+   │         ^^ requirement enforced here
+14 │         *y;
+   │         -- conflicting reference `y` used here
+
+error: mutable reference in local `x` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:18:9
    │
 17 │         let y = id_mut(x);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/dereference_full_invalid.no-opt.exp
@@ -1,6 +1,14 @@
 
 Diagnostics:
 error: mutable reference in local `x` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:13:9
+   │
+13 │         *x;
+   │         ^^ requirement enforced here
+14 │         *y;
+   │         -- conflicting reference `y` used here
+
+error: mutable reference in local `x` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/dereference_full_invalid.move:18:9
    │
 17 │         let y = id_mut(x);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.exp
@@ -40,6 +40,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 24 │         *f;
    │         -- conflicting reference `f` used here
 
+error: mutable reference in local `s` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
+   │
+32 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ requirement enforced here
+33 │         *f;
+   │         -- conflicting reference `f` used here
+
 error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_combo_invalid.no-opt.exp
@@ -40,6 +40,14 @@ error: mutable reference in local `s` requires exclusive access but is borrowed
 24 │         *f;
    │         -- conflicting reference `f` used here
 
+error: mutable reference in local `s` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:32:9
+   │
+32 │         *s = S { f: 0, g: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^^^ requirement enforced here
+33 │         *f;
+   │         -- conflicting reference `f` used here
+
 error: cannot write to reference in local `s` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_combo_invalid.move:41:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: mutable reference in local `x` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
+   │
+13 │         *x = 0;
+   │         ^^^^^^ requirement enforced here
+14 │         *f;
+   │         -- conflicting reference `f` used here
+
 error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/mutate_full_invalid.no-opt.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: mutable reference in local `x` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:13:9
+   │
+13 │         *x = 0;
+   │         ^^^^^^ requirement enforced here
+14 │         *f;
+   │         -- conflicting reference `f` used here
+
 error: cannot write to reference in local `x` which is still borrowed
    ┌─ tests/reference-safety/v1-tests/mutate_full_invalid.move:18:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.exp
@@ -1,5 +1,15 @@
 
 Diagnostics:
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:16:10
+   │
+15 │         let f = freeze(s1);
+   │                 ---------- previous freeze
+16 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:16:9
    │
@@ -7,6 +17,16 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                 ---------- previous freeze
 16 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:10
+   │
+19 │         let f = &s1.f;
+   │                 ----- previous field borrow
+20 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
 
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:9
@@ -41,6 +61,15 @@ error: cannot mutably borrow since immutable references exist
    │         │mutable borrow attempted here
    │         requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:32:14
+   │
+32 │         (s1, s1) // error in v1 since &mut cannot be copied
+   │         -----^^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
+
 error: same mutable reference in local `return[0]` is also used in other local `return[1]` in argument list
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:32:9
    │
@@ -49,6 +78,25 @@ error: same mutable reference in local `return[0]` is also used in other local `
 32 │         (s1, s1) // error in v1 since &mut cannot be copied
    │         ^^^^^^^^ requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:10
+   │
+35 │         let f =  &mut s1.f;
+   │                  --------- previous mutable field borrow
+36 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
+error: mutable reference in local `f` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:14
+   │
+36 │         (s1, f)
+   │         -----^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
+
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:9
    │
@@ -56,6 +104,16 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                  --------- previous mutable field borrow
 36 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:21
+   │
+39 │         (&mut s1.f, s1)
+   │         ------------^^-
+   │         ││          │
+   │         ││          requirement enforced here
+   │         │previous mutable field borrow
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:9
@@ -66,6 +124,16 @@ error: mutable reference in local `return[1]` requires exclusive access but is b
    │         │previous mutable field borrow
    │         requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:42:22
+   │
+42 │         (id_mut(s1), s1)
+   │         -------------^^-
+   │         ││           │
+   │         ││           requirement enforced here
+   │         │previous mutable call result
+   │         conflicting reference `return[0]` used here
+
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:42:9
    │
@@ -74,6 +142,28 @@ error: mutable reference in local `return[1]` requires exclusive access but is b
    │         ││
    │         │previous mutable call result
    │         requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:10
+   │
+45 │         let f = id_mut(&mut s1.f);
+   │                 -----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+46 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
+error: mutable reference in local `f` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:14
+   │
+46 │         (s1, f)
+   │         -----^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:9
@@ -85,6 +175,17 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                 used by mutable call result
 46 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:49:29
+   │
+49 │         (id_mut(&mut s1.f), s1)
+   │         --------------------^^-
+   │         ││      │           │
+   │         ││      │           requirement enforced here
+   │         ││      previous mutable field borrow
+   │         │used by mutable call result
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:49:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/return_mutual_borrows_invalid.no-opt.exp
@@ -1,5 +1,15 @@
 
 Diagnostics:
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:16:10
+   │
+15 │         let f = freeze(s1);
+   │                 ---------- previous freeze
+16 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:16:9
    │
@@ -7,6 +17,16 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                 ---------- previous freeze
 16 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:10
+   │
+19 │         let f = &s1.f;
+   │                 ----- previous field borrow
+20 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
 
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:20:9
@@ -41,6 +61,15 @@ error: cannot mutably borrow since immutable references exist
    │         │mutable borrow attempted here
    │         requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:32:14
+   │
+32 │         (s1, s1) // error in v1 since &mut cannot be copied
+   │         -----^^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
+
 error: same mutable reference in local `return[0]` is also used in other local `return[1]` in argument list
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:32:9
    │
@@ -49,6 +78,25 @@ error: same mutable reference in local `return[0]` is also used in other local `
 32 │         (s1, s1) // error in v1 since &mut cannot be copied
    │         ^^^^^^^^ requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:10
+   │
+35 │         let f =  &mut s1.f;
+   │                  --------- previous mutable field borrow
+36 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
+error: mutable reference in local `f` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:14
+   │
+36 │         (s1, f)
+   │         -----^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
+
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:36:9
    │
@@ -56,6 +104,16 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                  --------- previous mutable field borrow
 36 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:21
+   │
+39 │         (&mut s1.f, s1)
+   │         ------------^^-
+   │         ││          │
+   │         ││          requirement enforced here
+   │         │previous mutable field borrow
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:39:9
@@ -66,6 +124,16 @@ error: mutable reference in local `return[1]` requires exclusive access but is b
    │         │previous mutable field borrow
    │         requirement enforced here
 
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:42:22
+   │
+42 │         (id_mut(s1), s1)
+   │         -------------^^-
+   │         ││           │
+   │         ││           requirement enforced here
+   │         │previous mutable call result
+   │         conflicting reference `return[0]` used here
+
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:42:9
    │
@@ -74,6 +142,28 @@ error: mutable reference in local `return[1]` requires exclusive access but is b
    │         ││
    │         │previous mutable call result
    │         requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:10
+   │
+45 │         let f = id_mut(&mut s1.f);
+   │                 -----------------
+   │                 │      │
+   │                 │      previous mutable field borrow
+   │                 used by mutable call result
+46 │         (s1, f)
+   │          ^^  - conflicting reference `f` used here
+   │          │
+   │          requirement enforced here
+
+error: mutable reference in local `f` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:14
+   │
+46 │         (s1, f)
+   │         -----^-
+   │         │    │
+   │         │    requirement enforced here
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[0]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:46:9
@@ -85,6 +175,17 @@ error: mutable reference in local `return[0]` requires exclusive access but is b
    │                 used by mutable call result
 46 │         (s1, f)
    │         ^^^^^^^ requirement enforced here
+
+error: mutable reference in local `s1` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:49:29
+   │
+49 │         (id_mut(&mut s1.f), s1)
+   │         --------------------^^-
+   │         ││      │           │
+   │         ││      │           requirement enforced here
+   │         ││      previous mutable field borrow
+   │         │used by mutable call result
+   │         conflicting reference `return[0]` used here
 
 error: mutable reference in local `return[1]` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/return_mutual_borrows_invalid.move:49:9

--- a/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test4.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test4.exp
@@ -49,6 +49,17 @@ error: cannot immutably borrow since mutable references exist
    │                              -------------------------- previous mutable field borrow
    ·
 11 │             foo(freeze(s), { *({x = x + 1; f}) = 0; 1 })
+   │                 ^^^^^^^^^                  - requirement enforced here
+   │                 │
+   │                 immutable borrow attempted here
+
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/simplifier/simplifier_test4.move:11:17
+   │
+ 8 │         let f = { x = x + 1; &mut ({x = x + 1; z; s}).f };
+   │                              -------------------------- previous mutable field borrow
+   ·
+11 │             foo(freeze(s), { *({x = x + 1; f}) = 0; 1 })
    │                 ^^^^^^^^^    --------------------- requirement enforced here
    │                 │
    │                 immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -236,14 +236,14 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
-            dump_bytecode_filter: None,
+            dump_bytecode_filter:
             // For debugging:
-            // Some(vec![
-            //   INITIAL_BYTECODE_STAGE,
-            //   "ReferenceSafetyProcessor",
-            //   "DeadStoreElimination",
-            //   FILE_FORMAT_STAGE,
-            //]),
+             Some(vec![
+               INITIAL_BYTECODE_STAGE,
+               "ReferenceSafetyProcessor",
+               "DeadStoreElimination",
+               FILE_FORMAT_STAGE,
+            ]),
         },
         // Reference safety tests (without optimizations on)
         TestConfig {
@@ -258,7 +258,14 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
-            dump_bytecode_filter: None,
+            dump_bytecode_filter:
+            // For debugging:
+            Some(vec![
+                INITIAL_BYTECODE_STAGE,
+                "ReferenceSafetyProcessor",
+                "DeadStoreElimination",
+                FILE_FORMAT_STAGE,
+            ]),
         },
         // Abort analysis tests
         TestConfig {


### PR DESCRIPTION
## Description

This does a number of adaptions to reference safety to deal with some of the unexpected quirks of the v1 borrow semantics. Additional cases are now detected which are logical safe but anyway rejected by v1. Also, the treatment of freeze has been updated to relax some corner cases which led to failures in framework compilation. With this PR, all known bytecode verification failures are now detected except of a few which are sensitive to optimizations on and which pass without optimizations but not with it (see #12756).

This closes #12301 and closes #12701

- Fixes `borrow_global` borrow edge to carry a code offset, to be able to distinguish multiple global borrows with different addresses. Since the address in `borrow_global<R>(addr)` is dynamic, the reference checker cannot know whether two borrows result in the same reference. We already tackle this situation for calls which derive references, by adding the code offset to the edge kind, and now do the same for borrow global.
- Makes assignment a checkpoint for borrow safety. Until now, we have considered those operations as no-ops for safety (which is sound from memory safety perspective), but v1 insists on enforcing borrow checks. 
- Adds a new check to borrow safety for mut refs which are duplicated and live beyond a safety check point. A particular quirk in v1 is that a mut ref which was used to derive another mut ref is allowed, but one which is duplicated is not. Specifically, the following is _not_ allowed in v1: `let r = &mut s; let r1 = r; let x = &mut r.f; *x; *r1`. However, this is allowed: `let r = &mut s; let x = &mut r.f; *x; *r`. The v1 logic behind this seems to be that `x` is derived from `r` but not (for the first example) from `r1`.  Since the information from what temporaries refs have been derived is not present in the borrow graph (which is designed to abstract from temporaries), we needed to introduce a new field in the borrow state to track this information.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests + some new tests

## Key Areas to Review

Baseline files
