### PR TITLE
[Compiler-v2] Add a test case for issue 12670

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.exp
@@ -1,0 +1,31 @@
+// -- Model dump before bytecode pipeline
+module 0x1::Test {
+    use std::vector::{for_each_ref};
+    struct S {
+        x: u8,
+    }
+    private fun foo(xs: vector<Test::S>) {
+        {
+          let sum: u8 = 0;
+          {
+            let (v: &vector<Test::S>): (&vector<Test::S>) = Tuple(Borrow(Immutable)(xs));
+            {
+              let i: u64 = 0;
+              loop {
+                if Lt<u64>(i, vector::length<Test::S>(v)) {
+                  {
+                    let (e: &Test::S): (&Test::S) = Tuple(vector::borrow<Test::S>(v, i));
+                    sum: u8 = Add<u8>(sum, select Test::S.x<&Test::S>(e));
+                    Tuple()
+                  };
+                  i: u64 = Add<u64>(i, 1)
+                } else {
+                  break
+                }
+              }
+            }
+          };
+          Tuple()
+        }
+    }
+} // end 0x1::Test

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.move
@@ -1,0 +1,10 @@
+module 0x1::Test {
+    use std::vector::for_each_ref;
+    struct  S has drop {
+        x :u8,
+    }
+    fun foo(xs : vector<S>) {
+        let sum :u8 = 0;
+        for_each_ref(&xs , | e | {   sum = sum + e.x;});
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #12670 by adding a test for lambda parameter inference to v2.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added a new test and validated the output

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
