### PR TITLE
Use native implementation to optimize object derived address computation

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -301,6 +301,9 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [aggregator_v2_string_concat_per_byte: InternalGasPerByte, { 12.. =>"aggregator_v2.string_concat.per_byte" }, 3],
 
         [object_exists_at_base: InternalGas, { 7.. => "object.exists_at.base" }, 919],
+        // Based on SHA3-256's cost
+        [object_user_derived_address_base: InternalGas, { 16.. => "object.user_derived_address.base" }, 14704],
+
         // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs
         [object_exists_at_per_byte_loaded: InternalGasPerByte, { 7.. => "object.exists_at.per_byte_loaded" }, 183],
         [object_exists_at_per_item_loaded: InternalGas, { 7.. => "object.exists_at.per_item_loaded" }, 1470],

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -112,6 +112,7 @@ pub enum FeatureFlag {
     TransactionContextExtension,
     CoinToFungibleAssetMigration,
     PrimaryAPTFungibleStoreAtUserAddress,
+    ObjectNativeDerivedAddress,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -286,6 +287,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::PrimaryAPTFungibleStoreAtUserAddress => {
                 AptosFeatureFlag::PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS
             },
+            FeatureFlag::ObjectNativeDerivedAddress => {
+                AptosFeatureFlag::OBJECT_NATIVE_DERIVED_ADDRESS
+            },
         }
     }
 }
