### PR TITLE
Refactor and fix consensus-only-perf-test feature

### DIFF
--- a/aptos-node/src/storage.rs
+++ b/aptos-node/src/storage.rs
@@ -87,10 +87,10 @@ pub(crate) fn bootstrap_db(
 pub(crate) fn bootstrap_db(
     node_config: &NodeConfig,
 ) -> Result<(Arc<dyn DbReader>, DbReaderWriter, Option<Runtime>)> {
-    use aptos_db::fake_aptosdb::FakeAptosDB;
+    use aptos_db::db::fake_aptosdb::FakeAptosDB;
 
     let aptos_db = AptosDB::open(
-        &node_config.storage.dir(),
+        node_config.storage.get_dir_paths(),
         false, /* readonly */
         node_config.storage.storage_pruner_config,
         node_config.storage.rocksdb_configs,

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -210,6 +210,7 @@ impl ChunkOutput {
     ) -> Result<BlockOutput<TransactionOutput>> {
         use aptos_types::{
             state_store::{StateViewId, TStateView},
+            transaction::TransactionAuxiliaryData,
             write_set::WriteSet,
         };
 
@@ -227,10 +228,10 @@ impl ChunkOutput {
                             Vec::new(),
                             0, // Keep gas zero to match with StateCheckpoint txn output
                             TransactionStatus::Keep(ExecutionStatus::Success),
+                            TransactionAuxiliaryData::None,
                         )
                     })
                     .collect::<Vec<_>>(),
-                None,
             ),
         };
         Ok(transaction_outputs)

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -256,6 +256,8 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
 #[cfg(feature = "consensus-only-perf-test")]
 #[test]
 fn test_executor_execute_and_commit_chunk_without_verify() {
+    use aptos_types::block_executor::config::BlockExecutorConfigFromOnchain;
+
     let first_batch_size = 10;
     let second_batch_size = 10;
 
@@ -285,7 +287,11 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
             .map(|_| encode_mint_transaction(tests::gen_address(rng.gen::<u64>()), 100))
             .collect::<Vec<_>>();
         let output = executor
-            .execute_block((block_id, block(txns)).into(), parent_block_id, None)
+            .execute_block(
+                (block_id, block(txns)).into(),
+                parent_block_id,
+                BlockExecutorConfigFromOnchain::new_no_block_limit(),
+            )
             .unwrap();
         let ledger_info = tests::gen_ledger_info(6, output.root_hash(), block_id, 1);
         executor.commit_blocks(vec![block_id], ledger_info).unwrap();

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -50,14 +50,13 @@ use aptos_types::{
     },
     write_set::WriteSet,
 };
