### PR TITLE
[forge] Merge compat and framework test in k8s forge

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -21,7 +21,7 @@ on:
         type: string
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
   schedule:
-    - cron: "0 6 * * *"  # The main branch cadence. This runs every day at 6am UTC.
+    - cron: "0 6 * * *" # The main branch cadence. This runs every day at 6am UTC.
   pull_request:
     paths:
       - ".github/workflows/forge-stable.yaml"
@@ -115,12 +115,23 @@ jobs:
           fi
           echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
 
-
   ### Real-world-network tests.
+  # Run forge framework upgradability test. This is a PR required job.
+  run-forge-framework-upgrade-test:
+    needs:
+      - determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: aptos-node-v1.10.1 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-test-metadata.outputs.BRANCH_HASH }}
+      FORGE_RUNNER_DURATION_SECS: 7200 # Run for 2 hours
+      FORGE_TEST_SUITE: framework_upgrade
+      POST_TO_SLACK: true
 
   run-forge-realistic-env-max-load-long:
     if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
+    needs: [determine-test-metadata, run-forge-framework-upgrade-test] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -177,33 +177,37 @@ pub trait SwarmExt: Swarm {
         Ok(())
     }
 
+    // Checks if root_hashes are equal across all nodes at a given version
+    async fn are_root_hashes_equal_at_version(
+        clients: &[RestClient],
+        version: u64,
+    ) -> Result<bool> {
+        let root_hashes = try_join_all(
+            clients
+                .iter()
+                .map(|node| node.get_transaction_by_version(version))
+                .collect::<Vec<_>>(),
+        )
+        .await?
+        .into_iter()
+        .map(|r| {
+            r.into_inner()
+                .transaction_info()
+                .unwrap()
+                .accumulator_root_hash
+        })
+        .collect::<Vec<_>>();
+
+        Ok(root_hashes.windows(2).all(|w| w[0] == w[1]))
+    }
+
     /// Perform a safety check, ensuring that no forks have occurred in the network.
-    fn fork_check(&self) -> Result<()> {
-        // Checks if root_hashes are equal across all nodes at a given version
-        async fn are_root_hashes_equal_at_version(
-            clients: &[RestClient],
-            version: u64,
-        ) -> Result<bool> {
-            let root_hashes = try_join_all(
-                clients
-                    .iter()
-                    .map(|node| node.get_transaction_by_version(version))
-                    .collect::<Vec<_>>(),
-            )
-            .await?
-            .into_iter()
-            .map(|r| {
-                r.into_inner()
-                    .transaction_info()
-                    .unwrap()
-                    .accumulator_root_hash
-            })
-            .collect::<Vec<_>>();
-
-            Ok(root_hashes.windows(2).all(|w| w[0] == w[1]))
-        }
-
+    fn fork_check(&self, epoch_duration: Duration) -> Result<()> {
         let runtime = Runtime::new().unwrap();
+
+        // Lots of errors can actually occur after an epoch change so guarantee that we change epochs here
+        // This can wait for 2x epoch to at least force the caller to be explicit about the epoch duration
+        runtime.block_on(self.wait_for_all_nodes_to_change_epoch(epoch_duration * 2))?;
 
         let clients = self
             .validators()
@@ -232,7 +236,10 @@ pub trait SwarmExt: Swarm {
             .copied()
             .ok_or_else(|| anyhow!("Unable to query nodes for their latest version"))?;
 
-        if !runtime.block_on(are_root_hashes_equal_at_version(&clients, min_version))? {
+        if !runtime.block_on(Self::are_root_hashes_equal_at_version(
+            &clients,
+            min_version,
+        ))? {
             return Err(anyhow!("Fork check failed"));
         }
 
@@ -240,7 +247,10 @@ pub trait SwarmExt: Swarm {
             self.wait_for_all_nodes_to_catchup_to_version(max_version, Duration::from_secs(10)),
         )?;
 
-        if !runtime.block_on(are_root_hashes_equal_at_version(&clients, max_version))? {
+        if !runtime.block_on(Self::are_root_hashes_equal_at_version(
+            &clients,
+            max_version,
+        ))? {
             return Err(anyhow!("Fork check failed"));
         }
 

--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -10,6 +10,10 @@ use tokio::{runtime::Runtime, time::Duration};
 
 pub struct SimpleValidatorUpgrade;
 
+impl SimpleValidatorUpgrade {
+    pub const EPOCH_DURATION_SECS: u64 = 30;
+}
+
 impl Test for SimpleValidatorUpgrade {
     fn name(&self) -> &'static str {
         "compatibility::simple-validator-upgrade"
@@ -19,6 +23,8 @@ impl Test for SimpleValidatorUpgrade {
 impl NetworkTest for SimpleValidatorUpgrade {
     fn run(&self, ctx: &mut NetworkContext<'_>) -> Result<()> {
         let runtime = Runtime::new()?;
+
+        let epoch_duration = Duration::from_secs(Self::EPOCH_DURATION_SECS);
 
         // Get the different versions we're testing with
         let (old_version, new_version) = {
@@ -96,7 +102,7 @@ impl NetworkTest for SimpleValidatorUpgrade {
             &txn_stat,
         );
 
-        ctx.swarm().fork_check()?;
+        ctx.swarm().fork_check(epoch_duration)?;
 
         // Update the second batch
         let msg = format!("4. upgrading second batch to new version: {}", new_version);
@@ -114,7 +120,7 @@ impl NetworkTest for SimpleValidatorUpgrade {
         let msg = "5. check swarm health".to_string();
         info!("{}", msg);
         ctx.report.report_text(msg);
-        ctx.swarm().fork_check()?;
+        ctx.swarm().fork_check(epoch_duration)?;
         ctx.report.report_text(format!(
             "Compatibility test for {} ==> {} passed",
             old_version, new_version


### PR DESCRIPTION
Previously we wanted to test compatibility and test framework upgrades separately

As a part of the new release schedule (more regular / frequent / backwards compatible upgrades) we need to test compatibility throughout the upgrade process

So it no longer makes sense to have two tests, keep the previous compat test for local testing, but use only the framework upgrade test for k8s testing.

Test Plan: framework upgrade on the PR passes