### PR TITLE
[Compiler-v2] Treat unit as tuple in type constraints

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_arity.exp
@@ -1,10 +1,20 @@
 
 Diagnostics:
-error: the left-hand side has 0 items but the right-hand side provided 3
-  ┌─ tests/checking/typing/assign_wrong_arity.move:7:9
+error: tuple type `()` is not allowed as a local variable type
+  ┌─ tests/checking/typing/assign_wrong_arity.move:5:13
   │
-7 │         x = (0, 1, 2);
-  │         ^
+5 │         let x;
+  │             ^
+  │
+  = required by declaration of local `x`
+
+error: tuple type `(integer, integer, integer)` is not allowed as a local variable type
+  ┌─ tests/checking/typing/assign_wrong_arity.move:5:13
+  │
+5 │         let x;
+  │             ^
+  │
+  = required by declaration of local `x`
 
 error: cannot assign `integer` to left-hand side of type `()`
   ┌─ tests/checking/typing/assign_wrong_arity.move:8:9

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_wrong_type.exp
@@ -12,6 +12,14 @@ error: cannot assign `R` to left-hand side of type `S`
 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
   │          ^^^^^^^
 
+error: tuple type `()` is not allowed as a local variable type
+   ┌─ tests/checking/typing/assign_wrong_type.move:13:13
+   │
+13 │         let x;
+   │             ^
+   │
+   = required by declaration of local `x`
+
 error: cannot assign `integer` to left-hand side of type `()`
    ┌─ tests/checking/typing/assign_wrong_type.move:17:9
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_arity.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: tuple type `()` is not allowed as a local variable type
+  ┌─ tests/checking/typing/bind_wrong_arity.move:5:13
+  │
+5 │         let x: () = ();
+  │             ^
+  │
+  = required by declaration of local `x`
+
 error: cannot bind `u64` to left-hand side of type `()`
   ┌─ tests/checking/typing/bind_wrong_arity.move:6:13
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bind_wrong_type.exp
@@ -12,6 +12,14 @@ error: cannot bind `R` to left-hand side of type `S`
 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
   │              ^^^^^^^
 
+error: tuple type `()` is not allowed as a local variable type
+   ┌─ tests/checking/typing/bind_wrong_type.move:11:13
+   │
+11 │         let x = ();
+   │             ^
+   │
+   = required by declaration of local `x`
+
 error: cannot bind `integer` to left-hand side of type `()`
    ┌─ tests/checking/typing/bind_wrong_type.move:12:13
    │
@@ -29,6 +37,14 @@ error: the left-hand side has 3 items but the right-hand side provided 2
    │
 14 │         let (x, b, R{f}) = (0, false);
    │             ^^^^^^^^^^^^
+
+error: tuple type `()` is not allowed as a local variable type
+   ┌─ tests/checking/typing/bind_wrong_type.move:18:13
+   │
+18 │         let x: () = 0;
+   │             ^
+   │
+   = required by declaration of local `x`
 
 error: cannot adapt `integer` to annotated type `()`
    ┌─ tests/checking/typing/bind_wrong_type.move:18:21

