### PR TITLE
ability to charge io gas for writing the transaction itself and emitted events

### DIFF
--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -3,7 +3,9 @@
 
 use aptos_gas_algebra::{Fee, FeePerGasUnit, Gas, GasExpression, GasScalingFactor, Octa};
 use aptos_gas_schedule::VMGasParameters;
-use aptos_types::{state_store::state_key::StateKey, write_set::WriteOpSize};
+use aptos_types::{
+    contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOpSize,
+};
 use aptos_vm_types::{
     change_set::VMChangeSet,
     resolver::ExecutorView,
@@ -110,6 +112,12 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// The cost stays constant for transactions below a certain size, but will grow proportionally
     /// for bigger ones.
     fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+
+    /// Charges IO gas for the transaction itself.
+    fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+
+    /// Charges IO gas for an emitted event.
+    fn charge_io_gas_for_event(&mut self, event: &ContractEvent) -> VMResult<()>;
 
     /// Charges IO gas for an item in the write set.
     ///

--- a/aptos-move/aptos-gas-profiling/src/aggregate.rs
+++ b/aptos-move/aptos-gas-profiling/src/aggregate.rs
@@ -25,6 +25,8 @@ pub struct AggregatedExecutionGasEvents {
 
     // TODO: Make this more strongly typed?
     pub ops: Vec<(String, usize, InternalGas)>,
+    pub transaction_write: InternalGas,
+    pub event_writes: Vec<(String, usize, InternalGas)>,
     pub storage_reads: Vec<(String, usize, InternalGas)>,
     pub storage_writes: Vec<(String, usize, InternalGas)>,
 }
@@ -73,6 +75,7 @@ impl ExecutionAndIOCosts {
         let mut ops = BTreeMap::new();
         let mut storage_reads = BTreeMap::new();
         let mut storage_writes = BTreeMap::new();
+        let mut event_writes = BTreeMap::new();
 
         for event in self.gas_events() {
             match event {
@@ -104,6 +107,14 @@ impl ExecutionAndIOCosts {
             }
         }
 
+        for event in &self.events_transient {
+            insert_or_add(
+                &mut event_writes,
+                format!("{}", Render(&event.ty)),
+                event.cost,
+            );
+        }
+
         for write in &self.write_set_transient {
             use StateKeyInner::*;
 
@@ -123,6 +134,8 @@ impl ExecutionAndIOCosts {
             total: self.total,
 
             ops: into_sorted_vec(ops),
+            transaction_write: self.transaction_transient.unwrap_or_else(|| 0.into()),
+            event_writes: into_sorted_vec(event_writes),
             storage_reads: into_sorted_vec(storage_reads),
             storage_writes: into_sorted_vec(storage_writes),
         }

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -167,6 +167,12 @@ impl ExecutionAndIOCosts {
         }
         .visit(&self.call_graph);
 
+        if let Some(cost) = &self.transaction_transient {
+            lines.push("transaction_size", *cost)
+        }
+        for item in &self.events_transient {
+            lines.push(format!("event_emits;<{}>", Render(&item.ty)), item.cost)
+        }
         for item in &self.write_set_transient {
             lines.push(
                 format!("write_set;{}<{}>", Render(&item.op_type), Render(&item.key)),

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::log::{
-    CallFrame, Dependency, EventStorage, ExecutionAndIOCosts, ExecutionGasEvent, FrameName,
-    StorageFees, TransactionGasLog, WriteOpType, WriteStorage, WriteTransient,
+    CallFrame, Dependency, EventStorage, EventTransient, ExecutionAndIOCosts, ExecutionGasEvent,
+    FrameName, StorageFees, TransactionGasLog, WriteOpType, WriteStorage, WriteTransient,
 };
 use aptos_gas_algebra::{Fee, FeePerGasUnit, InternalGas, NumArgs, NumBytes, NumTypeNodes};
 use aptos_gas_meter::{AptosGasMeter, GasAlgebra};
@@ -34,6 +34,8 @@ pub struct GasProfiler<G> {
     intrinsic_cost: Option<InternalGas>,
     dependencies: Vec<Dependency>,
     frames: Vec<CallFrame>,
+    transaction_transient: Option<InternalGas>,
+    events_transient: Vec<EventTransient>,
     write_set_transient: Vec<WriteTransient>,
     storage_fees: Option<StorageFees>,
 }
@@ -88,6 +90,8 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_script()],
+            transaction_transient: None,
+            events_transient: vec![],
             write_set_transient: vec![],
             storage_fees: None,
         }
@@ -105,6 +109,8 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_function(module_id, func_name, ty_args)],
+            transaction_transient: None,
+            events_transient: vec![],
             write_set_transient: vec![],
             storage_fees: None,
         }
@@ -642,6 +648,8 @@ where
             intrinsic_cost: self.intrinsic_cost.unwrap_or_else(|| 0.into()),
             dependencies: self.dependencies,
             call_graph: self.frames.pop().expect("frame must exist"),
+            transaction_transient: self.transaction_transient,
+            events_transient: self.events_transient,
             write_set_transient: self.write_set_transient,
         };
         exec_io.assert_consistency();

--- a/aptos-move/aptos-gas-profiling/src/render.rs
+++ b/aptos-move/aptos-gas-profiling/src/render.rs
@@ -133,3 +133,9 @@ impl<'a> Display for Render<'a, WriteOpType> {
         })
     }
 }
