### PR TITLE
[CI/CD] Add targeted unit test job and delay all unit tests.

### DIFF
--- a/.github/actions/rust-targeted-unit-tests/action.yaml
+++ b/.github/actions/rust-targeted-unit-tests/action.yaml
@@ -1,0 +1,49 @@
+name: Rust Targeted Unit Tests
+description: Runs only the targeted rust unit tests
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # The source code must be checked out by the workflow that invokes this action.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Install nextest
+    - uses: taiki-e/install-action@v1.5.6
+      with:
+        tool: nextest
+
+    # Run a postgres database
+    - name: Run postgres database
+      run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      shell: bash
+
+    # Output the changed files
+    - name: Output the changed files
+      run: cargo x changed-files -vv
+      shell: bash
+
+    # Output the affected packages
+    - name: Output the affected packages
+      run: cargo x affected-packages -vv
+      shell: bash
+
+    # Run only the targeted rust unit tests
+    - name: Run only the targeted unit tests
+      run: |
+        cargo x targeted-unit-tests -vv run --profile ci --cargo-profile ci --locked --no-fail-fast --retries 3
+      shell: bash
+      env:
+        INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+        RUST_MIN_STACK: "4297152"
+        MVP_TEST_ON_CI: "true"
+        SOLC_EXE: /home/runner/bin/solc
+        Z3_EXE: /home/runner/bin/z3
+        CVC5_EXE: /home/runner/bin/cvc5
+        DOTNET_ROOT: /home/runner/.dotnet
+        BOOGIE_EXE: /home/runner/.dotnet/tools/boogie

--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -12,7 +12,6 @@ runs:
   using: composite
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
-
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
@@ -31,7 +30,7 @@ runs:
     - uses: taiki-e/install-action@v1.5.6
       with:
         tool: nextest
-    
+
     # Install buildkite-test-collector
     - name: Install buildkite-test-collector
       run: cargo install buildkite-test-collector

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -106,9 +106,30 @@ jobs:
       - run: echo "Skipping rust smoke tests! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
+  # Run only the targeted rust unit tests. This is a PR required job.
+  rust-targeted-unit-tests:
+    needs: file_change_determinator
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # Fetch all git history for accurate target determination
+      - name: Run targeted rust unit tests
+        uses: ./.github/actions/rust-targeted-unit-tests
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
   # Run all rust unit tests. This is a PR required job.
   rust-unit-tests:
     needs: file_change_determinator
+    if: | # Only run on each PR once an appropriate event occurs
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests') ||
+        github.event.pull_request.auto_merge != null
+      )
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v4

--- a/devtools/aptos-cargo-cli/src/cargo.rs
+++ b/devtools/aptos-cargo-cli/src/cargo.rs
@@ -1,12 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use log::debug;
+use log::info;
 use std::{
     ffi::{OsStr, OsString},
     process::{Command, Stdio},
 };
 
+#[derive(Debug)]
 pub struct Cargo {
     inner: Command,
     pass_through_args: Vec<OsString>,
@@ -46,14 +47,36 @@ impl Cargo {
     }
 
     pub fn run(&mut self) {
+        // Set up the output and arguments
         self.inner.stdout(Stdio::inherit()).stderr(Stdio::inherit());
-
         if !self.pass_through_args.is_empty() {
             self.inner.arg("--").args(&self.pass_through_args);
         }
 
-        debug!("Executing command: {:?}", self.inner);
+        // Log the command
+        let command_to_execute = format!("{:?}", self.inner);
+        info!("Executing command: {:?}", command_to_execute);
 
-        let _ = self.inner.output();
+        // Execute the command
+        let result = self.inner.output();
+
+        // If the command failed, panic immediately with the error.
+        // This will ensure that failures are not dropped silently.
+        match result {
+            Ok(output) => {
+                if !output.status.success() {
+                    panic!(
+                        "Command failed: {:?}. Output: {:?}",
+                        command_to_execute, output
+                    );
+                }
+            },
+            Err(error) => {
+                panic!(
+                    "Unexpected error executing command: {:?}. Error: {:?}",
+                    command_to_execute, error
+                );
+            },
+        }
     }
 }

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -3,8 +3,18 @@
 
 use anyhow::anyhow;
 use clap::Args;
