### PR TITLE
[Compiler-V2] Unused type parameter checking

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -131,11 +131,6 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Inherited(Experiment::OPTIMIZE.to_string()),
         },
         Experiment {
-            name: Experiment::DUPLICATE_STRUCT_PARAMS_CHECK.to_string(),
-            description: "Whether to check for duplicate struct type parameters".to_string(),
-            default: Inherited(Experiment::CHECKS.to_string()),
-        },
-        Experiment {
             name: Experiment::UNUSED_STRUCT_PARAMS_CHECK.to_string(),
             description: "Whether to check for unused struct type parameters".to_string(),
             default: Inherited(Experiment::CHECKS.to_string()),

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -131,6 +131,16 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Inherited(Experiment::OPTIMIZE.to_string()),
         },
         Experiment {
+            name: Experiment::DUPLICATE_STRUCT_PARAMS_CHECK.to_string(),
+            description: "Whether to check for duplicate struct type parameters".to_string(),
+            default: Inherited(Experiment::CHECKS.to_string()),
+        },
+        Experiment {
+            name: Experiment::UNUSED_STRUCT_PARAMS_CHECK.to_string(),
+            description: "Whether to check for unused struct type parameters".to_string(),
+            default: Inherited(Experiment::CHECKS.to_string()),
+        },
+        Experiment {
             name: Experiment::VARIABLE_COALESCING.to_string(),
             description: "Whether to run variable coalescing".to_string(),
             default: Inherited(Experiment::OPTIMIZE.to_string()),
@@ -183,6 +193,7 @@ impl Experiment {
     pub const CHECKS: &'static str = "checks";
     pub const COPY_PROPAGATION: &'static str = "copy-propagation";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
+    pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
@@ -195,6 +206,7 @@ impl Experiment {
     pub const SPEC_REWRITE: &'static str = "spec-rewrite";
     pub const SPLIT_CRITICAL_EDGES: &'static str = "split-critical-edges";
     pub const UNINITIALIZED_CHECK: &'static str = "uninitialized-check";
+    pub const UNUSED_STRUCT_PARAMS_CHECK: &'static str = "unused-struct-params-check";
     pub const USAGE_CHECK: &'static str = "usage-check";
     pub const VARIABLE_COALESCING: &'static str = "variable-coalescing";
     pub const VARIABLE_COALESCING_ANNOTATE: &'static str = "variable-coalescing-annotate";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -16,6 +16,7 @@ pub mod logging;
 pub mod options;
 pub mod pipeline;
 pub mod recursive_struct_checker;
+pub mod struct_params_checker;
 
 use crate::{
     env_pipeline::{
@@ -328,6 +329,18 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         });
         env_pipeline.add("check cyclic type instantiation", |env| {
             cyclic_instantiation_checker::check_cyclic_instantiations(env)
+        });
+    }
+
+    if !for_v1_model && options.experiment_on(Experiment::DUPLICATE_STRUCT_PARAMS_CHECK) {
+        env_pipeline.add("duplicate struct params check", |env| {
+            struct_params_checker::duplicate_params_checker(env)
+        });
+    }
+
+    if !for_v1_model && options.experiment_on(Experiment::UNUSED_STRUCT_PARAMS_CHECK) {
+        env_pipeline.add("unused struct params check", |env| {
+            struct_params_checker::unused_params_checker(env)
         });
     }
 

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -16,7 +16,7 @@ pub mod logging;
 pub mod options;
 pub mod pipeline;
 pub mod recursive_struct_checker;
-pub mod struct_params_checker;
+pub mod unused_params_checker;
 
 use crate::{
     env_pipeline::{
@@ -334,13 +334,13 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
 
     if !for_v1_model && options.experiment_on(Experiment::DUPLICATE_STRUCT_PARAMS_CHECK) {
         env_pipeline.add("duplicate struct params check", |env| {
-            struct_params_checker::duplicate_params_checker(env)
+            unused_params_checker::duplicate_params_checker(env)
         });
     }
 
     if !for_v1_model && options.experiment_on(Experiment::UNUSED_STRUCT_PARAMS_CHECK) {
         env_pipeline.add("unused struct params check", |env| {
-            struct_params_checker::unused_params_checker(env)
+            unused_params_checker::unused_params_checker(env)
         });
     }
 

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -332,12 +332,6 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         });
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::DUPLICATE_STRUCT_PARAMS_CHECK) {
-        env_pipeline.add("duplicate struct params check", |env| {
-            unused_params_checker::duplicate_params_checker(env)
-        });
-    }
-
     if !for_v1_model && options.experiment_on(Experiment::UNUSED_STRUCT_PARAMS_CHECK) {
         env_pipeline.add("unused struct params check", |env| {
             unused_params_checker::unused_params_checker(env)

--- a/third_party/move/move-compiler-v2/src/struct_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/struct_params_checker.rs
@@ -1,0 +1,103 @@
+use codespan_reporting::diagnostic::Severity;
+use move_model::{
+    model::{GlobalEnv, StructEnv, TypeParameter},
+    ty::Type,
+};
+use std::collections::{
+    btree_map::Entry::{Occupied, Vacant},
+    BTreeMap, BTreeSet,
+};
+
+/// Checks all modules in the given environment for
+/// duplicate type parameters in struct definitions.
+pub fn duplicate_params_checker(env: &GlobalEnv) {
+    for module in env.get_modules() {
+        if module.is_target() {
+            for struct_env in module.get_structs() {
+                check_duplicate_params(&struct_env);
+            }
+        }
+    }
+}
+
+/// Checks all modules in the given environment for
+/// unused type parameters in struct definitions.
+pub fn unused_params_checker(env: &GlobalEnv) {
+    for module in env.get_modules() {
+        if module.is_target() {
+            for struct_env in module.get_structs() {
+                check_unused_params(&struct_env);
+            }
+        }
+    }
+}
+
+/// Checks for duplicate type parameters in the struct definition, and reports errors if found.
+fn check_duplicate_params(struct_env: &StructEnv) {
+    let env = struct_env.module_env.env;
+    let mut param_to_loc = BTreeMap::new();
+    for TypeParameter(name, _kind, loc) in struct_env.get_type_parameters() {
+        match param_to_loc.entry(name) {
+            Vacant(e) => {
+                e.insert(loc.clone());
+            },
+            Occupied(e) => {
+                let prev_loc = e.get();
+                env.error_with_labels(loc, "duplicate type parameter", vec![(
+                    prev_loc.clone(),
+                    "previously defined here".to_string(),
+                )]);
+            },
+        }
+    }
+}
+
+/// Checks for unused type parameters for the given struct, and reports errors if found.
+fn check_unused_params(struct_env: &StructEnv) {
+    let env = struct_env.module_env.env;
+    let used_params_in_fields = used_type_parameters_in_fields(struct_env);
+    for (i, TypeParameter(name, kind, loc)) in struct_env.get_type_parameters().iter().enumerate() {
+        if !kind.is_phantom && !used_params_in_fields.contains(&(i as u16)) {
+            let name = name.display(struct_env.symbol_pool());
+            env.diag_with_labels(Severity::Warning, loc, "unused type parameter", vec![(
+                loc.clone(),
+                format!(
+                    "Unused type parameter `{}`. Consider declaring it as phantom",
+                    name
+                ),
+            )]);
+        }
+    }
+}
+
+/// Returns the indices of type parameters used in the fields of the given struct.
+fn used_type_parameters_in_fields(struct_env: &StructEnv) -> BTreeSet<u16> {
+    struct_env
+        .get_fields()
+        .flat_map(|field_env| used_type_parameters_in_ty(&field_env.get_type()))
+        .collect()
+}
+
+/// Returns the indices of type parameters used in the given type.
+fn used_type_parameters_in_ty(ty: &Type) -> BTreeSet<u16> {
+    match ty {
+        Type::Primitive(_) => BTreeSet::new(),
+        Type::Tuple(tys) | Type::Struct(_, _, tys) => {
+            tys.iter().flat_map(used_type_parameters_in_ty).collect()
+        },
+        Type::TypeParameter(i) => {
+            let mut set = BTreeSet::new();
+            set.insert(*i);
+            set
+        },
+        Type::Fun(from, to) => {
+            let mut used_in_from = used_type_parameters_in_ty(from);
+            used_in_from.append(&mut used_type_parameters_in_ty(to));
+            used_in_from
+        },
+        Type::Vector(ty) | Type::Reference(_, ty) => used_type_parameters_in_ty(ty),
+        Type::TypeDomain(_) | Type::ResourceDomain(_, _, _) | Type::Error | Type::Var(_) => {
+            unreachable!("unexpected type")
+        },
+    }
+}

--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -49,21 +49,20 @@ fn used_type_parameters_in_fields(struct_env: &StructEnv) -> BTreeSet<u16> {
         .collect()
 }
 
-/// Returns the indices of type parameters used in the given type.
+/// Returns the indices of type parameters used in the given type. The indices returned have the same scope.
 fn used_type_parameters_in_ty(ty: &Type) -> BTreeSet<u16> {
     match ty {
         Type::Primitive(_) => BTreeSet::new(),
-        Type::Tuple(tys) | Type::Struct(_, _, tys) => {
-            tys.iter().flat_map(used_type_parameters_in_ty).collect()
-        },
+        Type::Struct(_, _, tys) => tys.iter().flat_map(used_type_parameters_in_ty).collect(),
         Type::TypeParameter(i) => BTreeSet::from([*i]),
-        Type::Fun(from, to) => {
-            let mut used_in_from = used_type_parameters_in_ty(from);
-            used_in_from.append(&mut used_type_parameters_in_ty(to));
-            used_in_from
-        },
-        Type::Vector(ty) | Type::Reference(_, ty) => used_type_parameters_in_ty(ty),
-        Type::TypeDomain(_) | Type::ResourceDomain(_, _, _) | Type::Error | Type::Var(_) => {
+        Type::Vector(ty) => used_type_parameters_in_ty(ty),
+        Type::Reference(..)
+        | Type::Fun(..)
+        | Type::Tuple(..)
+        | Type::TypeDomain(..)
+        | Type::ResourceDomain(..)
+        | Type::Error
+        | Type::Var(..) => {
             unreachable!("unexpected type")
         },
     }

--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implements a environment pipeline which checks for unused type parameters in struct definitions.
+//! Implements an environment pipeline which checks for unused type parameters in struct definitions.
 
 use codespan_reporting::diagnostic::Severity;
 use move_model::{

--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -3,22 +3,7 @@ use move_model::{
     model::{GlobalEnv, StructEnv, TypeParameter},
     ty::Type,
 };
-use std::collections::{
-    btree_map::Entry::{Occupied, Vacant},
-    BTreeMap, BTreeSet,
-};
-
-/// Checks all modules in the given environment for
-/// duplicate type parameters in struct definitions.
-pub fn duplicate_params_checker(env: &GlobalEnv) {
-    for module in env.get_modules() {
-        if module.is_target() {
-            for struct_env in module.get_structs() {
-                check_duplicate_params(&struct_env);
-            }
-        }
-    }
-}
+use std::collections::BTreeSet;
 
 /// Checks all modules in the given environment for
 /// unused type parameters in struct definitions.
@@ -28,26 +13,6 @@ pub fn unused_params_checker(env: &GlobalEnv) {
             for struct_env in module.get_structs() {
                 check_unused_params(&struct_env);
             }
-        }
-    }
-}
-
-/// Checks for duplicate type parameters in the struct definition, and reports errors if found.
-fn check_duplicate_params(struct_env: &StructEnv) {
-    let env = struct_env.module_env.env;
-    let mut param_to_loc = BTreeMap::new();
-    for TypeParameter(name, _kind, loc) in struct_env.get_type_parameters() {
-        match param_to_loc.entry(name) {
-            Vacant(e) => {
-                e.insert(loc.clone());
-            },
-            Occupied(e) => {
-                let prev_loc = e.get();
-                env.error_with_labels(loc, "duplicate type parameter", vec![(
-                    prev_loc.clone(),
-                    "previously defined here".to_string(),
-                )]);
-            },
         }
     }
 }

--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implements an environment pipeline which checks for unused type parameters in struct definitions.
+//! Precondition: struct fields have valid types.
 
 use codespan_reporting::diagnostic::Severity;
 use move_model::{
@@ -55,11 +56,7 @@ fn used_type_parameters_in_ty(ty: &Type) -> BTreeSet<u16> {
         Type::Tuple(tys) | Type::Struct(_, _, tys) => {
             tys.iter().flat_map(used_type_parameters_in_ty).collect()
         },
-        Type::TypeParameter(i) => {
-            let mut set = BTreeSet::new();
-            set.insert(*i);
-            set
-        },
+        Type::TypeParameter(i) => BTreeSet::from([*i]),
         Type::Fun(from, to) => {
             let mut used_in_from = used_type_parameters_in_ty(from);
             used_in_from.append(&mut used_type_parameters_in_ty(to));

--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -1,3 +1,8 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements a environment pipeline which checks for unused type parameters in struct definitions.
+
 use codespan_reporting::diagnostic::Severity;
 use move_model::{
     model::{GlobalEnv, StructEnv, TypeParameter},

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/access_ok.move
@@ -3,7 +3,7 @@ module 0x42::m {
     struct S has store {}
     struct R has store {}
     struct T has store {}
-    struct G<T> has store {}
+    struct G<phantom T> has store {}
 
     fun f1() acquires S {
     }

--- a/third_party/move/move-compiler-v2/tests/checking/naming/duplicate_type_parameter_function.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/duplicate_type_parameter_function.exp
@@ -1,19 +1,25 @@
 
 Diagnostics:
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_function.move:2:16
   │
 2 │     fun foo<T, T>() {}
-  │                ^
+  │             -  ^
+  │             │
+  │             previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_function.move:3:23
   │
 3 │     fun foo2<T: drop, T: key, T>() {}
-  │                       ^
+  │              -        ^
+  │              │
+  │              previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_function.move:3:31
   │
 3 │     fun foo2<T: drop, T: key, T>() {}
-  │                               ^
+  │              -                ^
+  │              │
+  │              previously declared here

--- a/third_party/move/move-compiler-v2/tests/checking/naming/duplicate_type_parameter_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/duplicate_type_parameter_struct.exp
@@ -1,37 +1,49 @@
 
 Diagnostics:
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:2:17
   │
 2 │     struct S<T, T> { f: T }
-  │                 ^
+  │              -  ^
+  │              │
+  │              previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:3:24
   │
 3 │     struct S2<T: drop, T: key, T> { f: T }
-  │                        ^
+  │               -        ^
+  │               │
+  │               previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:3:32
   │
 3 │     struct S2<T: drop, T: key, T> { f: T }
-  │                                ^
+  │               -                ^
+  │               │
+  │               previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:4:17
   │
 4 │     struct R<T, T> { f: T }
-  │                 ^
+  │              -  ^
+  │              │
+  │              previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:5:24
   │
 5 │     struct R2<T: drop, T: key, T> { f: T }
-  │                        ^
+  │               -        ^
+  │               │
+  │               previously declared here
 
-error: duplicate declaration of type parameter `T`, previously found in type parameters
+error: duplicate declaration of type parameter `T`
   ┌─ tests/checking/naming/duplicate_type_parameter_struct.move:5:32
   │
 5 │     struct R2<T: drop, T: key, T> { f: T }
-  │                                ^
+  │               -                ^
+  │               │
+  │               previously declared here

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
@@ -1,0 +1,49 @@
+
+Diagnostics:
+warning: unused type parameter
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:2:12
+  │
+2 │     struct S0<T> {}
+  │               ^
+  │               │
+  │               Unused type parameter `T`. Consider declaring it as phantom
+
+warning: unused type parameter
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:12
+  │
+4 │     struct S1<T1, T2> {}
+  │               ^^
+  │               │
+  │               Unused type parameter `T1`. Consider declaring it as phantom
+
+warning: unused type parameter
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:16
+  │
+4 │     struct S1<T1, T2> {}
+  │                   ^^
+  │                   │
+  │                   Unused type parameter `T2`. Consider declaring it as phantom
+
+warning: unused type parameter
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:6:12
+  │
+6 │     struct S2<T1, phantom T2> {
+  │               ^^
+  │               │
+  │               Unused type parameter `T1`. Consider declaring it as phantom
+
+// -- Model dump before bytecode pipeline
+module 0x42::test {
+    struct S0 {
+        dummy_field: bool,
+    }
+    struct S1 {
+        dummy_field: bool,
+    }
+    struct S2 {
+        f: test::S3<#1>,
+    }
+    struct S3 {
+        dummy_field: bool,
+    }
+} // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
@@ -1,7 +1,7 @@
 
 Diagnostics:
 warning: unused type parameter
-  ┌─ tests/checking/naming/unused_type_parameter_struct.move:2:12
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:2:15
   │
 2 │     struct S0<T> {}
   │               ^
@@ -9,7 +9,7 @@ warning: unused type parameter
   │               Unused type parameter `T`. Consider declaring it as phantom
 
 warning: unused type parameter
-  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:12
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:15
   │
 4 │     struct S1<T1, T2> {}
   │               ^^
@@ -17,7 +17,7 @@ warning: unused type parameter
   │               Unused type parameter `T1`. Consider declaring it as phantom
 
 warning: unused type parameter
-  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:16
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:4:19
   │
 4 │     struct S1<T1, T2> {}
   │                   ^^
@@ -25,12 +25,20 @@ warning: unused type parameter
   │                   Unused type parameter `T2`. Consider declaring it as phantom
 
 warning: unused type parameter
-  ┌─ tests/checking/naming/unused_type_parameter_struct.move:6:12
+  ┌─ tests/checking/naming/unused_type_parameter_struct.move:6:15
   │
 6 │     struct S2<T1, phantom T2> {
   │               ^^
   │               │
   │               Unused type parameter `T1`. Consider declaring it as phantom
+
+warning: unused type parameter
+   ┌─ tests/checking/naming/unused_type_parameter_struct.move:12:18
+   │
+12 │     struct S4<T, U> {
+   │                  ^
+   │                  │
+   │                  Unused type parameter `U`. Consider declaring it as phantom
 
 // -- Model dump before bytecode pipeline
 module 0x42::test {
@@ -45,5 +53,12 @@ module 0x42::test {
     }
     struct S3 {
         dummy_field: bool,
+    }
+    struct S4 {
+        f: vector<#0>,
+    }
+    struct S5 {
+        f: vector<#0>,
+        g: vector<#1>,
     }
 } // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.move
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.move
@@ -1,0 +1,11 @@
+module 0x42::test {
+	struct S0<T> {}
+
+	struct S1<T1, T2> {}
+
+	struct S2<T1, phantom T2> {
+		f: S3<T2>,
+	}
+
+	struct S3<phantom T> {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.move
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.move
@@ -1,11 +1,20 @@
 module 0x42::test {
-	struct S0<T> {}
+    struct S0<T> {}
 
-	struct S1<T1, T2> {}
+    struct S1<T1, T2> {}
 
-	struct S2<T1, phantom T2> {
-		f: S3<T2>,
-	}
+    struct S2<T1, phantom T2> {
+        f: S3<T2>,
+    }
 
-	struct S3<phantom T> {}
+    struct S3<phantom T> {}
+
+    struct S4<T, U> {
+        f: vector<T>
+    }
+
+    struct S5<T, U> {
+        f: vector<T>,
+        g: vector<U>,
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct_invalid_fields.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct_invalid_fields.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: tuple type `(T, bool)` is not allowed as a field type
+   ┌─ tests/checking/naming/unused_type_parameter_struct_invalid_fields.move:13:12
+   │
+13 │         f: (T, bool),
+   │            ^^^^^^^^^
+   │
+   = required by declaration of field `f`
+
+error: reference type `&T` is not allowed as a field type
+   ┌─ tests/checking/naming/unused_type_parameter_struct_invalid_fields.move:14:12
+   │
+14 │         g: &T,
+   │            ^^
+   │
+   = required by declaration of field `g`

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct_invalid_fields.move
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct_invalid_fields.move
@@ -1,0 +1,16 @@
+module 0x42::test {
+    struct ListGood<T> {
+        head: T,
+        tail: ListGood<T>,
+    }
+
+    struct ListBad<T, U> {
+        head: T,
+        tail: ListBad<T, U>,
+    }
+
+    struct BadFields<T, U> {
+        f: (T, bool),
+        g: &T,
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -495,7 +495,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     );
                 self.error_with_labels(
                     loc,
-                    &format!("deplicate declaration of type parameter `{}`", param_name),
+                    &format!("duplicate declaration of type parameter `{}`", param_name),
                     vec![(
                         prev_loc.expect("location").clone(),
                         "previously declared here".to_string(),

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -481,13 +481,25 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         if let Type::TypeParameter(..) = &ty {
             if self.type_params_table.insert(name, ty.clone()).is_some() && report_errors {
                 let param_name = name.display(self.symbol_pool());
-                self.error(
+                let prev_loc = self
+                    .type_params
+                    .iter()
+                    .find_map(
+                        |(prev_name, _ty, _kind, loc)| {
+                            if prev_name == &name {
+                                Some(loc)
+                            } else {
+                                None
+                            }
+                        },
+                    );
+                self.error_with_labels(
                     loc,
-                    &format!(
-                        "duplicate declaration of type parameter `{}`, \
-                        previously found in type parameters",
-                        param_name
-                    ),
+                    &format!("deplicate declaration of type parameter `{}`", param_name),
+                    vec![(
+                        prev_loc.expect("location").clone(),
+                        "previously declared here".to_string(),
+                    )],
                 );
                 return;
             }

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -85,7 +85,8 @@ pub fn run_move_prover_v2<W: WriteColor>(
         warn_unused: false,
         whole_program: false,
         compile_test_code: false,
-    };
+    }
+    .set_experiment(Experiment::UNUSED_STRUCT_PARAMS_CHECK, false);
 
     let mut env = move_compiler_v2::run_move_compiler_for_analysis(error_writer, compiler_options)?;
     run_move_prover_with_model_v2(&mut env, error_writer, options, now)
@@ -119,7 +120,8 @@ pub fn run_move_prover_with_model<W: WriteColor>(
     // Run the compiler v2 checking and rewriting pipeline
     let compiler_options = move_compiler_v2::Options::default()
         .set_experiment(Experiment::OPTIMIZE, false)
-        .set_experiment(Experiment::SPEC_REWRITE, true);
+        .set_experiment(Experiment::SPEC_REWRITE, true)
+        .set_experiment(Experiment::UNUSED_STRUCT_PARAMS_CHECK, false);
     env.set_extension(compiler_options.clone());
     let pipeline = move_compiler_v2::check_and_rewrite_pipeline(
         &compiler_options,


### PR DESCRIPTION
## Description

- Implement a checker for unused parameters in struct definitions, as an environment pipeline
- Improve the error messages for duplicate type parameters for functions and structs, by adding the location of the duplication.

Fixed #11709

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Existing tests and `checking/naming/unused_type_parameter_struct.move`