+
+impl<'a> Display for Render<'a, TypeTag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -117,6 +117,16 @@ crate::gas_schedule::macros::define_gas_parameters!(
             { 0..=9 => "write_data.per_byte_in_val" },
             10_000
         ],
+        [
+            storage_io_per_event_byte_write: InternalGasPerByte,
+            { 16.. => "storage_io_per_event_byte_write" },
+            0,
+        ],
+        [
+            storage_io_per_transaction_byte_write: InternalGasPerByte,
+            { 16.. => "storage_io_per_transaction_byte_write" },
+            0,
+        ],
         [memory_quota: AbstractValueSize, { 1.. => "memory_quota" }, 10_000_000],
         [
             legacy_free_write_bytes_quota: NumBytes,

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V16
+///   - IO Gas for the transaction itself and events in the transaction output
 /// - V15
 ///   - Gas & limits for dependencies
 /// - V14
@@ -53,4 +55,4 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 15;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 16;

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -6,7 +6,8 @@ use aptos_gas_algebra::{
 };
 use aptos_gas_meter::AptosGasMeter;
 use aptos_types::{
-    account_config::CORE_CODE_ADDRESS, state_store::state_key::StateKey, write_set::WriteOpSize,
+    account_config::CORE_CODE_ADDRESS, contract_event::ContractEvent,
+    state_store::state_key::StateKey, write_set::WriteOpSize,
 };
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult, VMResult},
@@ -474,6 +475,10 @@ where
 
     delegate_mut! {
         fn algebra_mut(&mut self) -> &mut Self::Algebra;
+
+        fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+
+        fn charge_io_gas_for_event(&mut self, event: &ContractEvent) -> VMResult<()>;
 
         fn charge_io_gas_for_write(&mut self, key: &StateKey, op: &WriteOpSize) -> VMResult<()>;
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -872,6 +872,10 @@ impl AptosVM {
         txn_data: &TransactionMetadata,
         resolver: &impl AptosMoveResolver,
     ) -> Result<GasQuantity<Octa>, VMStatus> {
+        gas_meter.charge_io_gas_for_transaction(txn_data.transaction_size())?;
+        for (event, _layout) in change_set.events() {
+            gas_meter.charge_io_gas_for_event(event)?;
+        }
         for (key, op_size) in change_set.write_set_size_iter() {
             gas_meter.charge_io_gas_for_write(key, &op_size)?;
         }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

We used not to charge io gas for writing the transaction itself and events at all. Although we do charge execution gas in proportion to the sizes of both of them (intrinsic gas for the transaction and in write_event_to_store native funciton), it feels proper to charge for the writes in charge_change_set -- might benefit calibration accuracy. 

Notice that we used to charge storage fee for those sizes and that was removed due to https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-65.md

Also note, new gas parameters introduced are set to 0 for now. This should be a no op.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

planning to test in unit test with the gas profiler

probably need gas re-calibration

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

the numbers for the per txn byte and per event byte write gas.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation -- gonna follow up before new gas schedule is rolled in mainnet

<!-- Thank you for your contribution! -->