@@ -388,6 +392,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS => {
                 FeatureFlag::PrimaryAPTFungibleStoreAtUserAddress
+            },
+            AptosFeatureFlag::OBJECT_NATIVE_DERIVED_ADDRESS => {
+                FeatureFlag::ObjectNativeDerivedAddress
             },
         }
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -7,6 +7,7 @@ use aptos_framework::natives::{
     code::NativeCodeContext,
     cryptography::{algebra::AlgebraContext, ristretto255_point::NativeRistrettoPointContext},
     event::NativeEventContext,
+    object::NativeObjectContext,
     randomness::RandomnessContext,
     state_storage::NativeStateStorageContext,
     transaction_context::NativeTransactionContext,
@@ -217,6 +218,7 @@ impl MoveVmExt {
         extensions.add(NativeCodeContext::default());
         extensions.add(NativeStateStorageContext::new(resolver));
         extensions.add(NativeEventContext::default());
+        extensions.add(NativeObjectContext::default());
 
         // The VM code loader has bugs around module upgrade. After a module upgrade, the internal
         // cache needs to be flushed to work around those bugs.

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -223,6 +223,7 @@ pub fn configure_for_unit_test() {
 
 #[cfg(feature = "testing")]
 fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
+    use aptos_framework::natives::object::NativeObjectContext;
     use aptos_table_natives::NativeTableContext;
 
     exts.add(NativeTableContext::new([0u8; 32], &*DUMMY_RESOLVER));
@@ -241,6 +242,7 @@ fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
     exts.add(NativeRistrettoPointContext::new());
     exts.add(AlgebraContext::new());
     exts.add(NativeEventContext::default());
+    exts.add(NativeObjectContext::default());
 
     let mut randomness_ctx = RandomnessContext::new();
     randomness_ctx.mark_unbiasable();

--- a/aptos-move/e2e-benchmark/src/main.rs
+++ b/aptos-move/e2e-benchmark/src/main.rs
@@ -142,8 +142,8 @@ fn main() {
         (257, EntryPoints::TokenV1MintAndTransferFT),
         (412, EntryPoints::TokenV1MintAndTransferNFTSequential),
         (368, EntryPoints::TokenV2AmbassadorMint { numbered: true }),
-        (520, EntryPoints::LiquidityPoolSwap { is_stable: true }),
-        (500, EntryPoints::LiquidityPoolSwap { is_stable: false }),
+        (390, EntryPoints::LiquidityPoolSwap { is_stable: true }),
+        (350, EntryPoints::LiquidityPoolSwap { is_stable: false }),
     ];
 
     let mut failures = Vec::new();

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -39,6 +39,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `is_object`](#0x1_object_is_object)
 -  [Function `object_exists`](#0x1_object_object_exists)
 -  [Function `create_object_address`](#0x1_object_create_object_address)
+-  [Function `create_user_derived_object_address_impl`](#0x1_object_create_user_derived_object_address_impl)
 -  [Function `create_user_derived_object_address`](#0x1_object_create_user_derived_object_address)
 -  [Function `create_guid_object_address`](#0x1_object_create_guid_object_address)
 -  [Function `exists_at`](#0x1_object_exists_at)
@@ -89,6 +90,7 @@ make it so that a reference to a global object can be returned from a function.
     -  [Module-level Specification](#module-level-spec)
     -  [Function `address_to_object`](#@Specification_1_address_to_object)
     -  [Function `create_object_address`](#@Specification_1_create_object_address)
+    -  [Function `create_user_derived_object_address_impl`](#@Specification_1_create_user_derived_object_address_impl)
     -  [Function `create_user_derived_object_address`](#@Specification_1_create_user_derived_object_address)
     -  [Function `create_guid_object_address`](#@Specification_1_create_guid_object_address)
     -  [Function `exists_at`](#@Specification_1_exists_at)
@@ -846,6 +848,28 @@ Derives an object address from source material: sha3_256([creator address | seed
 
 </details>
 
+<a id="0x1_object_create_user_derived_object_address_impl"></a>
+
+## Function `create_user_derived_object_address_impl`
+
+
+
+<pre><code><b>fun</b> <a href="object.md#0x1_object_create_user_derived_object_address_impl">create_user_derived_object_address_impl</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="object.md#0x1_object_create_user_derived_object_address_impl">create_user_derived_object_address_impl</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b>;
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_object_create_user_derived_object_address"></a>
 
 ## Function `create_user_derived_object_address`
@@ -863,10 +887,14 @@ Derives an object address from the source address and an object: sha3_256([sourc
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_user_derived_object_address">create_user_derived_object_address</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b> {
-    <b>let</b> bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&source);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&derive_from));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="object.md#0x1_object_OBJECT_DERIVED_SCHEME">OBJECT_DERIVED_SCHEME</a>);
-    <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
+    <b>if</b> (std::features::object_native_derived_address_enabled()) {
+        <a href="object.md#0x1_object_create_user_derived_object_address_impl">create_user_derived_object_address_impl</a>(source, derive_from)
+    } <b>else</b> {
+        <b>let</b> bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&source);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&derive_from));
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="object.md#0x1_object_OBJECT_DERIVED_SCHEME">OBJECT_DERIVED_SCHEME</a>);
+        <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
+    }
 }
 </code></pre>
 
@@ -2304,6 +2332,32 @@ Return true if the provided address has indirect or direct ownership of the prov
 <b>pragma</b> aborts_if_is_strict = <b>false</b>;
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] result == <a href="object.md#0x1_object_spec_create_object_address">spec_create_object_address</a>(source, seed);
+</code></pre>
+
+
+
+
+<a id="0x1_object_spec_create_user_derived_object_address_impl"></a>
+
+
+<pre><code><b>fun</b> <a href="object.md#0x1_object_spec_create_user_derived_object_address_impl">spec_create_user_derived_object_address_impl</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_create_user_derived_object_address_impl"></a>
+
+### Function `create_user_derived_object_address_impl`
+
+
+<pre><code><b>fun</b> <a href="object.md#0x1_object_create_user_derived_object_address_impl">create_user_derived_object_address_impl</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>ensures</b> [abstract] result == <a href="object.md#0x1_object_spec_create_user_derived_object_address_impl">spec_create_user_derived_object_address_impl</a>(source, derive_from);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -202,12 +202,18 @@ module aptos_framework::object {
         from_bcs::to_address(hash::sha3_256(bytes))
     }
 
+    native fun create_user_derived_object_address_impl(source: address, derive_from: address): address;
+
     /// Derives an object address from the source address and an object: sha3_256([source | object addr | 0xFC]).
     public fun create_user_derived_object_address(source: address, derive_from: address): address {
-        let bytes = bcs::to_bytes(&source);
-        vector::append(&mut bytes, bcs::to_bytes(&derive_from));
-        vector::push_back(&mut bytes, OBJECT_DERIVED_SCHEME);
-        from_bcs::to_address(hash::sha3_256(bytes))
+        if (std::features::object_native_derived_address_enabled()) {
+            create_user_derived_object_address_impl(source, derive_from)
+        } else {
+            let bytes = bcs::to_bytes(&source);
+            vector::append(&mut bytes, bcs::to_bytes(&derive_from));
+            vector::push_back(&mut bytes, OBJECT_DERIVED_SCHEME);
+            from_bcs::to_address(hash::sha3_256(bytes))
+        }
     }
 
     /// Derives an object from an Account GUID.
@@ -782,6 +788,31 @@ module aptos_framework::object {
         std::vector::push_back(&mut bytes, DERIVE_AUID_ADDRESS_SCHEME);
         let auid2 = aptos_framework::from_bcs::to_address(std::hash::sha3_256(bytes));
         assert!(auid1 == auid2, 0);
+    }
+
+    #[test(fx = @std)]
+    fun test_correct_derived_object_address(fx: signer) {
+        use std::features;
+        use aptos_framework::object;
+        let feature = features::get_object_native_derived_address_feature();
+
+        let source = @0x12345;
+        let derive_from = @0x7890;
+
+        features::change_feature_flags_for_testing(&fx, vector[], vector[feature]);
+        let in_move = object::create_user_derived_object_address(source, derive_from);
+
+        features::change_feature_flags_for_testing(&fx, vector[feature], vector[]);
+        let in_native = object::create_user_derived_object_address(source, derive_from);
+
+        assert!(in_move == in_native, 0);
+
+        let bytes = bcs::to_bytes(&source);
+        vector::append(&mut bytes, bcs::to_bytes(&derive_from));
+        vector::push_back(&mut bytes, OBJECT_DERIVED_SCHEME);
+        let directly = from_bcs::to_address(hash::sha3_256(bytes));
+
+        assert!(directly == in_native, 0);
     }
 
     #[test(creator = @0x123)]

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -118,6 +118,13 @@ spec aptos_framework::object {
         ensures [abstract] result == spec_create_object_address(source, seed);
     }
 
+    spec fun spec_create_user_derived_object_address_impl(source: address, derive_from: address): address;
+
+    spec create_user_derived_object_address_impl(source: address, derive_from: address): address {
+        pragma opaque;
+        ensures [abstract] result == spec_create_user_derived_object_address_impl(source, derive_from);
+    }
+
     spec create_user_derived_object_address(source: address, derive_from: address): address {
         pragma opaque;
         pragma aborts_if_is_strict = false;

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -114,6 +114,8 @@ return true.
 -  [Function `coin_to_fungible_asset_migration_feature_enabled`](#0x1_features_coin_to_fungible_asset_migration_feature_enabled)
 -  [Function `get_primary_apt_fungible_store_at_user_address_feature`](#0x1_features_get_primary_apt_fungible_store_at_user_address_feature)
 -  [Function `primary_apt_fungible_store_at_user_address_enabled`](#0x1_features_primary_apt_fungible_store_at_user_address_enabled)
+-  [Function `get_object_native_derived_address_feature`](#0x1_features_get_object_native_derived_address_feature)
+-  [Function `object_native_derived_address_enabled`](#0x1_features_object_native_derived_address_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -617,6 +619,16 @@ Whether deploying to objects is enabled.
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_OBJECT_CODE_DEPLOYMENT">OBJECT_CODE_DEPLOYMENT</a>: u64 = 52;
+</code></pre>
+
+
+
+<a id="0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS"></a>
+
+Whether we use more efficient native implementation of computing object derived address
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS">OBJECT_NATIVE_DERIVED_ADDRESS</a>: u64 = 62;
 </code></pre>
 
 
@@ -2716,6 +2728,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_primary_apt_fungible_store_at_user_address_enabled">primary_apt_fungible_store_at_user_address_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS">PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_object_native_derived_address_feature"></a>
+
+## Function `get_object_native_derived_address_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_object_native_derived_address_feature">get_object_native_derived_address_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_object_native_derived_address_feature">get_object_native_derived_address_feature</a>(): u64 { <a href="features.md#0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS">OBJECT_NATIVE_DERIVED_ADDRESS</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_object_native_derived_address_enabled"></a>
+
+## Function `object_native_derived_address_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_object_native_derived_address_enabled">object_native_derived_address_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_object_native_derived_address_enabled">object_native_derived_address_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS">OBJECT_NATIVE_DERIVED_ADDRESS</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -510,6 +510,15 @@ module std::features {
         is_enabled(PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS)
     }
 
+    /// Whether we use more efficient native implementation of computing object derived address
+    const OBJECT_NATIVE_DERIVED_ADDRESS: u64 = 62;
+
+    public fun get_object_native_derived_address_feature(): u64 { OBJECT_NATIVE_DERIVED_ADDRESS }
+
+    public fun object_native_derived_address_enabled(): bool acquires Features {
+        is_enabled(OBJECT_NATIVE_DERIVED_ADDRESS)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -13,10 +13,7 @@ use aptos_types::{
     },
 };
 use better_any::{Tid, TidAble};
-use move_core_types::{
-    account_address::AccountAddress,
-    gas_algebra::{NumArgs, NumBytes},
-};
+use move_core_types::gas_algebra::{NumArgs, NumBytes};
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
@@ -105,16 +102,12 @@ fn native_generate_unique_address(
         .get_mut::<NativeTransactionContext>();
     transaction_context.auid_counter += 1;
 
-    let hash_vec = AuthenticationKey::auid(
+    let auid = AuthenticationKey::auid(
         transaction_context.txn_hash.clone(),
         transaction_context.auid_counter,
-    );
-    Ok(smallvec![Value::address(AccountAddress::new(
-        hash_vec
-            .to_vec()
-            .try_into()
-            .expect("Unable to convert hash vector into [u8]")
-    ))])
+    )
+    .account_address();
+    Ok(smallvec![Value::address(auid)])
 }
 
 /***************************************************************************************************

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -138,7 +138,7 @@ TESTS = [
 
     RunGroupConfig(expected_tps=14500, key=RunGroupKey("coin-init-and-mint", module_working_set_size=1), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(expected_tps=12000, key=RunGroupKey("coin-init-and-mint", module_working_set_size=20), included_in=Flow.CONTINUOUS),
-    RunGroupConfig(expected_tps=1590, key=RunGroupKey("fungible-asset-mint", module_working_set_size=1), included_in=LAND_BLOCKING_AND_C),
+    RunGroupConfig(expected_tps=1870, key=RunGroupKey("fungible-asset-mint", module_working_set_size=1), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(expected_tps=7900, key=RunGroupKey("fungible-asset-mint", module_working_set_size=20), included_in=Flow.CONTINUOUS),
 
     # RunGroupConfig(expected_tps=1000, key=RunGroupKey("token-v1ft-mint-and-store"), included_in=Flow(0)),
@@ -150,7 +150,7 @@ TESTS = [
     RunGroupConfig(expected_tps=7006, key=RunGroupKey("token-v2-ambassador-mint"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=6946, key=RunGroupKey("token-v2-ambassador-mint", module_working_set_size=20), included_in=Flow.CONTINUOUS),
 
-    RunGroupConfig(expected_tps=1030, key=RunGroupKey("liquidity-pool-swap"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
+    RunGroupConfig(expected_tps=1150, key=RunGroupKey("liquidity-pool-swap"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=4520, key=RunGroupKey("liquidity-pool-swap", module_working_set_size=20), included_in=Flow.CONTINUOUS),
 
     RunGroupConfig(expected_tps=970, key=RunGroupKey("liquidity-pool-swap-stable"), included_in=Flow.CONTINUOUS),

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -73,6 +73,7 @@ pub enum FeatureFlag {
     TRANSACTION_CONTEXT_EXTENSION = 59,
     COIN_TO_FUNGIBLE_ASSET_MIGRATION = 60,
     PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS = 61,
+    OBJECT_NATIVE_DERIVED_ADDRESS = 62,
 }
 
 impl FeatureFlag {
@@ -131,6 +132,7 @@ impl FeatureFlag {
             FeatureFlag::REJECT_UNSTABLE_BYTECODE,
             FeatureFlag::TRANSACTION_CONTEXT_EXTENSION,
             FeatureFlag::COIN_TO_FUNGIBLE_ASSET_MIGRATION,
+            FeatureFlag::OBJECT_NATIVE_DERIVED_ADDRESS,
         ]
     }
 }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -637,11 +637,18 @@ impl AuthenticationKey {
     }
 
     /// Construct a preimage from a transaction-derived AUID as (txn_hash || auid_scheme_id)
-    pub fn auid(txn_hash: Vec<u8>, auid_counter: u64) -> Self {
-        let mut hash_arg = Vec::new();
-        hash_arg.extend(txn_hash);
-        hash_arg.extend(auid_counter.to_le_bytes().to_vec());
-        Self::from_preimage(hash_arg, Scheme::DeriveAuid)
+    pub fn auid(mut txn_hash: Vec<u8>, auid_counter: u64) -> Self {
+        txn_hash.extend(auid_counter.to_le_bytes().to_vec());
+        Self::from_preimage(txn_hash, Scheme::DeriveAuid)
+    }
+
+    pub fn object_address_from_object(
+        source: &AccountAddress,
+        derive_from: &AccountAddress,
+    ) -> AuthenticationKey {
+        let mut bytes = source.to_vec();
+        bytes.append(&mut derive_from.to_vec());
+        Self::from_preimage(bytes, Scheme::DeriveObjectAddressFromObject)
     }
 
     /// Create an authentication key from an Ed25519 public key


### PR DESCRIPTION
## Description
Computing address for primary_fungible_asset store is expensive, and repeated multiple times. (especially if we start using fungible assets for gas charging)

This optimizes that computation by moving it to rust, and by caching it within a transaction (so computation in prologue gets saved for epilogue)

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## How Has This Been Tested?
added unit test
performance on Coin => FA migration


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
