### PR TITLE
set 10 minute timeout for nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,3 +14,7 @@ retries = 3
 status-level = "skip"
 failure-output = "immediate-final"
 junit = { path = "junit.xml" }
+
+[profile.default.slow-timeout]
+period = "600s"
+terminate-after = 1


### PR DESCRIPTION
## Description
I had a recent unit test failure running for over 4 hours in GHA test. Set `nextest` to timeout after 10 minutes.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [X] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [X] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
I have this in another branch and things pass within this timout. 30s and 90s were not enough (but we should push towards that and make slow tests faster)

## Key Areas to Review
Anyone know why `nextest` 'period' should be shorter but timeout after several of them? (instead of this config which is a long period and timeout after 1 of it)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation