### PR TITLE
[GH] Update version of GCloud actions

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -36,10 +36,9 @@ inputs:
     required: false
   GCP_AUTH_DURATION:
     description: "Duration of GCP auth token in seconds"
-    type: int
     # setting this to 1.5h since sometimes docker builds (special performance
     # builds etc.) take that long. Default is 1h.
-    default: 5400
+    default: "5400"
 
 outputs:
   CLOUDSDK_AUTH_ACCESS_TOKEN:
@@ -78,7 +77,7 @@ runs:
 
     - id: auth
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v1"
+      uses: "google-github-actions/auth@v2"
       with:
         create_credentials_file: false
         token_format: "access_token"

--- a/.github/workflows/cargo-metadata-upload.yaml
+++ b/.github/workflows/cargo-metadata-upload.yaml
@@ -13,14 +13,14 @@ jobs:
   cargo-metadata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - id: auth
-        uses: "google-github-actions/auth@v1"
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-      - uses: "google-github-actions/setup-gcloud@v1"
+      - uses: "google-github-actions/setup-gcloud@v2"
       - shell: bash
         run: |
           cargo metadata --all-features | gsutil cp - gs://aptos-core-cargo-metadata-public/metadata-${{ github.sha }}.json

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -31,7 +31,7 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: medium-perf-docker-with-local-ssd
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: "Install GCloud SDK"
         if: ${{ !inputs.SKIP_JOB }}
-        uses: "google-github-actions/setup-gcloud@v1"
+        uses: "google-github-actions/setup-gcloud@v2"
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -81,13 +81,13 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 720 }}
     runs-on: ${{ inputs.RUNS_ON }}
     strategy:
-        fail-fast: false
-        matrix:
-          number: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17] # runner number
+      fail-fast: false
+      matrix:
+        number: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17] # runner number
     steps:
       - name: Echo Runner Number
         run: echo "Runner is ${{ matrix.number }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.GIT_SHA }}
 
@@ -96,7 +96,7 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
       - name: Install GCloud SDK
-        uses: "google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587" # pin@v1
+        uses: "google-github-actions/setup-gcloud@v2"
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"


### PR DESCRIPTION
Also upgrade actions/checkout to v4.

The previous versions of the actions use Nodejs 16, which is deprecated.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Check that workflows run successfully.