-use arc_swap::ArcSwapOption;
 use dashmap::DashMap;
 use itertools::zip_eq;
 use move_core_types::move_resource::MoveStructType;
 use std::{
     borrow::Borrow,
     sync::{
-        atomic::{AtomicPtr, AtomicU64, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc,
     },
 };

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -117,7 +117,7 @@ impl AptosDB {
 
         if indexer.next_version() < ledger_next_version {
             use aptos_storage_interface::state_view::DbStateViewAtVersion;
-            let db : Arc<dyn DbReader> = self.state_store.clone();
+            let db: Arc<dyn DbReader> = self.state_store.clone();
 
             let state_view = db.state_view_at_version(Some(ledger_next_version - 1))?;
             let resolver = state_view.as_move_resolver();
@@ -144,7 +144,7 @@ impl AptosDB {
         Ok(())
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
+    #[cfg(any(test, feature = "fuzzing", feature = "consensus-only-perf-test"))]
     fn new_without_pruner<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,
@@ -239,7 +239,7 @@ fn gauged_api<T, F>(api_name: &'static str, api_impl: F) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
-    let nested =  ENTERED_GAUGED_API.with(|entered| {
+    let nested = ENTERED_GAUGED_API.with(|entered| {
         if entered.get() {
             true
         } else {
@@ -273,7 +273,6 @@ where
 
         res
     }
-
 }
 
 // Convert requested range and order to a range in ascending order.

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -144,7 +144,7 @@ impl AptosDB {
         Ok(())
     }
 
-    #[cfg(any(test, feature = "fuzzing", feature = "consensus-only-perf-test"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     fn new_without_pruner<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -144,7 +144,7 @@ impl AptosDB {
         Ok(())
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
+    #[cfg(any(test, feature = "fuzzing", feature = "consensus-only-perf-test"))]
     fn new_without_pruner<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,

--- a/storage/aptosdb/src/db/include/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_testonly.rs
@@ -6,6 +6,7 @@ use aptos_config::config::{
     BUFFERED_STATE_TARGET_ITEMS, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
 };
 use aptos_infallible::Mutex;
+use aptos_types::state_store::create_empty_sharded_state_updates;
 use std::default::Default;
 
 impl AptosDB {
@@ -89,5 +90,63 @@ impl AptosDB {
 
     pub(crate) fn state_merkle_db(&self) -> Arc<StateMerkleDb> {
         self.state_store.state_db.state_merkle_db.clone()
+    }
+}
+
+pub fn gather_state_updates_until_last_checkpoint(
+    first_version: Version,
+    latest_in_memory_state: &StateDelta,
+    txns_to_commit: &[TransactionToCommit],
+) -> Option<ShardedStateUpdates> {
+    if let Some(latest_checkpoint_version) = latest_in_memory_state.base_version {
+        if latest_checkpoint_version >= first_version {
+            let idx = (latest_checkpoint_version - first_version) as usize;
+            assert!(
+                    txns_to_commit[idx].is_state_checkpoint(),
+                    "The new latest snapshot version passed in {:?} does not match with the last checkpoint version in txns_to_commit {:?}",
+                    latest_checkpoint_version,
+                    first_version + idx as u64
+                );
+            let mut sharded_state_updates = create_empty_sharded_state_updates();
+            sharded_state_updates.par_iter_mut().enumerate().for_each(
+                |(shard_id, state_updates_shard)| {
+                    txns_to_commit[..=idx].iter().for_each(|txn_to_commit| {
+                        state_updates_shard.extend(txn_to_commit.state_updates()[shard_id].clone());
+                    })
+                },
+            );
+            return Some(sharded_state_updates);
+        }
+    }
+
+    None
+}
+
+/// Test only methods for the DB
+impl AptosDB {
+    pub fn save_transactions_for_test(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        sync_commit: bool,
+        latest_in_memory_state: StateDelta,
+    ) -> Result<()> {
+        let state_updates_until_last_checkpoint = gather_state_updates_until_last_checkpoint(
+            first_version,
+            &latest_in_memory_state,
+            txns_to_commit,
+        );
+        self.save_transactions(
+            txns_to_commit,
+            first_version,
+            base_state_version,
+            ledger_info_with_sigs,
+            sync_commit,
+            latest_in_memory_state,
+            state_updates_until_last_checkpoint,
+            None,
+        )
     }
 }

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -110,8 +110,11 @@ include!("include/aptosdb_writer.rs");
 // Other private methods.
 include!("include/aptosdb_internal.rs");
 // Testonly methods.
-#[cfg(any(test, feature = "fuzzing"))]
+#[cfg(any(test, feature = "fuzzing", feature = "consensus-only-perf-test"))]
 include!("include/aptosdb_testonly.rs");
+
+#[cfg(feature = "consensus-only-perf-test")]
+pub mod fake_aptosdb;
 
 impl AptosDB {
     pub fn open(

--- a/storage/aptosdb/src/db/test_helper.rs
+++ b/storage/aptosdb/src/db/test_helper.rs
@@ -32,16 +32,12 @@ use aptos_types::{
     ledger_info::{generate_ledger_info_with_sig, LedgerInfo, LedgerInfoWithSignatures},
     proof::accumulator::{InMemoryEventAccumulator, InMemoryTransactionAccumulator},
     proptest_types::{AccountInfoUniverse, BlockGen},
-    state_store::{
-        create_empty_sharded_state_updates, state_key::StateKey, state_value::StateValue,
-        ShardedStateUpdates,
-    },
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{Transaction, TransactionInfo, TransactionToCommit, Version},
 };
 #[cfg(test)]
 use arr_macro::arr;
 use proptest::{collection::vec, prelude::*, sample::Index};
-use rayon::prelude::*;
 use std::{collections::HashMap, fmt::Debug};
 
 prop_compose! {

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -12,8 +12,6 @@
 
 pub use crate::db::AptosDB;
 
-#[cfg(feature = "consensus-only-perf-test")]
-pub mod fake_aptosdb;
 // Used in this and other crates for testing.
 
 pub mod backup;

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -782,6 +782,7 @@ fn run_consensus_only_realistic_env_max_tps() -> ForgeConfig {
         }))
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             optimize_for_maximum_throughput(config, 20_000, 4_500, 3.0);
+            state_sync_config_execute_transactions(&mut config.state_sync);
         }))
         // TODO(ibalajiarun): tune these success critiera after we have a better idea of the test behavior
         .with_success_criteria(


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR fixes the consensus-only feature.
- It updates the FakeAptosDB implementation to mirror the recent refactorings of the original AptosDB.
- It bypasses the transaction proof verification during state sync chunk update stage. This was reintroduced after recent refactoring.
- Updates forge test to always execute transactions during state sync. 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