--- a/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/declare_wrong_arity.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+error: tuple type `()` is not allowed as a local variable type
+  ┌─ tests/checking/typing/declare_wrong_arity.move:5:13
+  │
+5 │         let x: ();
+  │             ^
+  │
+  = required by declaration of local `x`
+
 error: cannot adapt `()` to annotated type `u64`
   ┌─ tests/checking/typing/declare_wrong_arity.move:6:13
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq_invalid.exp
@@ -46,6 +46,14 @@ error: unable to infer instantiation of type `G2<_>` (consider providing type ar
 28 │         G2{} == G2{};
    │         ^^^^
 
+error: tuple type `()` is not allowed as a type argument (type was inferred)
+   ┌─ tests/checking/typing/eq_invalid.move:33:12
+   │
+33 │         () == ();
+   │            ^^
+   │
+   = required by instantiating type parameter `T` of function `==`
+
 error: tuple type `(integer, integer)` is not allowed as a type argument (type was inferred)
    ┌─ tests/checking/typing/eq_invalid.move:34:16
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -38,8 +38,13 @@ error: reference type `&integer` is not allowed as a type argument (type was inf
    │
    = required by instantiating type parameter `T` of function `+`
 
-error: cannot pass `|&integer|integer` to a function which expects argument of type `|&integer|`
-   ┌─ tests/checking/typing/lambda.move:73:21
+error: tuple type `()` is not allowed as a type argument (type was inferred)
+   ┌─ tests/checking/typing/lambda.move:73:37
    │
+ 4 │     public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                               - declaration of type parameter `T`
+   ·
 73 │         foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                     ^
+   │
+   = required by instantiating type parameter `T` of function `foreach`

--- a/third_party/move/move-compiler-v2/tests/checking/typing/loop_body_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/loop_body_invalid.exp
@@ -18,11 +18,11 @@ error: expected expression with no value but found `address`
 11 │         loop { @0x0 }
    │                ^^^^
 
-error: expected expression with no value but found `integer`
-   ┌─ tests/checking/typing/loop_body_invalid.move:15:27
+error: tuple type `()` is not allowed
+   ┌─ tests/checking/typing/loop_body_invalid.move:15:20
    │
 15 │         loop { let x = 0; x }
-   │                           ^
+   │                    ^
 
 error: expected expression with no value but found `integer`
    ┌─ tests/checking/typing/loop_body_invalid.move:19:26

--- a/third_party/move/move-compiler-v2/tests/checking/typing/loop_result_type_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/loop_result_type_invalid.exp
@@ -18,6 +18,14 @@ error: cannot pass `()` to a function which expects argument of type `u64`
 19 │         foo(loop { break })
    │             ^^^^^^^^^^^^^^
 
+error: tuple type `()` is not allowed as a local variable type
+   ┌─ tests/checking/typing/loop_result_type_invalid.move:25:13
+   │
+25 │         let x = loop { break };
+   │             ^
+   │
+   = required by declaration of local `x`
+
 error: the left-hand side has 2 items but the right-hand side provided 0
    ┌─ tests/checking/typing/loop_result_type_invalid.move:26:13
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq_invalid.exp
@@ -58,6 +58,14 @@ error: unable to infer instantiation of type `G2<_>` (consider providing type ar
 28 │         G2{} != G2{};
    │         ^^^^
 
+error: tuple type `()` is not allowed as a type argument (type was inferred)
+   ┌─ tests/checking/typing/neq_invalid.move:32:12
+   │
+32 │         () != ();
+   │            ^^
+   │
+   = required by instantiating type parameter `T` of function `!=`
+
 error: tuple type `(integer, integer)` is not allowed as a type argument (type was inferred)
    ┌─ tests/checking/typing/neq_invalid.move:33:16
    │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/pack_unit.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/pack_unit.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: tuple type `()` is not allowed as a type argument (type was inferred)
+  ┌─ tests/checking/typing/pack_unit.move:5:9
+  │
+2 │     struct Box<T> has drop { f: T }
+  │                - declaration of type parameter `T`
+  ·
+5 │         Box { f: () };
+  │         ^^^
+  │
+  = required by instantiating type parameter `T` of struct `Box`

--- a/third_party/move/move-compiler-v2/tests/checking/typing/pack_unit.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/pack_unit.move
@@ -1,0 +1,7 @@
+module 0x8675309::M {
+    struct Box<T> has drop { f: T }
+
+    fun t0() {
+        Box { f: () };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/vector_with_non_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/vector_with_non_base_type.exp
@@ -16,6 +16,14 @@ error: reference type `&mut u64` is not allowed as a type argument
   │
   = required by instantiating vector type parameter
 
+error: tuple type `()` is not allowed as a type argument
+  ┌─ tests/checking/typing/vector_with_non_base_type.move:6:24
+  │
+6 │         let v = vector<()>[];
+  │                        ^^
+  │
+  = required by instantiating vector type parameter
+
 error: tuple type `(u64, bool)` is not allowed as a type argument
   ┌─ tests/checking/typing/vector_with_non_base_type.move:7:24
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/vector_with_non_base_type_inferred.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/vector_with_non_base_type_inferred.exp
@@ -16,6 +16,14 @@ error: reference type `&mut integer` is not allowed as a type argument (type was
   │
   = required by instantiating vector type parameter
 
+error: tuple type `()` is not allowed as a type argument (type was inferred)
+  ┌─ tests/checking/typing/vector_with_non_base_type_inferred.move:6:9
+  │
+6 │         vector[()];
+  │         ^^^^^^
+  │
+  = required by instantiating vector type parameter
+
 error: tuple type `(integer, bool)` is not allowed as a type argument (type was inferred)
   ┌─ tests/checking/typing/vector_with_non_base_type_inferred.move:7:9
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/while_body_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/while_body_invalid.exp
@@ -18,11 +18,11 @@ error: expected expression with no value but found `address`
 5 │         while (cond) { @0x0 };
   │                        ^^^^
 
-error: expected expression with no value but found `integer`
-  ┌─ tests/checking/typing/while_body_invalid.move:6:35
+error: tuple type `()` is not allowed
+  ┌─ tests/checking/typing/while_body_invalid.move:6:28
   │
 6 │         while (cond) { let x = 0; x };
-  │                                   ^
+  │                            ^
 
 error: expected expression with no value but found `integer`
   ┌─ tests/checking/typing/while_body_invalid.move:7:34

--- a/third_party/move/move-compiler-v2/tests/v1.matched
+++ b/third_party/move/move-compiler-v2/tests/v1.matched
@@ -364,6 +364,7 @@ move-compiler/tests/move_check/typing/pack_invalid_argument.exp   move-compiler-
 move-compiler/tests/move_check/typing/pack_missing_field.exp   move-compiler-v2/tests/checking/typing/pack_missing_field.exp
 move-compiler/tests/move_check/typing/pack_multiple.exp   move-compiler-v2/tests/checking/typing/pack_multiple.exp
 move-compiler/tests/move_check/typing/pack_reference.exp   move-compiler-v2/tests/checking/typing/pack_reference.exp
+move-compiler/tests/move_check/typing/pack_unit.exp   move-compiler-v2/tests/checking/typing/pack_unit.exp
 move-compiler/tests/move_check/typing/phantom_param_op_abilities.exp   move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities.exp
 move-compiler/tests/move_check/typing/phantom_param_op_abilities_invalid.exp   move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities_invalid.exp
 move-compiler/tests/move_check/typing/phantom_params_constraint_abilities.exp   move-compiler-v2/tests/checking/abilities/v1/phantom_params_constraint_abilities.exp

--- a/third_party/move/move-compiler-v2/tests/v1.unmatched
+++ b/third_party/move/move-compiler-v2/tests/v1.unmatched
@@ -206,7 +206,6 @@ move-compiler/tests/move_check/typing/{
   non_phantom_in_phantom_pos.move,
   pack_constraint_not_satisfied.move,
   pack_private_with_field.move,
-  pack_unit.move,
   pack_unpack_private.move,
   pack_unpack_private_script.move,
   pay_me_a_river.move,

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1718,7 +1718,7 @@ impl Substitution {
                     }
                 },
                 (Constraint::NoTuple, ty) => {
-                    if ty.is_tuple() {
+                    if ty.is_tuple() || ty.is_unit() {
                         constraint_unsatisfied_error()
                     } else {
                         Ok(())
@@ -2796,6 +2796,14 @@ impl TypeUnificationError {
                         origin: ConstraintOrigin::Local(_),
                         ..
                     }) => "as a local variable type",
+                    Some(ConstraintContext {
+                        origin: ConstraintOrigin::Unspecified,
+                        ..
+                    }) => "",
+                    Some(ConstraintContext {
+                        origin: ConstraintOrigin::TupleElement(_, _),
+                        ..
+                    }) => "as a tuple element",
                     _ => "as a type argument",
                 };
                 let (mut note, mut hints, mut labels) = ctx_opt

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1313,8 +1313,13 @@ impl Type {
     }
 
     /// If this is a tuple and it is not a unit type, return true.
-    pub fn is_tuple(&self) -> bool {
+    pub fn is_non_unit_tuple(&self) -> bool {
         matches!(self, Type::Tuple(ts) if !ts.is_empty())
+    }
+
+    /// If this is a tuple, return true.
+    pub fn is_tuple(&self) -> bool {
+        matches!(self, Type::Tuple(_))
     }
 }
 
@@ -1718,7 +1723,7 @@ impl Substitution {
                     }
                 },
                 (Constraint::NoTuple, ty) => {
-                    if ty.is_tuple() || ty.is_unit() {
+                    if ty.is_tuple() {
                         constraint_unsatisfied_error()
                     } else {
                         Ok(())


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #12764 by treating unit as tuple in type constraints. 

Note that the error message in the test `third_party/move/move-compiler-v2/tests/checking/typing/lambda.move` and `third_party/move/move-compiler-v2/tests/checking/typing/while_body_invalid.exp` is less clearer after this fix, which should be fixed.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests;
2) migrate the test `pack_unit` from V1

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
