### PR TITLE
dkg rounding updates

### DIFF
--- a/dkg/src/counters.rs
+++ b/dkg/src/counters.rs
@@ -25,7 +25,7 @@ pub static DKG_STAGE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
 pub static ROUNDING_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_dkg_rounding_seconds",
-        "Rounding seconds and counts by result",
+        "Rounding seconds and counts by method",
         &["method"]
     )
     .unwrap()

--- a/dkg/src/counters.rs
+++ b/dkg/src/counters.rs
@@ -21,3 +21,12 @@ pub static DKG_STAGE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static ROUNDING_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_dkg_rounding_seconds",
+        "Rounding seconds and counts by result",
+        &["method"]
+    )
+    .unwrap()
+});

--- a/dkg/src/dkg_manager/mod.rs
+++ b/dkg/src/dkg_manager/mod.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    agg_trx_producer::TAggTranscriptProducer, counters::DKG_STAGE_SECONDS,
-    network::IncomingRpcRequest, DKGMessage,
+    agg_trx_producer::TAggTranscriptProducer,
+    counters::{DKG_STAGE_SECONDS, ROUNDING_SECONDS},
+    network::IncomingRpcRequest,
+    DKGMessage,
 };
 use anyhow::{anyhow, bail, ensure, Result};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
@@ -13,7 +15,7 @@ use aptos_logger::{debug, error, info, warn};
 use aptos_types::{
     dkg::{
         DKGSessionMetadata, DKGSessionState, DKGStartEvent, DKGTrait, DKGTranscript,
-        DKGTranscriptMetadata,
+        DKGTranscriptMetadata, MayHaveRoundingSummary,
     },
     epoch_state::EpochState,
     validator_txn::{Topic, ValidatorTransaction},
@@ -307,6 +309,16 @@ impl<DKG: DKGTrait> DKGManager<DKG> {
             "[DKG] Deal transcript started.",
         );
         let public_params = DKG::new_public_params(dkg_session_metadata);
+        if let Some(summary) = public_params.rounding_summary() {
+            info!(
+                epoch = self.epoch_state.epoch,
+                "Rounding summary: {:?}", summary
+            );
+            ROUNDING_SECONDS
+                .with_label_values(&[summary.method.as_str()])
+                .observe(summary.exec_time.as_secs_f64());
+        }
+
         let mut rng = if cfg!(feature = "smoke-test") {
             StdRng::from_seed(self.my_addr.into_bytes())
         } else {

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -947,6 +947,11 @@ async fn test_nodes_rewards() {
 #[tokio::test]
 async fn test_register_and_update_validator() {
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
+        .with_init_genesis_config(Arc::new(move |conf| {
+            // start with randomness disabled.
+            conf.consensus_config.enable_validator_txns();
+            conf.randomness_config_override = Some(OnChainRandomnessConfig::default_disabled());
+        }))
         .with_aptos()
         .build_with_cli(0)
         .await;

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -947,11 +947,6 @@ async fn test_nodes_rewards() {
 #[tokio::test]
 async fn test_register_and_update_validator() {
     let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_init_genesis_config(Arc::new(move |conf| {
-            // start with randomness disabled.
-            conf.consensus_config.enable_validator_txns();
-            conf.randomness_config_override = Some(OnChainRandomnessConfig::default_disabled());
-        }))
         .with_aptos()
         .build_with_cli(0)
         .await;

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -295,8 +295,6 @@ fn compute_profile_fixed_point(
     let mut delta_down_fixed = U64F64::from_num(0);
     let mut delta_up_fixed = U64F64::from_num(0);
     let mut validator_weights: Vec<u64> = vec![];
-    let x = (U64F64::from_num(1) / U64F64::from_num(2)).to_num::<f64>();
-    println!("x={}", x);
     for stake in validator_stakes {
         let ideal_weight_fixed = U64F64::from_num(*stake) / stake_per_weight;
         // rounded to the nearest integer

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -256,9 +256,12 @@ impl DKGRoundingProfile {
 
         let stake_total = U64F64::from_num(validator_stakes.clone().into_iter().sum::<u64>());
 
+        // This `stake_per_weight` value guarantees a weight assignment that achieves liveness and privacy
         let stake_per_weight = stake_total
             * 2
-            * (reconstruct_threshold_in_stake_ratio - secrecy_threshold_in_stake_ratio);
+            * (reconstruct_threshold_in_stake_ratio - secrecy_threshold_in_stake_ratio)
+            / U64F64::from_num(validator_stakes.len())
+            - U64F64::from_num(1);
         compute_profile_fixed_point(
             validator_stakes,
             stake_per_weight,
@@ -297,9 +300,8 @@ fn compute_profile_fixed_point(
     for stake in validator_stakes {
         let ideal_weight_fixed = U64F64::from_num(*stake) / stake_per_weight;
         // rounded to the nearest integer
-        let rounded_weight_fixed = (ideal_weight_fixed
-            + (U64F64::from_num(1) / U64F64::from_num(2)))
-        .floor();
+        let rounded_weight_fixed =
+            (ideal_weight_fixed + (U64F64::from_num(1) / U64F64::from_num(2))).floor();
         let rounded_weight = rounded_weight_fixed.to_num::<u64>();
         validator_weights.push(rounded_weight);
         if ideal_weight_fixed > rounded_weight_fixed {

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -16,7 +16,7 @@ pub fn total_weight_lower_bound(validator_stakes: &Vec<u64>) -> usize {
     validator_stakes.len()
 }
 
-/// Return the smallest `total weight` that guarantees a valid rounding.
+/// Find the smallest `stake_per_weight` that guarantees a valid rounding.
 /// Output the resulting total weight.
 pub fn total_weight_upper_bound(
     validator_stakes: &Vec<u64>,
@@ -37,6 +37,7 @@ pub fn total_weight_upper_bound(
 
 #[derive(Clone, Debug)]
 pub struct DKGRounding {
+    /// Currently either "binary_search" or "infallible".
     pub rounding_method: String,
     pub profile: DKGRoundingProfile,
     pub wconfig: WeightedConfig,

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -325,8 +325,10 @@ fn compute_profile_fixed_point(
         (secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight + delta_up_fixed)
             .ceil()
             + one;
-    let reconstruct_threshold_in_weights: u64 =
-        reconstruct_threshold_in_weights_fixed.to_num::<u64>();
+    let reconstruct_threshold_in_weights: u64 = min(
+        weight_total,
+        reconstruct_threshold_in_weights_fixed.to_num::<u64>(),
+    );
     let stake_gap_fixed = stake_per_weight * delta_total_fixed / stake_sum_fixed;
     let reconstruct_threshold_in_stake_ratio = secrecy_threshold_in_stake_ratio + stake_gap_fixed;
 
@@ -337,9 +339,10 @@ fn compute_profile_fixed_point(
             let recon_threshold = fast_secrecy_threshold_in_stake_ratio + stake_gap_fixed;
             let recon_weight = min(
                 weight_total,
-                (fast_secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight
+                ((fast_secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight
                     + delta_up_fixed)
                     .ceil()
+                    + one)
                     .to_num::<u64>(),
             );
             (Some(recon_threshold), Some(recon_weight))

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -1,11 +1,12 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, ensure};
 use aptos_dkg::pvss::WeightedConfig;
 use fixed::types::U64F64;
 use once_cell::sync::Lazy;
 use std::{
-    cmp::max,
+    cmp::{max, min},
     fmt,
     fmt::{Debug, Formatter},
 };
@@ -15,40 +16,45 @@ pub fn total_weight_lower_bound(validator_stakes: &Vec<u64>) -> usize {
     validator_stakes.len()
 }
 
+/// Return the smallest `total weight` that guarantees a valid rounding.
+/// Output the resulting total weight.
 pub fn total_weight_upper_bound(
     validator_stakes: &Vec<u64>,
-    reconstruct_threshold_in_stake_ratio: U64F64,
+    mut reconstruct_threshold_in_stake_ratio: U64F64,
     secrecy_threshold_in_stake_ratio: U64F64,
 ) -> usize {
-    assert!(reconstruct_threshold_in_stake_ratio > secrecy_threshold_in_stake_ratio);
-    let bound_1 = ((U64F64::from_num(1)
-        / (reconstruct_threshold_in_stake_ratio - secrecy_threshold_in_stake_ratio))
-        + U64F64::from_num(1))
-    .to_num::<u64>()
-        * (validator_stakes.len() as u64);
-
-    let stake_sum = validator_stakes.iter().sum::<u64>();
-    let stake_min = *validator_stakes.iter().min().unwrap();
-    let bound_2 = stake_sum / max(1, stake_min) + 1;
-
-    max(bound_1 as usize, bound_2 as usize)
+    reconstruct_threshold_in_stake_ratio = max(
+        reconstruct_threshold_in_stake_ratio,
+        secrecy_threshold_in_stake_ratio + U64F64::DELTA,
+    );
+    let n = U64F64::from_num(validator_stakes.len());
+    (n / U64F64::from_num(2)
+        / (reconstruct_threshold_in_stake_ratio - secrecy_threshold_in_stake_ratio)
+        + n)
+        .ceil()
+        .to_num::<usize>()
 }
 
 #[derive(Clone, Debug)]
 pub struct DKGRounding {
+    pub rounding_method: String,
     pub profile: DKGRoundingProfile,
     pub wconfig: WeightedConfig,
     pub fast_wconfig: Option<WeightedConfig>,
+    pub rounding_error: Option<String>,
 }
 
 impl DKGRounding {
     pub fn new(
         validator_stakes: &Vec<u64>,
         secrecy_threshold_in_stake_ratio: U64F64,
-        reconstruct_threshold_in_stake_ratio: U64F64,
+        mut reconstruct_threshold_in_stake_ratio: U64F64,
         fast_secrecy_threshold_in_stake_ratio: Option<U64F64>,
     ) -> Self {
-        assert!(reconstruct_threshold_in_stake_ratio > secrecy_threshold_in_stake_ratio);
+        reconstruct_threshold_in_stake_ratio = max(
+            reconstruct_threshold_in_stake_ratio,
+            secrecy_threshold_in_stake_ratio + U64F64::DELTA,
+        );
 
         let total_weight_min = total_weight_lower_bound(validator_stakes);
         let total_weight_max = total_weight_upper_bound(
@@ -57,14 +63,25 @@ impl DKGRounding {
             secrecy_threshold_in_stake_ratio,
         );
 
-        let profile = DKGRoundingProfile::new(
+        let (profile, rounding_error, rounding_method) = match DKGRoundingProfile::new(
             validator_stakes,
             total_weight_min,
             total_weight_max,
             secrecy_threshold_in_stake_ratio,
             reconstruct_threshold_in_stake_ratio,
             fast_secrecy_threshold_in_stake_ratio,
-        );
+        ) {
+            Ok(profile) => (profile, None, "binary_search".to_string()),
+            Err(e) => {
+                let profile = DKGRoundingProfile::infallible(
+                    validator_stakes,
+                    secrecy_threshold_in_stake_ratio,
+                    reconstruct_threshold_in_stake_ratio,
+                    fast_secrecy_threshold_in_stake_ratio,
+                );
+                (profile, Some(format!("{e}")), "infallible".to_string())
+            },
+        };
 
         let wconfig = WeightedConfig::new(
             profile.reconstruct_threshold_in_weights as usize,
@@ -91,14 +108,16 @@ impl DKGRounding {
         );
 
         Self {
+            rounding_method,
             profile,
             wconfig,
             fast_wconfig,
+            rounding_error,
         }
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DKGRoundingProfile {
     // calculated weights for each validator after rounding
     pub validator_weights: Vec<u64>,
@@ -160,32 +179,40 @@ impl DKGRoundingProfile {
         secrecy_threshold_in_stake_ratio: U64F64,
         reconstruct_threshold_in_stake_ratio: U64F64,
         fast_secrecy_threshold_in_stake_ratio: Option<U64F64>,
-    ) -> Self {
-        assert!(total_weight_min >= validator_stakes.len());
-        assert!(total_weight_max >= total_weight_min);
-        assert!(secrecy_threshold_in_stake_ratio * U64F64::from_num(3) > U64F64::from_num(1));
-        assert!(secrecy_threshold_in_stake_ratio < reconstruct_threshold_in_stake_ratio);
-        assert!(reconstruct_threshold_in_stake_ratio * U64F64::from_num(3) <= U64F64::from_num(2));
+    ) -> anyhow::Result<Self> {
+        ensure!(total_weight_min >= validator_stakes.len());
+        ensure!(total_weight_max >= total_weight_min);
+        ensure!(secrecy_threshold_in_stake_ratio * U64F64::from_num(3) > U64F64::from_num(1));
+        ensure!(secrecy_threshold_in_stake_ratio < reconstruct_threshold_in_stake_ratio);
+        ensure!(reconstruct_threshold_in_stake_ratio * U64F64::from_num(3) <= U64F64::from_num(2));
 
+        let stake_total: u64 = validator_stakes.iter().sum();
         let mut weight_low = total_weight_min as u64;
         let mut weight_high = total_weight_max as u64;
         let mut best_profile = compute_profile_fixed_point(
             validator_stakes,
-            weight_low,
+            max(
+                U64F64::from_num(1),
+                U64F64::from_num(stake_total) / U64F64::from_num(weight_low),
+            ),
             secrecy_threshold_in_stake_ratio,
             fast_secrecy_threshold_in_stake_ratio,
         );
 
         if is_valid_profile(&best_profile, reconstruct_threshold_in_stake_ratio) {
-            return best_profile;
+            return Ok(best_profile);
         }
 
         // binary search for the minimum weight that satisfies the conditions
         while weight_low <= weight_high {
             let weight_mid = weight_low + (weight_high - weight_low) / 2;
+            let stake_per_weight = max(
+                U64F64::from_num(1),
+                U64F64::from_num(stake_total) / U64F64::from_num(weight_mid),
+            );
             let profile = compute_profile_fixed_point(
                 validator_stakes,
-                weight_mid,
+                stake_per_weight,
                 secrecy_threshold_in_stake_ratio,
                 fast_secrecy_threshold_in_stake_ratio,
             );
@@ -199,34 +226,42 @@ impl DKGRoundingProfile {
             }
         }
 
-        // todo: remove once aptos-dkg supports 0 weights
-        if !is_valid_profile(&best_profile, reconstruct_threshold_in_stake_ratio) {
-            println!("[Randomness] Rounding error: failed to find a valid profile, using default");
-            return Self::default(
-                validator_stakes.len(),
-                secrecy_threshold_in_stake_ratio,
-                reconstruct_threshold_in_stake_ratio,
+        if is_valid_profile(&best_profile, reconstruct_threshold_in_stake_ratio) {
+            Ok(best_profile)
+        } else {
+            bail!(
+                "could not find a valid weight in the given weight range [{}, {}]",
+                total_weight_min,
+                total_weight_max
             );
         }
-
-        best_profile
     }
 
-    pub fn default(
-        num_validators: usize,
-        secrecy_threshold_in_stake_ratio: U64F64,
-        reconstruct_threshold_in_stake_ratio: U64F64,
+    pub fn infallible(
+        validator_stakes: &Vec<u64>,
+        mut secrecy_threshold_in_stake_ratio: U64F64,
+        mut reconstruct_threshold_in_stake_ratio: U64F64,
+        fast_secrecy_threshold_in_stake_ratio: Option<U64F64>,
     ) -> Self {
-        Self {
-            validator_weights: vec![1; num_validators],
+        let one = U64F64::from_num(1);
+        secrecy_threshold_in_stake_ratio = min(one, secrecy_threshold_in_stake_ratio);
+        reconstruct_threshold_in_stake_ratio = min(one, reconstruct_threshold_in_stake_ratio);
+        reconstruct_threshold_in_stake_ratio = max(
             secrecy_threshold_in_stake_ratio,
             reconstruct_threshold_in_stake_ratio,
-            reconstruct_threshold_in_weights: (U64F64::from_num(num_validators)
-                * secrecy_threshold_in_stake_ratio)
-                .to_num::<u64>(),
-            fast_reconstruct_threshold_in_stake_ratio: None,
-            fast_reconstruct_threshold_in_weights: None,
-        }
+        );
+
+        let stake_total = U64F64::from_num(validator_stakes.clone().into_iter().sum::<u64>());
+
+        let stake_per_weight = stake_total
+            * 2
+            * (reconstruct_threshold_in_stake_ratio - secrecy_threshold_in_stake_ratio);
+        compute_profile_fixed_point(
+            validator_stakes,
+            stake_per_weight,
+            secrecy_threshold_in_stake_ratio,
+            fast_secrecy_threshold_in_stake_ratio,
+        )
     }
 }
 
@@ -243,7 +278,7 @@ fn is_valid_profile(
 
 fn compute_profile_fixed_point(
     validator_stakes: &Vec<u64>,
-    weights_sum: u64,
+    stake_per_weight: U64F64,
     secrecy_threshold_in_stake_ratio: U64F64,
     maybe_fast_secrecy_threshold_in_stake_ratio: Option<U64F64>,
 ) -> DKGRoundingProfile {
@@ -252,49 +287,49 @@ fn compute_profile_fixed_point(
     // https://eprint.iacr.org/2024/198
     let stake_sum: u64 = validator_stakes.iter().sum::<u64>();
     let stake_sum_fixed = U64F64::from_num(stake_sum);
-    let stake_per_weight: u64 = max(1, stake_sum / weights_sum);
-    let stake_per_weight_fixed = U64F64::from_num(stake_per_weight);
     let mut delta_down_fixed = U64F64::from_num(0);
     let mut delta_up_fixed = U64F64::from_num(0);
     let mut validator_weights: Vec<u64> = vec![];
     for stake in validator_stakes {
-        let ideal_weight_fixed = U64F64::from_num(*stake) / stake_per_weight_fixed;
+        let ideal_weight_fixed = U64F64::from_num(*stake) / stake_per_weight;
         // rounded to the nearest integer
-        let rounded_weight_fixed =
-            (U64F64::from_num(*stake) / stake_per_weight_fixed + U64F64::from_num(0.5)).floor();
-        validator_weights.push(rounded_weight_fixed.to_num::<u64>());
+        let rounded_weight_fixed = (U64F64::from_num(*stake) / stake_per_weight
+            + U64F64::from_num(1) / U64F64::from_num(2))
+        .floor();
+        let rounded_weight = rounded_weight_fixed.to_num::<u64>();
+        validator_weights.push(rounded_weight);
         if ideal_weight_fixed > rounded_weight_fixed {
             delta_down_fixed += ideal_weight_fixed - rounded_weight_fixed;
         } else {
             delta_up_fixed += rounded_weight_fixed - ideal_weight_fixed;
         }
     }
+    let weight_total: u64 = validator_weights.clone().into_iter().sum();
     let delta_total_fixed = delta_down_fixed + delta_up_fixed;
     let reconstruct_threshold_in_weights_fixed =
-        (secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight_fixed
-            + delta_up_fixed)
+        (secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight + delta_up_fixed)
             .ceil();
     let reconstruct_threshold_in_weights: u64 =
         reconstruct_threshold_in_weights_fixed.to_num::<u64>();
-    let stake_gap_fixed = stake_per_weight_fixed * delta_total_fixed / stake_sum_fixed;
+    let stake_gap_fixed = stake_per_weight * delta_total_fixed / stake_sum_fixed;
     let reconstruct_threshold_in_stake_ratio = secrecy_threshold_in_stake_ratio + stake_gap_fixed;
 
-    let mut fast_reconstruct_threshold_in_stake_ratio = None;
-    let mut fast_reconstruct_threshold_in_weights = None;
-    if let Some(fast_secrecy_threshold_in_stake_ratio) = maybe_fast_secrecy_threshold_in_stake_ratio
-    {
-        let fast_reconstruct_threshold_in_stake_ratio_fixed =
-            fast_secrecy_threshold_in_stake_ratio + stake_gap_fixed;
-        fast_reconstruct_threshold_in_stake_ratio =
-            Some(fast_reconstruct_threshold_in_stake_ratio_fixed);
-        fast_reconstruct_threshold_in_weights = Some(
-            (fast_reconstruct_threshold_in_stake_ratio_fixed * stake_sum_fixed
-                / stake_per_weight_fixed
-                + delta_up_fixed)
-                .ceil()
-                .to_num::<u64>(),
-        );
-    }
+    let (fast_reconstruct_threshold_in_stake_ratio, fast_reconstruct_threshold_in_weights) =
+        if let Some(fast_secrecy_threshold_in_stake_ratio) =
+            maybe_fast_secrecy_threshold_in_stake_ratio
+        {
+            let recon_threshold = fast_secrecy_threshold_in_stake_ratio + stake_gap_fixed;
+            let recon_weight = min(
+                weight_total,
+                (fast_secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight
+                    + delta_up_fixed)
+                    .ceil()
+                    .to_num::<u64>(),
+            );
+            (Some(recon_threshold), Some(recon_weight))
+        } else {
+            (None, None)
+        };
 
     DKGRoundingProfile {
         validator_weights,

--- a/types/src/dkg/real_dkg/rounding/mod.rs
+++ b/types/src/dkg/real_dkg/rounding/mod.rs
@@ -323,7 +323,8 @@ fn compute_profile_fixed_point(
     let delta_total_fixed = delta_down_fixed + delta_up_fixed;
     let reconstruct_threshold_in_weights_fixed =
         (secrecy_threshold_in_stake_ratio * stake_sum_fixed / stake_per_weight + delta_up_fixed)
-            .ceil() + one;
+            .ceil()
+            + one;
     let reconstruct_threshold_in_weights: u64 =
         reconstruct_threshold_in_weights_fixed.to_num::<u64>();
     let stake_gap_fixed = stake_per_weight * delta_total_fixed / stake_sum_fixed;

--- a/types/src/dkg/real_dkg/rounding/tests.rs
+++ b/types/src/dkg/real_dkg/rounding/tests.rs
@@ -70,7 +70,8 @@ fn test_rounding_equal_stakes() {
         let wconfig = WeightedConfig::new(
             (U64F64::from_num(validator_num) * *DEFAULT_SECRECY_THRESHOLD.deref())
                 .ceil()
-                .to_num::<usize>(),
+                .to_num::<usize>()
+                + 1,
             vec![1; validator_num],
         )
         .unwrap();


### PR DESCRIPTION
## Description
- Add rounding metrics.
- Use a back-up rounding mechanism when the default search returns no result.
  The back-up mechanism:
  - guarantees privacy and liveness.
  - requires total weight to be ~3n where n is the number of validators.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Move/Aptos Virtual Machine
- [x] DKG

## How Has This Been Tested?
UTs

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