-use determinator::{Determinator, Utf8Paths0};
-use guppy::{graph::DependencyDirection, CargoMetadata, MetadataCommand};
+use determinator::{
+    rules::{DeterminatorMarkChanged, DeterminatorPostRule, DeterminatorRules, PathRule},
+    Determinator, Utf8Paths0,
+};
+use guppy::{
+    graph::{
+        cargo::{CargoOptions, CargoResolverVersion},
+        DependencyDirection, PackageGraph,
+    },
+    CargoMetadata, MetadataCommand,
+};
+use log::{debug, info};
 use std::{
     fs,
     io::Read,
@@ -12,6 +22,23 @@ use std::{
     process::Command,
 };
 use url::Url;
+
+// File types in `aptos-core` that are not relevant to the rust build and test process.
+// Note: this is a best effort list and will need to be updated as time goes on.
+const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 4] = ["*.json", "*.md", "*.yaml", "*.yml"];
+
+// Paths in `aptos-core` that are not relevant to the rust build and test process.
+// Note: this is a best effort list and will need to be updated as time goes on.
+const IGNORED_DETERMINATOR_PATHS: [&str; 8] = [
+    ".assets/*",
+    ".github/*",
+    ".vscode/*",
+    "dashboards/*",
+    "developer-docs-site/*",
+    "docker/*",
+    "scripts/*",
+    "terraform/*",
+];
 
 fn workspace_dir() -> PathBuf {
     let output = Command::new("cargo")
@@ -92,17 +119,17 @@ impl SelectedPackageArgs {
         Ok(CargoMetadata::parse_json(&contents)?)
     }
 
-    pub fn compute_packages(&self) -> anyhow::Result<Vec<String>> {
-        if !self.package.is_empty() {
-            return Ok(self.package.clone());
-        }
-
-        // Determine merge base
-        // TODO: support different merge bases
-        let merge_base = "origin/main";
+    /// Identifies the changed files compared to the merge base, and
+    /// returns the relevant package graphs and file list.
+    pub fn identify_changed_files(
+        &self,
+    ) -> anyhow::Result<(PackageGraph, PackageGraph, Utf8Paths0)> {
+        // Determine the merge base
+        let merge_base = self.identify_merge_base();
+        info!("Identified the merge base: {:?}", merge_base);
 
         // Download merge base metadata
-        let base_metadata = self.fetch_remote_metadata(merge_base)?;
+        let base_metadata = self.fetch_remote_metadata(&merge_base)?;
         let base_package_graph = base_metadata.build_graph().unwrap();
 
         // Compute head metadata
@@ -112,14 +139,72 @@ impl SelectedPackageArgs {
         let head_package_graph = head_metadata.build_graph().unwrap();
 
         // Compute changed files
-        let changed_files = self.compute_changed_files(merge_base)?;
+        let changed_files = self.compute_changed_files(&merge_base)?;
+        debug!("Identified the changed files: {:?}", changed_files);
 
-        // Run target determinator
+        // Return the package graphs and the changed files
+        Ok((base_package_graph, head_package_graph, changed_files))
+    }
+
+    /// Identifies the merge base to compare against. This is done by identifying
+    /// the commit at which the current branch forked off origin/main.
+    /// TODO: do we need to make this more intelligent?
+    fn identify_merge_base(&self) -> String {
+        // Run the git merge-base command
+        let output = Command::new("git")
+            .arg("merge-base")
+            .arg("HEAD")
+            .arg("origin/main")
+            .output()
+            .expect("failed to execute git merge-base");
+
+        // Return the output
+        String::from_utf8(output.stdout)
+            .expect("invalid UTF-8")
+            .trim()
+            .to_owned()
+    }
+
+    /// Computes the affected target packages based on the
+    /// merge base and changed file set.
+    pub fn compute_target_packages(&self) -> anyhow::Result<Vec<String>> {
+        if !self.package.is_empty() {
+            return Ok(self.package.clone());
+        }
+
+        // Compute changed files
+        let (base_package_graph, head_package_graph, changed_files) =
+            self.identify_changed_files()?;
+
+        // Create the determinator using the package graphs
         let mut determinator = Determinator::new(&base_package_graph, &head_package_graph);
-        // The determinator expects a list of changed files to be passed in.
+
+        // Add the changed files to the determinator
         determinator.add_changed_paths(&changed_files);
 
+        // Set the cargo options for the determinator
+        let mut cargo_options = CargoOptions::new();
+        cargo_options.set_resolver(CargoResolverVersion::V2);
+        determinator.set_cargo_options(&cargo_options);
+
+        // Set the ignore rules for the determinator
+        let mut rules = DeterminatorRules::default();
+        for globs in [
+            IGNORED_DETERMINATOR_FILE_TYPES.to_vec(),
+            IGNORED_DETERMINATOR_PATHS.to_vec(),
+        ] {
+            rules.path_rules.push(PathRule {
+                globs: globs.iter().map(|string| string.to_string()).collect(),
+                mark_changed: DeterminatorMarkChanged::Packages(vec![]),
+                post_rule: DeterminatorPostRule::Skip,
+            });
+        }
+        determinator.set_rules(&rules).unwrap();
+
+        // Run the target determinator
         let determinator_set = determinator.compute();
+
+        // Collect the affected packages
         let package_set = determinator_set
             .affected_set
             .packages(DependencyDirection::Forward)

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -7,7 +7,11 @@ mod common;
 use cargo::Cargo;
 use clap::{Args, Parser, Subcommand};
 pub use common::SelectedPackageArgs;
-use log::trace;
+use determinator::Utf8Paths0;
+use log::{debug, trace};
+
+// The targeted unit test packages to ignore (these will be run separately, by other jobs)
+const TARGETED_TEST_PACKAGES_TO_IGNORE: [&str; 2] = ["aptos-testcases", "smoke-test"];
 
 #[derive(Args, Clone, Debug)]
 #[command(disable_help_flag = true)]
@@ -29,10 +33,13 @@ impl CommonArgs {
 
 #[derive(Clone, Subcommand, Debug)]
 pub enum AptosCargoCommand {
+    AffectedPackages(CommonArgs),
+    ChangedFiles(CommonArgs),
     Check(CommonArgs),
     Xclippy(CommonArgs),
     Fmt(CommonArgs),
     Nextest(CommonArgs),
+    TargetedUnitTests(CommonArgs),
     Test(CommonArgs),
 }
 
@@ -43,16 +50,21 @@ impl AptosCargoCommand {
             AptosCargoCommand::Xclippy(_) => "clippy",
             AptosCargoCommand::Fmt(_) => "fmt",
             AptosCargoCommand::Nextest(_) => "nextest",
+            AptosCargoCommand::TargetedUnitTests(_) => "nextest", // Invoke the nextest command directly
             AptosCargoCommand::Test(_) => "test",
+            command => panic!("Unsupported command attempted! Command: {:?}", command),
         }
     }
 
     fn command_args(&self) -> &CommonArgs {
         match self {
+            AptosCargoCommand::AffectedPackages(args) => args,
+            AptosCargoCommand::ChangedFiles(args) => args,
             AptosCargoCommand::Check(args) => args,
             AptosCargoCommand::Xclippy(args) => args,
             AptosCargoCommand::Fmt(args) => args,
             AptosCargoCommand::Nextest(args) => args,
+            AptosCargoCommand::TargetedUnitTests(args) => args,
             AptosCargoCommand::Test(args) => args,
         }
     }
@@ -71,40 +83,157 @@ impl AptosCargoCommand {
         }
     }
 
-    fn split_args(&self) -> (Vec<String>, Vec<String>) {
-        self.command_args().args()
+    fn get_args_and_affected_packages(
+        &self,
+        package_args: &SelectedPackageArgs,
+    ) -> anyhow::Result<(Vec<String>, Vec<String>, Vec<String>)> {
+        // Parse the args
+        let (direct_args, push_through_args) = self.parse_args();
+
+        // Compute the affected packages
+        let packages = package_args.compute_target_packages()?;
+        trace!("affected packages: {:?}", packages);
+
+        // Return the parsed args and packages
+        Ok((direct_args, push_through_args, packages))
+    }
+
+    fn parse_args(&self) -> (Vec<String>, Vec<String>) {
+        // Parse the args
+        let (direct_args, push_through_args) = self.command_args().args();
+
+        // Trace log for debugging
+        trace!("parsed direct_arg`s: {:?}", direct_args);
+        trace!("parsed push_through_args: {:?}", push_through_args);
+
+        (direct_args, push_through_args)
     }
 
     pub fn execute(&self, package_args: &SelectedPackageArgs) -> anyhow::Result<()> {
-        let (mut direct_args, mut push_through_args) = self.split_args();
+        match self {
+            AptosCargoCommand::AffectedPackages(_) => {
+                // Calculate and display the affected packages
+                let packages = package_args.compute_target_packages()?;
+                output_affected_packages(packages)
+            },
+            AptosCargoCommand::ChangedFiles(_) => {
+                // Calculate and display the changed files
+                let (_, _, changed_files) = package_args.identify_changed_files()?;
+                output_changed_files(changed_files)
+            },
+            AptosCargoCommand::TargetedUnitTests(_) => {
+                // Calculate and run the targeted unit tests.
+                // Start by fetching the arguments and affected packages.
+                let (mut direct_args, push_through_args, packages) =
+                    self.get_args_and_affected_packages(package_args)?;
 
-        trace!("parsed direct_args: {:?}", direct_args);
-        trace!("parsed push_through_args: {:?}", push_through_args);
+                // Add each affected package to the arguments, but filter out
+                // the packages that should not be run as unit tests.
+                let mut found_package_to_test = false;
+                for package_path in packages {
+                    // Extract the package name from the full path
+                    let package_name = package_path.split('#').last().unwrap();
 
-        let packages = package_args.compute_packages()?;
+                    // Only add the package if it is not in the ignore list
+                    if TARGETED_TEST_PACKAGES_TO_IGNORE.contains(&package_name) {
+                        debug!(
+                            "Ignoring package when running targeted-unit-tests: {:?}",
+                            package_name
+                        );
+                    } else {
+                        // Add the arguments for the package
+                        direct_args.push("-p".into());
+                        direct_args.push(package_path);
 
-        trace!("affected packages: {:?}", packages);
+                        // Mark that we found a package to test
+                        found_package_to_test = true;
+                    }
+                }
 
-        for p in packages {
-            direct_args.push("-p".into());
-            direct_args.push(p);
+                // Create and run the command if we found a package to test
+                if found_package_to_test {
+                    println!("Running the targeted unit tests...");
+                    return self.create_and_run_command(direct_args, push_through_args);
+                }
+
+                println!("Skipping targeted unit tests because no packages were affected to test.");
+                Ok(())
+            },
+            _ => {
+                // Otherwise, we need to parse and run the command.
+                // Start by fetching the arguments and affected packages.
+                let (mut direct_args, mut push_through_args, packages) =
+                    self.get_args_and_affected_packages(package_args)?;
+
+                // Add each affected package to the arguments
+                for package_path in packages {
+                    direct_args.push("-p".into());
+                    direct_args.push(package_path);
+                }
+
+                // Add any additional arguments
+                if let Some(opts) = self.extra_opts() {
+                    for &opt in opts {
+                        push_through_args.push(opt.into());
+                    }
+                }
+
+                // Create and run the command
+                self.create_and_run_command(direct_args, push_through_args)
+            },
         }
+    }
 
-        if let Some(opts) = self.extra_opts() {
-            for &opt in opts {
-                push_through_args.push(opt.into());
-            }
-        }
-
+    fn create_and_run_command(
+        &self,
+        direct_args: Vec<String>,
+        push_through_args: Vec<String>,
+    ) -> anyhow::Result<()> {
+        // Output the final arguments before running the command
         trace!("final direct_args: {:?}", direct_args);
         trace!("final push_through_args: {:?}", push_through_args);
 
-        Cargo::command(self.command())
-            .args(direct_args)
-            .pass_through(push_through_args)
-            .run();
+        // Construct and run the final command
+        let mut command = Cargo::command(self.command());
+        command.args(direct_args).pass_through(push_through_args);
+        command.run();
+
         Ok(())
     }
+}
+
+/// Outputs the specified affected packages
+fn output_affected_packages(packages: Vec<String>) -> anyhow::Result<()> {
+    // Output the affected packages (if they exist)
+    if packages.is_empty() {
+        println!("No packages were affected!");
+    } else {
+        println!("Affected packages detected:");
+        for package in packages {
+            println!("\t{:?}", package)
+        }
+    }
+    Ok(())
+}
+
+/// Outputs the changed files from the given package args
+fn output_changed_files(changed_files: Utf8Paths0) -> anyhow::Result<()> {
+    // Output the results
+    let mut changes_detected = false;
+    for (index, file) in changed_files.into_iter().enumerate() {
+        if index == 0 {
+            println!("Changed files detected:"); // Only print this if changes were detected!
+            changes_detected = true;
+        }
+        println!("\t{:?}", file)
+    }
+
+    // If no changes were detected, make it obvious
+    if !changes_detected {
+        println!("No changes were detected!")
+    }
+
+    Ok(())
 }
 
 #[derive(Parser, Debug, Clone)]


### PR DESCRIPTION
## Description
This PR offers several improvements to CI/CD when running the rust unit tests on Github PRs:
1. Only run all rust unit tests when an appropriate event occurs (e.g., auto-merge is enabled or the `CICD:run-all-unit-tests` label is applied).
    - This will help to reduce the amount of wasted compute due to unnecessary runs.
1. Introduce a targeted rust unit tests job for PRs that only runs relevant rust unit tests. This builds on the existing `aptos-cargo-cli` and leverages target determination to decide which tests to run (i.e., based on changed files and the point at which the code forked off of the `main` branch in `aptos-core`).
    - This should reduce unit test time and provide developers with faster feedback, as it avoids running unnecessary rust unit tests.
1. Add several new commands to the `aptos-cargo-cli` so that users can see relevant target determination information (e.g., the files that were changed by the commit and how they affect the rust unit tests to run). Examples include:
```
cargo x changed-files  # To display the files that have changed
cargo x affected-packages  # To display the affected rust packages that should be tested
cargo x targeted-unit-tests -vv run. # To run the unit tests for the affected packages
```


Note:
1. Once we gain enough confidence in the targeted rust unit tests job, we should hopefully be able to remove the job that runs all rust unit tests. But, we need to see things in action first.
2. To improve the target determination results, I've had to tune the determinator to ignore irrelevant files and directories. Determination is better now, but still not perfect.

## Testing Plan
New and existing test infrastructure.